### PR TITLE
support ReversedType in Codec.rawTypeToDataType

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -683,7 +683,7 @@ public class Cluster {
                         ControlConnection.waitForSchemaAgreement(connection, metadata);
                         ControlConnection.refreshSchema(connection, keyspace, table, Cluster.Manager.this);
                     } catch (Exception e) {
-                        logger.error("Error during schema refresh ({}). The schema from Cluster.getMetadata() migth appear stale. Asynchronously submitting job to fix.", e.getMessage());
+                        logger.error("Error during schema refresh ({}). The schema from Cluster.getMetadata() might appear stale. Asynchronously submitting job to fix.", e);
                         submitSchemaRefresh(keyspace, table);
                     } finally {
                         // Always sets the result

--- a/driver-core/src/main/java/com/datastax/driver/core/Codec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Codec.java
@@ -67,6 +67,9 @@ class Codec {
     }
 
     public static DataType rawTypeToDataType(AbstractType<?> rawType) {
+        if (rawType instanceof ReversedType)
+            rawType = ((ReversedType) rawType).baseType;
+
         DataType type = rawNativeMap.get(rawType);
         if (type != null)
             return type;


### PR DESCRIPTION
doing something like

session.execute("CREATE TABLE spider.uphosts (prefix int, ip text, day timestamp, primary key(prefix,ip)) with compact storage and clustering order by (ip desc)");
