### PR TITLE
Fix a missing word in the documentation

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
@@ -47,8 +47,8 @@ public class BatchStatement extends Statement {
      */
     public enum Type {
         /**
-         * A logged batch: Cassandra will first the batch to its distributed batch log to
-         * ensure the atomicity of the batch.
+         * A logged batch: Cassandra will first write the batch to its distributed batch log
+         * to ensure the atomicity of the batch.
          */
         LOGGED,
 


### PR DESCRIPTION
The sentence doesn't make much sense without it.
