### PR TITLE
BoundStatment.toString (JAVA-115)

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -1250,11 +1250,20 @@ public class BoundStatement extends Statement implements SettableData<BoundState
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder("BoundStatement(" + statement.getQueryString() + ",[");
-        for(int i = 0; i < wrapper.values.length; i++) {
-            if(i > 0) {
+        for (int i = 0; i < wrapper.values.length; i++) {
+            if (i > 0) {
                 sb.append(",");
             }
-            sb.append(new String(wrapper.getValue(i).array(), StandardCharsets.UTF_8));
+
+            if (wrapper.getType(i).getName() == DataType.Name.BLOB) {
+                sb.append("<Blob>");
+            }
+            else if(wrapper.getType(i).getName() == DataType.Name.CUSTOM) {
+                sb.append("<Custom Type>");
+            }
+            else {
+                sb.append(new String(wrapper.getValue(i).array(), StandardCharsets.UTF_8));
+            }
         }
         sb.append("])");
         return sb.toString();

--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -19,6 +19,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import com.datastax.driver.core.exceptions.InvalidTypeException;
@@ -1245,4 +1246,17 @@ public class BoundStatement extends Statement implements SettableData<BoundState
              index += 1;
         }
     }
+
+   @Override
+   public String toString() {
+      StringBuilder sb = new StringBuilder("BoundStatement(" + statement.getQueryString() + ",[");
+      for(int i = 0; i < wrapper.values.length; i++) {
+         if(i > 0) {
+            sb.append(",");
+         }
+         sb.append(new String(wrapper.getValue(i).array(), StandardCharsets.UTF_8));
+      }
+      sb.append("])");
+      return sb.toString();
+   }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -19,7 +19,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import com.datastax.driver.core.exceptions.InvalidTypeException;

--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -1255,17 +1255,12 @@ public class BoundStatement extends Statement implements SettableData<BoundState
                 sb.append(",");
             }
 
-            if (statement.getVariables().getType(i).getName() == DataType.Name.BLOB) {
-                sb.append("<Blob>");
-            }
-            else if(statement.getVariables().getType(i).getName() == DataType.Name.CUSTOM) {
-                sb.append("<Custom Type>");
-            }
-            else if(wrapper.getValue(i) == null) {
-               sb.append("<null>");
-            }
-            else {
-                sb.append(new String(wrapper.getValue(i).array(), StandardCharsets.UTF_8));
+            DataType type = statement.getVariables().getType(i);
+            String formatted = type.format(wrapper.getValue(i));
+            if (DataType.blob().equals(type) && formatted.length() > 50) {
+               sb.append(formatted.substring(0, 50)).append("... [truncated output]");
+            } else {
+               sb.append(formatted);
             }
         }
         sb.append("])");

--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -1255,11 +1255,14 @@ public class BoundStatement extends Statement implements SettableData<BoundState
                 sb.append(",");
             }
 
-            if (wrapper.getType(i).getName() == DataType.Name.BLOB) {
+            if (statement.getVariables().getType(i).getName() == DataType.Name.BLOB) {
                 sb.append("<Blob>");
             }
-            else if(wrapper.getType(i).getName() == DataType.Name.CUSTOM) {
+            else if(statement.getVariables().getType(i).getName() == DataType.Name.CUSTOM) {
                 sb.append("<Custom Type>");
+            }
+            else if(wrapper.getValue(i) == null) {
+               sb.append("<null>");
             }
             else {
                 sb.append(new String(wrapper.getValue(i).array(), StandardCharsets.UTF_8));

--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -1247,16 +1247,16 @@ public class BoundStatement extends Statement implements SettableData<BoundState
         }
     }
 
-   @Override
-   public String toString() {
-      StringBuilder sb = new StringBuilder("BoundStatement(" + statement.getQueryString() + ",[");
-      for(int i = 0; i < wrapper.values.length; i++) {
-         if(i > 0) {
-            sb.append(",");
-         }
-         sb.append(new String(wrapper.getValue(i).array(), StandardCharsets.UTF_8));
-      }
-      sb.append("])");
-      return sb.toString();
-   }
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("BoundStatement(" + statement.getQueryString() + ",[");
+        for(int i = 0; i < wrapper.values.length; i++) {
+            if(i > 0) {
+                sb.append(",");
+            }
+            sb.append(new String(wrapper.getValue(i).array(), StandardCharsets.UTF_8));
+        }
+        sb.append("])");
+        return sb.toString();
+    }
 }


### PR DESCRIPTION
Add a toString method to BoundStatement.

BuiltStatement has one but BoundStatement doesn't and falls back to Objects.toString() which is not very helpful when logging errors.

Only thing I am not sure about is the use of StandardCharsets. Do we need to support versions of java less than 1.7?
