### PR TITLE
Fix CCMBridge.execute potentially hanging if waiting on output streams.  Support overriding PATH and JAVA_HOME variables used by CCM.

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -111,6 +111,13 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-exec</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/driver-examples/osgi/pom.xml
+++ b/driver-examples/osgi/pom.xml
@@ -117,10 +117,18 @@
       <version>3.1.0</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
       <version>1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-exec</artifactId>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Found that CCMBridge was hanging in my linux environment when
downloading cassandra 2.1.3.  This was because the output stream was not
being consumed, causing the process to block indefinitely.  See
documentation at
http://docs.oracle.com/javase/7/docs/api/java/lang/Process.html for an
explanation:

> By default, the created subprocess does not have its own terminal or console. All its standard I/O (i.e. stdin, stdout, stderr) operations will be redirected to the parent process, where they can be accessed via the streams obtained using the methods getOutputStream(), getInputStream(), and getErrorStream(). The parent process uses these streams to feed input to and get output from the subprocess. Because some native platforms only provide limited buffer size for standard input and output streams, failure to promptly write the input stream or read the output stream of the subprocess may cause the subprocess to block, or even deadlock.

Updated to use commons-exec's DefaultExecutor with PumpStreamHandler to
consume and log stdout and stderr as it occurs.
