### PR TITLE
Decouple entities from keyspace in driver-mapping.

### DIFF
--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
@@ -31,6 +31,7 @@ import com.datastax.driver.mapping.MethodMapper.UDTParamMapper;
 import com.datastax.driver.mapping.MethodMapper.UDTSetParamMapper;
 import com.datastax.driver.mapping.MethodMapper.EnumParamMapper;
 import com.datastax.driver.mapping.annotations.*;
+import com.google.common.base.Strings;
 
 /**
  * Static metods that facilitates parsing class annotations into the corresponding {@link EntityMapper}.
@@ -53,6 +54,10 @@ class AnnotationParser {
 
         ConsistencyLevel writeConsistency = table.writeConsistency().isEmpty() ? null : ConsistencyLevel.valueOf(table.writeConsistency().toUpperCase());
         ConsistencyLevel readConsistency = table.readConsistency().isEmpty() ? null : ConsistencyLevel.valueOf(table.readConsistency().toUpperCase());
+
+        if (Strings.isNullOrEmpty(table.keyspace())) {
+            ksName = mappingManager.getSession().getLoggedKeyspace();
+        }
 
         EntityMapper<T> mapper = factory.create(entityClass, ksName, tableName, writeConsistency, readConsistency);
 
@@ -97,6 +102,10 @@ class AnnotationParser {
 
         String ksName = udt.caseSensitiveKeyspace() ? udt.keyspace() : udt.keyspace().toLowerCase();
         String udtName = udt.caseSensitiveType() ? udt.name() : udt.name().toLowerCase();
+
+        if (Strings.isNullOrEmpty(udt.keyspace())) {
+            ksName = mappingManager.getSession().getLoggedKeyspace();
+        }
 
         EntityMapper<T> mapper = factory.create(udtClass, ksName, udtName, null, null);
 

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/Table.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/Table.java
@@ -33,7 +33,7 @@ public @interface Table {
      *
      * @return the name of the keyspace.
      */
-    String keyspace();
+    String keyspace() default "";
     /**
      * The name of the table.
      *

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/UDT.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/UDT.java
@@ -31,7 +31,7 @@ public @interface UDT {
      *
      * @return the name of the keyspace.
      */
-    String keyspace();
+    String keyspace() default "";
     /**
      * The name of the type.
      *

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperTest.java
@@ -38,7 +38,8 @@ public class MapperTest extends CCMBridge.PerClassSingleNodeCluster {
         // We'll allow to generate those create statement from the annotated entities later, but it's currently
         // a TODO
         return Arrays.asList("CREATE TABLE users (user_id uuid PRIMARY KEY, name text, email text, year int, gender text)",
-                             "CREATE TABLE posts (user_id uuid, post_id timeuuid, title text, content text, device inet, tags set<text>, PRIMARY KEY(user_id, post_id))");
+                             "CREATE TABLE posts (user_id uuid, post_id timeuuid, title text, content text, device inet, tags set<text>, PRIMARY KEY(user_id, post_id))",
+                             "CREATE TABLE groups (group_id uuid PRIMARY KEY, name text)");
     }
 
     /*
@@ -368,5 +369,79 @@ public class MapperTest extends CCMBridge.PerClassSingleNodeCluster {
         userAccessor.updateNameAndGender("Paule", User.Gender.FEMALE, u1.getUserId());
         Mapper<User> userMapper = manager.mapper(User.class);
         assertEquals(userMapper.get(u1.getUserId()).getGender(), User.Gender.FEMALE);
+    }
+
+    /*
+     * An entity that does not specify a keyspace in it's @Table annotation. When a keyspace is
+     * not specified, the mapper uses the session's logged in keyspace.
+     */
+    @Table(name = "groups")
+    public static class Group {
+
+        @PartitionKey
+        @Column(name = "group_id")
+        private UUID groupId;
+
+        private String name;
+
+        public Group() {}
+
+        public Group(String name) {
+            this.name = name;
+            this.groupId = UUIDs.random();
+        }
+
+        public UUID getGroupId() {
+            return groupId;
+        }
+
+        public void setGroupId(UUID groupId) {
+            this.groupId = groupId;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == null || other.getClass() != this.getClass())
+                return false;
+
+            Group that = (Group)other;
+            return Objects.equal(groupId, that.groupId)
+                && Objects.equal(name, that.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(groupId, name);
+        }
+    }
+
+    @Test(groups = "short")
+    public void testTableWithDefaultKeyspace() throws Exception {
+        // Ensure that the test session is logged into the "ks" keyspace.
+        session.execute("USE ks");
+
+        MappingManager manager = new MappingManager(session);
+        Mapper<Group> m = manager.mapper(Group.class);
+        Group group = new Group("testGroup");
+        UUID groupId = group.getGroupId();
+
+        // Check the save operation.
+        m.save(group);
+
+        // Check the select operation.
+        Group selectedGroup = m.get(groupId);
+        assertEquals(selectedGroup.getGroupId(), groupId);
+
+        // Check the delete operation.
+        m.delete(group);
+        assertNull(m.get(groupId));
     }
 }


### PR DESCRIPTION
The keyspace parameter of the Table annotation is now optional. If an entity does not specify a keyspace
in Table, the keyspace from the MappingManager's Session will be used.

I created a JIRA ticket to track this issue: JAVA-442
