### PR TITLE
Fixed link to Java Driver doc (new URL).

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ the Cassandra Query Language version 3 (CQL3) and Cassandra's binary protocol.
 - JIRA: https://datastax-oss.atlassian.net/browse/JAVA
 - MAILING LIST: https://groups.google.com/a/lists.datastax.com/forum/#!forum/java-driver-user
 - IRC: #datastax-drivers on `irc.freenode.net <http://freenode.net>`_
-- DOCS: http://www.datastax.com/documentation/developer/java-driver/1.0/webhelp/index.html
+- DOCS: http://www.datastax.com/documentation/developer/java-driver/1.0/index.html
 - API: http://www.datastax.com/drivers/java/1.0
 
 


### PR DESCRIPTION
Minor change to fix JD doc link in 1.0 README.rst file.
