### PR TITLE
2.1 release tests

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/SessionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionTest.java
@@ -130,4 +130,20 @@ public class SessionTest extends CCMBridge.PerClassSingleNodeCluster {
             cluster.getConfiguration().getProtocolOptions().setCompression(ProtocolOptions.Compression.NONE);
         }
     }
+
+    @Test(groups = "short")
+    public void getStateTest() throws Exception {
+        Session.State state = session.getState();
+        Host host = state.getConnectedHosts().iterator().next();
+
+        assertEquals(state.getConnectedHosts().size(), 1);
+        assertEquals(host.getAddress().toString(), "/127.0.1.1");
+        assertEquals(host.getDatacenter(), "datacenter1");
+        assertEquals(host.getRack(), "rack1");
+        assertEquals(host.getSocketAddress().toString(), "/127.0.1.1:9042");
+
+        assertEquals(state.getOpenConnections(host), 2);
+        assertEquals(state.getInFlightQueries(host), 0);
+        assertEquals(state.getSession(), session);
+    }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -23,11 +23,12 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 
 import org.testng.annotations.Test;
-import static org.testng.Assert.*;
 
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.Statement;
+
 import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+import static org.testng.Assert.*;
 
 public class QueryBuilderTest {
 
@@ -631,25 +632,6 @@ public class QueryBuilderTest {
     public void truncateTest() throws Exception {
         assertEquals(truncate("foo").toString(), "TRUNCATE foo;");
         assertEquals(truncate("foo", quote("Bar")).toString(), "TRUNCATE foo.\"Bar\";");
-    }
-
-    @Test(groups = "unit")
-    public void compoundWherClauseTest() throws Exception {
-        String query;
-        Statement select;
-
-        query = "SELECT * FROM foo WHERE k=4 AND (c1,c2)>('a',2);";
-        select = select().all().from("foo").where(eq("k", 4)).and(gt(Arrays.asList("c1", "c2"), Arrays.<Object>asList("a", 2)));
-        assertEquals(select.toString(), query);
-
-        query = "SELECT * FROM foo WHERE k=4 AND (c1,c2)>=('a',2) AND (c1,c2)<('b',0);";
-        select = select().all().from("foo").where(eq("k", 4)).and(gte(Arrays.asList("c1", "c2"), Arrays.<Object>asList("a", 2)))
-                                                             .and(lt(Arrays.asList("c1", "c2"), Arrays.<Object>asList("b", 0)));
-        assertEquals(select.toString(), query);
-
-        query = "SELECT * FROM foo WHERE k=4 AND (c1,c2)<=('a',2);";
-        select = select().all().from("foo").where(eq("k", 4)).and(lte(Arrays.asList("c1", "c2"), Arrays.<Object>asList("a", 2)));
-        assertEquals(select.toString(), query);
     }
 
     @Test(groups = "unit")

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
@@ -7,11 +7,14 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
-import static org.testng.Assert.assertEquals;
 
-import com.datastax.driver.core.*;
+import com.datastax.driver.core.CCMBridge;
+import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.utils.UUIDs;
 import com.datastax.driver.mapping.annotations.*;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class MapperUDTTest extends CCMBridge.PerClassSingleNodeCluster {
 
@@ -173,6 +176,9 @@ public class MapperUDTTest extends CCMBridge.PerClassSingleNodeCluster {
 
         @Query("UPDATE ks.users SET other_addresses[:name]=:address WHERE user_id=:id")
         ResultSet addAddress(@Param("id") UUID id, @Param("name") String addressName, @Param("address") Address address);
+
+        @Query("SELECT * FROM ks.users")
+        public Result<User> getAll();
     }
 
     @Test(groups = "short")
@@ -201,6 +207,11 @@ public class MapperUDTTest extends CCMBridge.PerClassSingleNodeCluster {
 
         User u2 = userAccessor.getOne(u1.getUserId());
         assertEquals(workAddress, u2.getOtherAddresses().get("work"));
+
+        // No argument call
+        Result<User> u = userAccessor.getAll();
+        assertEquals(u.one(), u2);
+        assertTrue(u.isExhausted());
     }
 
     @UDT(keyspace = "ks", name = "sub")


### PR DESCRIPTION
Add a Session.getState() test and remove the duplicate querybuilder test. 

(imports were rearranged automatically to fit suggested java-driver import order.)
