### PR TITLE
BuiltStatement#getQueryString() does less string copying.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Batch.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Batch.java
@@ -43,7 +43,7 @@ public class Batch extends BuiltStatement {
     }
 
     @Override
-    protected String buildQueryString() {
+    protected StringBuilder buildQueryString() {
         StringBuilder builder = new StringBuilder();
 
         builder.append(isCounterOp()
@@ -63,7 +63,7 @@ public class Batch extends BuiltStatement {
                 builder.append(";");
         }
         builder.append("APPLY BATCH;");
-        return builder.toString();
+        return builder;
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
@@ -43,14 +43,25 @@ abstract class BuiltStatement extends Statement {
     @Override
     public String getQueryString() {
         if (dirty || cache == null) {
-            cache = buildQueryString().trim();
-            if (!cache.endsWith(";"))
-                cache += ";";
+            StringBuilder sb = buildQueryString();
+
+            // Use the same test that String#trim() uses to determine
+            // if a character is a whitespace character.
+            int l = sb.length();
+            while (l > 0 && sb.charAt(l - 1) <= ' ')
+                l -= 1;
+            if (l != sb.length())
+                sb.setLength(l);
+
+            if (l == 0 || sb.charAt(l - 1) != ';')
+                sb.append(';');
+
+            cache = sb.toString();
         }
         return cache;
     }
 
-    protected abstract String buildQueryString();
+    protected abstract StringBuilder buildQueryString();
 
     protected void setDirty() {
         dirty = true;
@@ -131,7 +142,7 @@ abstract class BuiltStatement extends Statement {
         }
 
         @Override
-        protected String buildQueryString() {
+        protected StringBuilder buildQueryString() {
             throw new UnsupportedOperationException();
         }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
@@ -50,7 +50,7 @@ public class Delete extends BuiltStatement {
     }
 
     @Override
-    protected String buildQueryString() {
+    protected StringBuilder buildQueryString() {
         StringBuilder builder = new StringBuilder();
 
         builder.append("DELETE ");
@@ -71,7 +71,7 @@ public class Delete extends BuiltStatement {
             Utils.joinAndAppend(builder, " AND ", where.clauses);
         }
 
-        return builder.toString();
+        return builder;
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
@@ -47,7 +47,7 @@ public class Insert extends BuiltStatement {
     }
 
     @Override
-    protected String buildQueryString() {
+    protected StringBuilder buildQueryString() {
         StringBuilder builder = new StringBuilder();
 
         builder.append("INSERT INTO ");
@@ -65,7 +65,7 @@ public class Insert extends BuiltStatement {
             Utils.joinAndAppend(builder, " AND ", usings.usings);
         }
 
-        return builder.toString();
+        return builder;
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Select.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Select.java
@@ -54,7 +54,7 @@ public class Select extends BuiltStatement {
     }
 
     @Override
-    protected String buildQueryString() {
+    protected StringBuilder buildQueryString() {
         StringBuilder builder = new StringBuilder();
 
         builder.append("SELECT ");
@@ -86,7 +86,7 @@ public class Select extends BuiltStatement {
             builder.append(" ALLOW FILTERING");
         }
 
-        return builder.toString();
+        return builder;
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
@@ -51,7 +51,7 @@ public class Update extends BuiltStatement {
     }
 
     @Override
-    protected String buildQueryString() {
+    protected StringBuilder buildQueryString() {
         StringBuilder builder = new StringBuilder();
 
         builder.append("UPDATE ");
@@ -74,7 +74,7 @@ public class Update extends BuiltStatement {
             Utils.joinAndAppend(builder, " AND ", where.clauses);
         }
 
-        return builder.toString();
+        return builder;
     }
 
     /**


### PR DESCRIPTION
By having BuiltStatement#buildQueryString() return the StringBuilder
that it was using to build the string, doing any additional work using
it is faster than working on the string it generates.

Doing unnecessary work in string concatenation is one of my pet peeves ;)
