### PR TITLE
Expose node token and range information (JAVA-312).

### DIFF
--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -7,6 +7,7 @@ CHANGELOG
 - [new feature] Add AddressTranslater for EC2 multi-region deployment (JAVA-518)
 - [improvement] Add connection heartbeat (JAVA-533)
 - [improvement] Reduce level of logs on missing rpc_address (JAVA-568)
+- [improvement] Expose node token and range information (JAVA-312)
 
 Merged from 2.0.9_fixes branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -185,6 +185,9 @@ public class BoundStatement extends Statement {
                     }
                     break;
                 default:
+                    if (toSet instanceof Token)
+                        toSet = ((Token)toSet).getValue();
+
                     Class<?> providedClass = toSet.getClass();
                     Class<?> expectedClass = columnType.getName().javaType;
                     if (!expectedClass.isAssignableFrom(providedClass))
@@ -815,6 +818,42 @@ public class BoundStatement extends Statement {
             metadata().checkType(indexes[i], DataType.Name.INET);
             setValue(indexes[i], value);
         }
+        return this;
+    }
+
+    /**
+     * Sets the {@code i}th value to the provided {@link Token}.
+     *
+     * @param i the index of the variable to set.
+     * @param v the value to set.
+     * @return this BoundStatement.
+     *
+     * @throws IndexOutOfBoundsException if {@code i < 0 || i >= this.preparedStatement().variables().size()}.
+     * @throws InvalidTypeException if column {@code i} is not of the type of the token's value.
+     */
+    public BoundStatement setToken(int i, Token v) {
+        metadata().checkType(i, v.getType().getName());
+        return setValue(i, v.getType().serialize(v.getValue()));
+    }
+
+    /**
+     * Sets the value for (all occurrences of) variable {@code name} to the
+     * provided token.
+     *
+     * @param name the name of the variable to set; if multiple variables
+     * {@code name} are prepared, all of them are set.
+     * @param v the value to set.
+     * @return this BoundStatement.
+     *
+     * @throws IllegalArgumentException if {@code name} is not a prepared
+     * variable, that is, if {@code !this.preparedStatement().variables().names().contains(name)}.
+     * @throws InvalidTypeException if (any occurrence of) {@code name} is
+     * not of the type of the token's value.
+     */
+    public BoundStatement setToken(String name, Token v) {
+        int[] indexes = metadata().getAllIdx(name);
+        for (int i = 0; i < indexes.length; i++)
+            setToken(indexes[i], v);
         return this;
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Host.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Host.java
@@ -17,6 +17,7 @@ package com.datastax.driver.core;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -63,6 +64,8 @@ public class Host {
     // ControlConnection.refreshNodeInfo. We don't want to expose however because we don't always have the info
     // (partly because the 'System.local' doesn't have it for some weird reason for instance).
     volatile InetAddress listenAddress;
+
+    private volatile Set<Token> tokens;
 
     // ClusterMetadata keeps one Host object per inet address and we rely on this (more precisely,
     // we rely on the fact that we can use Object equality as a valid equality), so don't use
@@ -154,6 +157,19 @@ public class Host {
      */
     public VersionNumber getCassandraVersion() {
         return cassandraVersion;
+    }
+
+    /**
+     * Returns the tokens that this host owns.
+     *
+     * @return the (immutable) set of tokens.
+     */
+    public Set<Token> getTokens() {
+        return tokens;
+    }
+
+    void setTokens(Set<Token> tokens) {
+        this.tokens = tokens;
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.driver.core;
 
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.*;
@@ -24,6 +23,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -235,18 +235,60 @@ public class Metadata {
     }
 
     /**
+     * Returns the token ranges that define data distribution in the ring.
+     * <p>
+     * Note that this information is refreshed asynchronously by the control
+     * connection, when schema or ring topology changes. It might occasionally
+     * be stale.
+     *
+     * @return the token ranges.
+     */
+    public Set<TokenRange> getTokenRanges() {
+        TokenMap current = tokenMap;
+        return (current == null) ? Collections.<TokenRange>emptySet() : current.tokenRanges;
+    }
+
+    /**
+     * Returns the token ranges that are replicated on the given host, for the given
+     * keyspace.
+     * <p>
+     * Note that this information is refreshed asynchronously by the control
+     * connection, when schema or ring topology changes. It might occasionally
+     * be stale (or even empty).
+     *
+     * @param keyspace the name of the keyspace to get token ranges for.
+     * @param host the host.
+     * @return the (immutable) set of token ranges for {@code host} as known
+     * by the driver.
+     */
+    public Set<TokenRange> getTokenRanges(String keyspace, Host host) {
+        keyspace = handleId(keyspace);
+        TokenMap current = tokenMap;
+        if (current == null) {
+            return Collections.emptySet();
+        } else {
+            Map<Host, Set<TokenRange>> dcRanges = current.hostsToRanges.get(keyspace);
+            if (dcRanges == null) {
+                return Collections.emptySet();
+            } else {
+                Set<TokenRange> ranges = dcRanges.get(host);
+                return (ranges == null) ? Collections.<TokenRange>emptySet() : ranges;
+            }
+        }
+    }
+
+    /**
      * Returns the set of hosts that are replica for a given partition key.
      * <p>
-     * Note that this method is a best effort method. Consumers should not rely
-     * too heavily on the result of this method not being stale (or even empty).
+     * Note that this information is refreshed asynchronously by the control
+     * connection, when schema or ring topology changes. It might occasionally
+     * be stale (or even empty).
      *
      * @param keyspace the name of the keyspace to get replicas for.
      * @param partitionKey the partition key for which to find the set of
      * replica.
-     * @return the (immutable) set of replicas for {@code partitionKey} as know
-     * by the driver. No strong guarantee is provided on the stalelessness of
-     * this information. It is also not guarantee that the returned set won't
-     * be empty (which is then some form of staleness).
+     * @return the (immutable) set of replicas for {@code partitionKey} as known
+     * by the driver.
      */
     public Set<Host> getReplicas(String keyspace, ByteBuffer partitionKey) {
         keyspace = handleId(keyspace);
@@ -255,6 +297,28 @@ public class Metadata {
             return Collections.emptySet();
         } else {
             Set<Host> hosts = current.getReplicas(keyspace, current.factory.hash(partitionKey));
+            return hosts == null ? Collections.<Host>emptySet() : hosts;
+        }
+    }
+
+    /**
+     * Returns the set of hosts that are replica for a given token range.
+     * <p>
+     * Note that this information is refreshed asynchronously by the control
+     * connection, when schema or ring topology changes. It might occasionally
+     * be stale (or even empty).
+     *
+     * @param keyspace the name of the keyspace to get replicas for.
+     * @param range the token range.
+     * @return the (immutable) set of replicas for {@code range} as known by the driver.
+     */
+    public Set<Host> getReplicas(String keyspace, TokenRange range) {
+        keyspace = handleId(keyspace);
+        TokenMap current = tokenMap;
+        if (current == null) {
+            return Collections.emptySet();
+        } else {
+            Set<Host> hosts = current.getReplicas(keyspace, range.getEnd());
             return hosts == null ? Collections.<Host>emptySet() : hosts;
         }
     }
@@ -335,24 +399,42 @@ public class Metadata {
         return sb.toString();
     }
 
+    Token.Factory tokenFactory() {
+        TokenMap current = tokenMap;
+        return (current == null) ? null : current.factory;
+    }
+
     static class TokenMap {
 
         private final Token.Factory factory;
         private final Map<String, Map<Token, Set<Host>>> tokenToHosts;
+        private final Map<String, Map<Host, Set<TokenRange>>> hostsToRanges;
         private final List<Token> ring;
+        private final Set<TokenRange> tokenRanges;
         final Set<Host> hosts;
 
-        private TokenMap(Token.Factory factory, Map<String, Map<Token, Set<Host>>> tokenToHosts, List<Token> ring, Set<Host> hosts) {
+        private TokenMap(Token.Factory factory,
+                         Map<Host, Set<Token>> primaryToTokens,
+                         Map<String, Map<Token, Set<Host>>> tokenToHosts,
+                         Map<String, Map<Host, Set<TokenRange>>> hostsToRanges,
+                         List<Token> ring, Set<TokenRange> tokenRanges, Set<Host> hosts) {
             this.factory = factory;
             this.tokenToHosts = tokenToHosts;
+            this.hostsToRanges = hostsToRanges;
             this.ring = ring;
+            this.tokenRanges = tokenRanges;
             this.hosts = hosts;
+            for (Map.Entry<Host, Set<Token>> entry : primaryToTokens.entrySet()) {
+                Host host = entry.getKey();
+                host.setTokens(ImmutableSet.copyOf(entry.getValue()));
+            }
         }
 
         public static TokenMap build(Token.Factory factory, Map<Host, Collection<String>> allTokens, Collection<KeyspaceMetadata> keyspaces) {
 
             Set<Host> hosts = allTokens.keySet();
             Map<Token, Host> tokenToPrimary = new HashMap<Token, Host>();
+            Map<Host, Set<Token>> primaryToTokens = new HashMap<Host, Set<Token>>();
             Set<Token> allSorted = new TreeSet<Token>();
 
             for (Map.Entry<Host, Collection<String>> entry : allTokens.entrySet()) {
@@ -362,6 +444,12 @@ public class Metadata {
                         Token t = factory.fromString(tokenStr);
                         allSorted.add(t);
                         tokenToPrimary.put(t, host);
+                        Set<Token> hostTokens = primaryToTokens.get(host);
+                        if (hostTokens == null) {
+                            hostTokens = new HashSet<Token>();
+                            primaryToTokens.put(host, hostTokens);
+                        }
+                        hostTokens.add(t);
                     } catch (IllegalArgumentException e) {
                         // If we failed parsing that token, skip it
                     }
@@ -369,18 +457,23 @@ public class Metadata {
             }
 
             List<Token> ring = new ArrayList<Token>(allSorted);
+            Set<TokenRange> tokenRanges = makeTokenRanges(ring, factory);
 
             Map<String, Map<Token, Set<Host>>> tokenToHosts = new HashMap<String, Map<Token, Set<Host>>>();
+            Map<String, Map<Host, Set<TokenRange>>> hostsToRanges = new HashMap<String, Map<Host, Set<TokenRange>>>();
             for (KeyspaceMetadata keyspace : keyspaces)
             {
                 ReplicationStrategy strategy = keyspace.replicationStrategy();
-                if (strategy == null) {
-                    tokenToHosts.put(keyspace.getName(), makeNonReplicatedMap(tokenToPrimary));
-                } else {
-                    tokenToHosts.put(keyspace.getName(), strategy.computeTokenToReplicaMap(tokenToPrimary, ring));
-                }
+                Map<Token, Set<Host>> ksTokens = (strategy == null)
+                    ? makeNonReplicatedMap(tokenToPrimary)
+                    : strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+
+                tokenToHosts.put(keyspace.getName(), ksTokens);
+
+                Map<Host, Set<TokenRange>> ksRanges = computeHostsToRangesMap(tokenRanges, ksTokens, hosts.size());
+                hostsToRanges.put(keyspace.getName(), ksRanges);
             }
-            return new TokenMap(factory, tokenToHosts, ring, hosts);
+            return new TokenMap(factory, primaryToTokens, tokenToHosts, hostsToRanges, ring, tokenRanges, hosts);
         }
 
         private Set<Host> getReplicas(String keyspace, Token token) {
@@ -389,7 +482,12 @@ public class Metadata {
             if (keyspaceHosts == null)
                 return Collections.emptySet();
 
-            // Find the primary replica
+            // If the token happens to be one of the "primary" tokens, get result directly
+            Set<Host> hosts = keyspaceHosts.get(token);
+            if (hosts != null)
+                return hosts;
+
+            // Otherwise, find closest "primary" token on the ring
             int i = Collections.binarySearch(ring, token);
             if (i < 0) {
                 i = -i - 1;
@@ -405,6 +503,36 @@ public class Metadata {
             for (Map.Entry<Token, Host> entry : input.entrySet())
                 output.put(entry.getKey(), ImmutableSet.of(entry.getValue()));
             return output;
+        }
+
+        private static Set<TokenRange> makeTokenRanges(List<Token> ring, Token.Factory factory) {
+            ImmutableSet.Builder<TokenRange> builder = ImmutableSet.builder();
+            for (int i = 0; i < ring.size(); i++) {
+                Token start = ring.get(i);
+                Token end = ring.get((i + 1) % ring.size());
+                builder.add(new TokenRange(start, end, factory));
+            }
+            return builder.build();
+        }
+
+        private static Map<Host, Set<TokenRange>> computeHostsToRangesMap(Set<TokenRange> tokenRanges, Map<Token, Set<Host>> ksTokens, int hostCount) {
+            Map<Host, ImmutableSet.Builder<TokenRange>> builders = Maps.newHashMapWithExpectedSize(hostCount);
+            for (TokenRange range : tokenRanges) {
+                Set<Host> replicas = ksTokens.get(range.getEnd());
+                for (Host host : replicas) {
+                    ImmutableSet.Builder<TokenRange> hostRanges = builders.get(host);
+                    if (hostRanges == null) {
+                        hostRanges = ImmutableSet.builder();
+                        builders.put(host, hostRanges);
+                    }
+                    hostRanges.add(range);
+                }
+            }
+            Map<Host, Set<TokenRange>> ksRanges = Maps.newHashMapWithExpectedSize(hostCount);
+            for (Map.Entry<Host, ImmutableSet.Builder<TokenRange>> entry : builders.entrySet()) {
+                ksRanges.put(entry.getKey(), entry.getValue().build());
+            }
+            return ksRanges;
         }
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/Row.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Row.java
@@ -405,6 +405,50 @@ public interface Row {
     public InetAddress getInet(String name);
 
     /**
+     * Returns the {@code i}th value of this row as a {@link Token}.
+     *
+     * @param i the index ({@code 0 <= i < size()}) of the column to retrieve.
+     * @return the value of the {@code i}th column in this row as an Token.
+     * If the value is NULL, {@code null} is returned.
+     *
+     * @throws IndexOutOfBoundsException if {@code i < 0 || i >= this.columns().size()}.
+     * @throws InvalidTypeException if column {@code i} is not of the type of token values
+     * for this cluster (this depends on the configured partitioner).
+     */
+    public Token getToken(int i);
+
+    /**
+     * Returns the value of column {@code name} as a {@link Token}.
+     * <p>
+     * This method will first try with {@code token(name)}, because in most cases the column
+     * is named that way since it results from the application of a CQL function:
+     * <pre>
+     * {@code
+     * ResultSet rs = session.execute("SELECT token(k) FROM my_table WHERE k = 1");
+     * Token token = rs.one().getToken("k"); // retrieves token(k)
+     * }
+     * </pre>
+     * If that fails, it will try will {@code name}. This handles the case where the column
+     * was aliased:
+     * <pre>
+     * {@code
+     * ResultSet rs = session.execute("SELECT token(k) AS t FROM my_table WHERE k = 1");
+     * Token token = rs.one().getToken("t");
+     * }
+     * </pre>
+     *
+     * @param name the name of the column to retrieve.
+     * @return the value of column {@code name} as a Token.
+     * If the value is NULL, {@code null} is returned.
+     *
+     * @throws IllegalArgumentException if {@code name} is not part of the
+     * ResultSet this row is part of, i.e. if {@code !this.columns().names().contains(name)}.
+     * @throws InvalidTypeException if column {@code name} is not of the type of token values
+     * for this cluster (this depends on the configured partitioner).
+     */
+    public Token getToken(String name);
+
+    /**
      * Returns the {@code i}th value of this row as a list.
      *
      * @param <T> the type of the elements of the list to return.

--- a/driver-core/src/main/java/com/datastax/driver/core/SimpleStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SimpleStatement.java
@@ -92,11 +92,14 @@ public class SimpleStatement extends RegularStatement {
     private static ByteBuffer[] convert(Object[] values) {
         ByteBuffer[] serializedValues = new ByteBuffer[values.length];
         for (int i = 0; i < values.length; i++) {
+            Object value = values[i];
             try {
-                serializedValues[i] = DataType.serializeValue(values[i]);
+                if (value instanceof Token)
+                    value = ((Token)value).getValue();
+                serializedValues[i] = DataType.serializeValue(value);
             } catch (IllegalArgumentException e) {
                 // Catch and rethrow to provide a more helpful error message (one that include which value is bad)
-                throw new IllegalArgumentException(String.format("Value %d of type %s does not correspond to any CQL3 type", i, values[i].getClass()));
+                throw new IllegalArgumentException(String.format("Value %d of type %s does not correspond to any CQL3 type", i, value.getClass()));
             }
         }
         return serializedValues;

--- a/driver-core/src/main/java/com/datastax/driver/core/Token.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Token.java
@@ -19,15 +19,35 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.List;
 
-/*
- * It's not an interface because we don't want to expose it
- * Note: we may want to expose this later if people use custom partitioner and want to be able to extend that.
- * This is way premature however.
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.google.common.primitives.UnsignedBytes;
+
+import com.datastax.driver.core.utils.Bytes;
+
+/**
+ * A token on the Cassandra ring.
  */
-abstract class Token implements Comparable<Token> {
+public abstract class Token implements Comparable<Token> {
 
-    public static Token.Factory getFactory(String partitionerName) {
+    /**
+     * Returns the data type of this token's value.
+     *
+     * @return the datatype.
+     */
+    public abstract DataType getType();
+
+    /**
+     * Returns the raw value of this token.
+     *
+     * @return the value.
+     */
+    public abstract Object getValue();
+
+    static Token.Factory getFactory(String partitionerName) {
         if (partitionerName.endsWith("Murmur3Partitioner"))
             return M3PToken.FACTORY;
         else if (partitionerName.endsWith("RandomPartitioner"))
@@ -38,16 +58,50 @@ abstract class Token implements Comparable<Token> {
             return null;
     }
 
-    public interface Factory {
-        public Token fromString(String tokenStr);
-        public Token hash(ByteBuffer partitionKey);
+    static abstract class Factory {
+        abstract Token fromString(String tokenStr);
+        abstract DataType getTokenType();
+        abstract Token deserialize(ByteBuffer buffer);
+        /** The minimum token is a special value that no key ever hashes to, it's used both as lower and upper bound. */
+        abstract Token minToken();
+        abstract Token hash(ByteBuffer partitionKey);
+        abstract List<Token> split(Token startToken, Token endToken, int numberOfSplits);
+
+        // Base implementation for split
+        protected List<BigInteger> split(BigInteger start, BigInteger range,
+                                    BigInteger ringEnd, BigInteger ringLength,
+                                    int numberOfSplits) {
+            BigInteger[] tmp = range.divideAndRemainder(BigInteger.valueOf(numberOfSplits));
+            BigInteger divider = tmp[0];
+            int remainder = tmp[1].intValue();
+
+            List<BigInteger> results = Lists.newArrayListWithExpectedSize(numberOfSplits - 1);
+            BigInteger current = start;
+            BigInteger dividerPlusOne = (remainder == 0) ? null // won't be used
+                : divider.add(BigInteger.ONE);
+
+            for (int i = 1; i < numberOfSplits; i++) {
+                current = current.add(remainder-- > 0 ? dividerPlusOne : divider);
+                if (ringEnd != null && current.compareTo(ringEnd) > 0)
+                    current = current.subtract(ringLength);
+                results.add(current);
+            }
+            return results;
+        }
     }
 
     // Murmur3Partitioner tokens
     static class M3PToken extends Token {
         private final long value;
 
-        public static final Factory FACTORY = new Factory() {
+        public static final Factory FACTORY = new M3PTokenFactory();
+
+        private static class M3PTokenFactory extends Factory {
+
+            private static final BigInteger RING_END = BigInteger.valueOf(Long.MAX_VALUE);
+            private static final BigInteger RING_LENGTH = RING_END.subtract(BigInteger.valueOf(Long.MIN_VALUE));
+            public static final M3PToken MIN_TOKEN = new M3PToken(Long.MIN_VALUE);
+            public static final M3PToken MAX_TOKEN = new M3PToken(Long.MAX_VALUE);
 
             private long getblock(ByteBuffer key, int offset, int index) {
                 int i_8 = index << 3;
@@ -153,14 +207,61 @@ abstract class Token implements Comparable<Token> {
             }
 
             @Override
+            DataType getTokenType() {
+                return DataType.bigint();
+            }
+
+            @Override
+            Token deserialize(ByteBuffer buffer) {
+                return new M3PToken((Long) getTokenType().deserialize(buffer));
+            }
+
+            @Override
+            Token minToken() {
+                return MIN_TOKEN;
+            }
+
+            @Override
             public M3PToken hash(ByteBuffer partitionKey) {
                 long v = murmur(partitionKey);
                 return new M3PToken(v == Long.MIN_VALUE ? Long.MAX_VALUE : v);
             }
-        };
+
+            @Override
+            List<Token> split(Token startToken, Token endToken, int numberOfSplits) {
+                // edge case: ]min, min] means the whole ring
+                if (startToken.equals(endToken) && startToken.equals(MIN_TOKEN))
+                    endToken = MAX_TOKEN;
+
+                BigInteger start = BigInteger.valueOf(((M3PToken)startToken).value);
+                BigInteger end = BigInteger.valueOf(((M3PToken)endToken).value);
+
+                BigInteger range = end.subtract(start);
+                if (range.compareTo(BigInteger.ZERO) < 0)
+                    range = range.add(RING_LENGTH);
+
+                List<BigInteger> values = super.split(start, range,
+                    RING_END, RING_LENGTH,
+                    numberOfSplits);
+                List<Token> tokens = Lists.newArrayListWithExpectedSize(values.size());
+                for (BigInteger value : values)
+                    tokens.add(new M3PToken(value.longValue()));
+                return tokens;
+            }
+        }
 
         private M3PToken(long value) {
             this.value = value;
+        }
+
+        @Override
+        public DataType getType() {
+            return FACTORY.getTokenType();
+        }
+
+        @Override
+        public Object getValue() {
+            return value;
         }
 
         @Override
@@ -184,32 +285,186 @@ abstract class Token implements Comparable<Token> {
         public int hashCode() {
             return (int)(value^(value>>>32));
         }
+
+        @Override
+        public String toString() {
+            return Long.toString(value);
+        }
     }
 
     // OPPartitioner tokens
     static class OPPToken extends Token {
+
         private final ByteBuffer value;
 
-        public static final Factory FACTORY = new Factory() {
+        public static final Factory FACTORY = new OPPTokenFactory();
+
+        private static class OPPTokenFactory extends Factory {
+            private static final BigInteger TWO = BigInteger.valueOf(2);
+            private static final Token MIN_TOKEN = new OPPToken(ByteBuffer.allocate(0));
+
             @Override
             public OPPToken fromString(String tokenStr) {
-                return new OPPToken(TypeCodec.StringCodec.utf8Instance.serialize(tokenStr));
+                String prefix = (tokenStr.length() % 2 == 0) ? "0x" : "0x0";
+                ByteBuffer value = Bytes.fromHexString(prefix + tokenStr);
+                return new OPPToken(value);
+            }
+
+            @Override
+            DataType getTokenType() {
+                return DataType.blob();
+            }
+
+            @Override
+            Token deserialize(ByteBuffer buffer) {
+                return new OPPToken(buffer);
+            }
+
+            @Override
+            Token minToken() {
+                return MIN_TOKEN;
             }
 
             @Override
             public OPPToken hash(ByteBuffer partitionKey) {
                 return new OPPToken(partitionKey);
             }
-        };
 
-        private OPPToken(ByteBuffer value) {
-            this.value = value;
+            @Override
+            public List<Token> split(Token startToken, Token endToken, int numberOfSplits) {
+                int tokenOrder = startToken.compareTo(endToken);
+
+                // ]min,min] means the whole ring. However, since there is no "max token" with this partitioner, we can't come up
+                // with a magic end value that would cover the whole ring
+                if (tokenOrder == 0 && startToken.equals(MIN_TOKEN))
+                    throw new IllegalArgumentException("Cannot split whole ring with ordered partitioner");
+
+                OPPToken oppStartToken = (OPPToken)startToken;
+                OPPToken oppEndToken = (OPPToken)endToken;
+
+                int significantBytes;
+                BigInteger start, end, range, ringEnd, ringLength;
+                BigInteger bigNumberOfSplits = BigInteger.valueOf(numberOfSplits);
+                if (tokenOrder < 0) {
+                    // Since tokens are compared lexicographically, convert to integers using the largest length
+                    // (ex: given 0x0A and 0x0BCD, switch to 0x0A00 and 0x0BCD)
+                    significantBytes = Math.max(oppStartToken.value.capacity(), oppEndToken.value.capacity());
+
+                    // If the number of splits does not fit in the difference between the two integers, use more bytes
+                    // (ex: cannot fit 4 splits between 0x01 and 0x03, so switch to 0x0100 and 0x0300)
+                    // At most 4 additional bytes will be needed, since numberOfSplits is an integer.
+                    int addedBytes = 0;
+                    while (true) {
+                        start = toBigInteger(oppStartToken.value, significantBytes);
+                        end = toBigInteger(oppEndToken.value, significantBytes);
+                        range = end.subtract(start);
+                        if (addedBytes == 4 || range.compareTo(bigNumberOfSplits) >= 0)
+                            break;
+                        significantBytes += 1;
+                        addedBytes += 1;
+                    }
+                    ringEnd = ringLength = null; // won't be used
+                } else {
+                    // Same logic except that we wrap around the ring
+                    significantBytes = Math.max(oppStartToken.value.capacity(), oppEndToken.value.capacity());
+                    int addedBytes = 0;
+                    while (true) {
+                        start = toBigInteger(oppStartToken.value, significantBytes);
+                        end = toBigInteger(oppEndToken.value, significantBytes);
+                        ringLength = TWO.pow(significantBytes * 8);
+                        ringEnd = ringLength.subtract(BigInteger.ONE);
+                        range = end.subtract(start).add(ringLength);
+                        if (addedBytes == 4 || range.compareTo(bigNumberOfSplits) >= 0)
+                            break;
+                        significantBytes += 1;
+                        addedBytes += 1;
+                    }
+                }
+
+                List<BigInteger> values = super.split(start, range,
+                    ringEnd, ringLength,
+                    numberOfSplits);
+                List<Token> tokens = Lists.newArrayListWithExpectedSize(values.size());
+                for (BigInteger value : values)
+                    tokens.add(new OPPToken(toBytes(value, significantBytes)));
+                return tokens;
+            }
+
+            // Convert a token's byte array to a number in order to perform computations.
+            // This depends on the number of "significant bytes" that we use to normalize all tokens to the same size.
+            // For example if the token is 0x01 but significantBytes is 2, the result is 8 (0x0100).
+            private BigInteger toBigInteger(ByteBuffer bb, int significantBytes) {
+                byte[] bytes = Bytes.getArray(bb);
+                byte[] target;
+                if (significantBytes != bytes.length) {
+                    target = new byte[significantBytes];
+                    System.arraycopy(bytes, 0, target, 0, bytes.length);
+                } else
+                    target = bytes;
+                return new BigInteger(1, target);
+            }
+
+            // Convert a numeric representation back to a byte array.
+            // Again, the number of significant bytes matters: if the input value is 1 but significantBytes is 2, the
+            // expected result is 0x0001 (a simple conversion would produce 0x01).
+            protected ByteBuffer toBytes(BigInteger value, int significantBytes) {
+                byte[] rawBytes = value.toByteArray();
+                byte[] result;
+                if (rawBytes.length == significantBytes)
+                    result = rawBytes;
+                else {
+                    result = new byte[significantBytes];
+                    int start, length;
+                    if (rawBytes[0] == 0) { // that's a sign byte, ignore (it can cause rawBytes.length == significantBytes + 1)
+                        start = 1;
+                        length = rawBytes.length - 1;
+                    } else {
+                        start = 0;
+                        length = rawBytes.length;
+                    }
+                    System.arraycopy(rawBytes, start, result, significantBytes - length, length);
+                }
+                return ByteBuffer.wrap(result);
+            }
+        }
+
+        @VisibleForTesting
+        OPPToken(ByteBuffer value) {
+            this.value = stripTrailingZeroBytes(value);
+        }
+
+        /**
+         * @return A new ByteBuffer from the input Buffer with any trailing 0-bytes stripped off.
+         */
+        private static ByteBuffer stripTrailingZeroBytes(ByteBuffer b) {
+            byte result[] = Bytes.getArray(b);
+            int zeroIndex = result.length;
+            for(int i = result.length-1; i > 0; i--) {
+                if(result[i] == 0) {
+                    zeroIndex = i;
+                } else {
+                    break;
+                }
+            }
+            return ByteBuffer.wrap(result, 0, zeroIndex);
+        }
+
+        @Override
+        public DataType getType() {
+            return FACTORY.getTokenType();
+        }
+
+        @Override
+        public Object getValue() {
+            return value;
         }
 
         @Override
         public int compareTo(Token other) {
             assert other instanceof OPPToken;
-            return value.compareTo(((OPPToken)other).value);
+            return UnsignedBytes.lexicographicalComparator().compare(
+                Bytes.getArray(value),
+                Bytes.getArray(((OPPToken)other).value));
         }
 
         @Override
@@ -226,6 +481,11 @@ abstract class Token implements Comparable<Token> {
         public int hashCode() {
             return value.hashCode();
         }
+
+        @Override
+        public String toString() {
+            return Bytes.toHexString(value);
+        }
     }
 
     // RandomPartitioner tokens
@@ -233,7 +493,15 @@ abstract class Token implements Comparable<Token> {
 
         private final BigInteger value;
 
-        public static final Factory FACTORY = new Factory() {
+        public static final Factory FACTORY = new RPTokenFactory();
+
+        private static class RPTokenFactory extends Factory {
+
+            private static final BigInteger MIN_VALUE = BigInteger.ONE.negate();
+            private static final BigInteger MAX_VALUE = BigInteger.valueOf(2).pow(127);
+            private static final BigInteger RING_LENGTH = MAX_VALUE.add(BigInteger.ONE);
+            private static final Token MIN_TOKEN = new RPToken(MIN_VALUE);
+            private static final Token MAX_TOKEN = new RPToken(MAX_VALUE);
 
             private BigInteger md5(ByteBuffer data) {
                 try {
@@ -251,13 +519,60 @@ abstract class Token implements Comparable<Token> {
             }
 
             @Override
+            DataType getTokenType() {
+                return DataType.varint();
+            }
+
+            @Override
+            Token deserialize(ByteBuffer buffer) {
+                return new RPToken((BigInteger)getTokenType().deserialize(buffer));
+            }
+
+            @Override
+            Token minToken() {
+                return MIN_TOKEN;
+            }
+
+            @Override
             public RPToken hash(ByteBuffer partitionKey) {
                 return new RPToken(md5(partitionKey));
+            }
+
+            @Override
+            List<Token> split(Token startToken, Token endToken, int numberOfSplits) {
+                // edge case: ]min, min] means the whole ring
+                if (startToken.equals(endToken) && startToken.equals(MIN_TOKEN))
+                    endToken = MAX_TOKEN;
+
+                BigInteger start = ((RPToken)startToken).value;
+                BigInteger end = ((RPToken)endToken).value;
+
+                BigInteger range = end.subtract(start);
+                if (range.compareTo(BigInteger.ZERO) < 0)
+                    range = range.add(RING_LENGTH);
+
+                List<BigInteger> values = super.split(start, range,
+                    MAX_VALUE, RING_LENGTH,
+                    numberOfSplits);
+                List<Token> tokens = Lists.newArrayListWithExpectedSize(values.size());
+                for (BigInteger value : values)
+                    tokens.add(new RPToken(value));
+                return tokens;
             }
         };
 
         private RPToken(BigInteger value) {
             this.value = value;
+        }
+
+        @Override
+        public DataType getType() {
+            return FACTORY.getTokenType();
+        }
+
+        @Override
+        public Object getValue() {
+            return value;
         }
 
         @Override
@@ -279,6 +594,11 @@ abstract class Token implements Comparable<Token> {
         @Override
         public int hashCode() {
             return value.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return value.toString();
         }
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/TokenRange.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TokenRange.java
@@ -1,0 +1,265 @@
+/*
+ *      Copyright (C) 2012-2014 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * A range of tokens on the Cassandra ring.
+ * <p>
+ * A range is start-exclusive and end-inclusive. It is empty when start and end are the same token, except if that is the minimum
+ * token, in which case the range covers the whole ring (this is consistent with the behavior of CQL range queries).
+ * <p>
+ * Note that CQL does not handle wrapping. To query all partitions in a range, see {@link #unwrap()}.
+ */
+public final class TokenRange implements Comparable<TokenRange> {
+    private final Token start;
+    private final Token end;
+    private final Token.Factory factory;
+
+    TokenRange(Token start, Token end, Token.Factory factory) {
+        this.start = start;
+        this.end = end;
+        this.factory = factory;
+    }
+
+    /**
+     * Return the start of the range.
+     *
+     * @return the start of the range (exclusive).
+     */
+    public Token getStart() {
+        return start;
+    }
+
+    /**
+     * Return the end of the range.
+     *
+     * @return the end of the range (inclusive).
+     */
+    public Token getEnd() {
+        return end;
+    }
+
+    /**
+     * Splits this range into a number of smaller ranges of equal "size" (referring to the number of tokens, not the actual amount of data).
+     * <p>
+     * Splitting an empty range is not permitted. But note that, in edge cases, splitting a range might produce one or more empty ranges.
+     *
+     * @param numberOfSplits the number of splits to create.
+     * @return the splits.
+     *
+     * @throws IllegalArgumentException if the range is empty or if numberOfSplits < 1.
+     */
+    public List<TokenRange> splitEvenly(int numberOfSplits) {
+        if (numberOfSplits < 1)
+            throw new IllegalArgumentException(String.format("numberOfSplits (%d) must be greater than 0.", numberOfSplits));
+        if (isEmpty())
+            throw new IllegalArgumentException("Can't split empty range " + this);
+
+        List<TokenRange> tokenRanges = new ArrayList<TokenRange>();
+        List<Token> splitPoints = factory.split(start, end, numberOfSplits);
+        Token splitStart = start;
+        for (Token splitEnd : splitPoints) {
+            tokenRanges.add(new TokenRange(splitStart, splitEnd, factory));
+            splitStart = splitEnd;
+        }
+        tokenRanges.add(new TokenRange(splitStart, end, factory));
+        return tokenRanges;
+    }
+
+    /**
+     * Returns whether this range is empty.
+     * <p>
+     * A range is empty when start and end are the same token, except if that is the minimum token,
+     * in which case the range covers the whole ring (this is consistent with the behavior of CQL
+     * range queries).
+     *
+     * @return whether the range is empty.
+     */
+    public boolean isEmpty() {
+        return start.equals(end) && !start.equals(factory.minToken());
+    }
+
+    /**
+     * Returns whether this range wraps around the end of the ring.
+     *
+     * @return whether this range wraps around.
+     */
+    public boolean isWrappedAround() {
+        return start.compareTo(end) > 0 && !end.equals(factory.minToken());
+    }
+
+    /**
+     * Splits this range into a list of two non-wrapping ranges. This will return the range itself if it is
+     * non-wrapping, or two ranges otherwise.
+     * <p>
+     * For example:
+     * <ul>
+     *     <li>{@code ]1,10]} unwraps to itself;</li>
+     *     <li>{@code ]10,1]} unwraps to {@code ]10,min_token]} and {@code ]min_token,1]}.</li>
+     * </ul>
+     * <p>
+     * This is useful for CQL range queries, which do not handle wrapping:
+     * <pre>
+     * {@code
+     * List<Row> rows = new ArrayList<Row>();
+     * for (TokenRange subRange : range.unwrap()) {
+     *     ResultSet rs = session.execute("SELECT * FROM mytable WHERE token(pk) > ? and token(pk) <= ?",
+     *                                    subRange.getStart(), subRange.getEnd());
+     *     rows.addAll(rs.all());
+     * }
+     * }</pre>
+     *
+     * @return the list of non-wrapping ranges.
+     */
+    public List<TokenRange> unwrap() {
+        if (isWrappedAround()) {
+            return ImmutableList.of(
+                new TokenRange(start, factory.minToken(), factory),
+                new TokenRange(factory.minToken(), end, factory));
+        } else {
+            return ImmutableList.of(this);
+        }
+    }
+
+    /**
+     * Returns whether this range intersects another one.
+     * <p>
+     * For example:
+     * <ul>
+     *     <li>{@code ]3,5]} intersects {@code ]1,4]}, {@code ]4,5]}...</li>
+     *     <li>{@code ]3,5]} does not intersect {@code ]1,2]}, {@code ]2,3]}, {@code ]5,7]}...</li>
+     * </ul>
+     *
+     * @param that the other range.
+     * @return whether they intersect.
+     */
+    public boolean intersects(TokenRange that) {
+        // Empty ranges never intersect any other range
+        if (this.isEmpty() || that.isEmpty())
+            return false;
+
+        return this.contains(that.start, true)
+            || this.contains(that.end, false)
+            || that.contains(this.start, true)
+            || that.contains(this.end, false);
+    }
+
+    // isStart handles the case where the token is the start of another range, for example:
+    // * ]1,2] contains 2, but it does not contain the start of ]2,3]
+    // * ]1,2] does not contain 1, but it contains the start of ]1,3]
+    private boolean contains(Token token, boolean isStart) {
+        boolean isAfterStart = isStart ? token.compareTo(start) >= 0 : token.compareTo(start) > 0;
+        boolean isBeforeEnd = end.equals(factory.minToken()) ||
+            (isStart ? token.compareTo(end) < 0 : token.compareTo(end) <= 0);
+        return isWrappedAround()
+            ? isAfterStart || isBeforeEnd
+            : isAfterStart && isBeforeEnd;
+    }
+
+    /**
+     * Merges this range with another one.
+     * <p>
+     * The two ranges should either intersect or be adjacent; in other words, the merged range
+     * should not include tokens that are in neither of the original ranges.
+     * <p>
+     * For example:
+     * <ul>
+     *     <li>merging {@code ]3,5]} with {@code ]4,7]} produces {@code ]3,7]};</li>
+     *     <li>merging {@code ]3,5]} with {@code ]4,5]} produces {@code ]3,5]};</li>
+     *     <li>merging {@code ]3,5]} with {@code ]5,8]} produces {@code ]3,8]};</li>
+     *     <li>merging {@code ]3,5]} with {@code ]6,8]} fails.</li>
+     * </ul>
+     *
+     * @param that the other range.
+     * @return the resulting range.
+     *
+     * @throws IllegalArgumentException if the ranges neither intersect nor are adjacent.
+     */
+    public TokenRange mergeWith(TokenRange that) {
+        if (this.equals(that))
+            return this;
+
+        if (!(this.intersects(that) || this.end.equals(that.start) || that.end.equals(this.start)))
+            throw new IllegalArgumentException(String.format(
+                "Can't merge %s with %s because they neither intersect nor are adjacent",
+                this, that));
+
+        if (this.isEmpty())
+            return that;
+
+        if (that.isEmpty())
+            return this;
+
+        // That's actually "starts in or is adjacent to the end of"
+        boolean thisStartsInThat = that.contains(this.start, true) || this.start.equals(that.end);
+        boolean thatStartsInThis = this.contains(that.start, true) || that.start.equals(this.end);
+
+        // This takes care of all the cases that return the full ring, so that we don't have to worry about them below
+        if (thisStartsInThat && thatStartsInThis)
+            return fullRing();
+
+        // Starting at this.start, see how far we can go while staying in at least one of the ranges.
+        Token mergedEnd = (thatStartsInThis && !this.contains(that.end, false))
+            ? that.end
+            : this.end;
+
+        // Repeat in the other direction.
+        Token mergedStart = thisStartsInThat ? that.start : this.start;
+
+        return new TokenRange(mergedStart, mergedEnd, factory);
+    }
+
+    private TokenRange fullRing() {
+        return new TokenRange(factory.minToken(), factory.minToken(), factory);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this)
+            return true;
+        if (other instanceof TokenRange) {
+            TokenRange that = (TokenRange)other;
+            return Objects.equal(this.start, that.start) &&
+                Objects.equal(this.end, that.end);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(start, end);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("]%s, %s]", start, end);
+    }
+
+    @Override public int compareTo(TokenRange other) {
+        if(this.equals(other)) {
+            return 0;
+        } else {
+            int compareStart = this.start.compareTo(other.start);
+            return compareStart != 0 ? compareStart : this.end.compareTo(other.end);
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
@@ -11,4 +11,8 @@ public class Assertions extends org.assertj.core.api.Assertions{
     public static SessionAssert assertThat(Session session) {
         return new SessionAssert(session);
     }
+
+    public static TokenRangeAssert assertThat(TokenRange range) {
+        return new TokenRangeAssert(range);
+    }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -151,6 +151,11 @@ public class CCMBridge {
         execute("ccm remove");
     }
 
+    public void remove(int n) {
+        logger.info("Removing: " + IP_PREFIX + n);
+        execute("ccm node%d remove", n);
+    }
+
     public void ring() {
         ring(1);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -20,6 +20,7 @@ import com.datastax.driver.core.exceptions.AlreadyExistsException;
 import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 
+import com.google.common.base.Joiner;
 import com.google.common.io.Files;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,11 +90,11 @@ public class CCMBridge {
         return bridge;
     }
 
-    public static CCMBridge create(String name, int nbNodes) {
+    public static CCMBridge create(String name, int nbNodes, String... options) {
         checkArgument(!"current".equals(name.toLowerCase()),
                         "cluster can't be called \"current\"");
         CCMBridge bridge = new CCMBridge();
-        bridge.execute("ccm create %s -n %d -s -i %s -b %s", name, nbNodes, IP_PREFIX, CASSANDRA_VERSION);
+        bridge.execute("ccm create %s -n %d -s -i %s -b %s " + Joiner.on(" ").join(options), name, nbNodes, IP_PREFIX, CASSANDRA_VERSION);
         return bridge;
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterAssert.java
@@ -1,6 +1,12 @@
 package com.datastax.driver.core;
 
+import java.util.Iterator;
+import java.util.Set;
+import java.util.TreeSet;
+
 import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Iterators;
 import org.assertj.core.api.AbstractAssert;
 
 public class ClusterAssert extends AbstractAssert<ClusterAssert, Cluster> {
@@ -21,5 +27,60 @@ public class ClusterAssert extends AbstractAssert<ClusterAssert, Cluster> {
         Host host = TestUtils.findHost(actual, hostNumber);
 
         return new HostAssert(host, actual);
+    }
+
+    /**
+     * Asserts that {@link Cluster}'s {@link Host}s have valid {@link TokenRange}s with the given keyspace.
+     *
+     * Ensures that no ranges intersect and that they cover the entire ring.
+     * @param keyspace Keyspace to grab {@link TokenRange}s from.
+     */
+    public ClusterAssert hasValidTokenRanges(String keyspace) {
+        // Sort the token ranges so they are in order (needed for vnodes).
+        Set<TokenRange> ranges = new TreeSet<TokenRange>();
+        for(Host host : actual.getMetadata().getAllHosts()) {
+            ranges.addAll(actual.getMetadata().getTokenRanges(keyspace, host));
+        }
+        return hasValidTokenRanges(ranges);
+    }
+
+    /**
+     * Asserts that {@link Cluster}'s {@link Host}s have valid {@link TokenRange}s.
+     *
+     * Ensures that no ranges intersect and that they cover the entire ring.
+     */
+    public ClusterAssert hasValidTokenRanges() {
+        // Sort the token ranges so they are in order (needed for vnodes).
+        Set<TokenRange> ranges = new TreeSet<TokenRange>(actual.getMetadata().getTokenRanges());
+        return hasValidTokenRanges(ranges);
+    }
+
+    /**
+     * Asserts that given Set of {@link TokenRange}s are valid.
+     *
+     * Ensures that no ranges intersect and that they cover the entire ring.
+     */
+    private ClusterAssert hasValidTokenRanges(Set<TokenRange> ranges) {
+        // Ensure no ranges intersect.
+        Iterator<TokenRange> it = ranges.iterator();
+        while(it.hasNext()) {
+            TokenRange range = it.next();
+            Assertions.assertThat(range).doesNotIntersect(Iterators.toArray(it, TokenRange.class));
+        }
+
+        // Ensure the defined ranges cover the entire ring.
+        it = ranges.iterator();
+        TokenRange mergedRange = it.next();
+        while(it.hasNext()) {
+            TokenRange next = it.next();
+            mergedRange = mergedRange.mergeWith(next);
+        }
+        boolean isFullRing = mergedRange.getStart().equals(mergedRange.getEnd())
+            && !mergedRange.isEmpty();
+        assertThat(isFullRing)
+            .as("Ring is not fully defined for Cluster.")
+            .isTrue();
+
+        return this;
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/M3PTokenFactoryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/M3PTokenFactoryTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
 
 public class M3PTokenFactoryTest {
     Token.Factory factory = Token.M3PToken.FACTORY;
@@ -74,4 +75,5 @@ public class M3PTokenFactoryTest {
             factory.fromString("3074457345618258602")
         );
     }
+
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/M3PTokenFactoryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/M3PTokenFactoryTest.java
@@ -1,0 +1,77 @@
+package com.datastax.driver.core;
+
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class M3PTokenFactoryTest {
+    Token.Factory factory = Token.M3PToken.FACTORY;
+
+    @Test(groups = "unit")
+    public void should_split_range() {
+        List<Token> splits = factory.split(factory.fromString("-9223372036854775808"), factory.fromString("4611686018427387904"), 3);
+        assertThat(splits).containsExactly(
+            factory.fromString("-4611686018427387904"),
+            factory.fromString("0")
+        );
+    }
+
+    @Test(groups = "unit")
+    public void should_split_range_that_wraps_around_the_ring() {
+        List<Token> splits = factory.split(factory.fromString("4611686018427387904"), factory.fromString("0"), 3);
+        assertThat(splits).containsExactly(
+            factory.fromString("-9223372036854775807"),
+            factory.fromString("-4611686018427387903")
+        );
+    }
+
+    @Test(groups = "unit")
+    public void should_split_range_when_division_not_integral() {
+        List<Token> splits = factory.split(factory.fromString("0"), factory.fromString("11"), 3);
+        assertThat(splits).containsExactly(
+            factory.fromString("4"),
+            factory.fromString("8")
+        );
+    }
+
+    @Test(groups = "unit")
+    public void should_split_range_producing_empty_splits() {
+        List<Token> splits = factory.split(factory.fromString("0"), factory.fromString("2"), 5);
+        assertThat(splits).containsExactly(
+            factory.fromString("1"),
+            factory.fromString("2"),
+            factory.fromString("2"),
+            factory.fromString("2")
+        );
+    }
+
+    @Test(groups = "unit")
+    public void should_split_range_producing_empty_splits_near_ring_end() {
+        Token minToken = factory.fromString("-9223372036854775808");
+        Token maxToken = factory.fromString("9223372036854775807");
+
+        // These are edge cases where we want to make sure we don't accidentally generate the ]min,min] range (which is the whole ring)
+        List<Token> splits = factory.split(maxToken, minToken, 3);
+        assertThat(splits).containsExactly(
+            maxToken,
+            maxToken
+        );
+
+        splits = factory.split(minToken, factory.fromString("-9223372036854775807"), 3);
+        assertThat(splits).containsExactly(
+            factory.fromString("-9223372036854775807"),
+            factory.fromString("-9223372036854775807")
+        );
+    }
+
+    @Test(groups = "unit")
+    public void should_split_whole_ring() {
+        List<Token> splits = factory.split(factory.fromString("-9223372036854775808"), factory.fromString("-9223372036854775808"), 3);
+        assertThat(splits).containsExactly(
+            factory.fromString("-3074457345618258603"),
+            factory.fromString("3074457345618258602")
+        );
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/M3PTokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/M3PTokenIntegrationTest.java
@@ -1,0 +1,13 @@
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.Token.M3PToken;
+
+public class M3PTokenIntegrationTest extends TokenIntegrationTest {
+    public M3PTokenIntegrationTest() {
+        super("", DataType.bigint());
+    }
+
+    @Override protected Token.Factory tokenFactory() {
+        return M3PToken.FACTORY;
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/M3PTokenVnodeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/M3PTokenVnodeIntegrationTest.java
@@ -1,0 +1,11 @@
+package com.datastax.driver.core;
+
+public class M3PTokenVnodeIntegrationTest extends TokenIntegrationTest {
+    public M3PTokenVnodeIntegrationTest() {
+        super("", DataType.bigint(), true);
+    }
+
+    @Override protected Token.Factory tokenFactory() {
+        return Token.M3PToken.FACTORY;
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
@@ -1,0 +1,113 @@
+package com.datastax.driver.core;
+
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+import org.testng.annotations.Test;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+import static com.datastax.driver.core.TestUtils.waitFor;
+
+public class MetadataTest {
+
+    /**
+     * <p>
+     * Validates that when the topology of the cluster changes that Cluster Metadata is properly updated.
+     * </p>
+     *
+     * <p>
+     * This test does the following:
+     *
+     * <ol>
+     *     <li>Creates a 3 node cluster and capture token range data from the {@link Cluster}'s {@link Metadata}</li>
+     *     <li>Decommission node 3.</li>
+     *     <li>Validates that the token range data was updated to reflect node 3 leaving and the other nodes
+     *     taking on its token range.</li>
+     *     <li>Adds a new node, node 4.</li>
+     *     <li>Validates that the token range data was updated to reflect node 4 joining the {@link Cluster} and
+     *     the token ranges reflecting this.</li>
+     * </ol>
+     *
+     * @test_category metadata:token
+     * @expected_result cluster metadata is properly updated in response to node remove and add events.
+     * @jira_ticket JAVA-312
+     * @since 2.0.10, 2.1.5
+     */
+    @Test(groups="long")
+    public void should_update_metadata_on_topology_change() {
+        CCMBridge ccm = null;
+        Cluster cluster = null;
+
+        try {
+            ccm = CCMBridge.create("test", 3);
+
+            cluster = Cluster.builder()
+                .addContactPoint(CCMBridge.ipOfNode(1))
+                .build();
+            Session session = cluster.connect();
+
+            String keyspace = "test";
+            session.execute("CREATE KEYSPACE IF NOT EXISTS " + keyspace + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+            Metadata metadata = cluster.getMetadata();
+
+            // Capture all Token data.
+            assertThat(metadata.getTokenRanges()).hasSize(3);
+            Map<Host, Token> tokensForHost = getTokenForHosts(metadata);
+
+            // Capture host3s token and range before we take it down.
+            Host host3 = TestUtils.findHost(cluster, 3);
+            Token host3Token = tokensForHost.get(host3);
+
+            ccm.decommissionNode(3);
+            ccm.remove(3);
+
+            // Ensure that the token ranges were updated, there should only be 2 ranges now.
+            assertThat(metadata.getTokenRanges()).hasSize(2);
+
+            // The token should not be present for any Host.
+            assertThat(getTokenForHosts(metadata)).doesNotContainValue(host3Token);
+
+            // The ring should be fully accounted for.
+            assertThat(cluster).hasValidTokenRanges("test");
+            assertThat(cluster).hasValidTokenRanges();
+
+            // Add an additional node.
+            ccm.bootstrapNode(4);
+            waitFor(CCMBridge.IP_PREFIX + '4', cluster);
+
+            // Ensure that the token ranges were updated, there should only be 3 ranges now.
+            assertThat(metadata.getTokenRanges()).hasSize(3);
+
+            Host host4 = TestUtils.findHost(cluster, 4);
+            TokenRange host4Range = metadata.getTokenRanges(keyspace, host4).iterator().next();
+
+            // Ensure no host token range intersects with node 4.
+            for(Host host : metadata.getAllHosts()) {
+                if(!host.equals(host4)) {
+                    TokenRange hostRange = metadata.getTokenRanges(keyspace, host).iterator().next();
+                    assertThat(host4Range).doesNotIntersect(hostRange);
+                }
+            }
+
+            // The ring should be fully accounted for.
+            assertThat(cluster).hasValidTokenRanges("test");
+            assertThat(cluster).hasValidTokenRanges();
+        } finally {
+            if (cluster != null)
+                cluster.close();
+            if (ccm != null)
+                ccm.remove();
+        }
+    }
+
+    /**
+     * @return A mapping of Host -> Token for each Host in the given {@link Metadata}
+     */
+    private Map<Host, Token> getTokenForHosts(Metadata metadata) {
+        Map<Host, Token> tokensByHost = Maps.newHashMap();
+        for(Host host : metadata.getAllHosts()) {
+            tokensByHost.put(host, host.getTokens().iterator().next());
+        }
+        return tokensByHost;
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/OPPTokenFactoryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/OPPTokenFactoryTest.java
@@ -1,5 +1,6 @@
 package com.datastax.driver.core;
 
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -7,9 +8,12 @@ import com.google.common.collect.Lists;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
 
 public class OPPTokenFactoryTest {
-    Token.Factory factory = Token.OPPToken.FACTORY;
+    private static final Token.Factory factory = Token.OPPToken.FACTORY;
+
+    private static final Token minToken = factory.deserialize(ByteBuffer.allocate(0));
 
     @Test(groups = "unit")
     public void should_split_range() {
@@ -22,7 +26,6 @@ public class OPPTokenFactoryTest {
 
     @Test(groups = "unit")
     public void should_split_range_producing_empty_splits_near_ring_end() {
-        Token minToken = factory.deserialize(ByteBuffer.allocate(0));
         // the first token following min
         Token zero = factory.deserialize(ByteBuffer.wrap(new byte[]{0}));
 
@@ -34,7 +37,47 @@ public class OPPTokenFactoryTest {
         );
     }
 
+    @Test(groups = "unit")
+    public void should_strip_trailing_0_bytes() {
+        Token with0Bytes = factory.deserialize(ByteBuffer.wrap(new byte[]{4,0,0,0}));
+        Token without0Bytes = factory.deserialize(ByteBuffer.wrap(new byte[]{4}));
+        Token fromStringWith0Bytes = factory.fromString("040000");
+
+        assertThat(with0Bytes)
+            .isEqualTo(without0Bytes)
+            .isEqualTo(fromStringWith0Bytes);
+
+        Token withMixed0Bytes = factory.fromString("0004000400");
+        Token withoutMixed0Bytes = factory.fromString("00040004");
+
+        assertThat(withMixed0Bytes)
+            .isEqualTo(withoutMixed0Bytes);
+    }
+
+    @Test(groups = "unit")
+    public void should_split_range_that_wraps_around_the_ring() {
+        for(int start = 1; start < 128; start++) {
+            for(int end = start; end < start; end++) {
+                // Take the midpoint of the ring and offset by the midpoint of start+end.
+                long expected = 0x81 + ((start + end) / 2);
+                TokenRange tr = new TokenRange(token(start), token(end), factory);
+                assertThat(factory.split(tr.getStart(), tr.getEnd(), 2))
+                    .as("Expected 0x%X for start: %d, end: %d", expected, start, end)
+                    .containsExactly(token(expected));
+            }
+        }
+    }
+
+    @Test(groups = "unit", expectedExceptions = IllegalArgumentException.class)
+    public void should_not_be_allowed_to_split_with_min_token() {
+        factory.split(minToken, minToken, 1);
+    }
+
     private Token token(char c) {
         return new Token.OPPToken(ByteBuffer.wrap(new byte[]{ (byte)c }));
+    }
+
+    private Token token(long i) {
+        return new Token.OPPToken(ByteBuffer.wrap(BigInteger.valueOf(i).toByteArray()));
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/OPPTokenFactoryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/OPPTokenFactoryTest.java
@@ -1,0 +1,40 @@
+package com.datastax.driver.core;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OPPTokenFactoryTest {
+    Token.Factory factory = Token.OPPToken.FACTORY;
+
+    @Test(groups = "unit")
+    public void should_split_range() {
+        List<Token> splits = factory.split(token('a'), token('d'), 3);
+        assertThat(splits).containsExactly(
+            token('b'),
+            token('c')
+        );
+    }
+
+    @Test(groups = "unit")
+    public void should_split_range_producing_empty_splits_near_ring_end() {
+        Token minToken = factory.deserialize(ByteBuffer.allocate(0));
+        // the first token following min
+        Token zero = factory.deserialize(ByteBuffer.wrap(new byte[]{0}));
+
+        // These are edge cases where we want to make sure we don't accidentally generate the ]min,min] range (which is the whole ring)
+        List<Token> splits = factory.split(minToken, zero, 3);
+        assertThat(splits).containsExactly(
+            zero,
+            zero
+        );
+    }
+
+    private Token token(char c) {
+        return new Token.OPPToken(ByteBuffer.wrap(new byte[]{ (byte)c }));
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/OPPTokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/OPPTokenIntegrationTest.java
@@ -1,0 +1,13 @@
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.Token.OPPToken;
+
+public class OPPTokenIntegrationTest extends TokenIntegrationTest {
+    public OPPTokenIntegrationTest() {
+        super("-p ByteOrderedPartitioner", DataType.blob());
+    }
+
+    @Override protected Token.Factory tokenFactory() {
+        return OPPToken.FACTORY;
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/OPPTokenVnodeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/OPPTokenVnodeIntegrationTest.java
@@ -1,0 +1,11 @@
+package com.datastax.driver.core;
+
+public class OPPTokenVnodeIntegrationTest extends TokenIntegrationTest {
+    public OPPTokenVnodeIntegrationTest() {
+        super("-p ByteOrderedPartitioner", DataType.blob(), true);
+    }
+
+    @Override protected Token.Factory tokenFactory() {
+        return Token.OPPToken.FACTORY;
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/RPTokenFactoryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RPTokenFactoryTest.java
@@ -1,0 +1,61 @@
+package com.datastax.driver.core;
+
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RPTokenFactoryTest {
+    Token.Factory factory = Token.RPToken.FACTORY;
+
+    @Test(groups = "unit")
+    public void should_split_range() {
+        List<Token> splits = factory.split(factory.fromString("0"), factory.fromString("127605887595351923798765477786913079296"), 3);
+        assertThat(splits).containsExactly(
+            factory.fromString("42535295865117307932921825928971026432"),
+            factory.fromString("85070591730234615865843651857942052864")
+        );
+    }
+
+    @Test(groups = "unit")
+    public void should_split_range_that_wraps_around_the_ring() {
+        List<Token> splits = factory.split(
+            factory.fromString("127605887595351923798765477786913079296"),
+            factory.fromString("85070591730234615865843651857942052864"),
+            3);
+
+        assertThat(splits).containsExactly(
+            factory.fromString("0"),
+            factory.fromString("42535295865117307932921825928971026432")
+        );
+    }
+
+    @Test(groups = "unit")
+    public void should_split_range_producing_empty_splits_near_ring_end() {
+        Token minToken = factory.fromString("-1");
+        Token maxToken = factory.fromString("170141183460469231731687303715884105728");
+
+        // These are edge cases where we want to make sure we don't accidentally generate the ]min,min] range (which is the whole ring)
+        List<Token> splits = factory.split(maxToken, minToken, 3);
+        assertThat(splits).containsExactly(
+            maxToken,
+            maxToken
+        );
+
+        splits = factory.split(minToken, factory.fromString("0"), 3);
+        assertThat(splits).containsExactly(
+            factory.fromString("0"),
+            factory.fromString("0")
+        );
+    }
+
+    @Test(groups = "unit")
+    public void should_split_whole_ring() {
+        List<Token> splits = factory.split(factory.fromString("-1"), factory.fromString("-1"), 3);
+        assertThat(splits).containsExactly(
+            factory.fromString("56713727820156410577229101238628035242"),
+            factory.fromString("113427455640312821154458202477256070485")
+        );
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/RPTokenFactoryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RPTokenFactoryTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
 
 public class RPTokenFactoryTest {
     Token.Factory factory = Token.RPToken.FACTORY;

--- a/driver-core/src/test/java/com/datastax/driver/core/RPTokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RPTokenIntegrationTest.java
@@ -1,0 +1,13 @@
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.Token.RPToken;
+
+public class RPTokenIntegrationTest extends TokenIntegrationTest {
+    public RPTokenIntegrationTest() {
+        super("-p RandomPartitioner", DataType.varint());
+    }
+
+    @Override protected Token.Factory tokenFactory() {
+        return RPToken.FACTORY;
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/RPTokenVnodeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RPTokenVnodeIntegrationTest.java
@@ -1,0 +1,11 @@
+package com.datastax.driver.core;
+
+public class RPTokenVnodeIntegrationTest extends TokenIntegrationTest {
+    public RPTokenVnodeIntegrationTest() {
+        super("-p RandomPartitioner", DataType.varint(), true);
+    }
+
+    @Override protected Token.Factory tokenFactory() {
+        return Token.RPToken.FACTORY;
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
@@ -1,0 +1,212 @@
+package com.datastax.driver.core;
+
+import java.net.InetSocketAddress;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import com.beust.jcommander.internal.Sets;
+import com.google.common.collect.Lists;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
+import com.datastax.driver.core.policies.WhiteListPolicy;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+
+/**
+ * This class uses subclasses for each type of partitioner.
+ *
+ * There's normally a way to parametrize a TestNG class with @Factory and @DataProvider,
+ * but it doesn't seem to work with multiple methods.
+ */
+public abstract class TokenIntegrationTest {
+
+    List<String> schema = Lists.newArrayList(
+        "CREATE KEYSPACE IF NOT EXISTS test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+        "CREATE KEYSPACE IF NOT EXISTS test2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}",
+        "USE test",
+        "CREATE TABLE IF NOT EXISTS foo(i int primary key)",
+        "INSERT INTO foo (i) VALUES (1)",
+        "INSERT INTO foo (i) VALUES (2)",
+        "INSERT INTO foo (i) VALUES (3)",
+        "CREATE TABLE IF NOT EXISTS foo2(\"caseSensitiveKey\" int primary key)",
+        "INSERT INTO foo2 (\"caseSensitiveKey\") VALUES (1)"
+    );
+
+    private final String ccmOptions;
+    private final DataType expectedTokenType;
+    CCMBridge ccm;
+    Cluster cluster;
+    Session session;
+
+    public TokenIntegrationTest(String ccmOptions, DataType expectedTokenType) {
+        this.ccmOptions = ccmOptions;
+        this.expectedTokenType = expectedTokenType;
+    }
+
+    @BeforeClass(groups = "short")
+    public void setup() {
+        ccm = CCMBridge.create("test", 3, ccmOptions);
+
+        // Only connect to node 1, which makes it easier to query system tables in should_expose_tokens_per_host()
+        LoadBalancingPolicy lbp = new WhiteListPolicy(new RoundRobinPolicy(),
+            Lists.newArrayList(new InetSocketAddress(CCMBridge.ipOfNode(1), 9042)));
+
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withLoadBalancingPolicy(lbp)
+            .build();
+        cluster.init();
+        session = cluster.connect();
+
+        for (String statement : schema)
+            session.execute(statement);
+    }
+
+    @AfterClass(groups = "short")
+    public void teardown() {
+        if (cluster != null)
+            cluster.close();
+        if (ccm != null)
+            ccm.remove();
+    }
+
+    @Test(groups = "short")
+    public void should_expose_token_ranges() throws Exception {
+        Metadata metadata = cluster.getMetadata();
+
+        // Find the replica for a given partition key
+        int testKey = 1;
+        Set<Host> replicas = metadata.getReplicas("test", DataType.cint().serialize(testKey));
+        assertThat(replicas).hasSize(1);
+        Host replica = replicas.iterator().next();
+
+        // Iterate the cluster's token ranges. For each one, use a range query to ask Cassandra which partition keys
+        // are in this range.
+        TokenRange foundRange = null;
+        for (TokenRange range : metadata.getTokenRanges()) {
+            List<Row> rows = rangeQuery("SELECT i FROM foo WHERE token(i) > ? and token(i) <= ?", range);
+            for (Row row : rows) {
+                if (row.getInt("i") == testKey) {
+                    // We should find our test key exactly once
+                    assertThat(foundRange)
+                        .describedAs("found the same key in two ranges: " + foundRange + " and " + range)
+                        .isNull();
+                    foundRange = range;
+                    // That range should be managed by the replica
+                    assertThat(metadata.getReplicas("test", range)).contains(replica);
+                }
+            }
+        }
+        assertThat(foundRange).isNotNull();
+    }
+
+    private List<Row> rangeQuery(String query, TokenRange range) {
+        List<Row> rows = Lists.newArrayList();
+        for (TokenRange subRange : range.unwrap()) {
+            rows.addAll(session.execute(query,
+                subRange.getStart(), subRange.getEnd())
+                .all());
+        }
+        return rows;
+    }
+
+    @Test(groups = "short")
+    public void should_get_token_from_row_and_set_token_in_query() {
+        // get by index:
+        Row row = session.execute("SELECT token(i) FROM test.foo WHERE i = 1").one();
+        Token token = row.getToken(0);
+        assertThat(token.getType()).isEqualTo(expectedTokenType);
+
+        // get by "base" column name (will add token() around it):
+        assertThat(
+            row.getToken("i")
+        ).isEqualTo(token);
+
+        // get by name:
+        assertThat(
+            session.execute("SELECT token(i) AS t FROM test.foo WHERE i = 1").one()
+                .getToken("t")
+        ).isEqualTo(token);
+
+        // get by "base" column name when it's case-sensitive
+        session.execute("SELECT token(\"caseSensitiveKey\") FROM test.foo2 WHERE \"caseSensitiveKey\" = 1").one()
+            .getToken("\"caseSensitiveKey\"");
+
+
+        PreparedStatement pst = session.prepare("SELECT * FROM test.foo WHERE token(i) = ?");
+        row = session.execute(pst.bind(token)).one();
+        assertThat(row.getInt(0)).isEqualTo(1);
+
+        row = session.execute(pst.bind().setToken(0, token)).one();
+        assertThat(row.getInt(0)).isEqualTo(1);
+
+        row = session.execute("SELECT * FROM test.foo WHERE token(i) = ?", token).one();
+        assertThat(row.getInt(0)).isEqualTo(1);
+    }
+
+    @Test(groups = "short")
+    public void should_expose_token_ranges_per_host() {
+        checkRangesPerHost("test", 1);
+        checkRangesPerHost("test2", 2);
+    }
+
+    private void checkRangesPerHost(String keyspace, int replicationFactor) {
+        Set<TokenRange> allRanges = Sets.newHashSet();
+
+        // Get each host's ranges, the count should match the replication factor
+        for (int i = 1; i <= 3; i++) {
+            Host host = TestUtils.findHost(cluster, i);
+            Set<TokenRange> hostRanges = cluster.getMetadata().getTokenRanges(keyspace, host);
+            assertThat(hostRanges).hasSize(replicationFactor);
+            allRanges.addAll(hostRanges);
+        }
+
+        // Once we ignore duplicates, the number of ranges should match the number of nodes.
+        assertThat(allRanges).hasSize(3);
+        Iterator<TokenRange> it = allRanges.iterator();
+        TokenRange range1 = it.next();
+        TokenRange range2 = it.next();
+        TokenRange range3 = it.next();
+
+        // No two ranges should intersect
+        assertThat(range1)
+            .doesNotIntersect(range2)
+            .doesNotIntersect(range3);
+        assertThat(range2)
+            .doesNotIntersect(range3);
+
+        // And the ranges should cover the whole ring
+        TokenRange mergedRange = range1.mergeWith(range2.mergeWith(range3));
+        boolean isFullRing = mergedRange.getStart().equals(mergedRange.getEnd())
+            && !mergedRange.isEmpty();
+        assertThat(isFullRing).isTrue();
+    }
+
+    @Test(groups = "short")
+    public void should_expose_tokens_per_host() {
+        for (Host host : cluster.getMetadata().allHosts()) {
+            // We don't use virtual nodes in this test, so there is only one token
+            assertThat(host.getTokens()).hasSize(1);
+            Token tokenFromMetadata = host.getTokens().iterator().next();
+
+            // Check against the info in the system tables, which is a bit weak since it's exactly how the metadata is
+            // constructed in the first place, but there's not much else we can do.
+            // Note that this relies on all queries going to node 1, which is why we use a WhiteList LBP in setup().
+            Row row = (host.listenAddress == null)
+                ? session.execute("select tokens from system.local").one()
+                : session.execute("select tokens from system.peers where peer = ?", host.listenAddress).one();
+            Set<String> tokenStrings = row.getSet("tokens", String.class);
+            assertThat(tokenStrings).hasSize(1);
+            Token tokenFromSystemTable = tokenFactory().fromString(tokenStrings.iterator().next());
+
+            assertThat(tokenFromMetadata).isEqualTo(tokenFromSystemTable);
+        }
+    }
+
+    protected abstract Token.Factory tokenFactory();
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenRangeAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenRangeAssert.java
@@ -1,0 +1,41 @@
+package com.datastax.driver.core;
+
+import org.assertj.core.api.AbstractAssert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TokenRangeAssert extends AbstractAssert<TokenRangeAssert, TokenRange> {
+    protected TokenRangeAssert(TokenRange actual) {
+        super(actual, TokenRangeAssert.class);
+    }
+
+    public TokenRangeAssert intersects(TokenRange that) {
+        assertThat(actual.intersects(that))
+            .as("%s should intersect %s", actual, that)
+            .isTrue();
+        assertThat(that.intersects(actual))
+            .as("%s should intersect %s", that, actual)
+            .isTrue();
+        return this;
+    }
+
+    public TokenRangeAssert doesNotIntersect(TokenRange that) {
+        assertThat(actual.intersects(that))
+            .as("%s should not intersect %s", actual, that)
+            .isFalse();
+        assertThat(that.intersects(actual))
+            .as("%s should not intersect %s", that, actual)
+            .isFalse();
+        return this;
+    }
+
+    public TokenRangeAssert unwrapsToItself() {
+        assertThat(actual.unwrap()).containsExactly(actual);
+        return this;
+    }
+
+    public TokenRangeAssert unwrapsTo(TokenRange... subRanges) {
+        assertThat(actual.unwrap()).containsExactly(subRanges);
+        return this;
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenRangeAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenRangeAssert.java
@@ -1,5 +1,8 @@
 package com.datastax.driver.core;
 
+import java.util.Iterator;
+import java.util.List;
+
 import org.assertj.core.api.AbstractAssert;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,18 +22,36 @@ public class TokenRangeAssert extends AbstractAssert<TokenRangeAssert, TokenRang
         return this;
     }
 
-    public TokenRangeAssert doesNotIntersect(TokenRange that) {
-        assertThat(actual.intersects(that))
-            .as("%s should not intersect %s", actual, that)
-            .isFalse();
-        assertThat(that.intersects(actual))
-            .as("%s should not intersect %s", that, actual)
-            .isFalse();
+    public TokenRangeAssert doesNotIntersect(TokenRange ... that) {
+        for(TokenRange thatRange : that) {
+            assertThat(actual.intersects(thatRange))
+                .as("%s should not intersect %s", actual, thatRange)
+                .isFalse();
+            assertThat(thatRange.intersects(actual))
+                .as("%s should not intersect %s", thatRange, actual)
+                .isFalse();
+        }
         return this;
     }
 
     public TokenRangeAssert unwrapsToItself() {
         assertThat(actual.unwrap()).containsExactly(actual);
+        return this;
+    }
+
+    public TokenRangeAssert unwrapsOverMinToken(Token.Factory factory) {
+        List<TokenRange> unwrapped = actual.unwrap();
+        assertThat(unwrapped.size())
+            .as("%s should unwrap to two ranges, but unwrapped to %s", actual, unwrapped)
+            .isEqualTo(2);
+
+        Iterator<TokenRange> unwrappedIt = unwrapped.iterator();
+        TokenRange firstRange = unwrappedIt.next();
+        assertThat(firstRange.getEnd()).isEqualTo(factory.minToken());
+
+        TokenRange secondRange = unwrappedIt.next();
+        assertThat(secondRange.getStart()).isEqualTo(factory.minToken());
+
         return this;
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenRangeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenRangeTest.java
@@ -1,0 +1,149 @@
+package com.datastax.driver.core;
+
+import java.math.BigInteger;
+
+import org.testng.annotations.Test;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+
+public class TokenRangeTest {
+    // The tests in this class don't depend on the kind of factory used, so use Murmur3 everywhere
+    Token.Factory factory = Token.getFactory("Murmur3Partitioner");
+    private Token minToken = factory.minToken();
+
+    @Test(groups = "unit")
+    public void should_check_intersection() {
+        // NB - to make the test more visual, we use watch face numbers
+        assertThat(tokenRange(3, 9))
+            .doesNotIntersect(tokenRange(11, 1))
+            .doesNotIntersect(tokenRange(1, 2))
+            .doesNotIntersect(tokenRange(11, 3))
+            .doesNotIntersect(tokenRange(2, 3))
+            .doesNotIntersect(tokenRange(3, 3))
+            .intersects(tokenRange(2, 6))
+            .intersects(tokenRange(2, 10))
+            .intersects(tokenRange(6, 10))
+            .intersects(tokenRange(4, 8))
+            .intersects(tokenRange(3, 9))
+            .doesNotIntersect(tokenRange(9, 10))
+            .doesNotIntersect(tokenRange(10, 11))
+        ;
+        assertThat(tokenRange(9, 3))
+            .doesNotIntersect(tokenRange(5, 7))
+            .doesNotIntersect(tokenRange(7, 8))
+            .doesNotIntersect(tokenRange(5, 9))
+            .doesNotIntersect(tokenRange(8, 9))
+            .doesNotIntersect(tokenRange(9, 9))
+            .intersects(tokenRange(8, 2))
+            .intersects(tokenRange(8, 4))
+            .intersects(tokenRange(2, 4))
+            .intersects(tokenRange(10, 2))
+            .intersects(tokenRange(9, 3))
+            .doesNotIntersect(tokenRange(3, 4))
+            .doesNotIntersect(tokenRange(4, 5))
+        ;
+        assertThat(tokenRange(3, 3)).doesNotIntersect(tokenRange(3, 3));
+
+        // Reminder: minToken serves as both lower and upper bound
+        assertThat(tokenRange(minToken, 5))
+            .doesNotIntersect(tokenRange(6, 7))
+            .doesNotIntersect(tokenRange(6, minToken))
+            .intersects(tokenRange(6, 4))
+            .intersects(tokenRange(2, 4))
+            .intersects(tokenRange(minToken, 4))
+            .intersects(tokenRange(minToken, 5))
+        ;
+
+        assertThat(tokenRange(5, minToken))
+            .doesNotIntersect(tokenRange(3, 4))
+            .doesNotIntersect(tokenRange(minToken, 4))
+            .intersects(tokenRange(6, 7))
+            .intersects(tokenRange(4, 1))
+            .intersects(tokenRange(6, minToken))
+            .intersects(tokenRange(5, minToken))
+        ;
+
+        assertThat(tokenRange(minToken, minToken))
+            .intersects(tokenRange(3, 4))
+            .intersects(tokenRange(3, minToken))
+            .intersects(tokenRange(minToken, 3))
+            .doesNotIntersect(tokenRange(3, 3))
+        ;
+    }
+
+    @Test(groups = "unit")
+    public void should_merge_with_other_range() {
+        assertThat(tokenRange(3, 9).mergeWith(tokenRange(2, 3))).isEqualTo(tokenRange(2, 9));
+        assertThat(tokenRange(3, 9).mergeWith(tokenRange(2, 4))).isEqualTo(tokenRange(2, 9));
+        assertThat(tokenRange(3, 9).mergeWith(tokenRange(11, 3))).isEqualTo(tokenRange(11, 9));
+        assertThat(tokenRange(3, 9).mergeWith(tokenRange(11, 4))).isEqualTo(tokenRange(11, 9));
+
+        assertThat(tokenRange(3, 9).mergeWith(tokenRange(4, 8))).isEqualTo(tokenRange(3, 9));
+        assertThat(tokenRange(3, 9).mergeWith(tokenRange(3, 9))).isEqualTo(tokenRange(3, 9));
+        assertThat(tokenRange(3, 9).mergeWith(tokenRange(3, 3))).isEqualTo(tokenRange(3, 9));
+        assertThat(tokenRange(3, 3).mergeWith(tokenRange(3, 9))).isEqualTo(tokenRange(3, 9));
+
+        assertThat(tokenRange(3, 9).mergeWith(tokenRange(9, 11))).isEqualTo(tokenRange(3, 11));
+        assertThat(tokenRange(3, 9).mergeWith(tokenRange(8, 11))).isEqualTo(tokenRange(3, 11));
+        assertThat(tokenRange(3, 9).mergeWith(tokenRange(9, 1))).isEqualTo(tokenRange(3, 1));
+        assertThat(tokenRange(3, 9).mergeWith(tokenRange(8, 1))).isEqualTo(tokenRange(3, 1));
+
+        assertThat(tokenRange(3, 9).mergeWith(tokenRange(9, 3))).isEqualTo(tokenRange(minToken, minToken));
+        assertThat(tokenRange(3, 9).mergeWith(tokenRange(9, 4))).isEqualTo(tokenRange(minToken, minToken));
+        assertThat(tokenRange(3, 10).mergeWith(tokenRange(9, 4))).isEqualTo(tokenRange(minToken, minToken));
+
+        assertThat(tokenRange(9, 3).mergeWith(tokenRange(8, 9))).isEqualTo(tokenRange(8, 3));
+        assertThat(tokenRange(9, 3).mergeWith(tokenRange(8, 10))).isEqualTo(tokenRange(8, 3));
+        assertThat(tokenRange(9, 3).mergeWith(tokenRange(4, 9))).isEqualTo(tokenRange(4, 3));
+        assertThat(tokenRange(9, 3).mergeWith(tokenRange(4, 10))).isEqualTo(tokenRange(4, 3));
+
+        assertThat(tokenRange(9, 3).mergeWith(tokenRange(10, 2))).isEqualTo(tokenRange(9, 3));
+        assertThat(tokenRange(9, 3).mergeWith(tokenRange(9, 3))).isEqualTo(tokenRange(9, 3));
+        assertThat(tokenRange(9, 3).mergeWith(tokenRange(9, 9))).isEqualTo(tokenRange(9, 3));
+        assertThat(tokenRange(9, 9).mergeWith(tokenRange(9, 3))).isEqualTo(tokenRange(9, 3));
+
+        assertThat(tokenRange(9, 3).mergeWith(tokenRange(3, 5))).isEqualTo(tokenRange(9, 5));
+        assertThat(tokenRange(9, 3).mergeWith(tokenRange(2, 5))).isEqualTo(tokenRange(9, 5));
+        assertThat(tokenRange(9, 3).mergeWith(tokenRange(3, 7))).isEqualTo(tokenRange(9, 7));
+        assertThat(tokenRange(9, 3).mergeWith(tokenRange(2, 7))).isEqualTo(tokenRange(9, 7));
+
+        assertThat(tokenRange(9, 3).mergeWith(tokenRange(3, 9))).isEqualTo(tokenRange(minToken, minToken));
+        assertThat(tokenRange(9, 3).mergeWith(tokenRange(3, 10))).isEqualTo(tokenRange(minToken, minToken));
+
+        assertThat(tokenRange(3, 3).mergeWith(tokenRange(3, 3))).isEqualTo(tokenRange(3, 3));
+
+        assertThat(tokenRange(5, minToken).mergeWith(tokenRange(6, 7))).isEqualTo(tokenRange(5, minToken));
+        assertThat(tokenRange(5, minToken).mergeWith(tokenRange(minToken, 3))).isEqualTo(tokenRange(5, 3));
+        assertThat(tokenRange(5, minToken).mergeWith(tokenRange(3, 5))).isEqualTo(tokenRange(3, minToken));
+
+        assertThat(tokenRange(minToken, 5).mergeWith(tokenRange(2, 3))).isEqualTo(tokenRange(minToken, 5));
+        assertThat(tokenRange(minToken, 5).mergeWith(tokenRange(7, minToken))).isEqualTo(tokenRange(7, 5));
+        assertThat(tokenRange(minToken, 5).mergeWith(tokenRange(5, 7))).isEqualTo(tokenRange(minToken, 7));
+    }
+
+    @Test(groups = "unit")
+    public void should_unwrap_to_non_wrapping_ranges() {
+        assertThat(tokenRange(9, 3)).unwrapsTo(tokenRange(9, minToken), tokenRange(minToken, 3));
+        assertThat(tokenRange(3, 9)).unwrapsToItself();
+        assertThat(tokenRange(3, minToken)).unwrapsToItself();
+        assertThat(tokenRange(minToken, 3)).unwrapsToItself();
+        assertThat(tokenRange(3, 3)).unwrapsToItself();
+        assertThat(tokenRange(minToken, minToken)).unwrapsToItself();
+    }
+
+    private TokenRange tokenRange(long start, long end) {
+        return new TokenRange(factory.newToken(BigInteger.valueOf(start)), factory.newToken(BigInteger.valueOf(end)), factory);
+    }
+
+    private TokenRange tokenRange(Token start, long end) {
+        return new TokenRange(start, factory.newToken(BigInteger.valueOf(end)), factory);
+    }
+
+    private TokenRange tokenRange(long start, Token end) {
+        return new TokenRange(factory.newToken(BigInteger.valueOf(start)), end, factory);
+    }
+
+    private TokenRange tokenRange(Token start, Token end) {
+        return new TokenRange(start, end, factory);
+    }
+}


### PR DESCRIPTION
New features:
- `Token` class now public, new `TokenRange` class
- `Host#getTokens()`
- new methods in `Metadata`: `getTokenRanges()`, `getTokenRanges(String, Host)`, `getReplicas(String, TokenRange)`.
- using `Token` as a "pseudo data-type" in queries: `Row#getToken`, `BoundStatement#setToken`, using a token as an argument in a `SimpleStatement`.
