### PR TITLE
added default consistency level for sessions

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -61,6 +61,8 @@ public class Cluster {
 
     final Manager manager;
 
+    private volatile ConsistencyLevel consistency = ConsistencyLevel.ONE;
+
     private Cluster(List<InetAddress> contactPoints, Configuration configuration) {
         this.manager = new Manager(contactPoints, configuration);
         this.manager.init();
@@ -105,12 +107,36 @@ public class Cluster {
     }
 
     /**
+     * Sets the default consistency level for the cluster.
+     * <p>
+     * The default consistency level, if this method is not called, is ConsistencyLevel.ONE.
+     *
+     * @param consistency the consistency level to set.
+     * @return this {@code Cluster} object.
+     */
+    public Cluster setDefaultConsistencyLevel(ConsistencyLevel consistency) {
+        this.consistency = consistency;
+        return this;
+    }
+
+    /**
+     * The default consistency level set through {@link #setDefaultConsistencyLevel}.
+     *
+     * @return the default consistency level. Returns {@code ConsistencyLevel.ONE} if no
+     * consistency level has been set through this object {@code setDefaultConsistencyLevel}
+     * method.
+     */
+    public ConsistencyLevel getDefaultConsistencyLevel() {
+        return consistency;
+    }
+
+    /**
      * Creates a new session on this cluster.
      *
      * @return a new session on this cluster sets to no keyspace.
      */
     public Session connect() {
-        return manager.newSession();
+        return manager.newSession().setDefaultConsistencyLevel(consistency);
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/Query.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Query.java
@@ -31,20 +31,18 @@ public abstract class Query {
     // used when preparing a statement and for other internal queries. Do not expose publicly.
     static final Query DEFAULT = new Query() { public ByteBuffer getRoutingKey() { return null; } };
 
-    private volatile ConsistencyLevel consistency;
+    private volatile ConsistencyLevel consistency = ConsistencyLevel.ONE;
     private volatile boolean traceQuery;
 
     private volatile RetryPolicy retryPolicy;
 
     // We don't want to expose the constructor, because the code rely on this being only subclassed by Statement and BoundStatement
-    Query() {
-        this.consistency = ConsistencyLevel.ONE;
-    }
+    Query() {}
 
     /**
      * Sets the consistency level for the query.
      * <p>
-     * The default consistency level, if this method is not called, is ConsistencyLevel.ONE.
+     * By default it is set to the consistency level of the session.
      *
      * @param consistency the consistency level to set.
      * @return this {@code Query} object.
@@ -57,8 +55,7 @@ public abstract class Query {
     /**
      * The consistency level.
      *
-     * @return the consistency level. Returns {@code ConsistencyLevel.ONE} if no
-     * consistency level has been specified.
+     * @return the consistency level. By default it is set to the consistency level of the session.
      */
     public ConsistencyLevel getConsistencyLevel() {
         return consistency;

--- a/driver-core/src/test/java/com/datastax/driver/core/ConsistencyLevelTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ConsistencyLevelTest.java
@@ -1,0 +1,129 @@
+/*
+ *      Copyright (C) 2012 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.*;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+/**
+ * Simple test of the Sessions methods against a one node cluster.
+ */
+public class ConsistencyLevelTest extends CCMBridge.PerClassSingleNodeCluster {
+
+    private static final String TABLE1 = "test1";
+
+    protected Collection<String> getTableDefinitions() {
+        return Arrays.asList(String.format(TestUtils.CREATE_TABLE_SIMPLE_FORMAT, TABLE1));
+    }
+    
+    @Test(groups = "integration")
+    public void defaultConsistencyLevelONE() {
+    	
+    	String cqlQuery = String.format(TestUtils.SELECT_ALL_FORMAT + " WHERE k = ?", TABLE1);
+
+        assertEquals(ConsistencyLevel.ONE, cluster.getDefaultConsistencyLevel());
+        Session firstSession = cluster.connect(TestUtils.SIMPLE_KEYSPACE);
+        assertEquals(ConsistencyLevel.ONE, firstSession.getDefaultConsistencyLevel());
+        PreparedStatement firstPreparedStatement = session.prepare(cqlQuery);
+        assertEquals(ConsistencyLevel.ONE, firstPreparedStatement.getConsistencyLevel());
+    }
+    
+    @Test(groups = "integration")
+    public void defaultConsistencyLevelClusterTest() {
+    	
+    	String cqlQuery = String.format(TestUtils.SELECT_ALL_FORMAT + " WHERE k = ?", TABLE1);
+
+        assertEquals(ConsistencyLevel.ONE, cluster.getDefaultConsistencyLevel());
+        Session firstSession = cluster.connect(TestUtils.SIMPLE_KEYSPACE);
+        assertEquals(ConsistencyLevel.ONE, firstSession.getDefaultConsistencyLevel());
+        PreparedStatement firstPreparedStatement = session.prepare(cqlQuery);
+        assertEquals(ConsistencyLevel.ONE, firstPreparedStatement.getConsistencyLevel());
+
+        // switch default to QUORUM
+        cluster.setDefaultConsistencyLevel(ConsistencyLevel.QUORUM);
+        
+        // check for new consistency
+        assertEquals(ConsistencyLevel.QUORUM, cluster.getDefaultConsistencyLevel());
+        Session secondSession = cluster.connect(TestUtils.SIMPLE_KEYSPACE);
+        assertEquals(ConsistencyLevel.QUORUM, secondSession.getDefaultConsistencyLevel());
+        PreparedStatement secondPreparedStatement = secondSession.prepare(cqlQuery);
+        assertEquals(ConsistencyLevel.QUORUM, secondPreparedStatement.getConsistencyLevel());
+        
+        // keep consistency for existing objects
+        assertEquals(ConsistencyLevel.ONE, firstSession.getDefaultConsistencyLevel());
+        assertEquals(ConsistencyLevel.ONE, firstPreparedStatement.getConsistencyLevel());
+    }
+    
+    @Test(groups = "integration")
+    public void defaultConsistencyLevelSessionTest() {
+    	
+    	String cqlQuery = String.format(TestUtils.SELECT_ALL_FORMAT + " WHERE k = ?", TABLE1);
+
+        assertEquals(ConsistencyLevel.ONE, cluster.getDefaultConsistencyLevel());
+        Session firstSession = cluster.connect(TestUtils.SIMPLE_KEYSPACE);
+        assertEquals(ConsistencyLevel.ONE, firstSession.getDefaultConsistencyLevel());
+        PreparedStatement firstPreparedStatement = session.prepare(cqlQuery);
+        assertEquals(ConsistencyLevel.ONE, firstPreparedStatement.getConsistencyLevel());
+
+        // switch default to QUORUM
+        Session secondSession = cluster.connect(TestUtils.SIMPLE_KEYSPACE);
+        assertEquals(ConsistencyLevel.ONE, secondSession.getDefaultConsistencyLevel());
+        secondSession.setDefaultConsistencyLevel(ConsistencyLevel.QUORUM);
+        
+        // check for new consistency
+        assertEquals(ConsistencyLevel.QUORUM, secondSession.getDefaultConsistencyLevel());
+        PreparedStatement secondPreparedStatement = secondSession.prepare(cqlQuery);
+        assertEquals(ConsistencyLevel.QUORUM, secondPreparedStatement.getConsistencyLevel());
+        
+        // keep consistency for existing objects
+        assertEquals(ConsistencyLevel.ONE, cluster.getDefaultConsistencyLevel());
+        assertEquals(ConsistencyLevel.ONE, firstSession.getDefaultConsistencyLevel());
+        assertEquals(ConsistencyLevel.ONE, firstPreparedStatement.getConsistencyLevel());
+    }
+    
+    @Test(groups = "integration")
+    public void defaultConsistencyLevelStatementTest() {
+    	
+    	String cqlQuery = String.format(TestUtils.SELECT_ALL_FORMAT + " WHERE k = ?", TABLE1);
+
+        assertEquals(ConsistencyLevel.ONE, cluster.getDefaultConsistencyLevel());
+        Session firstSession = cluster.connect(TestUtils.SIMPLE_KEYSPACE);
+        assertEquals(ConsistencyLevel.ONE, firstSession.getDefaultConsistencyLevel());
+        PreparedStatement firstPreparedStatement = session.prepare(cqlQuery);
+        assertEquals(ConsistencyLevel.ONE, firstPreparedStatement.getConsistencyLevel());
+
+        // switch default to QUORUM
+        Session secondSession = cluster.connect(TestUtils.SIMPLE_KEYSPACE);
+        assertEquals(ConsistencyLevel.ONE, secondSession.getDefaultConsistencyLevel());
+        PreparedStatement secondPreparedStatement = secondSession.prepare(cqlQuery);
+        assertEquals(ConsistencyLevel.ONE, secondPreparedStatement.getConsistencyLevel());
+        secondPreparedStatement.setConsistencyLevel(ConsistencyLevel.QUORUM);
+        
+        // check for new consistency
+        assertEquals(ConsistencyLevel.QUORUM, secondPreparedStatement.getConsistencyLevel());
+        
+        // keep consistency for existing objects
+        assertEquals(ConsistencyLevel.ONE, cluster.getDefaultConsistencyLevel());
+        assertEquals(ConsistencyLevel.ONE, firstSession.getDefaultConsistencyLevel());
+        assertEquals(ConsistencyLevel.ONE, firstPreparedStatement.getConsistencyLevel());
+        assertEquals(ConsistencyLevel.ONE, secondSession.getDefaultConsistencyLevel());
+    }
+    
+
+}


### PR DESCRIPTION
A default consistency level can be set to be used for all new queries created by the Session.
This overwrites the default of ConsistencyLevel.ONE without the need to set it for every query manually.
