### PR TITLE
Use Cassandra 1.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cassandra.version>1.2.3</cassandra.version>
-    <cassandra-dependency.version>1.2.3</cassandra-dependency.version>
+    <cassandra.version>1.2.6</cassandra.version>
+    <cassandra-dependency.version>1.2.6</cassandra-dependency.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Cassandra 1.2.6 uses snappy-java 1.0.5 instead of 1.0.4.1.
snappy java 1.0.4.1 has problem on Java 7 environment.
https://github.com/ptaoussanis/carmine/issues/5
