### PR TITLE
Adding functionality to QueryBuilder

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
@@ -286,6 +286,18 @@ public final class QueryBuilder {
     public static Clause in(String name, Object... values) {
         return new Clause.InClause(name, Arrays.asList(values));
     }
+	
+    /**
+     * Create an "in" where clause stating the provided column must be equal
+     * to one of the provided values.
+     *
+     * @param name the column name
+     * @param values the values
+     * @return the corresponding where clause.
+     */
+	public static Clause in(String name, List<Object> values) {
+		return new Clause.InClause(name, values);
+	}
 
     /**
      * Creates a "lesser than" where clause stating the provided column must be less than


### PR DESCRIPTION
I have a case where I need to pass a list of objects to the 'in(...)' method in the QueryBuilder class. By design the method only supports a parameter block. I have looked for ways to get around this but the classes seem to be locked down (rightly so). My change is pretty simple: a new 'in(...)' method that takes a list as an argument.

Thanks for considering this.
