### PR TITLE
query delete().from... throws a NPE

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
@@ -38,7 +38,8 @@ public class Delete extends BuiltStatement {
         StringBuilder builder = new StringBuilder();
 
         builder.append("DELETE ");
-        Utils.joinAndAppendNames(builder, ",", columnNames);
+		if (columnNames != null)
+        	Utils.joinAndAppendNames(builder, ",", columnNames);
 
         builder.append(" FROM ");
         if (keyspace != null)


### PR DESCRIPTION
the query delete().from... throws a NPE.

no test is done onto the columnName into buildQueryString() for the class Delete. 
When columnName is null the Utils.joinAndAppendNames() throws a NPE.
