### PR TITLE
Ec2support

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -20,6 +20,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -86,7 +87,6 @@ public class Cluster implements Closeable {
     private Cluster(String name, List<InetAddress> contactPoints, Configuration configuration, Collection<Host.StateListener> listeners, boolean useContactPointsOnly) {
         this.manager = new Manager(name, contactPoints, configuration, listeners, useContactPointsOnly);
     }
-
 
     /**
      * Initialize this Cluster instance.

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -20,7 +20,6 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -80,13 +79,14 @@ public class Cluster implements Closeable {
      * @param contactPoints the list of contact points to use for the new cluster.
      * @param configuration the configuration for the new cluster.
      */
-    protected Cluster(String name, List<InetAddress> contactPoints, Configuration configuration) {
-        this(name, contactPoints, configuration, Collections.<Host.StateListener>emptySet());
+    protected Cluster(String name, List<InetAddress> contactPoints, Configuration configuration, boolean useContactPointsOnly) {
+        this(name, contactPoints, configuration, Collections.<Host.StateListener>emptySet(), useContactPointsOnly);
     }
 
-    private Cluster(String name, List<InetAddress> contactPoints, Configuration configuration, Collection<Host.StateListener> listeners) {
-        this.manager = new Manager(name, contactPoints, configuration, listeners);
+    private Cluster(String name, List<InetAddress> contactPoints, Configuration configuration, Collection<Host.StateListener> listeners, boolean useContactPointsOnly) {
+        this.manager = new Manager(name, contactPoints, configuration, listeners, useContactPointsOnly);
     }
+
 
     /**
      * Initialize this Cluster instance.
@@ -141,7 +141,7 @@ public class Cluster implements Closeable {
         if (contactPoints.isEmpty())
             throw new IllegalArgumentException("Cannot build a cluster without contact points");
 
-        return new Cluster(initializer.getClusterName(), contactPoints, initializer.getConfiguration(), initializer.getInitialListeners());
+        return new Cluster(initializer.getClusterName(), contactPoints, initializer.getConfiguration(), initializer.getInitialListeners(), initializer.isUseContactPointsOnly());
     }
 
     /**
@@ -429,6 +429,8 @@ public class Cluster implements Closeable {
      */
     public interface Initializer {
 
+       public boolean isUseContactPointsOnly();
+
         /**
          * An optional name for the created cluster.
          * <p>
@@ -485,6 +487,7 @@ public class Cluster implements Closeable {
     public static class Builder implements Initializer {
 
         private String clusterName;
+        private boolean useContactPointsOnly;
         private final List<InetAddress> addresses = new ArrayList<InetAddress>();
         private int port = ProtocolOptions.DEFAULT_PORT;
         private int protocolVersion = -1;
@@ -505,6 +508,15 @@ public class Cluster implements Closeable {
 
         private Collection<Host.StateListener> listeners;
 
+        @Override
+        public boolean isUseContactPointsOnly() {
+           return useContactPointsOnly;
+        }
+
+        public Builder useContactPointsOnly() {
+          this.useContactPointsOnly = true;
+          return this;
+        }
 
         @Override
         public String getClusterName() {
@@ -978,9 +990,12 @@ public class Cluster implements Closeable {
         final Set<Host.StateListener> listeners;
         final Set<LatencyTracker> trackers = new CopyOnWriteArraySet<LatencyTracker>();
 
-        private Manager(String clusterName, List<InetAddress> contactPoints, Configuration configuration, Collection<Host.StateListener> listeners) {
+        final boolean useContactPointsOnly;
+
+        private Manager(String clusterName, List<InetAddress> contactPoints, Configuration configuration, Collection<Host.StateListener> listeners, boolean useContactPointsOnly) {
             logger.debug("Starting new cluster with contact points " + contactPoints);
 
+            this.useContactPointsOnly = useContactPointsOnly;
             this.clusterName = clusterName == null ? generateClusterName() : clusterName;
             this.configuration = configuration;
             this.configuration.register(this);
@@ -1054,7 +1069,11 @@ public class Cluster implements Closeable {
             return Cluster.this;
         }
 
-        LoadBalancingPolicy loadBalancingPolicy() {
+      boolean isUseContactPointsOnly() {
+        return useContactPointsOnly;
+      }
+
+      LoadBalancingPolicy loadBalancingPolicy() {
             return configuration.getPolicies().getLoadBalancingPolicy();
         }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -452,6 +452,8 @@ class ControlConnection implements Host.StateListener {
             allTokens.add(row.getSet("tokens", String.class));
         }
 
+
+      if (!cluster.isUseContactPointsOnly()) {
         for (int i = 0; i < foundHosts.size(); i++) {
             Host host = cluster.metadata.getHost(foundHosts.get(i));
             boolean isNew = false;
@@ -472,8 +474,9 @@ class ControlConnection implements Host.StateListener {
             if (isNew)
                 cluster.onAdd(host);
         }
+      }
 
-        // Removes all those that seems to have been removed (since we lost the control connection)
+      // Removes all those that seems to have been removed (since we lost the control connection)
         Set<InetAddress> foundHostsSet = new HashSet<InetAddress>(foundHosts);
         for (Host host : cluster.metadata.allHosts())
             if (!host.getAddress().equals(connection.address) && !foundHostsSet.contains(host.getAddress()))

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -476,7 +476,7 @@ class ControlConnection implements Host.StateListener {
         }
       }
 
-      // Removes all those that seems to have been removed (since we lost the control connection)
+        // Removes all those that seems to have been removed (since we lost the control connection)
         Set<InetAddress> foundHostsSet = new HashSet<InetAddress>(foundHosts);
         for (Host host : cluster.metadata.allHosts())
             if (!host.getAddress().equals(connection.address) && !foundHostsSet.contains(host.getAddress()))

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -152,8 +152,6 @@ public class Metadata {
     }
 
     Host add(InetAddress address) {
-//        if (!includeHost())
-//          return null;
         Host newHost = new Host(address, cluster.convictionPolicyFactory);
         Host previous = hosts.putIfAbsent(address, newHost);
         return previous == null ? newHost : null;

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -152,6 +152,8 @@ public class Metadata {
     }
 
     Host add(InetAddress address) {
+//        if (!includeHost())
+//          return null;
         Host newHost = new Host(address, cluster.convictionPolicyFactory);
         Host previous = hosts.putIfAbsent(address, newHost);
         return previous == null ? newHost : null;


### PR DESCRIPTION
Add a new option called "useContactPointsOnly()" on the cluster to prevent it from discovering any new nodes other than the ones specified as contact points.  This is useful in cases where the driver discovers nodes but those nodes addresses are not accessible to the application.  Sometimes EC2 has this behaviour.  

Sorry - I have not added comments yet.  I thought I'd run it by you first.
