### PR TITLE
Test that BigInteger is associated with varint data type (JAVA-458)

### DIFF
--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/ReflectionMapperTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/ReflectionMapperTest.java
@@ -1,0 +1,20 @@
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.core.DataType;
+import junit.framework.TestCase;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public class ReflectionMapperTest extends TestCase {
+    @Test
+    public void bigdecimal_should_be_mapped_to_the_decimal_datatype() {
+        Assert.assertEquals(ReflectionMapper.getSimpleType(BigDecimal.class, null), DataType.decimal());
+    }
+    @Test
+    public void biginteger_should_be_mapped_to_the_varint_datatype() {
+        Assert.assertEquals(ReflectionMapper.getSimpleType(BigInteger.class, null), DataType.varint());
+    }
+}


### PR DESCRIPTION
This test is not strictly necessary as the case seems to be tested by `MapperPrimitiveTypesTest`, but I find it more explicit regarding the JIRA ticket.  Feel free to ignore the PR if you think it is not useful.
