### PR TITLE
Added a `USE` statement to the generated CQL

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/KeyspaceMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/KeyspaceMetadata.java
@@ -122,6 +122,7 @@ public class KeyspaceMetadata {
         StringBuilder sb = new StringBuilder();
 
         sb.append(asCQLQuery()).append("\n");
+        sb.append("USE ").append(name).append(";\n");
 
         for (TableMetadata tm : tables.values())
             sb.append("\n").append(tm.exportAsString()).append("\n");


### PR DESCRIPTION
If `exportAsString` is to generate the CQL required to recreate the schema then either the table names should be fully qualified or we need a `USE` statement. This commit adds a `USE` statement.
