### PR TITLE
Add connection heartbeat (JAVA-533).

### DIFF
--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -5,6 +5,7 @@ CHANGELOG
 -------
 
 - [new feature] Add AddressTranslater for EC2 multi-region deployment (JAVA-518)
+- [improvement] Add connection heartbeat (JAVA-533)
 
 Merged from 2.0.9_fixes branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/PoolingOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PoolingOptions.java
@@ -58,6 +58,7 @@ public class PoolingOptions {
     private static final int DEFAULT_MAX_POOL_REMOTE = 2;
 
     private static final int DEFAULT_POOL_TIMEOUT_MILLIS = 5000;
+    private static final int DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 30;
 
     private volatile Cluster.Manager manager;
 
@@ -68,6 +69,7 @@ public class PoolingOptions {
     private final int[] maxConnections = new int[] { DEFAULT_MAX_POOL_LOCAL , DEFAULT_MAX_POOL_REMOTE, 0 };
 
     private volatile int poolTimeoutMillis = DEFAULT_POOL_TIMEOUT_MILLIS;
+    private volatile int heartbeatIntervalSeconds = DEFAULT_HEARTBEAT_INTERVAL_SECONDS;
 
     public PoolingOptions() {}
 
@@ -263,6 +265,37 @@ public class PoolingOptions {
         if (poolTimeoutMillis < 0)
             throw new IllegalArgumentException("Pool timeout must be positive");
         this.poolTimeoutMillis = poolTimeoutMillis;
+        return this;
+    }
+
+    /**
+     * Returns the heart beat interval, after which a message is sent on an idle connection to make sure it's still alive.
+     * @return the interval.
+     */
+    public int getHeartbeatIntervalSeconds() {
+        return heartbeatIntervalSeconds;
+    }
+
+    /**
+     * Sets the heart beat interval, after which a message is sent on an idle connection to make sure it's still alive.
+     * <p>
+     * This is an application-level keep-alive, provided for convenience since adjusting the TCP keep-alive might not be
+     * practical in all environments.
+     * <p>
+     * This option should be set higher than {@link SocketOptions#getReadTimeoutMillis()}.
+     * <p>
+     * The default value for this option is 30 seconds.
+     *
+     * @param heartbeatIntervalSeconds the new value in seconds. If set to 0, it will disable the feature.
+     * @return this {@code PoolingOptions}
+     *
+     * @throws IllegalArgumentException if the interval is negative.
+     */
+    public PoolingOptions setHeartbeatIntervalSeconds(int heartbeatIntervalSeconds) {
+        if (poolTimeoutMillis < 0)
+            throw new IllegalArgumentException("Heartbeat interval must be positive");
+
+        this.heartbeatIntervalSeconds = heartbeatIntervalSeconds;
         return this;
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/HeartbeatTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HeartbeatTest.java
@@ -1,0 +1,63 @@
+package com.datastax.driver.core;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+
+public class HeartbeatTest {
+
+    Logger connectionLogger = Logger.getLogger(Connection.class);
+    MemoryAppender logs;
+
+    @BeforeMethod(groups = "long")
+    public void startCapturingLogs() {
+        connectionLogger.setLevel(Level.DEBUG);
+        logs = new MemoryAppender();
+        connectionLogger.addAppender(logs);
+    }
+
+    @AfterMethod(groups="long")
+    public void stopCapturingLogs() {
+        connectionLogger.setLevel(null);
+        connectionLogger.removeAppender(logs);
+    }
+
+    @Test(groups = "long")
+    public void should_send_heartbeat_when_connection_is_inactive() throws InterruptedException {
+        CCMBridge ccm = null;
+        Cluster cluster = null;
+        try {
+            ccm = CCMBridge.create("test", 1);
+            cluster = Cluster.builder().addContactPoint(CCMBridge.ipOfNode(1))
+                .withPoolingOptions(new PoolingOptions()
+                    .setHeartbeatIntervalSeconds(3))
+                .build();
+
+            // Don't create any session, only the control connection will be established
+            cluster.init();
+
+            for (int i = 0; i < 5; i++) {
+                // Simulate activity
+                cluster.manager.controlConnection.refreshNodeInfo(TestUtils.findHost(cluster, 1));
+                SECONDS.sleep(1);
+            }
+            assertThat(logs.get()).doesNotContain("sending heartbeat");
+
+            SECONDS.sleep(5);
+            assertThat(logs.get())
+                .contains("sending heartbeat")
+                .contains("heartbeat query succeeded");
+        } finally {
+            if (cluster != null)
+                cluster.close();
+            if (ccm != null)
+                ccm.remove();
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/MemoryAppender.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MemoryAppender.java
@@ -14,6 +14,8 @@ import org.apache.log4j.WriterAppender;
 public class MemoryAppender extends WriterAppender {
     public final StringWriter writer = new StringWriter();
 
+    private int nextLogIdx = 0;
+
     public MemoryAppender() {
         setWriter(writer);
         setLayout(new PatternLayout("%m%n"));
@@ -21,5 +23,14 @@ public class MemoryAppender extends WriterAppender {
 
     public String get() {
         return writer.toString();
+    }
+
+    /**
+     * @return The next set of logs after getNext was last called.  Not thread safe.
+     */
+    public String getNext() {
+        String next = get().substring(nextLogIdx);
+        nextLogIdx += next.length();
+        return next;
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicyTest.java
@@ -14,6 +14,7 @@ import static org.testng.Assert.assertEquals;
 import com.datastax.driver.core.*;
 
 public class DCAwareRoundRobinPolicyTest {
+    Logger policyLogger = Logger.getLogger(DCAwareRoundRobinPolicy.class);
     MemoryAppender logs;
     CCMBridge ccm;
 
@@ -31,18 +32,15 @@ public class DCAwareRoundRobinPolicyTest {
 
     @BeforeMethod(groups = "short")
     public void startRecordingLogs() {
-        Logger policyLogger = Logger.getLogger(DCAwareRoundRobinPolicy.class);
-        assertThat(Level.WARN.isGreaterOrEqual(policyLogger.getEffectiveLevel()))
-            .isTrue()
-            .as("Log level must be at least WARN for this test to work");
-
+        policyLogger.setLevel(Level.WARN);
         logs = new MemoryAppender();
         policyLogger.addAppender(logs);
     }
 
     @AfterMethod(groups = "short")
     public void stopRecordingLogs() {
-        Logger.getLogger(DCAwareRoundRobinPolicy.class).removeAppender(logs);
+        policyLogger.setLevel(null);
+        policyLogger.removeAppender(logs);
     }
 
     @Test(groups = "short")


### PR DESCRIPTION
I'm not a big fan of using logs for test assertions, but that's the only thing I've found for this one.

Also, reconnection after a failed heartbeat is not covered, I've tested that manually by "freezing" the target host with `kill -STOP`.
