### PR TITLE
Add stress test for opening/closing sessions (JAVA-432)

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
@@ -1,0 +1,135 @@
+package com.datastax.driver.core;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class ClusterStressTest extends CCMBridge.PerClassSingleNodeCluster {
+    private static final Logger logger = LoggerFactory.getLogger(ClusterStressTest.class);
+
+    private ExecutorService executorService;
+
+    public ClusterStressTest() {
+        // 8 threads should be enough so that we stress the driver and not the OS thread scheduler
+        executorService = Executors.newFixedThreadPool(8);
+    }
+
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return new ArrayList<String>(0);
+    }
+
+    @Test(groups = "long")
+    public void clusters_should_not_leak_connections() {
+        int numberOfClusters = 10;
+        for (int i = 0; i < 500; i++) {
+            List<Cluster> clusters = waitFor(createClustersConcurrently(numberOfClusters));
+            waitFor(closeClustersConcurrently(clusters));
+            logger.debug("# {} threads currently running", Thread.getAllStackTraces().keySet().size());
+        }
+    }
+
+    private List<Future<Cluster>> createClustersConcurrently(int numberOfClusters) {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        return createClustersConcurrently(numberOfClusters, countDownLatch);
+    }
+
+    private List<Future<Cluster>> createClustersConcurrently(int numberOfClusters, CountDownLatch countDownLatch) {
+        List<Future<Cluster>> clusterFutures = new ArrayList<Future<Cluster>>(numberOfClusters);
+        for (int i = 0; i < numberOfClusters; i++) {
+            clusterFutures.add(executorService.submit(new CreateClusterAndCheckConnections(countDownLatch)));
+        }
+        countDownLatch.countDown();
+        return clusterFutures;
+    }
+
+    private List<Future<Void>> closeClustersConcurrently(List<Cluster> clusters) {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        return closeClustersConcurrently(clusters, countDownLatch);
+    }
+
+    private List<Future<Void>> closeClustersConcurrently(List<Cluster> clusters, CountDownLatch startSignal) {
+        List<Future<Void>> closeFutures = new ArrayList<Future<Void>>(clusters.size());
+        for (Cluster cluster : clusters) {
+            closeFutures.add(executorService.submit(new CloseCluster(cluster, startSignal)));
+        }
+        startSignal.countDown();
+        return closeFutures;
+    }
+
+    private <E> List<E> waitFor(List<Future<E>> futures) {
+        List<E> result = new ArrayList<E>(futures.size());
+        for (Future<E> future : futures) {
+            try {
+                result.add(future.get());
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Interrupted while waiting for future", e);
+            } catch (ExecutionException e) {
+                e.printStackTrace();
+                fail(e.getMessage());
+            }
+        }
+        return result;
+    }
+
+    private static class CreateClusterAndCheckConnections implements Callable<Cluster> {
+        private final CountDownLatch startSignal;
+
+        CreateClusterAndCheckConnections(CountDownLatch startSignal) {
+            this.startSignal = startSignal;
+        }
+
+        @Override
+        public Cluster call() throws Exception {
+            startSignal.await();
+
+            Cluster cluster = Cluster.builder().addContactPoints(CCMBridge.IP_PREFIX + '1').build();
+
+            // The cluster has not been initialized yet, therefore the control connection is not opened
+            assertEquals(cluster.manager.sessions.size(), 0);
+            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 0);
+
+            // The first session initializes the cluster and its control connection
+            // This is a local cluster so we also have 2 connections per session
+            Session session = cluster.connect();
+            assertEquals(cluster.manager.sessions.size(), 1);
+            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 3);
+
+            // Closing the session keeps the control connection opened
+            session.close();
+            assertEquals(cluster.manager.sessions.size(), 0);
+            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
+
+            return cluster;
+        }
+    }
+
+    private static class CloseCluster implements Callable<Void> {
+        private final Cluster cluster;
+        private final CountDownLatch startSignal;
+
+        CloseCluster(Cluster cluster, CountDownLatch startSignal) {
+            this.cluster = cluster;
+            this.startSignal = startSignal;
+        }
+
+        @Override
+        public Void call() throws Exception {
+            startSignal.await();
+
+            cluster.close();
+            assertEquals(cluster.manager.sessions.size(), 0);
+            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 0);
+
+            return null;
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
@@ -1,0 +1,192 @@
+package com.datastax.driver.core;
+
+import org.testng.annotations.Test;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+import static org.testng.Assert.assertEquals;
+
+public class SessionStressTest extends CCMBridge.PerClassSingleNodeCluster {
+
+    private ExecutorService executorService;
+
+    public SessionStressTest() {
+        // 8 threads should be enough so that we stress the driver and not the OS thread scheduler
+        executorService = Executors.newFixedThreadPool(8);
+    }
+
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return new ArrayList<String>(0);
+    }
+
+
+    /**
+     * Stress test on opening/closing sessions.
+     * <p/>
+     * This test opens and closes {@code Session} in a multithreaded environment and makes sure that there is not
+     * connection leak. More specifically, this test performs the following steps:
+     * <p/>
+     * <ul>
+     * <li>Open 2000 {@code Session} concurrently</li>
+     * <li>Verify that 2000 sessions are reported as open by the {@code Cluster}</li>
+     * <li>Verify that 4001 connections are reported as open by the {@code Cluster}</li>
+     * <li>Close 1000 {@code Session} concurrently</li>
+     * <li>Verify that 1000 sessions are reported as open by the {@code Cluster}</li>
+     * <li>Verify that 2001 connections are reported as open by the {@code Cluster}</li>
+     * <li>Open concurrently 1000 {@code Session} while 1000 other {@code Session} are closed concurrently</li>
+     * <li>Verify that 1000 sessions are reported as open by the {@code Cluster}</li>
+     * <li>Verify that 2001 connections are reported as open by the {@code Cluster}</li>
+     * <li>Close 1000 {@code Session} concurrently</li>
+     * <li>Verify that 0 sessions are reported as open by the {@code Cluster}</li>
+     * <li>Verify that 1 connection is reported as open by the {@code Cluster}</li>
+     * </ul>
+     * <p/>
+     * This test is linked to JAVA-432.
+     */
+    @Test(groups = "long")
+    public void sessions_should_not_leak() {
+        // override inherited field with a new cluster object and ensure 0 sessions and connections
+        cluster = Cluster.builder().addContactPoints(CCMBridge.IP_PREFIX + '1').build();
+
+        // The cluster has not been initialized yet, therefore the control connection is not opened
+        assertEquals(cluster.manager.sessions.size(), 0);
+        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 0);
+
+        // The first session initializes the cluster and its control connection
+        // This is a local cluster so we also have 2 connections per session
+        Session session = cluster.connect();
+        assertEquals(cluster.manager.sessions.size(), 1);
+        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 3);
+
+        // Closing the session keeps the control connection opened
+        session.close();
+        assertEquals(cluster.manager.sessions.size(), 0);
+        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
+
+        try {
+            int nbOfSessions = 2000;
+            int halfOfTheSessions = nbOfSessions / 2;
+
+            for (int iteration = 0; iteration < 2; iteration++) {
+                waitFor(openSessionsConcurrently(nbOfSessions));
+
+                // We should see the exact number of opened sessions
+                // Since we have 2 connections per session, we should see 2 * sessions + control connection
+                assertEquals(cluster.manager.sessions.size(), nbOfSessions);
+                assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 2 * nbOfSessions + 1);
+
+                // Close half of the sessions asynchronously
+                waitFor(closeSessionsConcurrently(halfOfTheSessions));
+
+                // Check that we have the right number of sessions and connections
+                assertEquals(cluster.manager.sessions.size(), halfOfTheSessions);
+                assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), nbOfSessions + 1);
+
+                // Close and open the same number of sessions concurrently
+                CountDownLatch startSignal = new CountDownLatch(1);
+                List<Future<Session>> openSessionFutures = openSessionsConcurrently(halfOfTheSessions, startSignal);
+                List<Future<CloseFuture>> closeSessionsFutures = closeSessionsConcurrently(halfOfTheSessions,
+                        startSignal);
+                startSignal.countDown();
+                waitFor(openSessionFutures);
+                waitFor(closeSessionsFutures);
+
+                // Check that we have the same number of sessions and connections
+                assertEquals(cluster.manager.sessions.size(), halfOfTheSessions);
+                assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), nbOfSessions + 1);
+
+                // Close the remaining sessions
+                waitFor(closeSessionsConcurrently(halfOfTheSessions));
+
+                // Check that we have a clean state
+                assertEquals(cluster.manager.sessions.size(), 0);
+                assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
+            }
+        } finally {
+            cluster.close();
+        }
+    }
+
+    private List<Future<Session>> openSessionsConcurrently(int iterations) {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        return openSessionsConcurrently(iterations, countDownLatch);
+    }
+
+    private List<Future<Session>> openSessionsConcurrently(int iterations, CountDownLatch countDownLatch) {
+        // Open new sessions once all tasks have been created
+        List<Future<Session>> sessionFutures = new ArrayList<Future<Session>>(iterations);
+        for (int i = 0; i < iterations; i++) {
+            sessionFutures.add(executorService.submit(new OpenSession(cluster, countDownLatch)));
+        }
+        countDownLatch.countDown();
+        return sessionFutures;
+    }
+
+    private List<Future<CloseFuture>> closeSessionsConcurrently(int iterations) {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        return closeSessionsConcurrently(iterations, countDownLatch);
+    }
+
+    private List<Future<CloseFuture>> closeSessionsConcurrently(int iterations, CountDownLatch countDownLatch) {
+        // Get a reference to every session we want to close
+        Stack<Session> sessionsToClose = new Stack<Session>();
+        Iterator<? extends Session> iterator = cluster.manager.sessions.iterator();
+        for (int i = 0; i < iterations; i++) {
+            sessionsToClose.push(iterator.next());
+        }
+
+        // Close sessions asynchronously once all tasks have been created
+        List<Future<CloseFuture>> closeFutures = new ArrayList<Future<CloseFuture>>(iterations);
+        for (int i = 0; i < iterations; i++) {
+            closeFutures.add(executorService.submit(new CloseSession(sessionsToClose.pop(), countDownLatch)));
+        }
+        countDownLatch.countDown();
+        return closeFutures;
+    }
+
+    private <E> void waitFor(List<Future<E>> futures) {
+        for (Future<E> future : futures) {
+            try {
+                future.get();
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Interrupted while waiting for future", e);
+            } catch (ExecutionException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    static class OpenSession implements Callable<Session> {
+        private final Cluster cluster;
+        private final CountDownLatch startSignal;
+
+        OpenSession(Cluster cluster, CountDownLatch startSignal) {
+            this.cluster = cluster;
+            this.startSignal = startSignal;
+        }
+
+        @Override
+        public Session call() throws Exception {
+            startSignal.await();
+            return cluster.connect();
+        }
+    }
+
+    static class CloseSession implements Callable<CloseFuture> {
+        private final Session session;
+        private final CountDownLatch startSignal;
+
+        CloseSession(Session session, CountDownLatch startSignal) {
+            this.session = session;
+            this.startSignal = startSignal;
+        }
+
+        @Override
+        public CloseFuture call() throws Exception {
+            startSignal.await();
+            return session.closeAsync();
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/SessionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionTest.java
@@ -152,61 +152,6 @@ public class SessionTest extends CCMBridge.PerClassSingleNodeCluster {
         assertEquals(state.getSession(), session);
     }
 
-    /**
-     * Check for session memory leaks by creating and closing 10,000 connections.
-     * Each time a session is created and closed we check the number of sessions the
-     * cluster.manager is holding onto as well as the number of open connections.
-     *
-     * @throws Exception
-     */
-    @Test(groups = "long")
-    public void sessionMemoryLeakTest() throws Exception {
-        // Checking for JAVA-342
-
-        // give the driver time to close other sessions in this class
-        Thread.sleep(10);
-
-        // create a new cluster object and ensure 0 sessions and connections
-        Cluster cluster = Cluster.builder().addContactPoints(CCMBridge.IP_PREFIX + '1').build();
-        assertEquals(cluster.manager.sessions.size(), 0);
-        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 0);
-
-        Session session = cluster.connect();
-        assertEquals(cluster.manager.sessions.size(), 1);
-        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 3);
-
-        // ensure sessions.size() returns to 0 with only 1 active connection
-        session.close();
-        assertEquals(cluster.manager.sessions.size(), 0);
-        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
-
-        // give the driver time to close sessions
-        Thread.sleep(10);
-
-        try {
-            for (int i = 0; i < 10000; ++i) {
-                // ensure 0 sessions with a single control connection
-                assertEquals(cluster.manager.sessions.size(), 0);
-                assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
-
-                // ensure a new session gets registered and control connections are established
-                session = cluster.connect();
-                assertEquals(cluster.manager.sessions.size(), 1);
-                assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 3);
-                session.close();
-
-                // give the driver time to close sessions
-                Thread.sleep(10);
-
-                // ensure sessions.size() always returns to 0 with only 1 active connection
-                assertEquals(cluster.manager.sessions.size(), 0);
-                assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
-            }
-        } finally {
-            cluster.close();
-        }
-    }
-
     @Test(groups = "short")
     public void connectionLeakTest() throws Exception {
         // Checking for JAVA-342


### PR DESCRIPTION
At line 75, the number of repetitions can be specified for this test. This allows for opening a lot of sessions without hitting the limit on "Too many open files".

Note that on my machine, specifying more than 2 repetitions causes the test to fail because of a connection issue.
