### PR TITLE
Improve PoolingOptionsTest#should_refresh_single_connected_host() resiliency.

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/PoolingOptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PoolingOptionsTest.java
@@ -63,7 +63,7 @@ public class PoolingOptionsTest {
                                .hasState(State.UP)
                                .isAtDistance(HostDistance.LOCAL);
             assertThat(cluster).host(3)
-                               .hasState(State.UP)
+                               .comesUpWithin(120, SECONDS)
                                .isAtDistance(HostDistance.IGNORED);
             assertThat(session).hasNoPoolFor(3);
 


### PR DESCRIPTION
Makes PoolingOptionsTest#should_refresh_single_connected_host() more resilient by adding 'comesUpWithinCriteria(120, SECONDS) to nodes 3 as it may not have been marked as 'up' by the driver at this point.
