### PR TITLE
Fixed link to docs to point at 2.0 docs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ the Cassandra Query Language version 3 (CQL3) and Cassandra's binary protocol.
 - MAILING LIST: https://groups.google.com/a/lists.datastax.com/forum/#!forum/java-driver-user
 - IRC: #datastax-drivers on `irc.freenode.net <http://freenode.net>`_
 - TWITTER: Follow the latest news about DataStax Drivers - `@mfiguiere <http://twitter.com/mfiguiere>`_ 
-- DOCS: http://www.datastax.com/documentation/developer/java-driver/1.0/webhelp/index.html
+- DOCS: http://www.datastax.com/documentation/developer/java-driver/2.0/index.html
 - API: http://www.datastax.com/drivers/java/2.0
 
 


### PR DESCRIPTION
I have updated the README.rst file to point at the new 2.0 docs.
