### PR TITLE
Removed use of .stress.version file

### DIFF
--- a/driver-examples/stress/bin/build
+++ b/driver-examples/stress/bin/build
@@ -4,10 +4,7 @@ SCRIPT_DIR=$( cd "$( dirname "$0" )" && pwd )
 CURRENT_DIR=$( pwd )
 
 LOG_FILE="$CURRENT_DIR/stress_build.log"
-VERSION_FILE="$SCRIPT_DIR/../.stress.version"
-
 [ -f $LOG_FILE ] && rm $LOG_FILE
-[ -f $VERSION_FILE ] && rm $VERSION_FILE
 
 echo "Building java driver ..."
 echo "-- Driver build --\n" > $LOG_FILE
@@ -34,13 +31,6 @@ then
     cd $CURRENT_DIR
     exit $EXIT_CODE
 fi
-
-# We don't want to hardcode the version in the stress launch file, but maven takes an unreasonabe time
-# just to return project version (even if the internet has already been downloaded). So for the common
-# case, just compute that version now and save it to some hidden file, so we speed up the execution script
-
-VERSION=`cd $SCRIPT_DIR/.. && mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -Ev '(^\[|Download\w+:)'`
-echo "$VERSION" > $VERSION_FILE
 
 cd $CURRENT_DIR
 rm $LOG_FILE

--- a/driver-examples/stress/bin/stress
+++ b/driver-examples/stress/bin/stress
@@ -11,20 +11,11 @@ else
 fi
 
 if [ "x$STRESS_JAR" = "x" ]; then
-    # Get the current project version...
 
-    VERSION_FILE="$SCRIPT_DIR/../.stress.version"
-    if [ -f $VERSION_FILE ]; then
-        VERSION=`cat $VERSION_FILE`
-    else
-        VERSION=`cd $SCRIPT_DIR/.. && mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -Ev '(^\[|Download\w+:)'`
-    fi
-
-    STRESS_JAR="$SCRIPT_DIR/../target/cassandra-driver-examples-stress-$VERSION-jar-with-dependencies.jar"
+    STRESS_JAR="$SCRIPT_DIR/../target/cassandra-driver-examples-stress-*-jar-with-dependencies.jar"
 
     if [ ! -f $STRESS_JAR ]; then
         # Trash the version file in case there was some crap in it
-        [ -f $VERSION_FILE ] && rm $VERSION_FILE;
         RELATIVE_SCRIPT_DIR=`dirname $0`
         echo "Stress application does not seem to be build, try $RELATIVE_SCRIPT_DIR/build first" 1>&2
         exit 1


### PR DESCRIPTION
It seems this file was only used so that we could precisely reference
the jar-with-dependencies. It can be replaced by a wildcard since we
only generate one such jar.

The .stress.version file can contain more than the version number in
case the JAVA_HOME environment variable is not correctly defined.
Therefore I think we can simply delete it instead of adding more
exclusion rules in the 'grep -Ev' command.
