### PR TITLE
contains returns false for the first column in the row

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ColumnDefinitions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ColumnDefinitions.java
@@ -98,7 +98,7 @@ public class ColumnDefinitions implements Iterable<ColumnDefinitions.Definition>
      * {@code false} otherwise.
      */
     public boolean contains(String name) {
-        return findIdx(name) > 0;
+        return findIdx(name) >= 0;
     }
 
     /**


### PR DESCRIPTION
If you call contains on the column definitions for a row, it will return false for the first column in the row because contains requires >0 instead of >=0.
