### PR TITLE
Fix connection leaks in exception code paths

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -153,7 +153,12 @@ public class Cluster {
      */
     public Session connect(String keyspace) {
         SessionManager session = (SessionManager)connect();
-        session.setKeyspace(keyspace);
+        try {
+            session.setKeyspace(keyspace);
+        } catch (RuntimeException e) {
+            session.shutdown();
+            throw e;
+        }
         return session;
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -219,7 +219,11 @@ class ControlConnection implements Host.StateListener {
             refreshSchema(connection, null, null, cluster);
             return connection;
         } catch (BusyConnectionException e) {
+            connection.close(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
             throw new DriverInternalError("Newly created connection should not be busy");
+        } catch (RuntimeException e) {
+            connection.close(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+            throw e;
         }
     }
 


### PR DESCRIPTION
Particularly when server is under extreme high loads,
it may throw RuntimeException, and in these exception
code paths, opened connections has to be closed
before returning the control to the caller.
