### PR TITLE
Adding asc() and desc() operators to where()

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Select.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Select.java
@@ -200,6 +200,28 @@ public class Select extends BuiltStatement {
         }
 
         /**
+         * Adds an ORDER BY ASC clause to the SELECT statement this WHERE clause if
+         * part of.
+         *
+         * @param name - the column name dictating the order 
+         * @return the select statement this Where clause if part of.
+         */
+        public Select asc(String name) {
+            return statement.orderBy(new Ordering(name, false));
+        }
+        
+        /**
+         * Adds an ORDER BY DESC clause to the SELECT statement this WHERE clause if
+         * part of.
+         *
+         * @param name - the column name dictating the order 
+         * @return the select statement this Where clause if part of.
+         */
+        public Select desc(String name) {
+            return statement.orderBy(new Ordering(name, true));
+        }
+
+        /**
          * Adds a LIMIT clause to the SELECT statement this Where clause if
          * part of.
          *


### PR DESCRIPTION
The where statement doesn't have a way for me to add an order by clause. Note that the Ordering object constructor is protected, hence I can't instantiate one. Instead of making the constructor public, I think it's more elegant to have the asc() and desc() operator on the where statement. 

Here is my example table. 

cqlsh:puneet> select \* from scores; 

 name | score | date
------+-------+--------------------------
  bob |    33 | 2012-06-26 00:00:00-0700
  bob |    40 | 2012-06-27 00:00:00-0700
  bob |    42 | 2012-06-24 00:00:00-0700
  bob |    47 | 2012-06-25 00:00:00-0700

cqlsh:puneet> 

And here is the query that I want to run. 
cqlsh:puneet> select \* from scores where name = 'bob' and score > 40 order by score desc limit 2;

 name | score | date
------+-------+--------------------------
  bob |    47 | 2012-06-25 00:00:00-0700
  bob |    42 | 2012-06-24 00:00:00-0700

cqlsh:puneet> 

And here is the code that does that. 

Query query = QueryBuilder.select().all()
                .from("puneet", "scores")
                .where(eq("name", "bob"))
                .and(gte("score", 40))
                .desc("score")
                .limit(2)
                ;
