### PR TITLE
JAVA-469: added backward-compatible DataType.deserialize methods

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/DataType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataType.java
@@ -560,6 +560,22 @@ public abstract class DataType {
     }
 
     /**
+     * @deprecated This method is no longer supported, will be removed, and simply throws {@link UnsupportedOperationException}.
+     */
+    @Deprecated
+    public Object deserialize(ByteBuffer bytes) {
+        throw new UnsupportedOperationException("Method no longer supported; use deserialize(ByteBuffer,ProtocolVersion)");
+    }
+    
+    /**
+     * @deprecated Use {@link #deserialize(ByteBuffer,ProtocolVersion)}.
+     * @see #deserialize(ByteBuffer,ProtocolVersion)
+     */
+    public Object deserialize(ByteBuffer bytes, int protocolVersion) {
+        return deserialize(bytes, ProtocolVersion.fromInt(protocolVersion));
+    }
+    
+    /**
      * Deserialize a value of this type from the provided bytes using the given protocol version.
      *
      * @param bytes bytes holding the value to deserialize.


### PR DESCRIPTION
This at least gives Spring Data Cassandra the possibility of compiling and running against versions before, equal to, and after 2.1.0 without user intervention for deserialization.  If there are other, similar breaking changes, they might be able to be handled in a similar fashion.
