### PR TITLE
Avoid duplicate calls to Connection.release (JAVA-651)

### DIFF
--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -4,6 +4,7 @@ CHANGELOG
 2.0.9.2:
 --------
 
+- [bug] Fix edge cases where a connection was released twice (JAVA-651).
 
 2.0.9.1:
 --------

--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -5,6 +5,8 @@ CHANGELOG
 --------
 
 - [bug] Fix edge cases where a connection was released twice (JAVA-651).
+- [bug] Fix edge cases in query cancellation (JAVA-653).
+
 
 2.0.9.1:
 --------

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -841,8 +841,7 @@ class Connection {
         public boolean onTimeout(Connection connection, long latency, int retryCount) {
             assert connection != null; // We always timeout on a specific connection, so this shouldn't be null
             this.address = connection.address;
-            super.setException(new OperationTimedOutException(connection.address));
-            return true;
+            return super.setException(new OperationTimedOutException(connection.address));
         }
 
         public InetSocketAddress getAddress() {

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -833,7 +833,7 @@ class Connection {
         public boolean onTimeout(Connection connection, long latency, int retryCount) {
             assert connection != null; // We always timeout on a specific connection, so this shouldn't be null
             this.address = connection.address;
-            super.setException(new ConnectionException(connection.address, "Operation timed out"));
+            super.setException(new OperationTimedOutException(connection.address));
             return true;
         }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
@@ -141,7 +141,7 @@ class DefaultResultSetFuture extends AbstractFuture<ResultSet> implements Result
     public boolean onTimeout(Connection connection, long latency, int retryCount) {
         // This is only called for internal calls (i.e, when the future is not wrapped in RequestHandler).
         // So just set an exception for the final result, which should be handled correctly by said internal call.
-        setException(new ConnectionException(connection.address, "Operation timed out"));
+        setException(new OperationTimedOutException(connection.address));
         return true;
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/OperationTimedOutException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/OperationTimedOutException.java
@@ -1,0 +1,13 @@
+package com.datastax.driver.core;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Thrown on a client-side timeout, i.e. when the client didn't hear back from the server within
+ * {@link SocketOptions#getReadTimeoutMillis()}.
+ */
+class OperationTimedOutException extends ConnectionException {
+    public OperationTimedOutException(InetSocketAddress address) {
+        super(address, "Operation timed out");
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -56,7 +56,6 @@ class RequestHandler implements Connection.ResponseCallback {
     private volatile List<Host> triedHosts;
     private volatile HostConnectionPool currentPool;
     private final AtomicReference<QueryState> queryStateRef;
-    private volatile boolean shouldCancelConnectionHandler;
 
     // This represents the number of times a retry has been triggered by the RetryPolicy (this is different from
     // queryStateRef.get().retryCount, because some retries don't involve the policy, for example after an
@@ -99,7 +98,7 @@ class RequestHandler implements Connection.ResponseCallback {
 
     public void sendRequest() {
         try {
-            while (queryPlan.hasNext() && queryStateRef.get() != QueryState.CANCELLED) {
+            while (queryPlan.hasNext() && !queryStateRef.get().isCancelled()) {
                 Host host = queryPlan.next();
                 logger.trace("Querying node {}", host);
                 if (query(host))
@@ -159,25 +158,30 @@ class RequestHandler implements Connection.ResponseCallback {
         // before connection.write has completed
         connectionHandler = null;
 
-        // Set query state to "in progress" at next iteration
+        // Ensure query state is "in progress" (can be already if connection.write failed on a previous node and we're retrying)
         while (true) {
             QueryState previous = queryStateRef.get();
-            assert !previous.inProgress;
-            if (previous == QueryState.CANCELLED) {
+            if (previous.isCancelled()) {
+                if (connection instanceof PooledConnection)
+                    ((PooledConnection)connection).release();
                 return;
             }
-            if (queryStateRef.compareAndSet(previous, previous.startNext()))
+            if (previous.inProgress || queryStateRef.compareAndSet(previous, previous.startNext()))
                 break;
         }
 
-        connectionHandler = connection.write(responseCallback);
+        connectionHandler = connection.write(responseCallback, false);
+        // Only start the timeout when we're sure connectionHandler is set. This avoids an edge case where onTimeout() was triggered
+        // *before* the call to connection.write had returned.
+        connectionHandler.startTimeout();
 
-        // N.B: onSet/onException could have already been called at this point
+        // Note that we could have already received the response here (so onSet() / onException() would have been called). This is
+        // why we only test for CANCELLED_WHILE_IN_PROGRESS below.
 
-        // If cancel was called after we set the state to "in progress", but before connection.write, it might have seen a null connectionHandler.
-        // In this case we need to cancel it now to release the connection (because the next onSet/onException/onTimeout will see the CANCELLED
-        // state and return immediately).
-        if (shouldCancelConnectionHandler)
+        // If cancel() was called after we set the state to "in progress", but before connection.write had completed, it might have
+        // missed the new value of connectionHandler. So make sure that cancelHandler() gets called here (we might call it twice,
+        // but it knows how to deal with it).
+        if (queryStateRef.get() == QueryState.CANCELLED_WHILE_IN_PROGRESS)
             connectionHandler.cancelHandler();
     }
 
@@ -196,7 +200,7 @@ class RequestHandler implements Connection.ResponseCallback {
         manager.executor().execute(new Runnable() {
             @Override
             public void run() {
-                if (queryStateRef.get() == QueryState.CANCELLED)
+                if (queryStateRef.get().isCancelled())
                     return;
                 try {
                     if (retryCurrent) {
@@ -212,12 +216,21 @@ class RequestHandler implements Connection.ResponseCallback {
     }
 
     public void cancel() {
-        QueryState previous = queryStateRef.getAndSet(QueryState.CANCELLED);
-        if (previous.inProgress) {
-            if (connectionHandler != null)
-                connectionHandler.cancelHandler();
-            else
-                shouldCancelConnectionHandler = true;
+        // Atomically set a special QueryState, that will cause any further operation to abort.
+        // We want to remember whether a request was in progress when we did this, so there are two cancel states.
+        while (true) {
+            QueryState previous = queryStateRef.get();
+            if (previous.isCancelled()) {
+                return;
+            } else if (previous.inProgress && queryStateRef.compareAndSet(previous, QueryState.CANCELLED_WHILE_IN_PROGRESS)) {
+                // The connectionHandler should be non-null, but we might miss the update if we're racing with write().
+                // If it's still null, this will be handled by re-checking queryStateRef at the end of write().
+                if (connectionHandler != null)
+                    connectionHandler.cancelHandler();
+                return;
+            } else if (!previous.inProgress && queryStateRef.compareAndSet(previous, QueryState.CANCELLED_WHILE_COMPLETE)) {
+                return;
+            }
         }
     }
 
@@ -615,7 +628,8 @@ class RequestHandler implements Connection.ResponseCallback {
     // The count increments on each retry.
     static class QueryState {
         static final QueryState INITIAL = new QueryState(-1, false);
-        static final QueryState CANCELLED = new QueryState(Integer.MIN_VALUE, false);
+        static final QueryState CANCELLED_WHILE_IN_PROGRESS = new QueryState(Integer.MIN_VALUE, false);
+        static final QueryState CANCELLED_WHILE_COMPLETE = new QueryState(Integer.MIN_VALUE + 1, false);
 
         final int retryCount;
         final boolean inProgress;
@@ -639,9 +653,13 @@ class RequestHandler implements Connection.ResponseCallback {
             return new QueryState(retryCount + 1, true);
         }
 
+        public boolean isCancelled() {
+            return this == CANCELLED_WHILE_IN_PROGRESS || this == CANCELLED_WHILE_COMPLETE;
+        }
+
         @Override
         public String toString() {
-            return String.format("QueryState(count=%d, inProgress=%s)", retryCount, inProgress);
+            return String.format("QueryState(count=%d, inProgress=%s, cancelled=%s)", retryCount, inProgress, isCancelled());
         }
     }
 }


### PR DESCRIPTION
This fixes the 3 issues described in the ticket
##### When re-preparing to another host times out

Scenario is: client prepares a statement, the PREPARE query gets sent to host1 and succeeds. Following that, the driver sends the PREPARE query to the remaining hosts, one of these queries times out.

This won't be easy to express deterministically in an automated test, load testing might be a better approach.
##### on Connection.setKeyspace

Scenario: a newly created connection is borrowed from a pool. The pool belongs to a Session that is connected to a specific keyspace, so the pool calls setKeyspace before returning the connection, which issues a USE query. This query times out (connection gets released), but we still return the connection to the client, which will probably get an error, and release the connection again. 
##### when we reuse it to prepare query

Scenario: statement was already prepared, but a host restarted and cleared its cache. Upon getting an UNPREPARED response, RequestHandler reuses the same connection to send a PREPARE query before retrying. But it has already released the connection => if the PREPARE query times out, we release again.
