### PR TITLE
avoid NPE if colsDefs is null

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ClusterMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ClusterMetadata.java
@@ -104,15 +104,16 @@ public class ClusterMetadata {
     }
 
     private static void buildTableMetadata(KeyspaceMetadata ksm, List<Row> cfRows, Map<String, List<Row>> colsDefs) {
+        boolean hasColumns = (colsDefs != null) && !colsDefs.isEmpty();
         for (Row cfRow : cfRows) {
             String cfName = cfRow.getString(TableMetadata.CF_NAME);
-            TableMetadata tm = TableMetadata.build(ksm, cfRow, !colsDefs.isEmpty());
+            TableMetadata tm = TableMetadata.build(ksm, cfRow, hasColumns);
 
-            if (colsDefs == null || colsDefs.get(cfName) == null)
+            if (!hasColumns || colsDefs.get(cfName) == null)
                 continue;
 
             for (Row colRow : colsDefs.get(cfName)) {
-                ColumnMetadata cm = ColumnMetadata.build(tm, colRow);
+                ColumnMetadata.build(tm, colRow);
             }
         }
     }


### PR DESCRIPTION
code is written as if colsDef could be null, if it is you get an NPE in call to TableMetadata.build. Rework to add null check and pull that out of the loop.
