### PR TITLE
Add a setRoutingKey() method to BoundStatement so that we can ensure com...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
     <version>7</version>
+    <relativePath></relativePath>
   </parent>
   
   <groupId>com.datastax.cassandra</groupId>


### PR DESCRIPTION
Add a setRoutingKey() method to BoundStatement so that we can ensure compatibility with routing between Java and C# systems manipulating the same data in cassandra. We should not be forced to use PreparedStatement for this when the partition key isn't fixed
