### PR TITLE
Add size() method to BatchStatement class.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
@@ -177,6 +177,15 @@ public class BatchStatement extends Statement {
     }
 
     /**
+     * Returns the number of elements in this batch.
+     *
+     * @return the number of elements in this batch.
+     */
+    public int size() {
+        return statements.size();
+    }
+
+    /**
      * Throws an {@code UnsupportedOperationException} as setting the serial consistency is
      * currently not supported for protocol batches by Cassandra.
      * <p>

--- a/driver-core/src/test/java/com/datastax/driver/core/BatchStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/BatchStatementTest.java
@@ -44,6 +44,8 @@ public class BatchStatementTest extends CCMBridge.PerClassSingleNodeCluster {
             batch.add(st.bind("key1", 1));
             batch.add(st.bind("key2", 0));
 
+            assertEquals(3, batch.size());
+
             session.execute(batch);
 
             ResultSet rs = session.execute("SELECT * FROM test");
@@ -89,6 +91,8 @@ public class BatchStatementTest extends CCMBridge.PerClassSingleNodeCluster {
             batch.add(new SimpleStatement("INSERT INTO test (k, v) VALUES (?, ?)", "key1", 0));
             batch.add(st.bind("key1", 1));
             batch.add(st.bind("key1", 2));
+
+            assertEquals(3, batch.size());
 
             ResultSet rs = session.execute(batch);
             Row r = rs.one();


### PR DESCRIPTION
Since BatchStatement#getStatements() returns an immutable copy,
and that is probably a good design decision, then let's add a
size() method so that we don't need to create a copy by calling
batch.getStatements().size() in order to get the current number
of statements in the batch.
