### PR TITLE
Make Codec class public

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Codec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Codec.java
@@ -25,7 +25,7 @@ import org.apache.cassandra.db.marshal.*;
 /**
  * Static method to code/decode serialized data given their types.
  */
-class Codec {
+public class Codec {
 
     private static Map<AbstractType<?>, DataType> rawNativeMap = new HashMap<AbstractType<?>, DataType>() {{
         put(AsciiType.instance,         DataType.ascii());

--- a/driver-core/src/main/java/com/datastax/driver/core/Row.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Row.java
@@ -37,7 +37,7 @@ public class Row {
     private final ColumnDefinitions metadata;
     private final List<ByteBuffer> data;
 
-    private Row(ColumnDefinitions metadata, List<ByteBuffer> data) {
+    public Row(ColumnDefinitions metadata, List<ByteBuffer> data) {
         this.metadata = metadata;
         this.data = data;
     }


### PR DESCRIPTION
Codec class is very useful in other libraries, but it is protected.
I am using it in https://github.com/shvid/spring-data-cassandra
