### PR TITLE
Adding bundler plugin to generate OSGI manifest

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -115,6 +115,35 @@
               <showDeprecation>true</showDeprecation>
             </configuration>
           </plugin>
+          <plugin>
+            <artifactId>maven-jar-plugin</artifactId>
+            <configuration>
+              <archive>  
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+              </archive> 
+            </configuration>
+          </plugin>          
+          <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <version>2.4.0</version>
+            <configuration>
+              <instructions>
+                <Bundle-SymbolicName>${pom.groupId}.core.driver</Bundle-SymbolicName>
+                <Bundle-Name>${pom.artifactId}</Bundle-Name>
+                <Bundle-Version>${pom.version}</Bundle-Version>
+              </instructions>
+            </configuration>
+            <executions>
+              <execution>
+                <id>bundle-manifest</id>
+                <phase>process-classes</phase>
+                <goals>    
+                  <goal>manifest</goal>
+                </goals>   
+              </execution>
+            </executions>            
+          </plugin>                
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
While I was taking training for cassandra, I noticed that the driver driver did not contain the OSGI-manifest hence I added.  BTW, We (the company, where I work for) are using the hector and we will moving to CQL soon and our project is based on OSGI since I made change in the public repo so it will be useful for others.  The same needs to apply to version 1.x too.
