### PR TITLE
Upgrade to Jackson 2.3.0

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -40,15 +40,15 @@
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-      <version>1.9.13</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.3.0</version>
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>1.9.13</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.3.0</version>
     </dependency>
 
     <dependency>

--- a/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
@@ -18,10 +18,10 @@ package com.datastax.driver.core;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.map.ObjectMapper;
 
 /**
  * Describes a Table.


### PR DESCRIPTION
The [Jackson](http://wiki.fasterxml.com/JacksonHome) project has moved to another groupId some time ago.

Upgrading to Jackson 2.3.0 in the Java Driver is basically just updating the dependencies in the POM
and some import statements in TableMetadata.
