### PR TITLE
Add StateListener.onLocationUpdated (JAVA-315 #send-to-testing).

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -428,12 +428,8 @@ class ControlConnection implements Host.StateListener {
         if (Objects.equal(host.getDatacenter(), datacenter) && Objects.equal(host.getRack(), rack))
             return;
 
-        // If the dc/rack information changes, we need to update the load balancing policy.
-        // For that, we remove and re-add the node against the policy. Not the most elegant, and assumes
-        // that the policy will update correctly, but in practice this should work.
-        cluster.loadBalancingPolicy().onDown(host);
         host.setLocationInfo(datacenter, rack);
-        cluster.loadBalancingPolicy().onAdd(host);
+        cluster.onLocationUpdated(host);
     }
 
     private static void refreshNodeListAndTokenMap(Connection connection, Cluster.Manager cluster) throws ConnectionException, BusyConnectionException, ExecutionException, InterruptedException {
@@ -598,5 +594,9 @@ class ControlConnection implements Host.StateListener {
     @Override
     public void onRemove(Host host) {
         refreshNodeListAndTokenMap();
+    }
+
+    @Override
+    public void onLocationUpdated(Host host) {
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/Host.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Host.java
@@ -106,7 +106,7 @@ public class Host {
     /**
      * Returns the name of the datacenter this host is part of.
      * <p>
-     * The returned datacenter name is the one as known by Cassandra. 
+     * The returned datacenter name is the one as known by Cassandra.
      * It is also possible for this information to be unavailable. In that
      * case this method returns {@code null}, and the caller should always be aware
      * of this possibility.
@@ -182,7 +182,7 @@ public class Host {
      * Interface for listeners that are interested in hosts added, up, down and
      * removed events.
      * <p>
-     * It is possible for the same event to be fired multiple times, 
+     * It is possible for the same event to be fired multiple times,
      * particularly for up or down events. Therefore, a listener should
      * ignore the same event if it has already been notified of a
      * node's state.
@@ -218,5 +218,19 @@ public class Host {
          * @param host the removed host.
          */
         public void onRemove(Host host);
+
+        /**
+         * Called when the location information of a node (datacenter and/or
+         * rack) gets updated.
+         * <p>
+         * Note that under certain conditions, this event might get fired before
+         * {@link #onAdd(Host)} when a new node is added. Listener
+         * implementations can handle that by simply ignoring location updates
+         * for unknown nodes.
+         * </p>
+         *
+         * @param host the updated host.
+         */
+        public void onLocationUpdated(Host host);
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/LatencyAwarePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/LatencyAwarePolicy.java
@@ -278,6 +278,11 @@ public class LatencyAwarePolicy implements LoadBalancingPolicy {
         latencyTracker.resetHost(host);
     }
 
+    @Override
+    public void onLocationUpdated(Host host) {
+        childPolicy.onLocationUpdated(host);
+    }
+
     /**
      * An immutable snapshot of the per-host scores (and stats in general)
      * maintained by {@code LatencyAwarePolicy} to base its decision upon.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/RoundRobinPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/RoundRobinPolicy.java
@@ -162,4 +162,8 @@ public class RoundRobinPolicy implements LoadBalancingPolicy {
     public void onRemove(Host host) {
         onDown(host);
     }
+
+    @Override
+    public void onLocationUpdated(Host host) {
+    }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/TokenAwarePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/TokenAwarePolicy.java
@@ -151,4 +151,9 @@ public class TokenAwarePolicy implements LoadBalancingPolicy {
     public void onRemove(Host host) {
         childPolicy.onRemove(host);
     }
+
+    @Override
+    public void onLocationUpdated(Host host) {
+        childPolicy.onLocationUpdated(host);
+    }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/WhiteListPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/WhiteListPolicy.java
@@ -142,4 +142,10 @@ public class WhiteListPolicy implements LoadBalancingPolicy {
         if (whiteList.contains(host.getSocketAddress()))
             childPolicy.onRemove(host);
     }
+
+    @Override
+    public void onLocationUpdated(Host host) {
+        if (whiteList.contains(host.getSocketAddress()))
+            childPolicy.onLocationUpdated(host);
+    }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -165,6 +165,10 @@ public class CCMBridge {
         execute("ccm populate -n %d -i %s", n, IP_PREFIX);
     }
 
+    public void relocate(int n, String datacenter, String rack) {
+        execute("ccm node%d relocate %s %s", n, datacenter, rack);
+    }
+
     private void execute(String command, Object... args) {
         try {
             String fullCommand = String.format(command, args) + " --config-dir=" + ccmDir;

--- a/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyRefreshTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyRefreshTest.java
@@ -61,6 +61,7 @@ public class LoadBalancingPolicyRefreshTest {
         public void onRemove(Host h) {}
         public void onUp(Host h) {}
         public void onDown(Host h) {}
+        public void onLocationUpdated(Host host) {}
     }
 
     @Test(groups = "short")


### PR DESCRIPTION
:warning: **Depends on pcmanus/ccm#128**

As discussed in the issue comments, I've added the method to `StateListener` rather than `LoadBalancingPolicy`. If we decide that it's better to keep it only on the former, I can make the change quickly.

Currently, `onLocationUpdated` can be called before `onAdd` when a new node is added. I've mentioned that in the javadocs, I think listener implementations can easily deal with it. However, it could be handled in the code by passing the node's state (new or not), I just thought it wasn't worth the effort. Again, I can add that if needed.
