### PR TITLE
cancel timeout before invoking callback.onException

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -587,6 +587,7 @@ class Connection extends org.apache.cassandra.transport.Connection
             while (iter.hasNext())
             {
                 ResponseHandler handler = iter.next();
+                handler.cancelTimeout();
                 handler.callback.onException(Connection.this, ce, System.nanoTime() - handler.startTime);
                 iter.remove();
             }


### PR DESCRIPTION
When an exception was occurring on a connection, during a request, the timeout trigger was not cancelled.

**What was happening** :
Once the exception occurred, the request handler will try again with the next host(s), and the _not cancelled_ timeout could be triggered during one of those retries.
The involved retry will be interrupted prematurely, and the request handler invoked with a wrong connection (the defunct one of the first tried host).

The "wrong connection" issue has been fixed with the `JAVA-255` bug, but the premature interruption remains.

(this fix can be applied on branches `2.0` and `2.1`)
