### PR TITLE
put all host accesses in null guard

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -838,8 +838,8 @@ public class Cluster {
                 // (since the node status is not exposed by C* in the System tables). This
                 // may not be correct.
                 Host host = addHost(address, false);
-                host.setUp();
                 if (host != null) {
+                    host.setUp();
                     for (Host.StateListener listener : listeners)
                         listener.onAdd(host);
                 }

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/NoHostAvailableException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/NoHostAvailableException.java
@@ -68,7 +68,7 @@ public class NoHostAvailableException extends DriverException {
         // For small cluster, ship the whole error detail in the error message.
         // This is helpful when debugging on a localhost/test cluster in particular.
         if (errors.size() == 0)
-            return String.format("All host(s) tried for query failed (no host was tried)");
+            return "All host(s) tried for query failed (no host was tried)";
 
         if (errors.size() <= 3) {
             StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
code checks for hosts being null. Put all accesses in the null check, if null is possible otherwise npe as is..
