### PR TITLE
unbreak of jvm shutdown hooks

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -852,7 +852,7 @@ public class Cluster implements Closeable {
     }
 
     private static ThreadFactory threadFactory(String nameFormat) {
-        return new ThreadFactoryBuilder().setNameFormat(nameFormat).build();
+        return new ThreadFactoryBuilder().setNameFormat(nameFormat).setDaemon(true).build();
     }
 
     static long timeSince(long startNanos, TimeUnit destUnit) {

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -31,6 +31,7 @@ import org.jboss.netty.channel.*;
 import org.jboss.netty.channel.group.ChannelGroup;
 import org.jboss.netty.channel.group.DefaultChannelGroup;
 import org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory;
+import org.jboss.netty.channel.socket.nio.NioWorkerPool;
 import org.jboss.netty.handler.ssl.SslHandler;
 import org.jboss.netty.util.HashedWheelTimer;
 import org.jboss.netty.util.Timeout;
@@ -377,11 +378,14 @@ class Connection {
 
     public static class Factory {
 
-        private final ExecutorService bossExecutor = Executors.newCachedThreadPool();
-        private final ExecutorService workerExecutor = Executors.newCachedThreadPool();
-        public final HashedWheelTimer timer = new HashedWheelTimer(new ThreadFactoryBuilder().setNameFormat("Timeouter-%d").build());
+        private final ThreadFactory threadFactory = new ThreadFactoryBuilder().setDaemon(true).build();
+        private final ExecutorService bossExecutor = Executors.newCachedThreadPool(threadFactory);
+        private final ExecutorService workerExecutor = Executors.newCachedThreadPool(threadFactory);
+        public final HashedWheelTimer timer = new HashedWheelTimer(new ThreadFactoryBuilder().setNameFormat("Timeouter-%d").setDaemon(true).build());
 
-        private final ChannelFactory channelFactory = new NioClientSocketChannelFactory(bossExecutor, workerExecutor);
+        private final HashedWheelTimer channelFactoryTimer = new HashedWheelTimer(new ThreadFactoryBuilder().setDaemon(true).build());
+        private final NioWorkerPool channelNioWokerPool = new NioWorkerPool(workerExecutor, Runtime.getRuntime().availableProcessors() * 2);
+        private final ChannelFactory channelFactory = new NioClientSocketChannelFactory(bossExecutor, 1, channelNioWokerPool, channelFactoryTimer);
         private final ChannelGroup allChannels = new DefaultChannelGroup();
 
         private final ConcurrentMap<Host, AtomicInteger> idGenerators = new ConcurrentHashMap<Host, AtomicInteger>();

--- a/driver-core/src/test/java/com/datastax/driver/core/DaemonModeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DaemonModeTest.java
@@ -1,0 +1,61 @@
+/*
+ *      Copyright (C) 2012 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test the drivers threads for isDaemon
+ */
+public class DaemonModeTest {
+
+    /**
+     * Test the number of not daemon threads does not change
+     * @throws Throwable
+     */
+    @Test(groups = "short")
+    public void onlyDaemonThreads() throws Throwable
+    {
+        int runningThreads = getNumberOfNoneDaemonThreads();
+        
+        Cluster.Builder builder = Cluster.builder();
+        CCMBridge.CCMCluster c = CCMBridge.buildCluster(1, builder);        
+        assertEquals(getNumberOfNoneDaemonThreads(), runningThreads);
+
+        try {
+            c.session.execute("SELECT COUNT(*) FROM system.hints LIMIT 1").one().getLong(0);
+            assertEquals(getNumberOfNoneDaemonThreads(), runningThreads);
+        } catch (Throwable e) {
+            c.errorOut();
+            throw e;
+        } finally {
+            c.discard();
+            assertEquals(getNumberOfNoneDaemonThreads(), runningThreads);
+        }
+    }
+    
+    private int getNumberOfNoneDaemonThreads()
+    {
+        int count = 0;
+        for (Thread t : Thread.getAllStackTraces().keySet()) {
+            if (!t.isDaemon()) {
+                count++;
+            }
+        }
+        return count;
+    }
+}

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -26,6 +26,7 @@
 
   <modules>
     <module>stress</module>
+    <module>shutdownHook</module>
   </modules>
   
   <licenses>

--- a/driver-examples/shutdownHook/README.rst
+++ b/driver-examples/shutdownHook/README.rst
@@ -1,0 +1,21 @@
+ShutdownHook application
+==================
+
+A simple example application that uses the java driver and places the
+cluster build and shutdown code close to each. This way things like
+https://code.google.com/p/google-guice/wiki/ModulesShouldBeFastAndSideEffectFree
+can be used in a simple way.
+
+Usage
+-----
+
+You will need to build the shutdownhook application fist:
+    
+    ./bin/build
+
+After which you can run it using for instance:
+    
+    ./bin/shutdownhook [running-cassandra-host-address]
+
+Of course, you will need to have at least one Cassandra node running (on
+127.0.0.1 by default) for this to work.

--- a/driver-examples/shutdownHook/bin/build
+++ b/driver-examples/shutdownHook/bin/build
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+SCRIPT_DIR=$( cd "$( dirname "$0" )" && pwd )
+CURRENT_DIR=$( pwd )
+
+LOG_FILE="$CURRENT_DIR/shutdownhook_build.log"
+VERSION_FILE="$SCRIPT_DIR/../.shutdownhook.version"
+
+[ -f $LOG_FILE ] && rm $LOG_FILE
+[ -f $VERSION_FILE ] && rm $VERSION_FILE
+
+echo "Building java driver ..."
+echo "-- Driver build --\n" > $LOG_FILE
+
+cd $SCRIPT_DIR/../../..
+mvn clean install -Dmaven.test.skip=true >> $LOG_FILE 2>&1
+EXIT_CODE=$?
+if [ $EXIT_CODE -ne 0 ];
+then
+    echo "Error building driver. See $LOG_FILE for details." 1>&2
+    cd $CURRENT_DIR
+    exit $EXIT_CODE
+fi
+
+echo "Building shutdownhook application ..."
+echo "\n-- Shutdownhook build --\n" >> $LOG_FILE
+
+cd $SCRIPT_DIR/..
+mvn package assembly:single >> $LOG_FILE 2>&1
+EXIT_CODE=$?
+if [ $EXIT_CODE -ne 0 ];
+then
+    echo "Error building shutdownhook application. See $LOG_FILE for details." 1>&2
+    cd $CURRENT_DIR
+    exit $EXIT_CODE
+fi
+
+# We don't want to hardcode the version in the shutdownhook launch file, but maven takes an unreasonabe time
+# just to return project version (even if the internet has already been downloaded). So for the common
+# case, just compute that version now and save it to some hidden file, so we speed up the execution script
+
+VERSION=`cd $SCRIPT_DIR/.. && mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -Ev '(^\[|Download\w+:)'`
+echo "$VERSION" > $VERSION_FILE
+
+cd $CURRENT_DIR
+rm $LOG_FILE

--- a/driver-examples/shutdownHook/bin/shutdownhook
+++ b/driver-examples/shutdownHook/bin/shutdownhook
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+SCRIPT_DIR=$( cd "$( dirname "$0" )" && pwd )
+CURRENT_DIR=$( pwd )
+
+# Use $JAVA_HOME if set
+if [ -n "$JAVA_HOME" ]; then
+    JAVA="$JAVA_HOME/bin/java"
+else
+    JAVA=java
+fi
+
+if [ "x$SHUTDOWNHOOK_JAR" = "x" ]; then
+    # Get the current project version...
+
+    VERSION_FILE="$SCRIPT_DIR/../.shutdownhook.version"
+    if [ -f $VERSION_FILE ]; then
+        VERSION=`cat $VERSION_FILE`
+    else
+        VERSION=`cd $SCRIPT_DIR/.. && mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -Ev '(^\[|Download\w+:)'`
+    fi
+
+    SHUTDOWNHOOK_JAR="$SCRIPT_DIR/../target/cassandra-driver-examples-shutdownhook-$VERSION-jar-with-dependencies.jar"
+
+    if [ ! -f $SHUTDOWNHOOK_JAR ]; then
+        # Trash the version file in case there was some crap in it
+        [ -f $VERSION_FILE ] && rm $VERSION_FILE;
+        RELATIVE_SCRIPT_DIR=`dirname $0`
+        echo "ShutdownHook application does not seem to be build, try $RELATIVE_SCRIPT_DIR/build first" 1>&2
+        exit 1
+    fi
+else
+    if [ ! -f $SHUTDOWNHOOK_JAR ]; then
+        echo "Cannot find file $SHUTDOWNHOOK_JAR" 1>&2
+        exit 1
+    fi
+fi
+
+"$JAVA" -Dlog4j.configuration="$SCRIPT_DIR/../conf/log4j.properties" -jar $SHUTDOWNHOOK_JAR $@

--- a/driver-examples/shutdownHook/pom.xml
+++ b/driver-examples/shutdownHook/pom.xml
@@ -1,0 +1,100 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.datastax.cassandra</groupId>
+    <artifactId>cassandra-driver-examples-parent</artifactId>
+    <version>2.0.0-rc3-SNAPSHOT</version>
+  </parent>
+  <artifactId>cassandra-driver-examples-shutdownhook</artifactId>
+  <packaging>jar</packaging>
+  <name>DataStax Java Driver for Apache Cassandra Examples - ShutdownHook</name>
+  <description>A shutdownhook test example for DataStax Java Driver for Apache Cassandra.</description>
+  <url>https://github.com/datastax/java-driver</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-core</artifactId>
+      <version>2.0.0-rc3-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+        <groupId>com.yammer.metrics</groupId>
+        <artifactId>metrics-core</artifactId>
+        <version>2.2.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>net.sf.jopt-simple</groupId>
+      <artifactId>jopt-simple</artifactId>
+      <version>4.5</version>
+    </dependency>
+
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.17</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.5</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+      <plugins>
+          <plugin>
+              <artifactId>maven-assembly-plugin</artifactId>
+              <version>2.4</version>
+              <configuration>
+                  <archive>
+                      <manifest>
+                          <mainClass>com.datastax.driver.shutdownhook.ShutdownHook</mainClass>
+                      </manifest>
+                  </archive>
+                  <descriptorRefs>
+                      <descriptorRef>jar-with-dependencies</descriptorRef>
+                  </descriptorRefs>
+              </configuration>
+          </plugin>
+      </plugins>
+  </build>
+
+  <licenses>
+    <license>
+      <name>Apache 2</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+      <comments>Apache License Version 2.0</comments>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git@github.com:datastax/java-driver.git</connection>
+    <developerConnection>scm:git:git@github.com:datastax/java-driver.git</developerConnection>
+    <url>https://github.com/datastax/java-driver</url>
+  </scm>
+
+  <developers>
+    <developer>
+      <name>Various</name>
+      <organization>DataStax</organization>
+    </developer>
+  </developers>
+</project>
+

--- a/driver-examples/shutdownHook/src/main/java/com/datastax/driver/shutdownhook/ShutdownHook.java
+++ b/driver-examples/shutdownHook/src/main/java/com/datastax/driver/shutdownhook/ShutdownHook.java
@@ -1,0 +1,40 @@
+package com.datastax.driver.shutdownhook;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Cluster.Builder;
+import com.datastax.driver.core.Session;
+
+public class ShutdownHook {
+
+    public static void main(String[] args)
+    {
+        String host = "127.0.0.1";
+        if (args.length > 0 && args[0] != "-h") {
+            host = args[0];
+        }
+        else {
+            System.out.println("usage: shutdownhook [running-cassandra-host-address]");
+            System.out.println("127.0.0.1 is used by default.");
+        }
+
+        System.out.println("Cassandra on " + host + " gets connected.");
+        final Builder builder = Cluster.builder().addContactPoints(host);        
+        final Cluster cluster = builder.build();
+        // this hook stops the driver gracefully when the jvm has nothing more to do
+        Runtime.getRuntime().addShutdownHook(new Thread()
+        {
+            public void run()
+            {
+                cluster.close();
+            }
+        });
+           
+        Session session = cluster.connect();
+        session.execute("SELECT COUNT(*) FROM system.hints LIMIT 1").one().getLong(0);
+        System.out.println("A request successfully returned.");
+
+        System.out.println("The Java main() method ends now.");
+        System.out.println("The JVM should exit after the shutdown hook closed the cluster (stoped the driver gracefully).");    
+    }
+
+}


### PR DESCRIPTION
this change makes sure the drivers does not keep the jvm running on its own.
now the jvm can detect that all work is done and start to shutdown.
while shutting down registered hooks can be used to stop the driver.

cluster building and closing can be placed close the each other (in the source code) as suggested in:
https://code.google.com/p/google-guice/wiki/ModulesShouldBeFastAndSideEffectFree
