### PR TITLE
QueryBuilder where clause concatenation fix

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
@@ -54,7 +54,7 @@ public class Update extends BuiltStatement {
 
         if (!where.clauses.isEmpty()) {
             builder.append(" WHERE ");
-            Utils.joinAndAppend(builder, ",", where.clauses);
+            Utils.joinAndAppend(builder, " AND ", where.clauses);
         }
 
         return builder.toString();


### PR DESCRIPTION
Where clauses should be joined with ' AND ', not ','.
