### PR TITLE
Allow bind parameters for counter increments to be integers

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -178,6 +178,13 @@ public class BoundStatement extends Query {
                             throw new InvalidTypeException(String.format("Invalid type for value %d of CQL type %s, expecting map of %s->%s but provided set of %s->%s", i, columnType, expectedKeysClass, expectedValuesClass, providedKeysClass, providedValuesClass));
                     }
                     break;
+                case COUNTER:
+                    if (toSet instanceof Integer)
+                    {
+                        toSet = Long.valueOf(((Integer) toSet).longValue());
+                    }
+                    /* FALL-THRU */
+                    
                 default:
                     Class<?> providedClass = toSet.getClass();
                     Class<?> expectedClass = columnType.getName().javaType;


### PR DESCRIPTION
if you create a prepared statement such as

update foo set mycounter = mycounter + ? where mykey = ?

you can then execute it such as

myUpdatePS.bind(1, 'fookey');

This compiles fine, as int autoboxes to Object.

However, counter parms must be Longs, so this produces runtime exceptions.

Embellished BoundStatement.bind for counters such that if an Integer is provided, convert to Long.
