### PR TITLE
Insert buildQueryString was reversing bindValues and real values.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
@@ -86,14 +86,14 @@ public abstract class BuiltStatement extends RegularStatement {
         StringBuilder sb;
         values = null;
 
-        if (hasBindMarkers || forceNoValues) {
-            sb = buildQueryString(null);
-        } else {
-            List<ByteBuffer> l = new ArrayList<ByteBuffer>();
-            sb = buildQueryString(l);
-            if (!l.isEmpty())
-                values = l.toArray(new ByteBuffer[l.size()]);
-        }
+		if (hasBindMarkers || forceNoValues) {
+			List<ByteBuffer> l = new ArrayList<ByteBuffer>();
+			sb = buildQueryString(l);
+			if (!l.isEmpty())
+				values = l.toArray(new ByteBuffer[l.size()]);
+		} else {
+			sb = buildQueryString(null);
+		}
 
         maybeAddSemicolon(sb);
 

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
@@ -86,14 +86,14 @@ public abstract class BuiltStatement extends RegularStatement {
         StringBuilder sb;
         values = null;
 
-		if (hasBindMarkers || forceNoValues) {
-			List<ByteBuffer> l = new ArrayList<ByteBuffer>();
-			sb = buildQueryString(l);
-			if (!l.isEmpty())
-				values = l.toArray(new ByteBuffer[l.size()]);
-		} else {
-			sb = buildQueryString(null);
-		}
+        if (hasBindMarkers || forceNoValues) {
+            List<ByteBuffer> l = new ArrayList<ByteBuffer>();
+            sb = buildQueryString(l);
+            if (!l.isEmpty())
+                values = l.toArray(new ByteBuffer[l.size()]);
+        } else {
+            sb = buildQueryString(null);
+        }
 
         maybeAddSemicolon(sb);
 


### PR DESCRIPTION
This fix allows all of our existing integrations tests in spring-data-cassandra to pass after switching from the 1.0.6-dse driver to 2.0.2 driver.
