### PR TITLE
Fix guava dependecy when using OSGI (JAVA-620)

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -131,6 +131,7 @@
             <Bundle-SymbolicName>com.datastax.driver.core</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <_include>-osgi.bnd</_include>
+            <Import-Package><![CDATA[com.google.common.*;version="[14.0,17)",*]]></Import-Package>
           </instructions>
           <supportedProjectTypes>
             <supportedProjectType>jar</supportedProjectType>

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -131,7 +131,7 @@
             <Bundle-SymbolicName>com.datastax.driver.core</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
             <_include>-osgi.bnd</_include>
-            <Import-Package><![CDATA[com.google.common.*;version="[14.0,17)",*]]></Import-Package>
+            <Import-Package><![CDATA[com.google.common.*;version="[14.0,18)",*]]></Import-Package>
           </instructions>
           <supportedProjectTypes>
             <supportedProjectType>jar</supportedProjectType>


### PR DESCRIPTION
Set the version range for the guava dependency when deployed in an osgi environment so guava version 16.0.1 will fulfil the dependency.
