### PR TITLE
Fix tokenMap initialization at startup (JAVA-415).

### DIFF
--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -8,6 +8,7 @@ CHANGELOG
 - [bug] Fix handling of SimpleStatement with values in query builder
   batches (JAVA-393)
 - [bug] Ensure pool is properly closed in onDown (JAVA-417)
+- [bug] Fix tokenMap initialization at startup (JAVA-415)
 
 
 2.0.4:

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1772,7 +1772,7 @@ public class Cluster implements Closeable {
                         // that querying a table just after having created it don't fail.
                         if (!ControlConnection.waitForSchemaAgreement(connection, Cluster.Manager.this))
                             logger.warn("No schema agreement from live replicas after {} ms. The schema may not be up to date on some nodes.", ControlConnection.MAX_SCHEMA_AGREEMENT_WAIT_MS);
-                        ControlConnection.refreshSchema(connection, keyspace, table, Cluster.Manager.this, false, false);
+                        ControlConnection.refreshSchema(connection, keyspace, table, Cluster.Manager.this, false);
                     } catch (Exception e) {
                         logger.error("Error during schema refresh ({}). The schema from Cluster.getMetadata() might appear stale. Asynchronously submitting job to fix.", e.getMessage());
                         submitSchemaRefresh(keyspace, table);


### PR DESCRIPTION
This reverts the `dontReloadNodeInfo` boolean that was added to `ControlConnection#refreshSchema` as part of JAVA-315 to avoid calling `refreshNodeListAndTokenMap` twice at startup.

It turns out that we want to call it a second time, because the first time it is called the token map cannot be built since the keyspaces have not been loaded yet.
