### PR TITLE
Races between query completion and cancellation/timeout (JAVA-614, JAVA-632)

### DIFF
--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -8,6 +8,8 @@ CHANGELOG
 - [bug] Prevent race between cancellation and query completion (JAVA-614)
 - [bug] Prevent cancel and timeout from cancelling unrelated ResponseHandler if
   streamId was already released and reused (JAVA-632).
+- [bug] Fix issue when newly opened pool fails before we could mark the node UP
+  (JAVA-642)
 
 
 2.0.9:

--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -6,6 +6,8 @@ CHANGELOG
 
 - [new feature] Add AddressTranslater for EC2 multi-region deployment (JAVA-518)
 - [bug] Prevent race between cancellation and query completion (JAVA-614)
+- [bug] Prevent cancel and timeout from cancelling unrelated ResponseHandler if
+  streamId was already released and reused (JAVA-632).
 
 
 2.0.9:

--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -5,6 +5,8 @@ CHANGELOG
 -------
 
 - [new feature] Add AddressTranslater for EC2 multi-region deployment (JAVA-518)
+- [bug] Prevent race between cancellation and query completion (JAVA-614)
+
 
 2.0.9:
 ------

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -89,6 +89,20 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.scassandra</groupId>
+      <artifactId>java-client</artifactId>
+      <!-- N.B. later versions of scassandra require JDK 7 -->
+      <version>0.4.1</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -276,9 +276,19 @@ class Connection {
         // sure the "suspected" mechanism work as expected
         Host host = factory.manager.metadata.getHost(address);
         if (host != null) {
+
+            // If the host was reconnecting, and this error happens right after we opened a connection pool, but
+            // before we could mark the node UP, we don't want to go through the SUSPECTED state, because that can
+            // lead to a race condition that leaves the node UP with a closed pool.
+            boolean belongsToReconnectingPool = host.state != Host.State.UP &&
+                this instanceof PooledConnection &&
+                (((PooledConnection)this).pool == null || !((PooledConnection)this).pool.isClosed());
+
+            boolean markSuspected = isInitialized && !belongsToReconnectingPool;
+
             // This will trigger onDown, including when the defunct Connection is part of a reconnection attempt, which is redundant.
             // This is not too much of a problem since calling onDown on a node that is already down has no effect.
-            boolean isDown = factory.manager.signalConnectionFailure(host, ce, host.wasJustAdded(), isInitialized);
+            boolean isDown = factory.manager.signalConnectionFailure(host, ce, host.wasJustAdded(), markSuspected);
             notifyOwnerWhenDefunct(isDown);
         }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -260,6 +260,8 @@ class HostConnectionPool {
     }
 
     public void returnConnection(PooledConnection connection) {
+        int inFlight = connection.inFlight.decrementAndGet();
+
         if (isClosed()) {
             close(connection);
             return;
@@ -270,8 +272,6 @@ class HostConnectionPool {
             // closed the pool.
             return;
         }
-
-        int inFlight = connection.inFlight.decrementAndGet();
 
         if (trash.contains(connection)) {
             if (inFlight == 0 && trash.remove(connection))

--- a/driver-core/src/main/java/com/datastax/driver/core/PooledConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PooledConnection.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 class PooledConnection extends Connection {
 
-    private final HostConnectionPool pool;
+    final HostConnectionPool pool;
 
     /** Used in {@link HostConnectionPool} to handle races between two threads trying to trash the same connection */
     final AtomicBoolean markForTrash = new AtomicBoolean();

--- a/driver-core/src/test/java/com/datastax/driver/core/RequestHandlerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RequestHandlerTest.java
@@ -1,0 +1,72 @@
+package com.datastax.driver.core;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.google.common.collect.ImmutableMap;
+import org.scassandra.Scassandra;
+import org.scassandra.http.client.PrimingRequest;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RequestHandlerTest {
+
+    @Test(groups = "long")
+    public void should_handle_race_between_response_and_cancellation() {
+        Scassandra scassandra = TestUtils.createScassandraServer();
+        Cluster cluster = null;
+
+        try {
+            // Use a mock server that takes a constant time to reply
+            scassandra.start();
+            scassandra.primingClient().prime(
+                PrimingRequest.queryBuilder()
+                    .withQuery("mock query")
+                    .withRows(ImmutableMap.of("key", 1))
+                    .withFixedDelay(10)
+                    .build()
+            );
+
+            cluster = Cluster.builder().addContactPoint("127.0.0.1").withPort(scassandra.getBinaryPort())
+                .withPoolingOptions(new PoolingOptions()
+                    .setCoreConnectionsPerHost(HostDistance.LOCAL, 1)
+                    .setMaxConnectionsPerHost(HostDistance.LOCAL, 1))
+                .build();
+
+            Session session = cluster.connect();
+
+            // To reproduce, we need to cancel the query exactly when the reply arrives.
+            // Run a few queries to estimate how much that will take.
+            int samples = 100;
+            long start = System.currentTimeMillis();
+            for (int i = 0; i < samples; i++) {
+                session.execute("mock query");
+            }
+            long elapsed = System.currentTimeMillis() - start;
+            long queryDuration = elapsed / samples;
+
+            // Now run queries and cancel them after that estimated time
+            for (int i = 0; i < 2000; i++) {
+                ResultSetFuture future = session.executeAsync("mock query");
+                try {
+                    future.getUninterruptibly(queryDuration, TimeUnit.MILLISECONDS);
+                } catch (TimeoutException e) {
+                    future.cancel(true);
+                }
+            }
+
+            PooledConnection connection = getSingleConnection(session);
+            assertThat(connection.inFlight.get()).isEqualTo(0);
+        } finally {
+            if (cluster != null)
+                cluster.close();
+            scassandra.stop();
+        }
+    }
+
+    private PooledConnection getSingleConnection(Session session) {
+        HostConnectionPool pool = ((SessionManager)session).pools.values().iterator().next();
+        return pool.connections.get(0);
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -15,14 +15,18 @@
  */
 package com.datastax.driver.core;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
+import java.net.ServerSocket;
 import java.nio.ByteBuffer;
 import java.util.*;
 
 import static org.testng.Assert.fail;
 
+import org.scassandra.Scassandra;
+import org.scassandra.ScassandraFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.SkipException;
@@ -381,5 +385,35 @@ public abstract class TestUtils {
         }
         fail(address + " not found in cluster metadata");
         return null; // never reached
+    }
+
+    /**
+     * @return A Scassandra instance with an arbitrarily chosen binary port from 8042-8142 and admin port from
+     * 8052-8152.
+     */
+    public static Scassandra createScassandraServer() {
+        int binaryPort = findAvailablePort(8042);
+        int adminPort = findAvailablePort(8052);
+        return ScassandraFactory.createServer(binaryPort, adminPort);
+    }
+
+    /**
+     * @param startingWith The first port to try, if unused will keep trying the next port until one is found up to
+     *                     100 subsequent ports.
+     * @return A local port that is currently unused.
+     */
+    public static int findAvailablePort(int startingWith) {
+        IOException last = null;
+        for(int port = startingWith; port < startingWith+100; port++) {
+            try {
+                ServerSocket s = new ServerSocket(port);
+                s.close();
+                return port;
+            } catch (IOException e) {
+                last = e;
+            }
+        }
+        // If for whatever reason a port could not be acquired throw the last encountered exception.
+        throw new RuntimeException("Could not acquire an available port", last);
     }
 }

--- a/driver-core/src/test/resources/log4j.properties
+++ b/driver-core/src/test/resources/log4j.properties
@@ -1,6 +1,9 @@
 # Set root logger level to DEBUG and its only appender to A1.
 log4j.rootLogger=INFO, A1
 
+# Scassandra's info log is a bit verbose
+log4j.logger.org.scassandra=WARN
+
 # A1 is set to be a ConsoleAppender.
 log4j.appender.A1=org.apache.log4j.ConsoleAppender
 


### PR DESCRIPTION
Includes a test for cancellation vs. successful response (first commit). I'm not entirely satisfied with it, so let's discuss it before extending it to other scenarios.
