### PR TITLE
Delay initialization of frame compressors (JAVA-697).

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -104,7 +104,7 @@ class Connection {
             ProtocolOptions protocolOptions = factory.configuration.getProtocolOptions();
             int protocolVersion = factory.protocolVersion == 1 ? 1 : 2;
             bootstrap.handler(
-                new Initializer(this, protocolVersion, protocolOptions.getCompression().compressor, protocolOptions.getSSLOptions(),
+                new Initializer(this, protocolVersion, protocolOptions.getCompression().compressor(), protocolOptions.getSSLOptions(),
                     factory.configuration.getPoolingOptions().getHeartbeatIntervalSeconds()));
 
             ChannelFuture future = bootstrap.connect(address);

--- a/driver-core/src/main/java/com/datastax/driver/core/FrameCompressor.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/FrameCompressor.java
@@ -98,6 +98,7 @@ abstract class FrameCompressor {
 
         private LZ4Compressor() {
             final LZ4Factory lz4Factory = LZ4Factory.fastestInstance();
+            logger.info("Using {}", lz4Factory.toString());
             compressor = lz4Factory.fastCompressor();
             decompressor = lz4Factory.fastDecompressor();
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/ProtocolOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ProtocolOptions.java
@@ -25,23 +25,34 @@ public class ProtocolOptions {
      */
     public enum Compression {
         /** No compression */
-        NONE("", null),
+        NONE("") {
+            @Override
+            FrameCompressor compressor() {
+                return null;
+            }
+        },
         /** Snappy compression */
-        SNAPPY("snappy", FrameCompressor.SnappyCompressor.instance),
+        SNAPPY("snappy") {
+            @Override
+            FrameCompressor compressor() {
+                return FrameCompressor.SnappyCompressor.instance;
+            }
+        },
         /** LZ4 compression */
-        LZ4("lz4", FrameCompressor.LZ4Compressor.instance);
+        LZ4("lz4") {
+            @Override
+            FrameCompressor compressor() {
+                return FrameCompressor.LZ4Compressor.instance;
+            }
+        };
 
         final String protocolName;
-        final FrameCompressor compressor;
 
-        private Compression(String protocolName, FrameCompressor compressor) {
+        private Compression(String protocolName) {
             this.protocolName = protocolName;
-            this.compressor = compressor;
         }
 
-        FrameCompressor compressor() {
-            return compressor;
-        }
+        abstract FrameCompressor compressor();
 
         static Compression fromString(String str) {
             for (Compression c : values()) {
@@ -177,7 +188,7 @@ public class ProtocolOptions {
      * unavailable.
      */
     public ProtocolOptions setCompression(Compression compression) {
-        if (compression != Compression.NONE && compression.compressor == null)
+        if (compression != Compression.NONE && compression.compressor() == null)
             throw new IllegalStateException("The requested compression is not available (some compression require a JAR to be found in the classpath)");
 
         this.compression = compression;


### PR DESCRIPTION
Trivial fix to avoid warnings about compression dependencies if compression isn't going to be used.

This also logs the LZ4 implementation if LZ4 is loaded.
