### PR TITLE
Add simple support for creating PreparedStatements with QueryBuilder

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BindVariable.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BindVariable.java
@@ -1,0 +1,22 @@
+/*
+ *      Copyright (C) 2012 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.querybuilder;
+
+/**
+ * Represents a "?" bind variable inside of a statement.
+ */
+public class BindVariable {
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
@@ -89,6 +89,9 @@ abstract class Utils {
         if (value instanceof Integer || value instanceof Long || value instanceof Float || value instanceof Double || value instanceof UUID) {
             sb.append(value);
             return true;
+        } else if (value instanceof BindVariable) {
+            sb.append("?");
+            return true;
         } else if (value instanceof InetAddress) {
             sb.append(((InetAddress)value).getHostAddress());
             return true;


### PR DESCRIPTION
QueryBuilder is a convenient API for constructing queries, but it's not currently possible (that I could find) to use it to build a PreparedStatement. This just adds a simple new Literal named "BindVariable" that turns into a literal "?" in the generated CQL String. Currently you have to manage the array of bind variables independently of this.
