### PR TITLE
avoid multiple prepares per host with multiple sessions

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1106,14 +1106,10 @@ public class Cluster {
             }
         }
 
-        // Prepare a query on all nodes
-        // Note that this *assumes* the query is valid.
-        public void prepare(PreparedStatement stmt, InetAddress toExclude) throws InterruptedException {
+        public void addPrepared(PreparedStatement stmt) {
             if (preparedQueries.putIfAbsent(stmt.id, stmt) != null)
                 logger.warn("Re-preparing already prepared query {}. Please note that preparing the same query more than once is "
                           + "generally an anti-pattern and will likely affect performance. Consider preparing the statement only once.", stmt.getQueryString());
-            for (SessionManager s : sessions)
-                s.prepare(stmt.getQueryString(), toExclude);
         }
 
         private void prepareAllQueries(Host host) throws InterruptedException {

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -144,8 +144,9 @@ class SessionManager implements Session {
                         case PREPARED:
                             ResultMessage.Prepared pmsg = (ResultMessage.Prepared)rm;
                             PreparedStatement stmt = PreparedStatement.fromMessage(pmsg, cluster.getMetadata(), query, poolsState.keyspace);
+                            cluster.manager.addPrepared(stmt);
                             try {
-                                cluster.manager.prepare(stmt, future.getAddress());
+                                prepare(stmt.getQueryString(), future.getAddress());
                             } catch (InterruptedException e) {
                                 Thread.currentThread().interrupt();
                                 // This method doesn't propagate interruption, at least not for now. However, if we've


### PR DESCRIPTION
If there are multiple Sessions for a Cluster the statement gets prepared multiple times per host.

This is a possible improvement to broadcasting prepared statements.
