### PR TITLE
suppress jdk8 javadoc lint failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,18 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <javadoc.opts>-Xdoclint:none</javadoc.opts>
+      </properties>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>
@@ -96,6 +108,9 @@
               <goals>
                 <goal>jar</goal>
               </goals>
+              <configuration>
+                <additionalparam>${javadoc.opts}</additionalparam>
+              </configuration>
             </execution>
           </executions>
       </plugin>


### PR DESCRIPTION
build on jdk8 fails because of the aggressive failures caused by lint errors in javadoc generation. Convert those errors into warnings.
