### PR TITLE
Fix Integration Tests that were assuming 2 default core connections or depending on onUp for a new node

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Host.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Host.java
@@ -205,14 +205,17 @@ public class Host {
     }
 
     /**
-     * Triggers an asynchronous one-time reconnection attempt to this host.
+     * Triggers an asynchronous reconnection attempt to this host.
      * <p>
-     * If reconnection succeeds, the host will be marked {@code UP} and its connection pool(s)
-     * will be initialized (unless the load balancing policy returns {@link HostDistance#IGNORED}
-     * for it). If reconnection fails, no further attempts will be scheduled.
+     * This method is intended for load balancing policies that mark hosts as {@link HostDistance#IGNORED IGNORED},
+     * but still need a way to periodically check these hosts' states (UP / DOWN).
      * <p>
-     * This method has no effect if the node is already {@code UP}, or if a reconnection attempt
-     * is already in progress.
+     * For a host that is at distance {@code IGNORED}, this method will try to reconnect exactly once: if
+     * reconnection succeeds, the host is marked {@code UP}; otherwise, no further attempts will be scheduled.
+     * It has no effect if the node is already {@code UP}, or if a reconnection attempt is already in progress.
+     * <p>
+     * Note that if the host is <em>not</em> a distance {@code IGNORED}, this method <em>will</em> trigger a periodic
+     * reconnection attempt if the reconnection fails.
      */
     public void tryReconnectOnce() {
         this.manager.startSingleReconnectionAttempt(this);

--- a/driver-core/src/test/java/com/datastax/driver/core/BatchStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/BatchStatementTest.java
@@ -20,11 +20,11 @@ import java.util.Collections;
 
 import org.testng.annotations.Test;
 
-import com.datastax.driver.core.exceptions.UnsupportedFeatureException;
-
-import static com.datastax.driver.core.TestUtils.versionCheck;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+
+import com.datastax.driver.core.exceptions.UnsupportedFeatureException;
+import com.datastax.driver.core.utils.CassandraVersion;
 
 public class BatchStatementTest extends CCMBridge.PerClassSingleNodeCluster {
 
@@ -80,9 +80,8 @@ public class BatchStatementTest extends CCMBridge.PerClassSingleNodeCluster {
     }
 
     @Test(groups = "short")
+    @CassandraVersion(major=2.0, minor=9, description="This will only work with C* 2.0.9 (CASSANDRA-7337)")
     public void casBatchTest() throws Throwable {
-        versionCheck(2.0, 9, "This will only work with C* 2.0.9 (CASSANDRA-7337)");
-
         try {
             PreparedStatement st = session.prepare("INSERT INTO test (k, v) VALUES (?, ?) IF NOT EXISTS");
 

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
@@ -75,9 +75,12 @@ public class ClusterInitTest {
             long initTimeMs = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
             logger.info("Cluster and session initialized in {} ms", initTimeMs);
 
-            // We have one live host so 3 successful connections (1 control connection and 2 core connections in the pool).
+            // We have one live host so we expect 1 control connection + core connection count successful connections.
             // The other 5 hosts are unreachable, we should attempt to connect to each of them only once.
-            verify(socketOptions, times(3 + 5)).getKeepAlive();
+            int coreConnections = cluster.getConfiguration()
+                    .getPoolingOptions()
+                    .getCoreConnectionsPerHost(HostDistance.LOCAL);
+            verify(socketOptions, times(1 + coreConnections + 5)).getKeepAlive();
         } finally {
             if (cluster != null)
                 cluster.close();

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
@@ -18,9 +18,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.datastax.driver.core.policies.ConstantReconnectionPolicy;
+import com.datastax.driver.core.querybuilder.Insert;
 import com.datastax.driver.core.utils.UUIDs;
 
 import static com.datastax.driver.core.FakeHost.Behavior.THROWING_CONNECT_TIMEOUTS;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
 
 public class ClusterInitTest {
     private static final Logger logger = LoggerFactory.getLogger(ClusterInitTest.class);
@@ -68,6 +71,7 @@ public class ClusterInitTest {
                 CCMBridge.ipOfNode(4), CCMBridge.ipOfNode(5), CCMBridge.ipOfNode(6))
                 .withSocketOptions(socketOptions)
                 .withReconnectionPolicy(reconnectionPolicy)
+                .withProtocolVersion(TestUtils.getDesiredProtocolVersion())
                 .build();
             cluster.connect();
 
@@ -100,15 +104,17 @@ public class ClusterInitTest {
             String releaseVersion = session.execute("SELECT release_version FROM local")
                 .one().getString("release_version");
 
-            for (int i = 2; i <= 6; i++)
-                session.execute("INSERT INTO peers (peer, data_center, host_id, rack, release_version, rpc_address, schema_version) " +
-                        "VALUES (?, 'datacenter1', ?, 'rack1', ?, ?, ?)",
-                    InetAddress.getByName(CCMBridge.ipOfNode(i)),
-                    UUIDs.random(),
-                    releaseVersion,
-                    InetAddress.getByName(CCMBridge.ipOfNode(i)),
-                    UUIDs.random()
-                );
+            for (int i = 2; i <= 6; i++) {
+                Insert insertStmt = insertInto("peers")
+                    .value("peer", InetAddress.getByName(CCMBridge.ipOfNode(i)))
+                    .value("data_center", "datacenter1")
+                    .value("host_id", UUIDs.random())
+                    .value("rack", "rack1")
+                    .value("release_version", releaseVersion)
+                    .value("rpc_address", InetAddress.getByName(CCMBridge.ipOfNode(i)))
+                    .value("schema_version", UUIDs.random());
+                session.execute(insertStmt);
+            }
         } catch (Exception e) {
             fail("Error while inserting fake peer rows", e);
         } finally {

--- a/driver-core/src/test/java/com/datastax/driver/core/ConditionalUpdateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ConditionalUpdateTest.java
@@ -6,9 +6,12 @@ import java.util.Collections;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
+import com.datastax.driver.core.utils.CassandraVersion;
+
 /**
  * Test {@link ResultSet#wasApplied()} for conditional updates.
  */
+@CassandraVersion(major=2.0, description="Conditional Updates requires 2.0+.")
 public class ConditionalUpdateTest extends CCMBridge.PerClassSingleNodeCluster {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 import com.datastax.driver.core.exceptions.InvalidTypeException;
-
+import com.datastax.driver.core.utils.CassandraVersion;
 
 /**
  * Tests DataType class to ensure data sent in is the same as data received
@@ -517,8 +517,8 @@ public class DataTypeTest extends CCMBridge.PerClassSingleNodeCluster {
     }
 
     @Test(groups = "short")
+    @CassandraVersion(major=2.0, minor=0, description="This feature requires protocol v2")
     public void primitiveInsertWithValueTest() throws Throwable {
-        TestUtils.versionCheck(2.0, 0, "This feature requires protocol v2");
         for (DataType dt : DataType.allPrimitiveTypes()) {
             if (exclude(dt))
                 continue;

--- a/driver-core/src/test/java/com/datastax/driver/core/HostAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostAssert.java
@@ -35,7 +35,16 @@ public class HostAssert extends AbstractAssert<HostAssert, Host> {
     public HostAssert comesUpWithin(long duration, TimeUnit unit) {
         final CountDownLatch upSignal = new CountDownLatch(1);
         StateListener upListener = new StateListenerBase() {
+
+            @Override
             public void onUp(Host host) {
+                upSignal.countDown();
+            }
+
+            @Override
+            public void onAdd(Host host) {
+                // Special case, cassandra will sometimes not send an 'UP' topology change event
+                // for a new node, because of this we also listen for add events.
                 upSignal.countDown();
             }
         };

--- a/driver-core/src/test/java/com/datastax/driver/core/LargeDataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LargeDataTest.java
@@ -23,6 +23,8 @@ import static org.testng.Assert.assertTrue;
 
 import com.datastax.driver.core.querybuilder.Batch;
 import com.datastax.driver.core.querybuilder.Insert;
+import com.datastax.driver.core.utils.CassandraVersion;
+
 import static com.datastax.driver.core.TestUtils.CREATE_KEYSPACE_SIMPLE_FORMAT;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 
@@ -180,8 +182,8 @@ public class LargeDataTest {
      * @throws Throwable
      */
     @Test(groups = "long")
+    @CassandraVersion(major=2.0, minor=0, description="< 2.0 is skipped as 1.2 does not handle reading wide rows well.")
     public void wideRows() throws Throwable {
-        TestUtils.versionCheck(2, 0, "< 2.0 is skipped as 1.2 does not handle reading wide rows well.");
         Cluster.Builder builder = Cluster.builder();
         CCMBridge.CCMCluster c = CCMBridge.buildCluster(1, builder);
 
@@ -204,8 +206,8 @@ public class LargeDataTest {
      * @throws Throwable
      */
     @Test(groups = "short")
+    @CassandraVersion(major=2.0, minor=0, description="< 2.0 is skipped as 1.2 does not handle large batches well.")
     public void wideBatchRows() throws Throwable {
-        TestUtils.versionCheck(2, 0, "< 2.0 is skipped as 1.2 does not handle large batches well.");
         Cluster.Builder builder = Cluster.builder();
         CCMBridge.CCMCluster c = CCMBridge.buildCluster(1, builder);
 

--- a/driver-core/src/test/java/com/datastax/driver/core/LargeDataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LargeDataTest.java
@@ -181,6 +181,7 @@ public class LargeDataTest {
      */
     @Test(groups = "long")
     public void wideRows() throws Throwable {
+        TestUtils.versionCheck(2, 0, "< 2.0 is skipped as 1.2 does not handle reading wide rows well.");
         Cluster.Builder builder = Cluster.builder();
         CCMBridge.CCMCluster c = CCMBridge.buildCluster(1, builder);
 
@@ -204,6 +205,7 @@ public class LargeDataTest {
      */
     @Test(groups = "short")
     public void wideBatchRows() throws Throwable {
+        TestUtils.versionCheck(2, 0, "< 2.0 is skipped as 1.2 does not handle large batches well.");
         Cluster.Builder builder = Cluster.builder();
         CCMBridge.CCMCluster c = CCMBridge.buildCluster(1, builder);
 

--- a/driver-core/src/test/java/com/datastax/driver/core/MissingRpcAddressTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MissingRpcAddressTest.java
@@ -22,10 +22,10 @@ public class MissingRpcAddressTest {
     @Test(groups = "short")
     public void testMissingRpcAddressAtStartup() throws Exception {
         CCMBridge ccm = CCMBridge.create("ccm", 2);
-        deleteNode2RpcAddressFromNode1();
 
         Cluster cluster = null;
         try {
+            deleteNode2RpcAddressFromNode1();
             // Use only one contact point to make sure that the control connection is on node1
             cluster = Cluster.builder()
                              .addContactPoint(CCMBridge.IP_PREFIX + "1")
@@ -53,7 +53,9 @@ public class MissingRpcAddressTest {
                                                                           Lists.newArrayList(socketAddress(1))))
                              .build();
             Session session = cluster.connect();
-            session.execute("DELETE rpc_address FROM system.peers WHERE peer = ?", InetAddress.getByName(CCMBridge.IP_PREFIX + "2"));
+            String deleteStmt = String.format("DELETE rpc_address FROM system.peers WHERE peer = '%s'",
+                    InetAddress.getByName(CCMBridge.IP_PREFIX + "2").getHostName());
+            session.execute(deleteStmt);
             session.close();
         } finally {
             if (cluster != null)

--- a/driver-core/src/test/java/com/datastax/driver/core/PoolingOptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PoolingOptionsTest.java
@@ -48,8 +48,9 @@ public class PoolingOptionsTest {
                                .hasState(State.UP)
                                .isAtDistance(HostDistance.LOCAL);
             // Wait for the node to be up, because apparently on Jenkins it's still only ADDED when we reach this line
+            // Waiting for NEW_NODE_DELAY_SECONDS+1 allows the driver to create a connection pool and mark the node up
             assertThat(cluster).host(2)
-                               .comesUpWithin(120, SECONDS)
+                               .comesUpWithin(Cluster.NEW_NODE_DELAY_SECONDS+1, SECONDS)
                                .isAtDistance(HostDistance.LOCAL);
 
             // Bring host 3 up, its presence should be acknowledged but it should be ignored
@@ -63,13 +64,13 @@ public class PoolingOptionsTest {
                                .hasState(State.UP)
                                .isAtDistance(HostDistance.LOCAL);
             assertThat(cluster).host(3)
-                               .comesUpWithin(120, SECONDS)
+                               .comesUpWithin(Cluster.NEW_NODE_DELAY_SECONDS+1, SECONDS)
                                .isAtDistance(HostDistance.IGNORED);
             assertThat(session).hasNoPoolFor(3);
 
             // Kill host 2, host 3 should take its place
             ccm.stop(2);
-            TestUtils.waitFor(CCMBridge.ipOfNode(3), cluster, 120);
+            TestUtils.waitFor(CCMBridge.ipOfNode(3), cluster);
 
             assertThat(cluster).host(1)
                                .hasState(State.UP)

--- a/driver-core/src/test/java/com/datastax/driver/core/ReconnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReconnectionTest.java
@@ -260,6 +260,7 @@ public class ReconnectionTest {
 
             @Override
             Map<String, String> getCredentials() {
+                count.incrementAndGet();
                 return ImmutableMap.of("username", username,
                                        "password", password);
             }

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
@@ -9,6 +9,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.datastax.driver.core.utils.Bytes;
 
 import static com.datastax.driver.core.Assertions.assertThat;
@@ -101,8 +102,13 @@ public class SchemaChangesTest extends CCMBridge.PerClassSingleNodeCluster {
 
     @AfterMethod(groups = "short")
     public void cleanup() {
-        session.execute("DROP TABLE IF EXISTS ks.table1");
-        session.execute("DROP KEYSPACE IF EXISTS ks2");
+        try {
+            session.execute("DROP TABLE ks.table1");
+        } catch(InvalidQueryException ex) {}
+
+        try {
+            session.execute("DROP KEYSPACE ks2");
+        } catch(InvalidQueryException ex) {}
     }
 
     @AfterClass(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/SessionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionTest.java
@@ -149,13 +149,20 @@ public class SessionTest extends CCMBridge.PerClassSingleNodeCluster {
         Thread.sleep(10);
 
         // create a new cluster object and ensure 0 sessions and connections
-        Cluster cluster = Cluster.builder().addContactPoints(CCMBridge.IP_PREFIX + '1').build();
+        int corePoolSize = 2;
+        PoolingOptions poolingOptions = new PoolingOptions()
+                .setCoreConnectionsPerHost(HostDistance.LOCAL, corePoolSize);
+        Cluster cluster = Cluster.builder()
+                .addContactPoints(CCMBridge.IP_PREFIX + '1')
+                .withPoolingOptions(poolingOptions)
+                .build();
+
         assertEquals(cluster.manager.sessions.size(), 0);
         assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 0);
 
         Session session = cluster.connect();
         assertEquals(cluster.manager.sessions.size(), 1);
-        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 3);
+        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1 + corePoolSize);
 
         // ensure sessions.size() returns to 0 with only 1 active connection
         session.close();
@@ -174,7 +181,7 @@ public class SessionTest extends CCMBridge.PerClassSingleNodeCluster {
                 // ensure a new session gets registered and control connections are established
                 session = cluster.connect();
                 assertEquals(cluster.manager.sessions.size(), 1);
-                assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 3);
+                assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1 + corePoolSize);
                 session.close();
 
                 // give the driver time to close sessions
@@ -198,14 +205,20 @@ public class SessionTest extends CCMBridge.PerClassSingleNodeCluster {
 
         // create a new cluster object and ensure 0 sessions and connections
         Cluster cluster = Cluster.builder().addContactPoints(CCMBridge.IP_PREFIX + '1').build();
+
+        int corePoolSize = cluster.getConfiguration()
+                .getPoolingOptions()
+                .getCoreConnectionsPerHost(HostDistance.LOCAL);
+
         assertEquals(cluster.manager.sessions.size(), 0);
         assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 0);
 
+        // ensure sessions.size() returns with 1 control connection + core pool size.
         Session session = cluster.connect();
         assertEquals(cluster.manager.sessions.size(), 1);
-        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 3);
+        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1 + corePoolSize);
 
-        // ensure sessions.size() returns to 0 with only 1 active connection
+        // ensure sessions.size() returns to 0 with only 1 active connection (the control connection)
         session.close();
         assertEquals(cluster.manager.sessions.size(), 0);
         assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
@@ -218,11 +231,11 @@ public class SessionTest extends CCMBridge.PerClassSingleNodeCluster {
             assertEquals(cluster.manager.sessions.size(), 0);
             assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
 
-            // ensure a new session gets registered and control connections are established
-            // an additional 2 control connections should be seen for node2
+            // ensure a new session gets registered and core connections are established
+            // there should be corePoolSize more connections to accommodate for the new host.
             thisSession = cluster.connect();
             assertEquals(cluster.manager.sessions.size(), 1);
-            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 5);
+            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1 + (corePoolSize * 2));
 
             // ensure bootstrapping a node does not create additional connections that won't get cleaned up
             thisSession.close();

--- a/driver-core/src/test/java/com/datastax/driver/core/StateListenerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StateListenerTest.java
@@ -29,7 +29,7 @@ import static com.datastax.driver.core.TestUtils.*;
  */
 public class StateListenerTest {
 
-    @Test(groups = "short")
+    @Test(groups = "long")
     public void listenerTest() throws Throwable {
 
         CCMBridge.CCMCluster c = CCMBridge.buildCluster(1, Cluster.builder());

--- a/driver-core/src/test/java/com/datastax/driver/core/TestListener.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestListener.java
@@ -15,12 +15,16 @@
  */
 package com.datastax.driver.core;
 
-import org.testng.ITestResult;
-import org.testng.TestListenerAdapter;
+import org.testng.*;
+import org.testng.internal.ConstructorOrMethod;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 
-public class TestListener extends TestListenerAdapter {
+import com.datastax.driver.core.utils.CassandraVersion;
+
+public class TestListener extends TestListenerAdapter implements IInvokedMethodListener {
 
     private long start_time = System.nanoTime();
     private int test_index = 0;
@@ -77,5 +81,29 @@ public class TestListener extends TestListenerAdapter {
         return ((hours < 10 ? "0" : "") + hours
         + ':' + (minutes < 10 ? "0" : "") + minutes
         + ':' + (seconds< 10 ? "0" : "") + seconds);
+    }
+
+    @Override public void beforeInvocation(IInvokedMethod testMethod, ITestResult testResult) {
+        // Check to see if the class or method is annotated with 'CassandraVersion', if so ensure the
+        // version we are testing with meets the requirement, if not a SkipException is thrown
+        // and this test is skipped.
+        ITestNGMethod testNgMethod = testResult.getMethod();
+        ConstructorOrMethod constructorOrMethod = testNgMethod.getConstructorOrMethod();
+
+        Class<?> clazz = testNgMethod.getInstance().getClass();
+        if(clazz != null && clazz.isAnnotationPresent(CassandraVersion.class)) {
+            CassandraVersion cassandraVersion = clazz.getAnnotation(CassandraVersion.class);
+            TestUtils.versionCheck(cassandraVersion.major(), cassandraVersion.minor(), cassandraVersion.description());
+        }
+
+        Method method = constructorOrMethod.getMethod();
+        if(method != null && method.isAnnotationPresent(CassandraVersion.class)) {
+            CassandraVersion cassandraVersion = method.getAnnotation(CassandraVersion.class);
+            TestUtils.versionCheck(cassandraVersion.major(), cassandraVersion.minor(), cassandraVersion.description());
+        }
+    }
+
+    @Override public void afterInvocation(IInvokedMethod testMethod, ITestResult testResult) {
+        // Do nothing
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -183,7 +183,7 @@ public abstract class TestUtils {
                 case FLOAT:
                     return 3.142519f;
                 case INET:
-                    return InetAddress.getByAddress(new byte[]{(byte)127, (byte)0, (byte)0, (byte)1});
+                    return InetAddress.getByAddress(new byte[]{ (byte)127, (byte)0, (byte)0, (byte)1 });
                 case INT:
                     return 24;
                 case TEXT:
@@ -406,7 +406,7 @@ public abstract class TestUtils {
      */
     public static int findAvailablePort(int startingWith) {
         IOException last = null;
-        for(int port = startingWith; port < startingWith+100; port++) {
+        for (int port = startingWith; port < startingWith + 100; port++) {
             try {
                 ServerSocket s = new ServerSocket(port);
                 s.close();
@@ -417,5 +417,19 @@ public abstract class TestUtils {
         }
         // If for whatever reason a port could not be acquired throw the last encountered exception.
         throw new RuntimeException("Could not acquire an available port", last);
+    }
+
+    /**
+     * @return The desired target protocol version based on the 'cassandra.version' System property.
+     */
+    public static int getDesiredProtocolVersion() {
+        String version = System.getProperty("cassandra.version");
+        String[] versionArray = version.split("\\.|-");
+        double major = Double.parseDouble(versionArray[0] + "." + versionArray[1]);
+        if(major < 2.0) {
+            return 1;
+        } else {
+            return 2;
+        }
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -49,6 +49,8 @@ public abstract class TestUtils {
     public static final String INSERT_FORMAT = "INSERT INTO %s (k, t, i, f) VALUES ('%s', '%s', %d, %f)";
     public static final String SELECT_ALL_FORMAT = "SELECT * FROM %s";
 
+    public static final int TEST_BASE_NODE_WAIT = SystemProperties.getInt("com.datastax.driver.TEST_BASE_NODE_WAIT", 60);
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static BoundStatement setBoundValue(BoundStatement bs, String name, DataType type, Object value) {
         switch (type.getName()) {
@@ -267,7 +269,7 @@ public abstract class TestUtils {
     // This is used because there is some delay between when a node has been
     // added through ccm and when it's actually available for querying
     public static void waitFor(String node, Cluster cluster) {
-        waitFor(node, cluster, 60, false, false);
+        waitFor(node, cluster, TEST_BASE_NODE_WAIT, false, false);
     }
 
     public static void waitFor(String node, Cluster cluster, int maxTry) {
@@ -275,11 +277,11 @@ public abstract class TestUtils {
     }
 
     public static void waitForDown(String node, Cluster cluster) {
-        waitFor(node, cluster, 180, true, false);
+        waitFor(node, cluster, TEST_BASE_NODE_WAIT * 3, true, false);
     }
 
     public static void waitForDownWithWait(String node, Cluster cluster, int waitTime) {
-        waitFor(node, cluster, 180, true, false);
+        waitForDown(node, cluster);
 
         // FIXME: Once stop() works, remove this line
         try {
@@ -299,7 +301,7 @@ public abstract class TestUtils {
     }
 
     public static void waitForDecommission(String node, Cluster cluster) {
-        waitFor(node, cluster, 30, true, true);
+        waitFor(node, cluster, TEST_BASE_NODE_WAIT / 2, true, true);
     }
 
     public static void waitForDecommission(String node, Cluster cluster, int maxTry) {

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -374,7 +374,7 @@ public abstract class TestUtils {
         int minor = Integer.parseInt(versionArray[2]);
 
         if (major < majorCheck || (major == majorCheck && minor < minorCheck)) {
-            throw new SkipException(skipString);
+            throw new SkipException("Version >= " + majorCheck + "." + minorCheck + " required.  Description: " + skipString);
         }
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
@@ -85,8 +85,7 @@ public class QueryBuilderExecutionTest extends CCMBridge.PerClassSingleNodeClust
 
     @Test(groups = "short")
     public void batchNonBuiltStatementTest() throws Exception {
-
-        SimpleStatement simple = new SimpleStatement("INSERT INTO " + TABLE1 + " (k, t) VALUES (?, ?)", "batchTest1", "val1");
+        SimpleStatement simple = new SimpleStatement("INSERT INTO " + TABLE1 + " (k, t) VALUES ('batchTest1', 'val1')");
         RegularStatement built = insertInto(TABLE1).value("k", "batchTest2").value("t", "val2");
         session.execute(batch().add(simple).add(built));
 

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
@@ -25,6 +25,8 @@ import static org.testng.Assert.*;
 
 import com.datastax.driver.core.*;
 import com.datastax.driver.core.exceptions.SyntaxError;
+import com.datastax.driver.core.utils.CassandraVersion;
+
 import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 
 public class QueryBuilderITest extends CCMBridge.PerClassSingleNodeCluster {
@@ -206,7 +208,8 @@ public class QueryBuilderITest extends CCMBridge.PerClassSingleNodeCluster {
     }
 
     @Test(groups = "short")
-    public void conditionalDeletesTest() throws Exception {        
+    @CassandraVersion(major=2.0, minor=7, description="DELETE..IF EXISTS only supported in 2.0.7+ (CASSANDRA-5708)")
+    public void conditionalDeletesTest() throws Exception {
         session.execute("INSERT INTO ks.test_int (k, a, b) VALUES (1, 1, 1)");
         
         Statement delete;

--- a/driver-core/src/test/java/com/datastax/driver/core/utils/CassandraVersion.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/utils/CassandraVersion.java
@@ -1,0 +1,28 @@
+package com.datastax.driver.core.utils;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * <p>Annotation for a Class or Method that defines a Cassandra Version requirement.  If the cassandra verison in used
+ * does not meet the version requirement, the test is skipped.</p>
+ *
+ * @see {@link com.datastax.driver.core.TestListener#beforeInvocation(org.testng.IInvokedMethod, org.testng.ITestResult)} for usage.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CassandraVersion {
+    /**
+     * @return The major version required to execute this test, i.e. "2.0"
+     */
+    public double major();
+
+    /**
+     * @return The minor version required to execute this test, i.e. "0"
+     */
+    public int minor() default 0;
+
+    /**
+     * @return The description returned if this version requirement is not met.
+     */
+    public String description() default "Does not meet minimum version requirement.";
+}


### PR DESCRIPTION
In 2.0.9 the default number of core connections increased from 2 to 8 as
a stopgap until JAVA-419 is fixed.  ClusterInitTest and SessionTest have
been updated to use the # of core connections from PoolingOptions to
factor in how many expected connections are attempted or opened.
