### PR TITLE
add support for bytebuffer / blob constants

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
@@ -16,8 +16,11 @@
 package com.datastax.driver.core.querybuilder;
 
 import java.net.InetAddress;
+import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.regex.Pattern;
+
+import org.apache.cassandra.utils.ByteBufferUtil;
 
 // Static utilities private to the query builder
 abstract class Utils {
@@ -94,6 +97,10 @@ abstract class Utils {
             return true;
         } else if (value instanceof Date) {
             sb.append(((Date)value).getTime());
+            return true;
+        } else if (value instanceof ByteBuffer) {
+            sb.append("0x");
+            sb.append(ByteBufferUtil.bytesToHex((ByteBuffer)value));
             return true;
         } else if (value == QueryBuilder.BIND_MARKER) {
             sb.append("?");


### PR DESCRIPTION
This patch adds support for using ByteBuffer values both as top level values and as values inside of collections. ByteBuffers are transformed into a 0x[blob hex string].
