### PR TITLE
Make java-driver 2.0 compatible with DSE 3.x authentication

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Message.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Message.java
@@ -69,7 +69,7 @@ abstract class Message {
             EXECUTE        (10, Requests.Execute.coderV1, Requests.Execute.coderV2),
             REGISTER       (11, Requests.Register.coder, Requests.Register.coder),
             BATCH          (13, null, Requests.Batch.coder),
-            AUTH_RESPONSE  (15, null, Requests.AuthResponse.coder);
+            AUTH_RESPONSE  (15, Requests.AuthResponse.coder, Requests.AuthResponse.coder);
 
             public final int opcode;
             private final Coder<?> coderV1;
@@ -113,8 +113,8 @@ abstract class Message {
             SUPPORTED      (6, Responses.Supported.decoder, Responses.Supported.decoder),
             RESULT         (8, Responses.Result.decoderV1, Responses.Result.decoderV2),
             EVENT          (12, Responses.Event.decoder, Responses.Event.decoder),
-            AUTH_CHALLENGE (14, Responses.AuthChallenge.decoderV1, Responses.AuthChallenge.decoderV2),
-            AUTH_SUCCESS   (16, Responses.AuthSuccess.decoderV1, Responses.AuthSuccess.decoderV2);
+            AUTH_CHALLENGE (14, Responses.AuthChallenge.decoder, Responses.AuthChallenge.decoder),
+            AUTH_SUCCESS   (16, Responses.AuthSuccess.decoder, Responses.AuthSuccess.decoder);
 
             public final int opcode;
             private final Decoder<?> decoderV1;

--- a/driver-core/src/main/java/com/datastax/driver/core/Responses.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Responses.java
@@ -523,14 +523,7 @@ class Responses {
 
     public static class AuthChallenge extends Message.Response {
 
-        public static final Message.Decoder<AuthChallenge> decoderV1 = new Message.Decoder<AuthChallenge>() {
-            public AuthChallenge decode(ChannelBuffer body) {
-                // AUTH_CHALLENGE is protocol v2 only.
-                throw new DriverInternalError("Got AUTH_CHALLENGE in protocol V1, this shouldn't happen since AUTH_CHALLENGE is a protocol V2 only message");
-            }
-        };
-
-        public static final Message.Decoder<AuthChallenge> decoderV2 = new Message.Decoder<AuthChallenge>() {
+        public static final Message.Decoder<AuthChallenge> decoder = new Message.Decoder<AuthChallenge>() {
             public AuthChallenge decode(ChannelBuffer body) {
                 ByteBuffer b = CBUtil.readValue(body);
                 if (b == null)
@@ -552,14 +545,7 @@ class Responses {
 
     public static class AuthSuccess extends Message.Response {
 
-        public static final Message.Decoder<AuthSuccess> decoderV1 = new Message.Decoder<AuthSuccess>() {
-            public AuthSuccess decode(ChannelBuffer body) {
-                // AUTH_SUCCESS is protocol v2 only.
-                throw new DriverInternalError("Got AUTH_SUCCESS in protocol V1, this shouldn't happen since AUTH_SUCCESS is a protocol V2 only message");
-            }
-        };
-
-        public static final Message.Decoder<AuthSuccess> decoderV2 = new Message.Decoder<AuthSuccess>() {
+        public static final Message.Decoder<AuthSuccess> decoder = new Message.Decoder<AuthSuccess>() {
             public AuthSuccess decode(ChannelBuffer body) {
                 ByteBuffer b = CBUtil.readValue(body);
                 if (b == null)


### PR DESCRIPTION
- In Connection, if v1 but authenticator is not a ProtocolV1Authenticator, attempt v2 authentication
- Revised (de)coders in Auth\* messages as they may be used in a v1 context (by DSE 3.x)
