### PR TITLE
Add Travis CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+install: mvn --quiet install
+jdk:
+  - openjdk7
+  - openjdk6
+  - oraclejdk7


### PR DESCRIPTION
This PR adds a simple Travis CI configuration file to the root directory which will build the Maven projects with OpenJDK 6, OpenJDK 7, and Oracle JDK 7 by running `mvn install`.

Currently it only runs the default profile but other Maven profiles like `long` or `duration` could be added in the future.
