### PR TITLE
Fix ReplicationStrategy class (affects Metadata.getReplicas and TokenAwarePolicy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ testing/
 doc
 notes
 .DS_Store
+bin/
+test-output/

--- a/driver-core/src/main/java/com/datastax/driver/core/ReplicationStategy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ReplicationStategy.java
@@ -16,6 +16,9 @@
 package com.datastax.driver.core;
 
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,6 +40,7 @@ abstract class ReplicationStrategy {
 
         try {
             if (strategyClass.contains("SimpleStrategy")) {
+            	//replication_factor is only specified for SimpleStrategy
             	String repFactorString = replicationOptions.get("replication_factor");
             	if (repFactorString == null) {
             		return null;
@@ -83,10 +87,12 @@ abstract class ReplicationStrategy {
 
             Map<Token, Set<Host>> replicaMap = new HashMap<Token, Set<Host>>(tokenToPrimary.size());
             for (int i = 0; i < ring.size(); i++) {
-                ImmutableSet.Builder<Host> builder = ImmutableSet.builder();
-                for (int j = 0; j < rf; j++)
-                    builder.add(tokenToPrimary.get(getTokenWrapping(i+j, ring)));
-                replicaMap.put(ring.get(i), builder.build());
+            	//handle consecutive sections in the ring assigned to the same host
+            	Set<Host> replicas = new LinkedHashSet<Host>();
+            	//we stop when reached the desired RF or ran out of nodes
+                for (int j = 0; j < ring.size() && replicas.size() < rf; j++)
+                    replicas.add(tokenToPrimary.get(getTokenWrapping(i+j, ring)));
+                replicaMap.put(ring.get(i), ImmutableSet.<Host>builder().addAll(replicas).build());
             }
             return replicaMap;
         }
@@ -102,36 +108,87 @@ abstract class ReplicationStrategy {
 
         Map<Token, Set<Host>> computeTokenToReplicaMap(Map<Token, Host> tokenToPrimary, List<Token> ring) {
 
-            Map<Token, Set<Host>> replicaMap = new HashMap<Token, Set<Host>>(tokenToPrimary.size());
+        	/*
+             * This is essentially a copy of org.apache.cassandra.locator.NetworkTopologyStrategy
+             */
+        	
+        	final Map<String, Set<String>> racks = getRacksInDcs(tokenToPrimary.values());
+            final Map<Token, Set<Host>> replicaMap = new HashMap<Token, Set<Host>>(tokenToPrimary.size());
             for (int i = 0; i < ring.size(); i++) {
-                Map<String, Integer> remainings = new HashMap<String, Integer>(replicationFactors);
-                ImmutableSet.Builder<Host> builder = ImmutableSet.builder();
-                for (int j = 0; j < ring.size(); j++) {
-                    Host h = tokenToPrimary.get(getTokenWrapping(j, ring));
+                Map<String, Set<Host>> allDcReplicas = new HashMap<String, Set<Host>>();
+                Map<String, Set<String>> seenRacks = new HashMap<String, Set<String>>();
+                Map<String, Set<Host>> skippedDcEndpoints = new HashMap<String, Set<Host>>();
+                for (String dc : replicationFactors.keySet()) {
+                	allDcReplicas.put(dc, new HashSet<Host>());
+                	seenRacks.put(dc, new HashSet<String>());
+                	//preserve order
+                	skippedDcEndpoints.put(dc, new LinkedHashSet<Host>());
+                }
+                
+                //preserve order - primary replica will be first
+                Set<Host> replicas = new LinkedHashSet<Host>();
+                //we stop the inner iteration if all DCs have enough replicas or we reach the end of the ring
+                for (int j = 0; j < ring.size() && !allDone(allDcReplicas); j++) {
+                    Host h = tokenToPrimary.get(getTokenWrapping(i + j, ring));
                     String dc = h.getDatacenter();
                     if (dc == null)
                         continue;
 
-                    Integer remaining = remainings.get(dc);
-                    if (remaining <= 0)
+                    Integer rf = replicationFactors.get(dc);
+                    Set<Host> dcReplicas = allDcReplicas.get(dc); 
+                    if (dcReplicas.size() >= rf)
                         continue;
 
-                    builder.add(h);
-                    remainings.put(dc, remaining - 1);
-                    if (allDone(remainings))
-                        break;
+                    //check if we already visited all racks in dc
+                    if (seenRacks.get(dc).size() == racks.get(dc).size()) {
+                    	replicas.add(h);
+                    	dcReplicas.add(h);
+                    } else {
+                    	String rack = h.getRack();
+                    	//is this a new rack?
+                    	if (seenRacks.get(dc).contains(rack)) {
+                    		skippedDcEndpoints.get(dc).add(h);
+                    	} else {
+                    		replicas.add(h);
+                    		dcReplicas.add(h);
+                    		seenRacks.get(dc).add(rack);
+                    		//check if we have run out of all racks
+                    		//if yes, add all those nodes that we skipped so far
+                    		if (seenRacks.get(dc).size() == racks.get(dc).size()) {
+                    			Iterator<Host> skippedIt = skippedDcEndpoints.get(dc).iterator();
+                    			while (skippedIt.hasNext() && dcReplicas.size() < rf) {
+                    				Host nextSkipped = skippedIt.next();
+                    				replicas.add(nextSkipped);
+                    				dcReplicas.add(nextSkipped);
+                    			}
+                    		}
+                    	}
+                    }
                 }
-                replicaMap.put(ring.get(i), builder.build());
+                replicaMap.put(ring.get(i), ImmutableSet.<Host>builder().addAll(replicas).build());
             }
             return replicaMap;
         }
 
-        private boolean allDone(Map<String, Integer> map)
+        private boolean allDone(Map<String, Set<Host>> map)
         {
-            for (Map.Entry<String, Integer> entry : map.entrySet())
-                if (entry.getValue() > 0)
+            for (Map.Entry<String, Set<Host>> entry : map.entrySet())
+                if (entry.getValue().size() < replicationFactors.get(entry.getKey()))
                     return false;
             return true;
+        }
+        
+        private Map<String, Set<String>> getRacksInDcs(Iterable<Host> hosts) {
+        	Map<String, Set<String>> result = new HashMap<String, Set<String>>();
+        	for (Host host : hosts) {
+        		Set<String> racks = result.get(host.getDatacenter());
+        		if (racks == null) {
+        			racks = new HashSet<String>();
+        			result.put(host.getDatacenter(), racks);
+        		}
+        		racks.add(host.getRack());
+        	}
+        	return result;
         }
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/ReplicationStategy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ReplicationStategy.java
@@ -32,14 +32,18 @@ abstract class ReplicationStrategy {
     static ReplicationStrategy create(Map<String, String> replicationOptions) {
 
         String strategyClass = replicationOptions.get("class");
-        String repFactorString = replicationOptions.get("replication_factor");
-        if (strategyClass == null | repFactorString == null)
+        if (strategyClass == null)
             return null;
 
         try {
             if (strategyClass.contains("SimpleStrategy")) {
-                return new SimpleStrategy(Integer.parseInt(repFactorString));
-            } else if (strategyClass.contains("SimpleStrategy")) {
+            	String repFactorString = replicationOptions.get("replication_factor");
+            	if (repFactorString == null) {
+            		return null;
+            	} else {
+            		return new SimpleStrategy(Integer.parseInt(repFactorString));
+            	}
+            } else if (strategyClass.contains("NetworkTopologyStrategy")) {
                 Map<String, Integer> dcRfs = new HashMap<String, Integer>();
                 for (Map.Entry<String, String> entry : replicationOptions.entrySet())
                 {

--- a/driver-core/src/test/java/com/datastax/driver/core/AbstractReplicationStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AbstractReplicationStrategyTest.java
@@ -14,6 +14,13 @@ import java.util.Set;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 
+/**
+ * Base class for replication strategy tests. Currently only supports testing 
+ * using the Murmur3Partitioner, which is the default anyway
+ * 
+ * @author davibo
+ *
+ */
 public class AbstractReplicationStrategyTest {
 	
 	private static final Token.Factory partitioner = Token.getFactory("Murmur3Partitioner");
@@ -45,6 +52,13 @@ public class AbstractReplicationStrategyTest {
 		return partitioner;
 	}
 	
+	/**
+	 * Convenience method to quickly create a mock host by a given address.
+	 * Specified address must be accessible, otherwise a RuntimeException is thrown
+	 * 
+	 * @param address
+	 * @return
+	 */
 	protected static HostMock host(String address) {
 		try {
 			return new HostMock(address);
@@ -53,6 +67,15 @@ public class AbstractReplicationStrategyTest {
 		}
 	}
 	
+	/**
+	 * Convenience method to quickly create a mock host by the given address
+	 * located in the given datacenter/rack
+	 * 
+	 * @param address
+	 * @param dc
+	 * @param rack
+	 * @return
+	 */
 	protected static HostMock host(String address, String dc, String rack) {
 		try {
 			return new HostMock(address, dc, rack);
@@ -61,10 +84,25 @@ public class AbstractReplicationStrategyTest {
 		}
 	}
 	
+	/**
+	 * Convenience method to cast a Host object into a MockHost.
+	 * Returns null if parameter host is not a mock
+	 * 
+	 * @param host
+	 * @return
+	 */
 	protected static HostMock asMock(Host host) { 
 		return (host instanceof HostMock ? (HostMock)host : null);
 	}
 	
+	/**
+	 * Convenience method to quickly retrieve a mock host's address as specified
+	 * if created by the <code>host(...)</code> methods. Returns null if 
+	 * given host is not a mock.
+	 * 
+	 * @param host
+	 * @return
+	 */
 	protected static String mockAddress(Host host) {
 		HostMock mock = asMock(host);
 		return mock == null ? null : mock.getMockAddress();
@@ -82,12 +120,26 @@ public class AbstractReplicationStrategyTest {
 		return builder.build();
 	}
 	
+	/**
+	 * Asserts that the replica map for a given token contains the expected list of replica hosts.
+	 * Hosts are checked in order, replica placement should be an ordered set
+	 * 
+	 * @param replicaMap
+	 * @param token
+	 * @param expected
+	 */
 	protected static void assertReplicaPlacement(Map<Token, Set<Host>> replicaMap, Token token, String... expected) {
 		Set<Host> replicaSet = replicaMap.get(token);
 		assertNotNull(replicaSet);
 		assertReplicasForToken(replicaSet, expected);
 	}
 	
+	/**
+	 * Checks if a given ordered set of replicas matches the expected list of replica hosts
+	 * 
+	 * @param replicaSet
+	 * @param expected
+	 */
 	protected static void assertReplicasForToken(Set<Host> replicaSet, String... expected) {
 		final String message = "Contents of replica set: " + replicaSet + " do not match expected hosts: " + Arrays.toString(expected);
 		assertEquals(replicaSet.size(), expected.length, message);

--- a/driver-core/src/test/java/com/datastax/driver/core/AbstractReplicationStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AbstractReplicationStrategyTest.java
@@ -1,0 +1,105 @@
+package com.datastax.driver.core;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+
+public class AbstractReplicationStrategyTest {
+	
+	private static final Token.Factory partitioner = Token.getFactory("Murmur3Partitioner");
+	
+	protected static class HostMock extends Host {
+		private String address;
+		
+		private HostMock(String address) throws UnknownHostException {
+			super(InetAddress.getByName(address), new ConvictionPolicy.Simple.Factory());
+			this.address = address;
+		}
+		
+		private HostMock(String address, String dc, String rack) throws UnknownHostException {
+			this(address);
+			this.setLocationInfo(dc, rack);
+		}
+		
+		@Override
+		public String toString() {
+			return address;
+		}
+		
+		public String getMockAddress() {
+			return address;
+		}
+	}
+	
+	protected static Token.Factory partitioner() {
+		return partitioner;
+	}
+	
+	protected static HostMock host(String address) {
+		try {
+			return new HostMock(address);
+		} catch (UnknownHostException ex) {
+			throw new RuntimeException(ex); //wrap to avoid declarations
+		}
+	}
+	
+	protected static HostMock host(String address, String dc, String rack) {
+		try {
+			return new HostMock(address, dc, rack);
+		} catch (UnknownHostException ex) {
+			throw new RuntimeException(ex); //wrap to avoid declarations
+		}
+	}
+	
+	protected static HostMock asMock(Host host) { 
+		return (host instanceof HostMock ? (HostMock)host : null);
+	}
+	
+	protected static String mockAddress(Host host) {
+		HostMock mock = asMock(host);
+		return mock == null ? null : mock.getMockAddress();
+	}
+	
+	protected static Token token(String value) {
+		return partitioner.fromString(value);
+	}
+	
+	protected static List<Token> tokens(String... values) {
+		Builder<Token> builder = ImmutableList.<Token>builder();
+		for (String value : values) {
+			builder.add(token(value));
+		}
+		return builder.build();
+	}
+	
+	protected static void assertReplicaPlacement(Map<Token, Set<Host>> replicaMap, Token token, String... expected) {
+		Set<Host> replicaSet = replicaMap.get(token);
+		assertNotNull(replicaSet);
+		assertReplicasForToken(replicaSet, expected);
+	}
+	
+	protected static void assertReplicasForToken(Set<Host> replicaSet, String... expected) {
+		final String message = "Contents of replica set: " + replicaSet + " do not match expected hosts: " + Arrays.toString(expected);
+		assertEquals(replicaSet.size(), expected.length, message);
+		
+		int i = 0;
+		for (Host hostReturned : replicaSet) {
+			boolean match = true;
+			
+			if (!expected[i++].equals(mockAddress(hostReturned))) {
+				match = false;
+			}
+			assertTrue(match, message);
+		}
+	}
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -33,27 +33,27 @@ public class CCMBridge {
 
     private static final Logger logger = LoggerFactory.getLogger(CCMBridge.class);
 
-    public static final String IP_PREFIX;
+    public static String IP_PREFIX;
 
     private static final String CASSANDRA_VERSION_REGEXP = "\\d\\.\\d\\.\\d+(-\\w+)?";
 
-    static final File CASSANDRA_DIR;
-    static final String CASSANDRA_VERSION;
+    static File CASSANDRA_DIR;
+    static String CASSANDRA_VERSION;
     static {
-        String version = System.getProperty("cassandra.version");
-        if (version.matches(CASSANDRA_VERSION_REGEXP)) {
-            CASSANDRA_DIR = null;
-            CASSANDRA_VERSION = "-v " + version;
-        } else {
-            CASSANDRA_DIR = new File(version);
-            CASSANDRA_VERSION = "";
-        }
-
-        String ip_prefix = System.getProperty("ipprefix");
-        if (ip_prefix == null || ip_prefix.equals("")) {
-            ip_prefix = "127.0.1.";
-        }
-        IP_PREFIX = ip_prefix;
+//        String version = System.getProperty("cassandra.version");
+//        if (version.matches(CASSANDRA_VERSION_REGEXP)) {
+//            CASSANDRA_DIR = null;
+//            CASSANDRA_VERSION = "-v " + version;
+//        } else {
+//            CASSANDRA_DIR = new File(version);
+//            CASSANDRA_VERSION = "";
+//        }
+//
+//        String ip_prefix = System.getProperty("ipprefix");
+//        if (ip_prefix == null || ip_prefix.equals("")) {
+//            ip_prefix = "127.0.1.";
+//        }
+//        IP_PREFIX = ip_prefix;
     }
 
     private final Runtime runtime = Runtime.getRuntime();

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -33,27 +33,27 @@ public class CCMBridge {
 
     private static final Logger logger = LoggerFactory.getLogger(CCMBridge.class);
 
-    public static String IP_PREFIX;
+    public static final String IP_PREFIX;
 
     private static final String CASSANDRA_VERSION_REGEXP = "\\d\\.\\d\\.\\d+(-\\w+)?";
 
-    static File CASSANDRA_DIR;
-    static String CASSANDRA_VERSION;
+    static final File CASSANDRA_DIR;
+    static final String CASSANDRA_VERSION;
     static {
-//        String version = System.getProperty("cassandra.version");
-//        if (version.matches(CASSANDRA_VERSION_REGEXP)) {
-//            CASSANDRA_DIR = null;
-//            CASSANDRA_VERSION = "-v " + version;
-//        } else {
-//            CASSANDRA_DIR = new File(version);
-//            CASSANDRA_VERSION = "";
-//        }
-//
-//        String ip_prefix = System.getProperty("ipprefix");
-//        if (ip_prefix == null || ip_prefix.equals("")) {
-//            ip_prefix = "127.0.1.";
-//        }
-//        IP_PREFIX = ip_prefix;
+        String version = System.getProperty("cassandra.version");
+        if (version.matches(CASSANDRA_VERSION_REGEXP)) {
+            CASSANDRA_DIR = null;
+            CASSANDRA_VERSION = "-v " + version;
+        } else {
+            CASSANDRA_DIR = new File(version);
+            CASSANDRA_VERSION = "";
+        }
+
+        String ip_prefix = System.getProperty("ipprefix");
+        if (ip_prefix == null || ip_prefix.equals("")) {
+            ip_prefix = "127.0.1.";
+        }
+        IP_PREFIX = ip_prefix;
     }
 
     private final Runtime runtime = Runtime.getRuntime();

--- a/driver-core/src/test/java/com/datastax/driver/core/ReplicaMapWithNetworkTopologyStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReplicaMapWithNetworkTopologyStrategyTest.java
@@ -8,38 +8,57 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
 
 public class ReplicaMapWithNetworkTopologyStrategyTest extends AbstractReplicationStrategyTest {
+	
+	private static class ReplicationFactorDefinition {
+		public final String dc;
+		public final int replicationFactor;
+
+		public ReplicationFactorDefinition(String dc, int replicationFactor) {
+			this.dc = dc;
+			this.replicationFactor = replicationFactor;
+		}
+	}
+	
+	private static ReplicationFactorDefinition rf(String dc, int replicationFactor) {
+		return new ReplicationFactorDefinition(dc, replicationFactor);
+	}
+	
+	private static ReplicationStrategy networkTopologyStrategy(ReplicationFactorDefinition... rfs) {
+		Builder<String, String> builder = ImmutableMap.<String, String>builder()//
+				.put("class", "NetworkTopologyStrategy");
+		
+		for (ReplicationFactorDefinition rf : rfs) {
+			builder.put(rf.dc, String.valueOf(rf.replicationFactor));
+		}
+		
+		return ReplicationStrategy.create(builder.build());
+	}
+	
 	/*
 	 * ---------------------------------------------------------------------------
 	 * Ring, replication, etc... setup. These are reusable for the tests
+	 * This data is based on a real ring topology. Most tests are using
+	 * smaller and more specific topologies instead.
 	 * ---------------------------------------------------------------------------
 	 */
+	
 	private static final String DC1 = "DC1";
 	private static final String DC2 = "DC2";
+	private static final String DC3 = "DC3";
 	private static final String RACK11 = "RACK11";
 	private static final String RACK12 = "RACK12";
 	private static final String RACK21 = "RACK21";
 	private static final String RACK22 = "RACK22";
+	private static final String RACK31 = "RACK31";
 	
-	private static final Map<String, String> replicationOptions = ImmutableMap.<String, String>builder()//
-			.put("class", "NetworkTopologyStrategy")//
-			.put(DC1, "2")//
-			.put(DC2, "2")//
-			.build();
+	private static final ReplicationStrategy exampleStrategy = networkTopologyStrategy(rf(DC1, 2), rf(DC2, 2));
 	
-	//this will be used in scenarios where there are more replicas specified in strategy than available nodes
-	private static final Map<String, String> replicationOptionsTooManyReplicas = ImmutableMap.<String, String>builder()//
-			.put("class", "NetworkTopologyStrategy")//
-			.put(DC1, "4")//
-			.put(DC2, "4")//
-			.build();
-	
-	private static final ReplicationStrategy strategy = ReplicationStrategy.create(replicationOptions);
-	
-	private static final ReplicationStrategy strategyTooManyReplicas = ReplicationStrategy.create(replicationOptionsTooManyReplicas);
+	private static final ReplicationStrategy exampleStrategyTooManyReplicas = networkTopologyStrategy(rf(DC1, 4), rf(DC2, 4));
 
-	private static final List<Token> ring = ImmutableList.<Token>builder()
+	private static final List<Token> exampleRing = ImmutableList.<Token>builder()
 			.add(token("-9000000000000000000"))//
 			.add(token("-8000000000000000000"))// 
 			.add(token("-7000000000000000000"))//
@@ -60,7 +79,7 @@ public class ReplicaMapWithNetworkTopologyStrategyTest extends AbstractReplicati
 			.add(token("8000000000000000000"))//
 			.build();
 	
-	private static final Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
+	private static final Map<Token, Host> exampleTokenToPrimary = ImmutableMap.<Token, Host>builder()
 			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))//
 			.put(token("-8000000000000000000"), host("127.0.0.101", DC1, RACK11))//
 			.put(token("-7000000000000000000"), host("127.0.0.105", DC1, RACK12))//
@@ -88,8 +107,403 @@ public class ReplicaMapWithNetworkTopologyStrategyTest extends AbstractReplicati
 	 */
 	
 	@Test(groups = "unit")
-	public void networkTopologyStrategyMapTest() {
+	public void networkTopologyWithSimpleDCLayoutTest1() {
+		List<Token> ring = ImmutableList.<Token>builder()
+			.add(token("-9000000000000000000"))
+			.add(token("-4000000000000000000"))
+			.add(token("4000000000000000000"))
+			.add(token("9000000000000000000"))
+			.build();
+		
+		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
+			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("-4000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.put(token("4000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("9000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.build();
+		
+		ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 1), rf(DC2, 1));
+		
 		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+		
+		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.102", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.101", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.102", "127.0.0.101");
+	}
+	
+	@Test(groups = "unit")
+	public void networkTopologyWithSimpleDCLayoutTest2() {
+		List<Token> ring = ImmutableList.<Token>builder()
+			.add(token("-9000000000000000000"))
+			.add(token("-7000000000000000000"))
+			.add(token("-5000000000000000000"))
+			.add(token("-3000000000000000000"))
+			.add(token("3000000000000000000"))
+			.add(token("5000000000000000000"))
+			.add(token("7000000000000000000"))
+			.add(token("9000000000000000000"))
+			.build();
+		
+		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
+			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("-7000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.put(token("-5000000000000000000"), host("127.0.0.103", DC1, RACK11))
+			.put(token("-3000000000000000000"), host("127.0.0.104", DC2, RACK21))
+			.put(token("3000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("5000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.put(token("7000000000000000000"), host("127.0.0.103", DC1, RACK11))
+			.put(token("9000000000000000000"), host("127.0.0.104", DC2, RACK21))
+			.build();
+		
+		ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 1), rf(DC2, 1));
+		
+		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+		
+		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.102", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.103", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.104", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.101", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.102", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.103", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.104", "127.0.0.101");
+	}
+	
+	@Test(groups = "unit")
+	public void networkTopologyWithSimple3DCLayoutTest() {
+		List<Token> ring = ImmutableList.<Token>builder()
+			.add(token("-9000000000000000000"))
+			.add(token("-5000000000000000000"))
+			.add(token("-1000000000000000000"))
+			.add(token("1000000000000000000"))
+			.add(token("5000000000000000000"))
+			.add(token("9000000000000000000"))
+			.build();
+		
+		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
+			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("-5000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.put(token("-1000000000000000000"), host("127.0.0.103", DC3, RACK31))
+			.put(token("1000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("5000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.put(token("9000000000000000000"), host("127.0.0.103", DC3, RACK31))
+			.build();
+		
+		ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 1), rf(DC2, 1), rf(DC3, 1));
+		
+		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+		
+		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.102", "127.0.0.103", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("-1000000000000000000"), "127.0.0.103", "127.0.0.101", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, token("1000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.102", "127.0.0.103", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.103", "127.0.0.101", "127.0.0.102");
+	}
+	
+	@Test(groups = "unit")
+	public void networkTopologyWithUnbalancedRingTest() {
+		List<Token> ring = ImmutableList.<Token>builder()
+			.add(token("-9000000000000000000"))
+			.add(token("-7000000000000000000"))
+			.add(token("-5000000000000000000"))
+			.add(token("-3000000000000000000"))
+			.add(token("-1000000000000000000"))
+			.add(token("1000000000000000000"))
+			.add(token("3000000000000000000"))
+			.add(token("5000000000000000000"))
+			.add(token("7000000000000000000"))
+			.add(token("9000000000000000000"))
+			.build();
+		
+		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
+			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("-7000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("-5000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.put(token("-3000000000000000000"), host("127.0.0.103", DC1, RACK11))
+			.put(token("-1000000000000000000"), host("127.0.0.104", DC2, RACK21))
+			.put(token("1000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("3000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("5000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.put(token("7000000000000000000"), host("127.0.0.103", DC1, RACK11))
+			.put(token("9000000000000000000"), host("127.0.0.104", DC2, RACK21))
+			.build();
+		
+		ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 2), rf(DC2, 2));
+		
+		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+		
+		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.103", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.103", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.102", "127.0.0.103", "127.0.0.104", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.101", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, token("-1000000000000000000"), "127.0.0.104", "127.0.0.101", "127.0.0.102", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("1000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.103", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.103", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.102", "127.0.0.103", "127.0.0.104", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.101", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.104", "127.0.0.101", "127.0.0.102", "127.0.0.103");
+	}
+	
+	@Test(groups = "unit")
+	public void networkTopologyWithDCMultirackLayoutTest() {
+		List<Token> ring = ImmutableList.<Token>builder()
+			.add(token("-9000000000000000000"))
+			.add(token("-8000000000000000000"))
+			.add(token("-7000000000000000000"))
+			.add(token("-6000000000000000000"))
+			.add(token("-5000000000000000000"))
+			.add(token("-4000000000000000000"))
+			.add(token("-3000000000000000000"))
+			.add(token("-2000000000000000000"))
+			.add(token("2000000000000000000"))
+			.add(token("3000000000000000000"))
+			.add(token("4000000000000000000"))
+			.add(token("5000000000000000000"))
+			.add(token("6000000000000000000"))
+			.add(token("7000000000000000000"))
+			.add(token("8000000000000000000"))
+			.add(token("9000000000000000000"))
+			.build();
+		
+		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
+			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("-8000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.put(token("-7000000000000000000"), host("127.0.0.103", DC1, RACK12))
+			.put(token("-6000000000000000000"), host("127.0.0.104", DC2, RACK22))
+			.put(token("-5000000000000000000"), host("127.0.0.105", DC1, RACK11))
+			.put(token("-4000000000000000000"), host("127.0.0.106", DC2, RACK21))
+			.put(token("-3000000000000000000"), host("127.0.0.107", DC1, RACK12))
+			.put(token("-2000000000000000000"), host("127.0.0.108", DC2, RACK22))
+			.put(token("2000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("3000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.put(token("4000000000000000000"), host("127.0.0.103", DC1, RACK12))
+			.put(token("5000000000000000000"), host("127.0.0.104", DC2, RACK22))
+			.put(token("6000000000000000000"), host("127.0.0.105", DC1, RACK11))
+			.put(token("7000000000000000000"), host("127.0.0.106", DC2, RACK21))
+			.put(token("8000000000000000000"), host("127.0.0.107", DC1, RACK12))
+			.put(token("9000000000000000000"), host("127.0.0.108", DC2, RACK22))
+			.build();
+		
+		ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 2), rf(DC2, 2));
+		
+		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+		
+		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.103", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.102", "127.0.0.103", "127.0.0.104", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.106");
+		assertReplicaPlacement(replicaMap, token("-6000000000000000000"), "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.107");
+		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.105", "127.0.0.106", "127.0.0.107", "127.0.0.108");
+		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.106", "127.0.0.107", "127.0.0.108", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.107", "127.0.0.108", "127.0.0.101", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, token("-2000000000000000000"), "127.0.0.108", "127.0.0.101", "127.0.0.102", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("2000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.103", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.102", "127.0.0.103", "127.0.0.104", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.106");
+		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.107");
+		assertReplicaPlacement(replicaMap, token("6000000000000000000"), "127.0.0.105", "127.0.0.106", "127.0.0.107", "127.0.0.108");
+		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.106", "127.0.0.107", "127.0.0.108", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("8000000000000000000"), "127.0.0.107", "127.0.0.108", "127.0.0.101", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.108", "127.0.0.101", "127.0.0.102", "127.0.0.103");
+	}
+	
+	@Test(groups = "unit")
+	public void networkTopologyWithMultirackHostSkippingTest1() {
+		List<Token> ring = ImmutableList.<Token>builder()
+			.add(token("-9000000000000000000"))
+			.add(token("-8000000000000000000"))
+			.add(token("-7000000000000000000"))
+			.add(token("-6000000000000000000"))
+			.add(token("-5000000000000000000"))
+			.add(token("-4000000000000000000"))
+			.add(token("-3000000000000000000"))
+			.add(token("-2000000000000000000"))
+			.add(token("2000000000000000000"))
+			.add(token("3000000000000000000"))
+			.add(token("4000000000000000000"))
+			.add(token("5000000000000000000"))
+			.add(token("6000000000000000000"))
+			.add(token("7000000000000000000"))
+			.add(token("8000000000000000000"))
+			.add(token("9000000000000000000"))
+			.build();
+		
+		//this is to simulate when we hit the same rack in a DC first as a second replica
+		//so that'll get skipped and re-added later as a third
+		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
+			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("-8000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.put(token("-7000000000000000000"), host("127.0.0.103", DC1, RACK11))
+			.put(token("-6000000000000000000"), host("127.0.0.104", DC2, RACK21))
+			.put(token("-5000000000000000000"), host("127.0.0.105", DC1, RACK12))
+			.put(token("-4000000000000000000"), host("127.0.0.106", DC2, RACK22))
+			.put(token("-3000000000000000000"), host("127.0.0.107", DC1, RACK12))
+			.put(token("-2000000000000000000"), host("127.0.0.108", DC2, RACK22))
+			.put(token("2000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("3000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.put(token("4000000000000000000"), host("127.0.0.103", DC1, RACK11))
+			.put(token("5000000000000000000"), host("127.0.0.104", DC2, RACK21))
+			.put(token("6000000000000000000"), host("127.0.0.105", DC1, RACK12))
+			.put(token("7000000000000000000"), host("127.0.0.106", DC2, RACK22))
+			.put(token("8000000000000000000"), host("127.0.0.107", DC1, RACK12))
+			.put(token("9000000000000000000"), host("127.0.0.108", DC2, RACK22))
+			.build();
+		
+		ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 3), rf(DC2, 3));
+		
+		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+		
+		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.105", "127.0.0.103", "127.0.0.106", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.102", "127.0.0.103", "127.0.0.105", "127.0.0.106", "127.0.0.104", "127.0.0.107");
+		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.107", "127.0.0.108");
+		assertReplicaPlacement(replicaMap, token("-6000000000000000000"), "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.108", "127.0.0.101", "127.0.0.107");
+		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.105", "127.0.0.106", "127.0.0.101", "127.0.0.107", "127.0.0.102", "127.0.0.108");
+		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.106", "127.0.0.107", "127.0.0.101", "127.0.0.102", "127.0.0.108", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.107", "127.0.0.108", "127.0.0.101", "127.0.0.102", "127.0.0.103", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-2000000000000000000"), "127.0.0.108", "127.0.0.101", "127.0.0.102", "127.0.0.104", "127.0.0.105", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("2000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.105", "127.0.0.103", "127.0.0.106", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.102", "127.0.0.103", "127.0.0.105", "127.0.0.106", "127.0.0.104", "127.0.0.107");
+		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.107", "127.0.0.108");
+		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.108", "127.0.0.101", "127.0.0.107");
+		assertReplicaPlacement(replicaMap, token("6000000000000000000"), "127.0.0.105", "127.0.0.106", "127.0.0.101", "127.0.0.107", "127.0.0.102", "127.0.0.108");
+		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.106", "127.0.0.107", "127.0.0.101", "127.0.0.102", "127.0.0.108", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("8000000000000000000"), "127.0.0.107", "127.0.0.108", "127.0.0.101", "127.0.0.102", "127.0.0.103", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.108", "127.0.0.101", "127.0.0.102", "127.0.0.104", "127.0.0.105", "127.0.0.103");
+
+	}
+	
+	@Test(groups = "unit")
+	public void networkTopologyWithMultirackHostSkippingTest2() {
+		List<Token> ring = ImmutableList.<Token>builder()
+			.add(token("-9000000000000000000"))
+			.add(token("-8000000000000000000"))
+			.add(token("-7000000000000000000"))
+			.add(token("-6000000000000000000"))
+			.add(token("-5000000000000000000"))
+			.add(token("-4000000000000000000"))
+			.add(token("-3000000000000000000"))
+			.add(token("-2000000000000000000"))
+			.add(token("2000000000000000000"))
+			.add(token("3000000000000000000"))
+			.add(token("4000000000000000000"))
+			.add(token("5000000000000000000"))
+			.add(token("6000000000000000000"))
+			.add(token("7000000000000000000"))
+			.add(token("8000000000000000000"))
+			.add(token("9000000000000000000"))
+			.build();
+		
+		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
+			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("-8000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("-7000000000000000000"), host("127.0.0.103", DC1, RACK11))
+			.put(token("-6000000000000000000"), host("127.0.0.103", DC1, RACK11))
+			.put(token("-5000000000000000000"), host("127.0.0.105", DC1, RACK12))
+			.put(token("-4000000000000000000"), host("127.0.0.105", DC1, RACK12))
+			.put(token("-3000000000000000000"), host("127.0.0.107", DC1, RACK12))
+			.put(token("-2000000000000000000"), host("127.0.0.107", DC1, RACK12))
+			.put(token("2000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.put(token("3000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.put(token("4000000000000000000"), host("127.0.0.104", DC2, RACK21))
+			.put(token("5000000000000000000"), host("127.0.0.104", DC2, RACK21))
+			.put(token("6000000000000000000"), host("127.0.0.106", DC2, RACK22))
+			.put(token("7000000000000000000"), host("127.0.0.106", DC2, RACK22))
+			.put(token("8000000000000000000"), host("127.0.0.108", DC2, RACK22))
+			.put(token("9000000000000000000"), host("127.0.0.108", DC2, RACK22))
+			.build();
+		
+		ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 3), rf(DC2, 3));
+		
+		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+		
+		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.103", "127.0.0.105", "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-6000000000000000000"), "127.0.0.103", "127.0.0.105", "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.101", "127.0.0.107");
+		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.101", "127.0.0.107");
+		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.101", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("-2000000000000000000"), "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.101", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("2000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.101", "127.0.0.105", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.101", "127.0.0.105", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.104", "127.0.0.106", "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.104", "127.0.0.106", "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("6000000000000000000"), "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.108");
+		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.108");
+		assertReplicaPlacement(replicaMap, token("8000000000000000000"), "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.104");
+
+	}
+	
+	@Test(groups = "unit")
+	public void networkTopologyWithMultirackHostSkippingTest3() {
+		//this is the same topology as in the previous test, but with different rfs
+		List<Token> ring = ImmutableList.<Token>builder()
+			.add(token("-9000000000000000000"))
+			.add(token("-8000000000000000000"))
+			.add(token("-7000000000000000000"))
+			.add(token("-6000000000000000000"))
+			.add(token("-5000000000000000000"))
+			.add(token("-4000000000000000000"))
+			.add(token("-3000000000000000000"))
+			.add(token("-2000000000000000000"))
+			.add(token("2000000000000000000"))
+			.add(token("3000000000000000000"))
+			.add(token("4000000000000000000"))
+			.add(token("5000000000000000000"))
+			.add(token("6000000000000000000"))
+			.add(token("7000000000000000000"))
+			.add(token("8000000000000000000"))
+			.add(token("9000000000000000000"))
+			.build();
+		
+		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
+			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("-8000000000000000000"), host("127.0.0.101", DC1, RACK11))
+			.put(token("-7000000000000000000"), host("127.0.0.103", DC1, RACK11))
+			.put(token("-6000000000000000000"), host("127.0.0.103", DC1, RACK11))
+			.put(token("-5000000000000000000"), host("127.0.0.105", DC1, RACK12))
+			.put(token("-4000000000000000000"), host("127.0.0.105", DC1, RACK12))
+			.put(token("-3000000000000000000"), host("127.0.0.107", DC1, RACK12))
+			.put(token("-2000000000000000000"), host("127.0.0.107", DC1, RACK12))
+			.put(token("2000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.put(token("3000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.put(token("4000000000000000000"), host("127.0.0.104", DC2, RACK21))
+			.put(token("5000000000000000000"), host("127.0.0.104", DC2, RACK21))
+			.put(token("6000000000000000000"), host("127.0.0.106", DC2, RACK22))
+			.put(token("7000000000000000000"), host("127.0.0.106", DC2, RACK22))
+			.put(token("8000000000000000000"), host("127.0.0.108", DC2, RACK22))
+			.put(token("9000000000000000000"), host("127.0.0.108", DC2, RACK22))
+			.build();
+		
+		//all nodes will contain all data, question is the replica order
+		ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 4), rf(DC2, 4));
+		
+		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+		
+		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107","127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108");
+		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108");
+		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.103", "127.0.0.105", "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("-6000000000000000000"), "127.0.0.103", "127.0.0.105", "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108", "127.0.0.101", "127.0.0.107", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108", "127.0.0.101", "127.0.0.107", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108", "127.0.0.101", "127.0.0.103", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, token("-2000000000000000000"), "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108", "127.0.0.101", "127.0.0.103", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, token("2000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107");
+		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107");
+		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.104", "127.0.0.106", "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.104", "127.0.0.106", "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, token("6000000000000000000"), "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107", "127.0.0.102", "127.0.0.108", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107", "127.0.0.102", "127.0.0.108", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("8000000000000000000"), "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107", "127.0.0.102", "127.0.0.104", "127.0.0.106");
+		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107", "127.0.0.102", "127.0.0.104", "127.0.0.106");
+
+	}
+	
+	@Test(groups = "unit")
+	public void networkTopologyStrategyExampleTopologyTest() {
+		Map<Token, Set<Host>> replicaMap = exampleStrategy.computeTokenToReplicaMap(exampleTokenToPrimary, exampleRing);
 		
 		//105 and 106 will appear as replica for all as they're in separate racks
 		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.102", "127.0.0.106");
@@ -113,8 +527,8 @@ public class ReplicaMapWithNetworkTopologyStrategyTest extends AbstractReplicati
 	}
 	
 	@Test(groups = "unit")
-	public void networkTopologyStrategyMapTooManyReplicasTest() {
-		Map<Token, Set<Host>> replicaMap = strategyTooManyReplicas.computeTokenToReplicaMap(tokenToPrimary, ring);
+	public void networkTopologyStrategyExampleTopologyTooManyReplicasTest() {
+		Map<Token, Set<Host>> replicaMap = exampleStrategyTooManyReplicas.computeTokenToReplicaMap(exampleTokenToPrimary, exampleRing);
 		
 		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.104");
 		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.104");

--- a/driver-core/src/test/java/com/datastax/driver/core/ReplicaMapWithNetworkTopologyStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReplicaMapWithNetworkTopologyStrategyTest.java
@@ -53,51 +53,80 @@ public class ReplicaMapWithNetworkTopologyStrategyTest extends AbstractReplicati
 	private static final String RACK21 = "RACK21";
 	private static final String RACK22 = "RACK22";
 	private static final String RACK31 = "RACK31";
+
+	private static final Token TOKEN01 = token("-9000000000000000000");
+	private static final Token TOKEN02 = token("-8000000000000000000");
+	private static final Token TOKEN03 = token("-7000000000000000000");
+	private static final Token TOKEN04 = token("-6000000000000000000");
+	private static final Token TOKEN05 = token("-5000000000000000000");
+	private static final Token TOKEN06 = token("-4000000000000000000");
+	private static final Token TOKEN07 = token("-3000000000000000000");
+	private static final Token TOKEN08 = token("-2000000000000000000");
+	private static final Token TOKEN09 = token("-1000000000000000000");
+	private static final Token TOKEN10 = token("0");
+	private static final Token TOKEN11 = token("1000000000000000000");
+	private static final Token TOKEN12 = token("2000000000000000000");
+	private static final Token TOKEN13 = token("3000000000000000000");
+	private static final Token TOKEN14 = token("4000000000000000000");
+	private static final Token TOKEN15 = token("5000000000000000000");
+	private static final Token TOKEN16 = token("6000000000000000000");
+	private static final Token TOKEN17 = token("7000000000000000000");
+	private static final Token TOKEN18 = token("8000000000000000000");
+	private static final Token TOKEN19 = token("9000000000000000000");
+	
+	private static final String IP1 = "127.0.0.101";
+	private static final String IP2 = "127.0.0.102";
+	private static final String IP3 = "127.0.0.103";
+	private static final String IP4 = "127.0.0.104";
+	private static final String IP5 = "127.0.0.105";
+	private static final String IP6 = "127.0.0.106";
+	private static final String IP7 = "127.0.0.107";
+	private static final String IP8 = "127.0.0.108";
 	
 	private static final ReplicationStrategy exampleStrategy = networkTopologyStrategy(rf(DC1, 2), rf(DC2, 2));
 	
 	private static final ReplicationStrategy exampleStrategyTooManyReplicas = networkTopologyStrategy(rf(DC1, 4), rf(DC2, 4));
 
 	private static final List<Token> exampleRing = ImmutableList.<Token>builder()
-			.add(token("-9000000000000000000"))//
-			.add(token("-8000000000000000000"))// 
-			.add(token("-7000000000000000000"))//
-			.add(token("-6000000000000000000"))//
-			.add(token("-5000000000000000000"))//
-			.add(token("-4000000000000000000"))//
-			.add(token("-3000000000000000000"))//
-			.add(token("-2000000000000000000"))//
-			.add(token("-1000000000000000000"))//
-			.add(token("0"))//
-			.add(token("1000000000000000000"))//
-			.add(token("2000000000000000000"))//
-			.add(token("3000000000000000000"))//
-			.add(token("4000000000000000000"))//
-			.add(token("5000000000000000000"))//
-			.add(token("6000000000000000000"))//
-			.add(token("7000000000000000000"))//
-			.add(token("8000000000000000000"))//
+			.add(TOKEN01)//
+			.add(TOKEN02)//
+			.add(TOKEN03)//
+			.add(TOKEN04)//
+			.add(TOKEN05)//
+			.add(TOKEN06)//
+			.add(TOKEN07)//
+			.add(TOKEN08)//
+			.add(TOKEN09)//
+			.add(TOKEN10)//
+			.add(TOKEN11)//
+			.add(TOKEN12)//
+			.add(TOKEN13)//
+			.add(TOKEN14)//
+			.add(TOKEN15)//
+			.add(TOKEN16)//
+			.add(TOKEN17)//
+			.add(TOKEN18)//
 			.build();
 	
 	private static final Map<Token, Host> exampleTokenToPrimary = ImmutableMap.<Token, Host>builder()
-			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))//
-			.put(token("-8000000000000000000"), host("127.0.0.101", DC1, RACK11))//
-			.put(token("-7000000000000000000"), host("127.0.0.105", DC1, RACK12))//
-			.put(token("-6000000000000000000"), host("127.0.0.103", DC1, RACK11))//
-			.put(token("-5000000000000000000"), host("127.0.0.101", DC1, RACK11))//
-			.put(token("-4000000000000000000"), host("127.0.0.105", DC1, RACK12))//
-			.put(token("-3000000000000000000"), host("127.0.0.102", DC2, RACK21))//
-			.put(token("-2000000000000000000"), host("127.0.0.106", DC2, RACK22))//
-			.put(token("-1000000000000000000"), host("127.0.0.103", DC1, RACK11))//
-			.put(token("0"),                    host("127.0.0.104", DC2, RACK21))//
-			.put(token("1000000000000000000"), host("127.0.0.105", DC1, RACK12))//
-			.put(token("2000000000000000000"), host("127.0.0.104", DC2, RACK21))//
-			.put(token("3000000000000000000"), host("127.0.0.104", DC2, RACK21))//
-			.put(token("4000000000000000000"), host("127.0.0.102", DC2, RACK21))//
-			.put(token("5000000000000000000"), host("127.0.0.106", DC2, RACK22))//
-			.put(token("6000000000000000000"), host("127.0.0.103", DC1, RACK11))//
-			.put(token("7000000000000000000"), host("127.0.0.102", DC2, RACK21))//
-			.put(token("8000000000000000000"), host("127.0.0.106", DC2, RACK22))//
+			.put(TOKEN01, host(IP1, DC1, RACK11))//
+			.put(TOKEN02, host(IP1, DC1, RACK11))//
+			.put(TOKEN03, host(IP5, DC1, RACK12))//
+			.put(TOKEN04, host(IP3, DC1, RACK11))//
+			.put(TOKEN05, host(IP1, DC1, RACK11))//
+			.put(TOKEN06, host(IP5, DC1, RACK12))//
+			.put(TOKEN07, host(IP2, DC2, RACK21))//
+			.put(TOKEN08, host(IP6, DC2, RACK22))//
+			.put(TOKEN09, host(IP3, DC1, RACK11))//
+			.put(TOKEN10, host(IP4, DC2, RACK21))//
+			.put(TOKEN11, host(IP5, DC1, RACK12))//
+			.put(TOKEN12, host(IP4, DC2, RACK21))//
+			.put(TOKEN13, host(IP4, DC2, RACK21))//
+			.put(TOKEN14, host(IP2, DC2, RACK21))//
+			.put(TOKEN15, host(IP6, DC2, RACK22))//
+			.put(TOKEN16, host(IP3, DC1, RACK11))//
+			.put(TOKEN17, host(IP2, DC2, RACK21))//
+			.put(TOKEN18, host(IP6, DC2, RACK22))//
 			.build();
 	
 	/*
@@ -109,330 +138,330 @@ public class ReplicaMapWithNetworkTopologyStrategyTest extends AbstractReplicati
 	@Test(groups = "unit")
 	public void networkTopologyWithSimpleDCLayoutTest1() {
 		List<Token> ring = ImmutableList.<Token>builder()
-			.add(token("-9000000000000000000"))
-			.add(token("-4000000000000000000"))
-			.add(token("4000000000000000000"))
-			.add(token("9000000000000000000"))
+			.add(TOKEN01)
+			.add(TOKEN04)
+			.add(TOKEN14)
+			.add(TOKEN19)
 			.build();
 		
 		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
-			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("-4000000000000000000"), host("127.0.0.102", DC2, RACK21))
-			.put(token("4000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("9000000000000000000"), host("127.0.0.102", DC2, RACK21))
+			.put(TOKEN01, host(IP1, DC1, RACK11))
+			.put(TOKEN04, host(IP2, DC2, RACK21))
+			.put(TOKEN14, host(IP1, DC1, RACK11))
+			.put(TOKEN19, host(IP2, DC2, RACK21))
 			.build();
 		
 		ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 1), rf(DC2, 1));
 		
 		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
 		
-		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.102", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.101", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.102", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN04, IP2, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN14, IP1, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN19, IP2, IP1);
 	}
 	
 	@Test(groups = "unit")
 	public void networkTopologyWithSimpleDCLayoutTest2() {
 		List<Token> ring = ImmutableList.<Token>builder()
-			.add(token("-9000000000000000000"))
-			.add(token("-7000000000000000000"))
-			.add(token("-5000000000000000000"))
-			.add(token("-3000000000000000000"))
-			.add(token("3000000000000000000"))
-			.add(token("5000000000000000000"))
-			.add(token("7000000000000000000"))
-			.add(token("9000000000000000000"))
+			.add(TOKEN01)
+			.add(TOKEN03)
+			.add(TOKEN05)
+			.add(TOKEN07)
+			.add(TOKEN13)
+			.add(TOKEN15)
+			.add(TOKEN17)
+			.add(TOKEN19)
 			.build();
 		
 		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
-			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("-7000000000000000000"), host("127.0.0.102", DC2, RACK21))
-			.put(token("-5000000000000000000"), host("127.0.0.103", DC1, RACK11))
-			.put(token("-3000000000000000000"), host("127.0.0.104", DC2, RACK21))
-			.put(token("3000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("5000000000000000000"), host("127.0.0.102", DC2, RACK21))
-			.put(token("7000000000000000000"), host("127.0.0.103", DC1, RACK11))
-			.put(token("9000000000000000000"), host("127.0.0.104", DC2, RACK21))
+			.put(TOKEN01, host(IP1, DC1, RACK11))
+			.put(TOKEN03, host(IP2, DC2, RACK21))
+			.put(TOKEN05, host(IP3, DC1, RACK11))
+			.put(TOKEN07, host(IP4, DC2, RACK21))
+			.put(TOKEN13, host(IP1, DC1, RACK11))
+			.put(TOKEN15, host(IP2, DC2, RACK21))
+			.put(TOKEN17, host(IP3, DC1, RACK11))
+			.put(TOKEN19, host(IP4, DC2, RACK21))
 			.build();
 		
 		ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 1), rf(DC2, 1));
 		
 		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
 		
-		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.102", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.103", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.104", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.101", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.102", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.103", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.104", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN03, IP2, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN05, IP3, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN07, IP4, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN13, IP1, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN15, IP2, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN17, IP3, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN19, IP4, IP1);
 	}
 	
 	@Test(groups = "unit")
 	public void networkTopologyWithSimple3DCLayoutTest() {
 		List<Token> ring = ImmutableList.<Token>builder()
-			.add(token("-9000000000000000000"))
-			.add(token("-5000000000000000000"))
-			.add(token("-1000000000000000000"))
-			.add(token("1000000000000000000"))
-			.add(token("5000000000000000000"))
-			.add(token("9000000000000000000"))
+			.add(TOKEN01)
+			.add(TOKEN05)
+			.add(TOKEN09)
+			.add(TOKEN11)
+			.add(TOKEN15)
+			.add(TOKEN19)
 			.build();
 		
 		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
-			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("-5000000000000000000"), host("127.0.0.102", DC2, RACK21))
-			.put(token("-1000000000000000000"), host("127.0.0.103", DC3, RACK31))
-			.put(token("1000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("5000000000000000000"), host("127.0.0.102", DC2, RACK21))
-			.put(token("9000000000000000000"), host("127.0.0.103", DC3, RACK31))
+			.put(TOKEN01, host(IP1, DC1, RACK11))
+			.put(TOKEN05, host(IP2, DC2, RACK21))
+			.put(TOKEN09, host(IP3, DC3, RACK31))
+			.put(TOKEN11, host(IP1, DC1, RACK11))
+			.put(TOKEN15, host(IP2, DC2, RACK21))
+			.put(TOKEN19, host(IP3, DC3, RACK31))
 			.build();
 		
 		ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 1), rf(DC2, 1), rf(DC3, 1));
 		
 		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
 		
-		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.102", "127.0.0.103", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("-1000000000000000000"), "127.0.0.103", "127.0.0.101", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("1000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.102", "127.0.0.103", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.103", "127.0.0.101", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN05, IP2, IP3, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN09, IP3, IP1, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN11, IP1, IP2, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN15, IP2, IP3, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN19, IP3, IP1, IP2);
 	}
 	
 	@Test(groups = "unit")
 	public void networkTopologyWithUnbalancedRingTest() {
 		List<Token> ring = ImmutableList.<Token>builder()
-			.add(token("-9000000000000000000"))
-			.add(token("-7000000000000000000"))
-			.add(token("-5000000000000000000"))
-			.add(token("-3000000000000000000"))
-			.add(token("-1000000000000000000"))
-			.add(token("1000000000000000000"))
-			.add(token("3000000000000000000"))
-			.add(token("5000000000000000000"))
-			.add(token("7000000000000000000"))
-			.add(token("9000000000000000000"))
+			.add(TOKEN01)
+			.add(TOKEN03)
+			.add(TOKEN05)
+			.add(TOKEN07)
+			.add(TOKEN09)
+			.add(TOKEN11)
+			.add(TOKEN13)
+			.add(TOKEN15)
+			.add(TOKEN17)
+			.add(TOKEN19)
 			.build();
 		
 		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
-			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("-7000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("-5000000000000000000"), host("127.0.0.102", DC2, RACK21))
-			.put(token("-3000000000000000000"), host("127.0.0.103", DC1, RACK11))
-			.put(token("-1000000000000000000"), host("127.0.0.104", DC2, RACK21))
-			.put(token("1000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("3000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("5000000000000000000"), host("127.0.0.102", DC2, RACK21))
-			.put(token("7000000000000000000"), host("127.0.0.103", DC1, RACK11))
-			.put(token("9000000000000000000"), host("127.0.0.104", DC2, RACK21))
+			.put(TOKEN01, host(IP1, DC1, RACK11))
+			.put(TOKEN03, host(IP1, DC1, RACK11))
+			.put(TOKEN05, host(IP2, DC2, RACK21))
+			.put(TOKEN07, host(IP3, DC1, RACK11))
+			.put(TOKEN09, host(IP4, DC2, RACK21))
+			.put(TOKEN11, host(IP1, DC1, RACK11))
+			.put(TOKEN13, host(IP1, DC1, RACK11))
+			.put(TOKEN15, host(IP2, DC2, RACK21))
+			.put(TOKEN17, host(IP3, DC1, RACK11))
+			.put(TOKEN19, host(IP4, DC2, RACK21))
 			.build();
 		
 		ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 2), rf(DC2, 2));
 		
 		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
 		
-		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.103", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.103", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.102", "127.0.0.103", "127.0.0.104", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.101", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("-1000000000000000000"), "127.0.0.104", "127.0.0.101", "127.0.0.102", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("1000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.103", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.103", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.102", "127.0.0.103", "127.0.0.104", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.101", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.104", "127.0.0.101", "127.0.0.102", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2, IP3, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN03, IP1, IP2, IP3, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN05, IP2, IP3, IP4, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN07, IP3, IP4, IP1, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN09, IP4, IP1, IP2, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN11, IP1, IP2, IP3, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN13, IP1, IP2, IP3, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN15, IP2, IP3, IP4, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN17, IP3, IP4, IP1, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN19, IP4, IP1, IP2, IP3);
 	}
 	
 	@Test(groups = "unit")
 	public void networkTopologyWithDCMultirackLayoutTest() {
 		List<Token> ring = ImmutableList.<Token>builder()
-			.add(token("-9000000000000000000"))
-			.add(token("-8000000000000000000"))
-			.add(token("-7000000000000000000"))
-			.add(token("-6000000000000000000"))
-			.add(token("-5000000000000000000"))
-			.add(token("-4000000000000000000"))
-			.add(token("-3000000000000000000"))
-			.add(token("-2000000000000000000"))
-			.add(token("2000000000000000000"))
-			.add(token("3000000000000000000"))
-			.add(token("4000000000000000000"))
-			.add(token("5000000000000000000"))
-			.add(token("6000000000000000000"))
-			.add(token("7000000000000000000"))
-			.add(token("8000000000000000000"))
-			.add(token("9000000000000000000"))
+			.add(TOKEN01)
+			.add(TOKEN02)
+			.add(TOKEN03)
+			.add(TOKEN04)
+			.add(TOKEN05)
+			.add(TOKEN06)
+			.add(TOKEN07)
+			.add(TOKEN08)
+			.add(TOKEN12)
+			.add(TOKEN13)
+			.add(TOKEN14)
+			.add(TOKEN15)
+			.add(TOKEN16)
+			.add(TOKEN17)
+			.add(TOKEN18)
+			.add(TOKEN19)
 			.build();
 		
 		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
-			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("-8000000000000000000"), host("127.0.0.102", DC2, RACK21))
-			.put(token("-7000000000000000000"), host("127.0.0.103", DC1, RACK12))
-			.put(token("-6000000000000000000"), host("127.0.0.104", DC2, RACK22))
-			.put(token("-5000000000000000000"), host("127.0.0.105", DC1, RACK11))
-			.put(token("-4000000000000000000"), host("127.0.0.106", DC2, RACK21))
-			.put(token("-3000000000000000000"), host("127.0.0.107", DC1, RACK12))
-			.put(token("-2000000000000000000"), host("127.0.0.108", DC2, RACK22))
-			.put(token("2000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("3000000000000000000"), host("127.0.0.102", DC2, RACK21))
-			.put(token("4000000000000000000"), host("127.0.0.103", DC1, RACK12))
-			.put(token("5000000000000000000"), host("127.0.0.104", DC2, RACK22))
-			.put(token("6000000000000000000"), host("127.0.0.105", DC1, RACK11))
-			.put(token("7000000000000000000"), host("127.0.0.106", DC2, RACK21))
-			.put(token("8000000000000000000"), host("127.0.0.107", DC1, RACK12))
-			.put(token("9000000000000000000"), host("127.0.0.108", DC2, RACK22))
+			.put(TOKEN01, host(IP1, DC1, RACK11))
+			.put(TOKEN02, host(IP2, DC2, RACK21))
+			.put(TOKEN03, host(IP3, DC1, RACK12))
+			.put(TOKEN04, host(IP4, DC2, RACK22))
+			.put(TOKEN05, host(IP5, DC1, RACK11))
+			.put(TOKEN06, host(IP6, DC2, RACK21))
+			.put(TOKEN07, host(IP7, DC1, RACK12))
+			.put(TOKEN08, host(IP8, DC2, RACK22))
+			.put(TOKEN12, host(IP1, DC1, RACK11))
+			.put(TOKEN13, host(IP2, DC2, RACK21))
+			.put(TOKEN14, host(IP3, DC1, RACK12))
+			.put(TOKEN15, host(IP4, DC2, RACK22))
+			.put(TOKEN16, host(IP5, DC1, RACK11))
+			.put(TOKEN17, host(IP6, DC2, RACK21))
+			.put(TOKEN18, host(IP7, DC1, RACK12))
+			.put(TOKEN19, host(IP8, DC2, RACK22))
 			.build();
 		
 		ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 2), rf(DC2, 2));
 		
 		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
 		
-		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.103", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.102", "127.0.0.103", "127.0.0.104", "127.0.0.105");
-		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.106");
-		assertReplicaPlacement(replicaMap, token("-6000000000000000000"), "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.107");
-		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.105", "127.0.0.106", "127.0.0.107", "127.0.0.108");
-		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.106", "127.0.0.107", "127.0.0.108", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.107", "127.0.0.108", "127.0.0.101", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("-2000000000000000000"), "127.0.0.108", "127.0.0.101", "127.0.0.102", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("2000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.103", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.102", "127.0.0.103", "127.0.0.104", "127.0.0.105");
-		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.106");
-		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.107");
-		assertReplicaPlacement(replicaMap, token("6000000000000000000"), "127.0.0.105", "127.0.0.106", "127.0.0.107", "127.0.0.108");
-		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.106", "127.0.0.107", "127.0.0.108", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("8000000000000000000"), "127.0.0.107", "127.0.0.108", "127.0.0.101", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.108", "127.0.0.101", "127.0.0.102", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2, IP3, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN02, IP2, IP3, IP4, IP5);
+		assertReplicaPlacement(replicaMap, TOKEN03, IP3, IP4, IP5, IP6);
+		assertReplicaPlacement(replicaMap, TOKEN04, IP4, IP5, IP6, IP7);
+		assertReplicaPlacement(replicaMap, TOKEN05, IP5, IP6, IP7, IP8);
+		assertReplicaPlacement(replicaMap, TOKEN06, IP6, IP7, IP8, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN07, IP7, IP8, IP1, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN08, IP8, IP1, IP2, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN12, IP1, IP2, IP3, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN13, IP2, IP3, IP4, IP5);
+		assertReplicaPlacement(replicaMap, TOKEN14, IP3, IP4, IP5, IP6);
+		assertReplicaPlacement(replicaMap, TOKEN15, IP4, IP5, IP6, IP7);
+		assertReplicaPlacement(replicaMap, TOKEN16, IP5, IP6, IP7, IP8);
+		assertReplicaPlacement(replicaMap, TOKEN17, IP6, IP7, IP8, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN18, IP7, IP8, IP1, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN19, IP8, IP1, IP2, IP3);
 	}
 	
 	@Test(groups = "unit")
 	public void networkTopologyWithMultirackHostSkippingTest1() {
 		List<Token> ring = ImmutableList.<Token>builder()
-			.add(token("-9000000000000000000"))
-			.add(token("-8000000000000000000"))
-			.add(token("-7000000000000000000"))
-			.add(token("-6000000000000000000"))
-			.add(token("-5000000000000000000"))
-			.add(token("-4000000000000000000"))
-			.add(token("-3000000000000000000"))
-			.add(token("-2000000000000000000"))
-			.add(token("2000000000000000000"))
-			.add(token("3000000000000000000"))
-			.add(token("4000000000000000000"))
-			.add(token("5000000000000000000"))
-			.add(token("6000000000000000000"))
-			.add(token("7000000000000000000"))
-			.add(token("8000000000000000000"))
-			.add(token("9000000000000000000"))
+			.add(TOKEN01)
+			.add(TOKEN02)
+			.add(TOKEN03)
+			.add(TOKEN04)
+			.add(TOKEN05)
+			.add(TOKEN06)
+			.add(TOKEN07)
+			.add(TOKEN08)
+			.add(TOKEN12)
+			.add(TOKEN13)
+			.add(TOKEN14)
+			.add(TOKEN15)
+			.add(TOKEN16)
+			.add(TOKEN17)
+			.add(TOKEN18)
+			.add(TOKEN19)
 			.build();
 		
 		//this is to simulate when we hit the same rack in a DC first as a second replica
 		//so that'll get skipped and re-added later as a third
 		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
-			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("-8000000000000000000"), host("127.0.0.102", DC2, RACK21))
-			.put(token("-7000000000000000000"), host("127.0.0.103", DC1, RACK11))
-			.put(token("-6000000000000000000"), host("127.0.0.104", DC2, RACK21))
-			.put(token("-5000000000000000000"), host("127.0.0.105", DC1, RACK12))
-			.put(token("-4000000000000000000"), host("127.0.0.106", DC2, RACK22))
-			.put(token("-3000000000000000000"), host("127.0.0.107", DC1, RACK12))
-			.put(token("-2000000000000000000"), host("127.0.0.108", DC2, RACK22))
-			.put(token("2000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("3000000000000000000"), host("127.0.0.102", DC2, RACK21))
-			.put(token("4000000000000000000"), host("127.0.0.103", DC1, RACK11))
-			.put(token("5000000000000000000"), host("127.0.0.104", DC2, RACK21))
-			.put(token("6000000000000000000"), host("127.0.0.105", DC1, RACK12))
-			.put(token("7000000000000000000"), host("127.0.0.106", DC2, RACK22))
-			.put(token("8000000000000000000"), host("127.0.0.107", DC1, RACK12))
-			.put(token("9000000000000000000"), host("127.0.0.108", DC2, RACK22))
+			.put(TOKEN01, host(IP1, DC1, RACK11))
+			.put(TOKEN02, host(IP2, DC2, RACK21))
+			.put(TOKEN03, host(IP3, DC1, RACK11))
+			.put(TOKEN04, host(IP4, DC2, RACK21))
+			.put(TOKEN05, host(IP5, DC1, RACK12))
+			.put(TOKEN06, host(IP6, DC2, RACK22))
+			.put(TOKEN07, host(IP7, DC1, RACK12))
+			.put(TOKEN08, host(IP8, DC2, RACK22))
+			.put(TOKEN12, host(IP1, DC1, RACK11))
+			.put(TOKEN13, host(IP2, DC2, RACK21))
+			.put(TOKEN14, host(IP3, DC1, RACK11))
+			.put(TOKEN15, host(IP4, DC2, RACK21))
+			.put(TOKEN16, host(IP5, DC1, RACK12))
+			.put(TOKEN17, host(IP6, DC2, RACK22))
+			.put(TOKEN18, host(IP7, DC1, RACK12))
+			.put(TOKEN19, host(IP8, DC2, RACK22))
 			.build();
 		
 		ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 3), rf(DC2, 3));
 		
 		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
 		
-		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.105", "127.0.0.103", "127.0.0.106", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.102", "127.0.0.103", "127.0.0.105", "127.0.0.106", "127.0.0.104", "127.0.0.107");
-		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.107", "127.0.0.108");
-		assertReplicaPlacement(replicaMap, token("-6000000000000000000"), "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.108", "127.0.0.101", "127.0.0.107");
-		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.105", "127.0.0.106", "127.0.0.101", "127.0.0.107", "127.0.0.102", "127.0.0.108");
-		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.106", "127.0.0.107", "127.0.0.101", "127.0.0.102", "127.0.0.108", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.107", "127.0.0.108", "127.0.0.101", "127.0.0.102", "127.0.0.103", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-2000000000000000000"), "127.0.0.108", "127.0.0.101", "127.0.0.102", "127.0.0.104", "127.0.0.105", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("2000000000000000000"), "127.0.0.101", "127.0.0.102", "127.0.0.105", "127.0.0.103", "127.0.0.106", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.102", "127.0.0.103", "127.0.0.105", "127.0.0.106", "127.0.0.104", "127.0.0.107");
-		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.107", "127.0.0.108");
-		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.108", "127.0.0.101", "127.0.0.107");
-		assertReplicaPlacement(replicaMap, token("6000000000000000000"), "127.0.0.105", "127.0.0.106", "127.0.0.101", "127.0.0.107", "127.0.0.102", "127.0.0.108");
-		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.106", "127.0.0.107", "127.0.0.101", "127.0.0.102", "127.0.0.108", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("8000000000000000000"), "127.0.0.107", "127.0.0.108", "127.0.0.101", "127.0.0.102", "127.0.0.103", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.108", "127.0.0.101", "127.0.0.102", "127.0.0.104", "127.0.0.105", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2, IP5, IP3, IP6, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN02, IP2, IP3, IP5, IP6, IP4, IP7);
+		assertReplicaPlacement(replicaMap, TOKEN03, IP3, IP4, IP5, IP6, IP7, IP8);
+		assertReplicaPlacement(replicaMap, TOKEN04, IP4, IP5, IP6, IP8, IP1, IP7);
+		assertReplicaPlacement(replicaMap, TOKEN05, IP5, IP6, IP1, IP7, IP2, IP8);
+		assertReplicaPlacement(replicaMap, TOKEN06, IP6, IP7, IP1, IP2, IP8, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN07, IP7, IP8, IP1, IP2, IP3, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN08, IP8, IP1, IP2, IP4, IP5, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN12, IP1, IP2, IP5, IP3, IP6, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN13, IP2, IP3, IP5, IP6, IP4, IP7);
+		assertReplicaPlacement(replicaMap, TOKEN14, IP3, IP4, IP5, IP6, IP7, IP8);
+		assertReplicaPlacement(replicaMap, TOKEN15, IP4, IP5, IP6, IP8, IP1, IP7);
+		assertReplicaPlacement(replicaMap, TOKEN16, IP5, IP6, IP1, IP7, IP2, IP8);
+		assertReplicaPlacement(replicaMap, TOKEN17, IP6, IP7, IP1, IP2, IP8, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN18, IP7, IP8, IP1, IP2, IP3, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN19, IP8, IP1, IP2, IP4, IP5, IP3);
 
 	}
 	
 	@Test(groups = "unit")
 	public void networkTopologyWithMultirackHostSkippingTest2() {
 		List<Token> ring = ImmutableList.<Token>builder()
-			.add(token("-9000000000000000000"))
-			.add(token("-8000000000000000000"))
-			.add(token("-7000000000000000000"))
-			.add(token("-6000000000000000000"))
-			.add(token("-5000000000000000000"))
-			.add(token("-4000000000000000000"))
-			.add(token("-3000000000000000000"))
-			.add(token("-2000000000000000000"))
-			.add(token("2000000000000000000"))
-			.add(token("3000000000000000000"))
-			.add(token("4000000000000000000"))
-			.add(token("5000000000000000000"))
-			.add(token("6000000000000000000"))
-			.add(token("7000000000000000000"))
-			.add(token("8000000000000000000"))
-			.add(token("9000000000000000000"))
+			.add(TOKEN01)
+			.add(TOKEN02)
+			.add(TOKEN03)
+			.add(TOKEN04)
+			.add(TOKEN05)
+			.add(TOKEN06)
+			.add(TOKEN07)
+			.add(TOKEN08)
+			.add(TOKEN12)
+			.add(TOKEN13)
+			.add(TOKEN14)
+			.add(TOKEN15)
+			.add(TOKEN16)
+			.add(TOKEN17)
+			.add(TOKEN18)
+			.add(TOKEN19)
 			.build();
 		
 		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
-			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("-8000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("-7000000000000000000"), host("127.0.0.103", DC1, RACK11))
-			.put(token("-6000000000000000000"), host("127.0.0.103", DC1, RACK11))
-			.put(token("-5000000000000000000"), host("127.0.0.105", DC1, RACK12))
-			.put(token("-4000000000000000000"), host("127.0.0.105", DC1, RACK12))
-			.put(token("-3000000000000000000"), host("127.0.0.107", DC1, RACK12))
-			.put(token("-2000000000000000000"), host("127.0.0.107", DC1, RACK12))
-			.put(token("2000000000000000000"), host("127.0.0.102", DC2, RACK21))
-			.put(token("3000000000000000000"), host("127.0.0.102", DC2, RACK21))
-			.put(token("4000000000000000000"), host("127.0.0.104", DC2, RACK21))
-			.put(token("5000000000000000000"), host("127.0.0.104", DC2, RACK21))
-			.put(token("6000000000000000000"), host("127.0.0.106", DC2, RACK22))
-			.put(token("7000000000000000000"), host("127.0.0.106", DC2, RACK22))
-			.put(token("8000000000000000000"), host("127.0.0.108", DC2, RACK22))
-			.put(token("9000000000000000000"), host("127.0.0.108", DC2, RACK22))
+			.put(TOKEN01, host(IP1, DC1, RACK11))
+			.put(TOKEN02, host(IP1, DC1, RACK11))
+			.put(TOKEN03, host(IP3, DC1, RACK11))
+			.put(TOKEN04, host(IP3, DC1, RACK11))
+			.put(TOKEN05, host(IP5, DC1, RACK12))
+			.put(TOKEN06, host(IP5, DC1, RACK12))
+			.put(TOKEN07, host(IP7, DC1, RACK12))
+			.put(TOKEN08, host(IP7, DC1, RACK12))
+			.put(TOKEN12, host(IP2, DC2, RACK21))
+			.put(TOKEN13, host(IP2, DC2, RACK21))
+			.put(TOKEN14, host(IP4, DC2, RACK21))
+			.put(TOKEN15, host(IP4, DC2, RACK21))
+			.put(TOKEN16, host(IP6, DC2, RACK22))
+			.put(TOKEN17, host(IP6, DC2, RACK22))
+			.put(TOKEN18, host(IP8, DC2, RACK22))
+			.put(TOKEN19, host(IP8, DC2, RACK22))
 			.build();
 		
 		ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 3), rf(DC2, 3));
 		
 		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
 		
-		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.103", "127.0.0.105", "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-6000000000000000000"), "127.0.0.103", "127.0.0.105", "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.101", "127.0.0.107");
-		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.101", "127.0.0.107");
-		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.101", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("-2000000000000000000"), "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.101", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("2000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.101", "127.0.0.105", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.101", "127.0.0.105", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.104", "127.0.0.106", "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.104", "127.0.0.106", "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("6000000000000000000"), "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.108");
-		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.108");
-		assertReplicaPlacement(replicaMap, token("8000000000000000000"), "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP5, IP3, IP2, IP6, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN02, IP1, IP5, IP3, IP2, IP6, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN03, IP3, IP5, IP7, IP2, IP6, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN04, IP3, IP5, IP7, IP2, IP6, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN05, IP5, IP2, IP6, IP4, IP1, IP7);
+		assertReplicaPlacement(replicaMap, TOKEN06, IP5, IP2, IP6, IP4, IP1, IP7);
+		assertReplicaPlacement(replicaMap, TOKEN07, IP7, IP2, IP6, IP4, IP1, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN08, IP7, IP2, IP6, IP4, IP1, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN12, IP2, IP6, IP4, IP1, IP5, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN13, IP2, IP6, IP4, IP1, IP5, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN14, IP4, IP6, IP8, IP1, IP5, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN15, IP4, IP6, IP8, IP1, IP5, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN16, IP6, IP1, IP5, IP3, IP2, IP8);
+		assertReplicaPlacement(replicaMap, TOKEN17, IP6, IP1, IP5, IP3, IP2, IP8);
+		assertReplicaPlacement(replicaMap, TOKEN18, IP8, IP1, IP5, IP3, IP2, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN19, IP8, IP1, IP5, IP3, IP2, IP4);
 
 	}
 	
@@ -440,41 +469,41 @@ public class ReplicaMapWithNetworkTopologyStrategyTest extends AbstractReplicati
 	public void networkTopologyWithMultirackHostSkippingTest3() {
 		//this is the same topology as in the previous test, but with different rfs
 		List<Token> ring = ImmutableList.<Token>builder()
-			.add(token("-9000000000000000000"))
-			.add(token("-8000000000000000000"))
-			.add(token("-7000000000000000000"))
-			.add(token("-6000000000000000000"))
-			.add(token("-5000000000000000000"))
-			.add(token("-4000000000000000000"))
-			.add(token("-3000000000000000000"))
-			.add(token("-2000000000000000000"))
-			.add(token("2000000000000000000"))
-			.add(token("3000000000000000000"))
-			.add(token("4000000000000000000"))
-			.add(token("5000000000000000000"))
-			.add(token("6000000000000000000"))
-			.add(token("7000000000000000000"))
-			.add(token("8000000000000000000"))
-			.add(token("9000000000000000000"))
+			.add(TOKEN01)
+			.add(TOKEN02)
+			.add(TOKEN03)
+			.add(TOKEN04)
+			.add(TOKEN05)
+			.add(TOKEN06)
+			.add(TOKEN07)
+			.add(TOKEN08)
+			.add(TOKEN12)
+			.add(TOKEN13)
+			.add(TOKEN14)
+			.add(TOKEN15)
+			.add(TOKEN16)
+			.add(TOKEN17)
+			.add(TOKEN18)
+			.add(TOKEN19)
 			.build();
 		
 		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
-			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("-8000000000000000000"), host("127.0.0.101", DC1, RACK11))
-			.put(token("-7000000000000000000"), host("127.0.0.103", DC1, RACK11))
-			.put(token("-6000000000000000000"), host("127.0.0.103", DC1, RACK11))
-			.put(token("-5000000000000000000"), host("127.0.0.105", DC1, RACK12))
-			.put(token("-4000000000000000000"), host("127.0.0.105", DC1, RACK12))
-			.put(token("-3000000000000000000"), host("127.0.0.107", DC1, RACK12))
-			.put(token("-2000000000000000000"), host("127.0.0.107", DC1, RACK12))
-			.put(token("2000000000000000000"), host("127.0.0.102", DC2, RACK21))
-			.put(token("3000000000000000000"), host("127.0.0.102", DC2, RACK21))
-			.put(token("4000000000000000000"), host("127.0.0.104", DC2, RACK21))
-			.put(token("5000000000000000000"), host("127.0.0.104", DC2, RACK21))
-			.put(token("6000000000000000000"), host("127.0.0.106", DC2, RACK22))
-			.put(token("7000000000000000000"), host("127.0.0.106", DC2, RACK22))
-			.put(token("8000000000000000000"), host("127.0.0.108", DC2, RACK22))
-			.put(token("9000000000000000000"), host("127.0.0.108", DC2, RACK22))
+			.put(TOKEN01, host(IP1, DC1, RACK11))
+			.put(TOKEN02, host(IP1, DC1, RACK11))
+			.put(TOKEN03, host(IP3, DC1, RACK11))
+			.put(TOKEN04, host(IP3, DC1, RACK11))
+			.put(TOKEN05, host(IP5, DC1, RACK12))
+			.put(TOKEN06, host(IP5, DC1, RACK12))
+			.put(TOKEN07, host(IP7, DC1, RACK12))
+			.put(TOKEN08, host(IP7, DC1, RACK12))
+			.put(TOKEN12, host(IP2, DC2, RACK21))
+			.put(TOKEN13, host(IP2, DC2, RACK21))
+			.put(TOKEN14, host(IP4, DC2, RACK21))
+			.put(TOKEN15, host(IP4, DC2, RACK21))
+			.put(TOKEN16, host(IP6, DC2, RACK22))
+			.put(TOKEN17, host(IP6, DC2, RACK22))
+			.put(TOKEN18, host(IP8, DC2, RACK22))
+			.put(TOKEN19, host(IP8, DC2, RACK22))
 			.build();
 		
 		//all nodes will contain all data, question is the replica order
@@ -482,22 +511,22 @@ public class ReplicaMapWithNetworkTopologyStrategyTest extends AbstractReplicati
 		
 		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
 		
-		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107","127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108");
-		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108");
-		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.103", "127.0.0.105", "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("-6000000000000000000"), "127.0.0.103", "127.0.0.105", "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108", "127.0.0.101", "127.0.0.107", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108", "127.0.0.101", "127.0.0.107", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108", "127.0.0.101", "127.0.0.103", "127.0.0.105");
-		assertReplicaPlacement(replicaMap, token("-2000000000000000000"), "127.0.0.107", "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108", "127.0.0.101", "127.0.0.103", "127.0.0.105");
-		assertReplicaPlacement(replicaMap, token("2000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107");
-		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.104", "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107");
-		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.104", "127.0.0.106", "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.104", "127.0.0.106", "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("6000000000000000000"), "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107", "127.0.0.102", "127.0.0.108", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107", "127.0.0.102", "127.0.0.108", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("8000000000000000000"), "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107", "127.0.0.102", "127.0.0.104", "127.0.0.106");
-		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.108", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.107", "127.0.0.102", "127.0.0.104", "127.0.0.106");
+		assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP5, IP3, IP7, IP2, IP6, IP4, IP8);
+		assertReplicaPlacement(replicaMap, TOKEN02, IP1, IP5, IP3, IP7, IP2, IP6, IP4, IP8);
+		assertReplicaPlacement(replicaMap, TOKEN03, IP3, IP5, IP7, IP2, IP6, IP4, IP8, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN04, IP3, IP5, IP7, IP2, IP6, IP4, IP8, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN05, IP5, IP2, IP6, IP4, IP8, IP1, IP7, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN06, IP5, IP2, IP6, IP4, IP8, IP1, IP7, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN07, IP7, IP2, IP6, IP4, IP8, IP1, IP3, IP5);
+		assertReplicaPlacement(replicaMap, TOKEN08, IP7, IP2, IP6, IP4, IP8, IP1, IP3, IP5);
+		assertReplicaPlacement(replicaMap, TOKEN12, IP2, IP6, IP4, IP8, IP1, IP5, IP3, IP7);
+		assertReplicaPlacement(replicaMap, TOKEN13, IP2, IP6, IP4, IP8, IP1, IP5, IP3, IP7);
+		assertReplicaPlacement(replicaMap, TOKEN14, IP4, IP6, IP8, IP1, IP5, IP3, IP7, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN15, IP4, IP6, IP8, IP1, IP5, IP3, IP7, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN16, IP6, IP1, IP5, IP3, IP7, IP2, IP8, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN17, IP6, IP1, IP5, IP3, IP7, IP2, IP8, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN18, IP8, IP1, IP5, IP3, IP7, IP2, IP4, IP6);
+		assertReplicaPlacement(replicaMap, TOKEN19, IP8, IP1, IP5, IP3, IP7, IP2, IP4, IP6);
 
 	}
 	
@@ -506,47 +535,47 @@ public class ReplicaMapWithNetworkTopologyStrategyTest extends AbstractReplicati
 		Map<Token, Set<Host>> replicaMap = exampleStrategy.computeTokenToReplicaMap(exampleTokenToPrimary, exampleRing);
 		
 		//105 and 106 will appear as replica for all as they're in separate racks
-		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.102", "127.0.0.106");
-		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.102", "127.0.0.106");
-		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.106");
-		assertReplicaPlacement(replicaMap, token("-6000000000000000000"), "127.0.0.103", "127.0.0.105", "127.0.0.102", "127.0.0.106");
-		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.102", "127.0.0.106");
-		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.105");
-		assertReplicaPlacement(replicaMap, token("-2000000000000000000"), "127.0.0.106", "127.0.0.103", "127.0.0.104", "127.0.0.105");
-		assertReplicaPlacement(replicaMap, token("-1000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.106");
-		assertReplicaPlacement(replicaMap, token("0"),                    "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("1000000000000000000"), "127.0.0.105", "127.0.0.104", "127.0.0.106", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("2000000000000000000"), "127.0.0.104", "127.0.0.106", "127.0.0.103", "127.0.0.105");
-		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.104", "127.0.0.106", "127.0.0.103", "127.0.0.105");
-		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.105");
-		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.106", "127.0.0.103", "127.0.0.102", "127.0.0.105");
-		assertReplicaPlacement(replicaMap, token("6000000000000000000"), "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.105");
-		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.101", "127.0.0.105");
-		assertReplicaPlacement(replicaMap, token("8000000000000000000"), "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP5, IP2, IP6);
+		assertReplicaPlacement(replicaMap, TOKEN02, IP1, IP5, IP2, IP6);
+		assertReplicaPlacement(replicaMap, TOKEN03, IP5, IP3, IP2, IP6);
+		assertReplicaPlacement(replicaMap, TOKEN04, IP3, IP5, IP2, IP6);
+		assertReplicaPlacement(replicaMap, TOKEN05, IP1, IP5, IP2, IP6);
+		assertReplicaPlacement(replicaMap, TOKEN06, IP5, IP2, IP6, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN07, IP2, IP6, IP3, IP5);
+		assertReplicaPlacement(replicaMap, TOKEN08, IP6, IP3, IP4, IP5);
+		assertReplicaPlacement(replicaMap, TOKEN09, IP3, IP4, IP5, IP6);
+		assertReplicaPlacement(replicaMap, TOKEN10, IP4, IP5, IP6, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN11, IP5, IP4, IP6, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN12, IP4, IP6, IP3, IP5);
+		assertReplicaPlacement(replicaMap, TOKEN13, IP4, IP6, IP3, IP5);
+		assertReplicaPlacement(replicaMap, TOKEN14, IP2, IP6, IP3, IP5);
+		assertReplicaPlacement(replicaMap, TOKEN15, IP6, IP3, IP2, IP5);
+		assertReplicaPlacement(replicaMap, TOKEN16, IP3, IP2, IP6, IP5);
+		assertReplicaPlacement(replicaMap, TOKEN17, IP2, IP6, IP1, IP5);
+		assertReplicaPlacement(replicaMap, TOKEN18, IP6, IP1, IP5, IP2);
 	}
 	
 	@Test(groups = "unit")
 	public void networkTopologyStrategyExampleTopologyTooManyReplicasTest() {
 		Map<Token, Set<Host>> replicaMap = exampleStrategyTooManyReplicas.computeTokenToReplicaMap(exampleTokenToPrimary, exampleRing);
 		
-		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.105", "127.0.0.103", "127.0.0.101", "127.0.0.102", "127.0.0.106", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-6000000000000000000"), "127.0.0.103", "127.0.0.105", "127.0.0.101", "127.0.0.102", "127.0.0.106", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.104", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("-2000000000000000000"), "127.0.0.106", "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.102", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("-1000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.102", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("0"),                    "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.102", "127.0.0.103", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("1000000000000000000"), "127.0.0.105", "127.0.0.104", "127.0.0.106", "127.0.0.102", "127.0.0.103", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("2000000000000000000"), "127.0.0.104", "127.0.0.106", "127.0.0.102", "127.0.0.103", "127.0.0.105", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.104", "127.0.0.106", "127.0.0.102", "127.0.0.103", "127.0.0.105", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.105", "127.0.0.101", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.106", "127.0.0.103", "127.0.0.102", "127.0.0.105", "127.0.0.101", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("6000000000000000000"), "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.105", "127.0.0.101", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("8000000000000000000"), "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP5, IP3, IP2, IP6, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN02, IP1, IP5, IP3, IP2, IP6, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN03, IP5, IP3, IP1, IP2, IP6, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN04, IP3, IP5, IP1, IP2, IP6, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN05, IP1, IP5, IP2, IP6, IP3, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN06, IP5, IP2, IP6, IP3, IP4, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN07, IP2, IP6, IP3, IP4, IP5, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN08, IP6, IP3, IP4, IP5, IP2, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN09, IP3, IP4, IP5, IP6, IP2, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN10, IP4, IP5, IP6, IP2, IP3, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN11, IP5, IP4, IP6, IP2, IP3, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN12, IP4, IP6, IP2, IP3, IP5, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN13, IP4, IP6, IP2, IP3, IP5, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN14, IP2, IP6, IP3, IP5, IP1, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN15, IP6, IP3, IP2, IP5, IP1, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN16, IP3, IP2, IP6, IP5, IP1, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN17, IP2, IP6, IP1, IP5, IP3, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN18, IP6, IP1, IP5, IP3, IP2, IP4);
 	}
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/ReplicaMapWithNetworkTopologyStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReplicaMapWithNetworkTopologyStrategyTest.java
@@ -1,0 +1,138 @@
+package com.datastax.driver.core;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class ReplicaMapWithNetworkTopologyStrategyTest extends AbstractReplicationStrategyTest {
+	/*
+	 * ---------------------------------------------------------------------------
+	 * Ring, replication, etc... setup. These are reusable for the tests
+	 * ---------------------------------------------------------------------------
+	 */
+	private static final String DC1 = "DC1";
+	private static final String DC2 = "DC2";
+	private static final String RACK11 = "RACK11";
+	private static final String RACK12 = "RACK12";
+	private static final String RACK21 = "RACK21";
+	private static final String RACK22 = "RACK22";
+	
+	private static final Map<String, String> replicationOptions = ImmutableMap.<String, String>builder()//
+			.put("class", "NetworkTopologyStrategy")//
+			.put(DC1, "2")//
+			.put(DC2, "2")//
+			.build();
+	
+	//this will be used in scenarios where there are more replicas specified in strategy than available nodes
+	private static final Map<String, String> replicationOptionsTooManyReplicas = ImmutableMap.<String, String>builder()//
+			.put("class", "NetworkTopologyStrategy")//
+			.put(DC1, "4")//
+			.put(DC2, "4")//
+			.build();
+	
+	private static final ReplicationStrategy strategy = ReplicationStrategy.create(replicationOptions);
+	
+	private static final ReplicationStrategy strategyTooManyReplicas = ReplicationStrategy.create(replicationOptionsTooManyReplicas);
+
+	private static final List<Token> ring = ImmutableList.<Token>builder()
+			.add(token("-9000000000000000000"))//
+			.add(token("-8000000000000000000"))// 
+			.add(token("-7000000000000000000"))//
+			.add(token("-6000000000000000000"))//
+			.add(token("-5000000000000000000"))//
+			.add(token("-4000000000000000000"))//
+			.add(token("-3000000000000000000"))//
+			.add(token("-2000000000000000000"))//
+			.add(token("-1000000000000000000"))//
+			.add(token("0"))//
+			.add(token("1000000000000000000"))//
+			.add(token("2000000000000000000"))//
+			.add(token("3000000000000000000"))//
+			.add(token("4000000000000000000"))//
+			.add(token("5000000000000000000"))//
+			.add(token("6000000000000000000"))//
+			.add(token("7000000000000000000"))//
+			.add(token("8000000000000000000"))//
+			.build();
+	
+	private static final Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
+			.put(token("-9000000000000000000"), host("127.0.0.101", DC1, RACK11))//
+			.put(token("-8000000000000000000"), host("127.0.0.101", DC1, RACK11))//
+			.put(token("-7000000000000000000"), host("127.0.0.105", DC1, RACK12))//
+			.put(token("-6000000000000000000"), host("127.0.0.103", DC1, RACK11))//
+			.put(token("-5000000000000000000"), host("127.0.0.101", DC1, RACK11))//
+			.put(token("-4000000000000000000"), host("127.0.0.105", DC1, RACK12))//
+			.put(token("-3000000000000000000"), host("127.0.0.102", DC2, RACK21))//
+			.put(token("-2000000000000000000"), host("127.0.0.106", DC2, RACK22))//
+			.put(token("-1000000000000000000"), host("127.0.0.103", DC1, RACK11))//
+			.put(token("0"),                    host("127.0.0.104", DC2, RACK21))//
+			.put(token("1000000000000000000"), host("127.0.0.105", DC1, RACK12))//
+			.put(token("2000000000000000000"), host("127.0.0.104", DC2, RACK21))//
+			.put(token("3000000000000000000"), host("127.0.0.104", DC2, RACK21))//
+			.put(token("4000000000000000000"), host("127.0.0.102", DC2, RACK21))//
+			.put(token("5000000000000000000"), host("127.0.0.106", DC2, RACK22))//
+			.put(token("6000000000000000000"), host("127.0.0.103", DC1, RACK11))//
+			.put(token("7000000000000000000"), host("127.0.0.102", DC2, RACK21))//
+			.put(token("8000000000000000000"), host("127.0.0.106", DC2, RACK22))//
+			.build();
+	
+	/*
+	 * --------------
+	 *     Tests
+	 * --------------
+	 */
+	
+	@Test(groups = "unit")
+	public void networkTopologyStrategyMapTest() {
+		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+		
+		//105 and 106 will appear as replica for all as they're in separate racks
+		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.102", "127.0.0.106");
+		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.102", "127.0.0.106");
+		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.106");
+		assertReplicaPlacement(replicaMap, token("-6000000000000000000"), "127.0.0.103", "127.0.0.105", "127.0.0.102", "127.0.0.106");
+		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.102", "127.0.0.106");
+		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, token("-2000000000000000000"), "127.0.0.106", "127.0.0.103", "127.0.0.104", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, token("-1000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.106");
+		assertReplicaPlacement(replicaMap, token("0"),                    "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("1000000000000000000"), "127.0.0.105", "127.0.0.104", "127.0.0.106", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("2000000000000000000"), "127.0.0.104", "127.0.0.106", "127.0.0.103", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.104", "127.0.0.106", "127.0.0.103", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.106", "127.0.0.103", "127.0.0.102", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, token("6000000000000000000"), "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.101", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, token("8000000000000000000"), "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.102");
+	}
+	
+	@Test(groups = "unit")
+	public void networkTopologyStrategyMapTooManyReplicasTest() {
+		Map<Token, Set<Host>> replicaMap = strategyTooManyReplicas.computeTokenToReplicaMap(tokenToPrimary, ring);
+		
+		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.105", "127.0.0.103", "127.0.0.101", "127.0.0.102", "127.0.0.106", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-6000000000000000000"), "127.0.0.103", "127.0.0.105", "127.0.0.101", "127.0.0.102", "127.0.0.106", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.104", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("-2000000000000000000"), "127.0.0.106", "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.102", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("-1000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.102", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("0"),                    "127.0.0.104", "127.0.0.105", "127.0.0.106", "127.0.0.102", "127.0.0.103", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("1000000000000000000"), "127.0.0.105", "127.0.0.104", "127.0.0.106", "127.0.0.102", "127.0.0.103", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("2000000000000000000"), "127.0.0.104", "127.0.0.106", "127.0.0.102", "127.0.0.103", "127.0.0.105", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.104", "127.0.0.106", "127.0.0.102", "127.0.0.103", "127.0.0.105", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.105", "127.0.0.101", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.106", "127.0.0.103", "127.0.0.102", "127.0.0.105", "127.0.0.101", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("6000000000000000000"), "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.105", "127.0.0.101", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("8000000000000000000"), "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.104");
+	}
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/ReplicaMapWithSimpleStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReplicaMapWithSimpleStrategyTest.java
@@ -1,0 +1,129 @@
+package com.datastax.driver.core;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class ReplicaMapWithSimpleStrategyTest extends AbstractReplicationStrategyTest {
+
+	/*
+	 * ---------------------------------------------------------------------------
+	 * Ring, replication, etc... setup. These are reusable for the tests
+	 * ---------------------------------------------------------------------------
+	 */
+	
+	private static final Map<String, String> replicationOptions = ImmutableMap.<String, String>builder()//
+			.put("class", "SimpleStrategy")//
+			.put("replication_factor", "3")//
+			.build();
+	
+	private static final Map<String, String> replicationOptionsTooManyReplicas = ImmutableMap.<String, String>builder()//
+			.put("class", "SimpleStrategy")//
+			.put("replication_factor", "8")//
+			.build();
+	
+	private static final ReplicationStrategy strategy = ReplicationStrategy.create(replicationOptions);
+	
+	private static final ReplicationStrategy strategyTooManyReplicas = ReplicationStrategy.create(replicationOptionsTooManyReplicas);
+
+	private static final List<Token> ring = ImmutableList.<Token>builder()
+			.add(token("-9000000000000000000"))//
+			.add(token("-8000000000000000000"))// 
+			.add(token("-7000000000000000000"))//
+			.add(token("-6000000000000000000"))//
+			.add(token("-5000000000000000000"))//
+			.add(token("-4000000000000000000"))//
+			.add(token("-3000000000000000000"))//
+			.add(token("-2000000000000000000"))//
+			.add(token("-1000000000000000000"))//
+			.add(token("0"))//
+			.add(token("1000000000000000000"))//
+			.add(token("2000000000000000000"))//
+			.add(token("3000000000000000000"))//
+			.add(token("4000000000000000000"))//
+			.add(token("5000000000000000000"))//
+			.add(token("6000000000000000000"))//
+			.add(token("7000000000000000000"))//
+			.add(token("8000000000000000000"))//
+			.build();
+	
+	private static final Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
+			.put(token("-9000000000000000000"), host("127.0.0.101"))//
+			.put(token("-8000000000000000000"), host("127.0.0.101"))//
+			.put(token("-7000000000000000000"), host("127.0.0.105"))//
+			.put(token("-6000000000000000000"), host("127.0.0.103"))//
+			.put(token("-5000000000000000000"), host("127.0.0.101"))//
+			.put(token("-4000000000000000000"), host("127.0.0.105"))//
+			.put(token("-3000000000000000000"), host("127.0.0.102"))//
+			.put(token("-2000000000000000000"), host("127.0.0.106"))//
+			.put(token("-1000000000000000000"), host("127.0.0.103"))//
+			.put(token("0"),                    host("127.0.0.104"))//
+			.put(token("1000000000000000000"), host("127.0.0.105"))//
+			.put(token("2000000000000000000"), host("127.0.0.104"))//
+			.put(token("3000000000000000000"), host("127.0.0.104"))//
+			.put(token("4000000000000000000"), host("127.0.0.102"))//
+			.put(token("5000000000000000000"), host("127.0.0.106"))//
+			.put(token("6000000000000000000"), host("127.0.0.103"))//
+			.put(token("7000000000000000000"), host("127.0.0.102"))//
+			.put(token("8000000000000000000"), host("127.0.0.106"))//
+			.build();
+	
+	/*
+	 * --------------
+	 *     Tests
+	 * --------------
+	 */
+	
+	@Test(groups = "unit")
+	public void simpleStrategyReplicaMapTest() {
+		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+		
+		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.105", "127.0.0.103", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("-6000000000000000000"), "127.0.0.103", "127.0.0.101", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.105", "127.0.0.102", "127.0.0.106");
+		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("-2000000000000000000"), "127.0.0.106", "127.0.0.103", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-1000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, token("0"),                    "127.0.0.104", "127.0.0.105", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, token("1000000000000000000"), "127.0.0.105", "127.0.0.104", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, token("2000000000000000000"), "127.0.0.104", "127.0.0.102", "127.0.0.106");
+		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.104", "127.0.0.102", "127.0.0.106");
+		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.103");
+		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.106", "127.0.0.103", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, token("6000000000000000000"), "127.0.0.103", "127.0.0.102", "127.0.0.106");
+		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("8000000000000000000"), "127.0.0.106", "127.0.0.101", "127.0.0.105");
+	}
+	
+	@Test(groups = "unit")
+	public void simpleStrategyMapTooManyReplicasTest() {
+		Map<Token, Set<Host>> replicaMap = strategyTooManyReplicas.computeTokenToReplicaMap(tokenToPrimary, ring);
+		
+		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.105", "127.0.0.103", "127.0.0.101", "127.0.0.102", "127.0.0.106", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-6000000000000000000"), "127.0.0.103", "127.0.0.101", "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.104", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("-2000000000000000000"), "127.0.0.106", "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.102", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("-1000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("0"),                    "127.0.0.104", "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("1000000000000000000"), "127.0.0.105", "127.0.0.104", "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, token("2000000000000000000"), "127.0.0.104", "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.101", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.104", "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.101", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.101", "127.0.0.105", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.106", "127.0.0.103", "127.0.0.102", "127.0.0.101", "127.0.0.105", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("6000000000000000000"), "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, token("8000000000000000000"), "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.104");
+	}
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/ReplicaMapWithSimpleStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReplicaMapWithSimpleStrategyTest.java
@@ -26,50 +26,77 @@ public class ReplicaMapWithSimpleStrategyTest extends AbstractReplicationStrateg
 	 * ---------------------------------------------------------------------------
 	 */
 	
+	private static final Token TOKEN01 = token("-9000000000000000000");
+	private static final Token TOKEN02 = token("-8000000000000000000");
+	private static final Token TOKEN03 = token("-7000000000000000000");
+	private static final Token TOKEN04 = token("-6000000000000000000");
+	private static final Token TOKEN05 = token("-5000000000000000000");
+	private static final Token TOKEN06 = token("-4000000000000000000");
+	private static final Token TOKEN07 = token("-3000000000000000000");
+	private static final Token TOKEN08 = token("-2000000000000000000");
+	private static final Token TOKEN09 = token("-1000000000000000000");
+	private static final Token TOKEN10 = token("0");
+	private static final Token TOKEN11 = token("1000000000000000000");
+	private static final Token TOKEN12 = token("2000000000000000000");
+	private static final Token TOKEN13 = token("3000000000000000000");
+	private static final Token TOKEN14 = token("4000000000000000000");
+	private static final Token TOKEN15 = token("5000000000000000000");
+	private static final Token TOKEN16 = token("6000000000000000000");
+	private static final Token TOKEN17 = token("7000000000000000000");
+	private static final Token TOKEN18 = token("8000000000000000000");
+	private static final Token TOKEN19 = token("9000000000000000000");
+	
+	private static final String IP1 = "127.0.0.101";
+	private static final String IP2 = "127.0.0.102";
+	private static final String IP3 = "127.0.0.103";
+	private static final String IP4 = "127.0.0.104";
+	private static final String IP5 = "127.0.0.105";
+	private static final String IP6 = "127.0.0.106";
+	
 	private static final ReplicationStrategy exampleStrategy = simpleStrategy(3);
 	
 	private static final ReplicationStrategy exampleStrategyTooManyReplicas = simpleStrategy(8);
 
 	private static final List<Token> exampleRing = ImmutableList.<Token>builder()
-			.add(token("-9000000000000000000"))//
-			.add(token("-8000000000000000000"))// 
-			.add(token("-7000000000000000000"))//
-			.add(token("-6000000000000000000"))//
-			.add(token("-5000000000000000000"))//
-			.add(token("-4000000000000000000"))//
-			.add(token("-3000000000000000000"))//
-			.add(token("-2000000000000000000"))//
-			.add(token("-1000000000000000000"))//
-			.add(token("0"))//
-			.add(token("1000000000000000000"))//
-			.add(token("2000000000000000000"))//
-			.add(token("3000000000000000000"))//
-			.add(token("4000000000000000000"))//
-			.add(token("5000000000000000000"))//
-			.add(token("6000000000000000000"))//
-			.add(token("7000000000000000000"))//
-			.add(token("8000000000000000000"))//
+			.add(TOKEN01)//
+			.add(TOKEN02)// 
+			.add(TOKEN03)//
+			.add(TOKEN04)//
+			.add(TOKEN05)//
+			.add(TOKEN06)//
+			.add(TOKEN07)//
+			.add(TOKEN08)//
+			.add(TOKEN09)//
+			.add(TOKEN10)//
+			.add(TOKEN11)//
+			.add(TOKEN12)//
+			.add(TOKEN13)//
+			.add(TOKEN14)//
+			.add(TOKEN15)//
+			.add(TOKEN16)//
+			.add(TOKEN17)//
+			.add(TOKEN18)//
 			.build();
 	
 	private static final Map<Token, Host> exampleTokenToPrimary = ImmutableMap.<Token, Host>builder()
-			.put(token("-9000000000000000000"), host("127.0.0.101"))//
-			.put(token("-8000000000000000000"), host("127.0.0.101"))//
-			.put(token("-7000000000000000000"), host("127.0.0.105"))//
-			.put(token("-6000000000000000000"), host("127.0.0.103"))//
-			.put(token("-5000000000000000000"), host("127.0.0.101"))//
-			.put(token("-4000000000000000000"), host("127.0.0.105"))//
-			.put(token("-3000000000000000000"), host("127.0.0.102"))//
-			.put(token("-2000000000000000000"), host("127.0.0.106"))//
-			.put(token("-1000000000000000000"), host("127.0.0.103"))//
-			.put(token("0"),                    host("127.0.0.104"))//
-			.put(token("1000000000000000000"), host("127.0.0.105"))//
-			.put(token("2000000000000000000"), host("127.0.0.104"))//
-			.put(token("3000000000000000000"), host("127.0.0.104"))//
-			.put(token("4000000000000000000"), host("127.0.0.102"))//
-			.put(token("5000000000000000000"), host("127.0.0.106"))//
-			.put(token("6000000000000000000"), host("127.0.0.103"))//
-			.put(token("7000000000000000000"), host("127.0.0.102"))//
-			.put(token("8000000000000000000"), host("127.0.0.106"))//
+			.put(TOKEN01, host(IP1))//
+			.put(TOKEN02, host(IP1))//
+			.put(TOKEN03, host(IP5))//
+			.put(TOKEN04, host(IP3))//
+			.put(TOKEN05, host(IP1))//
+			.put(TOKEN06, host(IP5))//
+			.put(TOKEN07, host(IP2))//
+			.put(TOKEN08, host(IP6))//
+			.put(TOKEN09, host(IP3))//
+			.put(TOKEN10, host(IP4))//
+			.put(TOKEN11, host(IP5))//
+			.put(TOKEN12, host(IP4))//
+			.put(TOKEN13, host(IP4))//
+			.put(TOKEN14, host(IP2))//
+			.put(TOKEN15, host(IP6))//
+			.put(TOKEN16, host(IP3))//
+			.put(TOKEN17, host(IP2))//
+			.put(TOKEN18, host(IP6))//
 			.build();
 	
 	/*
@@ -81,126 +108,126 @@ public class ReplicaMapWithSimpleStrategyTest extends AbstractReplicationStrateg
 	@Test(groups = "unit")
 	public void simpleStrategySimpleTopologyTest() {
 		List<Token> ring = ImmutableList.<Token>builder()
-			.add(token("-9000000000000000000"))
-			.add(token("-4000000000000000000"))
-			.add(token("4000000000000000000"))
-			.add(token("9000000000000000000"))
+			.add(TOKEN01)
+			.add(TOKEN06)
+			.add(TOKEN14)
+			.add(TOKEN19)
 			.build();
 		
 		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
-			.put(token("-9000000000000000000"), host("127.0.0.101"))
-			.put(token("-4000000000000000000"), host("127.0.0.102"))
-			.put(token("4000000000000000000"), host("127.0.0.101"))
-			.put(token("9000000000000000000"), host("127.0.0.102"))
+			.put(TOKEN01, host(IP1))
+			.put(TOKEN06, host(IP2))
+			.put(TOKEN14, host(IP1))
+			.put(TOKEN19, host(IP2))
 			.build();
 		
 		ReplicationStrategy strategy = simpleStrategy(2);
 		
 		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
 		
-		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.102", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.101", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.102", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN06, IP2, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN14, IP1, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN19, IP2, IP1);
 	}
 	
 	@Test(groups = "unit")
 	public void simpleStrategyConsecutiveRingSectionsTest() {
 		List<Token> ring = ImmutableList.<Token>builder()
-			.add(token("-9000000000000000000"))
-			.add(token("-4000000000000000000"))
-			.add(token("4000000000000000000"))
-			.add(token("9000000000000000000"))
+			.add(TOKEN01)
+			.add(TOKEN06)
+			.add(TOKEN14)
+			.add(TOKEN19)
 			.build();
 		
 		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
-			.put(token("-9000000000000000000"), host("127.0.0.101"))
-			.put(token("-4000000000000000000"), host("127.0.0.101"))
-			.put(token("4000000000000000000"), host("127.0.0.102"))
-			.put(token("9000000000000000000"), host("127.0.0.102"))
+			.put(TOKEN01, host(IP1))
+			.put(TOKEN06, host(IP1))
+			.put(TOKEN14, host(IP2))
+			.put(TOKEN19, host(IP2))
 			.build();
 		
 		ReplicationStrategy strategy = simpleStrategy(2);
 		
 		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
 		
-		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.101", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.102", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.102", "127.0.0.101");
+		assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN06, IP1, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN14, IP2, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN19, IP2, IP1);
 	}
 	
 	@Test(groups = "unit")
 	public void simpleStrategyUnbalancedRingTest() {
 		List<Token> ring = ImmutableList.<Token>builder()
-			.add(token("-9000000000000000000"))
-			.add(token("-4000000000000000000"))
-			.add(token("4000000000000000000"))
-			.add(token("9000000000000000000"))
+			.add(TOKEN01)
+			.add(TOKEN06)
+			.add(TOKEN14)
+			.add(TOKEN19)
 			.build();
 		
 		Map<Token, Host> tokenToPrimary = ImmutableMap.<Token, Host>builder()
-			.put(token("-9000000000000000000"), host("127.0.0.101"))
-			.put(token("-4000000000000000000"), host("127.0.0.101"))
-			.put(token("4000000000000000000"), host("127.0.0.102"))
-			.put(token("9000000000000000000"), host("127.0.0.101"))
+			.put(TOKEN01, host(IP1))
+			.put(TOKEN06, host(IP1))
+			.put(TOKEN14, host(IP2))
+			.put(TOKEN19, host(IP1))
 			.build();
 		
 		ReplicationStrategy strategy = simpleStrategy(2);
 		
 		Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
 		
-		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.101", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.102", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("9000000000000000000"), "127.0.0.101", "127.0.0.102");
+		assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN06, IP1, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN14, IP2, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN19, IP1, IP2);
 	}
 	
 	@Test(groups = "unit")
 	public void simpleStrategyExampleTopologyMapTest() {
 		Map<Token, Set<Host>> replicaMap = exampleStrategy.computeTokenToReplicaMap(exampleTokenToPrimary, exampleRing);
 		
-		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.105", "127.0.0.103", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("-6000000000000000000"), "127.0.0.103", "127.0.0.101", "127.0.0.105");
-		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.105", "127.0.0.102", "127.0.0.106");
-		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("-2000000000000000000"), "127.0.0.106", "127.0.0.103", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-1000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.105");
-		assertReplicaPlacement(replicaMap, token("0"),                    "127.0.0.104", "127.0.0.105", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("1000000000000000000"), "127.0.0.105", "127.0.0.104", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("2000000000000000000"), "127.0.0.104", "127.0.0.102", "127.0.0.106");
-		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.104", "127.0.0.102", "127.0.0.106");
-		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.103");
-		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.106", "127.0.0.103", "127.0.0.102");
-		assertReplicaPlacement(replicaMap, token("6000000000000000000"), "127.0.0.103", "127.0.0.102", "127.0.0.106");
-		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("8000000000000000000"), "127.0.0.106", "127.0.0.101", "127.0.0.105");
+		assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP5, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN02, IP1, IP5, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN03, IP5, IP3, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN04, IP3, IP1, IP5);
+		assertReplicaPlacement(replicaMap, TOKEN05, IP1, IP5, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN06, IP5, IP2, IP6);
+		assertReplicaPlacement(replicaMap, TOKEN07, IP2, IP6, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN08, IP6, IP3, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN09, IP3, IP4, IP5);
+		assertReplicaPlacement(replicaMap, TOKEN10, IP4, IP5, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN11, IP5, IP4, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN12, IP4, IP2, IP6);
+		assertReplicaPlacement(replicaMap, TOKEN13, IP4, IP2, IP6);
+		assertReplicaPlacement(replicaMap, TOKEN14, IP2, IP6, IP3);
+		assertReplicaPlacement(replicaMap, TOKEN15, IP6, IP3, IP2);
+		assertReplicaPlacement(replicaMap, TOKEN16, IP3, IP2, IP6);
+		assertReplicaPlacement(replicaMap, TOKEN17, IP2, IP6, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN18, IP6, IP1, IP5);
 	}
 	
 	@Test(groups = "unit")
 	public void simpleStrategyExampleTopologyTooManyReplicasTest() {
 		Map<Token, Set<Host>> replicaMap = exampleStrategyTooManyReplicas.computeTokenToReplicaMap(exampleTokenToPrimary, exampleRing);
 		
-		assertReplicaPlacement(replicaMap, token("-9000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-8000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-7000000000000000000"), "127.0.0.105", "127.0.0.103", "127.0.0.101", "127.0.0.102", "127.0.0.106", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-6000000000000000000"), "127.0.0.103", "127.0.0.101", "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-5000000000000000000"), "127.0.0.101", "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("-4000000000000000000"), "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.104", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("-3000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("-2000000000000000000"), "127.0.0.106", "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.102", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("-1000000000000000000"), "127.0.0.103", "127.0.0.104", "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("0"),                    "127.0.0.104", "127.0.0.105", "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("1000000000000000000"), "127.0.0.105", "127.0.0.104", "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.101");
-		assertReplicaPlacement(replicaMap, token("2000000000000000000"), "127.0.0.104", "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.101", "127.0.0.105");
-		assertReplicaPlacement(replicaMap, token("3000000000000000000"), "127.0.0.104", "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.101", "127.0.0.105");
-		assertReplicaPlacement(replicaMap, token("4000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.103", "127.0.0.101", "127.0.0.105", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("5000000000000000000"), "127.0.0.106", "127.0.0.103", "127.0.0.102", "127.0.0.101", "127.0.0.105", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("6000000000000000000"), "127.0.0.103", "127.0.0.102", "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("7000000000000000000"), "127.0.0.102", "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.104");
-		assertReplicaPlacement(replicaMap, token("8000000000000000000"), "127.0.0.106", "127.0.0.101", "127.0.0.105", "127.0.0.103", "127.0.0.102", "127.0.0.104");
+		assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP5, IP3, IP2, IP6, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN02, IP1, IP5, IP3, IP2, IP6, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN03, IP5, IP3, IP1, IP2, IP6, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN04, IP3, IP1, IP5, IP2, IP6, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN05, IP1, IP5, IP2, IP6, IP3, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN06, IP5, IP2, IP6, IP3, IP4, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN07, IP2, IP6, IP3, IP4, IP5, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN08, IP6, IP3, IP4, IP5, IP2, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN09, IP3, IP4, IP5, IP2, IP6, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN10, IP4, IP5, IP2, IP6, IP3, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN11, IP5, IP4, IP2, IP6, IP3, IP1);
+		assertReplicaPlacement(replicaMap, TOKEN12, IP4, IP2, IP6, IP3, IP1, IP5);
+		assertReplicaPlacement(replicaMap, TOKEN13, IP4, IP2, IP6, IP3, IP1, IP5);
+		assertReplicaPlacement(replicaMap, TOKEN14, IP2, IP6, IP3, IP1, IP5, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN15, IP6, IP3, IP2, IP1, IP5, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN16, IP3, IP2, IP6, IP1, IP5, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN17, IP2, IP6, IP1, IP5, IP3, IP4);
+		assertReplicaPlacement(replicaMap, TOKEN18, IP6, IP1, IP5, IP3, IP2, IP4);
 	}
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/ReplicationStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReplicationStrategyTest.java
@@ -1,0 +1,77 @@
+package com.datastax.driver.core;
+
+import static org.testng.Assert.*;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+public class ReplicationStrategyTest {
+
+	/*
+	 * these should result in a correct strategy being created
+	 */
+	
+	@Test(groups = "unit")
+	public void createSimpleReplicationStrategyTest() throws Exception {
+		ReplicationStrategy strategy = ReplicationStrategy.create(
+			ImmutableMap.<String, String>builder()
+				.put("class", "SimpleStrategy")
+				.put("replication_factor", "3")
+				.build());
+		
+		assertNotNull(strategy);
+		assertTrue(strategy instanceof ReplicationStrategy.SimpleStrategy);
+	}
+	
+	@Test(groups = "unit")
+	public void createNetworkTopologyStrategyTest() throws Exception {
+		ReplicationStrategy strategy = ReplicationStrategy.create(
+			ImmutableMap.<String, String>builder()
+				.put("class", "NetworkTopologyStrategy")
+				.put("dc1", "2")
+				.put("dc2", "2")
+				.build());
+		
+		assertNotNull(strategy);
+		assertTrue(strategy instanceof ReplicationStrategy.NetworkTopologyStrategy);
+	}
+	
+	/*
+	 * if the parameters are incorrect/missing, null is expected 
+	 */
+	
+	@Test(groups = "unit")
+	public void createSimpleReplicationStrategyWithoutFactorTest() throws Exception {
+		ReplicationStrategy strategy = ReplicationStrategy.create(
+			ImmutableMap.<String, String>builder()
+				.put("class", "SimpleStrategy")
+				//no replication_factor
+				.build());
+		
+		assertNull(strategy);
+	}
+	
+	@Test(groups = "unit")
+	public void createUnknownStrategyTest() throws Exception {
+		ReplicationStrategy strategy = ReplicationStrategy.create(
+			ImmutableMap.<String, String>builder()
+				//no such strategy
+				.put("class", "FooStrategy") 
+				.put("foo_factor", "3")
+				.build());
+		
+		assertNull(strategy);
+	}
+	
+	@Test(groups = "unit")
+	public void createUnspecifiedStrategyTest() throws Exception {
+		ReplicationStrategy strategy = ReplicationStrategy.create(
+			ImmutableMap.<String, String>builder()
+				//nothing useful is set
+				.put("foo", "bar")
+				.build());
+		
+		assertNull(strategy);
+	}
+}


### PR DESCRIPTION
Current implementation of ReplicationStrategy in 2.0 branch is incorrect
 (1) does not correctly recognize NetworkTopologyStrategy
 (2) SimpleStrategy does not find all replicas when nodes are handling consecutive token segments (e.g. ring looks like node1, node1, node2...)
 (3) current implementation (that is actually never used because of (1)) of NetworkTopologyStrategy does not reflect the 2.0.x Cassandra server's implementation: rack placement is not considered. Additionally current implementation always yields replicas from the start of the ring and has the same problem as SimpleStrategy (2)

These issues result in Metadata.getReplicas not returning all replicas or returning incorrect ones and TokenAwarePolicy not always routing to the replica nodes when the keyspace is using NetworkTopologyStrategy (i.e. no optimization happens compared to DCAwareRoundRobinPolicy).

This request fixes the issues listed above and adds unit tests to cover this functionality. Unit tests are using hardcoded ring topologies and do not rely on CCM.

Additionally, the implementation of NetworkTopologyStrategy is essentially a duplication of the logic in org.apache.cassandra.locator.NetworkTopologyStrategy. This is a potential problem, but I'm not aware of any existing ways of sharing server/client code in current codebase. 
