### PR TITLE
Fixes JAVA-672 issue

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
@@ -117,7 +117,8 @@ abstract class Utils {
     static StringBuilder appendFlatValue(Object value, StringBuilder sb) {
         if (appendValueIfLiteral(value, sb))
             return sb;
-
+        if (appendValueIfUdt(value, sb))
+            return sb;
         appendStringIfValid(value, sb);
         return sb;
     }


### PR DESCRIPTION
This fixes the issue of updating a cassandra map with the QueryBuilder with an UDTValue (a cassandra type) as map value.
