### PR TITLE
Fixed issue: Unformatted TableMetada.asCQLQuery() appends options.* without spacing

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
@@ -376,7 +376,7 @@ public class TableMetadata {
     }
 
     private StringBuilder and(StringBuilder sb, boolean formatted) {
-        return newLine(sb, formatted).append(spaces(3, formatted)).append("AND ");
+        return newLine(sb, formatted).append(spaces(3, formatted)).append(" AND ");
     }
 
     private String spaces(int n, boolean formatted) {


### PR DESCRIPTION
.append("AND ") to .append(" AND ") (Line 379)

Example: 
"CREATE TABLE children (childid text,country text,firstname text,lastname text,state text,zip text,PRIMARY KEY (childid)) WITH COMPACT STORAGEAND read_repair_chance = 0.1AND dclocal_read_repair_chance = 0.0AND replicate_on_write = trueAND gc_grace_seconds = 864000AND bloom_filter_fp_chance = 0.01AND caching = KEYS_ONLYAND comment = ''AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy' }AND compression = { 'sstable_compression' : 'org.apache.cassandra.io.compress.SnappyCompressor' };"
