### PR TITLE
Corrected CQL generated for `CREATE INDEX`

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
@@ -153,8 +153,8 @@ public class ColumnMetadata {
             TableMetadata table = column.getTable();
             String ksName = table.getKeyspace().getName();
             return isCustomIndex()
-                 ? String.format("CREATE CUSTOM INDEX %s ON %s.%s (%s) USING '%s'", name, ksName, table.getName(), column.getName(), customClassName)
-                 : String.format("CREATE INDEX %s ON %s.%s (%s)", name, ksName, table.getName(), column.getName());
+                 ? String.format("CREATE CUSTOM INDEX %s ON %s.%s (%s) USING '%s';", name, ksName, table.getName(), column.getName(), customClassName)
+                 : String.format("CREATE INDEX %s ON %s.%s (%s);", name, ksName, table.getName(), column.getName());
         }
 
         private static IndexMetadata build(ColumnMetadata column, Map<String, String> indexColumns) {


### PR DESCRIPTION
When exporting CQL from ColumnMetadata the `CREATE CUSTOM INDEX` and `CREATE INDEX` statements do not end with a semicolon. This pull request adds a semicolon to these statements.
