### PR TITLE
Use System.nanoTime()

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -507,7 +507,7 @@ public class Cluster {
     }
 
     static long timeSince(long start, TimeUnit unit) {
-        return unit.convert(System.currentTimeMillis() - start, TimeUnit.MILLISECONDS);
+        return unit.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
     }
 
     /**
@@ -601,7 +601,7 @@ public class Cluster {
 
             logger.debug("Shutting down");
 
-            long start = System.currentTimeMillis();
+            long start = System.nanoTime();
             boolean success = true;
 
             success &= controlConnection.shutdown(timeout, unit);

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -306,13 +306,13 @@ class Connection extends org.apache.cassandra.transport.Connection
         // Make sure all new writes are rejected
         isClosed = true;
 
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         if (!isDefunct) {
             // Busy waiting, we just wait for request to be fully written, shouldn't take long
             while (writer.get() > 0 && Cluster.timeSince(start, unit) < timeout)
                 Uninterruptibles.sleepUninterruptibly(1, unit);
         }
-        return channel.close().await(timeout - unit.convert(System.currentTimeMillis() - start, TimeUnit.MILLISECONDS), unit);
+        return channel.close().await(timeout - Cluster.timeSince(start, unit), unit);
         // Note: we must not call releaseExternalResources on the bootstrap, because this shutdown the executors, which are shared
     }
 
@@ -419,7 +419,7 @@ class Connection extends org.apache.cassandra.transport.Connection
             // Make sure we skip creating connection from now on.
             isShutdown = true;
 
-            long start = System.currentTimeMillis();
+            long start = System.nanoTime();
             ChannelGroupFuture future = allChannels.close();
 
             channelFactory.releaseExternalResources();

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -381,7 +381,7 @@ class ControlConnection implements Host.StateListener {
 
     static boolean waitForSchemaAgreement(Connection connection, Metadata metadata) throws ConnectionException, BusyConnectionException, ExecutionException, InterruptedException {
 
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         long elapsed = 0;
         while (elapsed < MAX_SCHEMA_AGREEMENT_WAIT_MS) {
             ResultSetFuture peersFuture = new ResultSetFuture(null, new QueryMessage(SELECT_SCHEMA_PEERS, ConsistencyLevel.DEFAULT_CASSANDRA_CL));
@@ -415,7 +415,7 @@ class ControlConnection implements Host.StateListener {
             // let's not flood the node too much
             Thread.sleep(200);
 
-            elapsed = System.currentTimeMillis() - start;
+            elapsed = Cluster.timeSince(start, TimeUnit.MILLISECONDS);
         }
 
         return false;

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -127,10 +127,6 @@ class HostConnectionPool {
         return leastBusy;
     }
 
-    private static long elapsed(long start, TimeUnit unit) {
-        return unit.convert(System.currentTimeMillis() - start, TimeUnit.MILLISECONDS);
-    }
-
     private void awaitAvailableConnection(long timeout, TimeUnit unit) throws InterruptedException {
         waitLock.lock();
         try {
@@ -159,7 +155,7 @@ class HostConnectionPool {
     }
 
     private Connection waitForConnection(long timeout, TimeUnit unit) throws ConnectionException, TimeoutException {
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         long remaining = timeout;
         do {
             try {
@@ -193,7 +189,7 @@ class HostConnectionPool {
                     return leastBusy;
             }
 
-            remaining = timeout - elapsed(start, unit);
+            remaining = timeout - Cluster.timeSince(start, unit);
         } while (remaining > 0);
 
         throw new TimeoutException();
@@ -343,7 +339,7 @@ class HostConnectionPool {
     }
 
     private boolean discardAvailableConnections(long timeout, TimeUnit unit) throws InterruptedException {
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         boolean success = true;
         for (Connection connection : connections) {
             success &= connection.close(timeout - Cluster.timeSince(start, unit), unit);

--- a/driver-core/src/main/java/com/datastax/driver/core/Session.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Session.java
@@ -291,7 +291,7 @@ public class Session {
             if (!isShutdown.compareAndSet(false, true))
                 return true;
 
-            long start = System.currentTimeMillis();
+            long start = System.nanoTime();
             boolean success = true;
             for (HostConnectionPool pool : pools.values())
                 success &= pool.shutdown(timeout - Cluster.timeSince(start, unit), unit);


### PR DESCRIPTION
This is required to make code resilient to system clock adjustments.
Also it makes timeouts more precise.
