### PR TITLE
Added UpdatePolicy to Column annotation. Which offers more flexibility around how columns are updated 

### DIFF
--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
@@ -222,6 +222,11 @@ class AnnotationParser {
         return field.getName().toLowerCase();
     }
 
+    public static UpdatePolicy updatePolicy(Field field) {
+        Column appendMarker = field.getAnnotation(Column.class);
+        return appendMarker != null ? appendMarker.updatePolicy() : UpdatePolicy.OVERWRITE;
+    }
+
     public static <T> AccessorMapper<T> parseAccessor(Class<T> accClass, AccessorMapper.Factory factory, MappingManager mappingManager) {
         if (!accClass.isInterface())
             throw new IllegalArgumentException("@Accessor annotation is only allowed on interfaces");

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
@@ -217,6 +217,11 @@ class AnnotationParser {
         return field.getName().toLowerCase();
     }
 
+    public static UpdatePolicy updatePolicy(Field field) {
+        Column appendMarker = field.getAnnotation(Column.class);
+        return appendMarker != null ? appendMarker.updatePolicy() : UpdatePolicy.OVERWRITE;
+    }
+
     public static <T> AccessorMapper<T> parseAccessor(Class<T> accClass, AccessorMapper.Factory factory, MappingManager mappingManager) {
         if (!accClass.isInterface())
             throw new IllegalArgumentException("@Accessor annotation is only allowed on interfaces");

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/ColumnMapper.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/ColumnMapper.java
@@ -33,18 +33,20 @@ abstract class ColumnMapper<T> {
     protected final DataType dataType;
     protected final Kind kind;
     protected final int position;
+    protected final UpdatePolicy updatePolicy;
 
     protected ColumnMapper(Field field, DataType dataType, int position) {
-        this(AnnotationParser.columnName(field), field.getName(), field.getType(), dataType, AnnotationParser.kind(field), position);
+        this(AnnotationParser.columnName(field), field.getName(), field.getType(), dataType, AnnotationParser.kind(field), position, AnnotationParser.updatePolicy(field));
     }
 
-    private ColumnMapper(String columnName, String fieldName, Class<?> javaType, DataType dataType, Kind kind, int position) {
+    private ColumnMapper(String columnName, String fieldName, Class<?> javaType, DataType dataType, Kind kind, int position, UpdatePolicy updatePolicy) {
         this.columnName = columnName;
         this.fieldName = fieldName;
         this.javaType = javaType;
         this.dataType = dataType;
         this.kind = kind;
         this.position = position;
+        this.updatePolicy = updatePolicy;
     }
 
     public abstract Object getValue(T entity);
@@ -58,4 +60,7 @@ abstract class ColumnMapper<T> {
         return dataType;
     }
 
+    public UpdatePolicy updatePolicy() {
+        return updatePolicy;
+    }
 }

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/EntityMapper.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/EntityMapper.java
@@ -81,6 +81,10 @@ abstract class EntityMapper<T> {
         return allColumns;
     }
 
+    public List<ColumnMapper<T>> regularColumns() {
+        return regularColumns;
+    }
+
     interface Factory {
         public <T> EntityMapper<T> create(Class<T> entityClass, String keyspace, String table, ConsistencyLevel writeConsistency, ConsistencyLevel readConsistency);
         public <T> ColumnMapper<T> createColumnMapper(Class<T> componentClass, Field field, int position, MappingManager mappingManager);

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/UpdatePolicy.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/UpdatePolicy.java
@@ -1,0 +1,50 @@
+package com.datastax.driver.mapping;
+
+
+import com.datastax.driver.core.querybuilder.Assignment;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+
+/**
+ * UpdatePolicy determines how columns are updated in Cassandra
+ * @see com.datastax.driver.mapping.annotations.Column
+ */
+public enum UpdatePolicy {
+
+    /**
+     * The default UpdatePolicy, replaces the existing value that's currently stored in Cassandra
+     */
+    OVERWRITE {
+        @Override
+        public Assignment preparedAssignment(ColumnMapper<?> cm) {
+            return set(cm.getColumnName(), bindMarker());
+        }
+    },
+
+    /**
+     * For Collection types, append a value to what's currently stored in Cassandra
+     */
+    APPEND {
+        @Override
+        public Assignment preparedAssignment(ColumnMapper<?> cm) {
+            return append(cm.getColumnName(), bindMarker());
+        }
+    },
+
+    /**
+     * For List types, adds a value to the head of the List with what's currently stored in Cassandra
+     */
+    PREPEND {
+        @Override
+        public Assignment preparedAssignment(ColumnMapper<?> cm) {
+            return prepend(cm.getColumnName(), bindMarker());
+        }
+    };
+
+    /**
+     * Using the QueryBuilder, returns a preparedStatement Assignment for the given ColumnMapper
+     * @param cm The ColumnMapper to apply the Assignment to
+     * @return the Assignment
+     */
+    public abstract Assignment preparedAssignment(ColumnMapper<?> cm);
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/Column.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/Column.java
@@ -15,6 +15,8 @@
  */
 package com.datastax.driver.mapping.annotations;
 
+import com.datastax.driver.mapping.UpdatePolicy;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -42,6 +44,12 @@ public @interface Column {
      * the field name.
      */
     String name() default "";
+
+    /**
+     * Determines how updates should be applied.
+     * @return true of the column should be appended to on write.
+     */
+    UpdatePolicy updatePolicy() default UpdatePolicy.OVERWRITE;
 
     /**
      * Whether the column name is a case sensitive one.

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/Column.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/Column.java
@@ -46,8 +46,8 @@ public @interface Column {
     String name() default "";
 
     /**
-     * Determines how updates should be applied.
-     * @return true of the column should be appended to on write.
+     * Determines how updates should be applied to this column.
+     * @return the update policy for this Column
      */
     UpdatePolicy updatePolicy() default UpdatePolicy.OVERWRITE;
 


### PR DESCRIPTION
Hello DataStax java-driver team,

We had a use case where we wanted to append to a column that's a Collection type without first reading from cassandra. This pull request has our solution to that use case. We added a UpdatePolicy attribute to the Column annotation that lets you decide how it's handled (APPEND, PREPEND, OVERWRITE). The default of course is the current behavior of overwrite. This would be awesome if you could include this in the main line.

Thanks,

-Brandon
