### PR TITLE
Trivial Fixes

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -286,6 +286,8 @@ class ControlConnection implements Host.StateListener {
             // have a race between a node removal and this.
             if (host != null)
                 host.setLocationInfo(localRow.getString("data_center"), localRow.getString("rack"));
+            else
+                logger.warn("Found the host metadata for {} to be null. Perhaps the node was recently removed?", connection.address);
 
             partitioner = localRow.getString("partitioner");
             Set<String> tokens = localRow.getSet("tokens", String.class);

--- a/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyTest.java
@@ -127,7 +127,7 @@ public class LoadBalancingPolicyTest {
             c.errorOut();
             throw e;
         } finally {
-            coordinators.clear();
+            resetCoordinators();
             c.discard();
         }
     }
@@ -152,7 +152,7 @@ public class LoadBalancingPolicyTest {
             c.errorOut();
             throw e;
         } finally {
-            coordinators.clear();
+            resetCoordinators();
             c.discard();
         }
     }
@@ -197,7 +197,7 @@ public class LoadBalancingPolicyTest {
             c.errorOut();
             throw e;
         } finally {
-            coordinators.clear();
+            resetCoordinators();
             c.discard();
         }
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -327,8 +327,8 @@ public abstract class TestUtils {
                     return;
                 } else {
                     // logging it because this give use the timestamp of when this happens
-                    logger.info(node + " is part of the cluster but is not " + (waitForDead ? "DOWN" : "UP") + " after " + maxTry + "s");
-                    throw new IllegalStateException(node + " is part of the cluster but is not " + (waitForDead ? "DOWN" : "UP") + " after " + maxTry + "s");
+                    logger.info(node + " is not " + (waitForDead ? "DOWN" : "UP") + " and is still part of the cluster after " + maxTry + "s");
+                    throw new IllegalStateException(node + " is not " + (waitForDead ? "DOWN" : "UP") + " and is still part of the cluster after " + maxTry + "s");
                 }
             }
         }

--- a/testing/README.md
+++ b/testing/README.md
@@ -15,6 +15,8 @@
     sudo ifconfig lo0 alias 127.0.1.2 up
     sudo ifconfig lo0 alias 127.0.1.3 up
     sudo ifconfig lo0 alias 127.0.1.4 up
+    sudo ifconfig lo0 alias 127.0.1.5 up
+    sudo ifconfig lo0 alias 127.0.1.6 up
 
 
 

--- a/testing/bin/coverage
+++ b/testing/bin/coverage
@@ -45,6 +45,7 @@ def parse():
     parser.add_argument('--cassandra-version', help='run tests on a specific Cassandra version')
     parser.add_argument('--upload', action='store_true', help='upload cobertura site to configured server')
     parser.add_argument('--clean', action='store_true', help='runs the maven project from a clean environment')
+    parser.add_argument('--testdocs', action='store_true', help='generates the test\'s Javadoc')
     args = parser.parse_args()
     return args
 
@@ -114,6 +115,12 @@ def main():
     # Check if an upload is all that is required
     if args.upload:
         maybe_upload_cobertura_site()
+        sys.exit()
+
+    if args.testdocs:
+        execute('mvn javadoc:test-javadoc')
+        print '\nTo view test Javadocs:'
+        print '\topen driver-core/target/site/testapidocs/index.html'
         sys.exit()
 
     # Setup required ccm loopbacks

--- a/testing/bin/coverage
+++ b/testing/bin/coverage
@@ -133,8 +133,9 @@ def main():
     if args.clean or not args.test:
         cobertura_build_command += ' clean'
 
-    # Add the cobertura target for the integration tests
-    cobertura_build_command += ' cobertura:cobertura -Pintegration'
+    cobertura_build_command += ' versions:display-dependency-updates'   # Ensures dependencies are up to date
+    cobertura_build_command += ' cobertura:cobertura'                   # Runs code coverage plugin
+    cobertura_build_command += ' -Pintegration'                         # Runs the integration tests, not just tests
 
     # Use a specific Cassandra version, if asked
     if args.cassandra_version:

--- a/testing/bin/coverage
+++ b/testing/bin/coverage
@@ -117,7 +117,7 @@ def main():
     maybe_setup_loopbacks()
 
     # Start building the mvn command
-    cobertura_build_command = 'mvn cobertura:cobertura -Pintegration'
+    cobertura_build_command = 'mvn clean cobertura:cobertura -Pintegration'
     if args.cassandra_version:
         cobertura_build_command += ' -Dcassandra.version=%s' % args.cassandra_version
 

--- a/testing/bin/coverage
+++ b/testing/bin/coverage
@@ -43,7 +43,8 @@ def parse():
     parser = argparse.ArgumentParser(description='command line tool for quick testing commands.')
     parser.add_argument('--test', help='run a specific unit test')
     parser.add_argument('--cassandra-version', help='run tests on a specific Cassandra version')
-    parser.add_argument('--upload', action="store_true", help='upload cobertura site to configured server')
+    parser.add_argument('--upload', action='store_true', help='upload cobertura site to configured server')
+    parser.add_argument('--clean', action='store_true', help='runs the maven project from a clean environment')
     args = parser.parse_args()
     return args
 
@@ -73,6 +74,8 @@ def maybe_setup_loopbacks():
             execute('sudo ifconfig lo0 alias 127.0.1.2 up')
             execute('sudo ifconfig lo0 alias 127.0.1.3 up')
             execute('sudo ifconfig lo0 alias 127.0.1.4 up')
+            execute('sudo ifconfig lo0 alias 127.0.1.5 up')
+            execute('sudo ifconfig lo0 alias 127.0.1.6 up')
 
 def maybe_upload_cobertura_site():
     '''
@@ -117,22 +120,31 @@ def main():
     maybe_setup_loopbacks()
 
     # Start building the mvn command
-    cobertura_build_command = 'mvn clean cobertura:cobertura -Pintegration'
+    cobertura_build_command = 'mvn'
+
+    # Add the clean target, if asked or building the entire project
+    if args.clean or not args.test:
+        cobertura_build_command += ' clean'
+
+    # Add the cobertura target for the integration tests
+    cobertura_build_command += ' cobertura:cobertura -Pintegration'
+
+    # Use a specific Cassandra version, if asked
     if args.cassandra_version:
         cobertura_build_command += ' -Dcassandra.version=%s' % args.cassandra_version
 
     if args.test:
         # Run against a single mvn test
-        execute('%s '
-                '-Dmaven.test.failure.ignore=true '
-                '-DfailIfNoTests=false '
-                '-Dtest=%s' % (cobertura_build_command, args.test))
+        execute('%s'
+                ' -Dmaven.test.failure.ignore=true'
+                ' -DfailIfNoTests=false'
+                ' -Dtest=%s' % (cobertura_build_command, args.test))
     else:
         # Run against the entire integration suite
         execute('%s' % cobertura_build_command)
 
         try:
-            if raw_input("Save Cobertura Report? [y/N] ").lower() == 'y':
+            if raw_input('Save Cobertura Report? [y/N] ').lower() == 'y':
 
                 # Save out cobertura site files
                 save_cobertura_site()
@@ -150,5 +162,5 @@ def main():
         print '\topen driver-core/target/site/cobertura/index.html'
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
- Warn statement when a race condition is met with a null host. Useful if nodes are flapping.
- Proper use of clearing coordinators.
- Clearer error messages.
- Allocate two more nodes for multi-dc setups.
- Add ability to call maven clean or before building full coverage.
- Add ability to build test docs via `coverage`.
- Have `coverage` check to see if dependencies are up to date.
