### PR TITLE
Added 'long' profile in driver-mapping pom.xml.

### DIFF
--- a/driver-mapping/pom.xml
+++ b/driver-mapping/pom.xml
@@ -174,6 +174,30 @@
       </build>
     </profile>
 
+    <profile>
+      <id>long</id>
+      <properties>
+        <env>default</env>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.14</version>
+            <configuration>
+              <groups>unit,short,long</groups>
+              <useFile>false</useFile>
+              <systemPropertyVariables>
+                <cassandra.version>${cassandra.version}</cassandra.version>
+                <ipprefix>${ipprefix}</ipprefix>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
   </profiles>
 
   <licenses>


### PR DESCRIPTION
'short' and 'long' tests in driver-mapping were not being executed in
jenkins because there was no 'long' profile defined in the pom.xml.
This will enable these tests to be run when using the 'long' profile.
