### PR TITLE
Corrected default maxSimultaneousRequestsPerHostLocal in Javadoc

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/PoolingOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PoolingOptions.java
@@ -298,7 +298,7 @@ public class PoolingOptions {
      * <p>
      * This option is only used with {@code ProtocolVersion#V3} or above.
      * <p>
-     * The default value for this option is 8192 for {@code LOCAL} and 256 for
+     * The default value for this option is 1024 for {@code LOCAL} and 256 for
      * {@code REMOTE} hosts.
      *
      * @param distance the {@code HostDistance} for which to return this threshold.


### PR DESCRIPTION
Default value changed in 6b59411bf776118dbde5329428c96e97e1ca2c80 but Javadoc not updated.
