### PR TITLE
testnodes should move from 127.0.0.n to 127.0.1.n

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -79,6 +79,7 @@
           <useFile>false</useFile>
           <systemPropertyVariables>
               <cassandra.version>${cassandra.version}</cassandra.version>
+              <ipprefix>${ipprefix}</ipprefix>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyTest.java
@@ -87,18 +87,18 @@ public class LoadBalancingPolicyTest {
             init(c, 12);
             query(c, 12);
 
-            assertQueried("127.0.0.1", 6);
-            assertQueried("127.0.0.2", 6);
+            assertQueried(CCMBridge.IP_PREFIX + "1", 6);
+            assertQueried(CCMBridge.IP_PREFIX + "2", 6);
 
             resetCoordinators();
             c.bridge.bootstrapNode(3);
-            waitFor("127.0.0.3", c.cluster, 20);
+            waitFor(CCMBridge.IP_PREFIX + "3", c.cluster, 20);
 
             query(c, 12);
 
-            assertQueried("127.0.0.1", 4);
-            assertQueried("127.0.0.2", 4);
-            assertQueried("127.0.0.3", 4);
+            assertQueried(CCMBridge.IP_PREFIX + "1", 4);
+            assertQueried(CCMBridge.IP_PREFIX + "2", 4);
+            assertQueried(CCMBridge.IP_PREFIX + "3", 4);
 
         } catch (Throwable e) {
             c.errorOut();
@@ -119,10 +119,10 @@ public class LoadBalancingPolicyTest {
             init(c, 12);
             query(c, 12);
 
-            assertQueried("127.0.0.1", 0);
-            assertQueried("127.0.0.2", 0);
-            assertQueried("127.0.0.3", 6);
-            assertQueried("127.0.0.4", 6);
+            assertQueried(CCMBridge.IP_PREFIX + "1", 0);
+            assertQueried(CCMBridge.IP_PREFIX + "2", 0);
+            assertQueried(CCMBridge.IP_PREFIX + "3", 6);
+            assertQueried(CCMBridge.IP_PREFIX + "4", 6);
 
         } catch (Throwable e) {
             c.errorOut();
@@ -154,19 +154,19 @@ public class LoadBalancingPolicyTest {
             // Not the best test ever, we should use OPP and check we do it the
             // right nodes. But since M3P is hard-coded for now, let just check
             // we just hit only one node.
-            assertQueried("127.0.0.1", 0);
-            assertQueried("127.0.0.2", 12);
+            assertQueried(CCMBridge.IP_PREFIX + "1", 0);
+            assertQueried(CCMBridge.IP_PREFIX + "2", 12);
 
             resetCoordinators();
             c.bridge.bootstrapNode(3);
-            waitFor("127.0.0.3", c.cluster, 20);
+            waitFor(CCMBridge.IP_PREFIX + "3", c.cluster, 20);
 
             query(c, 12, usePrepared);
 
             // We should still be hitting only one node
-            assertQueried("127.0.0.1", 0);
-            assertQueried("127.0.0.2", 12);
-            assertQueried("127.0.0.3", 0);
+            assertQueried(CCMBridge.IP_PREFIX + "1", 0);
+            assertQueried(CCMBridge.IP_PREFIX + "2", 12);
+            assertQueried(CCMBridge.IP_PREFIX + "3", 0);
 
         } catch (Throwable e) {
             c.errorOut();

--- a/driver-examples/stress/src/main/java/com/datastax/driver/stress/Stress.java
+++ b/driver-examples/stress/src/main/java/com/datastax/driver/stress/Stress.java
@@ -45,6 +45,7 @@ public class Stress {
         parser.accepts("csv", "Save metrics into csv instead of displaying on stdout");
         parser.accepts("columns-per-row", "Number of columns per CQL3 row").withRequiredArg().ofType(Integer.class).defaultsTo(5);
         parser.accepts("value-size", "The size in bytes for column values").withRequiredArg().ofType(Integer.class).defaultsTo(34);
+        parser.accepts("ip", "The hosts ip to connect to").withRequiredArg().ofType(String.class).defaultsTo("127.0.0.1");
 
         register("insert", Generators.CASSANDRA_INSERTER);
         register("insert_prepared", Generators.CASSANDRA_PREPARED_INSERTER);
@@ -86,7 +87,7 @@ public class Stress {
 
         try {
             // Create session to hosts
-            Cluster cluster = new Cluster.Builder().addContactPoints("127.0.0.1").build();
+            Cluster cluster = new Cluster.Builder().addContactPoints(String.valueOf(options.valueOf("ip"))).build();
 
             //PoolingOptions pools = cluster.getConfiguration().getConnectionsConfiguration().getPoolingOptions();
             //pools.setCoreConnectionsPerHost(HostDistance.LOCAL, 2);


### PR DESCRIPTION
Running the testnodes on 127.0.0.1 depends on maybe already dedicated ports. The testnodes could run under 127.0.1.n to avoid this. This change would allow testing/developing/package-building without stopping/altering a already running default cassandra installation.

This depends on changes defined in https://github.com/pcmanus/ccm/pull/49
