### PR TITLE
Avoid LoadBalancingPolicy onDown+onUp at startup (JAVA-315).

### DIFF
--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -7,6 +7,7 @@ CHANGELOG
 - [improvement] Better handling of dead connections (JAVA-204)
 - [bug] Fix potential NPE in ControlConnection (JAVA-373)
 - [bug] Throws NPE when passed null for a contact point (JAVA-291)
+- [bug] Avoid LoadBalancingPolicy onDown+onUp at startup (JAVA-315)
 
 
 2.0.3:

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicy.java
@@ -177,6 +177,13 @@ public class DCAwareRoundRobinPolicy implements LoadBalancingPolicy {
 
         for (Host host : hosts) {
             String dc = dc(host);
+
+            // If the localDC was in "auto-discover" mode and it's the first host for which we have a DC, use it.
+            if (localDc == UNSET && dc != UNSET) {
+                logger.info("Using data-center name '{}' for DCAwareRoundRobinPolicy (if this is incorrect, please provide the correct datacenter name with DCAwareRoundRobinPolicy constructor)", dc);
+                localDc = dc;
+            }
+
             CopyOnWriteArrayList<Host> prev = perDcLiveHosts.get(dc);
             if (prev == null)
                 perDcLiveHosts.put(dc, new CopyOnWriteArrayList<Host>(Collections.singletonList(host)));

--- a/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyBootstrapTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyBootstrapTest.java
@@ -1,0 +1,99 @@
+package com.datastax.driver.core;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.testng.annotations.*;
+
+import static org.testng.Assert.assertEquals;
+
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
+
+public class LoadBalancingPolicyBootstrapTest {
+    CountingPolicy policy;
+    CCMBridge.CCMCluster c;
+
+    @BeforeClass
+    private void setup() {
+        policy = new CountingPolicy(new RoundRobinPolicy());
+        Cluster.Builder builder = Cluster.builder().withLoadBalancingPolicy(policy);
+        c = CCMBridge.buildCluster(2, builder);
+    }
+
+    @Test(groups = "short")
+    public void notificationsTest() throws Exception {
+        assertEquals(policy.adds, 2, "adds\n" + policy.history);
+        assertEquals(policy.suspecteds, 0, "suspecteds\n" + policy.history);
+        assertEquals(policy.removes, 0, "removes\n" + policy.history);
+        assertEquals(policy.ups, 0, "ups\n" + policy.history);
+        assertEquals(policy.downs, 0, "downs\n" + policy.history);
+    }
+
+    @AfterClass
+    private void tearDown() {
+        c.discard();
+    }
+
+    static class CountingPolicy implements LoadBalancingPolicy {
+
+        private final LoadBalancingPolicy delegate;
+        int adds;
+        int suspecteds;
+        int removes;
+        int ups;
+        int downs;
+
+        final StringWriter history = new StringWriter();
+        private final PrintWriter out = new PrintWriter(history);
+
+        CountingPolicy(LoadBalancingPolicy delegate) {
+            this.delegate = delegate;
+        }
+
+        public void onAdd(Host host) {
+            out.printf("add %s%n", host);
+            adds++;
+            delegate.onAdd(host);
+        }
+
+        public void onSuspected(Host host) {
+            out.printf("suspect %s%n", host);
+            suspecteds++;
+            delegate.onSuspected(host);
+        }
+
+        public void onUp(Host host) {
+            out.printf("up %s%n", host);
+            ups++;
+            delegate.onUp(host);
+        }
+
+        public void onDown(Host host) {
+            out.printf("down %s%n", host);
+            downs++;
+            delegate.onDown(host);
+        }
+
+        public void onRemove(Host host) {
+            out.printf("remove %s%n", host);
+            removes++;
+            delegate.onRemove(host);
+        }
+
+        public void init(Cluster cluster, Collection<Host> hosts) {
+            delegate.init(cluster, hosts);
+        }
+
+        public HostDistance distance(Host host) {
+            return delegate.distance(host);
+        }
+
+        @Override
+        public Iterator<Host> newQueryPlan(String loggedKeyspace, Statement statement) {
+            return delegate.newQueryPlan(loggedKeyspace, statement);
+        }
+    }
+}


### PR DESCRIPTION
Second attempt for this fix, with the alternate approach discussed in JIRA.

As suggested, I've created a dummy policy just for startup. We switch to the real one just after we've set the nodes' location info for the first time; as a consequence, `LoadBalancyPolicy#init()` is called with "complete" nodes.

We still get an "onDown+onUp+onAdd" sequence when a new node is added, but that's OK if policies ignore onDown for unknown nodes (see the change in the DC-aware one).
