### PR TITLE
Take into account new "frozen" attribute

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/DataType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataType.java
@@ -165,6 +165,26 @@ public abstract class DataType {
         this.name = name;
     }
 
+
+    /**
+     * Returns whether this data type is frozen.
+     * <p>
+     * This applies to User Defined Types, tuples and nested collections. Frozen types are serialized as a single value in
+     * Cassandra's storage engine, whereas non-frozen types are stored in a form that allows updates to individual subfields.
+     *
+     * @return whether this data type is frozen.
+     */
+    public boolean isFrozen() {
+        // With Cassandra 2.1.0, this is straightforward; in future versions, "frozenness" will be stored in the database.
+        switch (name) {
+            case UDT:
+            case TUPLE:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     static DataType decode(ChannelBuffer buffer) {
         Name name = Name.fromProtocolId(buffer.readUnsignedShort());
         switch (name) {

--- a/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
@@ -33,7 +33,7 @@ public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
     protected Collection<String> getTableDefinitions() {
         versionCheck(2.1, 0, "This will only work with Cassandra 2.1.0");
 
-        return Arrays.asList("CREATE TABLE t (k int PRIMARY KEY, v tuple<int, text, float>)");
+        return Arrays.asList("CREATE TABLE t (k int PRIMARY KEY, v frozen<tuple<int, text, float>>)");
     }
 
     @Test(groups = "short")
@@ -98,7 +98,7 @@ public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
             session.execute("CREATE KEYSPACE test_tuple_type " +
                             "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
             session.execute("USE test_tuple_type");
-            session.execute("CREATE TABLE mytable (a int PRIMARY KEY, b tuple<ascii, int, boolean>)");
+            session.execute("CREATE TABLE mytable (a int PRIMARY KEY, b frozen<tuple<ascii, int, boolean>>)");
 
             TupleType t = TupleType.of(DataType.ascii(), DataType.cint(), DataType.cboolean());
 
@@ -175,7 +175,7 @@ public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
                 for (int j = 0; j < i; ++j) {
                     ints.add("int");
                 }
-                valueSchema.add(String.format(" v_%d tuple<%s>", i, Joiner.on(',').join(ints)));
+                valueSchema.add(String.format(" v_%d frozen<tuple<%s>>", i, Joiner.on(',').join(ints)));
             }
             session.execute(String.format("CREATE TABLE mytable (k int PRIMARY KEY, %s)", Joiner.on(',').join(valueSchema)));
 
@@ -232,7 +232,7 @@ public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
             session.execute("USE test_tuple_subtypes");
 
             // programmatically create the table with a tuple of all datatypes
-            session.execute(String.format("CREATE TABLE mytable (k int PRIMARY KEY, v tuple<%s>)", Joiner.on(',').join(DATA_TYPE_PRIMITIVES)));
+            session.execute(String.format("CREATE TABLE mytable (k int PRIMARY KEY, v frozen<tuple<%s>>)", Joiner.on(',').join(DATA_TYPE_PRIMITIVES)));
 
             // insert tuples into same key using different columns
             // and verify the results
@@ -314,19 +314,19 @@ public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
 
             //create list values
             for (DataType datatype : DATA_TYPE_PRIMITIVES) {
-                values.add(String.format("v_%s tuple<list<%s>>", values.size(), datatype));
+                values.add(String.format("v_%s frozen<tuple<list<%s>>>", values.size(), datatype));
             }
 
             // create set values
             for (DataType datatype : DATA_TYPE_PRIMITIVES) {
-                values.add(String.format("v_%s tuple<set<%s>>", values.size(), datatype));
+                values.add(String.format("v_%s frozen<tuple<set<%s>>>", values.size(), datatype));
             }
 
             // create map values
             for (DataType datatype : DATA_TYPE_PRIMITIVES) {
                 DataType dataType1 = datatype;
                 DataType dataType2 = datatype;
-                values.add(String.format("v_%s tuple<map<%s, %s>>", values.size(), dataType1, dataType2));
+                values.add(String.format("v_%s frozen<tuple<map<%s, %s>>>", values.size(), dataType1, dataType2));
             }
 
             // create table
@@ -423,7 +423,7 @@ public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
         if (depth == 0)
             return "int";
         else
-            return String.format("tuple<%s>", nestedTuplesSchemaHelper(depth - 1));
+            return String.format("frozen<tuple<%s>>", nestedTuplesSchemaHelper(depth - 1));
     }
 
     /**
@@ -513,8 +513,8 @@ public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
             session.execute("USE testTuplesWithNulls");
 
             // create UDT
-            session.execute("CREATE TYPE user (a text, b tuple<text, int, uuid, blob>)");
-            session.execute("CREATE TABLE mytable (a int PRIMARY KEY, b user)");
+            session.execute("CREATE TYPE user (a text, b frozen<tuple<text, int, uuid, blob>>)");
+            session.execute("CREATE TABLE mytable (a int PRIMARY KEY, b frozen<user>)");
 
             // insert UDT data
             UserType userTypeDef = cluster.getMetadata().getKeyspace("testTuplesWithNulls").getUserType("user");

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationChecks.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationChecks.java
@@ -1,0 +1,182 @@
+/*
+ *      Copyright (C) 2012-2014 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.*;
+import java.lang.reflect.Field;
+import java.util.*;
+
+import com.google.common.primitives.Primitives;
+
+import com.datastax.driver.mapping.annotations.*;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet.Builder;
+
+import com.datastax.driver.core.DataType;
+
+/**
+ * Various checks on mapping annotations.
+ */
+class AnnotationChecks {
+
+    // The package containing the mapping annotations
+    private static final Package MAPPING_PACKAGE = Table.class.getPackage();
+
+    // The Java types that should not be annotated with @Frozen. Any other type is supposed
+    // to map to a UDT or tuple.
+    private static final Set<Class<?>> EXPECTED_NON_FROZEN_CLASSES;
+    static {
+        Builder<Class<?>> builder = ImmutableSet.<Class<?>>builder();
+        for (DataType type : DataType.allPrimitiveTypes()) {
+            builder.add(type.asJavaClass());
+            builder.add(Primitives.unwrap(type.asJavaClass()));
+        }
+        builder.add(List.class);
+        builder.add(Set.class);
+        builder.add(Map.class);
+
+        EXPECTED_NON_FROZEN_CLASSES = builder.build();
+    }
+
+    /**
+     * Checks that a class is decorated with the given annotation, and return the annotation instance.
+     * Also validates that no other mapping annotation is present.
+     */
+    static <T extends Annotation> T getTypeAnnotation(Class<T> annotation, Class<?> annotatedClass) {
+        T instance = annotatedClass.getAnnotation(annotation);
+        if (instance == null)
+            throw new IllegalArgumentException(String.format("@%s annotation was not found on type %s",
+                                                             annotation.getSimpleName(), annotatedClass.getName()));
+
+        // Check that no other mapping annotations are present
+        validateAnnotations(annotatedClass, annotation);
+
+        return instance;
+    }
+
+    private static void validateAnnotations(Class<?> clazz, Class<? extends Annotation> allowed) {
+        @SuppressWarnings("unchecked")
+        Class<? extends Annotation> invalid = validateAnnotations(clazz.getAnnotations(), allowed);
+        if (invalid != null)
+            throw new IllegalArgumentException(String.format("Cannot have both @%s and @%s on type %s",
+                                                             allowed.getSimpleName(), invalid.getSimpleName(),
+                                                             clazz.getName()));
+    }
+
+    /**
+     * Checks that a field is only annotated with the given mapping annotations, and that its "frozen" annotations are valid.
+     */
+    static void validateAnnotations(Field field, String classDescription, Class<? extends Annotation>... allowed) {
+        Class<? extends Annotation> invalid = validateAnnotations(field.getAnnotations(), allowed);
+        if (invalid != null)
+            throw new IllegalArgumentException(String.format("Annotation @%s is not allowed on field %s of %s %s",
+                                                             invalid.getSimpleName(),
+                                                             field.getName(), classDescription,
+                                                             field.getDeclaringClass().getName()));
+
+        try {
+            checkFrozenTypes(field);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(String.format("Error while checking frozen types on field %s of %s %s: %s",
+                                                             field.getName(), classDescription,
+                                                             field.getDeclaringClass().getName()));
+        }
+    }
+
+    // Returns the offending annotation if there is one
+    private static Class<? extends Annotation> validateAnnotations(Annotation[] annotations, Class<? extends Annotation>... allowed) {
+        for (Annotation annotation : annotations) {
+            Class<? extends Annotation> actual = annotation.annotationType();
+            if (actual.getPackage().equals(MAPPING_PACKAGE) && !contains(allowed, actual))
+                return actual;
+        }
+        return null;
+    }
+
+    private static boolean contains(Object[] array, Object target) {
+        for (Object element : array)
+            if (element.equals(target))
+                return true;
+        return false;
+    }
+
+    static void checkFrozenTypes(Field field) {
+        Type javaType = field.getGenericType();
+        CQLType cqlType = getCQLType(field);
+        checkFrozenTypes(javaType, cqlType);
+    }
+
+    // Builds a CQLType hierarchy based on the @Frozen* annotations on a field.
+    private static CQLType getCQLType(Field field) {
+        Frozen frozen = field.getAnnotation(Frozen.class);
+        if (frozen != null)
+            return CQLType.parse(frozen.value());
+
+        boolean frozenKey = field.getAnnotation(FrozenKey.class) != null;
+        boolean frozenValue = field.getAnnotation(FrozenValue.class) != null;
+        if (frozenKey && frozenValue)
+            return CQLType.FROZEN_MAP_KEY_AND_VALUE;
+        else if (frozenKey)
+            return CQLType.FROZEN_MAP_KEY;
+        else if (frozenValue && field.getType().equals(Map.class))
+            return CQLType.FROZEN_MAP_VALUE;
+        else if (frozenValue)
+            return CQLType.FROZEN_ELEMENT;
+        else
+            return CQLType.UNFROZEN_SIMPLE;
+    }
+
+    // Traverses the Java type and CQLType hierarchies in parallel, to ensure that all
+    // Java types mapping to UDTs and tuples are marked as frozen in the CQLType.
+    // We accept that parts of the CQLType be null, in which case the matching parts
+    // in the Java type will be considered as not frozen.
+    private static void checkFrozenTypes(Type javaType, CQLType cqlType) {
+        Class<?> javaClass;
+        Type[] childrenJavaTypes;
+        if (javaType instanceof Class<?>) {
+            javaClass = (Class<?>)javaType;
+            childrenJavaTypes = null;
+        } else if (javaType instanceof ParameterizedType){
+            ParameterizedType pt = (ParameterizedType)javaType;
+            javaClass = (Class<?>)pt.getRawType();
+            childrenJavaTypes = pt.getActualTypeArguments();
+        } else
+            throw new IllegalArgumentException("unexpected type: " + javaType);
+
+        boolean frozen = (cqlType != null && cqlType.frozen);
+        checkValidFrozen(javaClass, frozen);
+
+        if (childrenJavaTypes != null) {
+            for (int i = 0; i < childrenJavaTypes.length; i++) {
+                Type childJavaType = childrenJavaTypes[i];
+                CQLType childCQLType = null;
+                if (cqlType != null && cqlType.subTypes != null && cqlType.subTypes.size() > i)
+                    childCQLType = cqlType.subTypes.get(i);
+                checkFrozenTypes(childJavaType, childCQLType);
+            }
+        }
+    }
+
+    private static void checkValidFrozen(Class<?> clazz, boolean declared) {
+        boolean expected = !EXPECTED_NON_FROZEN_CLASSES.contains(clazz);
+        if (expected != declared)
+            throw new IllegalArgumentException(String.format("expected %s to be %sfrozen but was %sfrozen",
+                                                             clazz.getSimpleName(),
+                                                             expected ? "" : "not ",
+                                                             declared ? "" : "not "));
+    }
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
@@ -22,7 +22,12 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.*;
 
+import com.google.common.collect.ImmutableSet.Builder;
+import com.google.common.collect.ImmutableSet;
+import com.datastax.driver.mapping.annotations.Frozen;
+
 import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.DataType;
 
 import com.datastax.driver.mapping.MethodMapper.ParamMapper;
 import com.datastax.driver.mapping.MethodMapper.UDTListParamMapper;
@@ -46,7 +51,7 @@ class AnnotationParser {
     private AnnotationParser() {}
 
     public static <T> EntityMapper<T> parseEntity(Class<T> entityClass, EntityMapper.Factory factory, MappingManager mappingManager) {
-        Table table = getTypeAnnotation(Table.class, entityClass);
+        Table table = AnnotationChecks.getTypeAnnotation(Table.class, entityClass);
 
         String ksName = table.caseSensitiveKeyspace() ? table.keyspace() : table.keyspace().toLowerCase();
         String tableName = table.caseSensitiveTable() ? table.name() : table.name().toLowerCase();
@@ -61,8 +66,9 @@ class AnnotationParser {
         List<Field> rgs = new ArrayList<Field>();
 
         for (Field field : entityClass.getDeclaredFields()) {
-            validateAnnotations(field, "entity",
-                                Column.class, ClusteringColumn.class, Enumerated.class, PartitionKey.class, Transient.class);
+            AnnotationChecks.validateAnnotations(field, "entity",
+                                                 Column.class, ClusteringColumn.class, Enumerated.class, Frozen.class, FrozenKey.class,
+                                                 FrozenValue.class, PartitionKey.class, Transient.class);
 
             if (field.getAnnotation(Transient.class) != null)
                 continue;
@@ -93,7 +99,7 @@ class AnnotationParser {
     }
 
     public static <T> EntityMapper<T> parseUDT(Class<T> udtClass, EntityMapper.Factory factory, MappingManager mappingManager) {
-        UDT udt = getTypeAnnotation(UDT.class, udtClass);
+        UDT udt = AnnotationChecks.getTypeAnnotation(UDT.class, udtClass);
 
         String ksName = udt.caseSensitiveKeyspace() ? udt.keyspace() : udt.keyspace().toLowerCase();
         String udtName = udt.caseSensitiveType() ? udt.name() : udt.name().toLowerCase();
@@ -103,8 +109,9 @@ class AnnotationParser {
         List<Field> columns = new ArrayList<Field>();
 
         for (Field field : udtClass.getDeclaredFields()) {
-            validateAnnotations(field, "UDT",
-                                com.datastax.driver.mapping.annotations.Field.class, Enumerated.class, Transient.class);
+            AnnotationChecks.validateAnnotations(field, "UDT",
+                                                 com.datastax.driver.mapping.annotations.Field.class, Frozen.class, FrozenKey.class,
+                                                 FrozenValue.class, Enumerated.class, Transient.class);
 
             if (field.getAnnotation(Transient.class) != null)
                 continue;
@@ -193,7 +200,7 @@ class AnnotationParser {
         if (!accClass.isInterface())
             throw new IllegalArgumentException("@Accessor annotation is only allowed on interfaces");
 
-        getTypeAnnotation(Accessor.class, accClass);
+        AnnotationChecks.getTypeAnnotation(Accessor.class, accClass);
 
         List<MethodMapper> methods = new ArrayList<MethodMapper>();
         for (Method m : accClass.getDeclaredMethods()) {
@@ -284,54 +291,5 @@ class AnnotationParser {
         } else {
             throw new IllegalArgumentException(String.format("Cannot map class %s for parameter %s of %s.%s", paramType, paramName, className, methodName));
         }
-    }
-
-    private static <T extends Annotation> T getTypeAnnotation(Class<T> annotation, Class<?> annotatedClass) {
-        T instance = annotatedClass.getAnnotation(annotation);
-        if (instance == null)
-            throw new IllegalArgumentException(String.format("@%s annotation was not found on type %s",
-                                                             annotation.getSimpleName(), annotatedClass.getName()));
-
-        // Check that no other mapping annotations are present
-        validateAnnotations(annotatedClass, annotation);
-
-        return instance;
-    }
-
-    private static void validateAnnotations(Class<?> clazz, Class<? extends Annotation> allowed) {
-        @SuppressWarnings("unchecked")
-        Class<? extends Annotation> invalid = validateAnnotations(clazz.getAnnotations(), allowed);
-        if (invalid != null)
-            throw new IllegalArgumentException(String.format("Cannot have both @%s and @%s on type %s",
-                                                             allowed.getSimpleName(), invalid.getSimpleName(),
-                                                             clazz.getName()));
-    }
-
-    private static void validateAnnotations(Field field, String classDescription, Class<? extends Annotation>... allowed) {
-        Class<? extends Annotation> invalid = validateAnnotations(field.getAnnotations(), allowed);
-        if (invalid != null)
-            throw new IllegalArgumentException(String.format("Annotation @%s is not allowed on field %s of %s %s",
-                                                             invalid.getSimpleName(),
-                                                             field.getName(), classDescription,
-                                                             field.getDeclaringClass().getName()));
-    }
-
-    private static final Package MAPPING_PACKAGE = Table.class.getPackage();
-
-    // Returns the offending annotation if there is one
-    private static Class<? extends Annotation> validateAnnotations(Annotation[] annotations, Class<? extends Annotation>... allowed) {
-        for (Annotation annotation : annotations) {
-            Class<? extends Annotation> actual = annotation.annotationType();
-            if (actual.getPackage().equals(MAPPING_PACKAGE) && !contains(allowed, actual))
-                return actual;
-        }
-        return null;
-    }
-
-    private static boolean contains(Object[] array, Object target) {
-        for (Object element : array)
-            if (element.equals(target))
-                return true;
-        return false;
     }
 }

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/CQLType.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/CQLType.java
@@ -1,0 +1,163 @@
+package com.datastax.driver.mapping;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.util.Strings;
+
+import com.datastax.driver.mapping.annotations.Frozen;
+
+/** A CQL type definition parsed from {@link Frozen#value()}, for example map<text,map<text,frozen<user>>> */
+class CQLType {
+    String name;
+    boolean frozen;
+    List<CQLType> subTypes;
+
+    private CQLType(String name) {
+        this(name, false);
+    }
+
+    private CQLType(String name, boolean frozen, CQLType... subTypes) {
+        this.name = name;
+        this.frozen = frozen;
+        for (CQLType subType : subTypes) {
+            if (this.subTypes == null)
+                this.subTypes = new ArrayList<CQLType>();
+            this.subTypes.add(subType);
+        }
+    }
+
+    // Some constant types for the simple cases. Note that we can afford generic names because currently we don't include the name in our
+    // checks.
+    static final CQLType FROZEN_SIMPLE = new CQLType("root", true);
+    static final CQLType FROZEN_ELEMENT = new CQLType("collection", false,
+                                                      new CQLType("element", true));
+    static final CQLType FROZEN_MAP_KEY = new CQLType("map", false,
+                                                      new CQLType("key", true));
+    static final CQLType FROZEN_MAP_VALUE = new CQLType("map", false,
+                                                        new CQLType("key", false),
+                                                        new CQLType("value", true));
+    static final CQLType FROZEN_MAP_KEY_AND_VALUE = new CQLType("map", false,
+                                                                new CQLType("key", true),
+                                                                new CQLType("value", true));
+    static final CQLType UNFROZEN_SIMPLE = new CQLType("root");
+
+    static CQLType parse(String toParse) {
+        if (Strings.isNullOrEmpty(toParse))
+            // we allow that as a shorthand
+            return FROZEN_SIMPLE;
+        else
+            return new Parser(toParse).parse();
+    }
+
+    private static class Parser {
+        private final String toParse;
+        private int idx;
+
+        Parser(String toParse) {
+            this.toParse = toParse;
+        }
+
+        CQLType parse() {
+            skipSpaces();
+
+            if (toParse.charAt(idx) == '"') {
+                // quoted identifier: just return everything up to the next quote
+                int endQuote = idx + 1;
+                while (endQuote < toParse.length() && toParse.charAt(endQuote) != '"')
+                    endQuote += 1;
+                if (endQuote == toParse.length())
+                    throw fail("could not find matching quote");
+                if (endQuote == idx + 1)
+                    throw fail("empty quoted identifier");
+
+                String name = toParse.substring(idx + 1, endQuote);
+                idx = endQuote + 1;
+                // a quoted identifier cannot be parameterized, so we can return immediately
+                return new CQLType(name);
+            } else {
+                // unquoted identifier: could be "simpleType", "complexType<subType1, subType2...>" or "frozen<type>"
+                int n = skipWord();
+                String nextWord = toParse.substring(idx, n).toLowerCase();
+                idx = n;
+                if ("frozen".equals(nextWord)) {
+                    skipSpaces();
+                    if (idx >= toParse.length() || toParse.charAt(idx) != '<')
+                        throw fail("expected '<'");
+                    idx += 1;
+                    CQLType type = parse();
+                    skipSpaces();
+                    if (idx >= toParse.length() || toParse.charAt(idx) != '>')
+                        throw fail("expected '>'");
+                    idx += 1;
+                    type.frozen = true;
+                    return type;
+                } else {
+                    CQLType type = new CQLType(nextWord);
+                    skipSpaces();
+                    if (idx < toParse.length() && toParse.charAt(idx) == '<') {
+                        idx += 1;
+                        type.subTypes = new ArrayList<CQLType>();
+                        while (idx < toParse.length()) {
+                            type.subTypes.add(parse());
+                            skipSpaces();
+                            if (idx >= toParse.length())
+                                fail("unterminated list of subtypes");
+                            else if (toParse.charAt(idx) == '>') {
+                                idx += 1;
+                                break;
+                            }
+                            else if (toParse.charAt(idx) != ',')
+                                fail("expected ','");
+                            else
+                                idx += 1;
+                        }
+                    }
+                    return type;
+                }
+            }
+        }
+
+        private void skipSpaces() {
+            while (idx < toParse.length() && isBlank(idx))
+                idx += 1;
+        }
+
+        private int skipWord() {
+            if (idx >= toParse.length())
+                throw fail("expected type name");
+
+            // TODO check allowed characters in unquoted names
+            if (!isAlpha(idx))
+                throw fail("illegal character at start of type name");
+
+            int i = idx;
+            while (i < toParse.length() && isAlphaNum(i))
+                i += 1;
+
+            return i;
+        }
+
+        private boolean isBlank(int i) {
+            char c = toParse.charAt(i);
+            return c == ' ' || c == '\t' || c == '\n';
+        }
+
+        private boolean isAlpha(int i) {
+            char c = toParse.charAt(i);
+            return (c >= 'a' && c <= 'z') ||
+                   (c >= 'A' && c <= 'Z');
+        }
+
+        private boolean isAlphaNum(int i) {
+            if (isAlpha(i))
+                return true;
+            char c = toParse.charAt(i);
+            return c >= '0' && c <= '9';
+        }
+
+        private IllegalArgumentException fail(String cause) {
+            return new IllegalArgumentException(cause + " (" + toParse + " [" + idx + "])");
+        }
+    }
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/Frozen.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/Frozen.java
@@ -1,0 +1,58 @@
+/*
+ *      Copyright (C) 2012-2014 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.datastax.driver.core.DataType;
+
+/**
+ * Specifies that the field decorated with this annotation maps to a CQL type that is {@link DataType#isFrozen() frozen},
+ * or contains frozen subtypes.
+ * <p>
+ * This annotation is purely informational at this stage, but will become useful when a schema generation feature is
+ * added to the mapper.
+ *
+ * @see FrozenKey
+ * @see FrozenValue
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Frozen {
+
+    /**
+     * Contains the full CQL type of the target column. As a convenience, this can be left out when only the top-level
+     * type is frozen.
+     * <p>
+     * Examples:
+     * <pre>
+     * // Will map to frozen&lt;user&gt;
+     * &#64;Frozen
+     * private User user;
+     *
+     * &#64;Frozen("map&lt;text, map&lt;text, frozen&lt;user&gt;&gt;&gt;")
+     * private Map&lt;String, Map&lt;String, User&gt;&gt; m;
+     * </pre>
+     * <p>
+     * Also consider the {@link FrozenKey @FrozenKey} and {@link FrozenValue @FrozenValue} shortcuts for simple collections.
+     *
+     * @return the full CQL type of the target column.
+     */
+    String value() default "";
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/FrozenKey.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/FrozenKey.java
@@ -1,0 +1,30 @@
+/*
+ *      Copyright (C) 2012-2014 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * Shorthand to specify that the key type of a MAP field is frozen.
+ * <p>
+ * This is equivalent to {@code @Frozen("map<frozen<foo>, bar>")}.
+ *
+ * @see Frozen
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FrozenKey {
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/FrozenValue.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/FrozenValue.java
@@ -1,0 +1,35 @@
+/*
+ *      Copyright (C) 2012-2014 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * Shorthand to specify that the value type of a collection field is frozen.
+ * <p>
+ * This is equivalent to any of the following:
+ * <ul>
+ * <li>{@code @Frozen("list<frozen<foo>>")}</li>
+ * <li>{@code @Frozen("set<frozen<foo>>")}</li>
+ * <li>{@code @Frozen("map<foo, frozen<bar>>")}</li>
+ * </ul>
+ *
+ * @see Frozen
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FrozenValue {
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/AnnotationChecksTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/AnnotationChecksTest.java
@@ -1,0 +1,59 @@
+package com.datastax.driver.mapping;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+import com.datastax.driver.mapping.annotations.Frozen;
+import com.datastax.driver.mapping.annotations.FrozenValue;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.fail;
+
+public class AnnotationChecksTest {
+    // Dummy UDT class:
+    public class User {
+    }
+
+    // Dummy fields to run our checks on:
+    String string;
+    @Frozen
+    String frozenString;
+    List<String> listOfStrings;
+    User unfrozenUser;
+    @Frozen
+    User frozenUser;
+    List<User> listOfUnfrozenUsers;
+    @FrozenValue
+    List<User> listOfFrozenUsers;
+    Map<String, Map<String, User>> deeplyNestedUnfrozenUser;
+    @Frozen("map<text, map<text, frozen<user>>>")
+    Map<String, Map<String, User>> deeplyNestedFrozenUser;
+
+    @Test(groups = "unit")
+    public void checkFrozenTypesTest() throws Exception {
+        checkFrozenTypesTest("string", true);
+        checkFrozenTypesTest("frozenString", false);
+        checkFrozenTypesTest("listOfStrings", true);
+        checkFrozenTypesTest("unfrozenUser", false);
+        checkFrozenTypesTest("frozenUser", true);
+        checkFrozenTypesTest("listOfUnfrozenUsers", false);
+        checkFrozenTypesTest("listOfFrozenUsers", true);
+        checkFrozenTypesTest("deeplyNestedUnfrozenUser", false);
+        checkFrozenTypesTest("deeplyNestedFrozenUser", true);
+    }
+
+    private void checkFrozenTypesTest(String fieldName, boolean expectSuccess) throws Exception {
+        Field field = AnnotationChecksTest.class.getDeclaredField(fieldName);
+        Exception exception = null;
+        try {
+            AnnotationChecks.checkFrozenTypes(field);
+        } catch (IllegalArgumentException e) {
+            exception = e;
+        }
+        if (expectSuccess && exception != null)
+            fail("expected check to succeed but got exception " + exception.getMessage());
+        else if (!expectSuccess && exception == null)
+            fail("expected check to fail but got no exception");
+    }
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/CQLTypeTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/CQLTypeTest.java
@@ -1,0 +1,103 @@
+package com.datastax.driver.mapping;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+public class CQLTypeTest {
+    @Test(groups = "unit")
+    public void parseSimpleTypeTest() {
+        CQLType type = CQLType.parse(" foo");
+        assertEquals(type.name, "foo");
+        assertFalse(type.frozen);
+        assertNull(type.subTypes);
+    }
+
+    @Test(groups = "unit")
+    public void parseQuotedTypeTest() {
+        CQLType type = CQLType.parse("\"Foo bar\"");
+        assertEquals(type.name, "Foo bar");
+        assertFalse(type.frozen);
+        assertNull(type.subTypes);
+    }
+
+    @Test(groups = "unit")
+    public void parseNestedTypeTest() {
+        // list
+        CQLType type = CQLType.parse("list<foo>");
+        assertEquals(type.name, "list");
+        assertFalse(type.frozen);
+        assertEquals(type.subTypes.size(), 1);
+
+        CQLType subType0 = type.subTypes.get(0);
+        assertEquals(subType0.name, "foo");
+        assertFalse(subType0.frozen);
+        assertNull(subType0.subTypes);
+
+        // map
+        type = CQLType.parse("map < foo , bar >");
+        assertEquals(type.name, "map");
+        assertFalse(type.frozen);
+        assertEquals(type.subTypes.size(), 2);
+
+        subType0 = type.subTypes.get(0);
+        assertEquals(subType0.name, "foo");
+        assertFalse(subType0.frozen);
+        assertNull(subType0.subTypes);
+
+        CQLType subType1 = type.subTypes.get(1);
+        assertEquals(subType1.name, "bar");
+        assertFalse(subType1.frozen);
+        assertNull(subType1.subTypes);
+
+    }
+
+    @Test(groups = "unit")
+    public void parseSimpleFrozenTypeTest() {
+        CQLType type = CQLType.parse("frozen<foo>");
+        assertEquals(type.name, "foo");
+        assertTrue(type.frozen);
+        assertNull(type.subTypes);
+    }
+
+    @Test(groups = "unit")
+    public void parseNestedFrozenTypeTest() {
+        CQLType type = CQLType.parse("list<frozen<foo>>");
+        assertEquals(type.name, "list");
+        assertFalse(type.frozen);
+        assertEquals(type.subTypes.size(), 1);
+
+        CQLType subType0 = type.subTypes.get(0);
+        assertEquals(subType0.name, "foo");
+        assertTrue(subType0.frozen);
+        assertNull(subType0.subTypes);
+    }
+
+    @Test(groups = "unit")
+    public void parseDeeplyNestedTypeTest() {
+        // NB: nested collections are not allowed in C* 2.1, but might be in the future, so we want to handle that
+        CQLType type = CQLType.parse("map<text, map<text, frozen<foo>>>");
+        assertEquals(type.name, "map");
+        assertFalse(type.frozen);
+        assertEquals(type.subTypes.size(), 2);
+
+        CQLType subType0 = type.subTypes.get(0);
+        assertEquals(subType0.name, "text");
+        assertFalse(subType0.frozen);
+        assertNull(subType0.subTypes);
+
+        CQLType subType1 = type.subTypes.get(1);
+        assertEquals(subType1.name, "map");
+        assertFalse(subType1.frozen);
+        assertEquals(subType1.subTypes.size(), 2);
+
+        CQLType subType10 = subType1.subTypes.get(0);
+        assertEquals(subType10.name, "text");
+        assertFalse(subType10.frozen);
+        assertNull(subType10.subTypes);
+
+        CQLType subType11 = subType1.subTypes.get(1);
+        assertEquals(subType11.name, "foo");
+        assertTrue(subType11.frozen);
+        assertNull(subType11.subTypes);
+    }
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
@@ -17,19 +17,19 @@ package com.datastax.driver.mapping;
 
 import java.util.*;
 
+import com.datastax.driver.mapping.annotations.*;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
 import com.datastax.driver.core.CCMBridge;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.utils.UUIDs;
-import com.datastax.driver.mapping.annotations.*;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public class MapperUDTTest extends CCMBridge.PerClassSingleNodeCluster {
 
@@ -54,6 +54,7 @@ public class MapperUDTTest extends CCMBridge.PerClassSingleNodeCluster {
         private Address mainAddress;
 
         @Column(name = "other_addresses")
+        @FrozenValue
         private Map<String, Address> otherAddresses;
 
         public User() {

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
@@ -35,9 +35,9 @@ public class MapperUDTTest extends CCMBridge.PerClassSingleNodeCluster {
 
     protected Collection<String> getTableDefinitions() {
         return Arrays.asList("CREATE TYPE address (street text, city text, zip_code int, phones set<text>)",
-                             "CREATE TABLE users (user_id uuid PRIMARY KEY, name text, main_address address, other_addresses map<text,address>)",
+                             "CREATE TABLE users (user_id uuid PRIMARY KEY, name text, main_address frozen<address>, other_addresses map<text,frozen<address>>)",
                              "CREATE TYPE sub(i int)",
-                             "CREATE TABLE collection_examples (id int PRIMARY KEY, l list<sub>, s set<sub>, m1 map<int,sub>, m2 map<sub,int>, m3 map<sub,sub>)");
+                             "CREATE TABLE collection_examples (id int PRIMARY KEY, l list<frozen<sub>>, s set<frozen<sub>>, m1 map<int,frozen<sub>>, m2 map<frozen<sub>,int>, m3 map<frozen<sub>,frozen<sub>>)");
     }
 
     @Table(keyspace = "ks", name = "users",

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
@@ -51,6 +51,7 @@ public class MapperUDTTest extends CCMBridge.PerClassSingleNodeCluster {
         private String name;
 
         @Column(name = "main_address")
+        @Frozen
         private Address mainAddress;
 
         @Column(name = "other_addresses")
@@ -269,14 +270,20 @@ public class MapperUDTTest extends CCMBridge.PerClassSingleNodeCluster {
         @PartitionKey
         private int id;
 
+        @FrozenValue
         private List<Sub> l;
 
+        @FrozenValue
         private Set<Sub> s;
 
+        @FrozenValue
         private Map<Integer, Sub> m1;
 
+        @FrozenKey
         private Map<Sub, Integer> m2;
 
+        @FrozenKey
+        @FrozenValue
         private Map<Sub, Sub> m3;
 
         public CollectionExamples() {

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cassandra.version>2.1.0-rc6</cassandra.version>
+    <cassandra.version>2.1.0-rc7</cassandra.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
@pcmanus this is a work in progress, I wanted to make sure we agree on the `Frozen` annotation before I start implementing checks in the mapper.

There's a catch because we can't annotate type parameters on a collection (this will come in Java 8), so I've added a `targets` attribute:

``` java
@Frozen
private Address address;

@Frozen(targets = {Target.VALUE)}
private List<Address> addresses;

@Frozen(targets = {Target.KEY, Target.VALUE)}
private Map<CustomType1, CustomType2> someMap;
```

For tuples, this gets even more complicated because of nesting. But if the goal is schema generation, we'll have to provide the tuple type anyway because `TupleValue` does not provide enough information, so I suggest we include the whole tuple definition in an annotation:

``` java
@TupleDefinition("tuple<text, frozen<tuple<int, int>>>")
private TupleValue someTuple;
```
