### PR TITLE
added Ability to trigger cluster.shutdown() from within a ShutdownHook

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -569,7 +569,7 @@ public class Cluster {
     }
 
     private static ThreadFactory threadFactory(String nameFormat) {
-        return new ThreadFactoryBuilder().setNameFormat(nameFormat).build();
+        return new ThreadFactoryBuilder().setNameFormat(nameFormat).setDaemon(true).build();
     }
 
     static long timeSince(long startNanos, TimeUnit destUnit) {


### PR DESCRIPTION
- altered ThreadFactorys to create Threads in deamon-mode so the jvm can
  determine that all "real" Threads came to an end

As long as a single Thread is running in the jvm the jvm will not come to an end.
Threads created with setDaemon(true) do not count for this behavior.
When a jvm detects the state of "only daemon Threads", it will call all
prepared shutdown Threads in parallel, run all finalizers and then stop
all remaining daemon threads and itself.

ShutdownHooks will allways be called when the jvm comes to an end (expect
if you shut down the jvm very hard with a process killing linux command).

The Threads created by the driver behaved like every normal Programmthread.
This Change removes the need to call cluster.shutdown() at all and
enables a "nicer" shutdown by using something like this
Runtime.getRuntime().addShutdownHook(new Thread() {
    public void run() {
        cluster.shutdown();
    }
});
close to the code that creates the cluster object.
