### PR TITLE
Fix annotation parser ordering

### DIFF
--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
@@ -24,7 +24,7 @@ class AnnotationParser {
 
     private static final Comparator<Field> fieldComparator = new Comparator<Field>() {
         public int compare(Field f1, Field f2) {
-            return position(f2) - position(f1);
+            return position(f1) - position(f2);
         }
     };
 


### PR DESCRIPTION
Modifies annotation parser comparator to order fields to normal (growing) order, accordingly to passed parameter at keys annotations (@ClusteringColumn(0), @ClusteringColumn(1), ...).
