### PR TITLE
Avoid classloader leak in Tomcat (JAVA-343).

### DIFF
--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -8,6 +8,7 @@ CHANGELOG
 - [bug] Fix potential NPE in ControlConnection (JAVA-373)
 - [bug] Throws NPE when passed null for a contact point (JAVA-291)
 - [bug] Avoid LoadBalancingPolicy onDown+onUp at startup (JAVA-315)
+- [bug] Avoid classloader leak in Tomcat (JAVA-343)
 
 
 2.0.3:

--- a/driver-core/src/main/java/com/datastax/driver/core/Token.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Token.java
@@ -235,28 +235,14 @@ abstract class Token implements Comparable<Token> {
 
         public static final Factory FACTORY = new Factory() {
 
-            private final ThreadLocal<MessageDigest> md5Digests = new ThreadLocal<MessageDigest>() {
-                @Override
-                protected MessageDigest initialValue() {
-                    try {
-                        return MessageDigest.getInstance("MD5");
-                    } catch (NoSuchAlgorithmException e) {
-                        throw new RuntimeException("MD5 doesn't seem to be available on this JVM", e);
-                    }
-                }
-
-                @Override
-                public MessageDigest get() {
-                    MessageDigest digest = super.get();
-                    digest.reset();
-                    return digest;
-                }
-            };
-
             private BigInteger md5(ByteBuffer data) {
-                MessageDigest digest = md5Digests.get();
-                digest.update(data.duplicate());
-                return new BigInteger(digest.digest()).abs();
+                try {
+                    MessageDigest digest = MessageDigest.getInstance("MD5");
+                    digest.update(data.duplicate());
+                    return new BigInteger(digest.digest()).abs();
+                } catch (NoSuchAlgorithmException e) {
+                    throw new RuntimeException("MD5 doesn't seem to be available on this JVM", e);
+                }
             }
 
             @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
@@ -21,11 +21,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
-import java.nio.charset.CharsetDecoder;
-import java.nio.charset.CharsetEncoder;
 import java.text.ParseException;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
@@ -214,42 +210,13 @@ abstract class TypeCodec<T> {
 
     static class StringCodec extends TypeCodec<String> {
 
-        private static final Charset utf8Charset = Charset.forName("UTF-8");
-        private static final Charset asciiCharset = Charset.forName("US-ASCII");
+        static final StringCodec utf8Instance = new StringCodec(Charset.forName("UTF-8"));
+        static final StringCodec asciiInstance = new StringCodec(Charset.forName("US-ASCII"));
 
-        // We don't want to recreate the decoders/encoders every time and they're not threadSafe.
-        private static final ThreadLocal<CharsetDecoder> utf8Decoders = new ThreadLocal<CharsetDecoder>() {
-            @Override
-            protected CharsetDecoder initialValue() {
-                return utf8Charset.newDecoder();
-            }
-        };
-        private static final ThreadLocal<CharsetDecoder> asciiDecoders = new ThreadLocal<CharsetDecoder>() {
-            @Override
-            protected CharsetDecoder initialValue() {
-                return asciiCharset.newDecoder();
-            }
-        };
-        private static final ThreadLocal<CharsetEncoder> utf8Encoders = new ThreadLocal<CharsetEncoder>() {
-            @Override
-            protected CharsetEncoder initialValue() {
-                return utf8Charset.newEncoder();
-            }
-        };
-        private static final ThreadLocal<CharsetEncoder> asciiEncoders = new ThreadLocal<CharsetEncoder>() {
-            @Override
-            protected CharsetEncoder initialValue() {
-                return asciiCharset.newEncoder();
-            }
-        };
+        private final Charset charset;
 
-        static final StringCodec utf8Instance = new StringCodec(true);
-        static final StringCodec asciiInstance = new StringCodec(false);
-
-        private final boolean isUTF8;
-
-        private StringCodec(boolean isUTF8) {
-            this.isUTF8 = isUTF8;
+        private StringCodec(Charset charset) {
+            this.charset = charset;
         }
 
         @Override
@@ -259,22 +226,12 @@ abstract class TypeCodec<T> {
 
         @Override
         public ByteBuffer serialize(String value) {
-            try {
-                CharsetEncoder encoder = isUTF8 ? utf8Encoders.get() : asciiEncoders.get();
-                return encoder.encode(CharBuffer.wrap(value));
-            } catch (CharacterCodingException e) {
-                throw new InvalidTypeException("Invalid " + (isUTF8 ? "UTF-8" : "ASCII") + " string");
-            }
+            return ByteBuffer.wrap(value.getBytes(charset));
         }
 
         @Override
         public String deserialize(ByteBuffer bytes) {
-            try {
-                CharsetDecoder decoder = isUTF8 ? utf8Decoders.get() : asciiDecoders.get();
-                return decoder.decode(bytes.duplicate()).toString();
-            } catch (CharacterCodingException e) {
-                throw new InvalidTypeException("Invalid " + (isUTF8 ? "UTF-8" : "ASCII") + " bytes");
-            }
+            return new String(Bytes.getArray(bytes), charset);
         }
     }
 


### PR DESCRIPTION
We use ThreadLocals in two places, to cache objects that we don't want to re-instantiate on each call.

One obvious workaround is to forego that optimization and create a new object each time.

This commit takes another approach: wrap the object in a weak reference so that it can be garbage collected on redeployment. Tomcat no longer complains and I've checked with JVisualVM that the class loader is correctly garbage-collected.
