### PR TITLE
Added retry policy allowing fallback from LOCAL_QUORUM to QUORUM initial...

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicy.java
@@ -72,7 +72,7 @@ public class DowngradingConsistencyRetryPolicy implements RetryPolicy {
 
     private DowngradingConsistencyRetryPolicy() {}
 
-    private RetryDecision maxLikelyToWorkCL(int knownOk) {
+    RetryDecision maxLikelyToWorkCL(int knownOk) {
         if (knownOk >= 3)
             return RetryDecision.retry(ConsistencyLevel.THREE);
         else if (knownOk >= 2)

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/QuorumFallbackRetryPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/QuorumFallbackRetryPolicy.java
@@ -38,8 +38,16 @@ public class QuorumFallbackRetryPolicy implements RetryPolicy {
     public RetryDecision onUnavailable(Statement statement, ConsistencyLevel cl, int requiredReplica, int aliveReplica, int nbRetry) {
         if (nbRetry == 0 && ConsistencyLevel.LOCAL_QUORUM == cl)
             return RetryDecision.retry(ConsistencyLevel.QUORUM);
-        else if (nbRetry == 1 && ConsistencyLevel.ONE != cl)
-            return RetryDecision.retry(ConsistencyLevel.ONE);
+        else if (nbRetry == 1 && ConsistencyLevel.QUORUM != cl) {
+            if (aliveReplica >= 3)
+                return RetryDecision.retry(ConsistencyLevel.THREE);
+            else if (aliveReplica >= 2)
+                return RetryDecision.retry(ConsistencyLevel.TWO);
+            else if (aliveReplica >= 1)
+                return RetryDecision.retry(ConsistencyLevel.ONE);
+            else
+                return RetryDecision.rethrow();
+        }
         else
             return defaultPolicy.onUnavailable(statement, cl, requiredReplica, aliveReplica, nbRetry);
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/QuorumFallbackRetryPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/QuorumFallbackRetryPolicy.java
@@ -8,7 +8,7 @@ import com.datastax.driver.core.WriteType;
  * A retry policy that sometimes retry with a lower consistency level than
  * the one initially requested. It follows the same logic as the
  * {@link DowngradingConsistencyRetryPolicy}, except that it will retry
- * a LOCAL_QUORUM request at QUORUM first, before finally falling back to ONE.
+ * a LOCAL_QUORUM request at QUORUM first, before finally retrying at the highest achievable level.
  */
 public class QuorumFallbackRetryPolicy implements RetryPolicy {
     private RetryPolicy defaultPolicy = DowngradingConsistencyRetryPolicy.INSTANCE;
@@ -21,7 +21,7 @@ public class QuorumFallbackRetryPolicy implements RetryPolicy {
      * unavailable exception.
      * <p>
      * This method triggers a maximum of two retries. If the consistency level is
-     * initially set to LOCAL_QUORUM, it will first retry at QUORUM, then at ONE if
+     * initially set to LOCAL_QUORUM, it will first retry at QUORUM, then at the highest achievable level if
      * that fails. All other cases pass through to {@link DowngradingConsistencyRetryPolicy}.
      *
      * @param statement the original query for which the consistency level cannot

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/QuorumFallbackRetryPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/QuorumFallbackRetryPolicy.java
@@ -1,0 +1,85 @@
+package com.datastax.driver.core.policies;
+
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.WriteType;
+
+/**
+ * A retry policy that sometimes retry with a lower consistency level than
+ * the one initially requested. It follows the same logic as the
+ * {@link DowngradingConsistencyRetryPolicy}, except that it will retry
+ * a LOCAL_QUORUM request at QUORUM first, before finally falling back to ONE.
+ */
+public class QuorumFallbackRetryPolicy implements RetryPolicy {
+    private RetryPolicy defaultPolicy = DowngradingConsistencyRetryPolicy.INSTANCE;
+    public static final QuorumFallbackRetryPolicy INSTANCE = new QuorumFallbackRetryPolicy();
+
+    private QuorumFallbackRetryPolicy() {}
+
+    /**
+     * Defines whether to retry and at which consistency level on an
+     * unavailable exception.
+     * <p>
+     * This method triggers a maximum of two retries. If the consistency level is
+     * initially set to LOCAL_QUORUM, it will first retry at QUORUM, then at ONE if
+     * that fails. All other cases pass through to {@link DowngradingConsistencyRetryPolicy}.
+     *
+     * @param statement the original query for which the consistency level cannot
+     * be achieved.
+     * @param cl the original consistency level for the operation.
+     * @param requiredReplica the number of replica that should have been
+     * (known) alive for the operation to be attempted.
+     * @param aliveReplica the number of replica that were know to be alive by
+     * the coordinator of the operation.
+     * @param nbRetry the number of retry already performed for this operation.
+     * @return a RetryDecision as defined above.
+     */
+    @Override
+    public RetryDecision onUnavailable(Statement statement, ConsistencyLevel cl, int requiredReplica, int aliveReplica, int nbRetry) {
+        if (nbRetry == 0 && ConsistencyLevel.LOCAL_QUORUM == cl)
+            return RetryDecision.retry(ConsistencyLevel.QUORUM);
+        else if (nbRetry == 1 && ConsistencyLevel.ONE != cl)
+            return RetryDecision.retry(ConsistencyLevel.ONE);
+        else
+            return defaultPolicy.onUnavailable(statement, cl, requiredReplica, aliveReplica, nbRetry);
+    }
+
+    /**
+     * Defines whether to retry and at which consistency level on a read timeout.
+     * This method passes through to {@link DowngradingConsistencyRetryPolicy}.
+     *
+     * @param statement the original query that timed out.
+     * @param cl the original consistency level of the read that timed out.
+     * @param requiredResponses the number of responses that were required to
+     * achieve the requested consistency level.
+     * @param receivedResponses the number of responses that had been received
+     * by the time the timeout exception was raised.
+     * @param dataRetrieved whether actual data (by opposition to data checksum)
+     * was present in the received responses.
+     * @param nbRetry the number of retry already performed for this operation.
+     * @return a RetryDecision as defined above.
+     */
+    @Override
+    public RetryDecision onReadTimeout(Statement statement, ConsistencyLevel cl, int requiredResponses, int receivedResponses, boolean dataRetrieved, int nbRetry) {
+        return defaultPolicy.onReadTimeout(statement, cl, requiredResponses, receivedResponses, dataRetrieved, nbRetry);
+    }
+
+    /**
+     * Defines whether to retry and at which consistency level on a write timeout.
+     * This method passes through to {@link DowngradingConsistencyRetryPolicy}.
+     *
+     * @param statement the original query that timed out.
+     * @param cl the original consistency level of the write that timed out.
+     * @param writeType the type of the write that timed out.
+     * @param requiredAcks the number of acknowledgments that were required to
+     * achieve the requested consistency level.
+     * @param receivedAcks the number of acknowledgments that had been received
+     * by the time the timeout exception was raised.
+     * @param nbRetry the number of retry already performed for this operation.
+     * @return a RetryDecision as defined above.
+     */
+    @Override
+    public RetryDecision onWriteTimeout(Statement statement, ConsistencyLevel cl, WriteType writeType, int requiredAcks, int receivedAcks, int nbRetry) {
+        return defaultPolicy.onWriteTimeout(statement, cl, writeType, requiredAcks, receivedAcks, nbRetry);
+    }
+}


### PR DESCRIPTION
This retry policy wraps the DowngradingConsistencyRetryPolicy, essentially applying the same logic, EXCEPT when the initial consistency level is set to LOCAL_QUORUM. In that case it first attempts at QUORUM, then falls back to ONE. 

The idea is that you can make calls at LOCAL_QUORUM, which will fall back to QUORUM first if needed. The cost of full QUORUM is preferable in some use cases to ONE, where you want to be really sure a write made it. This is especially likely if RF=3 and you've lost two of your local replicas (resulting in the failed LOCAL_QUORUM).  Then if all else fails it goes to ONE. 
