### PR TITLE
QueryBuilder.in() wildcard List

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Clause.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Clause.java
@@ -66,9 +66,9 @@ public abstract class Clause extends Utils.Appendeable {
 
     static class InClause extends AbstractClause {
 
-        private final List<Object> values;
+        private final List<?> values;
 
-        InClause(String name, List<Object> values) {
+        InClause(String name, List<?> values) {
             super(name);
             this.values = values;
 

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
@@ -286,7 +286,7 @@ public final class QueryBuilder {
     public static Clause in(String name, Object... values) {
         return new Clause.InClause(name, Arrays.asList(values));
     }
-	
+
     /**
      * Create an "in" where clause stating the provided column must be equal
      * to one of the provided values.
@@ -295,9 +295,9 @@ public final class QueryBuilder {
      * @param values the values
      * @return the corresponding where clause.
      */
-	public static Clause in(String name, List<Object> values) {
-		return new Clause.InClause(name, values);
-	}
+    public static Clause in(String name, List<?> values) {
+        return new Clause.InClause(name, values);
+    }
 
     /**
      * Creates a "lesser than" where clause stating the provided column must be less than

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
@@ -51,7 +51,7 @@ abstract class Utils {
         return sb;
     }
 
-    static StringBuilder joinAndAppendValues(StringBuilder sb, String separator, List<Object> values, List<Object> variables) {
+    static StringBuilder joinAndAppendValues(StringBuilder sb, String separator, List<?> values, List<Object> variables) {
         for (int i = 0; i < values.size(); i++) {
             if (i > 0)
                 sb.append(separator);


### PR DESCRIPTION
QueryBuilder.in() exists (before change) in two variants:
1) in(String, Object... values)
2) in(String, List&lt;Object&gt; values) - this method was introduces in november 2014 and its contract is not good.
For example, client code has List<String> ids. When calling ...where(in("id", ids)) the first (with Object... values) method is matched by compiler, not second, that's unexpected.
So there are two variants: use argument List<Object> ids2 = guavaLists.newArrayList(ids) or ids.toArray() - both not suitable.

By the way, the same fix is needed in 2.0.9.2.
