### PR TITLE
Reintroduce pool idle timeout (JAVA-419)

### DIFF
--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -20,6 +20,8 @@ CHANGELOG
 - [improvement] Expose TokenRange#contains (JAVA-687)
 - [new feature] Expose values of BoundStatement (JAVA-547)
 - [new feature] Add getObject to BoundStatement and Row (JAVA-584)
+- [improvement] Improve connection pool resizing algorithm (JAVA-419)
+- [bug] Fix race condition between pool expansion and shutdown (JAVA-599)
 
 Merged from 2.0.9_fixes branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -56,7 +56,7 @@ class HostConnectionPool {
     final List<PooledConnection> connections;
     private final AtomicInteger open;
     /** The total number of in-flight requests on all connections of this pool. */
-    private final AtomicInteger totalInFlight = new AtomicInteger();
+    final AtomicInteger totalInFlight = new AtomicInteger();
     /** The maximum value of {@link #totalInFlight} since the last call to {@link #cleanupIdleConnections(long)}*/
     private final AtomicInteger maxTotalInFlight = new AtomicInteger();
     final Set<PooledConnection> trash = new CopyOnWriteArraySet<PooledConnection>();
@@ -531,6 +531,10 @@ class HostConnectionPool {
 
     public int opened() {
         return open.get();
+    }
+
+    public int trashed() {
+        return trash.size();
     }
 
     private List<CloseFuture> discardAvailableConnections() {

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -36,6 +36,8 @@ import org.slf4j.LoggerFactory;
 
 import com.datastax.driver.core.exceptions.AuthenticationException;
 
+import static com.datastax.driver.core.PooledConnection.State.*;
+
 class HostConnectionPool {
 
     private static final Logger logger = LoggerFactory.getLogger(HostConnectionPool.class);
@@ -53,7 +55,11 @@ class HostConnectionPool {
 
     final List<PooledConnection> connections;
     private final AtomicInteger open;
-    private final Set<Connection> trash = new CopyOnWriteArraySet<Connection>();
+    /** The total number of in-flight requests on all connections of this pool. */
+    private final AtomicInteger totalInFlight = new AtomicInteger();
+    /** The maximum value of {@link #totalInFlight} since the last call to {@link #cleanupIdleConnections(long)}*/
+    private final AtomicInteger maxTotalInFlight = new AtomicInteger();
+    final Set<PooledConnection> trash = new CopyOnWriteArraySet<PooledConnection>();
 
     private volatile int waiter = 0;
     private final Lock waitLock = new ReentrantLock(true);
@@ -63,6 +69,7 @@ class HostConnectionPool {
 
     private final AtomicInteger scheduledForCreation = new AtomicInteger();
 
+    private volatile boolean isClosing;
     private final AtomicReference<CloseFuture> closeFuture = new AtomicReference<CloseFuture>();
 
     public HostConnectionPool(Host host, HostDistance hostDistance, SessionManager manager) throws ConnectionException, UnsupportedProtocolVersionException, ClusterNameMismatchException {
@@ -132,6 +139,7 @@ class HostConnectionPool {
                 manager.blockingExecutor().submit(newConnectionTask);
             }
             PooledConnection c = waitForConnection(timeout, unit);
+            totalInFlight.incrementAndGet();
             c.setKeyspace(manager.poolsState.keyspace);
             return c;
         }
@@ -145,9 +153,6 @@ class HostConnectionPool {
                 leastBusy = connection;
             }
         }
-
-        if (minInFlight >= options().getMaxSimultaneousRequestsPerConnectionThreshold(hostDistance) && connections.size() < options().getMaxConnectionsPerHost(hostDistance))
-            maybeSpawnNewConnection();
 
         if (leastBusy == null) {
             // We could have raced with a shutdown since the last check
@@ -170,6 +175,24 @@ class HostConnectionPool {
                     break;
             }
         }
+
+        int totalInFlightCount = totalInFlight.incrementAndGet();
+        // update max atomically:
+        while (true) {
+            int oldMax = maxTotalInFlight.get();
+            if (totalInFlightCount <= oldMax || maxTotalInFlight.compareAndSet(oldMax, totalInFlightCount))
+                break;
+        }
+
+        int connectionCount = open.get() + scheduledForCreation.get();
+        if (connectionCount < options().getMaxConnectionsPerHost(hostDistance)) {
+            // Add a connection if we fill the first n-1 connections and almost fill the last one
+            int currentCapacity = (connectionCount - 1) * StreamIdGenerator.MAX_STREAM_PER_CONNECTION
+                + options().getMaxSimultaneousRequestsPerConnectionThreshold(hostDistance);
+            if (totalInFlightCount > currentCapacity)
+                maybeSpawnNewConnection();
+        }
+
         leastBusy.setKeyspace(manager.poolsState.keyspace);
         return leastBusy;
     }
@@ -260,7 +283,8 @@ class HostConnectionPool {
     }
 
     public void returnConnection(PooledConnection connection) {
-        int inFlight = connection.inFlight.decrementAndGet();
+        connection.inFlight.decrementAndGet();
+        totalInFlight.decrementAndGet();
 
         if (isClosed()) {
             close(connection);
@@ -273,13 +297,8 @@ class HostConnectionPool {
             return;
         }
 
-        if (trash.contains(connection)) {
-            if (inFlight == 0 && trash.remove(connection))
-                close(connection);
-        } else {
-            if (connections.size() > options().getCoreConnectionsPerHost(hostDistance) && inFlight <= options().getMinSimultaneousRequestsPerConnectionThreshold(hostDistance)) {
-                trashConnection(connection);
-            } else if (connection.maxAvailableStreams() < MIN_AVAILABLE_STREAMS) {
+        if (connection.state.get() != TRASHED) {
+            if (connection.maxAvailableStreams() < MIN_AVAILABLE_STREAMS) {
                 replaceConnection(connection);
             } else {
                 signalAvailableConnection();
@@ -290,44 +309,38 @@ class HostConnectionPool {
     // Trash the connection and create a new one, but we don't call trashConnection
     // directly because we want to make sure the connection is always trashed.
     private void replaceConnection(PooledConnection connection) {
-        if (connection.markForTrash.compareAndSet(false, true))
-            open.decrementAndGet();
+        if (!connection.state.compareAndSet(OPEN, TRASHED))
+            return;
+        open.decrementAndGet();
         maybeSpawnNewConnection();
+        connection.maxIdleTime = Long.MIN_VALUE;
         doTrashConnection(connection);
     }
 
     private boolean trashConnection(PooledConnection connection) {
-        if (connection.markForTrash.compareAndSet(false, true)) {
-            // First, make sure we don't go below core connections
-            for (;;) {
-                int opened = open.get();
-                if (opened <= options().getCoreConnectionsPerHost(hostDistance)) {
-                    connection.markForTrash.set(false);
-                    return false;
-                }
+        if (!connection.state.compareAndSet(OPEN, TRASHED))
+            return true;
 
-                if (open.compareAndSet(opened, opened - 1))
-                    break;
+        // First, make sure we don't go below core connections
+        for (;;) {
+            int opened = open.get();
+            if (opened <= options().getCoreConnectionsPerHost(hostDistance)) {
+                connection.state.set(OPEN);
+                return false;
             }
 
-            doTrashConnection(connection);
+            if (open.compareAndSet(opened, opened - 1))
+                break;
         }
-        // If compareAndSet failed, it means we raced and another thread will execute doTrashConnection.
-        // If the connection needs to be closed (inFlight == 0), we don't need to do it here because the other thread will necessarily do
-        // it:
-        // - the current thread decremented inFlight in returnConnection
-        // - we know it did it before the connection was trashed, because otherwise it would have entered `if (trash.contains(connection))`
-        //   in returnConnection and not arrived here.
-        // - so the other thread will see the up-to-date value of inFlight and take appropriate action.
+        logger.trace("Trashing {}", connection);
+        connection.maxIdleTime = System.currentTimeMillis() + options().getIdleTimeoutSeconds() * 1000;
+        doTrashConnection(connection);
         return true;
     }
 
     private void doTrashConnection(PooledConnection connection) {
-        trash.add(connection);
         connections.remove(connection);
-
-        if (connection.inFlight.get() == 0 && trash.remove(connection))
-            close(connection);
+        trash.add(connection);
     }
 
     private boolean addConnectionIfUnderMaximum() {
@@ -342,14 +355,29 @@ class HostConnectionPool {
                 break;
         }
 
-        if (isClosed()) {
+        if (isClosing) {
             open.decrementAndGet();
             return false;
         }
 
         // Now really open the connection
         try {
-            connections.add(manager.connectionFactory().open(this));
+            PooledConnection newConnection = tryResurrectFromTrash();
+            if (newConnection == null) {
+                logger.debug("Creating new connection on busy pool to {}", host);
+                newConnection = manager.connectionFactory().open(this);
+            }
+            connections.add(newConnection);
+
+            newConnection.state.compareAndSet(RESURRECTING, OPEN); // no-op if it was already OPEN
+
+            // We might have raced with pool shutdown since the last check; ensure the connection gets closed in case the pool did not do it.
+            if (isClosing && !newConnection.isClosed()) {
+                close(newConnection);
+                open.decrementAndGet();
+                return false;
+            }
+
             signalAvailableConnection();
             return true;
         } catch (InterruptedException e) {
@@ -378,6 +406,27 @@ class HostConnectionPool {
         }
     }
 
+    private PooledConnection tryResurrectFromTrash() {
+        long highestMaxIdleTime = System.currentTimeMillis();
+        PooledConnection chosen = null;
+
+        while (true) {
+            for (PooledConnection connection : trash)
+                if (connection.maxIdleTime > highestMaxIdleTime && connection.maxAvailableStreams() > MIN_AVAILABLE_STREAMS) {
+                    chosen = connection;
+                    highestMaxIdleTime = connection.maxIdleTime;
+                }
+
+            if (chosen == null)
+                return null;
+            else if (chosen.state.compareAndSet(TRASHED, RESURRECTING))
+                break;
+        }
+        logger.trace("Resurrecting {}", chosen);
+        trash.remove(chosen);
+        return chosen;
+    }
+
     private void maybeSpawnNewConnection() {
         while (true) {
             int inCreation = scheduledForCreation.get();
@@ -387,21 +436,71 @@ class HostConnectionPool {
                 break;
         }
 
-        logger.debug("Creating new connection on busy pool to {}", host);
         manager.blockingExecutor().submit(newConnectionTask);
     }
 
     void replaceDefunctConnection(final PooledConnection connection) {
-        if (connection.markForTrash.compareAndSet(false, true))
+        if (connection.state.compareAndSet(OPEN, GONE))
             open.decrementAndGet();
-        connections.remove(connection);
+        if (connections.remove(connection))
+            manager.blockingExecutor().submit(new Runnable() {
+                @Override
+                public void run() {
+                    addConnectionIfUnderMaximum();
+                }
+            });
         connection.closeAsync();
-        manager.blockingExecutor().submit(new Runnable() {
-            @Override
-            public void run() {
-                addConnectionIfUnderMaximum();
+    }
+
+    void cleanupIdleConnections(long now) {
+        if (isClosed())
+            return;
+
+        shrinkIfBelowCapacity();
+        cleanupTrash(now);
+    }
+
+    /** If we have more active connections than needed, trash some of them */
+    private void shrinkIfBelowCapacity() {
+        int currentLoad = maxTotalInFlight.getAndSet(totalInFlight.get());
+
+        int needed = currentLoad / StreamIdGenerator.MAX_STREAM_PER_CONNECTION + 1;
+        if (currentLoad % StreamIdGenerator.MAX_STREAM_PER_CONNECTION > options().getMaxSimultaneousRequestsPerConnectionThreshold(hostDistance))
+            needed += 1;
+        needed = Math.max(needed, options().getCoreConnectionsPerHost(hostDistance));
+        int actual = open.get();
+        int toTrash = Math.max(0, actual - needed);
+
+        logger.trace("Current inFlight = {}, {} connections needed, {} connections available, trashing {}",
+            currentLoad, needed, actual, toTrash);
+
+        if (toTrash <= 0)
+            return;
+
+        for (PooledConnection connection : connections)
+            if (trashConnection(connection)) {
+                toTrash -= 1;
+                if (toTrash == 0)
+                    return;
             }
-        });
+    }
+
+    /** Close connections that have been sitting in the trash for too long */
+    private void cleanupTrash(long now) {
+        for (PooledConnection connection : trash) {
+            if (connection.maxIdleTime < now && connection.state.compareAndSet(TRASHED, GONE)) {
+                if (connection.inFlight.get() == 0) {
+                    logger.trace("Cleaning up {}", connection);
+                    trash.remove(connection);
+                    close(connection);
+                } else {
+                    // Given that idleTimeout >> request timeout, all outstanding requests should
+                    // have finished by now, so we should not get here.
+                    // Restore the status so that it's retried on the next cleanup.
+                    connection.state.set(TRASHED);
+                }
+            }
+        }
     }
 
     private void close(final Connection connection) {
@@ -418,7 +517,9 @@ class HostConnectionPool {
         if (future != null)
             return future;
 
-        // Wake up all threads that waits
+        isClosing = true;
+
+        // Wake up all threads that wait
         signalAllAvailableConnection();
 
         future = new CloseFuture.Forwarding(discardAvailableConnections());
@@ -437,17 +538,23 @@ class HostConnectionPool {
         if (connections == null)
             return Lists.newArrayList(CloseFuture.immediateFuture());
 
-        List<CloseFuture> futures = new ArrayList<CloseFuture>(connections.size());
+        List<CloseFuture> futures = new ArrayList<CloseFuture>(connections.size() + trash.size());
+
         for (final PooledConnection connection : connections) {
             CloseFuture future = connection.closeAsync();
             future.addListener(new Runnable() {
                 public void run() {
-                    if (connection.markForTrash.compareAndSet(false, true))
+                    if (connection.state.compareAndSet(OPEN, GONE))
                         open.decrementAndGet();
                 }
             }, MoreExecutors.sameThreadExecutor());
             futures.add(future);
         }
+
+        // Some connections in the trash might still be open if they hadn't reached their idle timeout
+        for (PooledConnection connection : trash)
+            futures.add(connection.closeAsync());
+
         return futures;
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Metrics.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metrics.java
@@ -69,6 +69,16 @@ public class Metrics {
             return value;
         }
     });
+    private final Gauge<Integer> trashedConnections = registry.register("trashed-connections", new Gauge<Integer>() {
+        @Override
+        public Integer getValue() {
+            int value = 0;
+            for (SessionManager session : manager.sessions)
+                for (HostConnectionPool pool : session.pools.values())
+                    value += pool.trashed();
+            return value;
+        }
+    });
 
     private final Gauge<Integer> executorQueueDepth = registry.register("executor-queue-depth", new Gauge<Integer>() {
         @Override
@@ -203,6 +213,20 @@ public class Metrics {
      */
     public Gauge<Integer> getOpenConnections() {
         return openConnections;
+    }
+
+    /**
+     * Returns the total number of currently "trashed" connections to Cassandra hosts.
+     * <p>
+     * When the load to a host decreases, the driver will reclaim some connections in order to save
+     * resources. No requests are sent to these connections anymore, but they are kept open for an
+     * additional amount of time ({@link PoolingOptions#getIdleTimeoutSeconds()}), in case the load
+     * goes up again. This metric counts connections in that state.
+     *
+     * @return The total number of currently trashed connections to Cassandra hosts.
+     */
+    public Gauge<Integer> getTrashedConnections() {
+        return trashedConnections;
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/PoolingOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PoolingOptions.java
@@ -31,43 +31,36 @@ package com.datastax.driver.core;
  * more connections are created up to the configurable maximum number of
  * connections ({@link #getMaxConnectionsPerHost}). When the pool exceeds
  * the maximum number of connections, connections in excess are
- * reclaimed if the use of opened connections drops below the
- * configured threshold ({@link #getMinSimultaneousRequestsPerConnectionThreshold}).
+ * reclaimed.
  * <p>
  * Each of these parameters can be separately set for {@code LOCAL} and
  * {@code REMOTE} hosts ({@link HostDistance}). For {@code IGNORED} hosts,
  * the default for all those settings is 0 and cannot be changed.
- * <p>
- * Due to known issues with the current pool implementation (see
- * <a href="https://datastax-oss.atlassian.net/browse/JAVA-419">JAVA-419</a>),
- * it is <b>strongly recommended</b> to use a fixed-size pool (core connections =
- * max connections).
- * The default values respect this (8 for local hosts, 2 for remote hosts).
  */
 public class PoolingOptions {
 
     // Note: we could use an enumMap or similar, but synchronization would
     // be more costly so let's stick to volatile in for now.
-    private static final int DEFAULT_MIN_REQUESTS = 25;
     private static final int DEFAULT_MAX_REQUESTS = 100;
 
-    private static final int DEFAULT_CORE_POOL_LOCAL = 8;
-    private static final int DEFAULT_CORE_POOL_REMOTE = 2;
+    private static final int DEFAULT_CORE_POOL_LOCAL = 2;
+    private static final int DEFAULT_CORE_POOL_REMOTE = 1;
 
     private static final int DEFAULT_MAX_POOL_LOCAL = 8;
     private static final int DEFAULT_MAX_POOL_REMOTE = 2;
 
+    private static final int DEFAULT_IDLE_TIMEOUT_SECONDS = 120;
     private static final int DEFAULT_POOL_TIMEOUT_MILLIS = 5000;
     private static final int DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 30;
 
     private volatile Cluster.Manager manager;
 
-    private final int[] minSimultaneousRequests = new int[]{ DEFAULT_MIN_REQUESTS, DEFAULT_MIN_REQUESTS, 0 };
     private final int[] maxSimultaneousRequests = new int[]{ DEFAULT_MAX_REQUESTS, DEFAULT_MAX_REQUESTS, 0 };
 
     private final int[] coreConnections = new int[] { DEFAULT_CORE_POOL_LOCAL, DEFAULT_CORE_POOL_REMOTE, 0 };
     private final int[] maxConnections = new int[] { DEFAULT_MAX_POOL_LOCAL , DEFAULT_MAX_POOL_REMOTE, 0 };
 
+    private volatile int idleTimeoutSeconds = DEFAULT_IDLE_TIMEOUT_SECONDS;
     private volatile int poolTimeoutMillis = DEFAULT_POOL_TIMEOUT_MILLIS;
     private volatile int heartbeatIntervalSeconds = DEFAULT_HEARTBEAT_INTERVAL_SECONDS;
 
@@ -91,9 +84,12 @@ public class PoolingOptions {
      *
      * @param distance the {@code HostDistance} for which to return this threshold.
      * @return the configured threshold, or the default one if none have been set.
+     *
+     * @deprecated this option isn't used anymore with the current pool resizing algorithm.
      */
+    @Deprecated
     public int getMinSimultaneousRequestsPerConnectionThreshold(HostDistance distance) {
-        return minSimultaneousRequests[distance.ordinal()];
+        return 0;
     }
 
     /**
@@ -106,14 +102,11 @@ public class PoolingOptions {
      *
      * @throws IllegalArgumentException if {@code distance == HostDistance.IGNORED}, or if {@code minSimultaneousRequests}
      * is not in range, or if {@code newMinSimultaneousRequests} is greater than the maximum value for this distance.
+     *
+     * @deprecated this option isn't used anymore with the current pool resizing algorithm.
      */
+    @Deprecated
     public synchronized PoolingOptions setMinSimultaneousRequestsPerConnectionThreshold(HostDistance distance, int newMinSimultaneousRequests) {
-        if (distance == HostDistance.IGNORED)
-            throw new IllegalArgumentException("Cannot set min simultaneous requests per connection threshold for " + distance + " hosts");
-
-        checkRequestsPerConnectionRange(newMinSimultaneousRequests, "Min simultaneous requests per connection", distance);
-        checkRequestsPerConnectionOrder(newMinSimultaneousRequests, maxSimultaneousRequests[distance.ordinal()], distance);
-        minSimultaneousRequests[distance.ordinal()] = newMinSimultaneousRequests;
         return this;
     }
 
@@ -156,7 +149,6 @@ public class PoolingOptions {
             throw new IllegalArgumentException("Cannot set max simultaneous requests per connection threshold for " + distance + " hosts");
 
         checkRequestsPerConnectionRange(newMaxSimultaneousRequests, "Max simultaneous requests per connection", distance);
-        checkRequestsPerConnectionOrder(minSimultaneousRequests[distance.ordinal()], newMaxSimultaneousRequests, distance);
         maxSimultaneousRequests[distance.ordinal()] = newMaxSimultaneousRequests;
         return this;
     }
@@ -177,11 +169,6 @@ public class PoolingOptions {
 
     /**
      * Sets the core number of connections per host.
-     * <p>
-     * Due to known issues with the current pool implementation (see
-     * <a href="https://datastax-oss.atlassian.net/browse/JAVA-419">JAVA-419</a>),
-     * it is <b>strongly recommended</b> to use a fixed-size pool (core connections =
-     * max connections).
      *
      * @param distance the {@code HostDistance} for which to set this threshold.
      * @param newCoreConnections the value to set
@@ -217,11 +204,6 @@ public class PoolingOptions {
 
     /**
      * Sets the maximum number of connections per host.
-     * <p>
-     * Due to known issues with the current pool implementation (see
-     * <a href="https://datastax-oss.atlassian.net/browse/JAVA-419">JAVA-419</a>),
-     * it is <b>strongly recommended</b> to use a fixed-size pool (core connections =
-     * max connections).
      *
      * @param distance the {@code HostDistance} for which to set this threshold.
      * @param newMaxConnections the value to set
@@ -236,6 +218,33 @@ public class PoolingOptions {
 
         checkConnectionsPerHostOrder(coreConnections[distance.ordinal()], newMaxConnections, distance);
         maxConnections[distance.ordinal()] = newMaxConnections;
+        return this;
+    }
+
+    /**
+     * Returns the timeout before an idle connection is removed.
+     *
+     * @return the timeout.
+     */
+    public int getIdleTimeoutSeconds() {
+        return idleTimeoutSeconds;
+    }
+
+    /**
+     * Sets the timeout before an idle connection is removed.
+     * <p>
+     * The order of magnitude should be a few minutes (the default is 120 seconds). The
+     * timeout that triggers the removal has a granularity of 10 seconds.
+     *
+     * @param idleTimeoutSeconds the new timeout in seconds.
+     * @return this {@code PoolingOptions}.
+     *
+     * @throws IllegalArgumentException if the timeout is negative.
+     */
+    public PoolingOptions setIdleTimeoutSeconds(int idleTimeoutSeconds) {
+        if (idleTimeoutSeconds < 0)
+            throw new IllegalArgumentException("Idle timeout must be positive");
+        this.idleTimeoutSeconds = idleTimeoutSeconds;
         return this;
     }
 
@@ -324,12 +333,6 @@ public class PoolingOptions {
             throw new IllegalArgumentException(String.format("%s for %s hosts must be in the range (0, %d)",
                                                              description, distance,
                                                              StreamIdGenerator.MAX_STREAM_PER_CONNECTION));
-    }
-
-    private static void checkRequestsPerConnectionOrder(int min, int max, HostDistance distance) {
-        if (min > max)
-            throw new IllegalArgumentException(String.format("Min simultaneous requests per connection for %s hosts must be less than max (%d > %d)",
-                                                             distance, min, max));
     }
 
     private static void checkConnectionsPerHostOrder(int core, int max, HostDistance distance) {

--- a/driver-core/src/main/java/com/datastax/driver/core/Session.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Session.java
@@ -17,7 +17,6 @@ package com.datastax.driver.core;
 
 import java.io.Closeable;
 import java.util.Collection;
-import java.util.Map;
 
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -376,12 +375,29 @@ public interface Session extends Closeable {
 
         /**
          * The number of open connections to a given host.
+         * <p>
+         * Note that this refers to <em>active</em> connections. The actual number of connections also
+         * includes {@link #getTrashedConnections(Host)}.
          *
          * @param host the host to get open connections for.
          * @return The number of open connections to {@code host}. If the session
          * is not connected to that host, 0 is returned.
          */
         public int getOpenConnections(Host host);
+
+        /**
+         * The number of "trashed" connections to a given host.
+         * <p>
+         * When the load to a host decreases, the driver will reclaim some connections in order to save
+         * resources. No requests are sent to these connections anymore, but they are kept open for an
+         * additional amount of time ({@link PoolingOptions#getIdleTimeoutSeconds()}), in case the load
+         * goes up again. This method counts connections in that state.
+         *
+         * @param host the host to get trashed connections for.
+         * @return The number of trashed connections to {@code host}. If the session
+         * is not connected to that host, 0 is returned.
+         */
+        public int getTrashedConnections(Host host);
 
         /**
          * The number of queries that are currently being executed though a given host.

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -556,6 +556,12 @@ class SessionManager extends AbstractSession {
         return future;
     }
 
+    void cleanupIdleConnections(long now) {
+        for (HostConnectionPool pool : pools.values()) {
+            pool.cleanupIdleConnections(now);
+        }
+    }
+
     private static class State implements Session.State {
 
         private final SessionManager session;

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -567,6 +567,7 @@ class SessionManager extends AbstractSession {
         private final SessionManager session;
         private final List<Host> connectedHosts;
         private final int[] openConnections;
+        private final int[] trashedConnections;
         private final int[] inFlightQueries;
 
         private State(SessionManager session) {
@@ -574,6 +575,7 @@ class SessionManager extends AbstractSession {
             this.connectedHosts = ImmutableList.copyOf(session.pools.keySet());
 
             this.openConnections = new int[connectedHosts.size()];
+            this.trashedConnections = new int[connectedHosts.size()];
             this.inFlightQueries = new int[connectedHosts.size()];
 
             int i = 0;
@@ -584,14 +586,14 @@ class SessionManager extends AbstractSession {
                 // connections will be slightly weird, but it's unlikely enough that we don't bother avoiding.
                 if (p == null) {
                     openConnections[i] = 0;
+                    trashedConnections[i] = 0;
                     inFlightQueries[i] = 0;
                     continue;
                 }
 
                 openConnections[i] = p.connections.size();
-                for (Connection c : p.connections) {
-                    inFlightQueries[i] += c.inFlight.get();
-                }
+                trashedConnections[i] = p.trash.size();
+                inFlightQueries[i] = p.totalInFlight.get();
                 i++;
             }
         }
@@ -620,6 +622,11 @@ class SessionManager extends AbstractSession {
         public int getOpenConnections(Host host) {
             int i = getIdx(host);
             return i < 0 ? 0 : openConnections[i];
+        }
+
+        public int getTrashedConnections(Host host) {
+            int i = getIdx(host);
+            return i < 0 ? 0 : trashedConnections[i];
         }
 
         public int getInFlightQueries(Host host) {

--- a/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
@@ -13,6 +13,8 @@ import com.google.common.collect.Lists;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 import static org.testng.Assert.fail;
 
 public class HostConnectionPoolTest extends CCMBridge.PerClassSingleNodeCluster {
@@ -26,6 +28,14 @@ public class HostConnectionPoolTest extends CCMBridge.PerClassSingleNodeCluster 
         return Lists.newArrayList(sb.toString());
     }
 
+    /**
+     * Ensures that if a fixed-sized pool has filled its core connections that borrowConnection will timeout instead
+     * of creating a new connection.
+     *
+     * @since 2.0.10, 2.1.6
+     * @jira_ticket JAVA-419
+     * @test_category connection:connection_pool
+     */
     @Test(groups = "short")
     public void fixed_size_pool_should_fill_its_core_connections_and_then_timeout() throws ConnectionException, TimeoutException {
         HostConnectionPool pool = createPool(2, 2);
@@ -47,12 +57,53 @@ public class HostConnectionPoolTest extends CCMBridge.PerClassSingleNodeCluster 
         assertThat(timedOut).isTrue();
     }
 
+    /**
+     * Ensures that if a variable-sized pool has filled up to its maximum connections that borrowConnection will
+     * timeout instead of creating a new connection.
+     *
+     * @since 2.0.10, 2.1.6
+     * @jira_ticket JAVA-419
+     * @test_category connection:connection_pool
+     */
+    @Test(groups = "short")
+    public void variable_size_pool_should_fill_its_connections_and_then_timeout() throws ConnectionException, TimeoutException {
+        HostConnectionPool pool = createPool(1, 2);
+
+        assertThat(pool.connections.size()).isEqualTo(1);
+        List<PooledConnection> coreConnections = Lists.newArrayList(pool.connections);
+
+        //
+        for (int i = 0; i < 128; i++) {
+            PooledConnection connection = pool.borrowConnection(100, MILLISECONDS);
+            assertThat(coreConnections).contains(connection);
+        }
+
+        // Borrow more and ensure the connection returned is a non-core connection.
+        for (int i = 0; i < 128; i++) {
+            PooledConnection connection = pool.borrowConnection(100, MILLISECONDS);
+            assertThat(coreConnections).doesNotContain(connection);
+        }
+
+        boolean timedOut = false;
+        try {
+            pool.borrowConnection(100, MILLISECONDS);
+        } catch (TimeoutException e) {
+            timedOut = true;
+        }
+        assertThat(timedOut).isTrue();
+    }
+
+    /**
+     * Ensures that if the core connection pool is full that borrowConnection will create and use a new connection.
+     *
+     * @since 2.0.10, 2.1.6
+     * @jira_ticket JAVA-419
+     * @test_category connection:connection_pool
+     */
     @Test(groups = "short")
     public void should_add_extra_connection_when_core_full() throws ConnectionException, TimeoutException, InterruptedException {
         cluster.getConfiguration().getPoolingOptions()
-            .setIdleTimeoutSeconds(20)
-            .setMinSimultaneousRequestsPerConnectionThreshold(HostDistance.LOCAL, 1)
-            .setMaxConnectionsPerHost(HostDistance.LOCAL, 128);
+            .setIdleTimeoutSeconds(20);
 
         HostConnectionPool pool = createPool(1, 2);
         PooledConnection core = pool.connections.get(0);
@@ -66,59 +117,187 @@ public class HostConnectionPoolTest extends CCMBridge.PerClassSingleNodeCluster 
         // Reaching 128 on the core connection should have triggered the creation of an extra one
         TimeUnit.MILLISECONDS.sleep(100);
         assertThat(pool.connections).hasSize(2);
-        PooledConnection extra1 = pool.connections.get(1);
-
-        assertThat(
-            pool.borrowConnection(100, MILLISECONDS)
-        ).isEqualTo(extra1);
-
-        // If the extra connection is returned it gets trashed
-        pool.returnConnection(extra1);
-        assertThat(pool.connections).hasSize(1);
-
-        // If the core connection gets returned we can borrow it again
-        pool.returnConnection(core);
-        assertThat(
-            pool.borrowConnection(100, MILLISECONDS)
-        ).isEqualTo(core);
     }
 
-    @Test(groups = "short")
+    /**
+     * Ensures that a trashed connection that has not been timed out should be resurrected into the connection pool if
+     * borrowConnection is called and a new connection is needed.
+     *
+     * @since 2.0.10, 2.1.6
+     * @jira_ticket JAVA-419
+     * @test_category connection:connection_pool
+     */
+    @Test(groups = "long")
     public void should_resurrect_trashed_connection_within_idle_timeout() throws ConnectionException, TimeoutException, InterruptedException {
         cluster.getConfiguration().getPoolingOptions()
-            .setIdleTimeoutSeconds(20)
-            .setMinSimultaneousRequestsPerConnectionThreshold(HostDistance.LOCAL, 1)
-            .setMaxConnectionsPerHost(HostDistance.LOCAL, 128);
+            .setIdleTimeoutSeconds(20);
 
         HostConnectionPool pool = createPool(1, 2);
-        PooledConnection core = pool.connections.get(0);
+        PooledConnection connection1 = pool.connections.get(0);
 
-        for (int i = 0; i < 128; i++)
-            assertThat(pool.borrowConnection(100, MILLISECONDS)).isEqualTo(core);
+        for (int i = 0; i < 101; i++)
+            assertThat(pool.borrowConnection(100, MILLISECONDS)).isEqualTo(connection1);
 
         TimeUnit.MILLISECONDS.sleep(100);
         assertThat(pool.connections).hasSize(2);
-        PooledConnection extra1 = pool.connections.get(1);
+        PooledConnection connection2 = pool.connections.get(1);
 
-        assertThat(pool.borrowConnection(100, MILLISECONDS)).isEqualTo(extra1);
-        pool.returnConnection(extra1);
-        assertThat(pool.connections).hasSize(1);
+        assertThat(connection1.inFlight.get()).isEqualTo(101);
+        assertThat(connection2.inFlight.get()).isEqualTo(0);
 
-        // extra1 is now in the trash, core still full
-        // Borrowing again should resurrect extra1 from the trash
-        assertThat(
-            pool.borrowConnection(100, MILLISECONDS)
-        ).isEqualTo(extra1);
-        assertThat(pool.connections).hasSize(2);
+        // Go back under the capacity of 1 connection
+        for (int i = 0; i < 51; i++)
+            pool.returnConnection(connection1);
+
+        assertThat(connection1.inFlight.get()).isEqualTo(50);
+        assertThat(connection2.inFlight.get()).isEqualTo(0);
+
+        // Given enough time, one connection gets trashed (and the implementation picks the first one)
+        TimeUnit.SECONDS.sleep(20);
+        assertThat(pool.connections).containsExactly(connection2);
+        assertThat(pool.trash).containsExactly(connection1);
+
+        // Now borrow enough to go just under the 1 connection threshold
+        for (int i = 0; i < 50; i++)
+            pool.borrowConnection(100, MILLISECONDS);
+
+        assertThat(pool.connections).containsExactly(connection2);
+        assertThat(pool.trash).containsExactly(connection1);
+        assertThat(connection1.inFlight.get()).isEqualTo(50);
+        assertThat(connection2.inFlight.get()).isEqualTo(50);
+
+        // Borrowing one more time should resurrect the trashed connection
+        pool.borrowConnection(100, MILLISECONDS);
+        TimeUnit.MILLISECONDS.sleep(100);
+
+        assertThat(pool.connections).containsExactly(connection2, connection1);
+        assertThat(pool.trash).isEmpty();
+        assertThat(connection1.inFlight.get()).isEqualTo(50);
+        assertThat(connection2.inFlight.get()).isEqualTo(51);
     }
 
+    /**
+     * Ensures that a trashed connection that has been timed out should not be resurrected into the connection pool if
+     * borrowConnection is called and a new connection is needed.
+     *
+     * @since 2.0.10, 2.1.6
+     * @jira_ticket JAVA-419
+     * @test_category connection:connection_pool
+     */
     @Test(groups = "long")
     public void should_not_resurrect_trashed_connection_after_idle_timeout() throws ConnectionException, TimeoutException, InterruptedException {
         cluster.getConfiguration().getPoolingOptions()
-            .setIdleTimeoutSeconds(20)
-            .setMinSimultaneousRequestsPerConnectionThreshold(HostDistance.LOCAL, 1)
-            .setMaxConnectionsPerHost(HostDistance.LOCAL, 128);
+            .setIdleTimeoutSeconds(20);
 
+        HostConnectionPool pool = createPool(1, 2);
+        PooledConnection connection1 = pool.connections.get(0);
+
+        for (int i = 0; i < 101; i++)
+            assertThat(pool.borrowConnection(100, MILLISECONDS)).isEqualTo(connection1);
+
+        TimeUnit.MILLISECONDS.sleep(100);
+        assertThat(pool.connections).hasSize(2);
+        PooledConnection connection2 = pool.connections.get(1);
+
+        assertThat(connection1.inFlight.get()).isEqualTo(101);
+        assertThat(connection2.inFlight.get()).isEqualTo(0);
+
+        // Go back under the capacity of 1 connection
+        for (int i = 0; i < 51; i++)
+            pool.returnConnection(connection1);
+
+        assertThat(connection1.inFlight.get()).isEqualTo(50);
+        assertThat(connection2.inFlight.get()).isEqualTo(0);
+
+        // Given enough time, one connection gets trashed (and the implementation picks the first one)
+        TimeUnit.SECONDS.sleep(20);
+        assertThat(pool.connections).containsExactly(connection2);
+        assertThat(pool.trash).containsExactly(connection1);
+
+        // Return trashed connection down to 0 inFlight
+        for (int i = 0; i < 50; i++)
+            pool.returnConnection(connection1);
+        assertThat(connection1.inFlight.get()).isEqualTo(0);
+
+        // Give enough time for trashed connection to be cleaned up from the trash:
+        TimeUnit.SECONDS.sleep(30);
+        assertThat(pool.connections).containsExactly(connection2);
+        assertThat(pool.trash).isEmpty();
+        assertThat(connection1.isClosed()).isTrue();
+
+        // Fill the live connection to go over the threshold where a second one is needed
+        for (int i = 0; i < 101; i++)
+            assertThat(pool.borrowConnection(100, TimeUnit.MILLISECONDS)).isEqualTo(connection2);
+        assertThat(connection2.inFlight.get()).isEqualTo(101);
+        TimeUnit.MILLISECONDS.sleep(100);
+
+        // Borrow again to get the new connection
+        PooledConnection connection3 = pool.borrowConnection(100, MILLISECONDS);
+        assertThat(connection3)
+            .isNotEqualTo(connection2) // should not be the full connection
+            .isNotEqualTo(connection1); // should not be the previously trashed one
+    }
+
+    /**
+     * Ensures that a trashed connection that has been timed out should not be closed until it has 0 in flight requests.
+     *
+     * @since 2.0.10, 2.1.6
+     * @jira_ticket JAVA-419
+     * @test_category connection:connection_pool
+     */
+    @Test(groups = "long")
+    public void should_not_close_trashed_connection_until_no_in_flight()
+        throws ConnectionException, TimeoutException, InterruptedException {
+        cluster.getConfiguration().getPoolingOptions()
+            .setIdleTimeoutSeconds(20);
+
+        HostConnectionPool pool = createPool(1, 2);
+        PooledConnection connection1 = pool.connections.get(0);
+
+        // Fill core connection enough to trigger creation of another one
+        for (int i = 0; i < 110; i++)
+            assertThat(pool.borrowConnection(100, MILLISECONDS)).isEqualTo(connection1);
+
+        TimeUnit.MILLISECONDS.sleep(100);
+        assertThat(pool.connections).hasSize(2);
+
+        // Return enough times to get back under the threshold where one connection is enough
+        for (int i = 0; i < 50; i++)
+            pool.returnConnection(connection1);
+
+        // Give enough time for one connection to be trashed. Due to the implementation, this will be the first one.
+        // It still has in-flight requests so should not get closed.
+        TimeUnit.SECONDS.sleep(30);
+        assertThat(pool.trash).containsExactly(connection1);
+        assertThat(connection1.inFlight.get()).isEqualTo(60);
+        assertThat(connection1.isClosed()).isFalse();
+
+        // Consume all inFlight requests on the trashed connection.
+        while (connection1.inFlight.get() > 0) {
+            pool.returnConnection(connection1);
+        }
+
+        // Sleep enough time for the connection to be consider idled and closed.
+        TimeUnit.SECONDS.sleep(30);
+
+        // The connection should be now closed.
+        // The trashed connection should be closed and not in the pool or trash.
+        assertThat(connection1.isClosed()).isTrue();
+        assertThat(pool.connections).doesNotContain(connection1);
+        assertThat(pool.trash).doesNotContain(connection1);
+    }
+
+    /**
+     * Ensures that if a connection that has less than the minimum available stream ids is returned to the pool that
+     * the connection is put in the trash.
+     *
+     * @since 2.0.10, 2.1.6
+     * @jira_ticket JAVA-419
+     * @test_category connection:connection_pool
+     */
+    @Test(groups = "short")
+    public void should_trash_on_returning_connection_with_insufficient_streams()
+        throws ConnectionException, TimeoutException, InterruptedException {
         HostConnectionPool pool = createPool(1, 2);
         PooledConnection core = pool.connections.get(0);
 
@@ -127,19 +306,27 @@ public class HostConnectionPoolTest extends CCMBridge.PerClassSingleNodeCluster 
 
         TimeUnit.MILLISECONDS.sleep(100);
         assertThat(pool.connections).hasSize(2);
-        PooledConnection extra1 = pool.connections.get(1);
 
-        assertThat(pool.borrowConnection(100, MILLISECONDS)).isEqualTo(extra1);
+        // Grab the new non-core connection and replace it with a spy.
+        PooledConnection extra1 = spy(pool.connections.get(1));
+        pool.connections.set(1, extra1);
+
+        // Borrow 10 times to ensure pool is utilized.
+        for (int i = 0; i < 10; i++) {
+            assertThat(pool.borrowConnection(100, MILLISECONDS)).isEqualTo(extra1);
+        }
+
+        // Return connection, it should not be trashed since it still has 9 inflight requests.
+        pool.returnConnection(extra1);
+        assertThat(pool.connections).hasSize(2);
+
+        // stub the maxAvailableStreams method to return 0, indicating there are no remaining streams.
+        // this should cause the connection to be replaced and trashed on returnConnection.
+        doReturn(0).when(extra1).maxAvailableStreams();
+
+        // On returning of the connection, should detect that there are no available streams and trash it.
         pool.returnConnection(extra1);
         assertThat(pool.connections).hasSize(1);
-
-        // Give enough time for extra1 to be cleaned up from the trash:
-        TimeUnit.SECONDS.sleep(30);
-
-        // Next borrow should create another connection
-        PooledConnection extra2 = pool.borrowConnection(100, MILLISECONDS);
-        assertThat(extra2).isNotEqualTo(extra1);
-        assertThat(extra1.isClosed()).isTrue();
     }
 
     private HostConnectionPool createPool(int coreConnections, int maxConnections) {
@@ -152,14 +339,15 @@ public class HostConnectionPoolTest extends CCMBridge.PerClassSingleNodeCluster 
     }
 
     /**
-     * Test for #JAVA-349 - Negative openConnection count results in broken connection release.
-     * <p/>
+     * <p>
      * This test uses a table named "Java349" with 1000 column and performs asynchronously 100k insertions. While the
      * insertions are being executed, the number of opened connection is monitored.
      * <p/>
      * If at anytime, the number of opened connections is negative, this test will fail.
      *
-     * @throws InterruptedException
+     * @since 2.0.6, 2.1.1
+     * @jira_ticket JAVA-349
+     * @test_category connection:connection_pool
      */
     @Test(groups = "long", enabled = false /* this test causes timeouts on Jenkins */)
     public void open_connections_metric_should_always_be_positive() throws InterruptedException {


### PR DESCRIPTION
Revised implementation to fix [JAVA-419](https://datastax-oss.atlassian.net/browse/JAVA-419): underused connections are trashed but not closed immediately; when we need a new connection, first look into the trash for one to resurrect.

@tolbertam: I'm creating a pull request so that you can contribute more tests if needed. The branch is on the main repo, so feel free to add your own commits, we'll squash everything together when we're done.
