### PR TITLE
Support C* 2.1.3 nested collections (JAVA-570)

### DIFF
--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -4,7 +4,11 @@ CHANGELOG
 2.1.5:
 ------
 
+- [bug] Fix checks on mapped collection types (JAVA-612)
 - [bug] Authorize Null parameter in Accessor method (JAVA-575)
+- [improvement] Support C* 2.1.3's nested collections (JAVA-570)
+- [bug] Fix checks on mapped collection types (JAVA-612)
+- [bug] Fix QueryBuilder.putAll() when the collection contains UDTs (JAVA-672)
 
 Merged from 2.0 branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractGettableData.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractGettableData.java
@@ -21,6 +21,8 @@ import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.*;
 
+import com.google.common.reflect.TypeToken;
+
 public abstract class AbstractGettableData extends AbstractGettableByIndexData implements GettableData {
 
     /**
@@ -181,6 +183,14 @@ public abstract class AbstractGettableData extends AbstractGettableByIndexData i
      * {@inheritDoc}
      */
     @Override
+    public <T> List<T> getList(String name, TypeToken<T> elementsType) {
+        return getList(getIndexOf(name), elementsType);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public <T> Set<T> getSet(String name, Class<T> elementsClass) {
         return getSet(getIndexOf(name), elementsClass);
     }
@@ -189,8 +199,24 @@ public abstract class AbstractGettableData extends AbstractGettableByIndexData i
      * {@inheritDoc}
      */
     @Override
+    public <T> Set<T> getSet(String name, TypeToken<T> elementsType) {
+        return getSet(getIndexOf(name), elementsType);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public <K, V> Map<K, V> getMap(String name, Class<K> keysClass, Class<V> valuesClass) {
         return getMap(getIndexOf(name), keysClass, valuesClass);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <K, V> Map<K, V> getMap(String name, TypeToken<K> keysType, TypeToken<V> valuesType) {
+        return getMap(getIndexOf(name), keysType, valuesType);
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -21,6 +21,8 @@ import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.*;
 
+import com.google.common.reflect.TypeToken;
+
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 
 /**
@@ -1241,8 +1243,22 @@ public class BoundStatement extends Statement implements SettableData<BoundState
     /**
      * {@inheritDoc}
      */
+    public <T> List<T> getList(int i, TypeToken<T> elementsType) {
+        return wrapper.getList(i, elementsType);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public <T> List<T> getList(String name, Class<T> elementsClass) {
         return wrapper.getList(name, elementsClass);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public <T> List<T> getList(String name, TypeToken<T> elementsType) {
+        return wrapper.getList(name, elementsType);
     }
 
     /**
@@ -1255,8 +1271,22 @@ public class BoundStatement extends Statement implements SettableData<BoundState
     /**
      * {@inheritDoc}
      */
+    public <T> Set<T> getSet(int i, TypeToken<T> elementsType) {
+        return wrapper.getSet(i, elementsType);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public <T> Set<T> getSet(String name, Class<T> elementsClass) {
         return wrapper.getSet(name, elementsClass);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public <T> Set<T> getSet(String name, TypeToken<T> elementsType) {
+        return wrapper.getSet(name, elementsType);
     }
 
     /**
@@ -1269,8 +1299,22 @@ public class BoundStatement extends Statement implements SettableData<BoundState
     /**
      * {@inheritDoc}
      */
+    public <K, V> Map<K, V> getMap(int i, TypeToken<K> keysType, TypeToken<V> valuesType) {
+        return wrapper.getMap(i, keysType, valuesType);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public <K, V> Map<K, V> getMap(String name, Class<K> keysClass, Class<V> valuesClass) {
         return wrapper.getMap(name, keysClass, valuesClass);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public <K, V> Map<K, V> getMap(String name, TypeToken<K> keysType, TypeToken<V> valuesType) {
+        return wrapper.getMap(name, keysType, valuesType);
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/CassandraTypeParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CassandraTypeParser.java
@@ -18,6 +18,8 @@ package com.datastax.driver.core;
 import java.util.*;
 
 import com.google.common.collect.ImmutableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.datastax.driver.core.exceptions.DriverInternalError;
 import com.datastax.driver.core.utils.Bytes;
@@ -35,8 +37,10 @@ import com.datastax.driver.core.utils.Bytes;
  * so there shouldn't be anything wrong with them.
  */
 class CassandraTypeParser {
+    private static final Logger logger = LoggerFactory.getLogger(CassandraTypeParser.class);
 
     private static final String REVERSED_TYPE = "org.apache.cassandra.db.marshal.ReversedType";
+    private static final String FROZEN_TYPE = "org.apache.cassandra.db.marshal.FrozenType";
     private static final String COMPOSITE_TYPE = "org.apache.cassandra.db.marshal.CompositeType";
     private static final String COLLECTION_TYPE = "org.apache.cassandra.db.marshal.ColumnToCollectionType";
     private static final String LIST_TYPE = "org.apache.cassandra.db.marshal.ListType";
@@ -66,29 +70,32 @@ class CassandraTypeParser {
             .build();
 
     static DataType parseOne(String className) {
+        boolean frozen = false;
         if (isReversed(className)) {
             // Just skip the ReversedType part, we don't care
-            Parser p = new Parser(className, 0);
-            p.parseNextName();
-            List<String> l = p.getTypeParameters();
-            if (l.size() != 1)
-                throw new IllegalStateException();
-            className = l.get(0);
+            className = getNestedClassName(className);
+        } else if (isFrozen(className)) {
+            frozen = true;
+            className = getNestedClassName(className);
         }
 
         Parser parser = new Parser(className, 0);
         String next = parser.parseNextName();
 
         if (next.startsWith(LIST_TYPE))
-            return DataType.list(parseOne(parser.getTypeParameters().get(0)));
+            return DataType.list(parseOne(parser.getTypeParameters().get(0)), frozen);
 
         if (next.startsWith(SET_TYPE))
-            return DataType.set(parseOne(parser.getTypeParameters().get(0)));
+            return DataType.set(parseOne(parser.getTypeParameters().get(0)), frozen);
 
         if (next.startsWith(MAP_TYPE)) {
             List<String> params = parser.getTypeParameters();
-            return DataType.map(parseOne(params.get(0)), parseOne(params.get(1)));
+            return DataType.map(parseOne(params.get(0)), parseOne(params.get(1)), frozen);
         }
+
+        if (frozen)
+            logger.warn("Got o.a.c.db.marshal.FrozenType for something else than a collection, "
+                + "this driver version might be too old for your version of Cassandra");
 
         if (isUserType(next)) {
             ++parser.idx; // skipping '('
@@ -119,6 +126,20 @@ class CassandraTypeParser {
 
     public static boolean isReversed(String className) {
         return className.startsWith(REVERSED_TYPE);
+    }
+
+    public static boolean isFrozen(String className) {
+        return className.startsWith(FROZEN_TYPE);
+    }
+
+    private static String getNestedClassName(String className) {
+        Parser p = new Parser(className, 0);
+        p.parseNextName();
+        List<String> l = p.getTypeParameters();
+        if (l.size() != 1)
+            throw new IllegalStateException();
+        className = l.get(0);
+        return className;
     }
 
     public static boolean isUserType(String className) {

--- a/driver-core/src/main/java/com/datastax/driver/core/DataType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataType.java
@@ -24,6 +24,7 @@ import java.util.*;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.TypeToken;
 import org.jboss.netty.buffer.ChannelBuffer;
 
 import com.datastax.driver.core.exceptions.DriverInternalError;
@@ -163,26 +164,6 @@ public abstract class DataType {
 
     protected DataType(DataType.Name name) {
         this.name = name;
-    }
-
-
-    /**
-     * Returns whether this data type is frozen.
-     * <p>
-     * This applies to User Defined Types, tuples and nested collections. Frozen types are serialized as a single value in
-     * Cassandra's storage engine, whereas non-frozen types are stored in a form that allows updates to individual subfields.
-     *
-     * @return whether this data type is frozen.
-     */
-    public boolean isFrozen() {
-        // With Cassandra 2.1.0, this is straightforward; in future versions, "frozenness" will be stored in the database.
-        switch (name) {
-            case UDT:
-            case TUPLE:
-                return true;
-            default:
-                return false;
-        }
     }
 
     static DataType decode(ChannelBuffer buffer) {
@@ -374,23 +355,70 @@ public abstract class DataType {
      * Returns the type of lists of {@code elementType} elements.
      *
      * @param elementType the type of the list elements.
+     * @param frozen whether the list is frozen.
      * @return the type of lists of {@code elementType} elements.
      */
+    public static DataType list(DataType elementType, boolean frozen) {
+        return new DataType.Collection(Name.LIST, ImmutableList.of(elementType), frozen);
+    }
+
+    /**
+     * Returns the type of lists of "not frozen" {@code elementType} elements.
+     * <p>
+     * This is a shorthand for {@code list(elementType, false);}.
+     *
+     * @param elementType the type of the list elements.
+     * @return the type of lists of "not frozen" {@code elementType} elements.
+     */
     public static DataType list(DataType elementType) {
-        // TODO: for list, sets and maps, we could cache them (may or may not be worth it, but since we
-        // don't allow nesting of collections, even pregenerating all the lists/sets like we do for
-        // primitives wouldn't be very costly)
-        return new DataType.Collection(Name.LIST, ImmutableList.of(elementType));
+        return list(elementType, false);
+    }
+
+    /**
+     * Returns the type of lists of frozen {@code elementType} elements.
+     * <p>
+     * This is a shorthand for {@code list(elementType, true);}.
+     *
+     * @param elementType the type of the list elements.
+     * @return the type of lists of frozen {@code elementType} elements.
+     */
+    public static DataType frozenList(DataType elementType) {
+        return list(elementType, true);
     }
 
     /**
      * Returns the type of sets of {@code elementType} elements.
      *
      * @param elementType the type of the set elements.
+     * @param frozen whether the set is frozen.
      * @return the type of sets of {@code elementType} elements.
      */
+    public static DataType set(DataType elementType, boolean frozen) {
+        return new DataType.Collection(Name.SET, ImmutableList.of(elementType), frozen);
+    }
+
+    /**
+     * Returns the type of "not frozen" sets of {@code elementType} elements.
+     * <p>
+     * This is a shorthand for {@code set(elementType, false);}.
+     *
+     * @param elementType the type of the set elements.
+     * @return the type of sets of "not frozen" {@code elementType} elements.
+     */
     public static DataType set(DataType elementType) {
-        return new DataType.Collection(Name.SET, ImmutableList.of(elementType));
+        return set(elementType, false);
+    }
+
+    /**
+     * Returns the type of frozen sets of {@code elementType} elements.
+     * <p>
+     * This is a shorthand for {@code set(elementType, true);}.
+     *
+     * @param elementType the type of the set elements.
+     * @return the type of frozen sets of {@code elementType} elements.
+     */
+    public static DataType frozenSet(DataType elementType) {
+        return set(elementType, true);
     }
 
     /**
@@ -398,10 +426,37 @@ public abstract class DataType {
      *
      * @param keyType the type of the map keys.
      * @param valueType the type of the map values.
-     * @return the type of map of {@code keyType} to {@code valueType} elements.
+     * @param frozen whether the map is frozen.
+     * @return the type of maps of {@code keyType} to {@code valueType} elements.
+     */
+    public static DataType map(DataType keyType, DataType valueType, boolean frozen) {
+        return new DataType.Collection(Name.MAP, ImmutableList.of(keyType, valueType), frozen);
+    }
+
+    /**
+     * Returns the type of "not frozen" maps of {@code keyType} to {@code valueType} elements.
+     * <p>
+     * This is a shorthand for {@code map(keyType, valueType, false);}.
+     *
+     * @param keyType the type of the map keys.
+     * @param valueType the type of the map values.
+     * @return the type of "not frozen" maps of {@code keyType} to {@code valueType} elements.
      */
     public static DataType map(DataType keyType, DataType valueType) {
-        return new DataType.Collection(Name.MAP, ImmutableList.of(keyType, valueType));
+        return map(keyType, valueType, false);
+    }
+
+    /**
+     * Returns the type of frozen maps of {@code keyType} to {@code valueType} elements.
+     * <p>
+     * This is a shorthand for {@code map(keyType, valueType, true);}.
+     *
+     * @param keyType the type of the map keys.
+     * @param valueType the type of the map values.
+     * @return the type of frozen maps of {@code keyType} to {@code valueType} elements.
+     */
+    public static DataType frozenMap(DataType keyType, DataType valueType) {
+        return map(keyType, valueType, true);
     }
 
     /**
@@ -434,6 +489,16 @@ public abstract class DataType {
     }
 
     /**
+     * Returns whether this data type is frozen.
+     * <p>
+     * This applies to User Defined Types, tuples and nested collections. Frozen types are serialized as a single value in
+     * Cassandra's storage engine, whereas non-frozen types are stored in a form that allows updates to individual subfields.
+     *
+     * @return whether this data type is frozen.
+     */
+    public abstract boolean isFrozen();
+
+    /**
      * Returns the type arguments of this type.
      * <p>
      * Note that only the collection types (LIST, MAP, SET) have type
@@ -453,6 +518,8 @@ public abstract class DataType {
     public List<DataType> getTypeArguments() {
         return Collections.<DataType>emptyList();
     }
+
+    abstract boolean canBeDeserializedAs(TypeToken typeToken);
 
     /**
      * Returns the server-side class name for a custom type.
@@ -694,6 +761,16 @@ public abstract class DataType {
         }
 
         @Override
+        public boolean isFrozen() {
+            return false;
+        }
+
+        @Override
+        boolean canBeDeserializedAs(TypeToken typeToken) {
+            return typeToken.isAssignableFrom(getName().javaType);
+        }
+
+        @Override
         TypeCodec<Object> codec(ProtocolVersion protocolVersion) {
             return TypeCodec.createFor(name);
         }
@@ -725,10 +802,35 @@ public abstract class DataType {
     private static class Collection extends DataType {
 
         private final List<DataType> typeArguments;
+        private boolean frozen;
 
-        private Collection(DataType.Name name, List<DataType> typeArguments) {
+        private Collection(DataType.Name name, List<DataType> typeArguments, boolean frozen) {
             super(name);
             this.typeArguments = typeArguments;
+            this.frozen = frozen;
+        }
+
+        @Override
+        public boolean isFrozen() {
+            return frozen;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        boolean canBeDeserializedAs(TypeToken typeToken) {
+            switch (name) {
+                case LIST:
+                    return typeToken.getRawType().isAssignableFrom(List.class) &&
+                        typeArguments.get(0).canBeDeserializedAs(typeToken.resolveType(typeToken.getRawType().getTypeParameters()[0]));
+                case SET:
+                    return typeToken.getRawType().isAssignableFrom(Set.class) &&
+                        typeArguments.get(0).canBeDeserializedAs(typeToken.resolveType(typeToken.getRawType().getTypeParameters()[0]));
+                case MAP:
+                    return typeToken.getRawType().isAssignableFrom(Map.class) &&
+                        typeArguments.get(0).canBeDeserializedAs(typeToken.resolveType(typeToken.getRawType().getTypeParameters()[0])) &&
+                        typeArguments.get(1).canBeDeserializedAs(typeToken.resolveType(typeToken.getRawType().getTypeParameters()[1]));
+            }
+            throw new AssertionError();
         }
 
         @SuppressWarnings("unchecked")
@@ -764,10 +866,14 @@ public abstract class DataType {
 
         @Override
         public String toString() {
-            if (name == Name.MAP)
-                return String.format("%s<%s, %s>", name, typeArguments.get(0), typeArguments.get(1));
-            else
-                return String.format("%s<%s>", name, typeArguments.get(0));
+            if (name == Name.MAP) {
+                String template = frozen ? "frozen<%s<%s, %s>>" : "%s<%s, %s>";
+                return String.format(template, name, typeArguments.get(0), typeArguments.get(1));
+            }
+            else {
+                String template = frozen ? "frozen<%s<%s>>" : "%s<%s>";
+                return String.format(template, name, typeArguments.get(0));
+            }
         }
     }
 
@@ -778,6 +884,16 @@ public abstract class DataType {
         private Custom(DataType.Name name, String className) {
             super(name);
             this.customClassName = className;
+        }
+
+        @Override
+        public boolean isFrozen() {
+            return false;
+        }
+
+        @Override
+        boolean canBeDeserializedAs(TypeToken typeToken) {
+            return typeToken.getRawType().getName().equals(customClassName);
         }
 
         @SuppressWarnings("unchecked")

--- a/driver-core/src/main/java/com/datastax/driver/core/GettableByIndexData.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/GettableByIndexData.java
@@ -21,6 +21,8 @@ import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.*;
 
+import com.google.common.reflect.TypeToken;
+
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 
 /**
@@ -206,54 +208,127 @@ public interface GettableByIndexData {
 
     /**
      * Returns the {@code i}th value as a list.
+     * <p>
+     * If the type of the elements is generic, use {@link #getList(int, TypeToken)}.
      *
      * @param i the index ({@code 0 <= i < size()}) to retrieve.
      * @param elementsClass the class for the elements of the list to retrieve.
      * @return the value of the {@code i}th element as a list of
-     * {@code elementsClass} objects. If the value is NULL, an empty list is
+     * {@code T} objects. If the value is NULL, an empty list is
      * returned (note that Cassandra makes no difference between an empty list
      * and column of type list that is not set). The returned list is immutable.
      *
      * @throws IndexOutOfBoundsException if {@code i} is not a valid index for this object.
      * @throws InvalidTypeException if value {@code i} is not a list or if its
-     * elements are not of class {@code elementsClass}.
+     * elements are not of class {@code T}.
      */
     public <T> List<T> getList(int i, Class<T> elementsClass);
 
     /**
+     * Returns the {@code i}th value as a list.
+     * <p>
+     * Use this variant with nested collections, which produce a generic element type:
+     * <pre>
+     * {@code List<List<String>> l = row.getList(1, new TypeToken<List<String>>() {});}
+     * </pre>
+     *
+     * @param i the index ({@code 0 <= i < size()}) to retrieve.
+     * @param elementsType the type of the elements of the list to retrieve.
+     * @return the value of the {@code i}th element as a list of
+     * {@code T} objects. If the value is NULL, an empty list is
+     * returned (note that Cassandra makes no difference between an empty list
+     * and column of type list that is not set). The returned list is immutable.
+     *
+     * @throws IndexOutOfBoundsException if {@code i} is not a valid index for this object.
+     * @throws InvalidTypeException if value {@code i} is not a list or if its
+     * elements are not of class {@code T}.
+     */
+    public <T> List<T> getList(int i, TypeToken<T> elementsType);
+
+    /**
      * Returns the {@code i}th value as a set.
+     * <p>
+     * If the type of the elements is generic, use {@link #getSet(int, TypeToken)}.
      *
      * @param i the index ({@code 0 <= i < size()}) to retrieve.
      * @param elementsClass the class for the elements of the set to retrieve.
      * @return the value of the {@code i}th element as a set of
-     * {@code elementsClass} objects. If the value is NULL, an empty set is
+     * {@code T} objects. If the value is NULL, an empty set is
      * returned (note that Cassandra makes no difference between an empty set
      * and column of type set that is not set). The returned set is immutable.
      *
      * @throws IndexOutOfBoundsException if {@code i} is not a valid index for this object.
      * @throws InvalidTypeException if value {@code i} is not a set or if its
-     * elements are not of class {@code elementsClass}.
+     * elements are not of class {@code T}.
      */
     public <T> Set<T> getSet(int i, Class<T> elementsClass);
 
     /**
+     * Returns the {@code i}th value as a set.
+     * <p>
+     * Use this variant with nested collections, which produce a generic element type:
+     * <pre>
+     * {@code Set<List<String>> l = row.getSet(1, new TypeToken<List<String>>() {});}
+     * </pre>
+     *
+     * @param i the index ({@code 0 <= i < size()}) to retrieve.
+     * @param elementsType the type for the elements of the set to retrieve.
+     * @return the value of the {@code i}th element as a set of
+     * {@code T} objects. If the value is NULL, an empty set is
+     * returned (note that Cassandra makes no difference between an empty set
+     * and column of type set that is not set). The returned set is immutable.
+     *
+     * @throws IndexOutOfBoundsException if {@code i} is not a valid index for this object.
+     * @throws InvalidTypeException if value {@code i} is not a set or if its
+     * elements are not of class {@code T}.
+     */
+    public <T> Set<T> getSet(int i, TypeToken<T> elementsType);
+
+    /**
      * Returns the {@code i}th value as a map.
+     * <p>
+     * If the type of the keys and/or values is generic, use {@link #getMap(int, TypeToken, TypeToken)}.
      *
      * @param i the index ({@code 0 <= i < size()}) to retrieve.
      * @param keysClass the class for the keys of the map to retrieve.
      * @param valuesClass the class for the values of the map to retrieve.
      * @return the value of the {@code i}th element as a map of
-     * {@code keysClass} to {@code valuesClass} objects. If the value is NULL,
+     * {@code K} to {@code V} objects. If the value is NULL,
      * an empty map is returned (note that Cassandra makes no difference
      * between an empty map and column of type map that is not set). The
      * returned map is immutable.
      *
      * @throws IndexOutOfBoundsException if {@code i} is not a valid index for this object.
      * @throws InvalidTypeException if value {@code i} is not a map, if its
-     * keys are not of class {@code keysClass} or if its values are not of
-     * class {@code valuesClass}.
+     * keys are not of class {@code K} or if its values are not of
+     * class {@code V}.
      */
     public <K, V> Map<K, V> getMap(int i, Class<K> keysClass, Class<V> valuesClass);
+
+
+    /**
+     * Returns the {@code i}th value as a map.
+     * <p>
+     * Use this variant with nested collections, which produce a generic element type:
+     * <pre>
+     * {@code Map<Int, List<String>> l = row.getMap(1, TypeToken.of(Integer.class), new TypeToken<List<String>>() {});}
+     * </pre>
+     *
+     * @param i the index ({@code 0 <= i < size()}) to retrieve.
+     * @param keysType the type for the keys of the map to retrieve.
+     * @param valuesType the type for the values of the map to retrieve.
+     * @return the value of the {@code i}th element as a map of
+     * {@code K} to {@code V} objects. If the value is NULL,
+     * an empty map is returned (note that Cassandra makes no difference
+     * between an empty map and column of type map that is not set). The
+     * returned map is immutable.
+     *
+     * @throws IndexOutOfBoundsException if {@code i} is not a valid index for this object.
+     * @throws InvalidTypeException if value {@code i} is not a map, if its
+     * keys are not of class {@code K} or if its values are not of
+     * class {@code V}.
+     */
+    public <K, V> Map<K, V> getMap(int i, TypeToken<K> keysType, TypeToken<V> valuesType);
 
     /**
      * Return the {@code i}th value as a UDT value.

--- a/driver-core/src/main/java/com/datastax/driver/core/GettableByNameData.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/GettableByNameData.java
@@ -21,6 +21,8 @@ import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.*;
 
+import com.google.common.reflect.TypeToken;
+
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 
 /**
@@ -206,54 +208,126 @@ public interface GettableByNameData {
 
     /**
      * Returns the value for {@code name} as a list.
+     * <p>
+     * If the type of the elements is generic, use {@link #getList(String, TypeToken)}.
      *
      * @param name the name to retrieve.
      * @param elementsClass the class for the elements of the list to retrieve.
      * @return the value of the {@code i}th element as a list of
-     * {@code elementsClass} objects. If the value is NULL, an empty list is
+     * {@code T} objects. If the value is NULL, an empty list is
      * returned (note that Cassandra makes no difference between an empty list
      * and column of type list that is not set). The returned list is immutable.
      *
      * @throws IllegalArgumentException if {@code name} is not valid name for this object.
      * @throws InvalidTypeException if value {@code name} is not a list or if its
-     * elements are not of class {@code elementsClass}.
+     * elements are not of class {@code T}.
      */
     public <T> List<T> getList(String name, Class<T> elementsClass);
 
     /**
+     * Returns the value for {@code name} as a list.
+     * <p>
+     * Use this variant with nested collections, which produce a generic element type:
+     * <pre>
+     * {@code List<List<String>> l = row.getList("theColumn", new TypeToken<List<String>>() {});}
+     * </pre>
+     *
+     * @param name the name to retrieve.
+     * @param elementsType the type for the elements of the list to retrieve.
+     * @return the value of the {@code i}th element as a list of
+     * {@code T} objects. If the value is NULL, an empty list is
+     * returned (note that Cassandra makes no difference between an empty list
+     * and column of type list that is not set). The returned list is immutable.
+     *
+     * @throws IllegalArgumentException if {@code name} is not valid name for this object.
+     * @throws InvalidTypeException if value {@code name} is not a list or if its
+     * elements are not of class {@code T}.
+     */
+    public <T> List<T> getList(String name, TypeToken<T> elementsType);
+
+    /**
      * Returns the value for {@code name} as a set.
+     * <p>
+     * If the type of the elements is generic, use {@link #getSet(String, TypeToken)}.
      *
      * @param name the name to retrieve.
      * @param elementsClass the class for the elements of the set to retrieve.
      * @return the value of the {@code i}th element as a set of
-     * {@code elementsClass} objects. If the value is NULL, an empty set is
+     * {@code T} objects. If the value is NULL, an empty set is
      * returned (note that Cassandra makes no difference between an empty set
      * and column of type set that is not set). The returned set is immutable.
      *
      * @throws IllegalArgumentException if {@code name} is not valid name for this object.
      * @throws InvalidTypeException if value {@code name} is not a set or if its
-     * elements are not of class {@code elementsClass}.
+     * elements are not of class {@code T}.
      */
     public <T> Set<T> getSet(String name, Class<T> elementsClass);
 
     /**
+     * Returns the value for {@code name} as a set.
+     * <p>
+     * Use this variant with nested collections, which produce a generic element type:
+     * <pre>
+     * {@code Set<List<String>> l = row.getSet("theColumn", new TypeToken<List<String>>() {});}
+     * </pre>
+     *
+     * @param name the name to retrieve.
+     * @param elementsType the type for the elements of the set to retrieve.
+     * @return the value of the {@code i}th element as a set of
+     * {@code T} objects. If the value is NULL, an empty set is
+     * returned (note that Cassandra makes no difference between an empty set
+     * and column of type set that is not set). The returned set is immutable.
+     *
+     * @throws IllegalArgumentException if {@code name} is not valid name for this object.
+     * @throws InvalidTypeException if value {@code name} is not a set or if its
+     * elements are not of class {@code T}.
+     */
+    public <T> Set<T> getSet(String name, TypeToken<T> elementsType);
+
+    /**
      * Returns the value for {@code name} as a map.
+     * <p>
+     * If the type of the keys and/or values is generic, use {@link #getMap(String, TypeToken, TypeToken)}.
      *
      * @param name the name to retrieve.
      * @param keysClass the class for the keys of the map to retrieve.
      * @param valuesClass the class for the values of the map to retrieve.
      * @return the value of {@code name} as a map of
-     * {@code keysClass} to {@code valuesClass} objects. If the value is NULL,
+     * {@code K} to {@code V} objects. If the value is NULL,
      * an empty map is returned (note that Cassandra makes no difference
      * between an empty map and column of type map that is not set). The
      * returned map is immutable.
      *
      * @throws IllegalArgumentException if {@code name} is not valid name for this object.
      * @throws InvalidTypeException if value {@code name} is not a map, if its
-     * keys are not of class {@code keysClass} or if its values are not of
-     * class {@code valuesClass}.
+     * keys are not of class {@code K} or if its values are not of
+     * class {@code V}.
      */
     public <K, V> Map<K, V> getMap(String name, Class<K> keysClass, Class<V> valuesClass);
+
+    /**
+     * Returns the value for {@code name} as a map.
+     * <p>
+     * Use this variant with nested collections, which produce a generic element type:
+     * <pre>
+     * {@code Map<Int, List<String>> l = row.getMap("theColumn", TypeToken.of(Integer.class), new TypeToken<List<String>>() {});}
+     * </pre>
+     *
+     * @param name the name to retrieve.
+     * @param keysType the class for the keys of the map to retrieve.
+     * @param valuesType the class for the values of the map to retrieve.
+     * @return the value of {@code name} as a map of
+     * {@code K} to {@code V} objects. If the value is NULL,
+     * an empty map is returned (note that Cassandra makes no difference
+     * between an empty map and column of type map that is not set). The
+     * returned map is immutable.
+     *
+     * @throws IllegalArgumentException if {@code name} is not valid name for this object.
+     * @throws InvalidTypeException if value {@code name} is not a map, if its
+     * keys are not of class {@code K} or if its values are not of
+     * class {@code V}.
+     */
+    public <K, V> Map<K, V> getMap(String name, TypeToken<K> keysType, TypeToken<V> valuesType);
 
     /**
      * Return the value for {@code name} as a UDT value.

--- a/driver-core/src/main/java/com/datastax/driver/core/TupleType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TupleType.java
@@ -18,6 +18,7 @@ package com.datastax.driver.core;
 import java.util.*;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeToken;
 
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 
@@ -100,6 +101,16 @@ public class TupleType extends DataType {
     }
 
     @Override
+    public boolean isFrozen() {
+        return true;
+    }
+
+    @Override
+    boolean canBeDeserializedAs(TypeToken typeToken) {
+        return typeToken.isAssignableFrom(getName().javaType);
+    }
+
+    @Override
     public int hashCode() {
         return Arrays.hashCode(new Object[]{ name, types });
     }
@@ -117,9 +128,9 @@ public class TupleType extends DataType {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         for (DataType type : types) {
-            sb.append(sb.length() == 0 ? "tuple<" : ", ");
+            sb.append(sb.length() == 0 ? "frozen<tuple<" : ", ");
             sb.append(type);
         }
-        return sb.append(">").toString();
+        return sb.append(">>").toString();
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/UserType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/UserType.java
@@ -19,6 +19,7 @@ import java.util.*;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
+import com.google.common.reflect.TypeToken;
 
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 
@@ -167,6 +168,16 @@ public class UserType extends DataType implements Iterable<UserType.Field>{
     }
 
     @Override
+    public boolean isFrozen() {
+        return true;
+    }
+
+    @Override
+    boolean canBeDeserializedAs(TypeToken typeToken) {
+        return typeToken.isAssignableFrom(getName().javaType);
+    }
+
+    @Override
     public final int hashCode() {
         return Arrays.hashCode(new Object[]{ name, keyspace, typeName, byIdx });
     }
@@ -225,12 +236,12 @@ public class UserType extends DataType implements Iterable<UserType.Field>{
             TableMetadata.newLine(sb, formatted);
         }
 
-        return sb.append(')').toString();
+        return sb.append(");").toString();
     }
 
     @Override
     public String toString() {
-        return Metadata.escapeId(getKeyspace()) + '.' + Metadata.escapeId(getTypeName());
+        return "frozen<" + Metadata.escapeId(getKeyspace()) + '.' + Metadata.escapeId(getTypeName()) + ">";
     }
 
     // We don't want to expose that, it's already exposed through DataType.parse

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -361,7 +360,7 @@ public class Delete extends BuiltStatement {
             StringBuilder sb = new StringBuilder();
             Utils.appendName(columnName, sb);
             sb.append('[');
-            Utils.appendFlatValue(key, sb);
+            Utils.appendValue(key, sb);
             return column(sb.append(']').toString());
         }
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
@@ -26,7 +26,6 @@ import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.TupleValue;
 import com.datastax.driver.core.UDTValue;
-import com.datastax.driver.core.utils.Bytes;
 
 // Static utilities private to the query builder
 abstract class Utils {
@@ -96,7 +95,7 @@ abstract class Utils {
         return sb;
     }
 
-    private static StringBuilder appendValue(Object value, StringBuilder sb) {
+    static StringBuilder appendValue(Object value, StringBuilder sb) {
         // That is kind of lame but lacking a better solution
         if (appendValueIfLiteral(value, sb))
             return sb;
@@ -108,14 +107,6 @@ abstract class Utils {
             return sb;
 
         if (appendValueIfTuple(value, sb))
-            return sb;
-
-        appendStringIfValid(value, sb);
-        return sb;
-    }
-
-    static StringBuilder appendFlatValue(Object value, StringBuilder sb) {
-        if (appendValueIfLiteral(value, sb))
             return sb;
 
         appendStringIfValid(value, sb);
@@ -205,7 +196,7 @@ abstract class Utils {
         for (int i = 0; i < l.size(); i++) {
             if (i > 0)
                 sb.append(',');
-            appendFlatValue(l.get(i), sb);
+            appendValue(l.get(i), sb);
         }
         sb.append(']');
         return sb;
@@ -216,7 +207,7 @@ abstract class Utils {
         boolean first = true;
         for (Object elt : s) {
             if (first) first = false; else sb.append(',');
-            appendFlatValue(elt, sb);
+            appendValue(elt, sb);
         }
         sb.append('}');
         return sb;
@@ -230,9 +221,9 @@ abstract class Utils {
                 first = false;
             else
                 sb.append(',');
-            appendFlatValue(entry.getKey(), sb);
+            appendValue(entry.getKey(), sb);
             sb.append(':');
-            appendFlatValue(entry.getValue(), sb);
+            appendValue(entry.getValue(), sb);
         }
         sb.append('}');
         return sb;

--- a/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
@@ -15,4 +15,8 @@ public class Assertions extends org.assertj.core.api.Assertions{
     public static TokenRangeAssert assertThat(TokenRange range) {
         return new TokenRangeAssert(range);
     }
+
+    public static DataTypeAssert assertThat(DataType type) {
+        return new DataTypeAssert(type);
+    }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
@@ -12,6 +12,7 @@ import com.datastax.driver.core.policies.DelegatingLoadBalancingPolicy;
 import com.datastax.driver.core.policies.LoadBalancingPolicy;
 import com.datastax.driver.core.policies.Policies;
 import com.datastax.driver.core.policies.ReconnectionPolicy;
+import com.datastax.driver.core.utils.CassandraVersion;
 
 public class ControlConnectionTest {
     @Test(groups = "short")
@@ -73,9 +74,8 @@ public class ControlConnectionTest {
      * Therefore we use two different driver instances in this test.
      */
     @Test(groups = "short")
+    @CassandraVersion(major=2.1)
     public void should_parse_UDT_definitions_when_using_default_protocol_version() {
-        TestUtils.versionCheck(2.1, 0, "This will only work with C* 2.1.0");
-
         CCMBridge ccm = null;
         Cluster cluster = null;
 

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeAssert.java
@@ -1,0 +1,47 @@
+package com.datastax.driver.core;
+
+import com.google.common.reflect.TypeToken;
+import org.assertj.core.api.AbstractAssert;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+
+public class DataTypeAssert extends AbstractAssert<DataTypeAssert, DataType> {
+    public DataTypeAssert(DataType actual) {
+        super(actual, DataTypeAssert.class);
+    }
+
+    public DataTypeAssert hasName(DataType.Name name) {
+        assertThat(actual.name).isEqualTo(name);
+        return this;
+    }
+
+    public DataTypeAssert isFrozen() {
+        assertThat(actual.isFrozen()).isTrue();
+        return this;
+    }
+
+    public DataTypeAssert isNotFrozen() {
+        assertThat(actual.isFrozen()).isFalse();
+        return this;
+    }
+
+    public DataTypeAssert canBeDeserializedAs(TypeToken typeToken) {
+        assertThat(actual.canBeDeserializedAs(typeToken)).isTrue();
+        return this;
+    }
+
+    public DataTypeAssert cannotBeDeserializedAs(TypeToken typeToken) {
+        assertThat(actual.canBeDeserializedAs(typeToken)).isFalse();
+        return this;
+    }
+
+    public DataTypeAssert hasTypeArgument(int position, DataType expected) {
+        assertThat(actual.getTypeArguments().get(position)).isEqualTo(expected);
+        return this;
+    }
+
+    public DataTypeAssert hasTypeArguments(DataType... expected) {
+        assertThat(actual.getTypeArguments()).containsExactly(expected);
+        return this;
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
@@ -15,627 +15,209 @@
  */
 package com.datastax.driver.core;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.net.InetAddress;
-import java.nio.ByteBuffer;
-import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import com.google.common.collect.ImmutableSet;
-
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
-import static com.datastax.driver.core.DataTypeTest.exclude;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.driver.core.utils.CassandraVersion;
 
 /**
- * Tests DataType class to ensure data sent in is the same as data received
- * All tests are executed via a Simple Statements
- * Counters are the only datatype not tested within the entirety of the suite.
- *     There is, however, an isolated test case that needs to be implemented.
- * All statements and sample data is easily exportable via the print_*() methods.
+ * The goal of this test is to cover the serialization and deserialization of datatypes.
+ *
+ * It creates a table with a column of a given type, inserts a value and then tries to retrieve it.
+ * There are 3 variants for the insert query: a raw string, a simple statement with a parameter
+ * (protocol > v2 only) and a prepared statement.
+ * This is repeated with a large number of datatypes.
  */
 public class DataTypeIntegrationTest extends CCMBridge.PerClassSingleNodeCluster {
+    private static final Logger logger = LoggerFactory.getLogger(DataTypeIntegrationTest.class);
 
-    private final static Set<DataType> DATA_TYPE_PRIMITIVES = DataType.allPrimitiveTypes();
-    private final static Set<DataType.Name> DATA_TYPE_NON_PRIMITIVE_NAMES = EnumSet.of(DataType.Name.MAP, DataType.Name.SET, DataType.Name.LIST);
+    List<TestTable> tables = allTables();
+    VersionNumber cassandraVersion;
 
-    private final static String PRIMITIVE_INSERT_FORMAT = "INSERT INTO %1$s (k, v) VALUES (%2$s, %2$s);";
-    private final static String BASIC_SELECT_FORMAT = "SELECT k, v FROM %1$s;";
+    enum StatementType {RAW_STRING, SIMPLE_WITH_PARAM, PREPARED}
 
-    private final static String COLLECTION_INSERT_FORMAT = "INSERT INTO %1$s (k, v) VALUES (%2$s, %3$s);";
-    private final static String MAP_INSERT_FORMAT = "INSERT INTO %1$s (k, v) VALUES (%3$s, {%2$s: %3$s});";
-
-    private final static HashMap<DataType, Object> SAMPLE_DATA = getSampleData();
-    private final static HashMap<DataType, Object> SAMPLE_COLLECTIONS = getSampleCollections();
-
-    private final static Collection<String> PRIMITIVE_INSERT_STATEMENTS = getPrimitiveInsertStatements();
-    private final static HashMap<DataType, String> PRIMITIVE_SELECT_STATEMENTS = getPrimitiveSelectStatements();
-
-    private final static Collection<String> COLLECTION_INSERT_STATEMENTS = getCollectionInsertStatements();
-    private final static HashMap<DataType, String> COLLECTION_SELECT_STATEMENTS = getCollectionSelectStatements();
-
-    /**
-     * Generates the table definitions that will be used in testing
-     */
     @Override
     protected Collection<String> getTableDefinitions() {
-        ArrayList<String> tableDefinitions = new ArrayList<String>();
+        Host host = cluster.getMetadata().getAllHosts().iterator().next();
+        cassandraVersion = host.getCassandraVersion().nextStable();
 
-        // Create primitive data type definitions
-        for (DataType dataType : DATA_TYPE_PRIMITIVES) {
-            if (exclude(dataType))
+        List<String> statements = Lists.newArrayList();
+        for (TestTable table : tables) {
+            if (cassandraVersion.compareTo(table.minCassandraVersion) < 0)
+                logger.debug("Skipping table because it uses a feature not supported by Cassandra {}: {}",
+                    cassandraVersion, table.createStatement);
+            else
+                statements.add(table.createStatement);
+        }
+
+        return statements;
+    }
+
+    @Test(groups = "long")
+    public void should_insert_and_retrieve_data_with_legacy_statements() {
+        should_insert_and_retrieve_data(StatementType.RAW_STRING);
+    }
+
+    @Test(groups = "long")
+    public void should_insert_and_retrieve_data_with_prepared_statements() {
+        should_insert_and_retrieve_data(StatementType.PREPARED);
+    }
+
+    @Test(groups = "long")
+    @CassandraVersion(major = 2.0, description = "Uses parameterized simple statements, which are only available with protocol v2")
+    public void should_insert_and_retrieve_data_with_parameterized_simple_statements() {
+        should_insert_and_retrieve_data(StatementType.SIMPLE_WITH_PARAM);
+    }
+
+    protected void should_insert_and_retrieve_data(StatementType statementType) {
+        ProtocolVersion protocolVersion = cluster.getConfiguration().getProtocolOptions().getProtocolVersionEnum();
+
+        for (TestTable table : tables) {
+            if (cassandraVersion.compareTo(table.minCassandraVersion) < 0)
                 continue;
 
-            tableDefinitions.add(String.format("CREATE TABLE %1$s (k %2$s PRIMARY KEY, v %1$s)", dataType, dataType));
+            switch (statementType) {
+                case RAW_STRING:
+                    session.execute(table.insertStatement.replace("?", table.testColumnType.format(table.sampleValue)));
+                    break;
+                case SIMPLE_WITH_PARAM:
+                    session.execute(table.insertStatement, table.sampleValue);
+                    break;
+                case PREPARED:
+                    PreparedStatement ps = session.prepare(table.insertStatement);
+                    session.execute(ps.bind(table.sampleValue));
+                    break;
+            }
+
+            Row row = session.execute(table.selectStatement).one();
+            Object queriedValue = table.testColumnType.deserialize(row.getBytesUnsafe("v"), protocolVersion);
+
+            assertThat(queriedValue)
+                .as("Test failure on %s statement with table:%n%s;%n" +
+                        "insert statement:%n%s;%n",
+                    statementType,
+                    table.createStatement,
+                    table.insertStatement)
+                .isEqualTo(table.sampleValue);
+
+            session.execute(table.truncateStatement);
         }
+    }
 
-        // Create collection data type definitions
-        for (DataType.Name dataTypeName : DATA_TYPE_NON_PRIMITIVE_NAMES) {
-            // Create MAP data type definitions
-            if (dataTypeName == DataType.Name.MAP) {
-                for (DataType typeArgument1 : DATA_TYPE_PRIMITIVES) {
-                    if (exclude(typeArgument1))
-                        continue;
+    /**
+     * Abstracts information about a table (corresponding to a given column type).
+     */
+    static class TestTable {
+        private static final AtomicInteger counter = new AtomicInteger();
+        private String tableName = "date_type_test" + counter.incrementAndGet();
 
-                    for (DataType typeArgument2 : DATA_TYPE_PRIMITIVES) {
-                        if (exclude(typeArgument2))
-                            continue;
+        final DataType testColumnType;
+        final Object sampleValue;
 
-                        tableDefinitions.add(String.format("CREATE TABLE %1$s_%2$s_%3$s (k %3$s PRIMARY KEY, v %1$s<%2$s, %3$s>)", dataTypeName, typeArgument1, typeArgument2));
-                    }
-                }
-            // Create SET and LIST data type definitions
-            } else {
-                for (DataType typeArgument : DATA_TYPE_PRIMITIVES) {
-                    if (exclude(typeArgument))
-                        continue;
+        final String createStatement;
+        final String insertStatement = String.format("INSERT INTO %s (k, v) VALUES (1, ?)", tableName);
+        final String selectStatement = String.format("SELECT v FROM %s WHERE k = 1", tableName);
+        final String truncateStatement = String.format("TRUNCATE %s", tableName);
 
-                    tableDefinitions.add(String.format("CREATE TABLE %1$s_%2$s (k %2$s PRIMARY KEY, v %1$s<%2$s>)", dataTypeName, typeArgument));
-                }
+        final VersionNumber minCassandraVersion;
+
+        TestTable(DataType testColumnType, Object sampleValue, String minCassandraVersion) {
+            this.testColumnType = testColumnType;
+            this.sampleValue = sampleValue;
+            this.minCassandraVersion = VersionNumber.parse(minCassandraVersion);
+
+            this.createStatement = String.format("CREATE TABLE %s (k int PRIMARY KEY, v %s)", tableName, testColumnType);
+        }
+    }
+
+    private static List<TestTable> allTables() {
+        List<TestTable> tables = Lists.newArrayList();
+
+        tables.addAll(tablesWithPrimitives());
+        tables.addAll(tablesWithCollectionsOfPrimitives());
+        tables.addAll(tablesWithMapsOfPrimitives());
+        tables.addAll(tablesWithNestedCollections());
+
+        return ImmutableList.copyOf(tables);
+    }
+
+    private static List<TestTable> tablesWithPrimitives() {
+        List<TestTable> tables = Lists.newArrayList();
+        for (Map.Entry<DataType, Object> entry : PrimitiveTypeSamples.ALL.entrySet())
+            tables.add(new TestTable(entry.getKey(), entry.getValue(), "1.2.0"));
+        return tables;
+    }
+
+    private static List<TestTable> tablesWithCollectionsOfPrimitives() {
+        List<TestTable> tables = Lists.newArrayList();
+        for (Map.Entry<DataType, Object> entry : PrimitiveTypeSamples.ALL.entrySet()) {
+
+            DataType elementType = entry.getKey();
+            Object elementSample = entry.getValue();
+
+            tables.add(new TestTable(DataType.list(elementType), Lists.newArrayList(elementSample, elementSample), "1.2.0"));
+            tables.add(new TestTable(DataType.set(elementType), Sets.newHashSet(elementSample), "1.2.0"));
+        }
+        return tables;
+    }
+
+    private static List<TestTable> tablesWithMapsOfPrimitives() {
+        List<TestTable> tables = Lists.newArrayList();
+        for (Map.Entry<DataType, Object> keyEntry : PrimitiveTypeSamples.ALL.entrySet()) {
+            DataType keyType = keyEntry.getKey();
+            Object keySample = keyEntry.getValue();
+            for (Map.Entry<DataType, Object> valueEntry : PrimitiveTypeSamples.ALL.entrySet()) {
+                DataType valueType = valueEntry.getKey();
+                Object valueSample = valueEntry.getValue();
+
+                tables.add(new TestTable(DataType.map(keyType, valueType),
+                    ImmutableMap.builder().put(keySample, valueSample).build(),
+                    "1.2.0"));
             }
         }
-
-        return tableDefinitions;
+        return tables;
     }
 
-    /**
-     * Generates the sample data that will be used in testing
-     */
-    protected static HashMap<DataType, Object> getSampleData() {
-        HashMap<DataType, Object> sampleData = new HashMap<DataType, Object>();
+    private static Collection<? extends TestTable> tablesWithNestedCollections() {
+        List<TestTable> tables = Lists.newArrayList();
 
-        for (DataType dataType : DATA_TYPE_PRIMITIVES) {
-            switch (dataType.getName()) {
-                case ASCII:
-                    sampleData.put(dataType, new String("ascii"));
-                    break;
-                case BIGINT:
-                    sampleData.put(dataType, Long.MAX_VALUE);
-                    break;
-                case BLOB:
-                    ByteBuffer bb = ByteBuffer.allocate(58);
-                    bb.putShort((short) 0xCAFE);
-                    bb.flip();
-                    sampleData.put(dataType, bb);
-                    break;
-                case BOOLEAN:
-                    sampleData.put(dataType, Boolean.TRUE);
-                    break;
-                case COUNTER:
-                    // Not supported in an insert statement
-                    break;
-                case DECIMAL:
-                    sampleData.put(dataType, new BigDecimal("12.3E+7"));
-                    break;
-                case DOUBLE:
-                    sampleData.put(dataType, Double.MAX_VALUE);
-                    break;
-                case FLOAT:
-                    sampleData.put(dataType, Float.MAX_VALUE);
-                    break;
-                case INET:
-                    try {
-                        sampleData.put(dataType, InetAddress.getByName("123.123.123.123"));
-                    } catch (java.net.UnknownHostException e) {}
-                    break;
-                case INT:
-                    sampleData.put(dataType, Integer.MAX_VALUE);
-                    break;
-                case TEXT:
-                    sampleData.put(dataType, new String("text"));
-                    break;
-                case TIMESTAMP:
-                    sampleData.put(dataType, new Date(872835240000L));
-                    break;
-                case TIMEUUID:
-                    sampleData.put(dataType, UUID.fromString("FE2B4360-28C6-11E2-81C1-0800200C9A66"));
-                    break;
-                case UUID:
-                    sampleData.put(dataType, UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff00"));
-                    break;
-                case VARCHAR:
-                    sampleData.put(dataType, new String("varchar"));
-                    break;
-                case VARINT:
-                    sampleData.put(dataType, new BigInteger(Integer.toString(Integer.MAX_VALUE) + "000"));
-                    break;
-                default:
-                    throw new RuntimeException("Missing handling of " + dataType);
+        // To avoid combinatorial explosion, only use int as the primitive type, and two levels of nesting.
+        // This yields collections like list<frozen<map<int, int>>, map<frozen<set<int>>, frozen<list<int>>>, etc.
+
+        // Types and samples for the inner collections like frozen<list<int>>
+        Map<DataType, Object> childCollectionSamples = ImmutableMap.<DataType, Object>builder()
+            .put(DataType.frozenList(DataType.cint()), Lists.newArrayList(1, 1))
+            .put(DataType.frozenSet(DataType.cint()), Sets.newHashSet(1, 2))
+            .put(DataType.frozenMap(DataType.cint(), DataType.cint()), ImmutableMap.<Integer, Integer>builder().put(1, 2).put(3, 4).build())
+            .build();
+
+        for (Map.Entry<DataType, Object> entry : childCollectionSamples.entrySet()) {
+            DataType elementType = entry.getKey();
+            Object elementSample = entry.getValue();
+
+            tables.add(new TestTable(DataType.list(elementType), Lists.newArrayList(elementSample, elementSample), "2.1.3"));
+            tables.add(new TestTable(DataType.set(elementType), Sets.newHashSet(elementSample), "2.1.3"));
+
+            for (Map.Entry<DataType, Object> valueEntry : childCollectionSamples.entrySet()) {
+                DataType valueType = valueEntry.getKey();
+                Object valueSample = valueEntry.getValue();
+
+                tables.add(new TestTable(DataType.map(elementType, valueType),
+                    ImmutableMap.builder().put(elementSample, valueSample).build(), "2.1.3"));
             }
         }
-
-        return sampleData;
-    }
-
-    protected static Object getCollectionSample(DataType.Name collectionType, DataType dataType) {
-        if(collectionType == DataType.Name.LIST) {
-            List<Object> theList = new ArrayList<Object>();
-            theList.add(SAMPLE_DATA.get(dataType));
-            theList.add(SAMPLE_DATA.get(dataType));
-            return theList;
-        }
-        else if(collectionType == DataType.Name.SET)
-            return ImmutableSet.of(SAMPLE_DATA.get(dataType));
-        else if(collectionType == DataType.Name.MAP)
-                return new HashMap<Object, Object>().put(SAMPLE_DATA.get(dataType), SAMPLE_DATA.get(dataType));
-        else if(collectionType == DataType.Name.TUPLE) {
-            TupleType t = TupleType.of(dataType);
-            return t.newValue(SAMPLE_DATA.get(dataType));
-        }
-        else
-            throw new IllegalArgumentException("Missing handling of non-primitive type" + collectionType);
-    }
-
-    /**
-     * Generates the sample collections that will be used in testing
-     */
-    protected static HashMap<DataType, Object> getSampleCollections() {
-        HashMap<DataType, Object> sampleCollections = new HashMap<DataType, Object>();
-        HashMap<DataType, Object> setAndListCollection;
-        HashMap<DataType, HashMap<DataType, Object>> mapCollection;
-
-        for (DataType.Name dataTypeName : DATA_TYPE_NON_PRIMITIVE_NAMES) {
-            switch (dataTypeName) {
-                case LIST:
-                    for (DataType typeArgument : DATA_TYPE_PRIMITIVES) {
-                        if (exclude(typeArgument))
-                            continue;
-
-                        List<Object> list = new ArrayList<Object>();
-                        for (int i = 0; i < 5; i++) {
-                            list.add(SAMPLE_DATA.get(typeArgument));
-                        }
-
-                        setAndListCollection = new HashMap<DataType, Object>();
-                        setAndListCollection.put(typeArgument, list);
-                        sampleCollections.put(DataType.list(typeArgument), setAndListCollection);
-                    }
-                    break;
-                case SET:
-                    for (DataType typeArgument : DATA_TYPE_PRIMITIVES) {
-                        if (exclude(typeArgument))
-                            continue;
-
-                        Set<Object> set = new HashSet<Object>();
-                        for (int i = 0; i < 5; i++) {
-                            set.add(SAMPLE_DATA.get(typeArgument));
-                        }
-
-                        setAndListCollection = new HashMap<DataType, Object>();
-                        setAndListCollection.put(typeArgument, set);
-                        sampleCollections.put(DataType.set(typeArgument), setAndListCollection);
-                    }
-                    break;
-                case MAP:
-                    for (DataType typeArgument1 : DATA_TYPE_PRIMITIVES) {
-                        if (exclude(typeArgument1))
-                            continue;
-
-                        for (DataType typeArgument2 : DATA_TYPE_PRIMITIVES) {
-                            if (exclude(typeArgument2))
-                                continue;
-
-                            HashMap<DataType, Object> map = new HashMap<DataType, Object>();
-                            map.put(typeArgument1, SAMPLE_DATA.get(typeArgument2));
-
-                            mapCollection = new HashMap<DataType, HashMap<DataType, Object>>();
-                            mapCollection.put(typeArgument1, map);
-                            sampleCollections.put(DataType.map(typeArgument1, typeArgument2), mapCollection);
-                        }
-                    }
-                    break;
-                default:
-                    throw new RuntimeException("Missing handling of " + dataTypeName);
-            }
-        }
-
-        return sampleCollections;
-    }
-
-    /**
-     * Helper method to stringify SAMPLE_DATA for simple insert statements
-     */
-    @SuppressWarnings("fallthrough")
-    private static String helperStringifiedData(DataType dataType) {
-        String value = SAMPLE_DATA.get(dataType).toString();
-
-        switch (dataType.getName()) {
-            case BLOB:
-                value = "0xCAFE";
-                break;
-
-            case INET:
-                InetAddress v1 = (InetAddress) SAMPLE_DATA.get(dataType);
-                value = String.format("'%s'", v1.getHostAddress());
-                break;
-
-            case TIMESTAMP:
-                Date v2 = (Date) SAMPLE_DATA.get(dataType);
-                value = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").format(v2);
-            case ASCII:
-            case TEXT:
-            case VARCHAR:
-                value = String.format("'%s'", value);
-                break;
-
-            default:
-                break;
-        }
-
-        return value;
-    }
-
-    /**
-     * Generates the insert statements that will be used in testing
-     */
-    private static Collection<String> getPrimitiveInsertStatements() {
-        ArrayList<String> insertStatements = new ArrayList<String>();
-
-        for (DataType dataType : SAMPLE_DATA.keySet()) {
-            String value = helperStringifiedData(dataType);
-            insertStatements.add(String.format(PRIMITIVE_INSERT_FORMAT, dataType, value));
-        }
-
-        return insertStatements;
-    }
-
-    /**
-     * Generates the select statements that will be used in testing
-     */
-    private static HashMap<DataType, String> getPrimitiveSelectStatements() {
-        HashMap<DataType, String> selectStatements = new HashMap<DataType, String>();
-
-        for (DataType dataType : SAMPLE_DATA.keySet()) {
-            selectStatements.put(dataType, String.format(BASIC_SELECT_FORMAT, dataType));
-        }
-
-        return selectStatements;
-    }
-
-    /**
-     * Helper method to generate table names in the form of:
-     * DataType_TypeArgument[_TypeArgument]
-     */
-    private static String helperGenerateTableName(DataType dataType) {
-        String tableName = dataType.getName().toString();
-        for (DataType typeArgument : dataType.getTypeArguments())
-            tableName += "_" + typeArgument;
-
-        return tableName;
-    }
-
-    /**
-     * Generates the insert statements that will be used in testing
-     */
-    @SuppressWarnings("unchecked")
-    private static Collection<String> getCollectionInsertStatements() {
-        ArrayList<String> insertStatements = new ArrayList<String>();
-
-        String tableName;
-        String key;
-        String value;
-        for (DataType dataType : SAMPLE_COLLECTIONS.keySet()) {
-            HashMap<DataType, Object> sampleValueMap = (HashMap<DataType, Object>) SAMPLE_COLLECTIONS.get(dataType);
-
-            // Create tableName in form of: DataType_TypeArgument[_TypeArgument]
-            tableName = helperGenerateTableName(dataType);
-
-            if (dataType.getName() == DataType.Name.MAP) {
-                List<DataType> typeArgument = dataType.getTypeArguments();
-
-                key = helperStringifiedData(typeArgument.get(0));
-                value = helperStringifiedData(typeArgument.get(1));
-
-                insertStatements.add(String.format(MAP_INSERT_FORMAT, tableName, key, value));
-            } else if (dataType.getName() == DataType.Name.LIST) {
-                DataType typeArgument = sampleValueMap.keySet().iterator().next();
-                key = helperStringifiedData(typeArgument);
-
-                // Create the value to be a list of the same 5 elements
-                value = "[";
-                for (int i = 0; i < 5; i++)
-                    value += key + ',';
-                value = value.substring(0, value.length() - 1) + ']';
-
-                insertStatements.add(String.format(COLLECTION_INSERT_FORMAT, tableName, key, value));
-            } else {
-                DataType typeArgument = sampleValueMap.keySet().iterator().next();
-                key = helperStringifiedData(typeArgument);
-                value = '{' + key + '}';
-
-                insertStatements.add(String.format(COLLECTION_INSERT_FORMAT, tableName, key, value));
-            }
-        }
-
-        return insertStatements;
-    }
-
-    /**
-     * Generates the select statements that will be used in testing
-     */
-    private static HashMap<DataType, String> getCollectionSelectStatements() {
-        HashMap<DataType, String> selectStatements = new HashMap<DataType, String>();
-
-        String tableName;
-        for (DataType dataType : SAMPLE_COLLECTIONS.keySet()) {
-            tableName = helperGenerateTableName(dataType);
-            selectStatements.put(dataType, String.format(BASIC_SELECT_FORMAT, tableName));
-        }
-
-        return selectStatements;
-    }
-
-    /**
-     * Test simple statement inserts for all primitive data types
-     */
-    public void primitiveInsertTest() throws Throwable {
-        ResultSet rs;
-        for (String execute_string : PRIMITIVE_INSERT_STATEMENTS) {
-            rs = session.execute(execute_string);
-            assertTrue(rs.isExhausted());
-        }
-        assertEquals(SAMPLE_DATA.size(), 14);
-        assertEquals(PRIMITIVE_INSERT_STATEMENTS.size(), SAMPLE_DATA.size());
-    }
-
-    /**
-     * Validate simple statement selects for all primitive data types
-     */
-    public void primitiveSelectTest() throws Throwable {
-        String execute_string;
-        Object value;
-        Row row;
-        for (DataType dataType : PRIMITIVE_SELECT_STATEMENTS.keySet()) {
-            execute_string = PRIMITIVE_SELECT_STATEMENTS.get(dataType);
-            row = session.execute(execute_string).one();
-
-            value = SAMPLE_DATA.get(dataType);
-            assertEquals(TestUtils.getValue(row, "k", dataType), value);
-            assertEquals(TestUtils.getValue(row, "v", dataType), value);
-        }
-        assertEquals(SAMPLE_DATA.size(), 14);
-        assertEquals(PRIMITIVE_SELECT_STATEMENTS.keySet().size(), SAMPLE_DATA.size());
-    }
-
-    /**
-     * Test simple statement inserts and selects for all primitive data types
-     */
-    @Test(groups = "long")
-    public void primitiveTests() throws Throwable {
-        primitiveInsertTest();
-        primitiveSelectTest();
-    }
-
-    @Test(groups = "short")
-    @CassandraVersion(major=2.0, minor=0, description="This feature requires protocol v2")
-    public void primitiveInsertWithValueTest() throws Throwable {
-        for (DataType dt : DataType.allPrimitiveTypes()) {
-            if (exclude(dt))
-                continue;
-
-            session.execute(String.format(PRIMITIVE_INSERT_FORMAT, dt, "?"), SAMPLE_DATA.get(dt), SAMPLE_DATA.get(dt));
-        }
-        // Kind of checking results (kind of because the schema used by this class make it ultra painful
-        // somehow to use a different partition for different tests, so that the insert done here actually
-        // conflict with the one in primitiveInsertTest. So all we check is that we don't write something
-        // horribly wrong, but if the inserts of this test where to do nothing, the following check might
-        // not work. We should fix the schema used by this class)
-        primitiveSelectTest();
-    }
-
-    /**
-     * Test simple statement inserts for all collection data types
-     */
-    public void collectionInsertTest() throws Throwable {
-        ResultSet rs;
-        for (String execute_string : COLLECTION_INSERT_STATEMENTS) {
-            rs = session.execute(execute_string);
-            assertTrue(rs.isExhausted());
-        }
-        assertEquals(SAMPLE_COLLECTIONS.size(), 224);
-        assertEquals(COLLECTION_INSERT_STATEMENTS.size(), SAMPLE_COLLECTIONS.size());
-    }
-
-    /**
-     * Test simple statement selects for all collection data types
-     */
-    @SuppressWarnings("unchecked")
-    public void collectionSelectTest() throws Throwable {
-        HashMap<DataType, Object> sampleValueMap;
-        String execute_string;
-        DataType typeArgument1;
-        DataType typeArgument2;
-        Row row;
-        for (DataType dataType : COLLECTION_SELECT_STATEMENTS.keySet()) {
-            execute_string = COLLECTION_SELECT_STATEMENTS.get(dataType);
-            row = session.execute(execute_string).one();
-
-            sampleValueMap = (HashMap<DataType, Object>) SAMPLE_COLLECTIONS.get(dataType);
-            typeArgument1 = dataType.getTypeArguments().get(0);
-            if (dataType.getName() == DataType.Name.MAP) {
-                typeArgument2 = dataType.getTypeArguments().get(1);
-
-                // Create a copy of the map that is being expected
-                HashMap<DataType, Object> sampleMap = (HashMap<DataType, Object>) sampleValueMap.get(typeArgument1);
-                Object mapKey = SAMPLE_DATA.get(sampleMap.keySet().iterator().next());
-                Object mapValue = sampleMap.values().iterator().next();
-                HashMap<Object, Object> expectedMap = new HashMap<Object, Object>();
-                expectedMap.put(mapKey, mapValue);
-
-                assertEquals(TestUtils.getValue(row, "k", typeArgument2), SAMPLE_DATA.get(typeArgument2));
-                assertEquals(TestUtils.getValue(row, "v", dataType), expectedMap);
-            } else {
-                Object expectedValue = sampleValueMap.get(typeArgument1);
-
-                assertEquals(TestUtils.getValue(row, "k", typeArgument1), SAMPLE_DATA.get(typeArgument1));
-                assertEquals(TestUtils.getValue(row, "v", dataType), expectedValue);
-            }
-        }
-        assertEquals(SAMPLE_COLLECTIONS.size(), 224);
-        assertEquals(COLLECTION_SELECT_STATEMENTS.keySet().size(), SAMPLE_COLLECTIONS.size());
-    }
-
-    /**
-     * Test simple statement inserts and selects for all collection data types
-     */
-    @Test(groups = "long")
-    public void collectionTest() throws Throwable {
-        collectionInsertTest();
-        collectionSelectTest();
-    }
-
-    /**
-     * Prints the table definitions that will be used in testing
-     * (for exporting purposes)
-     */
-    @Test(groups = "doc")
-    public void printTableDefinitions() {
-        String objective = "Table Definitions";
-        System.out.println(String.format("Printing %s...", objective));
-
-        // Prints the full list of table definitions
-        for (String definition : getTableDefinitions()) {
-            System.out.println(definition);
-        }
-
-        System.out.println(String.format("\nEnd of %s\n\n", objective));
-    }
-
-    /**
-     * Prints the sample data that will be used in testing
-     * (for exporting purposes)
-     */
-    @Test(groups = "doc")
-    public void printSampleData() {
-        String objective = "Sample Data";
-        System.out.println(String.format("Printing %s...", objective));
-
-        for (DataType dataType : SAMPLE_DATA.keySet()) {
-            Object sampleValue = SAMPLE_DATA.get(dataType);
-            System.out.println(String.format("%1$-10s %2$s", dataType, sampleValue));
-        }
-
-        System.out.println(String.format("\nEnd of %s\n\n", objective));
-    }
-
-    /**
-     * Prints the sample collections that will be used in testing
-     * (for exporting purposes)
-     */
-    @Test(groups = "doc")
-    @SuppressWarnings("unchecked")
-    public void printSampleCollections() {
-        String objective = "Sample Collections";
-        System.out.println(String.format("Printing %s...", objective));
-
-        for (DataType dataType : SAMPLE_COLLECTIONS.keySet()) {
-            HashMap<DataType, Object> sampleValueMap = (HashMap<DataType, Object>) SAMPLE_COLLECTIONS.get(dataType);
-
-            if (dataType.getName() == DataType.Name.MAP) {
-                DataType typeArgument = sampleValueMap.keySet().iterator().next();
-                HashMap<DataType, Object> sampleMap = (HashMap<DataType, Object>) sampleValueMap.get(typeArgument);
-
-                Object mapKey = SAMPLE_DATA.get(typeArgument);
-                Object mapValue = sampleMap.get(typeArgument);
-                System.out.println(String.format("%1$-30s {%2$s : %3$s}", dataType, mapKey, mapValue));
-            } else {
-                DataType typeArgument = sampleValueMap.keySet().iterator().next();
-                Object sampleValue = sampleValueMap.get(typeArgument);
-
-                System.out.println(String.format("%1$-30s %2$s", dataType, sampleValue));
-            }
-        }
-
-        System.out.println(String.format("\nEnd of %s\n\n", objective));
-    }
-
-    /**
-     * Prints the simple insert statements that will be used in testing
-     * (for exporting purposes)
-     */
-    @Test(groups = "doc")
-    public void printPrimitiveInsertStatements() {
-        String objective = "Primitive Insert Statements";
-        System.out.println(String.format("Printing %s...", objective));
-
-        for (String execute_string : PRIMITIVE_INSERT_STATEMENTS) {
-            System.out.println(execute_string);
-        }
-
-        System.out.println(String.format("\nEnd of %s\n\n", objective));
-    }
-
-    /**
-     * Prints the simple select statements that will be used in testing
-     * (for exporting purposes)
-     */
-    @Test(groups = "doc")
-    public void printPrimitiveSelectStatements() {
-        String objective = "Primitive Select Statements";
-        System.out.println(String.format("Printing %s...", objective));
-
-        for (String execute_string : PRIMITIVE_SELECT_STATEMENTS.values()) {
-            System.out.println(execute_string);
-        }
-
-        System.out.println(String.format("\nEnd of %s\n\n", objective));
-    }
-
-    /**
-     * Prints the simple insert statements that will be used in testing
-     * (for exporting purposes)
-     */
-    @Test(groups = "doc")
-    public void printCollectionInsertStatements() {
-        String objective = "Collection Insert Statements";
-        System.out.println(String.format("Printing %s...", objective));
-
-        for (String execute_string : COLLECTION_INSERT_STATEMENTS) {
-            System.out.println(execute_string);
-        }
-
-        System.out.println(String.format("\nEnd of %s\n\n", objective));
-    }
-
-    /**
-     * Prints the simple insert statements that will be used in testing
-     * (for exporting purposes)
-     */
-    @Test(groups = "doc")
-    public void printCollectionSelectStatements() {
-        String objective = "Collection Select Statements";
-        System.out.println(String.format("Printing %s...", objective));
-
-        for (String execute_string : COLLECTION_SELECT_STATEMENTS.values()) {
-            System.out.println(execute_string);
-        }
-
-        System.out.println(String.format("\nEnd of %s\n\n", objective));
+        return tables;
     }
 }
-

--- a/driver-core/src/test/java/com/datastax/driver/core/PrimitiveTypeSamples.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PrimitiveTypeSamples.java
@@ -1,0 +1,74 @@
+/*
+ *      Copyright (C) 2012-2014 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.driver.core.utils.Bytes;
+
+/**
+ * This class provides sample values for each primitive data type.
+ *
+ * These values have no particular meaning, the goal is just to have an instance that can be used in automated tests.
+ */
+public class PrimitiveTypeSamples {
+
+    public static final Map<DataType, Object> ALL = generateAll();
+
+    private static Map<DataType, Object> generateAll() {
+        try {
+            ImmutableMap<DataType, Object> result = ImmutableMap.<DataType, Object>builder()
+                .put(DataType.ascii(), "ascii")
+                .put(DataType.bigint(), Long.MAX_VALUE)
+                .put(DataType.blob(), Bytes.fromHexString("0xCAFE"))
+                .put(DataType.cboolean(), Boolean.TRUE)
+                .put(DataType.decimal(), new BigDecimal("12.3E+7"))
+                .put(DataType.cdouble(), Double.MAX_VALUE)
+                .put(DataType.cfloat(), Float.MAX_VALUE)
+                .put(DataType.inet(), InetAddress.getByName("123.123.123.123"))
+                .put(DataType.cint(), Integer.MAX_VALUE)
+                .put(DataType.text(), "text")
+                .put(DataType.timestamp(), new Date(872835240000L))
+                .put(DataType.timeuuid(), UUID.fromString("FE2B4360-28C6-11E2-81C1-0800200C9A66"))
+                .put(DataType.uuid(), UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff00"))
+                .put(DataType.varint(), new BigInteger(Integer.toString(Integer.MAX_VALUE) + "000"))
+                .build();
+
+            // Check that we cover all types (except counter)
+            List<DataType> tmp = Lists.newArrayList(DataType.allPrimitiveTypes());
+            tmp.removeAll(result.keySet());
+            assertThat(tmp)
+                .as("new datatype not covered in test")
+                .containsOnly(DataType.counter());
+
+            return result;
+        } catch (UnknownHostException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryTimestampTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryTimestampTest.java
@@ -11,18 +11,16 @@ import static org.testng.Assert.assertTrue;
 import com.datastax.driver.core.Cluster.Builder;
 import com.datastax.driver.core.Metrics.Errors;
 import com.datastax.driver.core.policies.DowngradingConsistencyRetryPolicy;
-
-import static com.datastax.driver.core.TestUtils.versionCheck;
+import com.datastax.driver.core.utils.CassandraVersion;
 
 /**
  * Tests the behavior of client-provided timestamps with protocol v3.
  */
+@CassandraVersion(major=2.1)
 public class QueryTimestampTest extends CCMBridge.PerClassSingleNodeCluster {
 
     @Override
     protected Collection<String> getTableDefinitions() {
-        versionCheck(2.1, 0, "This will only work with Cassandra 2.1.0");
-
         return Lists.newArrayList("CREATE TABLE foo (k int PRIMARY KEY, v int)");
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
@@ -71,7 +71,7 @@ public class SchemaChangesTest extends CCMBridge.PerClassSingleNodeCluster {
         session.execute(String.format("CREATE TYPE %s.type1(i int)", keyspace));
 
         for (Metadata m : metadatas)
-            assertThat(m.getKeyspace(keyspace).getUserType("type1"))
+            assertThat((DataType) m.getKeyspace(keyspace).getUserType("type1"))
                 .isNotNull();
     }
 
@@ -93,7 +93,7 @@ public class SchemaChangesTest extends CCMBridge.PerClassSingleNodeCluster {
         session.execute(String.format("DROP TYPE %s.type1", keyspace));
 
         for (Metadata m : metadatas)
-            assertThat(m.getKeyspace(keyspace).getUserType("type1"))
+            assertThat((DataType) m.getKeyspace(keyspace).getUserType("type1"))
                 .isNull();
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/SingleConnectionPoolTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SingleConnectionPoolTest.java
@@ -12,11 +12,12 @@ import org.testng.collections.Lists;
 
 import static org.testng.Assert.fail;
 
+import com.datastax.driver.core.utils.CassandraVersion;
+
+@CassandraVersion(major=2.1)
 public class SingleConnectionPoolTest extends CCMBridge.PerClassSingleNodeCluster {
     @Override
     protected Collection<String> getTableDefinitions() {
-        TestUtils.versionCheck(2.1, 0, "This will only work with Cassandra 2.1.0+");
-
         return Lists.newArrayList();
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
@@ -25,15 +25,15 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
-import static com.datastax.driver.core.TestUtils.SIMPLE_KEYSPACE;
-import static com.datastax.driver.core.TestUtils.versionCheck;
+import com.datastax.driver.core.utils.CassandraVersion;
 
+import static com.datastax.driver.core.TestUtils.SIMPLE_KEYSPACE;
+
+@CassandraVersion(major=2.1)
 public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
 
     @Override
     protected Collection<String> getTableDefinitions() {
-        versionCheck(2.1, 0, "This will only work with Cassandra 2.1.0");
-
         return Arrays.asList("CREATE TABLE t (k int PRIMARY KEY, v frozen<tuple<int, text, float>>)");
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
@@ -15,17 +15,18 @@
  */
 package com.datastax.driver.core;
 
-import java.util.*;
 import java.nio.ByteBuffer;
+import java.util.*;
 
+import com.beust.jcommander.internal.Lists;
 import com.google.common.base.Joiner;
 import org.testng.annotations.Test;
 
-import static com.datastax.driver.core.DataTypeIntegrationTest.getSampleData;
-import static com.datastax.driver.core.TestUtils.SIMPLE_KEYSPACE;
-import static com.datastax.driver.core.TestUtils.versionCheck;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
+
+import static com.datastax.driver.core.TestUtils.SIMPLE_KEYSPACE;
+import static com.datastax.driver.core.TestUtils.versionCheck;
 
 public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
 
@@ -215,16 +216,7 @@ public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
     @Test(groups = "short")
     public void tupleSubtypesTest() throws Exception {
 
-        // hold onto constants
-        ArrayList<DataType> DATA_TYPE_PRIMITIVES = new ArrayList<DataType>();
-        for (DataType dt : DataType.allPrimitiveTypes()) {
-            // skip counter types since counters are not allowed inside tuples
-            if (dt == DataType.counter())
-                continue;
-
-            DATA_TYPE_PRIMITIVES.add(dt);
-        }
-        HashMap<DataType, Object> SAMPLE_DATA = getSampleData();
+        List<DataType> DATA_TYPE_PRIMITIVES = Lists.newArrayList(PrimitiveTypeSamples.ALL.keySet());
 
         try {
             session.execute("CREATE KEYSPACE test_tuple_subtypes " +
@@ -249,8 +241,8 @@ public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
                 for (int j = 0; j < i; ++j) {
                     dataTypes.add(DATA_TYPE_PRIMITIVES.get(j));
                     completeDataTypes.add(DATA_TYPE_PRIMITIVES.get(j));
-                    createdValues.add(SAMPLE_DATA.get(DATA_TYPE_PRIMITIVES.get(j)));
-                    completeValues.add(SAMPLE_DATA.get(DATA_TYPE_PRIMITIVES.get(j)));
+                    createdValues.add(PrimitiveTypeSamples.ALL.get(DATA_TYPE_PRIMITIVES.get(j)));
+                    completeValues.add(PrimitiveTypeSamples.ALL.get(DATA_TYPE_PRIMITIVES.get(j)));
                 }
 
                 // complete portion of the arrays needed for trailing nulls
@@ -290,19 +282,7 @@ public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
     @Test(groups = "short")
     public void tupleNonPrimitiveSubTypesTest() throws Exception {
 
-        // hold onto constants
-        ArrayList<DataType> DATA_TYPE_PRIMITIVES = new ArrayList<DataType>();
-        for (DataType dt : DataType.allPrimitiveTypes()) {
-            // skip counter types since counters are not allowed inside tuples
-            if (dt == DataType.counter())
-                continue;
-
-            DATA_TYPE_PRIMITIVES.add(dt);
-        }
-        ArrayList<DataType.Name> DATA_TYPE_NON_PRIMITIVE_NAMES = new ArrayList<DataType.Name>(Arrays.asList(DataType.Name.MAP,
-                                                                                                            DataType.Name.SET,
-                                                                                                            DataType.Name.LIST));
-        HashMap<DataType, Object> SAMPLE_DATA = getSampleData();
+        List<DataType> DATA_TYPE_PRIMITIVES = Lists.newArrayList(PrimitiveTypeSamples.ALL.keySet());
 
         try {
             session.execute("CREATE KEYSPACE test_tuple_non_primitive_subtypes " +
@@ -323,9 +303,7 @@ public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
 
             // create map values
             for (DataType datatype : DATA_TYPE_PRIMITIVES) {
-                DataType dataType1 = datatype;
-                DataType dataType2 = datatype;
-                values.add(String.format("v_%s frozen<tuple<map<%s, %s>>>", values.size(), dataType1, dataType2));
+                values.add(String.format("v_%s frozen<tuple<map<%s, %s>>>", values.size(), datatype, datatype));
             }
 
             // create table
@@ -340,7 +318,7 @@ public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
                 ArrayList<Object> createdValues = new ArrayList<Object>();
 
                 dataTypes.add(DataType.list(datatype));
-                createdValues.add(Arrays.asList(SAMPLE_DATA.get(datatype)));
+                createdValues.add(Arrays.asList(PrimitiveTypeSamples.ALL.get(datatype)));
 
                 TupleType t = new TupleType(dataTypes);
                 TupleValue createdTuple = t.newValue(createdValues.toArray());
@@ -363,7 +341,7 @@ public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
                 ArrayList<Object> createdValues = new ArrayList<Object>();
 
                 dataTypes.add(DataType.set(datatype));
-                createdValues.add(new HashSet<Object>(Arrays.asList(SAMPLE_DATA.get(datatype))));
+                createdValues.add(new HashSet<Object>(Arrays.asList(PrimitiveTypeSamples.ALL.get(datatype))));
 
                 TupleType t = new TupleType(dataTypes);
                 TupleValue createdTuple = t.newValue(createdValues.toArray());
@@ -386,7 +364,7 @@ public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
                 ArrayList<Object> createdValues = new ArrayList<Object>();
 
                 HashMap<Object, Object> hm = new HashMap<Object, Object>();
-                hm.put(SAMPLE_DATA.get(datatype), SAMPLE_DATA.get(datatype));
+                hm.put(PrimitiveTypeSamples.ALL.get(datatype), PrimitiveTypeSamples.ALL.get(datatype));
 
                 dataTypes.add(DataType.map(datatype, datatype));
                 createdValues.add(hm);
@@ -446,17 +424,6 @@ public class TupleTest extends CCMBridge.PerClassSingleNodeCluster {
      */
     @Test(groups = "short")
     public void nestedTuplesTest() throws Exception {
-
-        // hold onto constants
-        ArrayList<DataType> DATA_TYPE_PRIMITIVES = new ArrayList<DataType>();
-        for (DataType dt : DataType.allPrimitiveTypes()) {
-            // skip counter types since counters are not allowed inside tuples
-            if (dt == DataType.counter())
-                continue;
-
-            DATA_TYPE_PRIMITIVES.add(dt);
-        }
-        HashMap<DataType, Object> SAMPLE_DATA = getSampleData();
 
         try {
             session.execute("CREATE KEYSPACE test_nested_tuples " +

--- a/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
@@ -22,9 +22,12 @@ import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.*;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.base.Joiner;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 
@@ -37,8 +40,6 @@ public class UserTypesTest extends CCMBridge.PerClassSingleNodeCluster {
     private final static List<DataType> DATA_TYPE_PRIMITIVES = new ArrayList<DataType>(DataType.allPrimitiveTypes());
     private final static List<DataType.Name> DATA_TYPE_NON_PRIMITIVE_NAMES =
             new ArrayList<DataType.Name>(EnumSet.of(DataType.Name.LIST, DataType.Name.SET, DataType.Name.MAP, DataType.Name.TUPLE));
-
-    private final static HashMap<DataType, Object> SAMPLE_DATA = DataTypeIntegrationTest.getSampleData();
 
     @Override
     protected Collection<String> getTableDefinitions() {
@@ -242,7 +243,7 @@ public class UserTypesTest extends CCMBridge.PerClassSingleNodeCluster {
             for (int i = 0; i < DATA_TYPE_PRIMITIVES.size(); i++) {
                 DataType dataType = DATA_TYPE_PRIMITIVES.get(i);
                 String index = Character.toString((char) (startIndex + i));
-                Object sampleData = SAMPLE_DATA.get(dataType);
+                Object sampleData = PrimitiveTypeSamples.ALL.get(dataType);
 
                 switch (dataType.getName()) {
                     case ASCII:
@@ -365,19 +366,19 @@ public class UserTypesTest extends CCMBridge.PerClassSingleNodeCluster {
                     DataType dataType = DATA_TYPE_PRIMITIVES.get(j);
 
                     String index = Character.toString((char) (startIndex + i)) + "_" + Character.toString((char) (startIndex + j));
-                    Object sample = DataTypeIntegrationTest.getCollectionSample(name, dataType);
+                    Object sampleElement = PrimitiveTypeSamples.ALL.get(dataType);
                     switch(name) {
                         case LIST:
-                            alldatatypes.setList(index, (ArrayList<DataType>) sample);
+                            alldatatypes.setList(index, Lists.newArrayList(sampleElement));
                             break;
                         case SET:
-                            alldatatypes.setSet(index, (Set<DataType>) sample);
+                            alldatatypes.setSet(index, Sets.newHashSet(sampleElement));
                             break;
                         case MAP:
-                            alldatatypes.setMap(index, (HashMap<DataType, DataType>) sample);
+                            alldatatypes.setMap(index, ImmutableMap.of(sampleElement, sampleElement));
                             break;
                         case TUPLE:
-                            alldatatypes.setTupleValue(index, (TupleValue) sample);
+                            alldatatypes.setTupleValue(index, TupleType.of(dataType).newValue(sampleElement));
                     }
                 }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
@@ -32,9 +32,11 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 
 import static com.datastax.driver.core.Metadata.quote;
-import static com.datastax.driver.core.TestUtils.versionCheck;
 import static org.testng.Assert.assertNotEquals;
 
+import com.datastax.driver.core.utils.CassandraVersion;
+
+@CassandraVersion(major=2.1)
 public class UserTypesTest extends CCMBridge.PerClassSingleNodeCluster {
 
     private final static List<DataType> DATA_TYPE_PRIMITIVES = new ArrayList<DataType>(DataType.allPrimitiveTypes());
@@ -43,8 +45,6 @@ public class UserTypesTest extends CCMBridge.PerClassSingleNodeCluster {
 
     @Override
     protected Collection<String> getTableDefinitions() {
-        versionCheck(2.1, 0, "This will only work with Cassandra 2.1.0");
-
         String type1 = "CREATE TYPE phone (alias text, number text)";
         String type2 = "CREATE TYPE address (street text, \"ZIP\" int, phones set<frozen<phone>>)";
 

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -755,6 +755,10 @@ public class QueryBuilderTest {
         statement = update("foo").with(set("m", ImmutableMap.of(1, list, 2, list))).where(eq("k", 1));
         assertThat(statement.toString()).isEqualTo(query);
 
+        query = "UPDATE foo SET m=m+{1:[[1],[2]],2:[[1],[2]]} WHERE k=1;";
+        statement = update("foo").with(putAll("m", ImmutableMap.of(1, list, 2, list))).where(eq("k", 1));
+        assertThat(statement.toString()).isEqualTo(query);
+
         query = "UPDATE foo SET l=[[1]]+l WHERE k=1;";
         statement = update("foo").with(prepend("l", ImmutableList.of(1))).where(eq("k", 1));
         assertThat(statement.toString()).isEqualTo(query);

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderUDTExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderUDTExecutionTest.java
@@ -1,0 +1,83 @@
+package com.datastax.driver.core.querybuilder;
+
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
+
+import com.datastax.driver.core.*;
+import com.datastax.driver.core.utils.CassandraVersion;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.putAll;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.update;
+
+@CassandraVersion(major=2.1, minor=3)
+public class QueryBuilderUDTExecutionTest extends CCMBridge.PerClassSingleNodeCluster {
+
+    @Override
+    protected Collection<String> getTableDefinitions() {
+            return Arrays.asList("CREATE TYPE udt (i int, a inet)",
+                "CREATE TABLE udtTest(k int PRIMARY KEY, t frozen<udt>, l list<frozen<udt>>, m map<int, frozen<udt>>)");
+    }
+
+    @Test(groups = "short")
+    public void insertUdtTest() throws Exception {
+        UserType udtType = cluster.getMetadata().getKeyspace("ks").getUserType("udt");
+        UDTValue udtValue = udtType.newValue().setInt("i", 2).setInet("a", InetAddress.getByName("localhost"));
+
+        Statement insert = insertInto("udtTest").value("k", 1).value("t", udtValue);
+        assertEquals(insert.toString(), "INSERT INTO udtTest(k,t) VALUES (1,{i:2, a:'127.0.0.1'});");
+
+        session.execute(insert);
+
+        List<Row> rows = session.execute(select().from("udtTest").where(eq("k", 1))).all();
+
+        assertEquals(rows.size(), 1);
+
+        Row r1 = rows.get(0);
+        assertEquals("127.0.0.1", r1.getUDTValue("t").getInet("a").getHostAddress());
+    }
+
+    @Test(groups = "short")
+    public void should_handle_collections_of_UDT() throws Exception {
+        UserType udtType = cluster.getMetadata().getKeyspace("ks").getUserType("udt");
+        UDTValue udtValue = udtType.newValue().setInt("i", 2).setInet("a", InetAddress.getByName("localhost"));
+        UDTValue udtValue2 = udtType.newValue().setInt("i", 3).setInet("a", InetAddress.getByName("localhost"));
+
+        Statement insert = insertInto("udtTest").value("k", 1).value("l", ImmutableList.of(udtValue));
+        assertThat(insert.toString()).isEqualTo("INSERT INTO udtTest(k,l) VALUES (1,[{i:2, a:'127.0.0.1'}]);");
+
+        session.execute(insert);
+
+        List<Row> rows = session.execute(select().from("udtTest").where(eq("k", 1))).all();
+
+        assertThat(rows.size()).isEqualTo(1);
+
+        Row r1 = rows.get(0);
+        assertThat(r1.getList("l", UDTValue.class).get(0).getInet("a").getHostAddress()).isEqualTo("127.0.0.1");
+
+        Map<Integer, UDTValue> map = Maps.newHashMap();
+        map.put(0, udtValue);
+        map.put(2, udtValue2);
+        Statement updateMap = update("udtTest").with(putAll("m", map)).where(eq("k", 1));
+        assertThat(updateMap.toString())
+            .isEqualTo("UPDATE udtTest SET m=m+{0:{i:2, a:'127.0.0.1'},2:{i:3, a:'127.0.0.1'}} WHERE k=1;");
+
+        session.execute(updateMap);
+
+        rows = session.execute(select().from("udtTest").where(eq("k", 1))).all();
+        r1 = rows.get(0);
+        assertThat(r1.getMap("m", Integer.class, UDTValue.class)).isEqualTo(map);
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/SchemaBuilderIT.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/SchemaBuilderIT.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.fail;
 
 import com.datastax.driver.core.*;
 import com.datastax.driver.core.schemabuilder.TableOptions.CompactionOptions.DateTieredCompactionStrategyOptions.TimeStampResolution;
+import com.datastax.driver.core.utils.CassandraVersion;
 
 import static com.datastax.driver.core.schemabuilder.SchemaBuilder.dateTieredStrategy;
 import static com.datastax.driver.core.schemabuilder.SchemaBuilder.percentile;
@@ -25,9 +26,8 @@ public class SchemaBuilderIT extends CCMBridge.PerClassSingleNodeCluster{
     }
 
     @Test(groups = "short")
+    @CassandraVersion(major=2.1, minor=2)
     public void should_modify_table_metadata() {
-        TestUtils.versionCheck(2.1, 2, "This test requires Cassandra 2.1.2");
-
         // Create a table
         session.execute(SchemaBuilder.createTable("ks", "TableMetadata")
                 .addPartitionKey("a", DataType.cint())
@@ -122,9 +122,8 @@ public class SchemaBuilderIT extends CCMBridge.PerClassSingleNodeCluster{
     }
 
     @Test(groups = "short")
+    @CassandraVersion(major=2.1)
     public void should_create_a_table_and_a_udt() {
-        TestUtils.versionCheck(2.1, 0, "This test requires Cassandra 2.1.0");
-
         // Create a UDT and a table
         session.execute(SchemaBuilder.createType("MyUDT")
                 .ifNotExists()

--- a/driver-mapping/pom.xml
+++ b/driver-mapping/pom.xml
@@ -56,6 +56,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.8</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-all</artifactId>
       <version>5.0.3</version>

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
@@ -16,26 +16,21 @@
 package com.datastax.driver.mapping;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.*;
 import java.lang.reflect.Field;
-import java.util.*;
+import java.lang.reflect.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 
-import com.google.common.collect.ImmutableSet.Builder;
-import com.google.common.collect.ImmutableSet;
-
-import com.datastax.driver.mapping.annotations.Frozen;
+import com.google.common.base.Strings;
 
 import com.datastax.driver.core.ConsistencyLevel;
-import com.datastax.driver.core.DataType;
-
-import com.datastax.driver.mapping.MethodMapper.ParamMapper;
-import com.datastax.driver.mapping.MethodMapper.UDTListParamMapper;
-import com.datastax.driver.mapping.MethodMapper.UDTMapParamMapper;
-import com.datastax.driver.mapping.MethodMapper.UDTParamMapper;
-import com.datastax.driver.mapping.MethodMapper.UDTSetParamMapper;
 import com.datastax.driver.mapping.MethodMapper.EnumParamMapper;
+import com.datastax.driver.mapping.MethodMapper.NestedUDTParamMapper;
+import com.datastax.driver.mapping.MethodMapper.ParamMapper;
+import com.datastax.driver.mapping.MethodMapper.UDTParamMapper;
 import com.datastax.driver.mapping.annotations.*;
-import com.google.common.base.Strings;
 
 /**
  * Static metods that facilitates parsing class annotations into the corresponding {@link EntityMapper}.
@@ -291,29 +286,14 @@ class AnnotationParser {
             }
             return new ParamMapper(paramName, idx);
         } if (paramType instanceof ParameterizedType) {
-            ParameterizedType pt = (ParameterizedType) paramType;
-            Type raw = pt.getRawType();
-            if (!(raw instanceof Class))
-                throw new IllegalArgumentException(String.format("Cannot map class %s for parameter %s of %s.%s", paramType, paramName, className, methodName));
-            Class<?> klass = (Class<?>)raw;
-            Class<?> firstTypeParam = ReflectionUtils.getParam(pt, 0, paramName);
-            if (List.class.isAssignableFrom(klass) && firstTypeParam.isAnnotationPresent(UDT.class)) {
-                UDTMapper<?> valueMapper = mappingManager.getUDTMapper(firstTypeParam);
-                return new UDTListParamMapper(paramName, idx, valueMapper);
+            InferredCQLType inferredCQLType = InferredCQLType.from(className, methodName, idx, paramName, paramType, mappingManager);
+            if (inferredCQLType.containsMappedUDT) {
+                // We need a specialized mapper to convert UDT instances in the hierarchy.
+                return new NestedUDTParamMapper(paramName, idx, inferredCQLType);
+            } else {
+                // Use the default mapper but provide the extracted type
+                return new ParamMapper(paramName, idx, inferredCQLType.dataType);
             }
-            if (Set.class.isAssignableFrom(klass) && firstTypeParam.isAnnotationPresent(UDT.class)) {
-                UDTMapper<?> valueMapper = mappingManager.getUDTMapper(firstTypeParam);
-                return new UDTSetParamMapper(paramName, idx, valueMapper);
-            }
-            if (Map.class.isAssignableFrom(klass)) {
-                Class<?> secondTypeParam = ReflectionUtils.getParam(pt, 1, paramName);
-                UDTMapper<?> keyMapper = firstTypeParam.isAnnotationPresent(UDT.class) ? mappingManager.getUDTMapper(firstTypeParam) : null;
-                UDTMapper<?> valueMapper = secondTypeParam.isAnnotationPresent(UDT.class) ? mappingManager.getUDTMapper(secondTypeParam) : null;
-                if (keyMapper != null || valueMapper != null) {
-                    return new UDTMapParamMapper(paramName, idx, keyMapper, valueMapper);
-                }
-            }
-            return new ParamMapper(paramName, idx);
         } else {
             throw new IllegalArgumentException(String.format("Cannot map class %s for parameter %s of %s.%s", paramType, paramName, className, methodName));
         }

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/InferredCQLType.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/InferredCQLType.java
@@ -1,0 +1,101 @@
+/*
+ *      Copyright (C) 2012-2014 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+import com.datastax.driver.core.DataType;
+
+/**
+ * Describes the CQL type inferred from a generic Java field (which will always map
+ * to a collection, possibly with various levels of nesting).
+ *
+ * The reason we wrap {@code DataType} is because we also want to remember if there are mapped UDT
+ * types somewhere in the hierarchy.
+ */
+class InferredCQLType {
+    final DataType dataType;
+    final boolean containsMappedUDT;
+    final UDTMapper udtMapper;
+    final List<InferredCQLType> childTypes;
+
+    static InferredCQLType from(Field field, MappingManager mappingManager) {
+        String name = String.format("field %s of class %s", field.getName(), field.getDeclaringClass().getName());
+        return new InferredCQLType(field.getGenericType(), name, field.getGenericType(), mappingManager);
+    }
+
+    static InferredCQLType from(String className, String methodName, int idx, String paramName, Type paramType, MappingManager mappingManager) {
+        String name = String.format("parameter %s of %s.%s", paramName == null ? idx : paramName, className, methodName);
+        return new InferredCQLType(paramType, name, paramType, mappingManager);
+    }
+
+    private InferredCQLType(Type javaType, String rootName, Type rootType, MappingManager mappingManager) {
+        if (javaType instanceof ParameterizedType) {
+            ParameterizedType pt = (ParameterizedType)javaType;
+            Type raw = pt.getRawType();
+            if (!(raw instanceof Class))
+                throw fail(rootName, rootType);
+
+            Class<?> klass = (Class<?>)raw;
+            if (!TypeMappings.mapsToCollection(klass))
+                throw fail(rootName, rootType);
+
+            childTypes = Lists.newArrayList();
+            boolean childrenContainMappedUDT = false;
+            for (Type childJavaType : pt.getActualTypeArguments()) {
+                InferredCQLType child = new InferredCQLType(childJavaType, rootName, rootType, mappingManager);
+                childrenContainMappedUDT |= child.containsMappedUDT;
+                childTypes.add(child);
+            }
+            containsMappedUDT = childrenContainMappedUDT;
+            udtMapper = null;
+
+            if (TypeMappings.mapsToList(klass)) {
+                dataType = DataType.list(childTypes.get(0).dataType);
+            } else if (TypeMappings.mapsToSet(klass)) {
+                dataType = DataType.set(childTypes.get(0).dataType);
+            } else if (TypeMappings.mapsToMap(klass)) {
+                dataType = DataType.map(childTypes.get(0).dataType, childTypes.get(1).dataType);
+            } else
+                throw fail(rootName, rootType);
+        } else if (javaType instanceof Class) {
+            Class<?> klass = (Class<?>)javaType;
+            if (TypeMappings.isMappedUDT(klass)) {
+                containsMappedUDT = true;
+                udtMapper = mappingManager.udtMapper(klass);
+                dataType = udtMapper.getUserType();
+                childTypes = Collections.emptyList();
+            } else {
+                containsMappedUDT = false;
+                udtMapper = null;
+                dataType = TypeMappings.getSimpleType(klass, rootName);
+                childTypes = Collections.emptyList();
+            }
+        } else {
+            throw fail(rootName, rootType);
+        }
+    }
+
+    private IllegalArgumentException fail(String rootName, Type rootType) {
+        return new IllegalArgumentException(String.format("Cannot map class %s for %s", rootType, rootName));
+    }
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/MethodMapper.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/MethodMapper.java
@@ -18,9 +18,7 @@ package com.datastax.driver.mapping;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.nio.ByteBuffer;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -160,23 +158,32 @@ class MethodMapper {
         // We'll only set one of the other. If paramName is null, then paramIdx is used.
         private final String paramName;
         private final int paramIdx;
+        private final DataType dataType;
 
-        public ParamMapper(String paramName, int paramIdx) {
+        public ParamMapper(String paramName, int paramIdx, DataType dataType) {
             this.paramName = paramName;
             this.paramIdx = paramIdx;
+            this.dataType = dataType;
+        }
+
+        public ParamMapper(String paramName, int paramIdx) {
+            this(paramName, paramIdx, null);
         }
 
         void setValue(BoundStatement boundStatement, Object arg, ProtocolVersion protocolVersion) {
+            ByteBuffer serializedArg = (dataType == null)
+                ? DataType.serializeValue(arg, protocolVersion)
+                : dataType.serialize(arg, protocolVersion);
             if (paramName == null) {
                 if (arg == null)
                     boundStatement.setToNull(paramIdx);
                 else
-                    boundStatement.setBytesUnsafe(paramIdx, DataType.serializeValue(arg, protocolVersion));
+                    boundStatement.setBytesUnsafe(paramIdx, serializedArg);
             } else {
                 if (arg == null)
                     boundStatement.setToNull(paramName);
                 else
-                    boundStatement.setBytesUnsafe(paramName, DataType.serializeValue(arg, protocolVersion));
+                    boundStatement.setBytesUnsafe(paramName, serializedArg);
             }
         }
     }
@@ -198,53 +205,22 @@ class MethodMapper {
         }
     }
 
-    static class UDTListParamMapper<V> extends ParamMapper {
-        private final UDTMapper<V> valueMapper;
+    /**
+     * Maps a nested collection which has a mapped UDT somewhere in the hierarchy.
+     */
+    static class NestedUDTParamMapper extends ParamMapper {
+        private final InferredCQLType inferredCQLType;
 
-        UDTListParamMapper(String paramName, int paramIdx, UDTMapper<V> valueMapper) {
+        NestedUDTParamMapper(String paramName, int paramIdx, InferredCQLType inferredCQLType) {
             super(paramName, paramIdx);
-            this.valueMapper = valueMapper;
+            this.inferredCQLType = inferredCQLType;
         }
 
         @Override
         void setValue(BoundStatement boundStatement, Object arg, ProtocolVersion protocolVersion) {
-            @SuppressWarnings("unchecked")
-            List<V> entities = (List<V>) arg;
-            super.setValue(boundStatement, valueMapper.toUDTValues(entities), protocolVersion);
-        }
-    }
-
-    static class UDTSetParamMapper<V> extends ParamMapper {
-        private final UDTMapper<V> valueMapper;
-
-        UDTSetParamMapper(String paramName, int paramIdx, UDTMapper<V> valueMapper) {
-            super(paramName, paramIdx);
-            this.valueMapper = valueMapper;
-        }
-
-        @Override
-        void setValue(BoundStatement boundStatement, Object arg, ProtocolVersion protocolVersion) {
-            @SuppressWarnings("unchecked")
-            Set<V> entities = (Set<V>) arg;
-            super.setValue(boundStatement, valueMapper.toUDTValues(entities), protocolVersion);
-        }
-    }
-
-    static class UDTMapParamMapper<K, V> extends ParamMapper {
-        private final UDTMapper<K> keyMapper;
-        private final UDTMapper<V> valueMapper;
-
-        UDTMapParamMapper(String paramName, int paramIdx, UDTMapper<K> keyMapper, UDTMapper<V> valueMapper) {
-            super(paramName, paramIdx);
-            this.keyMapper = keyMapper;
-            this.valueMapper = valueMapper;
-        }
-
-        @Override
-        void setValue(BoundStatement boundStatement, Object arg, ProtocolVersion protocolVersion) {
-            @SuppressWarnings("unchecked")
-            Map<K, V> entities = (Map<K, V>) arg;
-            super.setValue(boundStatement, UDTMapper.toUDTValues(entities, keyMapper, valueMapper), protocolVersion);
+            super.setValue(boundStatement,
+                UDTMapper.convertEntitiesToUDTs(arg, inferredCQLType),
+                protocolVersion);
         }
     }
 

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/ReflectionMapper.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/ReflectionMapper.java
@@ -21,15 +21,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.Method;
-import java.net.InetAddress;
-import java.nio.ByteBuffer;
-import java.math.BigInteger;
-import java.math.BigDecimal;
 import java.util.*;
 
 import com.datastax.driver.core.*;
-
-import com.datastax.driver.mapping.annotations.UDT;
 
 /**
  * An {@link EntityMapper} implementation that use reflection to read and write fields
@@ -62,7 +56,7 @@ class ReflectionMapper<T> extends EntityMapper<T> {
         private final Method writeMethod;
 
         private LiteralMapper(Field field, int position, PropertyDescriptor pd) {
-            this(field, extractType(field), position, pd);
+            this(field, extractSimpleType(field), position, pd);
         }
 
         private LiteralMapper(Field field, DataType type, int position, PropertyDescriptor pd) {
@@ -166,159 +160,36 @@ class ReflectionMapper<T> extends EntityMapper<T> {
         }
     }
 
-    private static class UDTListMapper<T, V> extends LiteralMapper<T> {
+    private static class NestedUDTMapper<T> extends LiteralMapper<T> {
+        private final InferredCQLType inferredCQLType;
 
-        private final UDTMapper<V> valueMapper;
-
-        UDTListMapper(Field field, int position, PropertyDescriptor pd, UDTMapper<V> valueMapper) {
-            super(field, DataType.list(valueMapper.getUserType()), position, pd);
-            this.valueMapper = valueMapper;
-        }
-
-        @Override
-        public Object getValue(T entity) {
-            @SuppressWarnings("unchecked")
-            List<V> entities = (List<V>) super.getValue(entity);
-            return valueMapper.toUDTValues(entities);
-        }
-
-        @Override
-        public void setValue(Object entity, Object value) {
-            @SuppressWarnings("unchecked")
-            List<UDTValue> udtValues = (List<UDTValue>) value;
-            super.setValue(entity, valueMapper.toEntities(udtValues));
-        }
-    }
-
-    private static class UDTSetMapper<T, V> extends LiteralMapper<T> {
-
-        private final UDTMapper<V> valueMapper;
-
-        UDTSetMapper(Field field, int position, PropertyDescriptor pd, UDTMapper<V> valueMapper) {
-            super(field, DataType.set(valueMapper.getUserType()), position, pd);
-            this.valueMapper = valueMapper;
-        }
-
-        @Override
-        public Object getValue(T entity) {
-            @SuppressWarnings("unchecked")
-            Set<V> entities = (Set<V>) super.getValue(entity);
-            return valueMapper.toUDTValues(entities);
-        }
-
-        @Override
-        public void setValue(Object entity, Object value) {
-            @SuppressWarnings("unchecked")
-            Set<UDTValue> udtValues = (Set<UDTValue>) value;
-            super.setValue(entity, valueMapper.toEntities(udtValues));
-        }
-    }
-
-    /**
-     * A map field that contains UDT values.
-     * <p>
-     * UDTs may be used either as keys, or as values, or both. This is reflected
-     * in keyMapper and valueMapper being null or non-null.
-     * </p>
-     */
-    private static class UDTMapMapper<T, K, V> extends LiteralMapper<T> {
-        private final UDTMapper<K> keyMapper;
-        private final UDTMapper<V> valueMapper;
-
-        UDTMapMapper(Field field, int position, PropertyDescriptor pd, UDTMapper<K> keyMapper, UDTMapper<V> valueMapper, Class<?> keyClass, Class<?> valueClass) {
-            super(field, buildDataType(field, keyMapper, valueMapper, keyClass, valueClass), position, pd);
-            this.keyMapper = keyMapper;
-            this.valueMapper = valueMapper;
-        }
-
-        @Override
-        public Object getValue(T entity) {
-            @SuppressWarnings("unchecked")
-            Map<K, V> entities = (Map<K, V>) super.getValue(entity);
-            return UDTMapper.toUDTValues(entities, keyMapper, valueMapper);
+        public NestedUDTMapper(Field field, int position, PropertyDescriptor pd, InferredCQLType inferredCQLType) {
+            super(field, inferredCQLType.dataType, position, pd);
+            this.inferredCQLType = inferredCQLType;
         }
 
         @Override
         @SuppressWarnings("unchecked")
-        public void setValue(Object entity, Object fieldValue) {
-            Map<Object, Object> udtValues = (Map<Object, Object>) fieldValue;
-            super.setValue(entity, UDTMapper.toEntities(udtValues, keyMapper, valueMapper));
+        public Object getValue(T entity) {
+            Object valueWithEntities = super.getValue(entity);
+            return (T)UDTMapper.convertEntitiesToUDTs(valueWithEntities, inferredCQLType);
         }
 
-        private static <K, V> DataType buildDataType(Field field, UDTMapper<K> keyMapper, UDTMapper<V> valueMapper, Class<?> keyClass, Class<?> valueClass) {
-            assert keyMapper != null || valueMapper != null;
-
-            DataType keyType = (keyMapper != null) ?
-                                                  keyMapper.getUserType() :
-                                                  getSimpleType(keyClass, field);
-            DataType valueType = (valueMapper != null) ?
-                                                  valueMapper.getUserType() :
-                                                  getSimpleType(valueClass, field);
-            return DataType.map(keyType, valueType);
+        @Override
+        public void setValue(Object entity, Object valueWithUDTValues) {
+            super.setValue(entity, UDTMapper.convertUDTsToEntities(valueWithUDTValues, inferredCQLType));
         }
     }
 
-    static DataType extractType(Field f) {
+    static DataType extractSimpleType(Field f) {
         Type type = f.getGenericType();
 
-        if (type instanceof ParameterizedType) {
-            ParameterizedType pt = (ParameterizedType)type;
-            Type raw = pt.getRawType();
-            if (!(raw instanceof Class))
-                throw new IllegalArgumentException(String.format("Cannot map class %s for field %s", type, f.getName()));
-
-            Class<?> klass = (Class<?>)raw;
-            if (List.class.isAssignableFrom(klass)) {
-                return DataType.list(getSimpleType(ReflectionUtils.getParam(pt, 0, f.getName()), f));
-            }
-            if (Set.class.isAssignableFrom(klass)) {
-                return DataType.set(getSimpleType(ReflectionUtils.getParam(pt, 0, f.getName()), f));
-            }
-            if (Map.class.isAssignableFrom(klass)) {
-                return DataType.map(getSimpleType(ReflectionUtils.getParam(pt, 0, f.getName()), f), getSimpleType(ReflectionUtils.getParam(pt, 1, f.getName()), f));
-            }
-            throw new IllegalArgumentException(String.format("Cannot map class %s for field %s", type, f.getName()));
-        }
+        assert !(type instanceof ParameterizedType);
 
         if (!(type instanceof Class))
             throw new IllegalArgumentException(String.format("Cannot map class %s for field %s", type, f.getName()));
 
-        return getSimpleType((Class<?>)type, f);
-    }
-
-    static DataType getSimpleType(Class<?> klass, Field f) {
-        if (ByteBuffer.class.isAssignableFrom(klass))
-            return DataType.blob();
-
-        if (klass == int.class || Integer.class.isAssignableFrom(klass))
-                return DataType.cint();
-        if (klass == long.class || Long.class.isAssignableFrom(klass))
-            return DataType.bigint();
-        if (klass == float.class || Float.class.isAssignableFrom(klass))
-            return DataType.cfloat();
-        if (klass == double.class || Double.class.isAssignableFrom(klass))
-            return DataType.cdouble();
-        if (klass == boolean.class || Boolean.class.isAssignableFrom(klass))
-            return DataType.cboolean();
-
-        if (BigDecimal.class.isAssignableFrom(klass))
-            return DataType.decimal();
-        if (BigInteger.class.isAssignableFrom(klass))
-            return DataType.varint();
-
-        if (String.class.isAssignableFrom(klass))
-            return DataType.text();
-        if (InetAddress.class.isAssignableFrom(klass))
-            return DataType.inet();
-        if (Date.class.isAssignableFrom(klass))
-            return DataType.timestamp();
-        if (UUID.class.isAssignableFrom(klass))
-            return DataType.uuid();
-
-        if (Collection.class.isAssignableFrom(klass))
-            throw new IllegalArgumentException(String.format("Cannot map non-parametrized collection type %s for field %s; Please use a concrete type parameter", klass.getName(), f.getName()));
-
-        throw new IllegalArgumentException(String.format("Cannot map unknown class %s for field %s", klass.getName(), f));
+        return TypeMappings.getSimpleType((Class<?>)type, f.getName());
     }
 
     private static class ReflectionFactory implements Factory {
@@ -337,35 +208,19 @@ class ReflectionMapper<T> extends EntityMapper<T> {
                     return new EnumMapper<T>(field, position, pd, AnnotationParser.enumType(field));
                 }
 
-                if (field.getType().isAnnotationPresent(UDT.class)) {
+                if (TypeMappings.isMappedUDT(field.getType())) {
                     UDTMapper<?> udtMapper = mappingManager.getUDTMapper(field.getType());
                     return (ColumnMapper<T>) new UDTColumnMapper(field, position, pd, udtMapper);
                 }
 
                 if (field.getGenericType() instanceof ParameterizedType) {
-                    ParameterizedType pt = (ParameterizedType) field.getGenericType();
-                    Type raw = pt.getRawType();
-                    if (!(raw instanceof Class))
-                        throw new IllegalArgumentException(String.format("Cannot map class %s for field %s", field, field.getName()));
-
-                    Class<?> klass = (Class<?>)raw;
-                    Class<?> firstTypeParam = ReflectionUtils.getParam(pt, 0, field.getName());
-                    if (List.class.isAssignableFrom(klass) && firstTypeParam.isAnnotationPresent(UDT.class)) {
-                        UDTMapper<?> valueMapper = mappingManager.getUDTMapper(firstTypeParam);
-                        return (ColumnMapper<T>) new UDTListMapper(field, position, pd, valueMapper);
-                    }
-                    if (Set.class.isAssignableFrom(klass) && firstTypeParam.isAnnotationPresent(UDT.class)) {
-                        UDTMapper<?> valueMapper = mappingManager.getUDTMapper(firstTypeParam);
-                        return (ColumnMapper<T>) new UDTSetMapper(field, position, pd, valueMapper);
-                    }
-                    if (Map.class.isAssignableFrom(klass)) {
-                        Class<?> secondTypeParam = ReflectionUtils.getParam(pt, 1, field.getName());
-                        UDTMapper<?> keyMapper = firstTypeParam.isAnnotationPresent(UDT.class) ? mappingManager.getUDTMapper(firstTypeParam) : null;
-                        UDTMapper<?> valueMapper = secondTypeParam.isAnnotationPresent(UDT.class) ? mappingManager.getUDTMapper(secondTypeParam) : null;
-
-                        if (keyMapper != null || valueMapper != null) {
-                            return (ColumnMapper<T>) new UDTMapMapper(field, position, pd, keyMapper, valueMapper, firstTypeParam, secondTypeParam);
-                        }
+                    InferredCQLType inferredCQLType = InferredCQLType.from(field, mappingManager);
+                    if (inferredCQLType.containsMappedUDT) {
+                        // We need a specialized mapper to convert UDT instances in the hierarchy.
+                        return (ColumnMapper<T>)new NestedUDTMapper(field, position, pd, inferredCQLType);
+                    } else {
+                        // The default codecs will know how to handle the extracted datatype.
+                        return new LiteralMapper<T>(field, inferredCQLType.dataType, position, pd);
                     }
                 }
 

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/TypeMappings.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/TypeMappings.java
@@ -1,0 +1,95 @@
+/*
+ *      Copyright (C) 2012-2014 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.util.*;
+
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.TupleValue;
+import com.datastax.driver.core.UDTValue;
+import com.datastax.driver.mapping.annotations.UDT;
+
+/**
+ * Utility methods to determine which CQL type we expect for a given Java field type.
+ */
+class TypeMappings {
+
+    static DataType getSimpleType(Class<?> klass, String fieldName) {
+        if (ByteBuffer.class.isAssignableFrom(klass))
+            return DataType.blob();
+
+        if (klass == int.class || Integer.class.isAssignableFrom(klass))
+                return DataType.cint();
+        if (klass == long.class || Long.class.isAssignableFrom(klass))
+            return DataType.bigint();
+        if (klass == float.class || Float.class.isAssignableFrom(klass))
+            return DataType.cfloat();
+        if (klass == double.class || Double.class.isAssignableFrom(klass))
+            return DataType.cdouble();
+        if (klass == boolean.class || Boolean.class.isAssignableFrom(klass))
+            return DataType.cboolean();
+
+        if (BigDecimal.class.isAssignableFrom(klass))
+            return DataType.decimal();
+        if (BigInteger.class.isAssignableFrom(klass))
+            return DataType.varint();
+
+        if (String.class.isAssignableFrom(klass))
+            return DataType.text();
+        if (InetAddress.class.isAssignableFrom(klass))
+            return DataType.inet();
+        if (Date.class.isAssignableFrom(klass))
+            return DataType.timestamp();
+        if (UUID.class.isAssignableFrom(klass))
+            return DataType.uuid();
+
+        if (Collection.class.isAssignableFrom(klass))
+            throw new IllegalArgumentException(String.format("Cannot map non-parametrized collection type %s for field %s; Please use a concrete type parameter", klass.getName(), fieldName));
+
+        throw new IllegalArgumentException(String.format("Cannot map unknown class %s for field %s", klass.getName(), fieldName));
+    }
+
+    static boolean mapsToList(Class<?> klass) {
+        return List.class.equals(klass);
+    }
+
+    static boolean mapsToSet(Class<?> klass) {
+        return Set.class.equals(klass);
+    }
+
+    static boolean mapsToMap(Class<?> klass) {
+        return Map.class.equals(klass);
+    }
+
+    static boolean mapsToCollection(Class<?> klass) {
+        return mapsToList(klass) || mapsToSet(klass) || mapsToMap(klass);
+    }
+
+    static boolean isMappedUDT(Class<?> klass) {
+        return klass.isAnnotationPresent(UDT.class);
+    }
+
+    static boolean mapsToUserTypeOrTuple(Class<?> klass) {
+        return isMappedUDT(klass) ||
+            klass.equals(UDTValue.class) ||
+            klass.equals(TupleValue.class);
+    }
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/core/CoreHooks.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/core/CoreHooks.java
@@ -1,0 +1,10 @@
+package com.datastax.driver.core;
+
+import java.util.Collections;
+
+/**
+ * Provides access to package-private members of the core module.
+ */
+public class CoreHooks {
+    public static UserType MOCK_USER_TYPE = new UserType("mockKs", "mockUDT", Collections.<UserType.Field>emptyList());
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/AnnotationChecksTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/AnnotationChecksTest.java
@@ -3,15 +3,19 @@ package com.datastax.driver.mapping;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.datastax.driver.mapping.annotations.Frozen;
 import com.datastax.driver.mapping.annotations.FrozenValue;
+import com.datastax.driver.mapping.annotations.UDT;
+
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.fail;
 
 public class AnnotationChecksTest {
     // Dummy UDT class:
+    @UDT(name = "user")
     public class User {
     }
 
@@ -27,11 +31,21 @@ public class AnnotationChecksTest {
     @FrozenValue
     List<User> listOfFrozenUsers;
     Map<String, Map<String, User>> deeplyNestedUnfrozenUser;
-    @Frozen("map<text, map<text, frozen<user>>>")
+    @Frozen("map<text, frozen<map<text, frozen<user>>>>")
     Map<String, Map<String, User>> deeplyNestedFrozenUser;
 
+    Map<String, List<Integer>> mapOfUnfrozenListOfInt;
+    @FrozenValue
+    Map<String, List<Integer>> mapOfFrozenListOfInt;
+    @FrozenValue
+    Map<Integer, List<Set<Integer>>> deeplyNestedUnfrozenSet;
+    @Frozen("map<int, frozen<list<set<int>>>>")
+    Map<Integer, List<Set<Integer>>> deeplyNestedUnfrozenSet2;
+    @Frozen("map<int, frozen<list<frozen<set<int>>>>>")
+    Map<Integer, List<Set<Integer>>> deeplyNestedFrozenSet;
+
     @Test(groups = "unit")
-    public void checkFrozenTypesTest() throws Exception {
+    public void should_fail_if_udt_not_frozen() throws Exception {
         checkFrozenTypesTest("string", true);
         checkFrozenTypesTest("frozenString", false);
         checkFrozenTypesTest("listOfStrings", true);
@@ -41,6 +55,15 @@ public class AnnotationChecksTest {
         checkFrozenTypesTest("listOfFrozenUsers", true);
         checkFrozenTypesTest("deeplyNestedUnfrozenUser", false);
         checkFrozenTypesTest("deeplyNestedFrozenUser", true);
+    }
+
+    @Test(groups = "unit")
+    public void should_fail_if_nested_collection_not_frozen() throws Exception {
+        checkFrozenTypesTest("mapOfUnfrozenListOfInt", false);
+        checkFrozenTypesTest("mapOfFrozenListOfInt", true);
+        checkFrozenTypesTest("deeplyNestedUnfrozenSet", false);
+        checkFrozenTypesTest("deeplyNestedUnfrozenSet2", false);
+        checkFrozenTypesTest("deeplyNestedFrozenSet", true);
     }
 
     private void checkFrozenTypesTest(String fieldName, boolean expectSuccess) throws Exception {

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/DeclaredFrozenTypeTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/DeclaredFrozenTypeTest.java
@@ -3,10 +3,10 @@ package com.datastax.driver.mapping;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
-public class CQLTypeTest {
+public class DeclaredFrozenTypeTest {
     @Test(groups = "unit")
     public void parseSimpleTypeTest() {
-        CQLType type = CQLType.parse(" foo");
+        DeclaredFrozenType type = DeclaredFrozenType.parse(" foo");
         assertEquals(type.name, "foo");
         assertFalse(type.frozen);
         assertNull(type.subTypes);
@@ -14,7 +14,7 @@ public class CQLTypeTest {
 
     @Test(groups = "unit")
     public void parseQuotedTypeTest() {
-        CQLType type = CQLType.parse("\"Foo bar\"");
+        DeclaredFrozenType type = DeclaredFrozenType.parse("\"Foo bar\"");
         assertEquals(type.name, "Foo bar");
         assertFalse(type.frozen);
         assertNull(type.subTypes);
@@ -23,18 +23,18 @@ public class CQLTypeTest {
     @Test(groups = "unit")
     public void parseNestedTypeTest() {
         // list
-        CQLType type = CQLType.parse("list<foo1>");
+        DeclaredFrozenType type = DeclaredFrozenType.parse("list<foo1>");
         assertEquals(type.name, "list");
         assertFalse(type.frozen);
         assertEquals(type.subTypes.size(), 1);
 
-        CQLType subType0 = type.subTypes.get(0);
+        DeclaredFrozenType subType0 = type.subTypes.get(0);
         assertEquals(subType0.name, "foo1");
         assertFalse(subType0.frozen);
         assertNull(subType0.subTypes);
 
         // map
-        type = CQLType.parse("map < foo , bar >");
+        type = DeclaredFrozenType.parse("map < foo , bar >");
         assertEquals(type.name, "map");
         assertFalse(type.frozen);
         assertEquals(type.subTypes.size(), 2);
@@ -44,7 +44,7 @@ public class CQLTypeTest {
         assertFalse(subType0.frozen);
         assertNull(subType0.subTypes);
 
-        CQLType subType1 = type.subTypes.get(1);
+        DeclaredFrozenType subType1 = type.subTypes.get(1);
         assertEquals(subType1.name, "bar");
         assertFalse(subType1.frozen);
         assertNull(subType1.subTypes);
@@ -53,7 +53,7 @@ public class CQLTypeTest {
 
     @Test(groups = "unit")
     public void parseSimpleFrozenTypeTest() {
-        CQLType type = CQLType.parse("frozen<foo_1>");
+        DeclaredFrozenType type = DeclaredFrozenType.parse("frozen<foo_1>");
         assertEquals(type.name, "foo_1");
         assertTrue(type.frozen);
         assertNull(type.subTypes);
@@ -61,12 +61,12 @@ public class CQLTypeTest {
 
     @Test(groups = "unit")
     public void parseNestedFrozenTypeTest() {
-        CQLType type = CQLType.parse("list<frozen<foo>>");
+        DeclaredFrozenType type = DeclaredFrozenType.parse("list<frozen<foo>>");
         assertEquals(type.name, "list");
         assertFalse(type.frozen);
         assertEquals(type.subTypes.size(), 1);
 
-        CQLType subType0 = type.subTypes.get(0);
+        DeclaredFrozenType subType0 = type.subTypes.get(0);
         assertEquals(subType0.name, "foo");
         assertTrue(subType0.frozen);
         assertNull(subType0.subTypes);
@@ -75,27 +75,27 @@ public class CQLTypeTest {
     @Test(groups = "unit")
     public void parseDeeplyNestedTypeTest() {
         // NB: nested collections are not allowed in C* 2.1, but might be in the future, so we want to handle that
-        CQLType type = CQLType.parse("map<text, map<text, frozen<foo>>>");
+        DeclaredFrozenType type = DeclaredFrozenType.parse("map<text, map<text, frozen<foo>>>");
         assertEquals(type.name, "map");
         assertFalse(type.frozen);
         assertEquals(type.subTypes.size(), 2);
 
-        CQLType subType0 = type.subTypes.get(0);
+        DeclaredFrozenType subType0 = type.subTypes.get(0);
         assertEquals(subType0.name, "text");
         assertFalse(subType0.frozen);
         assertNull(subType0.subTypes);
 
-        CQLType subType1 = type.subTypes.get(1);
+        DeclaredFrozenType subType1 = type.subTypes.get(1);
         assertEquals(subType1.name, "map");
         assertFalse(subType1.frozen);
         assertEquals(subType1.subTypes.size(), 2);
 
-        CQLType subType10 = subType1.subTypes.get(0);
+        DeclaredFrozenType subType10 = subType1.subTypes.get(0);
         assertEquals(subType10.name, "text");
         assertFalse(subType10.frozen);
         assertNull(subType10.subTypes);
 
-        CQLType subType11 = subType1.subTypes.get(1);
+        DeclaredFrozenType subType11 = subType1.subTypes.get(1);
         assertEquals(subType11.name, "foo");
         assertTrue(subType11.frozen);
         assertNull(subType11.subTypes);

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/InferredCQLTypeTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/InferredCQLTypeTest.java
@@ -1,0 +1,94 @@
+package com.datastax.driver.mapping;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datastax.driver.core.CoreHooks;
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.UserType;
+import com.datastax.driver.mapping.annotations.UDT;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+
+public class InferredCQLTypeTest {
+    MappingManager manager;
+    UDTMapper mockMapper;
+    UserType mockUDTType = CoreHooks.MOCK_USER_TYPE;
+
+    @BeforeClass(groups = "unit")
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        mockMapper = mock(UDTMapper.class);
+        when(mockMapper.getUserType()).thenReturn(mockUDTType);
+
+        manager = mock(MappingManager.class);
+        when(manager.udtMapper(MockUDT.class)).thenReturn(mockMapper);
+    }
+
+    @Test(groups = "unit")
+    public void should_parse_collections_of_primitives() throws Exception {
+        InferredCQLType instance = newInstanceForField("listOfIntegers");
+        assertThat(instance.dataType).isEqualTo(DataType.list(DataType.cint()));
+        assertThat(instance.containsMappedUDT).isFalse();
+        assertThat(instance.udtMapper).isNull();
+
+        instance = newInstanceForField("setOfStrings");
+        assertThat(instance.dataType).isEqualTo(DataType.set(DataType.text()));
+        assertThat(instance.containsMappedUDT).isFalse();
+        assertThat(instance.udtMapper).isNull();
+
+        instance = newInstanceForField("mapOfIntegerToString");
+        assertThat(instance.dataType).isEqualTo(DataType.map(DataType.cint(), DataType.text()));
+        assertThat(instance.containsMappedUDT).isFalse();
+        assertThat(instance.udtMapper).isNull();
+    }
+
+    @Test(groups = "unit")
+    public void should_parse_collection_containing_UDT() throws Exception {
+        InferredCQLType instance = newInstanceForField("listOfUDT");
+        assertThat(instance.dataType).isEqualTo(DataType.list(mockUDTType));
+        assertThat(instance.containsMappedUDT).isTrue();
+        assertThat(instance.udtMapper).isNull();
+        assertThat(instance.childTypes.get(0).udtMapper).isEqualTo(mockMapper);
+
+        instance = newInstanceForField("complexMap");
+        assertThat(instance.dataType).isEqualTo(DataType.map(
+            DataType.list(DataType.cint()),
+            DataType.map(DataType.text(), DataType.set(mockUDTType))
+        ));
+        assertThat(instance.containsMappedUDT).isTrue();
+        assertThat(instance.udtMapper).isNull();
+        InferredCQLType key = instance.childTypes.get(0);
+        assertThat(key.containsMappedUDT).isFalse();
+        assertThat(key.udtMapper).isNull();
+        InferredCQLType value = instance.childTypes.get(1);
+        assertThat(value.containsMappedUDT).isTrue();
+        assertThat(value.udtMapper).isNull();
+        assertThat(value.childTypes.get(0).containsMappedUDT).isFalse();
+        assertThat(value.childTypes.get(1).containsMappedUDT).isTrue();
+        assertThat(value.childTypes.get(1).childTypes.get(0).udtMapper).isEqualTo(mockMapper);
+    }
+
+    private InferredCQLType newInstanceForField(String name) throws NoSuchFieldException {
+        Field field = InferredCQLTypeTest.class.getDeclaredField(name);
+        return InferredCQLType.from(field, manager);
+    }
+
+    @UDT(name = "mock")
+    static class MockUDT {
+    }
+
+    List<Integer> listOfIntegers;
+    Set<String> setOfStrings;
+    Map<Integer, String> mapOfIntegerToString;
+    List<MockUDT> listOfUDT;
+    Map<List<Integer>, Map<String, Set<MockUDT>>> complexMap;
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperInvalidCollectionTypesTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperInvalidCollectionTypesTest.java
@@ -1,0 +1,105 @@
+package com.datastax.driver.mapping;
+
+import java.util.*;
+
+import org.testng.annotations.Test;
+
+import com.datastax.driver.core.CCMBridge;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+
+public class MapperInvalidCollectionTypesTest extends CCMBridge.PerClassSingleNodeCluster {
+    protected Collection<String> getTableDefinitions() {
+        return Arrays.asList(
+            "CREATE TABLE table_list (id int PRIMARY KEY, l list<int>)",
+            "CREATE TABLE table_set (id int PRIMARY KEY, s set<int>)",
+            "CREATE TABLE table_map (id int PRIMARY KEY, m map<int, int>)");
+    }
+
+    @Table(keyspace="ks", name="table_list")
+    public class InvalidList {
+        @PartitionKey
+        private int id;
+
+        private ArrayList<Integer> l;
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public ArrayList<Integer> getL() {
+            return l;
+        }
+
+        public void setL(ArrayList<Integer> l) {
+            this.l = l;
+        }
+    }
+
+    @Table(keyspace="ks", name="table_set")
+    public class InvalidSet {
+        @PartitionKey
+        private int id;
+
+        private HashSet<Integer> s;
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public HashSet<Integer> getS() {
+            return s;
+        }
+
+        public void setS(HashSet<Integer> s) {
+            this.s = s;
+        }
+    }
+
+    @Table(keyspace="ks", name="table_map")
+    public class InvalidMap {
+        @PartitionKey
+        private int id;
+
+        private TreeMap<Integer, Integer> m;
+
+        public TreeMap<Integer, Integer> getM() {
+            return m;
+        }
+
+        public void setM(TreeMap<Integer, Integer> m) {
+            this.m = m;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+    }
+
+    @Test(groups="short", expectedExceptions = IllegalArgumentException.class)
+    public void list_type_is_enforced() {
+        new MappingManager(session).mapper(InvalidList.class);
+    }
+
+    @Test(groups="short", expectedExceptions = IllegalArgumentException.class)
+    public void map_type_is_enforced() {
+        new MappingManager(session).mapper(InvalidMap.class);
+    }
+
+    @Test(groups="short", expectedExceptions = IllegalArgumentException.class)
+    public void set_type_is_enforced() {
+        new MappingManager(session).mapper(InvalidSet.class);
+    }
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperNestedCollectionsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperNestedCollectionsTest.java
@@ -1,0 +1,144 @@
+package com.datastax.driver.mapping;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.testng.annotations.Test;
+
+import com.datastax.driver.core.CCMBridge;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.mapping.annotations.*;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+
+public class MapperNestedCollectionsTest extends CCMBridge.PerClassSingleNodeCluster {
+
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return Lists.newArrayList(
+            "CREATE TYPE testType(i int)",
+            "CREATE TABLE testTable (k int primary key, "
+                + "m1 map<text, frozen<map<int, int>>>, " // nested collection
+                + "m2 map<text, frozen<map<int, frozen<testType>>>>)" // nested collection with UDT
+        );
+    }
+
+    @Test(groups = "short")
+    public void should_map_fields_to_nested_collections() {
+        Mapper<TestTable> mapper = new MappingManager(session).mapper(TestTable.class);
+
+        TestTable testTable = new TestTable();
+        testTable.setK(1);
+        testTable.setM1(ImmutableMap.<String, Map<Integer, Integer>>of("bar", ImmutableMap.of(1, 2)));
+        testTable.setM2(ImmutableMap.<String, Map<Integer, TestType>>of("bar", ImmutableMap.of(1, new TestType(2))));
+
+        mapper.save(testTable);
+
+        TestTable testTable2 = mapper.get(1);
+        assertThat(testTable2.getM1()).isEqualTo(testTable.getM1());
+        assertThat(testTable2.getM2()).isEqualTo(testTable.getM2());
+    }
+
+    @Test(groups = "short")
+    public void should_map_accessor_params_to_nested_collections() {
+        MappingManager manager = new MappingManager(session);
+        Mapper<TestTable> mapper = manager.mapper(TestTable.class);
+        TestAccessor accessor = manager.createAccessor(TestAccessor.class);
+
+        TestTable testTable = new TestTable();
+        testTable.setK(1);
+        mapper.save(testTable);
+
+        Map<String, Map<Integer, Integer>> m1 = ImmutableMap.<String, Map<Integer, Integer>>of("bar", ImmutableMap.of(1, 2));
+        Map<String, Map<Integer, TestType>> m2 = ImmutableMap.<String, Map<Integer, TestType>>of("bar", ImmutableMap.of(1, new TestType(2)));
+        accessor.setM1(1, m1);
+        accessor.setM2(1, m2);
+
+        TestTable testTable2 = mapper.get(1);
+        assertThat(testTable2.getM1()).isEqualTo(m1);
+        assertThat(testTable2.getM2()).isEqualTo(m2);
+    }
+
+    @UDT(keyspace = "ks", name = "testType")
+    public static class TestType {
+        private int i;
+
+        public TestType() {
+        }
+
+        public TestType(int i) {
+            this.i = i;
+        }
+
+        public int getI() {
+            return i;
+        }
+
+        public void setI(int i) {
+            this.i = i;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other)
+                return true;
+            if (other instanceof TestType) {
+                TestType that = (TestType)other;
+                return this.i == that.i;
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return i;
+        }
+    }
+
+    @Table(keyspace = "ks", name = "testTable")
+    public static class TestTable {
+        @PartitionKey
+        private int k;
+
+        @Frozen("map<text, frozen<map<int, int>>>")
+        private Map<String, Map<Integer, Integer>> m1;
+
+        @Frozen("map<text, frozen<map<int, frozen<testType>>>>")
+        private Map<String, Map<Integer, TestType>> m2;
+
+        public int getK() {
+            return k;
+        }
+
+        public void setK(int k) {
+            this.k = k;
+        }
+
+        public Map<String, Map<Integer, Integer>> getM1() {
+            return m1;
+        }
+
+        public void setM1(Map<String, Map<Integer, Integer>> m1) {
+            this.m1 = m1;
+        }
+
+        public Map<String, Map<Integer, TestType>> getM2() {
+            return m2;
+        }
+
+        public void setM2(Map<String, Map<Integer, TestType>> m2) {
+            this.m2 = m2;
+        }
+    }
+
+    @Accessor
+    public static interface TestAccessor {
+        @Query("UPDATE testTable SET m1 = :m1 WHERE k = :k")
+        ResultSet setM1(@Param("k") int k, @Param("m1") Map<String, Map<Integer, Integer>> m1);
+
+        @Query("UPDATE testTable SET m2 = :m2 WHERE k = :k")
+        ResultSet setM2(@Param("k") int k, @Param("m2") Map<String, Map<Integer, TestType>> m2);
+    }
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/UDTFieldMapperTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/UDTFieldMapperTest.java
@@ -10,14 +10,14 @@ import com.datastax.driver.core.CCMBridge;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.TestUtils;
+import com.datastax.driver.core.utils.CassandraVersion;
 import com.datastax.driver.mapping.annotations.*;
 
+@CassandraVersion(major=2.1)
 public class UDTFieldMapperTest {
 
     @Test(groups = "short")
     public void udt_and_tables_with_ks_created_in_another_session_should_be_mapped() {
-        TestUtils.versionCheck(2.1, 0, "This will only work with C* 2.1.0");
-
         CCMBridge ccm = null;
         Cluster cluster = null;
 
@@ -65,8 +65,6 @@ public class UDTFieldMapperTest {
 
     @Test(groups = "short")
     public void udt_and_tables_without_ks_created_in_another_session_should_be_mapped() {
-        TestUtils.versionCheck(2.1, 0, "This will only work with C* 2.1.0");
-
         CCMBridge ccm = null;
         Cluster cluster = null;
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cassandra.version>2.1.2</cassandra.version>
+    <cassandra.version>2.1.3</cassandra.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
[JAVA-570](https://datastax-oss.atlassian.net/browse/JAVA-570)

New features:
- collection getters have a new variant that takes Guava `TypeToken`s to express complex types:
  
  ```
  Map<Integer, List<String>> m = row.getMap(0, TypeToken.of(Integer.class), 
                                               new TypeToken<List<String>>(){});
  ```
- in data types retrieved from cluster metadata, `isFrozen()` returns true for nested collections. There are new methods to build frozen types from scratch, for example `DataType.frozenList(DataType)`. N.B: data types retrieved from row or prepared statement metadata don't express frozenness (it's not needed and Cassandra doesn't expose it in native frames anyway).
- in the mapper, nested collections can be used as fields and accessor parameters. If `UDT`-annotated classes appear in the type hierarchy, they will be converted on the fly. See `MapperNestedCollectionsTest`.
