### PR TITLE
Expose dependency versions as properties so they may be overriden.

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -30,23 +30,19 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
-      <version>3.9.0.Final</version>
+      <version>${netty.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <!--
-        We use an old version of Guava to be compatible with Spark 1.1.
-        Check with the spark-cassandra-connector team before upgrading this.
-      -->
-      <version>14.0.1</version>
+      <version>${guava.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.codahale.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>3.0.2</version>
+      <version>${metrics.version}</version>
     </dependency>
 
     <!-- Compression libraries for the protocol. -->
@@ -55,14 +51,14 @@
     <dependency>
         <groupId>org.xerial.snappy</groupId>
         <artifactId>snappy-java</artifactId>
-        <version>1.0.5</version>
+        <version>${snappy.version}</version>
         <optional>true</optional>
     </dependency>
 
     <dependency>
         <groupId>net.jpountz.lz4</groupId>
         <artifactId>lz4</artifactId>
-        <version>1.2.0</version>
+        <version>${lz4.version}</version>
         <optional>true</optional>
     </dependency>
 
@@ -71,21 +67,21 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.8.8</version>
+      <version>${testng.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>1.7.0</version>
+      <version>${assertj.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.10.8</version>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -93,7 +89,7 @@
       <groupId>org.scassandra</groupId>
       <artifactId>java-client</artifactId>
       <!-- N.B. later versions of scassandra require JDK 7 -->
-      <version>0.4.1</version>
+      <version>${scassandra.version}</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/driver-examples/osgi/pom.xml
+++ b/driver-examples/osgi/pom.xml
@@ -88,14 +88,14 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.6</version>
+      <version>${slf4j-log4j12.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,20 +38,37 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cassandra.version>2.0.10</cassandra.version>
+    <java.version>1.6</java.version>
+    <log4j.version>1.2.17</log4j.version>
+    <slf4j-log4j12.version>1.7.6</slf4j-log4j12.version>
+    <!--
+      We use an old version of Guava to be compatible with Spark 1.1.
+      Check with the spark-cassandra-connector team before upgrading this.
+    -->
+    <guava.version>14.0.1</guava.version>
+    <netty.version>3.9.0.Final</netty.version>
+    <metrics.version>3.0.2</metrics.version>
+    <snappy.version>1.0.5</snappy.version>
+    <lz4.version>1.2.0</lz4.version>
+    <!-- test dependency versions -->
+    <testng.version>6.8.8</testng.version>
+    <assertj.version>1.7.0</assertj.version>
+    <mockito.version>1.10.8</mockito.version>
+    <scassandra.version>0.4.1</scassandra.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.6</version>
+      <version>${slf4j-log4j12.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -74,8 +91,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
             <optimize>true</optimize>
             <showDeprecation>true</showDeprecation>
             <showWarnings>true</showWarnings>


### PR DESCRIPTION
This is in support of enabling more convenient testing of the java-driver with different versions of libraries.  

For example, a lot of users will tend towards using a newer version of Guava rather than the provided 14.0.1 version.  With this change we could run tests in the
following manner:

```
mvn test -Dguava.version=18.0
```
