### PR TITLE
Remove waiters count in HostConnectionPool

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -42,7 +42,6 @@ class HostConnectionPool {
     private final AtomicInteger open;
     private final Set<Connection> trash = new CopyOnWriteArraySet<Connection>();
 
-    private volatile int waiter = 0;
     private final Lock waitLock = new ReentrantLock(true);
     private final Condition hasAvailableConnection = waitLock.newCondition();
 
@@ -134,20 +133,14 @@ class HostConnectionPool {
 
     private void awaitAvailableConnection(long timeout, TimeUnit unit) throws InterruptedException {
         waitLock.lock();
-        waiter++;
         try {
             hasAvailableConnection.await(timeout, unit);
         } finally {
-            waiter--;
             waitLock.unlock();
         }
     }
 
     private void signalAvailableConnection() {
-        // Quick check if it's worth signaling to avoid locking
-        if (waiter == 0)
-            return;
-
         waitLock.lock();
         try {
             hasAvailableConnection.signal();
@@ -157,10 +150,6 @@ class HostConnectionPool {
     }
 
     private void signalAllAvailableConnection() {
-        // Quick check if it's worth signaling to avoid locking
-        if (waiter == 0)
-            return;
-
         waitLock.lock();
         try {
             hasAvailableConnection.signalAll();


### PR DESCRIPTION
- It creates a race condition between the test if = 0 and the lock
- It avoids lock at shutdown where performance will be good enough
- While running, it avoids lock for the thread that create a new connection, and the creation pace is too low to make it worth doing it
- Meanwhile we pay the cost of volatile access several time for each waiting threads
