### PR TITLE
Added fixes for Jenkins issues

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyTest.java
@@ -15,18 +15,19 @@
  */
 package com.datastax.driver.core;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.datastax.driver.core.exceptions.UnavailableException;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.RoundRobinPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.datastax.driver.core.policies.WhiteListPolicy;
-import org.testng.annotations.Test;
-
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.util.Arrays;
-import java.util.List;
 
 import static com.datastax.driver.core.TestUtils.*;
 import static org.testng.Assert.*;
@@ -50,7 +51,7 @@ public class LoadBalancingPolicyTest extends AbstractPoliciesTest {
             resetCoordinators();
             c.cassandraCluster.bootstrapNode(3);
             waitFor(CCMBridge.IP_PREFIX + '3', c.cluster);
-            Thread.sleep(40000);
+            Thread.sleep(50000);
 
             query(c, 12);
 
@@ -134,7 +135,7 @@ public class LoadBalancingPolicyTest extends AbstractPoliciesTest {
             c.cassandraCluster.decommissionNode(1);
             waitFor(CCMBridge.IP_PREFIX + '5', c.cluster);
             waitForDecommission(CCMBridge.IP_PREFIX + '1', c.cluster);
-            Thread.sleep(40000);
+            Thread.sleep(50000);
 
             query(c, 12);
 
@@ -249,7 +250,7 @@ public class LoadBalancingPolicyTest extends AbstractPoliciesTest {
             //
             //resetCoordinators();
             c.cassandraCluster.decommissionNode(5);
-            waitForDecommission(CCMBridge.IP_PREFIX + '5', c.cluster, 60);
+            waitForDecommission(CCMBridge.IP_PREFIX + '5', c.cluster, 120);
 
             query(c, 12);
 
@@ -357,7 +358,7 @@ public class LoadBalancingPolicyTest extends AbstractPoliciesTest {
             assertQueried(CCMBridge.IP_PREFIX + '2', 12);
 
             resetCoordinators();
-            c.cassandraCluster.forceStop(2);
+            c.cassandraCluster.stop(2);
             waitForDownWithWait(CCMBridge.IP_PREFIX + '2', c.cluster, 10);
 
             try {

--- a/driver-core/src/test/java/com/datastax/driver/core/RetryPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RetryPolicyTest.java
@@ -15,9 +15,10 @@
  */
 package com.datastax.driver.core;
 
+import org.testng.annotations.Test;
+
 import com.datastax.driver.core.exceptions.*;
 import com.datastax.driver.core.policies.*;
-import org.testng.annotations.Test;
 
 import static com.datastax.driver.core.TestUtils.waitFor;
 import static com.datastax.driver.core.TestUtils.waitForDownWithWait;
@@ -296,7 +297,7 @@ public class RetryPolicyTest extends AbstractPoliciesTest {
             assertQueried(CCMBridge.IP_PREFIX + '3', 4);
 
             resetCoordinators();
-            c.cassandraCluster.forceStop(2);
+            c.cassandraCluster.stop(2);
             waitForDownWithWait(CCMBridge.IP_PREFIX + '2', c.cluster, 10);
 
             query(c, 12, ConsistencyLevel.ALL);
@@ -306,8 +307,8 @@ public class RetryPolicyTest extends AbstractPoliciesTest {
             assertQueried(CCMBridge.IP_PREFIX + '3', 6);
 
             resetCoordinators();
-            c.cassandraCluster.forceStop(1);
-            waitForDownWithWait(CCMBridge.IP_PREFIX + '1', c.cluster, 5);
+            c.cassandraCluster.stop(1);
+            waitForDownWithWait(CCMBridge.IP_PREFIX + '1', c.cluster, 10);
 
             try {
                 query(c, 12, ConsistencyLevel.ALL);

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
@@ -21,13 +21,15 @@ import java.util.Date;
 import java.util.List;
 
 import org.testng.annotations.Test;
-import static org.testng.Assert.*;
 
 import com.datastax.driver.core.CCMBridge;
 import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.TestUtils;
+import com.datastax.driver.core.exceptions.InvalidQueryException;
+
 import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+import static org.testng.Assert.*;
 
 public class QueryBuilderExecutionTest extends CCMBridge.PerClassSingleNodeCluster {
 
@@ -65,15 +67,21 @@ public class QueryBuilderExecutionTest extends CCMBridge.PerClassSingleNodeClust
     @Test(groups = "short")
     public void dateHandlingTest() throws Exception {
 
-        Date d = new Date();
-        session.execute(insertInto("dateTest").value("t", d));
-        String query = select().from("dateTest").where(eq(token("t"), fcall("token", d))).toString();
-        List<Row> rows = session.execute(query).all();
+        try {
+            Date d = new Date();
+            session.execute(insertInto("dateTest").value("t", d));
+            String query = select().from("dateTest").where(eq(token("t"), fcall("token", d))).toString();
+            List<Row> rows = session.execute(query).all();
 
-        assertEquals(1, rows.size());
+            assertEquals(1, rows.size());
 
-        Row r1 = rows.get(0);
-        assertEquals(d, r1.getDate("t"));
+            Row r1 = rows.get(0);
+            assertEquals(d, r1.getDate("t"));
+        } catch (InvalidQueryException e) {
+            // This is expected when testing the protocol v1
+            if (cluster.getConfiguration().getProtocolOptions().getProtocolVersion() != 1)
+                throw e;
+        }
     }
 
     @Test(groups = "unit")

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
@@ -26,7 +26,6 @@ import com.datastax.driver.core.CCMBridge;
 import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.TestUtils;
-import com.datastax.driver.core.exceptions.InvalidQueryException;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 import static org.testng.Assert.*;
@@ -67,21 +66,15 @@ public class QueryBuilderExecutionTest extends CCMBridge.PerClassSingleNodeClust
     @Test(groups = "short")
     public void dateHandlingTest() throws Exception {
 
-        try {
-            Date d = new Date();
-            session.execute(insertInto("dateTest").value("t", d));
-            String query = select().from("dateTest").where(eq(token("t"), fcall("token", d))).toString();
-            List<Row> rows = session.execute(query).all();
+        Date d = new Date();
+        session.execute(insertInto("dateTest").value("t", d));
+        String query = select().from("dateTest").where(eq(token("t"), fcall("token", d))).toString();
+        List<Row> rows = session.execute(query).all();
 
-            assertEquals(1, rows.size());
+        assertEquals(1, rows.size());
 
-            Row r1 = rows.get(0);
-            assertEquals(d, r1.getDate("t"));
-        } catch (InvalidQueryException e) {
-            // This is expected when testing the protocol v1
-            if (cluster.getConfiguration().getProtocolOptions().getProtocolVersion() != 1)
-                throw e;
-        }
+        Row r1 = rows.get(0);
+        assertEquals(d, r1.getDate("t"));
     }
 
     @Test(groups = "unit")


### PR DESCRIPTION
Added a few fixes to take care of race conditions on 2.0 and 2.0+1.2 tests, exception for a 2.0+1.2 querybuilder test, and corrected the import ordering via my new IntelliJ orderings.
