### PR TITLE
Fixed a typo in javadoc

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ResultSet.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ResultSet.java
@@ -56,7 +56,7 @@ public interface ResultSet extends Iterable<Row> {
     public boolean isExhausted();
 
     /**
-     * Returns the the next result from this ResultSet.
+     * Returns the next result from this ResultSet.
      *
      * @return the next row in this resultSet or null if this ResultSet is
      * exhausted.


### PR DESCRIPTION
This patch fixes a trivial typo in javadoc
