### PR TITLE
Add SchemaBuilder

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -71,6 +71,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>1.5.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/Alter.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/Alter.java
@@ -1,0 +1,253 @@
+package com.datastax.driver.core.schemabuilder;
+
+import java.util.List;
+import com.datastax.driver.core.DataType;
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+
+public class Alter extends SchemaStatement {
+
+    private Optional<String> keyspaceName = Optional.absent();
+    private String tableName;
+
+    Alter(String keyspaceName, String tableName) {
+        validateNotEmpty(keyspaceName, "Keyspace name");
+        validateNotEmpty(tableName, "Table name");
+        validateNotKeyWord(keyspaceName, String.format("The keyspace name '%s' is not allowed because it is a reserved keyword", keyspaceName));
+        validateNotKeyWord(tableName,String.format("The table name '%s' is not allowed because it is a reserved keyword",tableName));
+        this.tableName = tableName;
+        this.keyspaceName = Optional.fromNullable(keyspaceName);
+    }
+
+    Alter(String tableName) {
+        validateNotEmpty(tableName, "Table name");
+        validateNotKeyWord(tableName,String.format("The table name '%s' is not allowed because it is a reserved keyword",tableName));
+        this.tableName = tableName;
+    }
+
+    /**
+     * Alter a column
+     * <p>
+     *     Please note that you cannot rename a column that is not part of the primary key
+     * </p>
+     * @param columnName the name of the column to be altered;
+     * @return a new {@link Alter.AlterColumn} instance.
+     */
+    public AlterColumn alterColumn(String columnName) {
+        validateNotEmpty(columnName, "Column to be altered");
+        validateNotKeyWord(columnName,String.format("The altered column name '%s' is not allowed because it is a reserved keyword",columnName));
+        return new AlterColumn(this, columnName);
+    }
+
+    /**
+     * Add a new column
+     *
+     * @param columnName the name of the column to be added;
+     * @return a new {@link Alter.AddColumn} instance.
+     */
+    public AddColumn addColumn(String columnName) {
+        validateNotEmpty(columnName, "Added column");
+        validateNotKeyWord(columnName,String.format("The new column name '%s' is not allowed because it is a reserved keyword",columnName));
+        return new AddColumn(this, columnName, false);
+    }
+
+    /**
+     * Add a new static column
+     *
+     * @param columnName the name of the column to be added;
+     * @return a new {@link Alter.AddColumn} instance.
+     */
+    public AddColumn addStaticColumn(String columnName) {
+        validateNotEmpty(columnName, "Added static column");
+        validateNotKeyWord(columnName,String.format("The new static column name '%s' is not allowed because it is a reserved keyword",columnName));
+        return new AddColumn(this, columnName, true);
+    }
+
+    /**
+     * Shorthand method which takes a boolean and calls either {@code info.archinnov.achilles.schemabuilder.Alter.addStaticColumn}
+     * or {@code info.archinnov.achilles.schemabuilder.Alter.addColumn}
+     *
+     * @param columnName the name of the column to be added
+     * @param isStatic  whether the column is static or not
+     * @return a new {@link Alter.AddColumn} instance.
+     */
+    public AddColumn addColumn(String columnName,boolean isStatic) {
+        if (isStatic) {
+            return addStaticColumn(columnName);
+        } else {
+            return addColumn(columnName);
+        }
+    }
+
+    /**
+     * Drop a column
+     * <p>
+     *     Please note that you cannot drop a column that is part of the primary key
+     * </p>
+
+     * @param columnName the name of the column to be dropped;
+     * @return the final ALTER TABLE DROP COLUMN statement.
+     */
+    public String dropColumn(String columnName) {
+        validateNotEmpty(columnName, "Column to be dropped");
+        validateNotKeyWord(columnName,String.format("The dropped column name '%s' is not allowed because it is a reserved keyword",columnName));
+        return new StringBuilder(this.buildInternal())
+                .append(SPACE).append(DROP)
+                .append(SPACE).append(columnName).toString();
+    }
+
+    /**
+     * Rename a column
+     * <p>
+     *     Please note that you can only rename a column that is part of the primary key
+     * </p>
+
+     * @param columnName the name of the column to be renamed;
+     * @return a new {@link Alter.RenameColumn} instance.
+     */
+    public RenameColumn renameColumn(String columnName) {
+        validateNotEmpty(columnName, "Column to be renamed");
+        validateNotKeyWord(columnName,String.format("The renamed column name '%s' is not allowed because it is a reserved keyword",columnName));
+        return new RenameColumn(this, columnName);
+    }
+
+    /**
+     * Alter table options
+     *
+     * @return a new {@link Alter.Options} instance.
+     */
+    public Options withOptions() {
+        return new Options(this);
+    }
+
+    /**
+     * An alter column statement
+     */
+    public static class AlterColumn {
+
+        private final Alter alter;
+        private final String columnName;
+
+        AlterColumn(Alter alter, String columnName) {
+            this.alter = alter;
+            this.columnName = columnName;
+        }
+
+        /**
+         * Define the new type of the altered column
+         * @param type the new type of the altered column
+         * @return the final <strong>ALTER TABLE {@code columnName} TYPE {@code type} </strong> statement
+         */
+        public String type(DataType type) {
+            final StringBuilder statement = new StringBuilder(alter.buildInternal());
+            statement.append(SPACE).append(ALTER)
+                    .append(SPACE).append(columnName)
+                    .append(SPACE).append(TYPE)
+                    .append(SPACE).append(type.toString());
+            return statement.toString();
+        }
+    }
+
+    /**
+     * An add column statement
+     */
+    public static class AddColumn {
+
+        private final Alter alter;
+        private final String columnName;
+        private final boolean staticColumn;
+
+        AddColumn(Alter alter, String columnName, boolean staticColumn) {
+            this.alter = alter;
+            this.columnName = columnName;
+            this.staticColumn = staticColumn;
+        }
+
+        /**
+         * Define the type of the added column
+         * @param type the new type of the added column
+         * @return the final <strong>ALTER TABLE ADD {@code columnName} {@code type} </strong> statement
+         */
+        public String type(DataType type) {
+            final StringBuilder statement = new StringBuilder(alter.buildInternal());
+            statement.append(SPACE).append(ADD)
+                    .append(SPACE).append(columnName)
+                    .append(SPACE).append(type.toString());
+
+            if (staticColumn) {
+                statement.append(SPACE).append(STATIC);
+            }
+
+            return statement.toString();
+        }
+    }
+
+    /**
+     * A rename column statement
+     */
+    public static class RenameColumn {
+
+        private final Alter alter;
+        private final String columnName;
+
+        RenameColumn(Alter alter, String columnName) {
+            this.alter = alter;
+            this.columnName = columnName;
+        }
+
+        /**
+         * Define the new name of the column
+         * @param newColumnName the new name of the column*
+         * @return the final <strong>ALTER TABLE RENAME {@code columnName} TO {@code newColumnName} </strong> statement
+         */
+        public String to(String newColumnName) {
+            final StringBuilder statement = new StringBuilder(alter.buildInternal());
+            validateNotEmpty(newColumnName, "New column name");
+            validateNotKeyWord(newColumnName,String.format("The new column name '%s' is not allowed because it is a reserved keyword",newColumnName));
+            statement.append(SPACE).append(RENAME)
+                    .append(SPACE).append(columnName)
+                    .append(SPACE).append(TO)
+                    .append(SPACE).append(newColumnName);
+            return statement.toString();
+        }
+    }
+
+    /**
+     * The table options of an ALTER TABLE statement.
+     */
+    public static class Options extends TableOptions<Options> {
+
+        Options(Alter alter) {
+            super(alter);
+        }
+
+        @Override
+        String buildOptions() {
+            final List<String> commonOptions = super.buildCommonOptions();
+            return new StringBuilder(WITH).append(SPACE).append(Joiner.on(OPTION_SEPARATOR).join(commonOptions)).toString();
+        }
+
+
+        /**
+         * Generate the final ALTER TABLE statement <strong>with</strong> table options
+         *
+         * @return the final ALTER TABLE statement <strong>with</strong> table options
+         */
+        @Override
+        public String build() {
+            return new StringBuilder(super.build()).append(SPACE).append(buildOptions()).toString();
+        }
+
+    }
+
+    @Override
+    String buildInternal() {
+        StringBuilder alterStatement = new StringBuilder(NEW_LINE).append(TAB).append(ALTER_TABLE);
+        alterStatement.append(SPACE);
+        if (keyspaceName.isPresent()) {
+            alterStatement.append(keyspaceName.get()).append(DOT);
+        }
+        alterStatement.append(tableName);
+        return alterStatement.toString();
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/Create.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/Create.java
@@ -1,0 +1,466 @@
+package com.datastax.driver.core.schemabuilder;
+
+import static java.util.Map.Entry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import com.datastax.driver.core.DataType;
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+
+/**
+ * A built CREATE TABLE statement
+ */
+public class Create extends SchemaStatement {
+
+    private Optional<String> keyspaceName = Optional.absent();
+    private String tableName;
+    private Optional<Boolean> ifNotExists = Optional.absent();
+    private Map<String, DataType> partitionColumnsMap = new LinkedHashMap<String, DataType>();
+    private Map<String, DataType> clusteringColumnsMap = new LinkedHashMap<String, DataType>();
+    private Map<String, DataType> simpleColumnsMap = new LinkedHashMap<String, DataType>();
+    private Map<String, DataType> staticColumnsMap = new LinkedHashMap<String, DataType>();
+
+    Create(String keyspaceName, String tableName) {
+        validateNotEmpty(keyspaceName, "Keyspace name");
+        validateNotEmpty(tableName, "Table name");
+        validateNotKeyWord(keyspaceName, String.format("The keyspace name '%s' is not allowed because it is a reserved keyword", keyspaceName));
+        validateNotKeyWord(tableName, String.format("The table name '%s' is not allowed because it is a reserved keyword", tableName));
+        this.tableName = tableName;
+        this.keyspaceName = Optional.fromNullable(keyspaceName);
+    }
+
+    Create(String tableName) {
+        validateNotEmpty(tableName, "Table name");
+        validateNotKeyWord(tableName, String.format("The table name '%s' is not allowed because it is a reserved keyword", tableName));
+        this.tableName = tableName;
+    }
+
+    /**
+     * Use 'IF NOT EXISTS' CAS condition for the table creation.
+     *
+     * @param ifNotExists whether to use the CAS condition.
+     * @return this CREATE TABLE statement.
+     */
+    public Create ifNotExists(Boolean ifNotExists) {
+        this.ifNotExists = Optional.fromNullable(ifNotExists);
+        return this;
+    }
+
+    /**
+     * Adds a columnName and dataType for a partition key.
+     * <p>
+     * Please note that partition keys are added in the order of their declaration;
+     *
+     * @param columnName the name of the partition key to be added;
+     * @param dataType the data type of the partition key to be added.
+     * @return this INSERT statement.
+     */
+    public Create addPartitionKey(String columnName, DataType dataType) {
+        validateNotEmpty(tableName, "Partition key name");
+        validateNotNull(dataType, "Partition key type");
+        validateNotKeyWord(columnName, String.format("The partition key name '%s' is not allowed because it is a reserved keyword", columnName));
+        partitionColumnsMap.put(columnName, dataType);
+        return this;
+    }
+
+    /**
+     * Adds a columnName and dataType for a clustering key.
+     * <p>
+     * Please note that clustering keys are added in the order of their declaration;
+     *
+     * @param columnName the name of the clustering key to be added;
+     * @param dataType the data type of the clustering key to be added.
+     * @return this INSERT statement.
+     */
+    public Create addClusteringKey(String columnName, DataType dataType) {
+        validateNotEmpty(tableName, "Clustering key name");
+        validateNotNull(dataType, "Clustering key type");
+        validateNotKeyWord(columnName, String.format("The clustering key name '%s' is not allowed because it is a reserved keyword", columnName));
+        clusteringColumnsMap.put(columnName, dataType);
+        return this;
+    }
+
+    /**
+     * Adds a columnName and dataType for a simple column.
+     *
+     * <p>
+     *     To add a list column:
+     *     <pre class="code"><code class="java">
+     *         addColumn("myList",DataType.list(DataType.text()))
+     *     </code></pre>
+     *
+     *     To add a set column:
+     *     <pre class="code"><code class="java">
+     *         addColumn("myList",DataType.set(DataType.text()))
+     *     </code></pre>
+     *
+     *     To add a map column:
+     *     <pre class="code"><code class="java">
+     *         addColumn("myList",DataType.map(DataType.cint(),DataType.text()))
+     *     </code></pre>
+     * </p>
+     * @param columnName the name of the column to be added;
+     * @param dataType the data type of the column to be added.
+     * @return this INSERT statement.
+     *
+     */
+    public Create addColumn(String columnName, DataType dataType) {
+        validateNotEmpty(tableName, "Column name");
+        validateNotNull(dataType, "Column type");
+        validateNotKeyWord(columnName, String.format("The column name '%s' is not allowed because it is a reserved keyword", columnName));
+        simpleColumnsMap.put(columnName, dataType);
+        return this;
+    }
+
+    /**
+     * Shorthand method which takes a boolean and calls either {@code info.archinnov.achilles.schemabuilder.Create.addStaticColumn}
+     * or {@code info.archinnov.achilles.schemabuilder.Create.addColumn}
+     *
+     * @param columnName  the name of the column to be added;
+     * @param dataType the data type of the column to be added.
+     * @param isStatic whether the column is static or not
+     * @return this INSERT statement.
+     */
+    public Create addColumn(String columnName, DataType dataType, boolean isStatic) {
+        if (isStatic) {
+            addStaticColumn(columnName, dataType);
+        } else {
+            addColumn(columnName, dataType);
+        }
+        return this;
+    }
+
+    /**
+     * Adds a <strong>static</strong> columnName and dataType for a simple column.
+     *
+     * @param columnName the name of the <strong>static</strong> column to be added;
+     * @param dataType the data type of the column to be added.
+     * @return this INSERT statement.
+     */
+    public Create addStaticColumn(String columnName, DataType dataType) {
+        validateNotEmpty(tableName, "Column name");
+        validateNotNull(dataType, "Column type");
+        validateNotKeyWord(columnName, String.format("The static column name '%s' is not allowed because it is a reserved keyword", columnName));
+        staticColumnsMap.put(columnName, dataType);
+        return this;
+    }
+
+    /**
+     * Adds options for this CREATE TABLE statement.
+     *
+     * @return the options of this CREATE TABLE statement.
+     */
+    public Options withOptions() {
+        return new Options(this);
+    }
+
+    /**
+     * The table options of a CREATE TABLE statement.
+     */
+    public static class Options extends TableOptions<Options> {
+
+        private final Create create;
+
+        private Options(Create create) {
+            super(create);
+            this.create = create;
+        }
+
+        private List<ClusteringOrder> clusteringOrderKeys = Collections.emptyList();
+
+        private Optional<Boolean> compactStorage = Optional.absent();
+
+        /**
+         * Adds a {@link Create.Options.ClusteringOrder} for this table.
+         * <p>
+         * Please note that the {@link Create.Options.ClusteringOrder} are added in their declaration order
+         *
+         * @param clusteringOrders the list of {@link Create.Options.ClusteringOrder}.
+         * @return this {@code Options} object
+         */
+        public Options clusteringOrder(ClusteringOrder... clusteringOrders) {
+            if (clusteringOrders == null || clusteringOrders.length == 0) {
+                throw new IllegalArgumentException(String.format("Cannot create table '%s' with null or empty clustering order keys", create.tableName));
+            }
+            for (ClusteringOrder clusteringOrder : clusteringOrders) {
+                final String clusteringColumnName = clusteringOrder.getClusteringColumnName();
+                if (!create.clusteringColumnsMap.containsKey(clusteringColumnName)) {
+                    throw new IllegalArgumentException(String.format("Clustering key '%s' is unknown. Did you forget to declare it first ?", clusteringColumnName));
+                }
+            }
+            clusteringOrderKeys = Arrays.asList(clusteringOrders);
+            return this;
+        }
+
+        /**
+         * Whether to use compact storage option for the table
+         *
+         * @param compactStorage whether to use compact storage.
+         * @return this {@code Options} object
+         */
+        public Options compactStorage(Boolean compactStorage) {
+            this.compactStorage = Optional.fromNullable(compactStorage);
+            return this;
+        }
+
+
+        /**
+         * Defines a clustering order
+         */
+        public static class ClusteringOrder {
+            private String clusteringColumnName;
+            private Sorting sorting = Sorting.ASC;
+
+
+            /**
+             * Create a new clustering ordering with colummName/order
+             *
+             * @param clusteringColumnName the clustering column.
+             * @param sorting the {@link Create.Options.ClusteringOrder.Sorting}. Possible values are: ASC, DESC.
+             */
+            public ClusteringOrder(String clusteringColumnName, Sorting sorting) {
+                validateNotEmpty(clusteringColumnName, "Column name for clustering order");
+                this.clusteringColumnName = clusteringColumnName;
+                this.sorting = sorting;
+            }
+
+            /**
+             * Create a new clustering ordering with colummName and default ASC sorting order
+             *
+             * @param clusteringColumnName the clustering column.
+             */
+            public ClusteringOrder(String clusteringColumnName) {
+                validateNotEmpty(clusteringColumnName, "Column name for clustering order");
+                this.clusteringColumnName = clusteringColumnName;
+            }
+
+            public String getClusteringColumnName() {
+                return clusteringColumnName;
+            }
+
+            public Sorting getSorting() {
+                return sorting;
+            }
+
+            public String toStatement() {
+                return clusteringColumnName + " " + sorting.name();
+            }
+
+            @Override
+            public String toString() {
+                return toStatement();
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass()) {
+                    return false;
+                }
+
+                ClusteringOrder that = (ClusteringOrder) o;
+
+                if (clusteringColumnName != null ? !clusteringColumnName.equals(that.clusteringColumnName) : that.clusteringColumnName != null) {
+                    return false;
+                }
+                if (sorting != that.sorting) {
+                    return false;
+                }
+
+                return true;
+            }
+
+            @Override
+            public int hashCode() {
+                int result = clusteringColumnName != null ? clusteringColumnName.hashCode() : 0;
+                result = 31 * result + (sorting != null ? sorting.hashCode() : 0);
+                return result;
+            }
+
+            /**
+             * The clustering sorting order
+             */
+            public static enum Sorting {
+                ASC, DESC
+            }
+        }
+
+
+        @Override
+        String buildOptions() {
+            final List<String> commonOptions = super.buildCommonOptions();
+            List<String> options = new ArrayList<String>(commonOptions);
+
+            if (!clusteringOrderKeys.isEmpty()) {
+                options.add(new StringBuilder(CLUSTERING_ORDER_BY).append(OPEN_PAREN).append(Joiner.on(SUB_OPTION_SEPARATOR).join(clusteringOrderKeys)).append(CLOSE_PAREN).toString());
+            }
+
+            if (compactStorage.isPresent() && compactStorage.get()) {
+                if (!create.staticColumnsMap.isEmpty()) {
+                    throw new IllegalStateException(String.format("Cannot create table '%s' with compact storage and static columns '%s'", create.tableName, create.staticColumnsMap.keySet()));
+                }
+                options.add(COMPACT_STORAGE);
+            }
+
+            return new StringBuilder(NEW_LINE).append(TAB).append(WITH).append(SPACE).append(Joiner.on(OPTION_SEPARATOR).join(options)).toString();
+        }
+
+        /**
+         * Generate the final CREATE TABLE statement <strong>with</strong> table options
+         *
+         * @return the final CREATE TABLE statement <strong>with</strong> table options
+         */
+        @Override
+        public String build() {
+            StringBuilder statement = new StringBuilder(super.build());
+            statement.append(this.buildOptions());
+            return statement.toString();
+        }
+    }
+
+    @Override
+    String buildInternal() {
+        if (partitionColumnsMap.size() < 1) {
+            throw new IllegalStateException(String.format("There should be at least one partition key defined for the table '%s'", tableName));
+        }
+
+        validateColumnsDeclaration();
+
+        StringBuilder createStatement = new StringBuilder(NEW_LINE).append(TAB).append(CREATE_TABLE);
+        if (ifNotExists.isPresent() && ifNotExists.get()) {
+            createStatement.append(SPACE).append(IF_NOT_EXISTS);
+        }
+        createStatement.append(SPACE);
+        if (keyspaceName.isPresent()) {
+            createStatement.append(keyspaceName.get()).append(DOT);
+        }
+        createStatement.append(tableName);
+
+        List<String> allColumns = new ArrayList<String>();
+        List<String> partitionKeyColumns = new ArrayList<String>();
+        List<String> clusteringKeyColumns = new ArrayList<String>();
+
+
+        for (Entry<String, DataType> entry : partitionColumnsMap.entrySet()) {
+            allColumns.add(new StringBuilder(entry.getKey()).append(SPACE).append(entry.getValue().getName().toString()).toString());
+            partitionKeyColumns.add(entry.getKey());
+        }
+
+        for (Entry<String, DataType> entry : clusteringColumnsMap.entrySet()) {
+            allColumns.add(new StringBuilder(entry.getKey()).append(SPACE).append(entry.getValue().getName().toString()).toString());
+            clusteringKeyColumns.add(entry.getKey());
+        }
+
+        for (Entry<String, DataType> entry : staticColumnsMap.entrySet()) {
+            final StringBuilder column = new StringBuilder();
+            buildColumnType(entry, column);
+            column.append(SPACE).append(STATIC);
+            allColumns.add(column.toString());
+        }
+
+        for (Entry<String, DataType> entry : simpleColumnsMap.entrySet()) {
+            final StringBuilder column = new StringBuilder();
+            buildColumnType(entry, column);
+            allColumns.add(column.toString());
+        }
+
+        String partitionKeyPart = partitionKeyColumns.size() == 1 ?
+                partitionKeyColumns.get(0)
+                : new StringBuilder(OPEN_PAREN).append(Joiner.on(SEPARATOR).join(partitionKeyColumns)).append(CLOSE_PAREN).toString();
+
+        String primaryKeyPart = clusteringKeyColumns.size() == 0 ?
+                partitionKeyPart
+                : new StringBuilder(partitionKeyPart).append(SEPARATOR).append(Joiner.on(SEPARATOR).join(clusteringKeyColumns)).toString();
+
+        createStatement.append(OPEN_PAREN).append(NEW_LINE).append(TAB).append(TAB);
+        createStatement.append(Joiner.on(COLUMN_FORMATTING).join(allColumns));
+        createStatement.append(COLUMN_FORMATTING).append(PRIMARY_KEY);
+        createStatement.append(OPEN_PAREN).append(primaryKeyPart).append(CLOSE_PAREN);
+        createStatement.append(CLOSE_PAREN);
+
+        return createStatement.toString();
+    }
+
+    private void buildColumnType(Entry<String, DataType> entry, StringBuilder column) {
+        final DataType dataType = entry.getValue();
+        final String type = dataType.getName().toString();
+        column.append(entry.getKey()).append(SPACE).append(type);
+
+        if (dataType.isCollection()) {
+            final List<DataType> typeArguments = dataType.getTypeArguments();
+            if (typeArguments.size() == 1) {
+                column.append(OPEN_TYPE).append(typeArguments.get(0)).append(CLOSE_TYPE);
+            } else if (typeArguments.size() == 2) {
+                column.append(OPEN_TYPE).append(typeArguments.get(0)).append(COMMA).append(typeArguments.get(1)).append(CLOSE_TYPE);
+            }
+        }
+    }
+
+    /**
+     * Generate a CREATE TABLE statement <strong>without</strong> table options
+     * @return the final CREATE TABLE statement
+     */
+    public String build() {
+        return buildInternal();
+    }
+
+    private void validateColumnsDeclaration() {
+
+        final Collection partitionAndClusteringColumns = this.intersection(partitionColumnsMap.keySet(), clusteringColumnsMap.keySet());
+        final Collection partitionAndSimpleColumns = this.intersection(partitionColumnsMap.keySet(), simpleColumnsMap.keySet());
+        final Collection clusteringAndSimpleColumns = this.intersection(clusteringColumnsMap.keySet(), simpleColumnsMap.keySet());
+        final Collection partitionAndStaticColumns = this.intersection(partitionColumnsMap.keySet(), staticColumnsMap.keySet());
+        final Collection clusteringAndStaticColumns = this.intersection(clusteringColumnsMap.keySet(), staticColumnsMap.keySet());
+        final Collection simpleAndStaticColumns = this.intersection(simpleColumnsMap.keySet(), staticColumnsMap.keySet());
+
+        if (!partitionAndClusteringColumns.isEmpty()) {
+            throw new IllegalStateException(String.format("The '%s' columns can not be declared as partition keys and clustering keys at the same time", partitionAndClusteringColumns));
+        }
+
+        if (!partitionAndSimpleColumns.isEmpty()) {
+            throw new IllegalStateException(String.format("The '%s' columns can not be declared as partition keys and simple columns at the same time", partitionAndSimpleColumns));
+        }
+
+        if (!clusteringAndSimpleColumns.isEmpty()) {
+            throw new IllegalStateException(String.format("The '%s' columns can not be declared as clustering keys and simple columns at the same time", clusteringAndSimpleColumns));
+        }
+
+        if (!partitionAndStaticColumns.isEmpty()) {
+            throw new IllegalStateException(String.format("The '%s' columns can not be declared as partition keys and static columns at the same time", partitionAndStaticColumns));
+        }
+
+        if (!clusteringAndStaticColumns.isEmpty()) {
+            throw new IllegalStateException(String.format("The '%s' columns can not be declared as clustering keys and static columns at the same time", clusteringAndStaticColumns));
+        }
+
+        if (!simpleAndStaticColumns.isEmpty()) {
+            throw new IllegalStateException(String.format("The '%s' columns can not be declared as simple columns and static columns at the same time", simpleAndStaticColumns));
+        }
+
+        if (!staticColumnsMap.isEmpty() && clusteringColumnsMap.isEmpty()) {
+            throw new IllegalStateException(String.format("The table '%s' cannot declare static columns '%s' without clustering columns", tableName, staticColumnsMap.keySet()));
+        }
+    }
+
+    private <T> Collection<T> intersection(Collection<T> col1, Collection<T> col2) {
+        Set<T> set = new HashSet<T>();
+
+        for (T t : col1) {
+            if(col2.contains(t)) {
+                set.add(t);
+            }
+        }
+        return set;
+    }
+
+
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/CreateIndex.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/CreateIndex.java
@@ -1,0 +1,91 @@
+package com.datastax.driver.core.schemabuilder;
+
+import com.google.common.base.Optional;
+
+public class CreateIndex extends SchemaStatement {
+
+    private String indexName;
+    private boolean ifNotExists = false;
+    private Optional<String> keyspaceName = Optional.absent();
+    private String tableName;
+    private String columnName;
+
+
+    CreateIndex(String indexName) {
+        validateNotEmpty(indexName, "Index name");
+        validateNotKeyWord(indexName, String.format("The index name '%s' is not allowed because it is a reserved keyword", indexName));
+        this.indexName = indexName;
+    }
+
+    /**
+     * Use 'IF NOT EXISTS' CAS condition for the index creation.
+     *
+     * @return this CREATE INDEX statement.
+     */
+    public CreateIndex ifNotExists() {
+        this.ifNotExists = true;
+        return this;
+    }
+
+    /**
+     * Create index on the given keyspace and table
+     * @param keyspaceName
+     * @param tableName
+     * @return this CREATE INDEX statement
+     */
+    public CreateIndexOn onTable(String keyspaceName, String tableName) {
+        validateNotEmpty(keyspaceName, "Keyspace name");
+        validateNotEmpty(tableName, "Table name");
+        validateNotKeyWord(keyspaceName, String.format("The keyspace name '%s' is not allowed because it is a reserved keyword", keyspaceName));
+        validateNotKeyWord(tableName, String.format("The table name '%s' is not allowed because it is a reserved keyword", tableName));
+        this.keyspaceName = Optional.fromNullable(keyspaceName);
+        ;
+        this.tableName = tableName;
+        return new CreateIndexOn();
+    }
+
+    /**
+     * Create index on the given table
+     * @param tableName
+     * @return this CREATE INDEX statement
+     */
+    public CreateIndexOn onTable(String tableName) {
+        validateNotEmpty(tableName, "Table name");
+        validateNotKeyWord(tableName, String.format("The table name '%s' is not allowed because it is a reserved keyword", tableName));
+        this.tableName = tableName;
+        return new CreateIndexOn();
+    }
+
+    public class CreateIndexOn {
+        /**
+         * Create index on the given column
+         * @param columnName
+         * @return the final CREATE INDEX statement
+         */
+        public String andColumn(String columnName) {
+            validateNotEmpty(tableName, "Column name");
+            validateNotKeyWord(columnName, String.format("The column name '%s' is not allowed because it is a reserved keyword", columnName));
+            CreateIndex.this.columnName = columnName;
+            return buildInternal();
+        }
+    }
+
+
+    @Override
+    String buildInternal() {
+        StringBuilder createStatement = new StringBuilder(NEW_LINE).append(TAB).append(CREATE_INDEX).append(SPACE);
+
+        if (ifNotExists) {
+            createStatement.append(IF_NOT_EXISTS).append(SPACE);
+        }
+
+        createStatement.append(indexName).append(SPACE).append(ON).append(SPACE);
+
+        if (keyspaceName.isPresent()) {
+            createStatement.append(keyspaceName.get()).append(DOT);
+        }
+        createStatement.append(tableName);
+
+        return createStatement.append(OPEN_PAREN).append(columnName).append(CLOSE_PAREN).toString();
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/Drop.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/Drop.java
@@ -1,0 +1,62 @@
+package com.datastax.driver.core.schemabuilder;
+
+import com.google.common.base.Optional;
+
+/**
+ * A built DROP TABLE statement
+ */
+public class Drop extends SchemaStatement {
+
+    private Optional<String> keyspaceName = Optional.absent();
+    private String tableName;
+    private Optional<Boolean> ifExists = Optional.absent();
+
+    Drop(String keyspaceName, String tableName) {
+        validateNotEmpty(keyspaceName, "Keyspace name");
+        validateNotEmpty(tableName, "Table name");
+        validateNotKeyWord(keyspaceName, String.format("The keyspace name '%s' is not allowed because it is a reserved keyword", keyspaceName));
+        validateNotKeyWord(tableName,String.format("The table name '%s' is not allowed because it is a reserved keyword",tableName));
+        this.tableName = tableName;
+        this.keyspaceName = Optional.fromNullable(keyspaceName);
+    }
+
+    Drop(String tableName) {
+        validateNotEmpty(tableName, "Table name");
+        validateNotKeyWord(tableName,String.format("The table name '%s' is not allowed because it is a reserved keyword",tableName));
+        this.tableName = tableName;
+    }
+
+    /**
+     * Use 'IF EXISTS' CAS condition for the table drop.
+     *
+     * @param ifExists whether to use the CAS condition.
+     * @return a new {@link Drop} instance.
+     */
+    public Drop ifExists(Boolean ifExists) {
+        this.ifExists = Optional.fromNullable(ifExists);
+        return this;
+    }
+
+    @Override
+    String buildInternal() {
+        StringBuilder dropStatement = new StringBuilder(DROP_TABLE);
+        if (ifExists.isPresent() && ifExists.get()) {
+            dropStatement.append(SPACE).append(IF_EXISTS);
+        }
+        dropStatement.append(SPACE);
+        if (keyspaceName.isPresent()) {
+            dropStatement.append(keyspaceName.get()).append(DOT);
+        }
+
+        dropStatement.append(tableName);
+        return dropStatement.toString();
+    }
+
+    /**
+     * Generate a DROP TABLE statement
+     * @return the final DROP TABLE statement
+     */
+    public String build() {
+        return this.buildInternal();
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/SchemaBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/SchemaBuilder.java
@@ -1,0 +1,88 @@
+package com.datastax.driver.core.schemabuilder;
+
+/**
+ * Static methods to build a CQL3 DML statement.
+ * <p>
+ * Available DML statements: CREATE/ALTER/DROP
+ * <p>
+ * Note that it could be convenient to use an 'import static' to use the methods of this class.
+ */
+public final class SchemaBuilder {
+
+    private SchemaBuilder() {
+    }
+
+    /**
+     * Start building a new CREATE TABLE statement
+     *
+     * @param tableName the name of the table to create.
+     * @return an in-construction CREATE TABLE statement.
+     */
+    public static Create createTable(String tableName) {
+        return new Create(tableName);
+    }
+
+    /**
+     * Start building a new CREATE TABLE statement
+     *
+     * @param keyspaceName the name of the keyspace to be used.
+     * @param tableName the name of the table to create.
+     * @return an in-construction CREATE TABLE statement.
+     */
+    public static Create createTable(String keyspaceName, String tableName) {
+        return new Create(keyspaceName, tableName);
+    }
+
+    /**
+     * Start building a new ALTER TABLE statement
+     *
+     * @param tableName the name of the table to be altered.
+     * @return an in-construction ALTER TABLE statement.
+     */
+    public static Alter alterTable(String tableName) {
+        return new Alter(tableName);
+    }
+
+    /**
+     * Start building a new ALTER TABLE statement
+     *
+     * @param keyspaceName the name of the keyspace to be used.
+     * @param tableName the name of the table to be altered.
+     * @return an in-construction ALTER TABLE statement.
+     */
+    public static Alter alterTable(String keyspaceName, String tableName) {
+        return new Alter(keyspaceName, tableName);
+    }
+
+    /**
+     * Start building a new DROP TABLE statement
+     *
+     * @param tableName the name of the table to be dropped.
+     * @return an in-construction DROP TABLE statement.
+     */
+    public static Drop dropTable(String tableName) {
+        return new Drop(tableName);
+    }
+
+    /**
+     * Start building a new DROP TABLE statement
+     *
+     * @param keyspaceName the name of the keyspace to be used.
+     * @param tableName the name of the table to be dropped.
+     * @return an in-construction DROP TABLE statement.
+     */
+    public static Drop dropTable(String keyspaceName, String tableName) {
+        return new Drop(keyspaceName, tableName);
+    }
+
+
+    /**
+     * Start building a new CREATE INDEX statement
+     *
+     * @param indexName the name of the table to create.
+     * @return an in-construction CREATE INDEX statement.
+     */
+    public static CreateIndex createIndex(String indexName) {
+        return new CreateIndex(indexName);
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/SchemaStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/SchemaStatement.java
@@ -1,0 +1,66 @@
+package com.datastax.driver.core.schemabuilder;
+
+import java.util.Arrays;
+import java.util.List;
+import com.google.common.base.Strings;
+
+public abstract class SchemaStatement {
+
+    static final String NEW_LINE = "\n";
+    static final String TAB = "\t";
+    static final String COLUMN_FORMATTING = ",\n\t\t";
+    static final String OPEN_PAREN = "(";
+    static final String CLOSE_PAREN = ")";
+    static final String OPEN_TYPE = "<";
+    static final String CLOSE_TYPE = ">";
+    static final String SPACE = " ";
+    static final String SEPARATOR = ", ";
+    static final String COMMA = ",";
+    static final String DOT = ".";
+    static final String STATIC = "static";
+    static final String CREATE_TABLE = "CREATE TABLE";
+    static final String IF_NOT_EXISTS = "IF NOT EXISTS";
+    static final String PRIMARY_KEY = "PRIMARY KEY";
+
+    static final String ALTER_TABLE = "ALTER TABLE";
+    static final String ALTER = "ALTER";
+    static final String TYPE = "TYPE";
+    static final String ADD = "ADD";
+    static final String RENAME = "RENAME";
+    static final String TO = "TO";
+    static final String WITH = "WITH";
+    static final String DROP = "DROP";
+
+    static final String DROP_TABLE = "DROP TABLE";
+    static final String IF_EXISTS = "IF EXISTS";
+
+
+    static final String CLUSTERING_ORDER_BY = "CLUSTERING ORDER BY";
+    static final String COMPACT_STORAGE = "COMPACT STORAGE";
+
+    static final String CREATE_INDEX = "CREATE INDEX";
+    static final String ON = "ON";
+
+
+    static final List<String> RESERVED_KEYWORDS = Arrays.asList("add,allow,alter,and,any,apply,asc,authorize,batch,begin,by,columnfamily,create,delete,desc,drop,each_quorum,from,grant,in,index,inet,infinity,insert,into,keyspace,keyspaces,limit,local_one,local_quorum,modify,nan,norecursive,of,on,order,password,primary,quorum,rename,revoke,schema,select,set,table,three,to,token,truncate,two,unlogged,update,use,using,where,with".split(","));
+
+    abstract String buildInternal();
+
+    protected static void validateNotEmpty(String columnName, String label) {
+        if (Strings.isNullOrEmpty(columnName)) {
+            throw new IllegalArgumentException(label + " should not be null or blank");
+        }
+    }
+
+    protected static void validateNotNull(Object value, String label) {
+        if (value == null) {
+            throw new IllegalArgumentException(label + " should not be null");
+        }
+    }
+
+    protected static void validateNotKeyWord(String label, String message) {
+        if (RESERVED_KEYWORDS.contains(label)) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/TableOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/TableOptions.java
@@ -1,0 +1,889 @@
+package com.datastax.driver.core.schemabuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+
+/**
+ * Table options
+ * <p>
+ *     This class is abstract and not meant to use directly.
+ *     <br/>
+ *     Concrete implementations are {@link com.datastax.driver.core.schemabuilder.Create.Options} and {@link com.datastax.driver.core.schemabuilder.Alter.Options}
+ * </p>
+ * <p>
+ *     The &lt;T&gt; parameter type is here to allow the usage of <strong>covariant return type</strong> and makes the builder pattern work for different sub-classes
+ * </p>
+ * <p>
+ *     @see <a href="http://www.datastax.com/documentation/cql/3.1/cql/cql_reference/tabProp.html" target="_blank">details on table options</a>
+ * </p>
+ * @param <T> the concrete sub-class of {@link com.datastax.driver.core.schemabuilder.TableOptions}
+ */
+public abstract class TableOptions<T extends TableOptions> {
+
+    static final String VALUE_SEPARATOR = " : ";
+    static final String START_SUB_OPTIONS = "{";
+    static final String SUB_OPTION_SEPARATOR = ", ";
+    static final String END_SUB_OPTIONS = "}";
+    static final String OPTION_ASSIGNMENT = " = ";
+    static final String QUOTE = "'";
+    static final String OPTION_SEPARATOR = " AND ";
+
+
+    private SchemaStatement schemaStatement;
+
+    private Optional<Caching> caching = Optional.absent();
+
+    private Optional<Double> bloomFilterFPChance = Optional.absent();
+
+    private Optional<String> comment = Optional.absent();
+
+    private Optional<CompressionOptions> compressionOptions = Optional.absent();
+
+    private Optional<CompactionOptions> compactionOptions = Optional.absent();
+
+    private Optional<Double> dcLocalReadRepairChance = Optional.absent();
+
+    private Optional<Integer> defaultTTL = Optional.absent();
+
+    private Optional<Long> gcGraceSeconds = Optional.absent();
+
+    private Optional<Integer> indexInterval = Optional.absent();
+
+    private Optional<Long> memtableFlushPeriodInMillis = Optional.absent();
+
+    private Optional<Boolean> populateIOOnCacheFlush = Optional.absent();
+
+    private Optional<Double> readRepairChance = Optional.absent();
+
+    private Optional<Boolean> replicateOnWrite = Optional.absent();
+
+    private Optional<SpeculativeRetryValue> speculativeRetry = Optional.absent();
+
+    TableOptions(SchemaStatement schemaStatement) {
+        this.schemaStatement = schemaStatement;
+    }
+
+    /**
+     * Define the caching type
+     * @param caching caching type. Available values are NONE, ALL, KEYS_ONLY & ROWS_ONLY
+     * @return this table options
+     */
+    public T caching(Caching caching) {
+        this.caching = Optional.fromNullable(caching);
+        return (T) this;
+    }
+
+    /**
+     * Desired false-positive probability for SSTable Bloom filters
+     * <p>
+     *     If not set, for SizeTiered strategy, default = <strong>0.01</strong>, for Leveled strategy, default = <strong>0.1</strong>
+     * </p>
+     * @param fpChance the false positive change. This value should be between 0 and 1.0
+     * @return this table options
+     */
+    public T bloomFilterFPChance(Double fpChance) {
+        validateRateValue(fpChance, "Bloom filter false positive change");
+        this.bloomFilterFPChance = Optional.fromNullable(fpChance);
+        return (T) this;
+    }
+
+    /**
+     * A human readable comment describing the table
+     * @param comment comment for the table
+     * @return this table options
+     */
+    public T comment(String comment) {
+        this.comment = Optional.fromNullable(comment);
+        return (T) this;
+    }
+
+    /**
+     * Define the compression options
+     * @param compressionOptions the compression options.
+     *        Use the {@link com.datastax.driver.core.schemabuilder.TableOptions.CompressionOptions} to build an instance of compression options
+     * @return this table options
+     */
+    public T compressionOptions(CompressionOptions compressionOptions) {
+        this.compressionOptions = Optional.fromNullable(compressionOptions);
+        return (T) this;
+    }
+
+    /**
+     * Define the compaction options
+     * @param compactionOptions the compaction options.
+     *        Use the {@link TableOptions.CompactionOptions} to build an instance of compaction options
+     * @return this table options
+     */
+    public T compactionOptions(CompactionOptions compactionOptions) {
+        this.compactionOptions = Optional.fromNullable(compactionOptions);
+        return (T) this;
+    }
+
+    /**
+     * Specifies the probability of read repairs being invoked over all replicas in the current data center
+     * <p>
+     *     If not set, default to 0.0
+     * </p>
+     * @param dcLocalReadRepairChance local Data Center read repair change
+     * @return this table options
+     */
+    public T dcLocalReadRepairChance(Double dcLocalReadRepairChance) {
+        validateRateValue(dcLocalReadRepairChance, "DC local read repair chance");
+        this.dcLocalReadRepairChance = Optional.fromNullable(dcLocalReadRepairChance);
+        return (T) this;
+    }
+
+
+    /**
+     * The default expiration time in seconds for a table. Used in MapReduce/Hive scenarios when you have no control of TTL
+     * <p>
+     *     If not set, default =0
+     * </p>
+     * @param defaultTimeToLive default time to live in seconds for a table
+     * @return this table options
+     */
+    public T defaultTimeToLive(Integer defaultTimeToLive) {
+        this.defaultTTL = Optional.fromNullable(defaultTimeToLive);
+        return (T) this;
+    }
+
+    /**
+     * Specifies the time to wait before garbage collecting tombstones (deletion markers).
+     * The default value allows a great deal of time for consistency to be achieved prior to deletion.
+     * In many deployments this interval can be reduced, and in a single-node cluster it can be safely set to zero
+     * <p>
+     *     If not set, default = 864000 secs (10 days)
+     * </p>
+     * @param gcGraceSeconds GC grace seconds
+     * @return this table options
+     */
+    public T gcGraceSeconds(Long gcGraceSeconds) {
+        this.gcGraceSeconds = Optional.fromNullable(gcGraceSeconds);
+        return (T) this;
+    }
+
+    /**
+     * To control the sampling of entries from the primary row index, configure sample frequency of the partition summary by changing the index_interval property.
+     * After changing the value of index_interval, SSTables are written to disk with new value.
+     * The interval corresponds to the number of index entries that are skipped between taking each sample.
+     * By default Cassandra samples one row key out of every 128.
+     * The larger the interval, the smaller and less effective the sampling.
+     * The larger the sampling, the more effective the index, but with increased memory usage.
+     * Generally, the best trade off between memory usage and performance is a value between 128 and 512 in combination with a large table key cache.
+     * However, if you have small rows (many to an OS page), you may want to increase the sample size, which often lowers memory usage without an impact on performance.
+     * For large rows, decreasing the sample size may improve read performance
+     * <p>
+     *     If not set, default = 128
+     * </p>
+     * @param indexInterval index interval
+     * @return this table options
+     */
+    public T indexInterval(Integer indexInterval) {
+        this.indexInterval = Optional.fromNullable(indexInterval);
+        return (T) this;
+    }
+
+    /**
+     * Forces flushing of the memtable after the specified time in milliseconds elapses
+     * <p>
+     *     If not set, default = 0
+     * </p>
+     * @param memtableFlushPeriodInMillis memtable flush period in milli seconds
+     * @return this table options
+     */
+    public T memtableFlushPeriodInMillis(Long memtableFlushPeriodInMillis) {
+        this.memtableFlushPeriodInMillis = Optional.fromNullable(memtableFlushPeriodInMillis);
+        return (T) this;
+    }
+
+    /**
+     * Adds newly flushed or compacted sstables to the operating system page cache, potentially evicting other cached data to make room.
+     * Enable when all data in the table is expected to fit in memory.
+     *
+     * See also the global option <a href="http://www.datastax.com/documentation/cassandra/2.0/cassandra/configuration/configCassandra_yaml_r.html?scroll=reference_ds_qfg_n1r_1k__compaction_preheat_key_cache">compaction_preheat_key_cache</a>
+     * @param populateIOOnCacheFlush whether populate IO cache on flush of sstables
+     * @return this table options
+     */
+    public T populateIOOnCacheFlush(Boolean populateIOOnCacheFlush) {
+        this.populateIOOnCacheFlush = Optional.fromNullable(populateIOOnCacheFlush);
+        return (T) this;
+    }
+
+    /**
+     * Specifies the probability with which read repairs should be invoked on non-quorum reads. The value must be between 0 and 1.
+     * <p>
+     *     If not set, default = 0.1
+     * </p>
+     * @param readRepairChance read repair chance
+     * @return this table options
+     */
+    public T readRepairChance(Double readRepairChance) {
+        validateRateValue(readRepairChance, "Read repair chance");
+        this.readRepairChance = Optional.fromNullable(readRepairChance);
+        return (T) this;
+    }
+
+
+    /**
+     * Applies only to counter tables.
+     * When set to true, replicates writes to all affected replicas regardless of the consistency level specified by the client for a write request.
+     * For counter tables, this should always be set to true
+     * <p>
+     *     If not set, default = true
+     * </p>
+     * @param replicateOnWrite whether replicate data on write
+     * @return this table options
+     */
+    public T replicateOnWrite(Boolean replicateOnWrite) {
+        this.replicateOnWrite = Optional.fromNullable(replicateOnWrite);
+        return (T) this;
+    }
+
+    /**
+     * To override normal read timeout when read_repair_chance is not 1.0, sending another request to read, choose one of these values and use the property to create
+     * or alter the table:
+     * <ul>
+     *     <li>ALWAYS: Retry reads of all replicas.</li>
+     *     <li>Xpercentile: Retry reads based on the effect on throughput and latency.</li>
+     *     <li>Yms: Retry reads after specified milliseconds.</li>
+     *     <li>NONE: Do not retry reads.</li>
+     * </ul>
+     *
+     * Using the speculative retry property, you can configure rapid read protection in Cassandra 2.0.2.
+     * Use this property to retry a request after some milliseconds have passed or after a percentile of the typical read latency has been reached,
+     * which is tracked per table.
+     *
+     * <p>
+     *     If not set, default = 99percentile Cassandra 2.0.2 and later
+     * </p>
+     * @param speculativeRetry the speculative retry.
+     *      Use {@link TableOptions.SpeculativeRetryValue} class to build an instance
+     * @return this table options
+     */
+    public T speculativeRetry(SpeculativeRetryValue speculativeRetry) {
+        this.speculativeRetry = Optional.fromNullable(speculativeRetry);
+        return (T) this;
+    }
+
+
+    List<String> buildCommonOptions() {
+        List<String> options = new ArrayList<String>();
+
+        if (caching.isPresent()) {
+            options.add(new StringBuilder("caching").append(OPTION_ASSIGNMENT).append(caching.get()).toString());
+        }
+
+        if (bloomFilterFPChance.isPresent()) {
+            options.add(new StringBuilder("bloom_filter_fp_chance").append(OPTION_ASSIGNMENT).append(bloomFilterFPChance.get()).toString());
+        }
+
+        if (comment.isPresent()) {
+            options.add(new StringBuilder("comment").append(OPTION_ASSIGNMENT).append(QUOTE).append(comment.get()).append(QUOTE).toString());
+        }
+
+        if (compressionOptions.isPresent()) {
+            options.add(new StringBuilder("compression").append(OPTION_ASSIGNMENT).append(compressionOptions.get().build()).toString());
+        }
+
+        if (compactionOptions.isPresent()) {
+            options.add(new StringBuilder("compaction").append(OPTION_ASSIGNMENT).append(compactionOptions.get().build()).toString());
+        }
+
+        if (dcLocalReadRepairChance.isPresent()) {
+            options.add(new StringBuilder("dclocal_read_repair_chance").append(OPTION_ASSIGNMENT).append(dcLocalReadRepairChance.get()).toString());
+        }
+
+        if (defaultTTL.isPresent()) {
+            options.add(new StringBuilder("default_time_to_live").append(OPTION_ASSIGNMENT).append(defaultTTL.get()).toString());
+        }
+
+        if (gcGraceSeconds.isPresent()) {
+            options.add(new StringBuilder("gc_grace_seconds").append(OPTION_ASSIGNMENT).append(gcGraceSeconds.get()).toString());
+        }
+
+        if (indexInterval.isPresent()) {
+            options.add(new StringBuilder("index_interval").append(OPTION_ASSIGNMENT).append(indexInterval.get()).toString());
+        }
+
+        if (memtableFlushPeriodInMillis.isPresent()) {
+            options.add(new StringBuilder("memtable_flush_period_in_ms").append(OPTION_ASSIGNMENT).append(memtableFlushPeriodInMillis.get()).toString());
+        }
+
+        if (populateIOOnCacheFlush.isPresent()) {
+            options.add(new StringBuilder("populate_io_cache_on_flush").append(OPTION_ASSIGNMENT).append(populateIOOnCacheFlush.get()).toString());
+        }
+
+        if (readRepairChance.isPresent()) {
+            options.add(new StringBuilder("read_repair_chance").append(OPTION_ASSIGNMENT).append(readRepairChance.get()).toString());
+        }
+
+        if (replicateOnWrite.isPresent()) {
+            options.add(new StringBuilder("replicate_on_write").append(OPTION_ASSIGNMENT).append(replicateOnWrite.get()).toString());
+        }
+
+        if (speculativeRetry.isPresent()) {
+            options.add(new StringBuilder("speculative_retry").append(OPTION_ASSIGNMENT).append(speculativeRetry.get().value()).toString());
+        }
+
+        return options;
+    }
+
+    abstract String buildOptions();
+
+    String build() {
+        return schemaStatement.buildInternal();
+    }
+
+    static void validateRateValue(Double rateValue, String property) {
+        if (rateValue != null && (rateValue < 0 || rateValue > 1.0)) {
+            throw new IllegalArgumentException(property + " should be between 0 and 1");
+        }
+    }
+
+    /**
+     * Define table caching.
+     * <p>
+     *     Possible values are NONE, ALL, KEYS_ONLY & ROWS_ONLY
+     * </p>
+     *
+     */
+    public static enum Caching {
+        ALL("'all'"), KEYS_ONLY("'keys_only'"), ROWS_ONLY("'rows_only'"), NONE("'none'");
+
+        private String value;
+
+        Caching(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+
+    /**
+     * Compaction options
+     * <p>
+     *      This is an abstract class. Concrete classes are {@link TableOptions.CompactionOptions.SizeTieredCompactionStrategyOptions}
+     *      and {@link TableOptions.CompactionOptions.LeveledCompactionStrategyOptions}
+     * </p>
+     * <p>
+     *      The parameter type &lt;T&gt; allows the usage of <strong>covariant return type</strong> to make the builder work
+     * </p>
+     * <p>
+     *     @see <a href="http://www.datastax.com/documentation/cql/3.1/cql/cql_reference/compactSubprop.html" target="_blank">details on sub-properties of compaction</a>
+     * </p>
+     * </p>
+     * @param <T> the type of the sub-class
+     */
+    public static abstract class CompactionOptions<T extends CompactionOptions> {
+
+        private Strategy strategy;
+
+        private Optional<Double> bucketHigh = Optional.absent();
+
+        private Optional<Double> bucketLow = Optional.absent();
+
+        private Optional<Double> coldReadsRatioToOmit = Optional.absent();
+
+        private Optional<Boolean> enableAutoCompaction = Optional.absent();
+
+        private Optional<Integer> minThreshold = Optional.absent();
+
+        private Optional<Integer> maxThreshold = Optional.absent();
+
+        private Optional<Long> minSSTableSizeInBytes = Optional.absent();
+
+        private Optional<Integer> ssTableSizeInMB = Optional.absent();
+
+        private Optional<Integer> tombstoneCompactionIntervalInDay = Optional.absent();
+
+        private Optional<Double> tombstoneThreshold = Optional.absent();
+
+
+        private CompactionOptions(Strategy compactionStrategy) {
+            this.strategy = compactionStrategy;
+        }
+
+        /**
+         * Compaction options for SizeTiered strategy
+         * @return a {@link TableOptions.CompactionOptions.SizeTieredCompactionStrategyOptions} instance
+         */
+        public static SizeTieredCompactionStrategyOptions sizedTieredStategy() {
+            return new SizeTieredCompactionStrategyOptions();
+        }
+
+        /**
+         * Compaction options for Leveled strategy
+         * @return a {@link TableOptions.CompactionOptions.LeveledCompactionStrategyOptions} instance
+         */
+        public static LeveledCompactionStrategyOptions leveledStrategy() {
+            return new LeveledCompactionStrategyOptions();
+        }
+
+        /**
+         * Enables or disables background compaction
+         * <p>
+         *     If not set, default = true
+         * </p>
+         * @param enableAutoCompaction whether to enable auto compaction for the table
+         * @return this compaction options
+         */
+        public T enableAutoCompaction(Boolean enableAutoCompaction) {
+            this.enableAutoCompaction = Optional.fromNullable(enableAutoCompaction);
+            return (T) this;
+        }
+
+        /**
+         * In SizeTieredCompactionStrategy, sets the maximum number of SSTables to allow in a minor compaction.
+         * In LeveledCompactionStrategy (LCS), it applies to L0 when L0 gets behind, that is, when L0 accumulates more than MAX_COMPACTING_L0 SSTables.
+         * <p>
+         *     If not set, default = 32
+         * </p>
+         * @param maxThreshold max threshold
+         * @return this compaction options
+         */
+        public T maxThreshold(Integer maxThreshold) {
+            this.maxThreshold = Optional.fromNullable(maxThreshold);
+            return (T) this;
+        }
+
+        /**
+         * The minimum number of days to wait after an SSTable creation time before considering the SSTable for tombstone compaction.
+         * Tombstone compaction is the compaction triggered if the SSTable has more garbage-collectable tombstones than tombstone_threshold.
+         * <p>
+         *     If not set, default = 1 (day)
+         * </p>
+         * @param tombstoneCompactionInterval tombstone compaction interval in day.
+         * @return this compaction options
+         */
+        public T tombstoneCompactionIntervalInDay(Integer tombstoneCompactionInterval) {
+            this.tombstoneCompactionIntervalInDay = Optional.fromNullable(tombstoneCompactionInterval);
+            return (T) this;
+        }
+
+        /**
+         * A ratio of garbage-collectable tombstones to all contained columns,
+         * which if exceeded by the SSTable triggers compaction (with no other SSTables) for the purpose of purging the tombstones
+         * <p>
+         *     If not set, default = 0.2
+         * </p>
+         * @param tombstoneCompactionInterval tombstone compaction interval in day.
+         * @return this compaction options
+         */
+        public T tombstoneThreshold(Double tombstoneThreshold) {
+            validateRateValue(tombstoneThreshold, "Tombstone threshold");
+            this.tombstoneThreshold = Optional.fromNullable(tombstoneThreshold);
+            return (T) this;
+        }
+
+
+        List<String> buildCommonOptions() {
+
+            List<String> options = new ArrayList<String>();
+            options.add(new StringBuilder("'class'").append(VALUE_SEPARATOR).append(strategy.strategyClass()).toString());
+
+            if (enableAutoCompaction.isPresent()) {
+                options.add(new StringBuilder("'enabled'").append(VALUE_SEPARATOR).append(enableAutoCompaction.get()).toString());
+            }
+
+            if (maxThreshold.isPresent()) {
+                options.add(new StringBuilder("'max_threshold'").append(VALUE_SEPARATOR).append(maxThreshold.get()).toString());
+            }
+
+            if (tombstoneCompactionIntervalInDay.isPresent()) {
+                options.add(new StringBuilder("'tombstone_compaction_interval'").append(VALUE_SEPARATOR).append(tombstoneCompactionIntervalInDay.get()).toString());
+            }
+
+            if (tombstoneThreshold.isPresent()) {
+                options.add(new StringBuilder("'tombstone_threshold'").append(VALUE_SEPARATOR).append(tombstoneThreshold.get()).toString());
+            }
+
+            return options;
+        }
+
+        public abstract String build();
+
+        /**
+         * Compaction options specific to SizeTiered strategy
+         */
+        public static class SizeTieredCompactionStrategyOptions extends CompactionOptions<SizeTieredCompactionStrategyOptions> {
+
+            private SizeTieredCompactionStrategyOptions() {
+                super(Strategy.SIZED_TIERED);
+            }
+
+            /**
+             * Size-tiered compaction strategy (STCS) considers SSTables to be within the same bucket if the SSTable size diverges by 50%
+             * or less from the default bucket_low and default bucket_high values: [average-size × bucket_low, average-size × bucket_high].
+             * <p>
+             *     If not set, default = 1.5
+             * </p>
+             * @param bucketHigh bucket high
+             * @return
+             */
+            public SizeTieredCompactionStrategyOptions bucketHigh(Double bucketHigh) {
+                super.bucketHigh = Optional.fromNullable(bucketHigh);
+                return this;
+            }
+
+            /**
+             * Size-tiered compaction strategy (STCS) considers SSTables to be within the same bucket if the SSTable size diverges by 50%
+             * or less from the default bucket_low and default bucket_high values: [average-size × bucket_low, average-size × bucket_high].
+             * <p>
+             *     If not set, default = 0.5
+             * </p>
+             * @param bucketLow bucket low
+             * @return
+             */
+            public SizeTieredCompactionStrategyOptions bucketLow(Double bucketLow) {
+                super.bucketLow = Optional.fromNullable(bucketLow);
+                return this;
+            }
+
+            /**
+             * The maximum percentage of reads/sec that ignored SSTables may account for.
+             * The recommended range of values is 0.0 and 1.0.
+             * In Cassandra 2.0.3 and later, you can enable the cold_reads_to_omit property to tune performace per table.
+             * The <a href="http://www.datastax.com/dev/blog/optimizations-around-cold-sstables">Optimizations around Cold SSTables</a> blog includes detailed information tuning performance using this property,
+             * which avoids compacting cold SSTables. Use the ALTER TABLE command to configure cold_reads_to_omit.
+             * <p>
+             *     If not set, default = 0.0 (disabled)
+             * </p>
+             * @param coldReadsRatio
+             * @return
+             */
+            public SizeTieredCompactionStrategyOptions coldReadsRatioToOmit(Double coldReadsRatio) {
+                validateRateValue(coldReadsRatio, "Cold read ratio to omit ");
+                super.coldReadsRatioToOmit = Optional.fromNullable(coldReadsRatio);
+                return this;
+            }
+
+            /**
+             * In SizeTieredCompactionStrategy sets the minimum number of SSTables to trigger a minor compaction
+             * <p>
+             *     If not set, default = 4
+             * </p>
+             * @param minThreshold min threshold
+             * @return
+             */
+            public SizeTieredCompactionStrategyOptions minThreshold(Integer minThreshold) {
+                super.minThreshold = Optional.fromNullable(minThreshold);
+                return this;
+            }
+
+            /**
+             * The SizeTieredCompactionStrategy groups SSTables for compaction into buckets.
+             * The bucketing process groups SSTables that differ in size by less than 50%. This results in a bucketing process that is too fine grained for small SSTables.
+             * If your SSTables are small, use min_sstable_size to define a size threshold (in bytes) below which all SSTables belong to one unique bucket
+             * <p>
+             *     If not set, default = 52428800 (50Mb)
+             * </p>
+             * @param minSSTableSize min SSTable size in bytes
+             * @return
+             */
+            public SizeTieredCompactionStrategyOptions minSSTableSizeInBytes(Long minSSTableSize) {
+                super.minSSTableSizeInBytes = Optional.fromNullable(minSSTableSize);
+                return this;
+            }
+
+            @Override
+            public String build() {
+                final List<String> generalOptions = super.buildCommonOptions();
+
+                List<String> options = new ArrayList<String>(generalOptions);
+
+                if (super.bucketHigh.isPresent()) {
+                    options.add(new StringBuilder("'bucket_high'").append(VALUE_SEPARATOR).append(super.bucketHigh.get()).toString());
+                }
+
+                if (super.bucketLow.isPresent()) {
+                    options.add(new StringBuilder("'bucket_low'").append(VALUE_SEPARATOR).append(super.bucketLow.get()).toString());
+                }
+
+                if (super.coldReadsRatioToOmit.isPresent()) {
+                    options.add(new StringBuilder("'cold_reads_to_omit'").append(VALUE_SEPARATOR).append(super.coldReadsRatioToOmit.get()).toString());
+                }
+
+                if (super.minThreshold.isPresent()) {
+                    options.add(new StringBuilder("'min_threshold'").append(VALUE_SEPARATOR).append(super.minThreshold.get()).toString());
+                }
+
+                if (super.minSSTableSizeInBytes.isPresent()) {
+                    options.add(new StringBuilder("'min_sstable_size'").append(VALUE_SEPARATOR).append(super.minSSTableSizeInBytes.get()).toString());
+                }
+                return new StringBuilder(START_SUB_OPTIONS).append(Joiner.on(SUB_OPTION_SEPARATOR).join(options)).append(END_SUB_OPTIONS).toString();
+            }
+        }
+
+        /**
+         * Compaction options specific to Leveled strategy
+         */
+        public static class LeveledCompactionStrategyOptions extends CompactionOptions<LeveledCompactionStrategyOptions> {
+
+            private LeveledCompactionStrategyOptions() {
+                super(Strategy.LEVELED);
+            }
+
+            /**
+             * The target size for SSTables that use the leveled compaction strategy.
+             * Although SSTable sizes should be less or equal to sstable_size_in_mb, it is possible to have a larger SSTable during compaction.
+             * This occurs when data for a given partition key is exceptionally large. The data is not split into two SSTables
+             * <p>
+             *     If not set, default = 160 Mb
+             * </p>
+             * @param ssTableSizeInMB  SSTable size in Mb
+             * @return
+             */
+            public LeveledCompactionStrategyOptions ssTableSizeInMB(Integer ssTableSizeInMB) {
+                super.ssTableSizeInMB = Optional.fromNullable(ssTableSizeInMB);
+                return this;
+            }
+
+            @Override
+            public String build() {
+                final List<String> generalOptions = super.buildCommonOptions();
+
+                List<String> options = new ArrayList<String>(generalOptions);
+
+                if (super.ssTableSizeInMB.isPresent()) {
+                    options.add(new StringBuilder("'sstable_size_in_mb'").append(VALUE_SEPARATOR).append(super.ssTableSizeInMB.get()).toString());
+                }
+                return new StringBuilder(START_SUB_OPTIONS).append(Joiner.on(SUB_OPTION_SEPARATOR).join(options)).append(END_SUB_OPTIONS).toString();
+            }
+
+        }
+
+        /**
+         * Compaction strategies. Possible values: SIZED_TIERED & LEVELED
+         */
+        public static enum Strategy {
+            SIZED_TIERED("'SizeTieredCompactionStrategy'"), LEVELED("'LeveledCompactionStrategy'");
+
+            private String strategyClass;
+
+            Strategy(String strategyClass) {
+                this.strategyClass = strategyClass;
+            }
+
+            public String strategyClass() {
+                return strategyClass;
+            }
+
+            @Override
+            public String toString() {
+                return strategyClass;
+            }
+        }
+
+    }
+
+    /**
+     * Compression options
+     */
+    public static class CompressionOptions {
+
+        private Algorithm algorithm;
+
+        private Optional<Integer> chunckLengthInKb = Optional.absent();
+
+        private Optional<Double> crcCheckChance = Optional.absent();
+
+
+        public CompressionOptions(Algorithm algorithm) {
+            this.algorithm = algorithm;
+        }
+
+        /**
+         * No compression
+         * @return compression options
+         */
+        public static CompressionOptions none() {
+            return new NoCompression();
+        }
+
+        /**
+         * LZ4 compression
+         * @return compression options
+         */
+        public static CompressionOptions lz4() {
+            return new CompressionOptions(Algorithm.LZ4);
+        }
+
+        /**
+         * Snappy compression
+         * @return compression options
+         */
+        public static CompressionOptions snappy() {
+            return new CompressionOptions(Algorithm.SNAPPY);
+        }
+
+        /**
+         * Deflate compression
+         * @return compression options
+         */
+        public static CompressionOptions deflate() {
+            return new CompressionOptions(Algorithm.DEFLATE);
+        }
+
+        /**
+         * On disk, SSTables are compressed by block to allow random reads.
+         * This subproperty of compression defines the size (in KB) of the block.
+         * Values larger than the default value might improve the compression rate, but increases the minimum size of data to be read from disk when a read occurs.
+         * The default value is a good middle-ground for compressing tables.
+         * Adjust compression size to account for read/write access patterns (how much data is typically requested at once) and the average size of rows in the table.
+         * <p>
+         *     If not set, default = 64kb
+         * </p>
+         * @param chunkLengthInKb chunk length in Kb
+         * @return
+         */
+        public CompressionOptions withChunkLengthInKb(Integer chunkLengthInKb) {
+            this.chunckLengthInKb = Optional.fromNullable(chunkLengthInKb);
+            return this;
+        }
+
+        /**
+         * When compression is enabled, each compressed block includes a checksum of that block for the purpose of detecting disk bitrate and avoiding the propagation
+         * of corruption to other replica. This option defines the probability with which those checksums are checked during read.
+         * By default they are always checked. Set to 0 to disable checksum checking and to 0.5, for instance, to check them on every other read.
+         * <p>
+         *     If not set, default = 1.0 (always check)
+         * </p>
+         * @param crcCheckChance CRC check chance
+         * @return
+         */
+        public CompressionOptions withCRCCheckChance(Double crcCheckChance) {
+            validateRateValue(crcCheckChance, "CRC check chance");
+            this.crcCheckChance = Optional.fromNullable(crcCheckChance);
+            return this;
+        }
+
+        public String build() {
+            List<String> options = new ArrayList<String>();
+            options.add(new StringBuilder("'sstable_compression'").append(VALUE_SEPARATOR).append(algorithm.value()).toString());
+
+            if (chunckLengthInKb.isPresent()) {
+                options.add(new StringBuilder("'chunk_length_kb'").append(VALUE_SEPARATOR).append(chunckLengthInKb.get()).toString());
+            }
+
+            if (crcCheckChance.isPresent()) {
+                options.add(new StringBuilder("'crc_check_chance'").append(VALUE_SEPARATOR).append(crcCheckChance.get()).toString());
+            }
+            return new StringBuilder().append(START_SUB_OPTIONS).append(Joiner.on(SUB_OPTION_SEPARATOR).join(options)).append(END_SUB_OPTIONS).toString();
+        }
+
+        /**
+         * Compression algorithms. Possible values: NONE, LZ4, SNAPPY, DEFLATE
+         */
+        public static enum Algorithm {
+            NONE("''"), LZ4("'LZ4Compressor'"), SNAPPY("'SnappyCompressor'"), DEFLATE("'DeflateCompressor'");
+
+            private String value;
+
+            Algorithm(String value) {
+                this.value = value;
+            }
+
+            public String value() {
+                return value;
+            }
+
+            @Override
+            public String toString() {
+                return value;
+            }
+        }
+
+        public static class NoCompression extends CompressionOptions {
+
+            public NoCompression() {
+                super(Algorithm.NONE);
+            }
+
+            public CompressionOptions withChunkLengthInKb(Integer chunkLengthInKb) {
+                return this;
+            }
+
+            public CompressionOptions withCRCCheckChance(Double crcCheckChance) {
+                return this;
+            }
+        }
+    }
+
+    /**
+     * To override normal read timeout when read_repair_chance is not 1.0, sending another request to read, choose one of these values and use the property to create
+     * or alter the table:
+     * <ul>
+     *     <li>ALWAYS: Retry reads of all replicas.</li>
+     *     <li>Xpercentile: Retry reads based on the effect on throughput and latency.</li>
+     *     <li>Yms: Retry reads after specified milliseconds.</li>
+     *     <li>NONE: Do not retry reads.</li>
+     * </ul>
+     *
+     * Using the speculative retry property, you can configure rapid read protection in Cassandra 2.0.2.
+     * Use this property to retry a request after some milliseconds have passed or after a percentile of the typical read latency has been reached,
+     * which is tracked per table.
+     *
+     * <p>
+     *     If not set, default = 99percentile Cassandra 2.0.2 and later
+     * </p>
+     */
+    public static class SpeculativeRetryValue {
+
+        private String value;
+
+        private SpeculativeRetryValue(String value) {
+            this.value = value;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        /**
+         * Deactivate speculative retry
+         * @return speculative retry value
+         */
+        public static SpeculativeRetryValue none() {
+            return new SpeculativeRetryValue("'NONE'");
+        }
+
+        /**
+         * Always use speculative retry
+         * @return speculative retry value
+         */
+        public static SpeculativeRetryValue always() {
+            return new SpeculativeRetryValue("'ALWAYS'");
+        }
+
+        /**
+         * Define a percentile for speculative retry. The percentile value should be between 0 and 100
+         * @return speculative retry value
+         */
+        public static SpeculativeRetryValue percentile(int percentile) {
+            if (percentile < 0 || percentile > 100) {
+                throw new IllegalArgumentException("Percentile value for speculative retry should be between 0 and 100");
+            }
+            return new SpeculativeRetryValue("'" + percentile + "percentile'");
+        }
+
+        /**
+         * Define a threshold in milli seconds for speculative retry
+         * @return speculative retry value
+         */
+        public static SpeculativeRetryValue millisecs(int millisecs) {
+            if (millisecs < 0) {
+                throw new IllegalArgumentException("Millisecond value for speculative retry should be positive");
+            }
+            return new SpeculativeRetryValue("'" + millisecs + "ms'");
+        }
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/package-info.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * A CQL3 schema builder.
+ * <p>
+ * The main entry for this package is the {@code SchemaBuilder} class.
+ */
+package com.datastax.driver.core.schemabuilder;

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/AlterTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/AlterTest.java
@@ -1,0 +1,202 @@
+package com.datastax.driver.core.schemabuilder;
+
+import static com.datastax.driver.core.schemabuilder.TableOptions.Caching.ROWS_ONLY;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.testng.annotations.Test;
+import com.datastax.driver.core.DataType;
+
+public class AlterTest {
+
+
+    @Test
+    public void should_alter_column_type() throws Exception {
+        //When
+        final String built = SchemaBuilder.alterTable("test").alterColumn("name").type(DataType.ascii());
+
+        //Then
+        assertThat(built).isEqualTo("\n\tALTER TABLE test ALTER name TYPE ascii");
+    }
+
+    @Test
+    public void should_alter_column_type_with_keyspace() throws Exception {
+        //When
+        final String built = SchemaBuilder.alterTable("ks", "test").alterColumn("name").type(DataType.ascii());
+
+        //Then
+        assertThat(built).isEqualTo("\n\tALTER TABLE ks.test ALTER name TYPE ascii");
+    }
+
+    @Test
+    public void should_add_column() throws Exception {
+        //When
+        final String built = SchemaBuilder.alterTable("test").addColumn("location").type(DataType.ascii());
+
+        //Then
+        assertThat(built).isEqualTo("\n\tALTER TABLE test ADD location ascii");
+    }
+
+    @Test
+    public void should_rename_column() throws Exception {
+        //When
+        final String built = SchemaBuilder.alterTable("test").renameColumn("name").to("description");
+
+        //Then
+        assertThat(built).isEqualTo("\n\tALTER TABLE test RENAME name TO description");
+    }
+
+    @Test
+    public void should_drop_column() throws Exception {
+        //When
+        final String built = SchemaBuilder.alterTable("test").dropColumn("name");
+
+        //Then
+        assertThat(built).isEqualTo("\n\tALTER TABLE test DROP name");
+    }
+
+    @Test
+    public void should_alter_table_options() throws Exception {
+        //When
+        final String built = SchemaBuilder.alterTable("test").withOptions()
+                .bloomFilterFPChance(0.01)
+                .caching(ROWS_ONLY)
+                .comment("This is a comment")
+                .compactionOptions(TableOptions.CompactionOptions.leveledStrategy().ssTableSizeInMB(160))
+                .compressionOptions(TableOptions.CompressionOptions.lz4())
+                .dcLocalReadRepairChance(0.21)
+                .defaultTimeToLive(100)
+                .gcGraceSeconds(9999L)
+                .indexInterval(512)
+                .memtableFlushPeriodInMillis(12L)
+                .populateIOOnCacheFlush(true)
+                .replicateOnWrite(true)
+                .speculativeRetry(TableOptions.SpeculativeRetryValue.always())
+                .build();
+
+        //Then
+        assertThat(built).isEqualTo("\n\tALTER TABLE test " +
+                "WITH caching = 'rows_only' " +
+                "AND bloom_filter_fp_chance = 0.01 " +
+                "AND comment = 'This is a comment' " +
+                "AND compression = {'sstable_compression' : 'LZ4Compressor'} " +
+                "AND compaction = {'class' : 'LeveledCompactionStrategy', 'sstable_size_in_mb' : 160} " +
+                "AND dclocal_read_repair_chance = 0.21 " +
+                "AND default_time_to_live = 100 " +
+                "AND gc_grace_seconds = 9999 " +
+                "AND index_interval = 512 " +
+                "AND memtable_flush_period_in_ms = 12 " +
+                "AND populate_io_cache_on_flush = true " +
+                "AND replicate_on_write = true " +
+                "AND speculative_retry = 'ALWAYS'");
+    }
+
+    @Test
+    public void should_fail_if_keyspace_name_is_a_reserved_keyword() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.alterTable("add", "test")
+                    .addColumn("test").type(DataType.ascii());
+        } catch (IllegalArgumentException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The keyspace name 'add' is not allowed because it is a reserved keyword");
+        }
+
+        assertThat(hasFailed).isTrue();
+
+
+    }
+
+    @Test
+    public void should_fail_if_table_name_is_a_reserved_keyword() throws Exception {
+
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.alterTable("add")
+                    .addColumn("test").type(DataType.ascii());
+        } catch (IllegalArgumentException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The table name 'add' is not allowed because it is a reserved keyword");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_added_column_is_a_reserved_keyword() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.alterTable("test")
+                    .addColumn("add").type(DataType.ascii());
+
+        } catch (IllegalArgumentException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The new column name 'add' is not allowed because it is a reserved keyword");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_altered_column_is_a_reserved_keyword() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.alterTable("test")
+                    .alterColumn("add").type(DataType.ascii());
+        } catch (IllegalArgumentException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The altered column name 'add' is not allowed because it is a reserved keyword");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_renamed_column_is_a_reserved_keyword() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.alterTable("test")
+                    .renameColumn("add");
+        } catch (IllegalArgumentException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The renamed column name 'add' is not allowed because it is a reserved keyword");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_new_renamed_column_is_a_reserved_keyword() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.alterTable("test")
+                    .renameColumn("col").to("add");
+        } catch (IllegalArgumentException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The new column name 'add' is not allowed because it is a reserved keyword");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_drop_column_is_a_reserved_keyword() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.alterTable("test")
+                    .dropColumn("add");
+        } catch (IllegalArgumentException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The dropped column name 'add' is not allowed because it is a reserved keyword");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_add_static_column() throws Exception {
+        //When
+        final String alterTable = SchemaBuilder.alterTable("test").addStaticColumn("stat").type(DataType.text());
+
+        //Then
+        assertThat(alterTable).isEqualTo("\n\tALTER TABLE test ADD stat text static");
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/CompactionOptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/CompactionOptionsTest.java
@@ -1,0 +1,83 @@
+package com.datastax.driver.core.schemabuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.testng.annotations.Test;
+
+public class CompactionOptionsTest {
+
+    @Test
+    public void should_create_sized_tiered_compaction_options() throws Exception {
+        //When
+        final String build = TableOptions.CompactionOptions
+                .sizedTieredStategy()
+                .bucketLow(0.5)
+                .bucketHigh(1.2)
+                .coldReadsRatioToOmit(0.89)
+                .minThreshold(2)
+                .maxThreshold(4)
+                .minSSTableSizeInBytes(5000000L)
+                .enableAutoCompaction(true)
+                .tombstoneCompactionIntervalInDay(3)
+                .tombstoneThreshold(0.7)
+                .build();
+
+        //Then
+        assertThat(build).isEqualTo("{'class' : 'SizeTieredCompactionStrategy', 'enabled' : true, 'max_threshold' : 4, 'tombstone_compaction_interval' : 3, 'tombstone_threshold' : 0.7, 'bucket_high' : 1.2, 'bucket_low' : 0.5, 'cold_reads_to_omit' : 0.89, 'min_threshold' : 2, 'min_sstable_size' : 5000000}");
+    }
+
+    @Test
+    public void should_create_leveled_compaction_option() throws Exception {
+        //When
+        final String build = TableOptions.CompactionOptions
+                .leveledStrategy()
+                .ssTableSizeInMB(160)
+                .enableAutoCompaction(true)
+                .maxThreshold(5)
+                .tombstoneCompactionIntervalInDay(3)
+                .tombstoneThreshold(0.7)
+                .build();
+
+        //Then
+        assertThat(build).isEqualTo("{'class' : 'LeveledCompactionStrategy', 'enabled' : true, 'max_threshold' : 5, 'tombstone_compaction_interval' : 3, 'tombstone_threshold' : 0.7, 'sstable_size_in_mb' : 160}");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void should_throw_exception_if_cold_read_ration_out_of_range() throws Exception {
+        TableOptions.CompactionOptions
+                .sizedTieredStategy()
+                .bucketLow(0.5)
+                .bucketHigh(1.2)
+                .coldReadsRatioToOmit(1.89)
+                .build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void should_throw_exception_if_cold_read_ration_negative() throws Exception {
+        TableOptions.CompactionOptions
+                .sizedTieredStategy()
+                .bucketLow(0.5)
+                .bucketHigh(1.2)
+                .coldReadsRatioToOmit(-1.0)
+                .build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void should_throw_exception_if_tombstone_threshold_out_of_range() throws Exception {
+        TableOptions.CompactionOptions
+                .sizedTieredStategy()
+                .bucketLow(0.5)
+                .bucketHigh(1.2)
+                .tombstoneThreshold(1.89)
+                .build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void should_throw_exception_if_tombstone_threshold_negative() throws Exception {
+        TableOptions.CompactionOptions
+                .sizedTieredStategy()
+                .bucketLow(0.5)
+                .bucketHigh(1.2)
+                .coldReadsRatioToOmit(-1.0)
+                .build();
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/CompressionOptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/CompressionOptionsTest.java
@@ -1,0 +1,44 @@
+package com.datastax.driver.core.schemabuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.testng.annotations.Test;
+
+
+public class CompressionOptionsTest {
+
+    @Test
+    public void should_build_compressions_options_for_lz4() throws Exception {
+        //When
+        final String build = TableOptions.CompressionOptions.lz4().withChunkLengthInKb(128).withCRCCheckChance(0.6D).build();
+
+        //Then
+        assertThat(build).isEqualTo("{'sstable_compression' : 'LZ4Compressor', 'chunk_length_kb' : 128, 'crc_check_chance' : 0.6}");
+    }
+
+    @Test
+    public void should_create_snappy_compressions_options() throws Exception {
+        //When
+        final String build = TableOptions.CompressionOptions.snappy().withChunkLengthInKb(128).withCRCCheckChance(0.6D).build();
+
+        //Then
+        assertThat(build).isEqualTo("{'sstable_compression' : 'SnappyCompressor', 'chunk_length_kb' : 128, 'crc_check_chance' : 0.6}");
+    }
+
+    @Test
+    public void should_create_deflate_compressions_options() throws Exception {
+        //When
+        final String build = TableOptions.CompressionOptions.deflate().withChunkLengthInKb(128).withCRCCheckChance(0.6D).build();
+
+        //Then
+        assertThat(build).isEqualTo("{'sstable_compression' : 'DeflateCompressor', 'chunk_length_kb' : 128, 'crc_check_chance' : 0.6}");
+    }
+
+    @Test
+    public void should_create_no_compressions_options() throws Exception {
+        //When
+        final String build = TableOptions.CompressionOptions.none().withChunkLengthInKb(128).withCRCCheckChance(0.6D).build();
+
+        //Then
+        assertThat(build).isEqualTo("{'sstable_compression' : ''}");
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/CreateIndexTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/CreateIndexTest.java
@@ -1,0 +1,18 @@
+package com.datastax.driver.core.schemabuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.testng.annotations.Test;
+
+public class CreateIndexTest {
+
+    @Test
+    public void should_create_index() throws Exception {
+        //Given //When
+        final String statement = SchemaBuilder.createIndex("myIndex").ifNotExists().onTable("ks", "test").andColumn("col");
+
+        //Then
+        assertThat(statement).isEqualTo("\n\tCREATE INDEX IF NOT EXISTS myIndex ON ks.test(col)");
+    }
+
+
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/CreateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/CreateTest.java
@@ -1,0 +1,599 @@
+package com.datastax.driver.core.schemabuilder;
+
+import static com.datastax.driver.core.schemabuilder.Create.Options.ClusteringOrder.Sorting.ASC;
+import static com.datastax.driver.core.schemabuilder.Create.Options.ClusteringOrder.Sorting.DESC;
+import static com.datastax.driver.core.schemabuilder.TableOptions.Caching.ROWS_ONLY;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.testng.annotations.Test;
+import com.datastax.driver.core.DataType;
+
+public class CreateTest {
+
+    @Test
+    public void should_create_simple_table() throws Exception {
+        //When
+        final String built = SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addColumn("name", DataType.text())
+                .build();
+        //Then
+        assertThat(built).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
+                "id bigint,\n\t\t" +
+                "name text,\n\t\t" +
+                "PRIMARY KEY(id))");
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void should_exception_when_creating_table_without_partition_key() throws Exception {
+        SchemaBuilder.createTable("test").addColumn("name", DataType.text()).build();
+    }
+
+    @Test
+    public void should_create_simple_table_if_not_exists() throws Exception {
+        //When
+        final String built = SchemaBuilder.createTable("test")
+                .ifNotExists(true)
+                .addPartitionKey("id", DataType.bigint())
+                .addColumn("name", DataType.text())
+                .build();
+        //Then
+        assertThat(built).isEqualTo("\n\tCREATE TABLE IF NOT EXISTS test(\n\t\t" +
+                "id bigint,\n\t\t" +
+                "name text,\n\t\t" +
+                "PRIMARY KEY(id))");
+    }
+
+    @Test
+    public void should_create_simple_table_with_keyspace() throws Exception {
+        //When
+        final String built = SchemaBuilder.createTable("ks", "test")
+                .addPartitionKey("id", DataType.bigint())
+                .addColumn("name", DataType.text())
+                .build();
+        //Then
+        assertThat(built).isEqualTo("\n\tCREATE TABLE ks.test(\n\t\t" +
+                "id bigint,\n\t\t" +
+                "name text,\n\t\t" +
+                "PRIMARY KEY(id))");
+    }
+
+
+    @Test
+    public void should_create_simple_table_with_list() throws Exception {
+        //When
+        final String built = SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addColumn("friends", DataType.list(DataType.text()))
+                .build();
+        //Then
+        assertThat(built).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
+                "id bigint,\n\t\t" +
+                "friends list<text>,\n\t\t" +
+                "PRIMARY KEY(id))");
+    }
+
+    @Test
+    public void should_create_simple_table_with_set() throws Exception {
+        //When
+        final String built = SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addColumn("friends", DataType.set(DataType.text()))
+                .build();
+        //Then
+        assertThat(built).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
+                "id bigint,\n\t\t" +
+                "friends set<text>,\n\t\t" +
+                "PRIMARY KEY(id))");
+    }
+
+    @Test
+    public void should_create_simple_table_with_map() throws Exception {
+        //When
+        final String built = SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addColumn("friends", DataType.map(DataType.cint(), DataType.text()))
+                .build();
+        //Then
+        assertThat(built).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
+                "id bigint,\n\t\t" +
+                "friends map<int,text>,\n\t\t" +
+                "PRIMARY KEY(id))");
+    }
+
+    @Test
+    public void should_create_table_with_clustering_keys() throws Exception {
+        //When
+        final String built = SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addClusteringKey("col1", DataType.uuid())
+                .addClusteringKey("col2", DataType.uuid())
+                .addColumn("name", DataType.text())
+                .build();
+        //Then
+        assertThat(built).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
+                "id bigint,\n\t\t" +
+                "col1 uuid,\n\t\t" +
+                "col2 uuid,\n\t\t" +
+                "name text,\n\t\t" +
+                "PRIMARY KEY(id, col1, col2))");
+    }
+
+    @Test
+    public void should_create_table_with_composite_partition_key() throws Exception {
+        //When
+        final String built = SchemaBuilder.createTable("test")
+                .addPartitionKey("id1", DataType.bigint())
+                .addPartitionKey("id2", DataType.text())
+                .addColumn("name", DataType.text())
+                .build();
+        //Then
+        assertThat(built).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
+                "id1 bigint,\n\t\t" +
+                "id2 text,\n\t\t" +
+                "name text,\n\t\t" +
+                "PRIMARY KEY((id1, id2)))");
+    }
+
+    @Test
+    public void should_create_table_with_composite_partition_key_and_clustering_keys() throws Exception {
+        //When
+        final String built = SchemaBuilder.createTable("test")
+                .addPartitionKey("id1", DataType.bigint())
+                .addPartitionKey("id2", DataType.text())
+                .addClusteringKey("col1", DataType.uuid())
+                .addClusteringKey("col2", DataType.uuid())
+                .addColumn("name", DataType.text())
+                .build();
+        //Then
+        assertThat(built).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
+                "id1 bigint,\n\t\t" +
+                "id2 text,\n\t\t" +
+                "col1 uuid,\n\t\t" +
+                "col2 uuid,\n\t\t" +
+                "name text,\n\t\t" +
+                "PRIMARY KEY((id1, id2), col1, col2))");
+    }
+
+    @Test
+    public void should_create_table_with_static_column() throws Exception {
+        //When
+        final String built = SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addClusteringKey("col", DataType.uuid())
+                .addStaticColumn("bucket", DataType.cint())
+                .addColumn("name", DataType.text())
+                .build();
+        //Then
+        assertThat(built).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
+                "id bigint,\n\t\t" +
+                "col uuid,\n\t\t" +
+                "bucket int static,\n\t\t" +
+                "name text,\n\t\t" +
+                "PRIMARY KEY(id, col))");
+    }
+
+    @Test
+    public void should_create_table_with_clustering_order() throws Exception {
+        //When
+        final String built = SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addClusteringKey("col1", DataType.uuid())
+                .addClusteringKey("col2", DataType.uuid())
+                .addColumn("name", DataType.text())
+                .withOptions()
+                .clusteringOrder(new Create.Options.ClusteringOrder("col1", ASC), new Create.Options.ClusteringOrder("col2", DESC))
+                .build();
+        //Then
+        assertThat(built).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
+                "id bigint,\n\t\t" +
+                "col1 uuid,\n\t\t" +
+                "col2 uuid,\n\t\t" +
+                "name text,\n\t\t" +
+                "PRIMARY KEY(id, col1, col2))\n\t" +
+                "WITH CLUSTERING ORDER BY(col1 ASC, col2 DESC)");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void should_exception_when_no_clustering_order_provided() throws Exception {
+        SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addClusteringKey("col1", DataType.uuid())
+                .addClusteringKey("col2", DataType.uuid())
+                .addColumn("name", DataType.text())
+                .withOptions().clusteringOrder().build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void should_exception_when_blank_clustering_order_column_provided() throws Exception {
+        SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addClusteringKey("col1", DataType.uuid())
+                .addClusteringKey("col2", DataType.uuid())
+                .addColumn("name", DataType.text())
+                .withOptions().clusteringOrder(new Create.Options.ClusteringOrder("", DESC)).build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void should_exception_when_clustering_order_column_does_not_match_declared_clustering_keys() throws Exception {
+        SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addClusteringKey("col1", DataType.uuid())
+                .addClusteringKey("col2", DataType.uuid())
+                .addColumn("name", DataType.text())
+                .withOptions().clusteringOrder(new Create.Options.ClusteringOrder("col3", ASC)).build();
+    }
+
+    @Test
+    public void should_create_table_with_compact_storage() throws Exception {
+        //When
+        final String built = SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addClusteringKey("col1", DataType.uuid())
+                .addClusteringKey("col2", DataType.uuid())
+                .addColumn("name", DataType.text())
+                .withOptions()
+                .compactStorage(true)
+                .build();
+        //Then
+        assertThat(built).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
+                "id bigint,\n\t\t" +
+                "col1 uuid,\n\t\t" +
+                "col2 uuid,\n\t\t" +
+                "name text,\n\t\t" +
+                "PRIMARY KEY(id, col1, col2))\n\t" +
+                "WITH COMPACT STORAGE");
+    }
+
+    @Test
+    public void should_create_table_with_all_options() throws Exception {
+        //When
+        final String built = SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addClusteringKey("col1", DataType.uuid())
+                .addClusteringKey("col2", DataType.uuid())
+                .addColumn("name", DataType.text())
+                .withOptions()
+                .clusteringOrder(new Create.Options.ClusteringOrder("col1", ASC), new Create.Options.ClusteringOrder("col2", DESC))
+                .compactStorage(true)
+                .bloomFilterFPChance(0.01)
+                .caching(ROWS_ONLY)
+                .comment("This is a comment")
+                .compactionOptions(TableOptions.CompactionOptions.leveledStrategy().ssTableSizeInMB(160))
+                .compressionOptions(TableOptions.CompressionOptions.lz4())
+                .dcLocalReadRepairChance(0.21)
+                .defaultTimeToLive(100)
+                .gcGraceSeconds(9999L)
+                .indexInterval(512)
+                .memtableFlushPeriodInMillis(12L)
+                .populateIOOnCacheFlush(true)
+                .replicateOnWrite(true)
+                .speculativeRetry(TableOptions.SpeculativeRetryValue.always())
+                .build();
+
+        //Then
+        assertThat(built).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
+                "id bigint,\n\t\t" +
+                "col1 uuid,\n\t\t" +
+                "col2 uuid,\n\t\t" +
+                "name text,\n\t\tPRIMARY KEY(id, col1, col2))\n\t" +
+                "WITH caching = 'rows_only' " +
+                "AND bloom_filter_fp_chance = 0.01 " +
+                "AND comment = 'This is a comment' " +
+                "AND compression = {'sstable_compression' : 'LZ4Compressor'} " +
+                "AND compaction = {'class' : 'LeveledCompactionStrategy', 'sstable_size_in_mb' : 160} " +
+                "AND dclocal_read_repair_chance = 0.21 " +
+                "AND default_time_to_live = 100 " +
+                "AND gc_grace_seconds = 9999 " +
+                "AND index_interval = 512 " +
+                "AND memtable_flush_period_in_ms = 12 " +
+                "AND populate_io_cache_on_flush = true " +
+                "AND replicate_on_write = true " +
+                "AND speculative_retry = 'ALWAYS' AND CLUSTERING ORDER BY(col1 ASC, col2 DESC) AND COMPACT STORAGE");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void should_exception_when_read_repair_chance_out_of_bound() throws Exception {
+        SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addColumn("name", DataType.text())
+                .withOptions()
+                .readRepairChance(1.3)
+                .build();
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void should_exception_when_read_repair_chance_negative() throws Exception {
+        SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addColumn("name", DataType.text())
+                .withOptions()
+                .readRepairChance(-1.3)
+                .build();
+    }
+
+    @Test
+    public void should_create_table_with_speculative_retry_none() throws Exception {
+        //When
+        final String built = SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addColumn("name", DataType.text())
+                .withOptions()
+                .speculativeRetry(TableOptions.SpeculativeRetryValue.none())
+                .build();
+        //Then
+        assertThat(built).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
+                "id bigint,\n\t\t" +
+                "name text,\n\t\t" +
+                "PRIMARY KEY(id))\n\t" +
+                "WITH speculative_retry = 'NONE'");
+    }
+
+    @Test
+    public void should_create_table_with_speculative_retry_in_percentile() throws Exception {
+        //When
+        final String built = SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addColumn("name", DataType.text())
+                .withOptions()
+                .speculativeRetry(TableOptions.SpeculativeRetryValue.percentile(95))
+                .build();
+        //Then
+        assertThat(built).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
+                "id bigint,\n\t\t" +
+                "name text,\n\t\t" +
+                "PRIMARY KEY(id))\n\t" +
+                "WITH speculative_retry = '95percentile'");
+    }
+
+    @Test
+    public void should_create_table_with_speculative_retry_in_milli_secs() throws Exception {
+        //When
+        final String built = SchemaBuilder.createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addColumn("name", DataType.text())
+                .withOptions()
+                .speculativeRetry(TableOptions.SpeculativeRetryValue.millisecs(12))
+                .build();
+        //Then
+        assertThat(built).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
+                "id bigint,\n\t\t" +
+                "name text,\n\t\t" +
+                "PRIMARY KEY(id))\n\t" +
+                "WITH speculative_retry = '12ms'");
+    }
+
+    @Test
+    public void should_fail_if_same_partition_and_clustering_column() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.createTable("test")
+                    .addPartitionKey("pk", DataType.bigint())
+                    .addClusteringKey("pk", DataType.bigint())
+                    .build();
+        } catch (IllegalStateException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The '[pk]' columns can not be declared as partition keys and clustering keys at the same time");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_same_partition_and_simple_column() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.createTable("test")
+                    .addPartitionKey("pk", DataType.bigint())
+                    .addColumn("pk", DataType.text())
+                    .build();
+        } catch (IllegalStateException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The '[pk]' columns can not be declared as partition keys and simple columns at the same time");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_same_clustering_and_simple_column() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.createTable("test")
+                    .addPartitionKey("pk", DataType.bigint())
+                    .addClusteringKey("cluster", DataType.bigint())
+                    .addColumn("cluster", DataType.text())
+                    .build();
+        } catch (IllegalStateException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The '[cluster]' columns can not be declared as clustering keys and simple columns at the same time");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_same_partition_and_static_column() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.createTable("test")
+                    .addPartitionKey("pk", DataType.bigint())
+                    .addStaticColumn("pk", DataType.text())
+                    .build();
+        } catch (IllegalStateException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The '[pk]' columns can not be declared as partition keys and static columns at the same time");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_same_clustering_and_static_column() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.createTable("test")
+                    .addPartitionKey("pk", DataType.bigint())
+                    .addClusteringKey("cluster", DataType.bigint())
+                    .addStaticColumn("cluster", DataType.text())
+                    .build();
+        } catch (IllegalStateException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The '[cluster]' columns can not be declared as clustering keys and static columns at the same time");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_same_simple_and_static_column() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.createTable("test")
+                    .addPartitionKey("pk", DataType.bigint())
+                    .addClusteringKey("cluster",DataType.uuid())
+                    .addColumn("col", DataType.bigint())
+                    .addStaticColumn("col", DataType.text())
+                    .build();
+        } catch (IllegalStateException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The '[col]' columns can not be declared as simple columns and static columns at the same time");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_static_column_in_non_clustered_table() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.createTable("test")
+                    .addPartitionKey("pk", DataType.bigint())
+                    .addStaticColumn("stat", DataType.text())
+                    .build();
+        } catch (IllegalStateException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The table 'test' cannot declare static columns '[stat]' without clustering columns");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_keyspace_name_is_a_reserved_keyword() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.createTable("add","test")
+                    .addPartitionKey("pk", DataType.bigint())
+                    .addColumn("col", DataType.text())
+                    .build();
+        } catch (IllegalArgumentException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The keyspace name 'add' is not allowed because it is a reserved keyword");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+
+    @Test
+    public void should_fail_if_table_name_is_a_reserved_keyword() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.createTable("add")
+                    .addPartitionKey("pk", DataType.bigint())
+                    .addColumn("col", DataType.text())
+                    .build();
+        } catch (IllegalArgumentException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The table name 'add' is not allowed because it is a reserved keyword");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_partition_key_is_a_reserved_keyword() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.createTable("test")
+                    .addPartitionKey("add", DataType.bigint())
+                    .addColumn("col", DataType.text())
+                    .build();
+        } catch (IllegalArgumentException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The partition key name 'add' is not allowed because it is a reserved keyword");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_clustering_key_is_a_reserved_keyword() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.createTable("test")
+                    .addPartitionKey("pk", DataType.bigint())
+                    .addClusteringKey("add", DataType.uuid())
+                    .addColumn("col", DataType.text())
+                    .build();
+        } catch (IllegalArgumentException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The clustering key name 'add' is not allowed because it is a reserved keyword");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_simple_column_is_a_reserved_keyword() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.createTable("test")
+                    .addPartitionKey("pk", DataType.bigint())
+                    .addClusteringKey("cluster", DataType.uuid())
+                    .addColumn("add", DataType.text())
+                    .build();
+        } catch (IllegalArgumentException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The column name 'add' is not allowed because it is a reserved keyword");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_static_column_is_a_reserved_keyword() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.createTable("test")
+                    .addPartitionKey("pk", DataType.bigint())
+                    .addClusteringKey("cluster", DataType.uuid())
+                    .addStaticColumn("add", DataType.text())
+                    .addColumn("col", DataType.text())
+                    .build();
+        } catch (IllegalArgumentException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The static column name 'add' is not allowed because it is a reserved keyword");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_creating_table_with_static_columns_and_compact_storage() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.createTable("test")
+                    .addPartitionKey("pk", DataType.bigint())
+                    .addClusteringKey("cluster", DataType.uuid())
+                    .addStaticColumn("stat", DataType.text())
+                    .withOptions().compactStorage(true).build();
+        } catch (IllegalStateException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("Cannot create table 'test' with compact storage and static columns '[stat]'");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/DropTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/DropTest.java
@@ -1,0 +1,61 @@
+package com.datastax.driver.core.schemabuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.testng.annotations.Test;
+
+
+public class DropTest {
+
+    @Test
+    public void should_drop_table() throws Exception {
+        //When
+        final String built = SchemaBuilder.dropTable("test").build();
+
+        //Then
+        assertThat(built).isEqualTo("DROP TABLE test");
+    }
+
+    @Test
+    public void should_drop_table_with_keyspace() throws Exception {
+        //When
+        final String built = SchemaBuilder.dropTable("ks", "test").build();
+
+        //Then
+        assertThat(built).isEqualTo("DROP TABLE ks.test");
+    }
+
+    @Test
+    public void should_drop_table_with_keyspace_if_exists() throws Exception {
+        //When
+        final String built = SchemaBuilder.dropTable("ks", "test").ifExists(true).build();
+
+        //Then
+        assertThat(built).isEqualTo("DROP TABLE IF EXISTS ks.test");
+    }
+
+    @Test
+    public void should_fail_if_keyspace_name_is_a_reserved_keyword() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.dropTable("add", "test").build();
+        } catch (IllegalArgumentException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The keyspace name 'add' is not allowed because it is a reserved keyword");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+
+    @Test
+    public void should_fail_if_table_name_is_a_reserved_keyword() throws Exception {
+        boolean hasFailed = false;
+        try {
+            SchemaBuilder.dropTable("add").build();
+        } catch (IllegalArgumentException e) {
+            hasFailed = true;
+            assertThat(e.getMessage()).isEqualTo("The table name 'add' is not allowed because it is a reserved keyword");
+        }
+
+        assertThat(hasFailed).isTrue();
+    }
+}


### PR DESCRIPTION
As promised, here is the **`SchemaBuilder`** to create/alter/drop table easily.

The code has all necessary Java doc and unit test coverage is 91% for classes and 96% for line coverage

I also added dependency to **`assertj`** with scope **`test`** so that assertions are more fluent than the classical **`assertTrue`**  and **`assertEquals`** 
