### PR TITLE
Add tests for JAVA-543

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -255,7 +255,7 @@ class ControlConnection implements Host.StateListener {
             // We want that because the token map was not properly initialized by the first call above, since it requires the list of keyspaces
             // to be loaded.
             logger.debug("[Control connection] Refreshing schema");
-            refreshSchema(connection, null, null, cluster, isInitialConnection);
+            refreshSchema(connection, null, null);
             return connection;
         } catch (BusyConnectionException e) {
             connection.closeAsync().get();
@@ -273,7 +273,7 @@ class ControlConnection implements Host.StateListener {
             // At startup, when we add the initial nodes, this will be null, which is ok
             if (c == null)
                 return;
-            refreshSchema(c, keyspace, table, cluster, false);
+            refreshSchema(c, keyspace, table);
         } catch (ConnectionException e) {
             logger.debug("[Control connection] Connection error while refreshing schema ({})", e.getMessage());
             signalError();
@@ -288,7 +288,7 @@ class ControlConnection implements Host.StateListener {
         }
     }
 
-    static void refreshSchema(Connection connection, String keyspace, String table, Cluster.Manager cluster, boolean isInitialConnection) throws ConnectionException, BusyConnectionException, ExecutionException, InterruptedException {
+    void refreshSchema(Connection connection, String keyspace, String table) throws ConnectionException, BusyConnectionException, ExecutionException, InterruptedException {
         // Make sure we're up to date on schema
         String whereClause = "";
         if (keyspace != null) {

--- a/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
@@ -88,8 +88,9 @@ class DefaultResultSetFuture extends AbstractFuture<ResultSet> implements Result
                                         if (keyspace == null)
                                             logger.warn("Received a DROPPED notification for {}.{}, but this keyspace is unknown in our metadata",
                                                 scc.keyspace, scc.columnFamily);
-                                        else
-                                            keyspace.removeTable(scc.columnFamily);
+                                        else {
+                                            session.cluster.manager.metadata.removeTable(scc.keyspace, scc.columnFamily);
+                                        }
                                     }
                                     this.setResult(rs);
                                     break;

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -334,6 +334,16 @@ public class Metadata {
         return sb.toString();
     }
 
+    /**
+     * Remove a table of a given keyspace metadata.
+     *
+     * @param keyspace the keyspace name, must be an existing keyspace identifier
+     * @param table the name of the table to be removed
+     */
+    public void removeTable(String keyspace, String table) {
+        keyspaces.get(handleId(keyspace)).removeTable(table);
+    }
+
     static class TokenMap {
 
         private final Token.Factory factory;

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.List;
 
 import com.google.common.collect.Lists;
+import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -12,6 +13,7 @@ import org.testng.annotations.Test;
 import com.datastax.driver.core.utils.Bytes;
 
 import static com.datastax.driver.core.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 public class SchemaChangesTest extends CCMBridge.PerClassSingleNodeCluster {
 
@@ -28,75 +30,202 @@ public class SchemaChangesTest extends CCMBridge.PerClassSingleNodeCluster {
     @BeforeClass(groups = "short")
     public void setup() {
         cluster2 = Cluster.builder().addContactPoint(CCMBridge.ipOfNode(1)).build();
+
+        cluster.manager.controlConnection = spy(cluster.manager.controlConnection);
+        cluster2.manager.controlConnection = spy(cluster2.manager.controlConnection);
+        cluster.manager.metadata = spy(cluster.manager.metadata);
+        cluster2.manager.metadata = spy(cluster2.manager.metadata);
+
         metadatas = Lists.newArrayList(cluster.getMetadata(), cluster2.getMetadata());
     }
 
+    /**
+     * Test that schema refresh are as specific as possible for a CREATE TABLE event.
+     *
+     * This method verifies that when a table is created in a keyspace, the Cluster manager only fetches metadata for
+     * that table, and not for the whole keyspace.
+     *
+     * First, we wait for the Cluster instance to be initialized.  We then spy what happens on its controlConnection.
+     * Once the CREATE TABLE statement has been issued, we verify that the method ControlConnection#refreshSchema has
+     * been called with "ks" and "created_table" as parameter, thus targeting this table only.
+     *
+     * Note: a possible improvement for that test would be to verify that no call to controlConnection.refreshSchema is
+     * made with other parameters that "ks" and "created_table".
+     *
+     * @since 2.0
+     * @jira_ticket JAVA-543
+     * @expected_result The ControlConnection.refreshSchema method is called with the keyspace and table created
+     */
     @Test(groups = "short")
-    public void should_notify_of_table_creation() {
-        session.execute("CREATE TABLE ks.table1(i int primary key)");
+    public void should_notify_of_table_creation() throws InterruptedException {
+        resetSpies();
+        session.execute("CREATE TABLE ks.created_table(i int primary key)");
 
         for (Metadata m : metadatas)
-            assertThat(m.getKeyspace("ks").getTable("table1"))
-                .isNotNull();
+            assertThat(m.getKeyspace("ks").getTable("created_table")).isNotNull();
+        verify(cluster.manager.controlConnection).refreshSchema("ks", "created_table");
+        verify(cluster2.manager.controlConnection).refreshSchema("ks", "created_table");
     }
 
+    /**
+     * Test that schema refresh are as specific as possible for a ALTER TABLE event.
+     *
+     * This method verifies that when a table is altered in a keyspace, the Cluster manager only fetches metadata for
+     * that table, and not for the whole keyspace.
+     *
+     * First, we wait for the Cluster instance to be initialized and for the CREATE TABLE statement to be issued. We
+     * then spy what happens on its controlConnection. Once the ALTER TABLE statement has been issued, we verify that
+     * the method ControlConnection#refreshSchema has been called with "ks" and "updated_table" as parameter, thus
+     * targeting this table only.
+     *
+     * Note: a possible improvement for that test would be to verify that no call to controlConnection.refreshSchema is
+     * made with other parameters that "ks" and "updated_table".
+     *
+     * @since 2.0
+     * @jira_issue JAVA-543
+     * @expected_result The ControlConnection.refreshSchema method is called with the keyspace and table altered
+     */
     @Test(groups = "short")
-    public void should_notify_of_table_update() {
-        session.execute("CREATE TABLE ks.table1(i int primary key)");
-        session.execute("ALTER TABLE ks.table1 ADD j int");
+    public void should_notify_of_table_update() throws InterruptedException {
+        session.execute("CREATE TABLE ks.updated_table(i int primary key)");
+
+        resetSpies();
+        session.execute("ALTER TABLE ks.updated_table ADD j int");
 
         for (Metadata m : metadatas)
-            assertThat(m.getKeyspace("ks").getTable("table1").getColumn("j"))
-                .isNotNull();
+            assertThat(m.getKeyspace("ks").getTable("updated_table").getColumn("j")).isNotNull();
+        verify(cluster.manager.controlConnection).refreshSchema("ks", "updated_table");
+        verify(cluster2.manager.controlConnection).refreshSchema("ks", "updated_table");
     }
 
+    /**
+     * Test that schema refresh are as specific as possible for a DROP TABLE event.
+     *
+     * This method verifies that when a table is removed from a keyspace, the Cluster manager does not fetch any
+     * metadata but rather use the change event to update its internal keyspace representation.
+     *
+     * First, we wait for the Cluster instance to be initialized and for the CREATE TABLE statement to be issued. We
+     * then spy what happens on its controlConnection. Once the DROP TABLE statement has been issued, we verify that
+     * the method Metadata#removeTable has been called with "ks" and "deleted_table" as parameter, thus
+     * targeting this table only.
+     *
+     * @since 2.0
+     * @jira_issue JAVA-543
+     * @expected_result The ControlConnection.refreshSchema method is called with the keyspace and table altered
+     */
     @Test(groups = "short")
-    public void should_notify_of_table_drop() {
-        session.execute("CREATE TABLE ks.table1(i int primary key)");
-        session.execute("DROP TABLE ks.table1");
+    public void should_notify_of_table_drop() throws InterruptedException {
+        session.execute("CREATE TABLE ks.deleted_table(i int primary key)");
+
+        resetSpies();
+        session.execute("DROP TABLE ks.deleted_table");
 
         for (Metadata m : metadatas)
-            assertThat(m.getKeyspace("ks").getTable("table1"))
-                .isNull();
+            assertThat(m.getKeyspace("ks").getTable("deleted_table")).isNull();
+        // Note that atLeastOnce() required here. We try to remove the table twice.
+        verify(cluster.getMetadata(), atLeastOnce()).removeTable("ks", "deleted_table");
+        verify(cluster2.getMetadata()).removeTable("ks", "deleted_table");
     }
 
+    /**
+     * Test that schema refresh are as specific as possible for a CREATE KEYSPACE event.
+     *
+     * This method verifies that when a keyspace is created, the Cluster manager only fetches metadata for that
+     * keyspace.
+     *
+     * First, we wait for the Cluster instance to be initialized.  We then spy what happens on its controlConnection.
+     * Once the CREATE KEYSPACE statement has been issued, we verify that the method ControlConnection#refreshSchema has
+     * been called with "ks2" as parameter, thus targeting this keyspace only.
+     *
+     * Note: a possible improvement for that test would be to verify that no call to controlConnection.refreshSchema is
+     * made with other parameters that "ks2".
+     *
+     * @since 2.0
+     * @jira_ticket JAVA-543
+     * @expected_result The ControlConnection.refreshSchema method is called with the keyspace and table created
+     */
     @Test(groups = "short")
-    public void should_notify_of_keyspace_creation() {
+    public void should_notify_of_keyspace_creation() throws InterruptedException {
+        resetSpies();
         session.execute("CREATE KEYSPACE ks2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
 
         for (Metadata m : metadatas)
-            assertThat(m.getKeyspace("ks2"))
-                .isNotNull();
+            assertThat(m.getKeyspace("ks2")).isNotNull();
+        verify(cluster.manager.controlConnection).refreshSchema("ks2", null);
+        verify(cluster2.manager.controlConnection).refreshSchema("ks2", null);
     }
 
+    /**
+     * Test that schema refresh are as specific as possible for a ALTER KEYSPACE event.
+     *
+     * This method verifies that when a keyspace is altered, the Cluster manager only fetches metadata for that
+     * keyspace.
+     *
+     * First, we wait for the Cluster instance to be initialized.  We then spy what happens on its controlConnection.
+     * Once the ALTER KEYSPACE statement has been issued, we verify that the method ControlConnection#refreshSchema has
+     * been called with "ks2" as parameter, thus targeting this keyspace only.
+     *
+     * @jira_ticket JAVA-543
+     * @expected_result The ControlConnection.refreshSchema method is called with the keyspace and table created
+     * @since 2.0
+     */
     @Test(groups = "short")
-    public void should_notify_of_keyspace_update() {
+    public void should_notify_of_keyspace_update() throws InterruptedException {
         session.execute("CREATE KEYSPACE ks2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
         for (Metadata m : metadatas)
-            assertThat(m.getKeyspace("ks2").isDurableWrites())
-                .isTrue();
+            assertThat(m.getKeyspace("ks2").isDurableWrites()).isTrue();
 
+        resetSpies();
         session.execute("ALTER KEYSPACE ks2 WITH durable_writes = false");
+
         for (Metadata m : metadatas)
-            assertThat(m.getKeyspace("ks2").isDurableWrites())
-                .isFalse();
+            assertThat(m.getKeyspace("ks2").isDurableWrites()).isFalse();
+        verify(cluster.manager.controlConnection).refreshSchema("ks2", null);
+        verify(cluster2.manager.controlConnection).refreshSchema("ks2", null);
     }
 
+    /**
+     * Test that schema refresh are as specific as possible for a DROP KEYSPACE event.
+     *
+     * This method verifies that when a keyspace is dropped, the Cluster manager does not fetch any metadata but rather
+     * use the change event to update its internal database representation.
+     *
+     * First, we wait for the Cluster instance to be initialized and for the CREATE KEYSPACE statement to be issued. We
+     * then spy what happens on its controlConnection. Once the DROP KEYSPACE statement has been issued, we verify that
+     * the method Metadata#removeKeyspace has been called with "ks2" as parameter, thus targeting this table only.
+     *
+     * @jira_issue JAVA-543
+     * @expected_result The ControlConnection.refreshSchema method is called with the keyspace and table altered
+     * @since 2.0
+     */
     @Test(groups = "short")
     public void should_notify_of_keyspace_drop() {
         session.execute("CREATE KEYSPACE ks2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
         for (Metadata m : metadatas)
-            assertThat(m.getReplicas("ks2", Bytes.fromHexString("0xCAFEBABE")))
-                .isNotEmpty();
+            assertThat(m.getReplicas("ks2", Bytes.fromHexString("0xCAFEBABE"))).isNotEmpty();
 
+        resetSpies();
         session.execute("DROP KEYSPACE ks2");
 
         for (Metadata m : metadatas) {
-            assertThat(m.getKeyspace("ks2"))
-                .isNull();
-            assertThat(m.getReplicas("ks2", Bytes.fromHexString("0xCAFEBABE")))
-                .isEmpty();
+            assertThat(m.getKeyspace("ks2")).isNull();
+            assertThat(m.getReplicas("ks2", Bytes.fromHexString("0xCAFEBABE"))).isEmpty();
         }
+        // Note that atLeastOnce() required here. We try to remove the keyspace twice.
+        verify(cluster.getMetadata(), atLeastOnce()).removeKeyspace("ks2");
+        verify(cluster2.getMetadata()).removeKeyspace("ks2");
+    }
+
+    /**
+     * Resets the spies counters for clusters control connections and metadata.
+     *
+     * This method is necessary since the {@code Cluster} instances are shared between tests.
+     */
+    private void resetSpies() {
+        Mockito.reset(cluster.manager.controlConnection);
+        Mockito.reset(cluster2.manager.controlConnection);
+        Mockito.reset(cluster.manager.metadata);
+        Mockito.reset(cluster2.manager.metadata);
     }
 
     @AfterMethod(groups = "short")


### PR DESCRIPTION
This changed required to remove the "static" modifier from the
refreshSchema method.

Now that refreshSchema is an instance method, the Manager instance can
be retrieved from the local "cluster" field.  The isInitialConnection
parameter was unused and has been removed as well.

A utility method has been created in Keyspace so that table removal
operation are processed by that object for test purposes.
