### PR TITLE
Unnecessary Local Before Return 

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
@@ -154,8 +154,8 @@ public class ColumnMetadata {
             if (type == null)
                 return null;
 
-            IndexMetadata index = new IndexMetadata(column, type, row.getString(INDEX_NAME));
-            return index;
+            return new IndexMetadata(column, type, row.getString(INDEX_NAME));
+        
         }
     }
 


### PR DESCRIPTION
Is simpler returning the value than storing it in local variable and then return the value.
