### PR TITLE
equalsIgnoreCase is cleaner than toLowerCase().equals()

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ColumnDefinitions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ColumnDefinitions.java
@@ -232,7 +232,7 @@ public class ColumnDefinitions implements Iterable<ColumnDefinitions.Definition>
                     if (name.equals(byIdx[idx].name))
                         return idx;
                 } else {
-                    if (name.toLowerCase().equals(byIdx[idx].name))
+                    if (name.equalsIgnoreCase(byIdx[idx].name))
                         return idx;
                 }
             }


### PR DESCRIPTION
Using equalsIgnoreCase() is cleaner than using toLowerCase().equals().
