### PR TITLE
Signal host monitor as soon as a connection is marked defunct (JAVA-367).

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1542,6 +1542,9 @@ public class Cluster implements Closeable {
         }
 
         public boolean signalConnectionFailure(Host host, ConnectionException exception, boolean isHostAddition) {
+            if (isClosed())
+                return true;
+
             boolean isDown = host.signalConnectionFailure(exception);
             if (isDown)
                 triggerOnDown(host, isHostAddition);

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -139,21 +139,13 @@ class ControlConnection implements Host.StateListener {
     }
 
     private void signalError() {
-
-        // Try just signaling the host monitor, as this will trigger a reconnect as part to marking the host down.
+        // If the connection was marked as defunct, this already reported the
+        // node down, which will trigger a reconnect. Otherwise, just reconnect
+        // manually
         Connection connection = connectionRef.get();
-        if (connection != null && connection.isDefunct()) {
-            Host host = cluster.metadata.getHost(connection.address);
-            // Host might be null in the case the host has been removed, but it means this has
-            // been reported already so it's fine.
-            if (host != null) {
-                cluster.signalConnectionFailure(host, connection.lastException(), false);
-                return;
-            }
+        if (connection == null || !connection.isDefunct()) {
+            reconnect();
         }
-
-        // If the connection is not defunct, or the host has left, just reconnect manually
-        reconnect();
     }
 
     private void setNewConnection(Connection newConnection) {

--- a/driver-core/src/main/java/com/datastax/driver/core/PooledConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PooledConnection.java
@@ -36,4 +36,18 @@ class PooledConnection extends Connection {
     public void release() {
         pool.returnConnection(this);
     }
+
+    @Override
+    protected void notifyOwnerWhenDefunct(boolean hostIsDown) {
+        // This can happen if an exception is thrown at construction time. In
+        // that case the pool will handle it itself.
+        if (pool == null)
+            return;
+
+        if (hostIsDown) {
+            pool.closeAsync();
+        } else {
+            pool.replace(this);
+        }
+    }
 }


### PR DESCRIPTION
I've had to change to an enum instead of a boolean for the Host state, in order to compute `isHostAddition` when signal... is called.
