### PR TITLE
JAVA-626 Add metrics to track queue backlog in Cluster executors.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1081,12 +1081,12 @@ public class Cluster implements Closeable {
         return "cluster" + CLUSTER_ID.incrementAndGet();
     }
 
-    private static ListeningExecutorService makeExecutor(int threads, String name) {
+    private static ListeningExecutorService makeExecutor(int threads, String name, LinkedBlockingQueue<Runnable> workQueue) {
         ThreadPoolExecutor executor = new ThreadPoolExecutor(threads,
                                                              threads,
                                                              DEFAULT_THREAD_KEEP_ALIVE,
                                                              TimeUnit.SECONDS,
-                                                             new LinkedBlockingQueue<Runnable>(),
+                                                             workQueue,
                                                              threadFactory(name));
 
         executor.allowCoreThreadTimeOut(true);
@@ -1119,16 +1119,22 @@ public class Cluster implements Closeable {
 
         final ConvictionPolicy.Factory convictionPolicyFactory = new ConvictionPolicy.Simple.Factory();
 
-        final ScheduledExecutorService reconnectionExecutor = Executors.newScheduledThreadPool(2, threadFactory("Reconnection-%d"));
+        final ScheduledThreadPoolExecutor reconnectionExecutor = new ScheduledThreadPoolExecutor(2, threadFactory("Reconnection-%d"));
         // scheduledTasksExecutor is used to process C* notifications. So having it mono-threaded ensures notifications are
         // applied in the order received.
-        final ScheduledExecutorService scheduledTasksExecutor = Executors.newScheduledThreadPool(1, threadFactory("Scheduled Tasks-%d"));
+        final ScheduledThreadPoolExecutor scheduledTasksExecutor = new ScheduledThreadPoolExecutor(1, threadFactory("Scheduled Tasks-%d"));
 
         // Executor used for tasks that shouldn't be executed on an IO thread. Used for short-lived, generally non-blocking tasks
         final ListeningExecutorService executor;
 
+        // Work Queue used by executor.
+        final LinkedBlockingQueue<Runnable> executorQueue = new LinkedBlockingQueue<Runnable>();
+
         // An executor for tasks that might block some time, like creating new connection, but are generally not too critical.
         final ListeningExecutorService blockingExecutor;
+
+        // Work Queue used by blockingExecutor.
+        final LinkedBlockingQueue<Runnable> blockingExecutorQueue = new LinkedBlockingQueue<Runnable>();
 
         final ConnectionReaper reaper;
 
@@ -1150,8 +1156,8 @@ public class Cluster implements Closeable {
             this.configuration = configuration;
             this.configuration.register(this);
 
-            this.executor = makeExecutor(NON_BLOCKING_EXECUTOR_SIZE, "Cassandra Java Driver worker-%d");
-            this.blockingExecutor = makeExecutor(2, "Cassandra Java Driver blocking tasks worker-%d");
+            this.executor = makeExecutor(NON_BLOCKING_EXECUTOR_SIZE, "Cassandra Java Driver worker-%d", executorQueue);
+            this.blockingExecutor = makeExecutor(2, "Cassandra Java Driver blocking tasks worker-%d", blockingExecutorQueue);
 
             this.reaper = new ConnectionReaper();
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Metrics.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metrics.java
@@ -70,6 +70,34 @@ public class Metrics {
         }
     });
 
+    private final Gauge<Integer> executorQueueDepth = registry.register("executor-queue-depth", new Gauge<Integer>() {
+        @Override
+        public Integer getValue() {
+            return manager.executorQueue.size();
+        }
+    });
+
+    private final Gauge<Integer> blockingExecutorQueueDepth = registry.register("blocking-executor-queue-depth", new Gauge<Integer>() {
+        @Override
+        public Integer getValue() {
+            return manager.blockingExecutorQueue.size();
+        }
+    });
+
+    private final Gauge<Integer> reconnectionSchedulerQueueSize= registry.register("reconnection-scheduler-task-count", new Gauge<Integer>() {
+        @Override
+        public Integer getValue() {
+            return manager.reconnectionExecutor.getQueue().size();
+        }
+    });
+
+    private final Gauge<Integer> taskSchedulerQueueSize = registry.register("task-scheduler-task-count", new Gauge<Integer>() {
+        @Override
+        public Integer getValue() {
+            return manager.scheduledTasksExecutor.getQueue().size();
+        }
+    });
+
     Metrics(Cluster.Manager manager) {
         this.manager = manager;
         if (manager.configuration.getMetricsOptions().isJMXReportingEnabled()) {
@@ -175,6 +203,36 @@ public class Metrics {
      */
     public Gauge<Integer> getOpenConnections() {
         return openConnections;
+    }
+
+    /**
+     * @return The number of queued up tasks in the non-blocking executor (Cassandra Java Driver workers).
+     */
+    public Gauge<Integer> getExecutorQueueDepth() {
+        return executorQueueDepth;
+    }
+
+    /**
+     * @return The number of queued up tasks in the blocking executor (Cassandra Java Driver blocking tasks worker).
+     */
+    public Gauge<Integer> getBlockingExecutorQueueDepth() {
+        return blockingExecutorQueueDepth;
+    }
+
+    /**
+     * @return The size of the work queue for the reconnection scheduler (Reconnection).  A queue size > 0 does not
+     * necessarily indicate a backlog as some tasks may not have been scheduled to execute yet.
+     */
+    public Gauge<Integer> getReconnectionSchedulerQueueSize() {
+        return reconnectionSchedulerQueueSize;
+    }
+
+    /**
+     * @return The size of the work queue for the task scheduler (Scheduled Tasks).  A queue size > 0 does not
+     * necessarily indicate a backlog as some tasks may not have been scheduled to execute yet.
+     */
+    public Gauge<Integer> getTaskSchedulerQueueSize() {
+        return taskSchedulerQueueSize;
     }
 
     void shutdown() {


### PR DESCRIPTION
Adds 4 new metrics:
- executor-queue-depth
- blocking-executor-queue-depth
- reconnection-scheduler-task-count
- task-scheduler-task-count

These can be used for monitoring whether or not a Cluster's executors are becoming backlogged which could help understand abnormal behavior of the driver.
