### PR TITLE
typo in Readme, awkward exception wording, and fix for CASSANDRA-5101

### DIFF
--- a/driver-core/README.rst
+++ b/driver-core/README.rst
@@ -70,7 +70,7 @@ cass1, cass2 and cass3. A simple example using this core driver could be::
                         .build();
     Session session = cluster.connect("db1");
 
-    for (CQLRow row : session.execute("SELECT * FROM table1"))
+    for (Row row : session.execute("SELECT * FROM table1"))
         // do something ...
 
 

--- a/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
@@ -96,7 +96,9 @@ public class TableMetadata {
             List<AbstractType<?>> keyTypes = kt instanceof CompositeType
                                            ? ((CompositeType)kt).types
                                            : Collections.<AbstractType<?>>singletonList(kt);
-            List<String> keyAliases = fromJsonList(row.getString(KEY_ALIASES));
+
+            // check if key_aliases is null, and set to [] due to CASSANDRA-5101
+            List<String> keyAliases = row.getString(KEY_ALIASES) == null ? new ArrayList<String>() : fromJsonList(row.getString(KEY_ALIASES));
             for (int i = 0; i < keyTypes.size(); i++) {
                 String cn = keyAliases.size() > i
                           ? keyAliases.get(i)

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/NoHostAvailableException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/NoHostAvailableException.java
@@ -38,6 +38,6 @@ public class NoHostAvailableException extends DriverException {
     }
 
     private static String makeMessage(Map<InetAddress, String> errors) {
-        return String.format("All host tried for query are in error (tried: %s)", errors.keySet());
+        return String.format("All host(s) tried for query failed (tried: %s)", errors.keySet());
     }
 }


### PR DESCRIPTION
Appears that somewhere along the line CQLRow was renamed to Row. Fixing Readme to reflect that. and a fix for CASSANDRA-5101 where upgraded tables have a null key_aliases column
