### PR TITLE
Refactoring CCMCluster.PerClassSingleNodeCluster (Java 659)

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -15,31 +15,34 @@
  */
 package com.datastax.driver.core;
 
-import com.datastax.driver.core.Cluster.Builder;
-import com.datastax.driver.core.exceptions.AlreadyExistsException;
-import com.datastax.driver.core.exceptions.DriverException;
-import com.datastax.driver.core.exceptions.NoHostAvailableException;
-
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.io.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-
 import java.io.*;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
-import static org.testng.Assert.fail;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.ByteStreams;
+import com.google.common.io.Closer;
+import com.google.common.io.Files;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.testng.Assert.fail;
+
+import com.datastax.driver.core.Cluster.Builder;
+import com.datastax.driver.core.exceptions.AlreadyExistsException;
+import com.datastax.driver.core.exceptions.DriverException;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
 
 import static com.datastax.driver.core.TestUtils.CREATE_KEYSPACE_SIMPLE_FORMAT;
 import static com.datastax.driver.core.TestUtils.SIMPLE_KEYSPACE;
@@ -70,6 +73,7 @@ public class CCMBridge {
 
     static final File CASSANDRA_DIR;
     static final String CASSANDRA_VERSION;
+
     static {
         String version = System.getProperty("cassandra.version");
         if (version.matches(CASSANDRA_VERSION_REGEXP)) {
@@ -90,8 +94,7 @@ public class CCMBridge {
     private final Runtime runtime = Runtime.getRuntime();
     private final File ccmDir;
 
-    private CCMBridge()
-    {
+    private CCMBridge() {
         this.ccmDir = Files.createTempDir();
     }
 
@@ -118,7 +121,7 @@ public class CCMBridge {
             OutputStream trustStoreOs = new FileOutputStream(f);
             closer.register(trustStoreOs);
             ByteStreams.copy(trustStoreIs, trustStoreOs);
-        } catch(IOException e) {
+        } catch (IOException e) {
             logger.warn("Failure to write keystore, SSL-enabled servers may fail to start.", e);
         } finally {
             try {
@@ -141,7 +144,7 @@ public class CCMBridge {
 
     public static CCMBridge create(String name, int nbNodes, String... options) {
         checkArgument(!"current".equals(name.toLowerCase()),
-                        "cluster can't be called \"current\"");
+            "cluster can't be called \"current\"");
         CCMBridge bridge = new CCMBridge();
         bridge.execute("ccm create %s -n %d -s -i %s -b %s " + Joiner.on(" ").join(options), name, nbNodes, IP_PREFIX, CASSANDRA_VERSION);
         return bridge;
@@ -157,7 +160,7 @@ public class CCMBridge {
 
     public static CCMBridge create(String name, int nbNodesDC1, int nbNodesDC2) {
         checkArgument(!"current".equals(name.toLowerCase()),
-                        "cluster can't be called \"current\"");
+            "cluster can't be called \"current\"");
         CCMBridge bridge = new CCMBridge();
         bridge.execute("ccm create %s -n %d:%d -s -i %s -b %s", name, nbNodesDC1, nbNodesDC2, IP_PREFIX, CASSANDRA_VERSION);
         return bridge;
@@ -198,6 +201,11 @@ public class CCMBridge {
         execute("ccm node%d stop", n);
     }
 
+    public void stop(String clusterName) {
+        logger.info("Stopping Cluster : "+clusterName);
+        execute("ccm stop "+clusterName);
+    }
+
     public void forceStop(int n) {
         logger.info("Force stopping: " + IP_PREFIX + n);
         execute("ccm node%d stop --not-gently", n);
@@ -206,6 +214,11 @@ public class CCMBridge {
     public void remove() {
         stop();
         execute("ccm remove");
+    }
+
+    public void remove(String clusterName) {
+        stop(clusterName);
+        execute("ccm remove " + clusterName);
     }
 
     public void remove(int n) {
@@ -227,9 +240,19 @@ public class CCMBridge {
 
     public void bootstrapNode(int n, String dc) {
         if (dc == null)
-            execute("ccm add node%d -i %s%d -j %d -r %d -b -s", n, IP_PREFIX, n, 7000 + 100*n, 8000 + 100*n);
+            execute("ccm add node%d -i %s%d -j %d -r %d -b -s", n, IP_PREFIX, n, 7000 + 100 * n, 8000 + 100 * n);
         else
-            execute("ccm add node%d -i %s%d -j %d -b -d %s -s", n, IP_PREFIX, n, 7000 + 100*n, dc);
+            execute("ccm add node%d -i %s%d -j %d -b -d %s -s", n, IP_PREFIX, n, 7000 + 100 * n, dc);
+        execute("ccm node%d start --wait-other-notice --wait-for-binary-proto", n);
+    }
+
+    public void bootstrapNodeWithPorts(int n, int thriftPort, int storagePort, int binaryPort, int jmxPort, int remoteDebugPort) {
+        String thriftItf = IP_PREFIX + n + ":" + thriftPort;
+        String storageItf = IP_PREFIX + n + ":" + storagePort;
+        String binaryItf = IP_PREFIX + n + ":" + binaryPort;
+        String remoteLogItf = IP_PREFIX + n + ":" + remoteDebugPort;
+        execute("ccm add node%d -i %s%d -b -t %s -l %s --binary-itf %s -j %d -r %s -s",
+            n, IP_PREFIX, n, thriftItf, storageItf, binaryItf, jmxPort, remoteLogItf);
         execute("ccm node%d start --wait-other-notice --wait-for-binary-proto", n);
     }
 
@@ -243,7 +266,7 @@ public class CCMBridge {
 
     public void updateConfig(Map<String, String> configs) {
         StringBuilder confStr = new StringBuilder();
-        for(Map.Entry<String,String> entry : configs.entrySet()) {
+        for (Map.Entry<String, String> entry : configs.entrySet()) {
             confStr.append(entry.getKey() + ":" + entry.getValue() + " ");
         }
         execute("ccm updateconf " + confStr);
@@ -339,13 +362,13 @@ public class CCMBridge {
      * @param requireClientAuth Whether or not to require Clients used authentication.
      */
     public void enableSSL(boolean requireClientAuth) {
-        ImmutableMap.Builder<String,String> configs = ImmutableMap.builder();
+        ImmutableMap.Builder<String, String> configs = ImmutableMap.builder();
 
         configs.put("client_encryption_options.enabled", "true");
         configs.put("client_encryption_options.keystore", DEFAULT_SERVER_KEYSTORE_FILE.getAbsolutePath());
         configs.put("client_encryption_options.keystore_password", DEFAULT_SERVER_KEYSTORE_PASSWORD);
 
-        if(requireClientAuth) {
+        if (requireClientAuth) {
             configs.put("client_encryption_options.require_client_auth", "true");
             configs.put("client_encryption_options.truststore", DEFAULT_SERVER_TRUSTSTORE_FILE.getAbsolutePath());
             configs.put("client_encryption_options.truststore_password", DEFAULT_SERVER_TRUSTSTORE_PASSWORD);
@@ -396,12 +419,37 @@ public class CCMBridge {
         return IP_PREFIX + Integer.toString(nodeNumber);
     }
 
+    public static class terminationHook extends Thread {
+        public void run() {
+            logger.debug("shut down hook task..");
+
+            if (PerClassSingleNodeCluster.cluster != null) {
+                PerClassSingleNodeCluster.cluster.close();
+            }
+            if (PerClassSingleNodeCluster.ccmBridge == null) {
+                logger.error("No cluster to discard");
+            } else if (PerClassSingleNodeCluster.erroredOut) {
+                PerClassSingleNodeCluster.ccmBridge.remove("test-class");
+                logger.info("Error during tests, kept C* logs in " + PerClassSingleNodeCluster.ccmBridge.ccmDir);
+            } else {
+                PerClassSingleNodeCluster.ccmBridge.remove("test-class");
+                PerClassSingleNodeCluster.ccmBridge.ccmDir.delete();
+            }
+
+        }
+    }
+
     // One cluster for the whole test class
     public static abstract class PerClassSingleNodeCluster {
 
-        protected static CCMBridge cassandraCluster;
+        protected static CCMBridge ccmBridge;
         private static boolean erroredOut;
-        private static boolean schemaCreated;
+        private static boolean clusterInitialized=false;
+        private static AtomicLong ksNumber;
+        protected String keyspace;
+
+        protected static InetSocketAddress hostAddress;
+        protected static int[] ports;
 
         protected static Cluster cluster;
         protected static Session session;
@@ -417,59 +465,57 @@ public class CCMBridge {
             erroredOut = true;
         }
 
-        public void createCluster() {
-            erroredOut = false;
-            schemaCreated = false;
-            cassandraCluster = CCMBridge.create("test", 1);
+        @BeforeClass(groups = { "short", "long" })
+        public void beforeClass() {
+            maybeInitCluster();
+            initKeyspace();
+        }
+
+        @AfterClass(groups = { "short", "long" })
+        public void afterClass() {
+            clearSimpleKeyspace();
+        }
+
+        private void maybeInitCluster(){
+            if (!clusterInitialized){
+                try {
+                    //launch ccm cluster
+                    ccmBridge = CCMBridge.create("test-class");
+
+                    ports = new int[5];
+                    for (int i = 0; i < 5; i++) {
+                        ports[i] = TestUtils.findAvailablePort(10000 + i);
+                    }
+
+                    ccmBridge.bootstrapNodeWithPorts(1, ports[0], ports[1], ports[2], ports[3], ports[4]);
+                    ksNumber = new AtomicLong(0);
+                    erroredOut = false;
+                    hostAddress = new InetSocketAddress(InetAddress.getByName(IP_PREFIX + 1), ports[2]);
+
+                    Runtime r = Runtime.getRuntime();
+                    r.addShutdownHook(new terminationHook());
+                    clusterInitialized = true;
+
+                } catch (UnknownHostException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+        }
+
+
+        private void initKeyspace() {
             try {
                 Builder builder = Cluster.builder();
+
                 builder = configure(builder);
-                cluster = builder.addContactPoints(IP_PREFIX + '1').build();
+
+                cluster = builder.addContactPointsWithPorts(Collections.singletonList(hostAddress)).build();
                 session = cluster.connect();
-            } catch (NoHostAvailableException e) {
-                erroredOut = true;
-                for (Map.Entry<InetSocketAddress, Throwable> entry : e.getErrors().entrySet())
-                    logger.info("Error connecting to " + entry.getKey() + ": " + entry.getValue());
-                throw new RuntimeException(e);
-            }
-        }
+                keyspace = SIMPLE_KEYSPACE + "_" + ksNumber.incrementAndGet();
+                session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, keyspace, 1));
 
-        @AfterClass(groups = {"short", "long"})
-        public static void discardCluster() {
-            if (cluster != null)
-                cluster.close();
-
-            if (cassandraCluster == null) {
-                logger.error("No cluster to discard");
-            } else if (erroredOut) {
-                cassandraCluster.stop();
-                logger.info("Error during tests, kept C* logs in " + cassandraCluster.ccmDir);
-            } else {
-                cassandraCluster.remove();
-                cassandraCluster.ccmDir.delete();
-            }
-        }
-
-        @BeforeClass(groups = {"short", "long"})
-        public void beforeClass() {
-            createCluster();
-            maybeCreateSchema();
-        }
-
-        public void maybeCreateSchema() {
-
-            try {
-                if (schemaCreated)
-                    return;
-
-                try {
-                    session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, SIMPLE_KEYSPACE, 1));
-                } catch (AlreadyExistsException e) {
-                    // It's ok, ignore
-                }
-
-                session.execute("USE " + SIMPLE_KEYSPACE);
-
+                session.execute("USE " + keyspace);
                 for (String tableDef : getTableDefinitions()) {
                     try {
                         session.execute(tableDef);
@@ -477,13 +523,26 @@ public class CCMBridge {
                         // It's ok, ignore
                     }
                 }
-
-                schemaCreated = true;
+            } catch (AlreadyExistsException e) {
+                // It's ok, ignore (not supposed to go there)
+            } catch (NoHostAvailableException e) {
+                erroredOut = true;
+                for (Map.Entry<InetSocketAddress, Throwable> entry : e.getErrors().entrySet())
+                    logger.info("Error connecting to " + entry.getKey() + ": " + entry.getValue());
+                throw new RuntimeException(e);
             } catch (DriverException e) {
                 erroredOut = true;
                 throw e;
             }
         }
+
+        private void clearSimpleKeyspace() {
+            session.execute("DROP KEYSPACE " + keyspace);
+            if (cluster != null) {
+                cluster.close();
+            }
+        }
+
     }
 
     public static class CCMCluster {
@@ -518,10 +577,12 @@ public class CCMBridge {
             try {
                 String[] contactPoints = new String[totalNodes];
                 for (int i = 0; i < totalNodes; i++)
-                    contactPoints[i] = IP_PREFIX + (i+1);
+                    contactPoints[i] = IP_PREFIX + (i + 1);
 
-                try { Thread.sleep(1000); } catch (Exception e) {}
-
+                try {
+                    Thread.sleep(1000);
+                } catch (Exception e) {
+                }
                 this.cluster = builder.addContactPoints(contactPoints).build();
                 this.session = cluster.connect();
             } catch (NoHostAvailableException e) {

--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.assertTrue;
 
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.datastax.driver.core.exceptions.UnsupportedFeatureException;
+
 import static com.datastax.driver.core.TestUtils.*;
 
 /**
@@ -301,10 +302,10 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
 
         assertEquals(session.execute(ps.bind("123")).one().getInt("i"), 17);
 
-        cassandraCluster.stop();
+        ccmBridge.stop();
         waitForDown(CCMBridge.IP_PREFIX + '1', cluster);
 
-        cassandraCluster.start();
+        ccmBridge.start();
         waitFor(CCMBridge.IP_PREFIX + '1', cluster, 120);
 
         try
@@ -413,9 +414,9 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
 
     @Test(groups="short")
     public void should_set_routing_key_on_case_insensitive_keyspace_and_table() {
-        session.execute("CREATE TABLE ks.foo (i int PRIMARY KEY)");
+        session.execute(String.format("CREATE TABLE %s.foo (i int PRIMARY KEY)",keyspace));
 
-        PreparedStatement ps = session.prepare("INSERT INTO ks.foo (i) VALUES (?)");
+        PreparedStatement ps = session.prepare(String.format("INSERT INTO %s.foo (i) VALUES (?)",keyspace));
         BoundStatement bs = ps.bind(1);
         assertThat(bs.getRoutingKey()).isNotNull();
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
@@ -7,11 +7,13 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
+
 import com.datastax.driver.core.utils.CassandraVersion;
 
 import static com.datastax.driver.core.Assertions.*;
 import static com.datastax.driver.core.Host.State.DOWN;
 import static com.datastax.driver.core.Host.State.UP;
+
 
 /**
  * Due to C* gossip bugs, system.peers may report nodes that are gone from the cluster.

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaTest.java
@@ -33,52 +33,52 @@ public class SchemaTest extends CCMBridge.PerClassSingleNodeCluster {
     @Override
     protected Collection<String> getTableDefinitions() {
 
-        String sparse = "CREATE TABLE ks.sparse (\n"
+        String sparse = String.format("CREATE TABLE %s.sparse (\n"
                       + "    k text,\n"
                       + "    c1 int,\n"
                       + "    c2 float,\n"
                       + "    l list<text>,\n"
                       + "    v int,\n"
                       + "    PRIMARY KEY (k, c1, c2)\n"
-                      + ");";
+                      + ");", keyspace);
 
-        String st = "CREATE TABLE ks.static (\n"
+        String st = String.format("CREATE TABLE %s.static (\n"
                   + "    k text,\n"
                   + "    i int,\n"
                   + "    m map<text, timeuuid>,\n"
                   + "    v int,\n"
                   + "    PRIMARY KEY (k)\n"
-                  + ");";
+                  + ");", keyspace);
 
-        String counters = "CREATE TABLE ks.counters (\n"
+        String counters = String.format("CREATE TABLE %s.counters (\n"
                         + "    k text,\n"
                         + "    c counter,\n"
                         + "    PRIMARY KEY (k)\n"
-                        + ");";
+                        + ");", keyspace);
 
-        String compactStatic = "CREATE TABLE ks.compact_static (\n"
+        String compactStatic = String.format("CREATE TABLE %s.compact_static (\n"
                              + "    k text,\n"
                              + "    i int,\n"
                              + "    t timeuuid,\n"
                              + "    v int,\n"
                              + "    PRIMARY KEY (k)\n"
-                             + ") WITH COMPACT STORAGE;";
+                             + ") WITH COMPACT STORAGE;", keyspace);
 
-        String compactDynamic = "CREATE TABLE ks.compact_dynamic (\n"
+        String compactDynamic = String.format("CREATE TABLE %s.compact_dynamic (\n"
                               + "    k text,\n"
                               + "    c int,\n"
                               + "    v timeuuid,\n"
                               + "    PRIMARY KEY (k, c)\n"
-                              + ") WITH COMPACT STORAGE;";
+                              + ") WITH COMPACT STORAGE;", keyspace);
 
-        String compactComposite = "CREATE TABLE ks.compact_composite (\n"
+        String compactComposite = String.format("CREATE TABLE %s.compact_composite (\n"
                                 + "    k text,\n"
                                 + "    c1 int,\n"
                                 + "    c2 float,\n"
                                 + "    c3 double,\n"
                                 + "    v timeuuid,\n"
                                 + "    PRIMARY KEY (k, c1, c2, c3)\n"
-                                + ") WITH COMPACT STORAGE;";
+                                + ") WITH COMPACT STORAGE;", keyspace);
 
         cql3.put("sparse", sparse);
         cql3.put("static", st);
@@ -87,7 +87,7 @@ public class SchemaTest extends CCMBridge.PerClassSingleNodeCluster {
         compact.put("compact_dynamic", compactDynamic);
         compact.put("compact_composite", compactComposite);
 
-        withOptions = "CREATE TABLE ks.with_options (\n"
+        withOptions = String.format("CREATE TABLE %s.with_options (\n"
                     + "    k text,\n"
                     + "    v1 int,\n"
                     + "    v2 int,\n"
@@ -102,7 +102,7 @@ public class SchemaTest extends CCMBridge.PerClassSingleNodeCluster {
                     + "   AND caching = 'ALL'\n"
                     + "   AND comment = 'My awesome table'\n"
                     + "   AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'sstable_size_in_mb' : 15 }\n"
-                    + "   AND compression = { 'sstable_compression' : 'org.apache.cassandra.io.compress.SnappyCompressor', 'chunk_length_kb' : 128 };";
+                    + "   AND compression = { 'sstable_compression' : 'org.apache.cassandra.io.compress.SnappyCompressor', 'chunk_length_kb' : 128 };", keyspace);
 
         List<String> allDefs = new ArrayList<String>();
         allDefs.addAll(cql3.values());
@@ -126,7 +126,7 @@ public class SchemaTest extends CCMBridge.PerClassSingleNodeCluster {
     @Test(groups = "short")
     public void schemaExportTest() {
 
-        KeyspaceMetadata metadata = cluster.getMetadata().getKeyspace(TestUtils.SIMPLE_KEYSPACE);
+        KeyspaceMetadata metadata = cluster.getMetadata().getKeyspace(keyspace);
 
         for (Map.Entry<String, String> tableEntry : cql3.entrySet()) {
             String table = tableEntry.getKey();
@@ -144,7 +144,7 @@ public class SchemaTest extends CCMBridge.PerClassSingleNodeCluster {
     // Same remark as the preceding test
     @Test(groups = "short")
     public void schemaExportOptionsTest() {
-        TableMetadata metadata = cluster.getMetadata().getKeyspace(TestUtils.SIMPLE_KEYSPACE).getTable("with_options");
+        TableMetadata metadata = cluster.getMetadata().getKeyspace(keyspace).getTable("with_options");
 
         String withOpts = withOptions;
         // With C* 2.0 we'll have a few additional options

--- a/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
@@ -1,0 +1,85 @@
+package com.datastax.driver.core;
+
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class SessionLeakTest {
+
+
+    @Test(groups = "short")
+    public void connectionLeakTest() throws Exception {
+        // Checking for JAVA-342
+        CCMBridge ccmBridge;
+        ccmBridge = CCMBridge.create("test", 1);
+
+        // give the driver time to close other sessions in this class
+        //Thread.sleep(10);
+
+        // create a new cluster object and ensure 0 sessions and connections
+        Cluster cluster = Cluster.builder().addContactPoints(CCMBridge.IP_PREFIX + '1').build();
+
+        int corePoolSize = cluster.getConfiguration()
+                .getPoolingOptions()
+                .getCoreConnectionsPerHost(HostDistance.LOCAL);
+
+        assertEquals(cluster.manager.sessions.size(), 0);
+        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 0);
+
+        // ensure sessions.size() returns with 1 control connection + core pool size.
+        Session session = cluster.connect();
+        assertEquals(cluster.manager.sessions.size(), 1);
+        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1 + corePoolSize);
+
+        // ensure sessions.size() returns to 0 with only 1 active connection (the control connection)
+        session.close();
+        assertEquals(cluster.manager.sessions.size(), 0);
+        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
+
+        try {
+            Session thisSession;
+
+            // ensure bootstrapping a node does not create additional connections
+
+
+            ccmBridge.bootstrapNode(2);
+            assertEquals(cluster.manager.sessions.size(), 0);
+            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
+
+            // ensure a new session gets registered and core connections are established
+            // there should be corePoolSize more connections to accommodate for the new host.
+            thisSession = cluster.connect();
+            assertEquals(cluster.manager.sessions.size(), 1);
+
+            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1 + (corePoolSize * 2));
+
+            // ensure bootstrapping a node does not create additional connections that won't get cleaned up
+            thisSession.close();
+
+            assertEquals(cluster.manager.sessions.size(), 0);
+
+            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
+
+
+        } finally {
+            // ensure we decommission node2 for the rest of the tests
+
+            assertEquals(cluster.manager.sessions.size(), 0);
+            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
+
+            if(cluster != null){
+                cluster.close();
+
+            }
+
+            if (ccmBridge != null) {
+                ccmBridge.remove();
+            }
+
+
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
@@ -19,7 +19,7 @@ public class TableMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
 
     @Test(groups = "short")
     public void should_escape_single_quote_table_comment() {
-        TableMetadata table = cluster.getMetadata().getKeyspace("ks").getTable("single_quote");
+        TableMetadata table = cluster.getMetadata().getKeyspace(keyspace).getTable("single_quote");
         assertThat(table.asCQLQuery()).contains("comment with single quote '' should work");
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
@@ -15,12 +15,12 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.TreeSet;
 
 import org.testng.annotations.Test;
+
 import static org.testng.Assert.*;
 
 import com.datastax.driver.core.*;
@@ -44,10 +44,10 @@ public class QueryBuilderITest extends CCMBridge.PerClassSingleNodeCluster {
     public void remainingDeleteTests() throws Exception {
 
         Statement query;
-        TableMetadata table = cluster.getMetadata().getKeyspace(TestUtils.SIMPLE_KEYSPACE).getTable(TABLE_TEXT);
+        TableMetadata table = cluster.getMetadata().getKeyspace(keyspace).getTable(TABLE_TEXT);
         assertNotNull(table);
 
-        String expected = "DELETE k FROM ks.test_text;";
+        String expected = String.format("DELETE k FROM %s.test_text;", keyspace);
         query = delete("k").from(table);
         assertEquals(query.toString(), expected);
         try {
@@ -210,25 +210,25 @@ public class QueryBuilderITest extends CCMBridge.PerClassSingleNodeCluster {
     @Test(groups = "short")
     @CassandraVersion(major=2.0, minor=7, description="DELETE..IF EXISTS only supported in 2.0.7+ (CASSANDRA-5708)")
     public void conditionalDeletesTest() throws Exception {
-        session.execute("INSERT INTO ks.test_int (k, a, b) VALUES (1, 1, 1)");
+        session.execute(String.format("INSERT INTO %s.test_int (k, a, b) VALUES (1, 1, 1)",keyspace));
         
         Statement delete;
         Row row;
-        delete = delete().from(TestUtils.SIMPLE_KEYSPACE, TABLE_INT).where(eq("k", 2)).ifExists();
+        delete = delete().from(keyspace, TABLE_INT).where(eq("k", 2)).ifExists();
         row = session.execute(delete).one();
         assertFalse(row.getBool("[applied]"));
         
-        delete = delete().from(TestUtils.SIMPLE_KEYSPACE, TABLE_INT).where(eq("k", 1)).ifExists();
+        delete = delete().from(keyspace, TABLE_INT).where(eq("k", 1)).ifExists();
         row = session.execute(delete).one();
         assertTrue(row.getBool("[applied]"));
 
-        session.execute("INSERT INTO ks.test_int (k, a, b) VALUES (1, 1, 1)");
+        session.execute(String.format("INSERT INTO %s.test_int (k, a, b) VALUES (1, 1, 1)", keyspace));
 
-        delete = delete().from(TestUtils.SIMPLE_KEYSPACE, TABLE_INT).where(eq("k", 1)).onlyIf(eq("a", 1)).and(eq("b", 2));
+        delete = delete().from(keyspace, TABLE_INT).where(eq("k", 1)).onlyIf(eq("a", 1)).and(eq("b", 2));
         row = session.execute(delete).one();
         assertFalse(row.getBool("[applied]"));
         
-        delete = delete().from(TestUtils.SIMPLE_KEYSPACE, TABLE_INT).where(eq("k", 1)).onlyIf(eq("a", 1)).and(eq("b", 1));
+        delete = delete().from(keyspace, TABLE_INT).where(eq("k", 1)).onlyIf(eq("a", 1)).and(eq("b", 1));
         row = session.execute(delete).one();
         assertTrue(row.getBool("[applied]"));
     }


### PR DESCRIPTION
JAVA-659 : creating only one ccm instance for all child classes
-added static initalizer for ccm instance
-added termination hook for ccm remove operations
-added minor changes for handling tests who still want to use the keyspace "ks" or create new keyspaces
-modified 2 tests because they were not connecting to cluster with the new ports
