### PR TITLE
Fix PoolingOptionsTest#should_refresh_single_connected_host()

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/PoolingOptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PoolingOptionsTest.java
@@ -63,7 +63,7 @@ public class PoolingOptionsTest {
                                .hasState(State.UP)
                                .isAtDistance(HostDistance.LOCAL);
             assertThat(cluster).host(3)
-                               .hasState(State.ADDED)
+                               .hasState(State.UP)
                                .isAtDistance(HostDistance.IGNORED);
             assertThat(session).hasNoPoolFor(3);
 

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/LimitingLoadBalancingPolicy.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/LimitingLoadBalancingPolicy.java
@@ -46,11 +46,13 @@ public class LimitingLoadBalancingPolicy extends DelegatingLoadBalancingPolicy {
     @Override
     public void init(Cluster cluster, Collection<Host> hosts) {
         this.cluster = cluster;
-        for (Host host : hosts)
-            if (host.isUp())
-                this.liveHosts.add(host);
-        this.delegate.init(cluster, Collections.<Host>emptyList());
-        updateChosenHosts();
+
+        Iterator<Host> hostIt = hosts.iterator();
+        while(hostIt.hasNext() && chosenHosts.size() <= maxHosts - threshold) {
+            chosenHosts.add(hostIt.next());
+        }
+
+        this.delegate.init(cluster, new ArrayList<Host>(chosenHosts));
     }
 
     private void updateChosenHosts() {


### PR DESCRIPTION
Changed LimitingLoadBalancingPolicy to treat hosts passed in the constructor as chosen hosts and pass to its delegate LoadBalancingPolicy as hosts passed into the constructor this way are to be set to up after LoadBalancingPolicy#init is called in Cluster.Manager.init().

There was a change for JAVA-511 to make it so LoadBalancingPolicy#onUp is not called for contactPoints on initialization as it caused some extraneous warning messages (d0eacbb3f8f6ca093383773d4b770cd9d9e95661) and this integration test has been failing ever since.
