### PR TITLE
Fix handling of DROP events when ks name is case-sensitive (JAVA-678).

### DIFF
--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -9,6 +9,7 @@ CHANGELOG
 - [improvement] Reduce level of logs on missing rpc_address (JAVA-568)
 - [improvement] Expose node token and range information (JAVA-312)
 - [bug] Fix guava dependency when using OSGI (JAVA-620)
+- [bug] Fix handling of DROP events when ks name is case-sensitive (JAVA-678)
 
 Merged from 2.0.9_fixes branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -2131,7 +2131,7 @@ public class Cluster implements Closeable {
                             if (scc.table.isEmpty())
                                 manager.metadata.removeKeyspace(scc.keyspace);
                             else {
-                                KeyspaceMetadata keyspace = manager.metadata.getKeyspace(scc.keyspace);
+                                KeyspaceMetadata keyspace = manager.metadata.getKeyspaceInternal(scc.keyspace);
                                 if (keyspace == null)
                                     logger.warn("Received a DROPPED notification for {}.{}, but this keyspace is unknown in our metadata",
                                         scc.keyspace, scc.table);

--- a/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
@@ -84,7 +84,7 @@ class DefaultResultSetFuture extends AbstractFuture<ResultSet> implements Result
                                         //    session.poolsState.setKeyspace(null);
                                         session.cluster.manager.metadata.removeKeyspace(scc.keyspace);
                                     } else {
-                                        KeyspaceMetadata keyspace = session.cluster.manager.metadata.getKeyspace(scc.keyspace);
+                                        KeyspaceMetadata keyspace = session.cluster.manager.metadata.getKeyspaceInternal(scc.keyspace);
                                         if (keyspace == null)
                                             logger.warn("Received a DROPPED notification for {}.{}, but this keyspace is unknown in our metadata",
                                                 scc.keyspace, scc.columnFamily);

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -362,6 +362,14 @@ public class Metadata {
         return keyspaces.get(handleId(keyspace));
     }
 
+    /**
+     * Used when the keyspace name is unquoted and in the exact case we store it in
+     * (typically when we got it from an internal call, not from the user).
+     */
+    KeyspaceMetadata getKeyspaceInternal(String keyspace) {
+        return keyspaces.get(keyspace);
+    }
+
     void removeKeyspace(String keyspace) {
         keyspaces.remove(keyspace);
         if (tokenMap != null)

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
@@ -4,12 +4,10 @@ import java.util.Collection;
 import java.util.List;
 
 import com.google.common.collect.Lists;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.testng.annotations.*;
 
-import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.datastax.driver.core.utils.Bytes;
 
 import static com.datastax.driver.core.Assertions.assertThat;
@@ -23,7 +21,12 @@ public class SchemaChangesTest extends CCMBridge.PerClassSingleNodeCluster {
 
     @Override
     protected Collection<String> getTableDefinitions() {
-        return Lists.newArrayList();
+        return Lists.newArrayList("CREATE KEYSPACE \"CaseSensitive\" WITH REPLICATION = { 'class' : 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1' }");
+    }
+
+    @DataProvider(name = "existingKeyspaceName")
+    public static Object[][] existingKeyspaceName() {
+        return new Object[][]{ { "ks" }, { "\"CaseSensitive\"" } };
     }
 
     @BeforeClass(groups = "short")
@@ -32,83 +35,88 @@ public class SchemaChangesTest extends CCMBridge.PerClassSingleNodeCluster {
         metadatas = Lists.newArrayList(cluster.getMetadata(), cluster2.getMetadata());
     }
 
-    @Test(groups = "short")
-    public void should_notify_of_table_creation() {
-        session.execute("CREATE TABLE ks.table1(i int primary key)");
+    @Test(groups = "short", dataProvider = "existingKeyspaceName")
+    public void should_notify_of_table_creation(String keyspace) {
+        session.execute(String.format("CREATE TABLE %s.table1(i int primary key)", keyspace));
 
         for (Metadata m : metadatas)
-            assertThat(m.getKeyspace("ks").getTable("table1"))
+            assertThat(m.getKeyspace(keyspace).getTable("table1"))
                 .isNotNull();
     }
 
-    @Test(groups = "short")
-    public void should_notify_of_table_update() {
-        session.execute("CREATE TABLE ks.table1(i int primary key)");
-        session.execute("ALTER TABLE ks.table1 ADD j int");
+    @Test(groups = "short", dataProvider = "existingKeyspaceName")
+    public void should_notify_of_table_update(String keyspace) {
+        session.execute(String.format("CREATE TABLE %s.table1(i int primary key)", keyspace));
+        session.execute(String.format("ALTER TABLE %s.table1 ADD j int", keyspace));
 
         for (Metadata m : metadatas)
-            assertThat(m.getKeyspace("ks").getTable("table1").getColumn("j"))
+            assertThat(m.getKeyspace(keyspace).getTable("table1").getColumn("j"))
                 .isNotNull();
     }
 
-    @Test(groups = "short")
-    public void should_notify_of_table_drop() {
-        session.execute("CREATE TABLE ks.table1(i int primary key)");
-        session.execute("DROP TABLE ks.table1");
+    @Test(groups = "short", dataProvider = "existingKeyspaceName")
+    public void should_notify_of_table_drop(String keyspace) {
+        session.execute(String.format("CREATE TABLE %s.table1(i int primary key)", keyspace));
+        session.execute(String.format("DROP TABLE %s.table1", keyspace));
 
         for (Metadata m : metadatas)
-            assertThat(m.getKeyspace("ks").getTable("table1"))
+            assertThat(m.getKeyspace(keyspace).getTable("table1"))
                 .isNull();
     }
 
-    @Test(groups = "short")
-    public void should_notify_of_keyspace_creation() {
-        session.execute("CREATE KEYSPACE ks2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+    @DataProvider(name = "newKeyspaceName")
+    public static Object[][] newKeyspaceName() {
+        return new Object[][]{ { "ks2" }, { "\"CaseSensitive2\"" } };
+    }
+
+    @Test(groups = "short", dataProvider = "newKeyspaceName")
+    public void should_notify_of_keyspace_creation(String keyspace) {
+        session.execute(String.format("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}", keyspace));
 
         for (Metadata m : metadatas)
-            assertThat(m.getKeyspace("ks2"))
+            assertThat(m.getKeyspace(keyspace))
                 .isNotNull();
     }
 
-    @Test(groups = "short")
-    public void should_notify_of_keyspace_update() {
-        session.execute("CREATE KEYSPACE ks2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+    @Test(groups = "short", dataProvider = "newKeyspaceName")
+    public void should_notify_of_keyspace_update(String keyspace) {
+        session.execute(String.format("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}", keyspace));
         for (Metadata m : metadatas)
-            assertThat(m.getKeyspace("ks2").isDurableWrites())
+            assertThat(m.getKeyspace(keyspace).isDurableWrites())
                 .isTrue();
 
-        session.execute("ALTER KEYSPACE ks2 WITH durable_writes = false");
+        session.execute(String.format("ALTER KEYSPACE %s WITH durable_writes = false", keyspace));
         for (Metadata m : metadatas)
-            assertThat(m.getKeyspace("ks2").isDurableWrites())
+            assertThat(m.getKeyspace(keyspace).isDurableWrites())
                 .isFalse();
     }
 
-    @Test(groups = "short")
-    public void should_notify_of_keyspace_drop() {
-        session.execute("CREATE KEYSPACE ks2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+    @Test(groups = "short", dataProvider = "newKeyspaceName")
+    public void should_notify_of_keyspace_drop(String keyspace) {
+        session.execute(String.format("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}", keyspace));
         for (Metadata m : metadatas)
-            assertThat(m.getReplicas("ks2", Bytes.fromHexString("0xCAFEBABE")))
+            assertThat(m.getReplicas(keyspace, Bytes.fromHexString("0xCAFEBABE")))
                 .isNotEmpty();
 
-        session.execute("DROP KEYSPACE ks2");
+        session.execute(String.format("DROP KEYSPACE %s", keyspace));
 
         for (Metadata m : metadatas) {
-            assertThat(m.getKeyspace("ks2"))
+            assertThat(m.getKeyspace(keyspace))
                 .isNull();
-            assertThat(m.getReplicas("ks2", Bytes.fromHexString("0xCAFEBABE")))
+            assertThat(m.getReplicas(keyspace, Bytes.fromHexString("0xCAFEBABE")))
                 .isEmpty();
         }
     }
 
     @AfterMethod(groups = "short")
     public void cleanup() {
-        try {
-            session.execute("DROP TABLE ks.table1");
-        } catch(InvalidQueryException ex) {}
-
-        try {
-            session.execute("DROP KEYSPACE ks2");
-        } catch(InvalidQueryException ex) {}
+        ListenableFuture<List<ResultSet>> f = Futures.successfulAsList(Lists.newArrayList(
+            session.executeAsync("DROP TABLE ks.table1"),
+            session.executeAsync("DROP TABLE \"CaseSensitive\".table1"),
+            session.executeAsync("DROP KEYSPACE ks2"),
+            session.executeAsync("DROP KEYSPACE \"CaseSensitive2\"")
+        ));
+        Futures.getUnchecked(f);
     }
 
     @AfterClass(groups = "short")


### PR DESCRIPTION
Old code used the wrong case to get keyspace metadata, issued a warning and did not delete the table metadata (reproduced by `should_notify_of_table_drop` with case-sensitive ks).
