### PR TITLE
Add ResultSet.wasApplied() for conditional queries (JAVA-358).

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ResultSet.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ResultSet.java
@@ -185,4 +185,32 @@ public interface ResultSet extends Iterable<Row> {
      * @return a list of the execution info for all the queries made for this ResultSet.
      */
     public List<ExecutionInfo> getAllExecutionInfo();
+
+    /**
+     * If the query that produced this ResultSet was a conditional update,
+     * return whether it was successfully applied.
+     * <p>
+     * This is equivalent to calling:
+     *
+     * <pre>
+     * rs.one().getBool("[applied]");
+     * </pre>
+     *
+     * <p>
+     * For consistency, this method always returns {@code true} for
+     * non-conditional queries (although there is no reason to call the method
+     * in that case).
+     *
+     * <p>
+     * Note that, for versions of Cassandra strictly lower than 2.0.9 and 2.1.0-rc2,
+     * a server-side bug (CASSANDRA-7337) causes this method to always return
+     * {@code true} for batches containing conditional queries.
+     * </p>
+     *
+     * @return if the query was a conditional update, whether it was applied.
+     * {@code true} for other types of queries.
+     *
+     * @see <a href="https://issues.apache.org/jira/browse/CASSANDRA-7337">CASSANDRA-7337</a>
+     */
+    public boolean wasApplied();
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/ConditionalUpdateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ConditionalUpdateTest.java
@@ -1,0 +1,67 @@
+package com.datastax.driver.core;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Test {@link ResultSet#wasApplied()} for conditional updates.
+ */
+public class ConditionalUpdateTest extends CCMBridge.PerClassSingleNodeCluster {
+
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return Collections.singletonList("CREATE TABLE test(k1 int, k2 int, v int, PRIMARY KEY (k1, k2))");
+    }
+
+    @Test(groups = "short")
+    public void singleUpdateTest() {
+        session.execute("TRUNCATE test");
+        session.execute("INSERT INTO test (k1, k2, v) VALUES (1, 1, 1)");
+
+        ResultSet rs = session.execute("UPDATE test SET v = 3 WHERE k1 = 1 AND k2 = 1 IF v = 2");
+        assertFalse(rs.wasApplied());
+        // Ensure that reading the status does not consume a row:
+        assertFalse(rs.isExhausted());
+
+        rs = session.execute("UPDATE test SET v = 3 WHERE k1 = 1 AND k2 = 1 IF v = 1");
+        assertTrue(rs.wasApplied());
+        assertFalse(rs.isExhausted());
+
+        // Non-conditional statement
+        rs = session.execute("UPDATE test SET v = 4 WHERE k1 = 1 AND k2 = 1");
+        assertTrue(rs.wasApplied());
+    }
+
+    @Test(groups = "short")
+    public void batchUpdateTest() {
+        session.execute("TRUNCATE test");
+        session.execute("INSERT INTO test (k1, k2, v) VALUES (1, 1, 1)");
+        session.execute("INSERT INTO test (k1, k2, v) VALUES (1, 2, 1)");
+
+        PreparedStatement ps = session.prepare("UPDATE test SET v = :new WHERE k1 = :k1 AND k2 = :k2 IF v = :old");
+        BatchStatement batch = new BatchStatement();
+        batch.add(ps.bind().setInt("k1", 1).setInt("k2", 1).setInt("old", 2).setInt("new", 3)); // will fail
+        batch.add(ps.bind().setInt("k1", 1).setInt("k2", 2).setInt("old", 1).setInt("new", 3));
+
+
+        ResultSet rs = session.execute(batch);
+        assertFalse(rs.wasApplied());
+    }
+
+
+    @Test(groups = "short")
+    public void multipageResultSetTest() {
+        session.execute("TRUNCATE test");
+        session.execute("INSERT INTO test (k1, k2, v) VALUES (1, 1, 1)");
+        session.execute("INSERT INTO test (k1, k2, v) VALUES (1, 2, 1)");
+
+        // This is really contrived, we just want to cover the code path in ArrayBackedResultSet#MultiPage.
+        // Currently CAS update results are never multipage, so it's hard to come up with a meaningful example.
+        ResultSet rs = session.execute(new SimpleStatement("SELECT * FROM test WHERE k1 = 1").setFetchSize(1));
+
+        assertTrue(rs.wasApplied());
+    }
+}


### PR DESCRIPTION
The flag is computed at construction time by peeking at the first row. For paged results, this assumes that the first page contains at least one row, which I think is always the case.

I didn't want to build a temporary `ArrayBackedRow` just to read a column, so I did it manually. This leads to some code duplication. I have mixed feelings about that, if you prefer it the other way I'll change it.

The method returns `true` whenever the `[applied]` column doesn't exist, the reasoning being that non-conditional statements are always "applied". It could also throw an exception (again I can easily change that).

Finally, as noted in the API docs, this feature is subject to CASSANDRA-7337 for conditional batches.
