### PR TITLE
Empty TokenRange returned in a one token cluster (JAVA-684).

### DIFF
--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -16,6 +16,7 @@ CHANGELOG
 - [improvement] Exclude Netty POM from META-INF in shaded JAR (JAVA-654)
 - [bug] Quote single quotes contained in table comments in asCQLQuery method
   (JAVA-655)
+- [bug] Empty TokenRange returned in a one token cluster (JAVA-684)
 
 Merged from 2.0.9_fixes branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -547,10 +547,15 @@ public class Metadata {
 
         private static Set<TokenRange> makeTokenRanges(List<Token> ring, Token.Factory factory) {
             ImmutableSet.Builder<TokenRange> builder = ImmutableSet.builder();
-            for (int i = 0; i < ring.size(); i++) {
-                Token start = ring.get(i);
-                Token end = ring.get((i + 1) % ring.size());
-                builder.add(new TokenRange(start, end, factory));
+            // JAVA-684: if there is only one token, return the range ]minToken, minToken]
+            if(ring.size() == 1) {
+                builder.add(new TokenRange(factory.minToken(), factory.minToken(), factory));                
+            } else {
+                for (int i = 0; i < ring.size(); i++) {
+                    Token start = ring.get(i);
+                    Token end = ring.get((i + 1) % ring.size());
+                    builder.add(new TokenRange(start, end, factory));
+                }
             }
             return builder.build();
         }

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenMapTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenMapTest.java
@@ -16,16 +16,26 @@
 package com.datastax.driver.core;
 
 import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.testng.annotations.*;
 
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.*;
 
 import com.datastax.driver.core.CCMBridge.CCMCluster;
 
+import static com.datastax.driver.core.Token.M3PToken.FACTORY;
+
 /**
- * Tests that the token map is correctly initialized at startup (JAVA-415).
+ * Tests for {@link com.datastax.driver.core.Metadata.TokenMap}.
  */
 public class TokenMapTest {
     CCMCluster ccmCluster = null;
@@ -37,12 +47,37 @@ public class TokenMapTest {
         cluster = ccmCluster.cluster;
     }
 
+    /**
+     * Tests that the token map is correctly initialized at startup (JAVA-415).
+     */
     @Test(groups = "short")
     public void initTest() {
         // If the token map is initialized correctly, we should get replicas for any partition key
         ByteBuffer anyKey = ByteBuffer.wrap(new byte[]{});
         Set<Host> replicas = cluster.getMetadata().getReplicas("system", anyKey);
         assertFalse(replicas.isEmpty());
+    }
+
+    /**
+     * DEVC-684: Empty TokenRange returned in a one token cluster
+     */
+    @Test(groups = "unit")
+    public void should_return_single_non_empty_range_when_cluster_has_one_single_token() {
+        // given a single node cluster with one single token "1"
+        // ("1" is purposely chosen because it is not the minimum token for the partitioner in use)
+        Collection<String> tokens = Sets.newHashSet("1");
+        Map<Host, Collection<String>> allTokens = ImmutableMap.of(mock(Host.class), tokens);
+        // when the token map is built
+        Metadata metadata = new Metadata(mock(Cluster.Manager.class));
+        metadata.rebuildTokenMap("Murmur3Partitioner", allTokens);
+        // then
+        Set<TokenRange> tokenRanges = metadata.getTokenRanges();
+        assertThat(tokenRanges).hasSize(1);
+        TokenRange tokenRange = tokenRanges.iterator().next();
+        assertThat(tokenRange.getStart()).isEqualTo(FACTORY.minToken());
+        assertThat(tokenRange.getEnd()).isEqualTo(FACTORY.minToken());
+        assertThat(tokenRange.isEmpty()).isFalse();
+        assertThat(tokenRange.isWrappedAround()).isFalse();
     }
 
     @AfterMethod(groups = "short")


### PR DESCRIPTION
In `com.datastax.driver.core.Metadata.TokenMap#makeTokenRanges()` we now treat separately the special case where the entire ring contains only one token.
Adding unit test in `com.datastax.driver.core.TokenMapTest`.
