### PR TITLE
Fluent insert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 .settings
 .classpath
 .project
+
+*.iml

--- a/driver-core/src/main/java/com/datastax/driver/core/utils/querybuilder/Insert.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/utils/querybuilder/Insert.java
@@ -2,6 +2,10 @@ package com.datastax.driver.core.utils.querybuilder;
 
 import com.datastax.driver.core.TableMetadata;
 
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * A built INSERT statement.
  */
@@ -67,9 +71,6 @@ public class Insert extends BuiltStatement {
         private String table;
 
         Builder(String[] columnNames) {
-            if (columnNames.length == 0)
-                throw new IllegalArgumentException("Invalid empty column names");
-
             this.columnNames = columnNames;
         }
 
@@ -122,7 +123,7 @@ public class Insert extends BuiltStatement {
          * @param values the values to insert. The {@code i}th value
          * corresponds to the {@code i}th column used when constructing this
          * {@code Insert.Builder object}.
-         * @return the newly built UPDATE statement.
+         * @return the newly built INSERT statement.
          *
          * @throws IllegalArgumentException if the number of provided values
          * doesn't correspond to the number of columns used when constructing
@@ -130,16 +131,69 @@ public class Insert extends BuiltStatement {
          * @throws IllegalStateException if no INTO clause have been defined.
          */
         public Insert values(Object... values) {
-
             if (values.length != columnNames.length)
                 throw new IllegalArgumentException(String.format("Number of provided values (%d) doesn't match the number of inserted columns (%d)", values.length, columnNames.length));
+            return build(values);
+        }
 
+        private Insert build(Object... values){
+            return build(keyspace, table, tableMetadata, columnNames, values);
+        }
+
+        private static Insert build(String keyspace, String table, TableMetadata tableMetadata, String[] columnNames, Object[] values) {
+            if (columnNames.length == 0)
+                throw new IllegalStateException("Invalid empty columns list");
             if (tableMetadata != null)
                 return new Insert(tableMetadata, columnNames, values);
             else if (table != null)
                 return new Insert(keyspace, table, columnNames, values);
             else
                 throw new IllegalStateException("Missing INTO clause");
+        }
+
+        public <T> ColumnsSpecification column(String columnName, T value) {
+           return new ColumnsSpecification(this).add(columnName, value);
+        }
+
+        public static class ColumnsSpecification {
+            private List<String> columnNames = new ArrayList<String>();
+            private List<Object> values = new ArrayList<Object>();
+            private final Builder builder ;
+
+            ColumnsSpecification(Builder builder) {
+               this.builder = builder;
+            }
+
+            <T> ColumnsSpecification add(String columnName, T value) {
+                columnNames.add(columnName);
+                values.add(value);
+                return this;
+            }
+
+            public <T> ColumnsSpecification column(String columnName, T value) {
+                return add(columnName, value);
+            }
+
+            /**
+             * Syntaxic sugar
+             * @return the unchange INSERT statement
+             */
+            public ColumnsSpecification and() {
+                return this;
+            }
+
+            /**
+             * @see Insert#using(Using...)
+             */
+            public Insert using(Using... usings) {
+                return builder.build(
+                       builder.keyspace,
+                       builder.table,
+                       builder.tableMetadata,
+                       this.columnNames.toArray(new String[this.columnNames.size()]),
+                       this.values.toArray(new Object[this.values.size()])
+               ).using(usings);
+            }
         }
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/utils/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/utils/QueryBuilderTest.java
@@ -59,6 +59,38 @@ public class QueryBuilderTest {
         assertEquals(query, insert.toString());
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void insertTestWithEmptyColumns() {
+        insert().into("foo").values().using(ttl(24), timestamp(42));
+    }
+
+    @Test
+    public void fluentInsertTest() throws Exception {
+
+        String query;
+        Insert insert;
+
+        query = "INSERT INTO foo(a,b,\"C\",d) VALUES (123,127.0.0.1,'foo''bar',{'x':3,'y':2}) USING TIMESTAMP 42 AND TTL 24;";
+        insert = insert().into("foo")
+                .column("a", 123)
+                .and().column("b", InetAddress.getByName("127.0.0.1"))
+                .and().column(quote("C"), "foo'bar")
+                .and().column("d", new TreeMap() {{
+                    put("x", 3);
+                    put("y", 2);
+                }})
+                .using(timestamp(42), ttl(24));
+        assertEquals(query, insert.toString());
+
+        query = "INSERT INTO foo(a,b) VALUES ({2,3,4},3.4) USING TTL 24 AND TIMESTAMP 42;";
+        insert = insert("a", "b").into("foo").column("a", new TreeSet() {{
+            add(2);
+            add(3);
+            add(4);
+        }}).and().column("b", 3.4).using(ttl(24), timestamp(42));
+        assertEquals(query, insert.toString());
+    }
+
     @Test
     public void updateTest() throws Exception {
 


### PR DESCRIPTION
I have looked to the driver API which is better than Hector. Thank you for that.

I think you can make a better API.  I'm not expecting the pull request being accepted, it's just an example to help you make a better API.

Arrays and "Stuff..." are really annoying to use. So i recommend to try to remove it from all public API methods or at least propose an alternative API for dynamicaly built statements.

If this example is accepted, I can finish the job by improving the rest of the Query API the same way (for Update, Delete and Select)
