### PR TITLE
Bump Maven dependency versions in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ it in your application using the following Maven dependency::
     <dependency>
       <groupId>com.datastax.cassandra</groupId>
       <artifactId>cassandra-driver-core</artifactId>
-      <version>2.1.0</version>
+      <version>2.1.1</version>
     </dependency>
 
 Note that the object mapper is published as a separate artifact::
@@ -43,7 +43,7 @@ Note that the object mapper is published as a separate artifact::
     <dependency>
       <groupId>com.datastax.cassandra</groupId>
       <artifactId>cassandra-driver-mapping</artifactId>
-      <version>2.1.0</version>
+      <version>2.1.1</version>
     </dependency>
 
 Compatibility


### PR DESCRIPTION
Changed from 2.1.0 to 2.1.1 to reflect latest version available on maven central.
