### PR TITLE
Use a non fair ordering policy for the wait lock in HostConnectionPool

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -55,7 +55,7 @@ class HostConnectionPool {
     private final Set<Connection> trash = new CopyOnWriteArraySet<Connection>();
 
     private volatile int waiter = 0;
-    private final Lock waitLock = new ReentrantLock(true);
+    private final Lock waitLock = new ReentrantLock();
     private final Condition hasAvailableConnection = waitLock.newCondition();
 
     private final Runnable newConnectionTask;


### PR DESCRIPTION
The default fairness setting for j.u.c.locks.ReentrantLock is false for a good reason.

[1] mentions a fairness penalty of nearly two orders of magnitudes.
So "Don't pay for fairness if you don't need it" [1]

[1] http://goo.gl/FUbfHt p.284
