### PR TITLE
Makes public UDTDefinition's constructor

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/UDTDefinition.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/UDTDefinition.java
@@ -45,7 +45,7 @@ public class UDTDefinition implements Iterable<UDTDefinition.Field> {
     // implementation.
     final Map<String, int[]> byName;
 
-    UDTDefinition(String keyspace, String name, Collection<Field> fields) {
+    public UDTDefinition(String keyspace, String name, Collection<Field> fields) {
         this.keyspace = keyspace;
         this.name = name;
         this.byIdx = fields.toArray(new Field[fields.size()]);
@@ -286,7 +286,7 @@ public class UDTDefinition implements Iterable<UDTDefinition.Field> {
         private final String name;
         private final DataType type;
 
-        Field(String name, DataType type) {
+        public Field(String name, DataType type) {
             this.name = name;
             this.type = type;
         }


### PR DESCRIPTION
Makes able to create an instance of UDTValue with the knowledge of the structure of the User Defined Type.
## Example

```
CREATE TYPE IF NOT EXISTS my_type ( bla ascii, val int);
CREATE TABLE IF NOT EXISTS udt_table (key uuid, udt my_type, PRIMARY KEY (key));
```

Usually, we do ;

```
INSERT INTO udt_table (key, udt) VALUES  (?, { bla : ?, val : ? });
```

But it would also allow from the Java driver (the second parameter is an instance of UDTValue) ;

```
INSERT INTO udt_table (key, udt) VALUES  (?, ?);
```
