### PR TITLE
Fix for Cassanda 1.2.2 which no longer supports boolean values passed as quoted strings 'true' and 'false'.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
@@ -86,7 +86,7 @@ abstract class Utils {
     }
 
     private static boolean appendValueIfLiteral(Object value, StringBuilder sb) {
-        if (value instanceof Integer || value instanceof Long || value instanceof Float || value instanceof Double || value instanceof UUID) {
+        if (value instanceof Integer || value instanceof Long || value instanceof Float || value instanceof Double || value instanceof UUID || value instanceof Boolean) {
             sb.append(value);
             return true;
         } else if (value instanceof InetAddress) {


### PR DESCRIPTION
In Cassandra 1.2.2 only literals true and false are supported.
