### PR TITLE
enable BEGIN COUNTER BATCH support

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Batch.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Batch.java
@@ -42,7 +42,7 @@ public class Batch extends BuiltStatement {
 
     protected String buildQueryString() {
         StringBuilder builder = new StringBuilder();
-        builder.append("BEGIN BATCH");
+        builder.append(isCounterOp() ? "BEGIN COUNTER BATCH" : "BEGIN BATCH");
 
         if (!usings.usings.isEmpty()) {
             builder.append(" USING ");
@@ -67,6 +67,15 @@ public class Batch extends BuiltStatement {
      * @return this batch.
      */
     public Batch add(Statement statement) {
+        boolean isCounterOp = statement instanceof BuiltStatement
+                && ((BuiltStatement) statement).isCounterOp();
+
+        if (this.isCounterOp == null)
+            setCounterOp(isCounterOp);
+        else if (isCounterOp() != isCounterOp)
+            throw new RuntimeException(
+                    "can't mix counter operations and non-counter operations in a batch statement");
+
         this.statements.add(statement);
         setDirty();
 

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
@@ -28,6 +28,7 @@ abstract class BuiltStatement extends Statement {
     private final ByteBuffer[] routingKey;
     private boolean dirty;
     private String cache;
+    protected Boolean isCounterOp;
 
     protected BuiltStatement() {
         this.partitionKey = null;
@@ -52,6 +53,14 @@ abstract class BuiltStatement extends Statement {
 
     protected void setDirty() {
         dirty = true;
+    }
+
+    protected boolean isCounterOp() {
+        return isCounterOp == null ? false : isCounterOp;
+    }
+
+    protected void setCounterOp(boolean isCounterOp) {
+        this.isCounterOp = isCounterOp;
     }
 
     // TODO: Correctly document the InvalidTypeException
@@ -131,5 +140,11 @@ abstract class BuiltStatement extends Statement {
         protected void setDirty() {
             statement.setDirty();
         }
+
+        @Override
+        protected boolean isCounterOp() {
+            return statement.isCounterOp();
+        }
+
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.datastax.driver.core.TableMetadata;
+import com.datastax.driver.core.querybuilder.Assignment.CounterAssignment;
 
 /**
  * A built UPDATE statement.
@@ -145,6 +146,7 @@ public class Update extends BuiltStatement {
          * @return these Assignments.
          */
         public Assignments and(Assignment assignment) {
+            statement.setCounterOp(assignment instanceof CounterAssignment);
             assignments.add(assignment);
             setDirty();
             return this;

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -123,6 +123,36 @@ public class QueryBuilderTest {
     }
 
     @Test(groups = "unit")
+    public void batchCounterTest() throws Exception {
+        String query;
+        Query batch;
+
+        query = "BEGIN COUNTER BATCH USING TIMESTAMP 42 ";
+        query += "UPDATE foo SET a=a+1;";
+        query += "UPDATE foo SET b=b+2;";
+        query += "UPDATE foo SET c=c+3;";
+        query += "APPLY BATCH;";
+        batch = batch()
+            .add(update("foo").with(incr("a", 1)))
+            .add(update("foo").with(incr("b", 2)))
+            .add(update("foo").with(incr("c", 3)))
+            .using(timestamp(42));
+        assertEquals(batch.toString(), query);
+    }
+
+    @Test(groups = "unit", expectedExceptions={RuntimeException.class})
+    public void batchMixedCounterTest() throws Exception {
+        String query;
+        Query batch;
+
+        batch = batch()
+            .add(update("foo").with(incr("a", 1)))
+            .add(update("foo").with(set("b", 2)))
+            .add(update("foo").with(incr("c", 3)))
+            .using(timestamp(42));
+    }
+
+    @Test(groups = "unit")
     public void markerTest() throws Exception {
         String query;
         Query insert;


### PR DESCRIPTION
Added QueryBuilder support for batch counter operations.
