### PR TITLE
Export getter of values in BoundStatement.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -863,8 +863,12 @@ public class BoundStatement extends Query {
         return statement.metadata;
     }
 
-    private BoundStatement setValue(int i, ByteBuffer value) {
+    public BoundStatement setValue(int i, ByteBuffer value) {
         values[i] = value;
         return this;
+    }
+
+    public ByteBuffer[] getValues() {
+        return Arrays.copyOf(values, values.length);
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -153,7 +153,12 @@ public class Cluster {
      */
     public Session connect(String keyspace) {
         SessionManager session = (SessionManager)connect();
-        session.setKeyspace(keyspace);
+        try {
+            session.setKeyspace(keyspace);
+        } catch (RuntimeException e) {
+            session.shutdown();
+            throw e;
+        }
         return session;
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -219,7 +219,11 @@ class ControlConnection implements Host.StateListener {
             refreshSchema(connection, null, null, cluster);
             return connection;
         } catch (BusyConnectionException e) {
+            connection.close(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
             throw new DriverInternalError("Newly created connection should not be busy");
+        } catch (RuntimeException e) {
+            connection.close(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+            throw e;
         }
     }
 


### PR DESCRIPTION
There are some circumstances that we need to access (read-only) the bound values in the BoundStatement. For example, if you are writing a client wrapper of Session, and when query execution failed several times and you decide to try to reconnect the session (close the old session and create a new one), and if you try to execute the same bound statement using new session object, you'll get the DriverInternalError. In this case, you want to re-create prepare statement and bound statement from the bound statement object that caller gives you. Without this change, it's not possible to recreate the BoundStatement object.
