### PR TITLE
Added OSGi example with Integration Test for testing different bundle configs.

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -122,6 +122,19 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+            <phase>test-compile</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
@@ -196,6 +209,35 @@
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <versionRange>[2.2,)</versionRange>
+                    <goals>
+                      <goal>test-jar</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore />
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <profiles>

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
@@ -76,7 +76,6 @@ public abstract class TokenIntegrationTest {
 
     @AfterClass(groups = "short", alwaysRun=true)
     public void teardown() {
-        System.out.println("Tearing down");
         if (cluster != null)
             cluster.close();
         if (ccm != null)

--- a/driver-examples/osgi/README.rst
+++ b/driver-examples/osgi/README.rst
@@ -1,0 +1,32 @@
+OSGi Example
+============
+
+A simple example application that demonstrates using the Java Driver in
+an OSGi service.
+
+MailboxService is an activated service that uses Cassandra to
+persist a Mailbox by email address.
+
+Usage
+-----
+
+To build the bundle and run tests execute the following maven task::
+
+    mvn install -P short
+
+The short profile needs to be activated since the tests run under
+this group.
+
+After which the bundle jar will be present in the target/ directory.
+
+The project includes an integration test that verifies the service can
+be activated and used in an OSGi container.  It also verifies that
+driver-core can be used in an OSGi container in the following
+configurations:
+
+1. Default (default classifier with all dependencies)
+2. Netty-Shaded (shaded classifier with all depedencies w/o Netty)
+3. Guava 15 (default classifier with Guava 15.0)
+4. Guava 16
+5. Guava 17
+6. Guava 18

--- a/driver-examples/osgi/pom.xml
+++ b/driver-examples/osgi/pom.xml
@@ -1,0 +1,255 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.datastax.cassandra</groupId>
+    <artifactId>cassandra-driver-examples-parent</artifactId>
+    <version>2.0.10-SNAPSHOT</version>
+  </parent>
+  <artifactId>cassandra-driver-examples-osgi</artifactId>
+  <packaging>bundle</packaging>
+  <name>DataStax Java Driver for Apache Cassandra Examples - OSGi</name>
+  <description>An example of using DataStax Java Driver in an OSGi container.</description>
+  <url>https://github.com/datastax/java-driver</url>
+
+  <properties>
+    <felix.version>3.2.2</felix.version>
+    <pax-exam.version>3.4.0</pax-exam.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-core</artifactId>
+      <version>2.0.10-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.framework</artifactId>
+      <version>${felix.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-core</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam</artifactId>
+      <version>${pax-exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-testng</artifactId>
+      <version>${pax-exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-container-native</artifactId>
+      <version>${pax-exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-link-mvn</artifactId>
+      <version>${pax-exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.transaction</groupId>
+      <artifactId>jta</artifactId>
+      <version>1.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.17</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.6</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.jcabi</groupId>
+      <artifactId>jcabi-manifests</artifactId>
+      <version>1.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <version>2.4.0</version>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.datastax.driver.osgi</Bundle-SymbolicName>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <Export-Package>com.datastax.driver.osgi.api,!com.datastax.driver.osgi.impl</Export-Package>
+            <Bundle-Activator>com.datastax.driver.osgi.impl.Activator</Bundle-Activator>
+            <_include>-osgi.bnd</_include>
+          </instructions>
+          <supportedProjectTypes>
+            <supportedProjectType>jar</supportedProjectType>
+            <supportedProjectType>bundle</supportedProjectType>
+            <supportedProjectType>pom</supportedProjectType>
+          </supportedProjectTypes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <!-- Skip test by default, short or long is required to run unit tests since pax-exam will throw exception if it encounters a
+           test with no matching methods. -->
+      <id>default</id>
+      <properties>
+        <env>default</env>
+      </properties>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.14</version>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerArgument>-Xlint:all</compilerArgument>
+              <showWarnings>true</showWarnings>
+              <showDeprecation>true</showDeprecation>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>short</id>
+      <properties>
+        <env>default</env>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.14</version>
+            <configuration>
+              <groups>unit,short</groups>
+              <useFile>false</useFile>
+              <systemPropertyVariables>
+                <cassandra.version>${cassandra.version}</cassandra.version>
+                <ipprefix>${ipprefix}</ipprefix>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>long</id>
+      <properties>
+        <env>default</env>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.16</version>
+            <configuration>
+              <groups>unit,short,long</groups>
+              <useFile>false</useFile>
+              <systemPropertyVariables>
+                <cassandra.version>${cassandra.version}</cassandra.version>
+                <ipprefix>${ipprefix}</ipprefix>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+  
+  <licenses>
+    <license>
+      <name>Apache 2</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+      <comments>Apache License Version 2.0</comments>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git@github.com:datastax/java-driver.git</connection>
+    <developerConnection>scm:git:git@github.com:datastax/java-driver.git</developerConnection>
+    <url>https://github.com/datastax/java-driver</url>
+  </scm>
+
+  <developers>
+    <developer>
+      <name>Various</name>
+      <organization>DataStax</organization>
+    </developer>
+  </developers>
+</project>
+

--- a/driver-examples/osgi/src/main/java/com/datastax/driver/osgi/api/MailboxException.java
+++ b/driver-examples/osgi/src/main/java/com/datastax/driver/osgi/api/MailboxException.java
@@ -1,0 +1,23 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.osgi.api;
+
+public class MailboxException extends Exception {
+
+    public MailboxException(Throwable cause) {
+        super("Failure interacting with Mailbox", cause);
+    }
+}

--- a/driver-examples/osgi/src/main/java/com/datastax/driver/osgi/api/MailboxMessage.java
+++ b/driver-examples/osgi/src/main/java/com/datastax/driver/osgi/api/MailboxMessage.java
@@ -1,0 +1,60 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.osgi.api;
+
+import java.util.Date;
+
+public class MailboxMessage {
+    private String recipient;
+    private Date date;
+    private String sender;
+    private String body;
+
+    public MailboxMessage(String recipient, Date date, String sender, String body) {
+        this.recipient = recipient;
+        this.date = date;
+        this.sender = sender;
+        this.body = body;
+    }
+
+    public String getRecipient() {
+        return recipient;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public String getSender() {
+        return sender;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    @Override public boolean equals(Object that) {
+        if(that instanceof MailboxMessage) {
+            MailboxMessage thatM = (MailboxMessage)that;
+            return recipient.equals(thatM.getRecipient()) &&
+                date.equals(thatM.getDate()) &&
+                sender.equals(thatM.getSender()) &&
+                body.equals(thatM.getBody());
+        } else {
+            return false;
+        }
+    }
+}

--- a/driver-examples/osgi/src/main/java/com/datastax/driver/osgi/api/MailboxService.java
+++ b/driver-examples/osgi/src/main/java/com/datastax/driver/osgi/api/MailboxService.java
@@ -1,0 +1,42 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.osgi.api;
+
+import java.util.Collection;
+import java.util.UUID;
+
+public interface MailboxService {
+
+    /**
+     * Retrieve all messages for a given recipient.
+     * @param recipient User whose mailbox is being read.
+     * @return All messages in the mailbox.
+     */
+    public Collection<MailboxMessage> getMessages(String recipient) throws MailboxException;
+
+    /**
+     * Stores the given message in the appropriate mailbox.
+     * @param message Message to send.
+     * @return UUID generated for the message.
+     */
+    public UUID sendMessage(MailboxMessage message) throws MailboxException;
+
+    /**
+     * Deletes all mail for the given recipient.
+     * @param recipient User whose mailbox will be cleared.
+     */
+    public void clearMailbox(String recipient) throws MailboxException;
+}

--- a/driver-examples/osgi/src/main/java/com/datastax/driver/osgi/impl/Activator.java
+++ b/driver-examples/osgi/src/main/java/com/datastax/driver/osgi/impl/Activator.java
@@ -1,0 +1,57 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.osgi.impl;
+
+import java.util.Hashtable;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.osgi.api.MailboxService;
+
+public class Activator implements BundleActivator {
+
+    private Cluster cluster;
+
+    @Override public void start(BundleContext context) throws Exception {
+        String contactPointsStr = context.getProperty("cassandra.contactpoints");
+        if(contactPointsStr == null) {
+            contactPointsStr = "127.0.0.1";
+        }
+        String[] contactPoints = contactPointsStr.split(",");
+
+        String keyspace = context.getProperty("cassandra.keyspace");
+        if(keyspace == null) {
+            keyspace = "mailbox";
+        }
+
+        cluster = Cluster.builder().addContactPoints(contactPoints).build();
+        Session session = cluster.connect();
+
+        MailboxImpl mailbox = new MailboxImpl(session, keyspace);
+        mailbox.init();
+
+        context.registerService(MailboxService.class.getName(), mailbox, new Hashtable<String, String>());
+    }
+
+    @Override public void stop(BundleContext context) throws Exception {
+        if(cluster != null) {
+            cluster.close();
+        }
+    }
+}

--- a/driver-examples/osgi/src/main/java/com/datastax/driver/osgi/impl/MailboxImpl.java
+++ b/driver-examples/osgi/src/main/java/com/datastax/driver/osgi/impl/MailboxImpl.java
@@ -1,0 +1,138 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.osgi.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.UUID;
+
+import com.datastax.driver.core.*;
+import com.datastax.driver.core.exceptions.InvalidQueryException;
+import com.datastax.driver.core.utils.UUIDs;
+import com.datastax.driver.osgi.api.MailboxException;
+import com.datastax.driver.osgi.api.MailboxMessage;
+import com.datastax.driver.osgi.api.MailboxService;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.delete;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+
+public class MailboxImpl implements MailboxService {
+
+    private static final String TABLE = "mailbox";
+
+    private final Session session;
+
+    private final String keyspace;
+
+    private volatile boolean initialized = false;
+
+    private PreparedStatement retrieveStatement;
+
+    private PreparedStatement insertStatement;
+
+    private PreparedStatement deleteStatement;
+
+    public MailboxImpl(Session session, String keyspace) {
+        this.session = session;
+        this.keyspace = keyspace;
+    }
+
+    public synchronized void init() {
+        if(initialized)
+            return;
+
+        // Create the schema if it does not exist.
+        try {
+            session.execute("USE " + keyspace);
+        } catch (InvalidQueryException e) {
+            session.execute("CREATE KEYSPACE " + keyspace +
+                " with replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}");
+
+            session.execute("CREATE TABLE " + keyspace + "." + TABLE + " (" +
+                "recipient text," +
+                "time timeuuid," +
+                "sender text," +
+                "body text," +
+                "PRIMARY KEY (recipient, time))");
+        }
+
+        retrieveStatement = session.prepare(select()
+            .from(keyspace, TABLE)
+            .where(eq("recipient", bindMarker("recipient"))));
+
+        insertStatement = session.prepare(insertInto(keyspace, TABLE)
+            .value("recipient", bindMarker("recipient"))
+            .value("time", bindMarker("time"))
+            .value("sender", bindMarker("sender"))
+            .value("body", bindMarker("body")));
+
+        deleteStatement = session.prepare(delete().from(keyspace, TABLE)
+            .where(eq("recipient", bindMarker("recipient"))));
+
+        initialized = true;
+    }
+
+    @Override public Collection<MailboxMessage> getMessages(String recipient) throws MailboxException {
+        try {
+            BoundStatement statement = new BoundStatement(retrieveStatement);
+            statement.setString("recipient", recipient);
+            ResultSet result = session.execute(statement);
+
+            Collection<MailboxMessage> messages = new ArrayList<MailboxMessage>();
+            for(Row input : result) {
+                Date date = new Date(UUIDs.unixTimestamp(input.getUUID("time")));
+                messages.add(new MailboxMessage(input.getString("recipient"),
+                    date,
+                    input.getString("sender"),
+                    input.getString("body")));
+            }
+            return messages;
+        } catch(Exception e) {
+            throw new MailboxException(e);
+        }
+    }
+
+    @Override public UUID sendMessage(MailboxMessage message) throws MailboxException {
+        try {
+            UUID time = UUIDs.startOf(message.getDate().getTime());
+
+            BoundStatement statement = new BoundStatement(insertStatement);
+            statement.setString("recipient", message.getRecipient());
+            statement.setUUID("time", time);
+            statement.setString("sender", message.getSender());
+            statement.setString("body", message.getBody());
+
+            session.execute(statement);
+            return time;
+        } catch(Exception e) {
+            throw new MailboxException(e);
+        }
+    }
+
+    @Override public void clearMailbox(String recipient) throws MailboxException {
+        try {
+            BoundStatement statement = new BoundStatement(deleteStatement);
+            statement.setString("recipient", recipient);
+            session.execute(statement);
+        } catch(Exception e) {
+            throw new MailboxException(e);
+        }
+    }
+}

--- a/driver-examples/osgi/src/test/java/com/datastax/driver/osgi/CCMBridgeListener.java
+++ b/driver-examples/osgi/src/test/java/com/datastax/driver/osgi/CCMBridgeListener.java
@@ -1,0 +1,54 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.osgi;
+
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
+
+import com.datastax.driver.core.CCMBridge;
+
+/**
+ * A listener that fires up a single node CCM instance on test class start and tears it
+ * down on test class end.
+ *
+ * This is needed for tests that use Pax-Exam since it runs some methods in the OSGi container
+ * which we do not want.
+ */
+public class CCMBridgeListener implements ITestListener {
+
+    private CCMBridge ccm;
+
+    @Override public void onStart(ITestContext context) {
+        ccm = CCMBridge.create("test", 1);
+    }
+
+    @Override public void onFinish(ITestContext context) {
+        if(ccm != null) {
+            ccm.remove();
+        }
+    }
+
+    @Override public void onTestStart(ITestResult result) {}
+
+    @Override public void onTestSuccess(ITestResult result) {}
+
+    @Override public void onTestFailure(ITestResult result) {}
+
+    @Override public void onTestSkipped(ITestResult result) {}
+
+    @Override public void onTestFailedButWithinSuccessPercentage(ITestResult result) {}
+}

--- a/driver-examples/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceTest.java
+++ b/driver-examples/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceTest.java
@@ -1,0 +1,173 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.osgi;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.GregorianCalendar;
+
+import javax.inject.Inject;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.options.CompositeOption;
+import org.ops4j.pax.exam.options.MavenArtifactProvisionOption;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
+import org.ops4j.pax.exam.testng.listener.PaxExam;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.ops4j.pax.exam.CoreOptions.bundle;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+import static org.ops4j.pax.exam.CoreOptions.systemPackages;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+import static org.testng.Assert.assertEquals;
+
+import com.datastax.driver.core.CCMBridge;
+import com.datastax.driver.osgi.api.MailboxException;
+import com.datastax.driver.osgi.api.MailboxMessage;
+import com.datastax.driver.osgi.api.MailboxService;
+
+import static com.datastax.driver.osgi.VersionProvider.projectVersion;
+
+@ExamReactorStrategy(PerMethod.class)
+@Listeners({CCMBridgeListener.class, PaxExam.class})
+@Test(groups="short")
+public class MailboxServiceTest {
+    @Inject MailboxService service;
+
+    private MavenArtifactProvisionOption driverBundle = mavenBundle("com.datastax.cassandra", "cassandra-driver-core", projectVersion());
+
+    private MavenArtifactProvisionOption guavaBundle = mavenBundle("com.google.guava", "guava", "14.0.1");
+
+    private MavenArtifactProvisionOption nettyBundle = mavenBundle("io.netty", "netty", "3.9.0.Final");
+
+    private CompositeOption defaultOptions = new CompositeOption() {
+
+        @Override public Option[] getOptions() {
+            return options(
+                systemProperty("cassandra.contactpoints").value(CCMBridge.IP_PREFIX + 1),
+                bundle("reference:file:target/classes"),
+                mavenBundle("com.codahale.metrics", "metrics-core", "3.0.2"),
+                mavenBundle("org.slf4j", "slf4j-api", "1.7.5"),
+                mavenBundle("org.slf4j", "slf4j-simple", "1.7.5").noStart(),
+                systemPackages("org.testng", "org.junit", "org.junit.runner", "org.junit.runner.manipulation",
+                    "org.junit.runner.notification", "com.jcabi.manifests")
+            );
+        }
+    };
+
+    @Configuration
+    public Option[] shadedConfig() {
+        return options(
+            driverBundle.classifier("shaded"),
+            guavaBundle,
+            defaultOptions
+        );
+    }
+
+    @Configuration
+    public Option[] defaultConfig() {
+        return options(
+            driverBundle,
+            guavaBundle,
+            nettyBundle,
+            defaultOptions
+        );
+    }
+
+    @Configuration
+    public Option[] guava15Config() {
+        return options(
+            driverBundle,
+            nettyBundle,
+            guavaBundle.version("15.0"),
+            defaultOptions
+        );
+    }
+
+    @Configuration
+    public Option[] guava16Config() {
+        return options(
+            driverBundle,
+            nettyBundle,
+            guavaBundle.version("16.0.1"),
+            defaultOptions
+        );
+    }
+
+    @Configuration
+    public Option[] guava17Config() {
+        return options(
+            driverBundle,
+            nettyBundle,
+            guavaBundle.version("17.0"),
+            defaultOptions
+        );
+    }
+
+    @Configuration
+    public Option[] guava18Config() {
+        return options(
+            driverBundle,
+            nettyBundle,
+            guavaBundle.version("18.0"),
+            defaultOptions
+        );
+    }
+
+    /**
+     * <p>
+     * Exercises a 'mailbox' service provided by an OSGi bundle that depends on the driver.  Ensures that
+     * queries can be made through the service with the current given configuration.
+     * </p>
+     *
+     * The following configurations are tried (defined via methods with the @Configuration annotation):
+     * <ol>
+     *   <li>Default bundle (Driver with all of it's dependencies)</li>
+     *   <li>Shaded bundle (Driver with netty shaded)</li>
+     *   <li>With Guava 15</li>
+     *   <li>With Guava 16</li>
+     *   <li>With Guava 17</li>
+     *   <li>With Guava 18</li>
+     * </ol>
+     *
+     * @test_category packaging
+     * @expected_result Can create, retrieve and delete data using the mailbox service.
+     * @jira_ticket JAVA-620
+     * @since 2.0.10, 2.1.5
+     */
+    public void service_api_functional() throws MailboxException {
+        // Insert some data into mailbox for a particular user.
+        String recipient = "user@datastax.com";
+
+        try {
+            Collection<MailboxMessage> inMessages = new ArrayList<MailboxMessage>();
+            for (int i = 0; i < 30; i++) {
+                MailboxMessage message = new MailboxMessage(recipient, new GregorianCalendar(2015, 1, i).getTime(), recipient, "" + i);
+                inMessages.add(message);
+                service.sendMessage(message);
+            }
+
+            Collection<MailboxMessage> messages = service.getMessages(recipient);
+
+            assertEquals(messages, inMessages);
+        } finally {
+            service.clearMailbox(recipient);
+        }
+    }
+}

--- a/driver-examples/osgi/src/test/java/com/datastax/driver/osgi/VersionProvider.java
+++ b/driver-examples/osgi/src/test/java/com/datastax/driver/osgi/VersionProvider.java
@@ -1,0 +1,41 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.osgi;
+
+import com.jcabi.manifests.Manifests;
+
+/**
+ * Attempts to resolve the project version from the Bundle manifest.  If not present, will throw RuntimeException
+ * on initialization.   If this happens, try building with 'mvn compile' to generate the Bundle manifest.
+ *
+ * In IntelliJ you can have compile run after make by right clicking on 'compile' in the 'Maven Projects' tool window.
+ */
+public class VersionProvider {
+
+    private static String PROJECT_VERSION;
+    static {
+        String bundleName = Manifests.read("Bundle-SymbolicName");
+        if (bundleName.equals("com.datastax.driver.osgi")) {
+            PROJECT_VERSION = Manifests.read("Bundle-Version").replaceAll("\\.SNAPSHOT", "-SNAPSHOT");
+        } else {
+            throw new RuntimeException("Couldn't resolve bundle manifest (try building with mvn compile)");
+        }
+    }
+
+    public static String projectVersion() {
+        return PROJECT_VERSION;
+    }
+}

--- a/driver-examples/osgi/src/test/resources/log4j.properties
+++ b/driver-examples/osgi/src/test/resources/log4j.properties
@@ -1,0 +1,12 @@
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=INFO, A1
+
+# Scassandra's info log is a bit verbose
+log4j.logger.org.scassandra=WARN
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=\    %-6r [%t] %-5p %c %x - %m%n

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -26,6 +26,7 @@
 
   <modules>
     <module>stress</module>
+    <module>osgi</module>
   </modules>
   
   <licenses>


### PR DESCRIPTION
Includes a simple example of creating an OSGi bundle with a service that
uses driver-core.  Includes an Integration test that tests with the
following configs:
- Default (default classifier with all dependencies)
- Netty-Shaded (shaded classifier with all dependencies w/o netty)
- Guava 15 (default classifier with Guava 15.0)
- Guava 16
- Guava 17
- Guava 18

This test will if using the 'short' or 'long' profiles, so will be
pulled into continuous integration.

Uses pax-exam (https://ops4j1.jira.com/wiki/display/PAXEXAM4/Pax+Exam)
to test with different OSGi configurations.
