### PR TITLE
changed jmx-port for tests

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -80,6 +80,7 @@
           <systemPropertyVariables>
               <cassandra.version>${cassandra.version}</cassandra.version>
               <ipprefix>${ipprefix}</ipprefix>
+              <jmxport>${jmxport}</jmxport>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -24,6 +24,8 @@ public class CCMBridge {
 
     public static final String IP_PREFIX;
 
+    public static final String JMX_PORT;
+
     private static final String CASSANDRA_VERSION_REGEXP = "\\d\\.\\d\\.\\d(-\\w+)?";
 
     private static final File CASSANDRA_DIR;
@@ -43,6 +45,12 @@ public class CCMBridge {
             ip_prefix = "127.0.1.";
         }
         IP_PREFIX = ip_prefix;
+
+        String jmxport = System.getProperty("jmxport");
+        if (jmxport == null || jmxport.equals("")) {
+        	jmxport = "17199";
+        }
+        JMX_PORT = jmxport;
     }
 
     private final Runtime runtime = Runtime.getRuntime();
@@ -101,7 +109,7 @@ public class CCMBridge {
     }
 
     public void bootstrapNode(int n) {
-        execute("ccm add node%d -i %s%d -b", n, IP_PREFIX, n);
+        execute("ccm add node%d -i %s%d -j %s -b", n, IP_PREFIX, n, JMX_PORT);
         execute("ccm node%d start", n);
     }
 


### PR DESCRIPTION
- defaults for ccm nodes to 17199
- can be set with mvn -Djmxport=...

The jmxport 7199 from a default installation is bound to all ips. This led to a failing "node3" while testing.
With this new change it is possible to run tests without stopping a concurrent running cassandra (again).
I'm sorry, changing the ip was not enough.
