### PR TITLE
use generics in QueryBuilder's API

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Clause.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Clause.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 
 public abstract class Clause extends Utils.Appendeable {
@@ -66,9 +65,9 @@ public abstract class Clause extends Utils.Appendeable {
 
     static class InClause extends AbstractClause {
 
-        private final List<Object> values;
+        private final List<?> values;
 
-        InClause(String name, List<Object> values) {
+        InClause(String name, List<?> values) {
             super(name);
             this.values = values;
 
@@ -114,9 +113,9 @@ public abstract class Clause extends Utils.Appendeable {
     static class CompoundClause extends Clause {
         private String op;
         private final List<String> names;
-        private final List<Object> values;
+        private final List<?> values;
 
-        CompoundClause(List<String> names, String op, List<Object> values) {
+        CompoundClause(List<String> names, String op, List<?> values) {
             assert names.size() == values.size();
             this.op = op;
             this.names = names;

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
@@ -15,8 +15,11 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import java.util.*;
-
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.TableMetadata;
 
@@ -295,7 +298,7 @@ public final class QueryBuilder {
      * @param values the values
      * @return the corresponding where clause.
      */
-	public static Clause in(String name, List<Object> values) {
+	public static Clause in(String name, List<?> values) {
 		return new Clause.InClause(name, values);
 	}
 
@@ -325,7 +328,7 @@ public final class QueryBuilder {
      *
      * @throws IllegalArgumentException if {@code names.size() != values.size()}.
      */
-    public static Clause lt(List<String> names, List<Object> values) {
+    public static Clause lt(List<String> names, List<?> values) {
         if (names.size() != values.size())
             throw new IllegalArgumentException(String.format("The number of names (%d) and values (%d) don't match", names.size(), values.size()));
 
@@ -358,7 +361,7 @@ public final class QueryBuilder {
      *
      * @throws IllegalArgumentException if {@code names.size() != values.size()}.
      */
-    public static Clause lte(List<String> names, List<Object> values) {
+    public static Clause lte(List<String> names, List<?> values) {
         if (names.size() != values.size())
             throw new IllegalArgumentException(String.format("The number of names (%d) and values (%d) don't match", names.size(), values.size()));
 
@@ -391,7 +394,7 @@ public final class QueryBuilder {
      *
      * @throws IllegalArgumentException if {@code names.size() != values.size()}.
      */
-    public static Clause gt(List<String> names, List<Object> values) {
+    public static Clause gt(List<String> names, List<?> values) {
         if (names.size() != values.size())
             throw new IllegalArgumentException(String.format("The number of names (%d) and values (%d) don't match", names.size(), values.size()));
 
@@ -424,7 +427,7 @@ public final class QueryBuilder {
      *
      * @throws IllegalArgumentException if {@code names.size() != values.size()}.
      */
-    public static Clause gte(List<String> names, List<Object> values) {
+    public static Clause gte(List<String> names, List<?> values) {
         if (names.size() != values.size())
             throw new IllegalArgumentException(String.format("The number of names (%d) and values (%d) don't match", names.size(), values.size()));
 

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
@@ -19,14 +19,16 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.regex.Pattern;
-
 import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.TupleValue;
 import com.datastax.driver.core.UDTValue;
-import com.datastax.driver.core.utils.Bytes;
 
 // Static utilities private to the query builder
 abstract class Utils {
@@ -51,7 +53,7 @@ abstract class Utils {
         return sb;
     }
 
-    static StringBuilder joinAndAppendValues(StringBuilder sb, String separator, List<Object> values, List<Object> variables) {
+    static StringBuilder joinAndAppendValues(StringBuilder sb, String separator, List<?> values, List<Object> variables) {
         for (int i = 0; i < values.size(); i++) {
             if (i > 0)
                 sb.append(separator);


### PR DESCRIPTION
The QueryBuilder uses generic Lists bound to Object, which is annoying to use from a client POV.
If I have a List<Something> with Something not being Object, I have to either copy my List to a 
List<Object> or using toArray() to then call the varargs overload of the method.

This PR changes the bound to the wildcard ( List<?> instead of List<Object> ) so the client are not forced 
to create wasteful copies of their List to workaround this limitation.

Existing client will not be impacted a method with List<?> as parameter may still be given a List<Object>.
