### PR TITLE
Add test for JAVA-573; Add Scassandra as a test dependency

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -89,6 +89,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.scassandra</groupId>
+      <artifactId>java-client</artifactId>
+      <version>0.4.1</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTimeoutTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTimeoutTest.java
@@ -2,11 +2,21 @@ package com.datastax.driver.core;
 
 import java.net.InetSocketAddress;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.codahale.metrics.Gauge;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.scassandra.Scassandra;
+import org.scassandra.ScassandraFactory;
+import org.scassandra.http.client.PrimingRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,6 +25,9 @@ import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 
 public class HostConnectionPoolTimeoutTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(HostConnectionPoolTimeoutTest.class);
+
     @Test(groups = "long")
     public void should_wait_for_idle_timeout_before_trashing_connections() throws Exception {
         CCMBridge ccm = null;
@@ -161,6 +174,109 @@ public class HostConnectionPoolTimeoutTest {
             if (ccm != null)
                 ccm.remove();
         }
+    }
+
+    /**
+     * Test that an unused connection is properly cleaned up with the configured idle timeout.
+     *
+     * Sends queries that are cancelled on a single connection which causes the connection to be replaced
+     * with a new one that is never used as no more queries are sent.  Validates that the unused connection is cleaned
+     * up after the idle timeout.
+     */
+    @Test(groups="short")
+    public void should_timeout_unused_connection() throws Exception {
+        int idleTimeoutSeconds = 10;
+        int requestThreshold = 128;
+
+        // Create a simulated cassandra instance that responds to a particular query slowly.  This provides
+        // headroom to cancel queries, in addition to allowing us to fill up maxSimultaneousRequestsPerConnection
+        // on a connection, creating more connections in a HostConnectionPool.
+        String slowQuery = "select key from table";
+        int slowQuerySeconds = 15;
+        Scassandra scassandra = TestUtils.createScassandraServer();
+        Cluster cluster = null;
+
+        try {
+            scassandra.start();
+            scassandra.primingClient().prime(
+                    PrimingRequest.queryBuilder()
+                            .withQuery(slowQuery)
+                            .withRows(ImmutableMap.of("key", 1))
+                            .withFixedDelay(slowQuerySeconds * 1000)
+                            .build()
+            );
+
+            // Set the read timeout to the query time * 2 to allow slow queries.
+            SocketOptions socketOptions = new SocketOptions().setReadTimeoutMillis(slowQuerySeconds*1000*2);
+
+            // Configure a core pool size of 1 to reduce the complexity of the test.
+            PoolingOptions poolOptions = new PoolingOptions()
+                    .setCoreConnectionsPerHost(HostDistance.LOCAL, 1)
+                    .setMaxSimultaneousRequestsPerConnectionThreshold(HostDistance.LOCAL, requestThreshold)
+                    .setIdleTimeoutSeconds(idleTimeoutSeconds);
+
+            cluster = Cluster.builder()
+                    .addContactPoint("127.0.0.1")
+                    .withPort(scassandra.getBinaryPort())
+                    .withPoolingOptions(poolOptions)
+                    .withSocketOptions(socketOptions)
+                    .build();
+
+            Session session = cluster.connect();
+
+            // Fill up the core connection.
+            for(int i = 0; i < requestThreshold; i++) {
+                session.executeAsync(slowQuery);
+            }
+
+            // Sleep to ensure queries are submitted.
+            TimeUnit.MILLISECONDS.sleep(100);
+
+            // Grab the single host's connection pool.
+            HostConnectionPool pool = ((SessionManager)session).pools.values().iterator().next();
+
+            // The pool should be at one since we did not submit beyond the threshold.
+            assertThat(pool.connections.size()).isEqualTo(1);
+
+            // Submit 75 requests and cancel them near immediately, this creates enough friction to cause the stream ids
+            // on the connection to be exhausted.
+            List<ResultSetFuture> toCancel = Lists.newArrayList();
+            for(int i = 0; i < 75; i++) {
+                toCancel.add(session.executeAsync(slowQuery));
+            }
+
+            // Sleep to ensure queries are submitted.
+            TimeUnit.MILLISECONDS.sleep(100);
+
+            // The pool size should grow by 1 after enqueuing requests beyond the threshold.
+            assertThat(pool.connections.size()).isEqualTo(2);
+
+            // Cancel these requests, this should trigger the connection that was assigned these queries to exhaust it's
+            // stream ids and become replaced with a new connection.
+            for(ResultSetFuture future : toCancel) {
+                future.cancel(true);
+            }
+
+            // Sleep for idleTimeout * 2 seconds to anticipate idle connection cleanup.
+            TimeUnit.SECONDS.sleep(idleTimeoutSeconds * 2);
+
+            // Log the remaining connections for debugging.
+            for(PooledConnection c : pool.connections) {
+                logger.info("Remaining connection: {} [trashTime={}, now={}]", c, c.getTrashTime(),
+                        System.currentTimeMillis());
+            }
+
+            // Ensure that the new unused connection was trashed after idleTimeout of never being used.
+            // If not there will be 2 connections here.
+            assertThat(pool.connections.size()).isEqualTo(1);
+
+        } finally {
+            if(cluster != null) {
+                cluster.close();
+            }
+            scassandra.stop();
+        }
+
     }
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTimeoutTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTimeoutTest.java
@@ -183,7 +183,7 @@ public class HostConnectionPoolTimeoutTest {
      * with a new one that is never used as no more queries are sent.  Validates that the unused connection is cleaned
      * up after the idle timeout.
      */
-    @Test(groups="short")
+    @Test(groups="long")
     public void should_timeout_unused_connection() throws Exception {
         int idleTimeoutSeconds = 10;
         int requestThreshold = 128;
@@ -256,6 +256,8 @@ public class HostConnectionPoolTimeoutTest {
             for(ResultSetFuture future : toCancel) {
                 future.cancel(true);
             }
+
+            pool.
 
             // Sleep for idleTimeout * 2 seconds to anticipate idle connection cleanup.
             TimeUnit.SECONDS.sleep(idleTimeoutSeconds * 2);


### PR DESCRIPTION
Introduced test that ensures that connections that are never used are appropriately cleaned up on idle timeout.  It also adds scassandra as a test dependency.
