### PR TITLE
prevent table value display when value is null

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -231,7 +231,7 @@ class ControlConnection implements Host.StateListener {
     }
 
     public void refreshSchema(String keyspace, String table) throws InterruptedException {
-        logger.debug("[Control connection] Refreshing schema for {}.{}", keyspace, table);
+        logger.debug("[Control connection] Refreshing schema for {}{}", keyspace == null ? "" : keyspace, table == null ? "" : "." + table)
         try {
             refreshSchema(connectionRef.get(), keyspace, table, cluster);
         } catch (ConnectionException e) {


### PR DESCRIPTION
Hi, 

I noticed a couple of logs such as this one, where nil value show up for "table": 

ef169132 [Cassandra Java Driver worker-1] 2013-06-21 11:46:50,250 DEBUG com.datastax.driver.core.ControlConnection  - [Control connection] Refreshing schema for stats.null

The format of the logging message is now the same as the one found in Cluster.java for the same event.
