### PR TITLE
Trivial fixes

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -119,6 +119,10 @@ public class CCMBridge {
         execute("ccm remove");
     }
 
+    public void ring(int n) {
+        executeAndPrint("ccm node%d ring", n);
+    }
+
     public void bootstrapNode(int n) {
         bootstrapNode(n, null);
     }
@@ -157,6 +161,26 @@ public class CCMBridge {
                     line = errReader.readLine();
                 }
                 throw new RuntimeException();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void executeAndPrint(String command, Object... args) {
+        try {
+            String fullCommand = String.format(command, args) + " --config-dir=" + ccmDir;
+            logger.debug("Executing: " + fullCommand);
+            Process p = runtime.exec(fullCommand, null, CASSANDRA_DIR);
+            int retValue = p.waitFor();
+
+            BufferedReader outReaderOutput = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            String line = outReaderOutput.readLine();
+            while (line != null) {
+                System.out.println(line);
+                line = outReaderOutput.readLine();
             }
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
@@ -514,32 +514,45 @@ public class DataTypeTest extends CCMBridge.PerClassSingleNodeCluster {
      * Prints the table definitions that will be used in testing
      * (for exporting purposes)
      */
-    @Test(groups = { "docs" })
+    @Test(groups = { "doc" })
     public void printTableDefinitions() {
+        String objective = "Table Definitions";
+        System.out.println(String.format("Printing %s...", objective));
+
         // Prints the full list of table definitions
         for (String definition : getTableDefinitions()) {
             System.out.println(definition);
         }
+
+        System.out.println(String.format("\nEnd of %s\n\n", objective));
     }
 
     /**
      * Prints the sample data that will be used in testing
      * (for exporting purposes)
      */
-    @Test(groups = { "docs" })
+    @Test(groups = { "doc" })
     public void printSampleData() {
+        String objective = "Sample Data";
+        System.out.println(String.format("Printing %s...", objective));
+
         for (DataType dataType : SAMPLE_DATA.keySet()) {
             Object sampleValue = SAMPLE_DATA.get(dataType);
             System.out.println(String.format("%1$-10s %2$s", dataType, sampleValue));
         }
+
+        System.out.println(String.format("\nEnd of %s\n\n", objective));
     }
 
     /**
      * Prints the sample collections that will be used in testing
      * (for exporting purposes)
      */
-    @Test(groups = { "docs" })
+    @Test(groups = { "doc" })
     public void printSampleCollections() {
+        String objective = "Sample Collections";
+        System.out.println(String.format("Printing %s...", objective));
+
         for (DataType dataType : SAMPLE_COLLECTIONS.keySet()) {
             HashMap<DataType, Object> sampleValueMap = (HashMap<DataType, Object>) SAMPLE_COLLECTIONS.get(dataType);
 
@@ -557,49 +570,71 @@ public class DataTypeTest extends CCMBridge.PerClassSingleNodeCluster {
                 System.out.println(String.format("%1$-30s %2$s", dataType, sampleValue));
             }
         }
+
+        System.out.println(String.format("\nEnd of %s\n\n", objective));
     }
 
     /**
      * Prints the simple insert statements that will be used in testing
      * (for exporting purposes)
      */
-    @Test(groups = { "docs" })
+    @Test(groups = { "doc" })
     public void printPrimitiveInsertStatements() {
+        String objective = "Primitive Insert Statements";
+        System.out.println(String.format("Printing %s...", objective));
+
         for (String execute_string : PRIMITIVE_INSERT_STATEMENTS) {
             System.out.println(execute_string);
         }
+
+        System.out.println(String.format("\nEnd of %s\n\n", objective));
     }
 
     /**
      * Prints the simple select statements that will be used in testing
      * (for exporting purposes)
      */
-    @Test(groups = { "docs" })
+    @Test(groups = { "doc" })
     public void printPrimitiveSelectStatements() {
+        String objective = "Primitive Select Statements";
+        System.out.println(String.format("Printing %s...", objective));
+
         for (String execute_string : PRIMITIVE_SELECT_STATEMENTS.values()) {
             System.out.println(execute_string);
         }
+
+        System.out.println(String.format("\nEnd of %s\n\n", objective));
     }
 
     /**
      * Prints the simple insert statements that will be used in testing
      * (for exporting purposes)
      */
-    @Test(groups = { "docs" })
+    @Test(groups = { "doc" })
     public void printCollectionInsertStatements() {
+        String objective = "Collection Insert Statements";
+        System.out.println(String.format("Printing %s...", objective));
+
         for (String execute_string : COLLECTION_INSERT_STATEMENTS) {
             System.out.println(execute_string);
         }
+
+        System.out.println(String.format("\nEnd of %s\n\n", objective));
     }
 
     /**
      * Prints the simple insert statements that will be used in testing
      * (for exporting purposes)
      */
-    @Test(groups = { "docs" })
+    @Test(groups = { "doc" })
     public void printCollectionSelectStatements() {
+        String objective = "Collection Select Statements";
+        System.out.println(String.format("Printing %s...", objective));
+
         for (String execute_string : COLLECTION_SELECT_STATEMENTS.values()) {
             System.out.println(execute_string);
         }
+
+        System.out.println(String.format("\nEnd of %s\n\n", objective));
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -334,8 +334,8 @@ public abstract class TestUtils {
                     return;
                 } else {
                     // logging it because this give use the timestamp of when this happens
-                    logger.info(node + " is not " + (waitForDead ? "DOWN" : "UP") + " and is still part of the cluster after " + maxTry + "s");
-                    throw new IllegalStateException(node + " is not " + (waitForDead ? "DOWN" : "UP") + " and is still part of the cluster after " + maxTry + "s");
+                    logger.info(node + " is not " + (waitForDead ? "DOWN" : "UP") + " after " + maxTry + "s");
+                    throw new IllegalStateException(node + " is not " + (waitForDead ? "DOWN" : "UP") + " after " + maxTry + "s");
                 }
             }
         }

--- a/testing/bin/coverage
+++ b/testing/bin/coverage
@@ -46,6 +46,7 @@ def parse():
     parser.add_argument('--upload', action='store_true', help='upload cobertura site to configured server')
     parser.add_argument('--clean', action='store_true', help='runs the maven project from a clean environment')
     parser.add_argument('--testdocs', action='store_true', help='generates the test\'s Javadoc')
+    parser.add_argument('--samplecode', action='store_true', help='prints generated sample CQL')
     args = parser.parse_args()
     return args
 
@@ -135,7 +136,11 @@ def main():
 
     cobertura_build_command += ' versions:display-dependency-updates'   # Ensures dependencies are up to date
     cobertura_build_command += ' cobertura:cobertura'                   # Runs code coverage plugin
-    cobertura_build_command += ' -Pintegration'                         # Runs the integration tests, not just tests
+
+    if args.samplecode:
+        cobertura_build_command += ' -Pdoc'                             # Runs the docs "tests" and prints sample code
+    else:
+        cobertura_build_command += ' -Pintegration'                     # Runs the integration tests, not just tests
 
     # Use a specific Cassandra version, if asked
     if args.cassandra_version:


### PR DESCRIPTION
- Nicer formatting for -Pdocs.
- Allow `coverage --samplecode` to run with -Pdocs
- One last pass over same error message from before
- Added `nodetool ring` option to CCMBridge, for debugging purposes.
