### PR TITLE
Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+jdk:
+  - openjdk6
+  - oraclejdk7
+  - oraclejdk8

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 DataStax Java Driver for Apache Cassandra
 =========================================
 
+.. image:: https://travis-ci.org/datastax/java-driver.svg?branch=2.0
+   :target: https://travis-ci.org/datastax/java-driver
+   :alt: Travis Build
+
 A Java client driver for Apache Cassandra. This driver works exclusively with
 the Cassandra Query Language version 3 (CQL3) and Cassandra's binary protocol.
 


### PR DESCRIPTION
This commit adds [travis-ci](https://travis-ci.org/) support to the java driver.  The travis build (which would be located [here](https://travis-ci.org/datastax/java-driver)) will run the maven 'test' goal from the parent module using openjdk6, oraclejdk7, and oraclejdk8.   This will only run tests in the 'unit' group (though we could extend this to run 'short' group integration tests as well).

Example result can be found [here](https://travis-ci.org/tolbertam/java-driver/builds/43388661).  You'll see that the jdk8 build failed as a unit test does not pass while it does for jdk6 and 7 (has to do with ordering of errors, I'm looking into this).

When also merging into 2.1, we will need to change the branch link at line 4 on README.rst to:

``` rst
.. image:: https://travis-ci.org/datastax/java-driver.svg?branch=2.1
```
