### PR TITLE
Removed insertion-order dependent check for JAVA-511

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicyTest.java
@@ -90,7 +90,7 @@ public class DCAwareRoundRobinPolicyTest {
             Host host1 = TestUtils.findHost(cluster, 1);
             Host host2 = TestUtils.findHost(cluster, 2);
 
-            assertThat(policy.initHosts).containsExactly(host1, host2);
+            assertThat(policy.initHosts).containsOnly(host1, host2);
 
             assertThat(logs.get())
                 .contains("Some contact points don't match local data center");
@@ -148,7 +148,7 @@ public class DCAwareRoundRobinPolicyTest {
 
             assertEquals(policy.getLocalDc(), providedLocalDc);
 
-            assertThat(policy.initHosts).containsExactly(host1, host2);
+            assertThat(policy.initHosts).containsOnly(host1, host2);
 
             assertThat(logs.get())
                 .contains("Some contact points don't match local data center");


### PR DESCRIPTION
The test used containsExactly assertion which assumes that the elements
appear in order.  This is not possible due to the collection
implementation and has to be replaced by containsOnly, which ignores
insertion order.
