### PR TITLE
JAVA-326: add support for conditional DELETEs in QueryBuilder

### DIFF
--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -5,6 +5,7 @@ CHANGELOG
 ------
 
 - [bug] Check cluster name when connecting to a new node (JAVA-397)
+- [bug] Add missing CAS delete support in QueryBuilder (JAVA-326)
 
 2.0.5:
 ------

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
@@ -30,6 +30,8 @@ public class Delete extends BuiltStatement {
     private final List<Object> columnNames;
     private final Where where;
     private final Options usings;
+    private final Conditions conditions;
+    private boolean ifExists;
 
     Delete(String keyspace, String table, List<Object> columnNames) {
         super(keyspace);
@@ -37,6 +39,7 @@ public class Delete extends BuiltStatement {
         this.columnNames = columnNames;
         this.where = new Where(this);
         this.usings = new Options(this);
+        this.conditions = new Conditions(this);
     }
 
     Delete(TableMetadata table, List<Object> columnNames) {
@@ -45,6 +48,7 @@ public class Delete extends BuiltStatement {
         this.columnNames = columnNames;
         this.where = new Where(this);
         this.usings = new Options(this);
+        this.conditions = new Conditions(this);
     }
 
     @Override
@@ -67,6 +71,15 @@ public class Delete extends BuiltStatement {
         if (!where.clauses.isEmpty()) {
             builder.append(" WHERE ");
             Utils.joinAndAppend(builder, " AND ", where.clauses, variables);
+        }
+
+        if (ifExists) {
+            builder.append(" IF EXISTS ");
+        }
+
+        if (!conditions.conditions.isEmpty()) {
+            builder.append(" IF ");
+            Utils.joinAndAppend(builder, " AND ", conditions.conditions, variables);
         }
 
         return builder;
@@ -94,6 +107,27 @@ public class Delete extends BuiltStatement {
     }
 
     /**
+     * Adds a conditions clause (IF) to this statement.
+     * <p>
+     * This is a shorter/more readable version for {@code onlyIf().and(condition)}.
+     *
+     * @param condition the condition to add.
+     * @return the conditions of this query to which more conditions can be added.
+     */
+    public Conditions onlyIf(Clause condition) {
+        return conditions.and(condition);
+    }
+
+    /**
+     * Adds a conditions clause (IF) to this statement.
+     *
+     * @return the conditions of this query to which more conditions can be added.
+     */
+    public Conditions onlyIf() {
+        return conditions;
+    }
+
+    /**
      * Adds a new options for this DELETE statement.
      *
      * @param using the option to add.
@@ -101,6 +135,27 @@ public class Delete extends BuiltStatement {
      */
     public Options using(Using using) {
         return usings.and(using);
+    }
+
+    /**
+     * Sets the 'IF EXISTS' option for this DELETE statement.
+     *
+     * <p>
+     * A delete with that option will report whether the statement actually
+     * resulted in data being deleted. The existence check and deletion are
+     * done transactionally in the sense that if multiple clients attempt to
+     * delete a given row with this option, then at most one may succeed.
+     * </p>
+     * <p>
+     * Please keep in mind that using this option has a non negligible
+     * performance impact and should be avoided when possible.
+     * </p>
+     *
+     * @return this DELETE statement.
+     */
+    public Delete ifExists() {
+        this.ifExists = true;
+        return this;
     }
 
     /**
@@ -136,6 +191,37 @@ public class Delete extends BuiltStatement {
          */
         public Options using(Using using) {
             return statement.using(using);
+        }
+
+        /**
+         * Sets the 'IF EXISTS' option for the DELETE statement this WHERE clause
+         * is part of.
+         *
+         * <p>
+         * A delete with that option will report whether the statement actually
+         * resulted in data being deleted. The existence check and deletion are
+         * done transactionally in the sense that if multiple clients attempt to
+         * delete a given row with this option, then at most one may succeed.
+         * </p>
+         * <p>
+         * Please keep in mind that using this option has a non negligible
+         * performance impact and should be avoided when possible.
+         * </p>
+         *
+         * @return the DELETE statement this WHERE clause is part of.
+         */
+        public Delete ifExists() {
+            return statement.ifExists();
+        }
+
+        /**
+         * Adds a condition to the DELETE statement this WHERE clause is part of.
+         *
+         * @param condition the condition to add.
+         * @return the conditions for the DELETE statement this WHERE clause is part of.
+         */
+        public Conditions onlyIf(Clause condition) {
+            return statement.onlyIf(condition);
         }
     }
 
@@ -277,6 +363,61 @@ public class Delete extends BuiltStatement {
             sb.append('[');
             Utils.appendFlatValue(key, sb);
             return column(sb.append(']').toString());
+        }
+    }
+
+    /**
+     * Conditions for a DELETE statement.
+     * <p>
+     * When provided some conditions, a deletion will not apply unless the
+     * provided conditions applies.
+     * </p>
+     * <p>
+     * Please keep in mind that provided conditions have a non negligible
+     * performance impact and should be avoided when possible.
+     * </p>
+     */
+    public static class Conditions extends BuiltStatement.ForwardingStatement<Delete> {
+
+        private final List<Clause> conditions = new ArrayList<Clause>();
+
+        Conditions(Delete statement) {
+            super(statement);
+        }
+
+        /**
+         * Adds the provided condition for the deletion.
+         * <p>
+         * Note that while the query builder accept any type of {@code Clause}
+         * as conditions, Cassandra currently only allows equality ones.
+         *
+         * @param condition the condition to add.
+         * @return this {@code Conditions} clause.
+         */
+        public Conditions and(Clause condition) {
+            conditions.add(condition);
+            checkForBindMarkers(condition);
+            return this;
+        }
+
+        /**
+         * Adds a where clause to the DELETE statement these conditions are part of.
+         *
+         * @param clause clause to add.
+         * @return the WHERE clause of the DELETE statement these conditions are part of.
+         */
+        public Where where(Clause clause) {
+            return statement.where(clause);
+        }
+
+        /**
+         * Adds an option to the DELETE statement these conditions are part of.
+         *
+         * @param using the using clause to add.
+         * @return the options of the DELETE statement these conditions are part of.
+         */
+        public Options using(Using using) {
+            return statement.using(using);
         }
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
@@ -205,4 +205,28 @@ public class QueryBuilderITest extends CCMBridge.PerClassSingleNodeCluster {
         assertEquals(delete.toString(), query);
     }
 
+    @Test(groups = "short")
+    public void conditionalDeletesTest() throws Exception {        
+        session.execute("INSERT INTO ks.test_int (k, a, b) VALUES (1, 1, 1)");
+        
+        Statement delete;
+        Row row;
+        delete = delete().from(TestUtils.SIMPLE_KEYSPACE, TABLE_INT).where(eq("k", 2)).ifExists();
+        row = session.execute(delete).one();
+        assertFalse(row.getBool("[applied]"));
+        
+        delete = delete().from(TestUtils.SIMPLE_KEYSPACE, TABLE_INT).where(eq("k", 1)).ifExists();
+        row = session.execute(delete).one();
+        assertTrue(row.getBool("[applied]"));
+
+        session.execute("INSERT INTO ks.test_int (k, a, b) VALUES (1, 1, 1)");
+
+        delete = delete().from(TestUtils.SIMPLE_KEYSPACE, TABLE_INT).where(eq("k", 1)).onlyIf(eq("a", 1)).and(eq("b", 2));
+        row = session.execute(delete).one();
+        assertFalse(row.getBool("[applied]"));
+        
+        delete = delete().from(TestUtils.SIMPLE_KEYSPACE, TABLE_INT).where(eq("k", 1)).onlyIf(eq("a", 1)).and(eq("b", 1));
+        row = session.execute(delete).one();
+        assertTrue(row.getBool("[applied]"));
+    }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -315,6 +315,14 @@ public class QueryBuilderTest {
         } catch (IllegalArgumentException e) {
             assertEquals(e.getMessage(), "Invalid timestamp, must be positive");
         }
+        
+        query = "DELETE FROM foo.bar WHERE k1='foo' IF EXISTS;";
+        delete = delete().from("foo", "bar").where(eq("k1", "foo")).ifExists();
+        assertEquals(delete.toString(), query);
+        
+        query = "DELETE FROM foo.bar WHERE k1='foo' IF a=1 AND b=2;";
+        delete = delete().from("foo", "bar").where(eq("k1", "foo")).onlyIf(eq("a", 1)).and(eq("b", 2));
+        assertEquals(delete.toString(), query);
     }
 
     @Test(groups = "unit")


### PR DESCRIPTION
Notes:
- the DSL is not 100% foolproof, for example you can specify both `ifExists` and `onlyIf` on a query, which leads to malformed CQL.
- I duplicated `Update.Conditions`. Factoring the code would require a new common supertype for `Update` and `Delete`, which is not worth it IMO.
