### PR TITLE
Speculative query execution (JAVA-561)

### DIFF
--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -43,6 +43,8 @@ CHANGELOG
 - [improvement] Remove "suspected" mechanism (JAVA-617)
 - [improvement] Don't mark connection defunct on client timeout (reverts
   JAVA-425)
+- [new feature] Speculative query executions (JAVA-561)
+- [bug] Release connection before completing the ResultSetFuture (JAVA-666)
 
 Merged from 2.0.9_fixes branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/ExecutionInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ExecutionInfo.java
@@ -62,11 +62,16 @@ public class ExecutionInfo {
      * The list of tried hosts for this query.
      * <p>
      * In general, this will be a singleton list with the host that coordinated
-     * that query. However, if an host is tried by the driver but is dead or in
-     * error, that host is recorded and the query is retry. Also, on a timeout
-     * or unavailable exception, some
+     * that query. However:
+     * <ul>
+     * <li>if a host is tried by the driver but is dead or in
+     * error, that host is recorded and the query is retried;</li>
+     * <li>on a timeout or unavailable exception, some
      * {@link com.datastax.driver.core.policies.RetryPolicy} may retry the
-     * query on the same host, so the same host might appear twice.
+     * query on the same host, so the same host might appear twice.</li>
+     * <li>if {@link com.datastax.driver.core.policies.SpeculativeExecutionPolicy speculative executions}
+     * are enabled, other hosts might have been tried speculatively as well.</li>
+     * </ul>
      * <p>
      * If you are only interested in fetching the final (and often only) node
      * coordinating the query, {@link #getQueriedHost} provides a shortcut to

--- a/driver-core/src/main/java/com/datastax/driver/core/Message.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Message.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.driver.core;
 
+import java.nio.ByteBuffer;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
@@ -101,6 +102,31 @@ abstract class Message {
 
         public boolean isTracingRequested() {
             return tracingRequested;
+        }
+
+        ConsistencyLevel consistency() {
+            switch (this.type) {
+                case QUERY:   return ((Requests.Query)this).options.consistency;
+                case EXECUTE: return ((Requests.Execute)this).options.consistency;
+                case BATCH:   return ((Requests.Batch)this).consistency;
+                default:      return null;
+            }
+        }
+
+        ConsistencyLevel serialConsistency() {
+            switch (this.type) {
+                case QUERY:   return ((Requests.Query)this).options.serialConsistency;
+                case EXECUTE: return ((Requests.Execute)this).options.serialConsistency;
+                default:      return null;
+            }
+        }
+
+        ByteBuffer pagingState() {
+            switch (this.type) {
+                case QUERY:   return ((Requests.Query)this).options.pagingState;
+                case EXECUTE: return ((Requests.Execute)this).options.pagingState;
+                default:      return null;
+            }
         }
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Metrics.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metrics.java
@@ -18,10 +18,9 @@ package com.datastax.driver.core;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.MetricRegistryListener;
-
 import com.codahale.metrics.*;
+
+import com.datastax.driver.core.policies.SpeculativeExecutionPolicy;
 
 /**
  * Metrics exposed by the driver.
@@ -286,6 +285,8 @@ public class Metrics {
         private final Counter ignoresOnReadTimeout = registry.counter("ignores-on-read-timeout");
         private final Counter ignoresOnUnavailable = registry.counter("ignores-on-unavailable");
 
+        private final Counter speculativeExecutions = registry.counter("speculative-executions");
+
         /**
          * Returns the number of connection to Cassandra nodes errors.
          * <p>
@@ -444,6 +445,17 @@ public class Metrics {
          */
         public Counter getIgnoresOnUnavailable() {
             return ignoresOnUnavailable;
+        }
+
+        /**
+         * Returns the number of times a speculative execution was started
+         * because a previous execution did not complete within the delay
+         * specified by {@link SpeculativeExecutionPolicy}.
+         *
+         * @return the number of speculative executions.
+         */
+        public Counter getSpeculativeExecutions() {
+            return speculativeExecutions;
         }
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/QueryLogger.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/QueryLogger.java
@@ -535,6 +535,9 @@ public class QueryLogger implements LatencyTracker {
     }
 
     private int append(Statement statement, StringBuilder buffer, int remaining) {
+        if (statement instanceof StatementWrapper)
+            statement = ((StatementWrapper)statement).getWrappedStatement();
+
         if (statement instanceof RegularStatement) {
             remaining = append(((RegularStatement)statement).getQueryString().trim(), buffer, remaining);
         } else if (statement instanceof BoundStatement) {

--- a/driver-core/src/main/java/com/datastax/driver/core/QueryOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/QueryOptions.java
@@ -37,9 +37,15 @@ public class QueryOptions {
      */
     public static final int DEFAULT_FETCH_SIZE = 5000;
 
+    /**
+     * The default value for {@link #getDefaultIdempotence()}: {@code false}.
+     */
+    public static final boolean DEFAULT_IDEMPOTENCE = false;
+
     private volatile ConsistencyLevel consistency = DEFAULT_CONSISTENCY_LEVEL;
     private volatile ConsistencyLevel serialConsistency = DEFAULT_SERIAL_CONSISTENCY_LEVEL;
     private volatile int fetchSize = DEFAULT_FETCH_SIZE;
+    private volatile boolean defaultIdempotence = DEFAULT_IDEMPOTENCE;
     private volatile Cluster.Manager manager;
 
     /**
@@ -137,5 +143,30 @@ public class QueryOptions {
      */
     public int getFetchSize() {
         return fetchSize;
+    }
+
+    /**
+     * Sets the default idempotence for queries.
+     * <p>
+     * This will be used for statements for which {@link com.datastax.driver.core.Statement#isIdempotent()}
+     * returns {@code null}.
+     *
+     * @param defaultIdempotence the new value to set as default idempotence.
+     * @return this {@code QueryOptions} instance.
+     */
+    public QueryOptions setDefaultIdempotence(boolean defaultIdempotence) {
+        this.defaultIdempotence = defaultIdempotence;
+        return this;
+    }
+
+    /**
+     * The default idempotence for queries.
+     * <p>
+     * It defaults to {@link #DEFAULT_IDEMPOTENCE}.
+     *
+     * @return the default idempotence for queries.
+     */
+    public boolean getDefaultIdempotence() {
+        return defaultIdempotence;
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -16,71 +16,205 @@
 package com.datastax.driver.core;
 
 import java.net.InetSocketAddress;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.codahale.metrics.Timer;
+import com.google.common.collect.Sets;
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.Timeout;
+import io.netty.util.TimerTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.datastax.driver.core.exceptions.*;
-import com.datastax.driver.core.policies.*;
+import com.datastax.driver.core.policies.RetryPolicy;
 import com.datastax.driver.core.policies.RetryPolicy.RetryDecision.Type;
+import com.datastax.driver.core.policies.SpeculativeExecutionPolicy.SpeculativeExecutionPlan;
 
 /**
  * Handles a request to cassandra, dealing with host failover and retries on
  * unavailable/timeout.
  */
-class RequestHandler implements Connection.ResponseCallback {
+class RequestHandler {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
+
+    final String id;
 
     private final SessionManager manager;
     private final Callback callback;
 
-    private final Iterator<Host> queryPlan;
+    private final QueryPlan queryPlan;
+    private final SpeculativeExecutionPlan speculativeExecutionPlan;
+    private final boolean allowSpeculativeExecutions;
+    private final Set<SpeculativeExecution> runningExecutions = Sets.newCopyOnWriteArraySet();
+    private final Set<Timeout> scheduledExecutions = Sets.newCopyOnWriteArraySet();
     private final Statement statement;
-    private volatile Host current;
+    private final HashedWheelTimer scheduler;
+
     private volatile List<Host> triedHosts;
-    private volatile HostConnectionPool currentPool;
-    private final AtomicReference<QueryState> queryStateRef;
-
-    // This represents the number of times a retry has been triggered by the RetryPolicy (this is different from
-    // queryStateRef.get().retryCount, because some retries don't involve the policy, for example after an
-    // OVERLOADED error).
-    // This is incremented by one writer at a time, so volatile is good enough.
-    private volatile int retriesByPolicy;
-
-    private volatile ConsistencyLevel retryConsistencyLevel;
 
     private volatile Map<InetSocketAddress, Throwable> errors;
-
-    private volatile Connection.ResponseHandler connectionHandler;
 
     private final Timer.Context timerContext;
     private final long startTime;
 
+    private final AtomicBoolean isDone = new AtomicBoolean();
+    private AtomicInteger executionCount = new AtomicInteger();
+
     public RequestHandler(SessionManager manager, Callback callback, Statement statement) {
+        this.id = Long.toString(System.identityHashCode(this));
+        if(logger.isTraceEnabled())
+            logger.trace("[{}] {}", id, statement);
         this.manager = manager;
         this.callback = callback;
+        this.scheduler = manager.cluster.manager.connectionFactory.timer;
 
         callback.register(this);
 
-        this.queryPlan = manager.loadBalancingPolicy().newQueryPlan(manager.poolsState.keyspace, statement);
+        this.queryPlan = new QueryPlan(manager.loadBalancingPolicy().newQueryPlan(manager.poolsState.keyspace, statement));
+        this.speculativeExecutionPlan = manager.speculativeRetryPolicy().newPlan(manager.poolsState.keyspace, statement);
+        this.allowSpeculativeExecutions = statement != Statement.DEFAULT
+            && statement.isIdempotentWithDefault(manager.configuration().getQueryOptions());
         this.statement = statement;
-        this.queryStateRef = new AtomicReference<QueryState>(QueryState.INITIAL);
 
         this.timerContext = metricsEnabled()
-                          ? metrics().getRequestsTimer().time()
-                          : null;
+            ? metrics().getRequestsTimer().time()
+            : null;
         this.startTime = System.nanoTime();
+    }
+
+    void sendRequest() {
+        startNewExecution();
+    }
+
+    // Called when the corresponding ResultSetFuture is cancelled by the client
+    void cancel() {
+        if (!isDone.compareAndSet(false, true))
+            return;
+
+        cancelPendingExecutions(null);
+    }
+
+    private void startNewExecution() {
+        if (isDone.get())
+            return;
+
+        Message.Request request = callback.request();
+        int position = executionCount.incrementAndGet();
+        // Clone the request after the first execution, since we set the streamId on it later and we
+        // don't want to share that across executions.
+        if (position > 1)
+            request = manager.makeRequestMessage(statement, request.pagingState()) ;
+
+        SpeculativeExecution execution = new SpeculativeExecution(request, position);
+        runningExecutions.add(execution);
+        execution.sendRequest();
+    }
+
+    private void scheduleExecution(long delayMillis) {
+        if (isDone.get() || delayMillis <= 0)
+            return;
+        if(logger.isTraceEnabled())
+            logger.trace("[{}] Schedule next speculative execution in {} ms", id, delayMillis);
+        scheduledExecutions.add(scheduler.newTimeout(newExecutionTask, delayMillis, TimeUnit.MILLISECONDS));
+    }
+
+    private final TimerTask newExecutionTask = new TimerTask() {
+        @Override
+        public void run(final Timeout timeout) throws Exception {
+            scheduledExecutions.remove(timeout);
+            if (!isDone.get())
+                // We're on the timer thread so reschedule to another executor
+                manager.executor().execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        metrics().getErrorMetrics().getSpeculativeExecutions().inc();
+                        startNewExecution();
+                    }
+                });
+        }
+    };
+
+    private void cancelPendingExecutions(SpeculativeExecution ignore) {
+        for (SpeculativeExecution execution : runningExecutions)
+            if (execution != ignore) // not vital but this produces nicer logs
+                execution.cancel();
+        for (Timeout execution : scheduledExecutions)
+            execution.cancel();
+    }
+
+    private void logError(InetSocketAddress address, Throwable exception) {
+        logger.debug("Error querying {}, trying next host (error is: {})", address, exception.toString());
+        if (errors == null)
+            errors = new ConcurrentHashMap<InetSocketAddress, Throwable>();
+        errors.put(address, exception);
+    }
+
+    private void setFinalResult(SpeculativeExecution execution, Connection connection, Message.Response response) {
+        if (!isDone.compareAndSet(false, true)) {
+            if(logger.isTraceEnabled())
+                logger.trace("[{}] Got beaten to setting the result", execution.id);
+            return;
+        }
+
+        if(logger.isTraceEnabled())
+            logger.trace("[{}] Setting final result", execution.id);
+
+        cancelPendingExecutions(execution);
+
+        try {
+            if (timerContext != null)
+                timerContext.stop();
+
+            ExecutionInfo info = execution.current.defaultExecutionInfo;
+            if (triedHosts != null) {
+                triedHosts.add(execution.current);
+                info = new ExecutionInfo(triedHosts);
+            }
+            if (execution.retryConsistencyLevel != null)
+                info = info.withAchievedConsistency(execution.retryConsistencyLevel);
+            callback.onSet(connection, response, info, statement, System.nanoTime() - startTime);
+        } catch (Exception e) {
+            callback.onException(connection,
+                new DriverInternalError("Unexpected exception while setting final result from " + response, e),
+                System.nanoTime() - startTime, /*unused*/0);
+        }
+    }
+
+    private void setFinalException(SpeculativeExecution execution, Connection connection, Exception exception) {
+        if (!isDone.compareAndSet(false, true)) {
+            if(logger.isTraceEnabled())
+                logger.trace("[{}] Got beaten to setting final exception", execution.id);
+            return;
+        }
+
+        if(logger.isTraceEnabled())
+            logger.trace("[{}] Setting final exception", execution.id);
+
+        cancelPendingExecutions(execution);
+
+        try {
+            if (timerContext != null)
+                timerContext.stop();
+        } finally {
+            callback.onException(connection, exception, System.nanoTime() - startTime, /*unused*/0);
+        }
+    }
+
+    // Triggered when an execution reaches the end of the query plan.
+    // This is only a failure if there are no other running executions.
+    private void reportNoMoreHosts(SpeculativeExecution execution) {
+        runningExecutions.remove(execution);
+        if (runningExecutions.isEmpty())
+            setFinalException(execution, null, new NoHostAvailableException(
+                errors == null ? Collections.<InetSocketAddress, Throwable>emptyMap() : errors));
     }
 
     private boolean metricsEnabled() {
@@ -91,533 +225,536 @@ class RequestHandler implements Connection.ResponseCallback {
         return manager.cluster.manager.metrics;
     }
 
-    public void sendRequest() {
-        try {
-            while (queryPlan.hasNext() && !queryStateRef.get().isCancelled()) {
-                Host host = queryPlan.next();
-                logger.trace("Querying node {}", host);
-                if (query(host))
-                    return;
-            }
-            setFinalException(null, new NoHostAvailableException(errors == null ? Collections.<InetSocketAddress, Throwable>emptyMap() : errors));
-        } catch (Exception e) {
-            // Shouldn't happen really, but if ever the loadbalancing policy returned iterator throws, we don't want to block.
-            setFinalException(null, new DriverInternalError("An unexpected error happened while sending requests", e));
-        }
+    interface Callback extends Connection.ResponseCallback {
+        void onSet(Connection connection, Message.Response response, ExecutionInfo info, Statement statement, long latency);
+        void register(RequestHandler handler);
     }
 
-    private boolean query(Host host) {
-        currentPool = manager.pools.get(host);
-        if (currentPool == null || currentPool.isClosed())
-            return false;
+    /**
+     * An execution of the query against the cluster.
+     * There is at least one instance per RequestHandler, and possibly more (depending on the SpeculativeExecutionPolicy).
+     * Each instance may retry on the same host, or on other hosts as defined by the RetryPolicy.
+     * All instances run concurrently and share the same query plan.
+     * There are three ways a SpeculativeExecution can stop:
+     * - it completes the query (with either a success or a fatal error), and reports the result to the RequestHandler
+     * - it gets cancelled, either because another execution completed the query, or because the RequestHandler was cancelled
+     * - it reaches the end of the query plan and informs the RequestHandler, which will decide what to do
+     */
+    class SpeculativeExecution implements Connection.ResponseCallback {
+        final String id;
+        private final Message.Request request;
+        private volatile Host current;
+        private volatile ConsistencyLevel retryConsistencyLevel;
+        private final AtomicReference<QueryState> queryStateRef;
+        private final AtomicBoolean nextExecutionScheduled = new AtomicBoolean();
 
-        Connection connection = null;
-        try {
-            connection = currentPool.borrowConnection(manager.configuration().getPoolingOptions().getPoolTimeoutMillis(), TimeUnit.MILLISECONDS);
-            if (current != null) {
-                if (triedHosts == null)
-                    triedHosts = new ArrayList<Host>();
-                triedHosts.add(current);
-            }
-            current = host;
-            write(connection, this);
-            return true;
-        } catch (ConnectionException e) {
-            // If we have any problem with the connection, move to the next node.
-            if (metricsEnabled())
-                metrics().getErrorMetrics().getConnectionErrors().inc();
-            if (connection != null)
-                connection.release();
-            logError(host.getSocketAddress(), e);
-            return false;
-        } catch (BusyConnectionException e) {
-            // The pool shouldn't have give us a busy connection unless we've maxed up the pool, so move on to the next host.
-            connection.release();
-            logError(host.getSocketAddress(), e);
-            return false;
-        } catch (TimeoutException e) {
-            // We timeout, log it but move to the next node.
-            logError(host.getSocketAddress(), new DriverException("Timeout while trying to acquire available connection (you may want to increase the driver number of per-host connections)"));
-            return false;
-        } catch (RuntimeException e) {
-            if (connection != null)
-                connection.release();
-            logger.error("Unexpected error while querying " + host.getAddress(), e);
-            logError(host.getSocketAddress(), e);
-            return false;
-        }
-    }
+        // This represents the number of times a retry has been triggered by the RetryPolicy (this is different from
+        // queryStateRef.get().retryCount, because some retries don't involve the policy, for example after an
+        // OVERLOADED error).
+        // This is incremented by one writer at a time, so volatile is good enough.
+        private volatile int retriesByPolicy;
 
-    private void write(Connection connection, Connection.ResponseCallback responseCallback) throws ConnectionException, BusyConnectionException {
-        // Make sure cancel() does not see a stale connectionHandler if it sees the new query state
-        // before connection.write has completed
-        connectionHandler = null;
+        private volatile Connection.ResponseHandler connectionHandler;
 
-        // Ensure query state is "in progress" (can be already if connection.write failed on a previous node and we're retrying)
-        while (true) {
-            QueryState previous = queryStateRef.get();
-            if (previous.isCancelled()) {
-                connection.release();
-                return;
-            }
-            if (previous.inProgress || queryStateRef.compareAndSet(previous, previous.startNext()))
-                break;
+        SpeculativeExecution(Message.Request request, int position) {
+            this.id = RequestHandler.this.id + "-" + position;
+            this.request = request;
+            this.queryStateRef = new AtomicReference<QueryState>(QueryState.INITIAL);
+            if(logger.isTraceEnabled())
+                logger.trace("[{}] Starting", id);
         }
 
-        connectionHandler = connection.write(responseCallback, false);
-        // Only start the timeout when we're sure connectionHandler is set. This avoids an edge case where onTimeout() was triggered
-        // *before* the call to connection.write had returned.
-        connectionHandler.startTimeout();
-
-        // Note that we could have already received the response here (so onSet() / onException() would have been called). This is
-        // why we only test for CANCELLED_WHILE_IN_PROGRESS below.
-
-        // If cancel() was called after we set the state to "in progress", but before connection.write had completed, it might have
-        // missed the new value of connectionHandler. So make sure that cancelHandler() gets called here (we might call it twice,
-        // but it knows how to deal with it).
-        if (queryStateRef.get() == QueryState.CANCELLED_WHILE_IN_PROGRESS)
-            connectionHandler.cancelHandler();
-    }
-
-    private void logError(InetSocketAddress address, Throwable exception) {
-        logger.debug("Error querying {}, trying next host (error is: {})", address, exception.toString());
-        if (errors == null)
-            errors = new HashMap<InetSocketAddress, Throwable>();
-        errors.put(address, exception);
-    }
-
-    private void retry(final boolean retryCurrent, ConsistencyLevel newConsistencyLevel) {
-        final Host h = current;
-        this.retryConsistencyLevel = newConsistencyLevel;
-
-        // We should not retry on the current thread as this will be an IO thread.
-        manager.executor().execute(new Runnable() {
-            @Override
-            public void run() {
-                if (queryStateRef.get().isCancelled())
-                    return;
-                try {
-                    if (retryCurrent) {
-                        if (query(h))
-                            return;
-                    }
-                    sendRequest();
-                } catch (Exception e) {
-                    setFinalException(null, new DriverInternalError("Unexpected exception while retrying query", e));
+        void sendRequest() {
+            try {
+                Host host;
+                while (!isDone.get() && (host = queryPlan.next()) != null && !queryStateRef.get().isCancelled()) {
+                    if(logger.isTraceEnabled())
+                        logger.trace("[{}] Querying node {}", id, host);
+                    if (query(host))
+                        return;
                 }
-            }
-        });
-    }
-
-    public void cancel() {
-        // Atomically set a special QueryState, that will cause any further operation to abort.
-        // We want to remember whether a request was in progress when we did this, so there are two cancel states.
-        while (true) {
-            QueryState previous = queryStateRef.get();
-            if (previous.isCancelled()) {
-                return;
-            } else if (previous.inProgress && queryStateRef.compareAndSet(previous, QueryState.CANCELLED_WHILE_IN_PROGRESS)) {
-                // The connectionHandler should be non-null, but we might miss the update if we're racing with write().
-                // If it's still null, this will be handled by re-checking queryStateRef at the end of write().
-                if (connectionHandler != null)
-                    connectionHandler.cancelHandler();
-                return;
-            } else if (!previous.inProgress && queryStateRef.compareAndSet(previous, QueryState.CANCELLED_WHILE_COMPLETE)) {
-                return;
+                reportNoMoreHosts(this);
+            } catch (Exception e) {
+                // Shouldn't happen really, but if ever the loadbalancing policy returned iterator throws, we don't want to block.
+                setFinalException(null, new DriverInternalError("An unexpected error happened while sending requests", e));
             }
         }
-    }
 
-    @Override
-    public Message.Request request() {
+        private boolean query(final Host host) {
+            HostConnectionPool currentPool = manager.pools.get(host);
+            if (currentPool == null || currentPool.isClosed())
+                return false;
 
-        Message.Request request = callback.request();
-        if (retryConsistencyLevel != null && retryConsistencyLevel != consistencyOf(request))
-            request = manager.makeRequestMessage(statement, retryConsistencyLevel, serialConsistencyOf(request), pagingStateOf(request));
-        return request;
-    }
+            if (allowSpeculativeExecutions && nextExecutionScheduled.compareAndSet(false, true))
+                scheduleExecution(speculativeExecutionPlan.nextExecution(host));
 
-    private ConsistencyLevel consistencyOf(Message.Request request) {
-        switch (request.type) {
-            case QUERY:   return ((Requests.Query)request).options.consistency;
-            case EXECUTE: return ((Requests.Execute)request).options.consistency;
-            case BATCH:   return ((Requests.Batch)request).consistency;
-            default:      return null;
-        }
-    }
-
-    private ConsistencyLevel serialConsistencyOf(Message.Request request) {
-        switch (request.type) {
-            case QUERY:   return ((Requests.Query)request).options.serialConsistency;
-            case EXECUTE: return ((Requests.Execute)request).options.serialConsistency;
-            default:      return null;
-        }
-    }
-
-    private ByteBuffer pagingStateOf(Message.Request request) {
-        switch (request.type) {
-            case QUERY:   return ((Requests.Query)request).options.pagingState;
-            case EXECUTE: return ((Requests.Execute)request).options.pagingState;
-            default:      return null;
-        }
-    }
-
-    private void setFinalResult(Connection connection, Message.Response response) {
-        try {
-            if (timerContext != null)
-                timerContext.stop();
-
-            ExecutionInfo info = current.defaultExecutionInfo;
-            if (triedHosts != null) {
-                triedHosts.add(current);
-                info = new ExecutionInfo(triedHosts);
-            }
-            if (retryConsistencyLevel != null)
-                info = info.withAchievedConsistency(retryConsistencyLevel);
-            callback.onSet(connection, response, info, statement, System.nanoTime() - startTime);
-        } catch (Exception e) {
-            callback.onException(connection, new DriverInternalError("Unexpected exception while setting final result from " + response, e), System.nanoTime() - startTime, retryCount());
-        }
-    }
-
-    private void setFinalException(Connection connection, Exception exception) {
-        try {
-            if (timerContext != null)
-                timerContext.stop();
-        } finally {
-            callback.onException(connection, exception, System.nanoTime() - startTime, retryCount());
-        }
-    }
-
-    @Override
-    public void onSet(Connection connection, Message.Response response, long latency, int retryCount) {
-        QueryState queryState = queryStateRef.get();
-        if (!queryState.isInProgressAt(retryCount) ||
-            !queryStateRef.compareAndSet(queryState, queryState.complete())) {
-            logger.debug("onSet triggered but the response was completed by another thread, cancelling (retryCount = {}, queryState = {}, queryStateRef = {})",
-                         retryCount, queryState, queryStateRef.get());
-            return;
-        }
-
-        Host queriedHost = current;
-
-        boolean releaseConnection = true;
-        Exception exceptionToReport = null;
-        try {
-            switch (response.type) {
-                case RESULT:
-                    setFinalResult(connection, response);
-                    break;
-                case ERROR:
-                    Responses.Error err = (Responses.Error)response;
-                    exceptionToReport = err.asException(connection.address);
-                    RetryPolicy.RetryDecision retry = null;
-                    RetryPolicy retryPolicy = statement.getRetryPolicy() == null
-                                            ? manager.configuration().getPolicies().getRetryPolicy()
-                                            : statement.getRetryPolicy();
-                    switch (err.code) {
-                        case READ_TIMEOUT:
-                            assert err.infos instanceof ReadTimeoutException;
-                            if (metricsEnabled())
-                                metrics().getErrorMetrics().getReadTimeouts().inc();
-
-                            ReadTimeoutException rte = (ReadTimeoutException)err.infos;
-                            retry = retryPolicy.onReadTimeout(statement,
-                                                              rte.getConsistencyLevel(),
-                                                              rte.getRequiredAcknowledgements(),
-                                                              rte.getReceivedAcknowledgements(),
-                                                              rte.wasDataRetrieved(),
-                                                              retriesByPolicy);
-
-                            if (metricsEnabled()) {
-                                if (retry.getType() == Type.RETRY)
-                                    metrics().getErrorMetrics().getRetriesOnReadTimeout().inc();
-                                if (retry.getType() == Type.IGNORE)
-                                    metrics().getErrorMetrics().getIgnoresOnReadTimeout().inc();
-                            }
-                            break;
-                        case WRITE_TIMEOUT:
-                            assert err.infos instanceof WriteTimeoutException;
-                            if (metricsEnabled())
-                                metrics().getErrorMetrics().getWriteTimeouts().inc();
-
-                            WriteTimeoutException wte = (WriteTimeoutException)err.infos;
-                            retry = retryPolicy.onWriteTimeout(statement,
-                                                               wte.getConsistencyLevel(),
-                                                               wte.getWriteType(),
-                                                               wte.getRequiredAcknowledgements(),
-                                                               wte.getReceivedAcknowledgements(),
-                                                               retriesByPolicy);
-
-                            if (metricsEnabled()) {
-                                if (retry.getType() == Type.RETRY)
-                                    metrics().getErrorMetrics().getRetriesOnWriteTimeout().inc();
-                                if (retry.getType() == Type.IGNORE)
-                                    metrics().getErrorMetrics().getIgnoresOnWriteTimeout().inc();
-                            }
-                            break;
-                        case UNAVAILABLE:
-                            assert err.infos instanceof UnavailableException;
-                            if (metricsEnabled())
-                                metrics().getErrorMetrics().getUnavailables().inc();
-
-                            UnavailableException ue = (UnavailableException)err.infos;
-                            retry = retryPolicy.onUnavailable(statement,
-                                                              ue.getConsistencyLevel(),
-                                                              ue.getRequiredReplicas(),
-                                                              ue.getAliveReplicas(),
-                                                              retriesByPolicy);
-
-                            if (metricsEnabled()) {
-                                if (retry.getType() == Type.RETRY)
-                                    metrics().getErrorMetrics().getRetriesOnUnavailable().inc();
-                                if (retry.getType() == Type.IGNORE)
-                                    metrics().getErrorMetrics().getIgnoresOnUnavailable().inc();
-                            }
-                            break;
-                        case OVERLOADED:
-                            // Try another node
-                            logger.warn("Host {} is overloaded, trying next host.", connection.address);
-                            DriverException overloaded = new DriverException("Host overloaded");
-                            logError(connection.address, overloaded);
-                            if (metricsEnabled())
-                                metrics().getErrorMetrics().getOthers().inc();
-                            retry(false, null);
-                            return;
-                        case SERVER_ERROR:
-                            // Defunct connection and try another node
-                            logger.warn("{} replied with server error ({}), trying next host.", connection.address, err.message);
-                            DriverException exception = new DriverException("Host replied with server error: " + err.message);
-                            logError(connection.address, exception);
-                            connection.defunct(exception);
-                            if (metricsEnabled())
-                                metrics().getErrorMetrics().getOthers().inc();
-                            retry(false, null);
-                            return;
-                        case IS_BOOTSTRAPPING:
-                            // Try another node
-                            logger.error("Query sent to {} but it is bootstrapping. This shouldn't happen but trying next host.", connection.address);
-                            DriverException bootstrapping = new DriverException("Host is bootstrapping");
-                            logError(connection.address, bootstrapping);
-                            if (metricsEnabled())
-                                metrics().getErrorMetrics().getOthers().inc();
-                            retry(false, null);
-                            return;
-                        case UNPREPARED:
-                            assert err.infos instanceof MD5Digest;
-                            MD5Digest id = (MD5Digest)err.infos;
-                            PreparedStatement toPrepare = manager.cluster.manager.preparedQueries.get(id);
-                            if (toPrepare == null) {
-                                // This shouldn't happen
-                                String msg = String.format("Tried to execute unknown prepared query %s", id);
-                                logger.error(msg);
-                                setFinalException(connection, new DriverInternalError(msg));
-                                return;
-                            }
-
-                            String currentKeyspace = connection.keyspace();
-                            String prepareKeyspace = toPrepare.getQueryKeyspace();
-                            if (prepareKeyspace != null && (currentKeyspace == null || !currentKeyspace.equals(prepareKeyspace))) {
-                                // This shouldn't happen in normal use, because a user shouldn't try to execute
-                                // a prepared statement with the wrong keyspace set.
-                                // Fail fast (we can't change the keyspace to reprepare, because we're using a pooled connection
-                                // that's shared with other requests).
-                                throw new IllegalStateException(String.format("Statement was prepared on keyspace %s, can't execute it on %s (%s)",
-                                    toPrepare.getQueryKeyspace(), connection.keyspace(), toPrepare.getQueryString()));
-                            }
-
-                            logger.info("Query {} is not prepared on {}, preparing before retrying executing. "
-                                      + "Seeing this message a few times is fine, but seeing it a lot may be source of performance problems",
-                                        toPrepare.getQueryString(), connection.address);
-
-                            releaseConnection = false; // we're reusing it for the prepare call
-                            write(connection, prepareAndRetry(toPrepare.getQueryString()));
-                            // we're done for now, the prepareAndRetry callback will handle the rest
-                            return;
-                        default:
-                            if (metricsEnabled())
-                                metrics().getErrorMetrics().getOthers().inc();
-                            break;
-                    }
-
-                    if (retry == null)
-                        setFinalResult(connection, response);
-                    else {
-                        switch (retry.getType()) {
-                            case RETRY:
-                                ++retriesByPolicy;
-                                if (logger.isDebugEnabled())
-                                    logger.debug("Doing retry {} for query {} at consistency {}", retriesByPolicy, statement, retry.getRetryConsistencyLevel());
-                                if (metricsEnabled())
-                                    metrics().getErrorMetrics().getRetries().inc();
-                                retry(true, retry.getRetryConsistencyLevel());
-                                break;
-                            case RETHROW:
-                                setFinalResult(connection, response);
-                                break;
-                            case IGNORE:
-                                if (metricsEnabled())
-                                    metrics().getErrorMetrics().getIgnores().inc();
-                                setFinalResult(connection, new Responses.Result.Void());
-                                break;
-                        }
-                    }
-                    break;
-                default:
-                    setFinalResult(connection, response);
-                    break;
-            }
-        } catch (Exception e) {
-            exceptionToReport = e;
-            setFinalException(connection, e);
-        } finally {
-            connection.release();
-            if (queriedHost != null && statement != Statement.DEFAULT)
-                manager.cluster.manager.reportLatency(queriedHost, statement, exceptionToReport, latency);
-        }
-    }
-
-    private Connection.ResponseCallback prepareAndRetry(final String toPrepare) {
-        return new Connection.ResponseCallback() {
-
-            @Override
-            public Message.Request request() {
-                return new Requests.Prepare(toPrepare);
-            }
-
-            @Override
-            public int retryCount() {
-                return RequestHandler.this.retryCount();
-            }
-
-            @Override
-            public void onSet(Connection connection, Message.Response response, long latency, int retryCount) {
-                QueryState queryState = queryStateRef.get();
-                if (!queryState.isInProgressAt(retryCount) ||
-                    !queryStateRef.compareAndSet(queryState, queryState.complete())) {
-                    logger.debug("onSet triggered but the response was completed by another thread, cancelling (retryCount = {}, queryState = {}, queryStateRef = {})",
-                                 retryCount, queryState, queryStateRef.get());
-                    return;
+            Connection connection = null;
+            try {
+                connection = currentPool.borrowConnection(manager.configuration().getPoolingOptions().getPoolTimeoutMillis(), TimeUnit.MILLISECONDS);
+                if (current != null) {
+                    if (triedHosts == null)
+                        triedHosts = new CopyOnWriteArrayList<Host>();
+                    triedHosts.add(current);
                 }
-
-                connection.release();
-
-                // TODO should we check the response ?
-                switch (response.type) {
-                    case RESULT:
-                        if (((Responses.Result)response).kind == Responses.Result.Kind.PREPARED) {
-                            logger.debug("Scheduling retry now that query is prepared");
-                            retry(true, null);
-                        } else {
-                            logError(connection.address, new DriverException("Got unexpected response to prepare message: " + response));
-                            retry(false, null);
-                        }
-                        break;
-                    case ERROR:
-                        logError(connection.address, new DriverException("Error preparing query, got " + response));
-                        if (metricsEnabled())
-                            metrics().getErrorMetrics().getOthers().inc();
-                        retry(false, null);
-                        break;
-                    default:
-                        // Something's wrong, so we return but we let setFinalResult propagate the exception
-                        RequestHandler.this.setFinalResult(connection, response);
-                        break;
-                }
-            }
-
-            @Override
-            public void onException(Connection connection, Exception exception, long latency, int retryCount) {
-                RequestHandler.this.onException(connection, exception, latency, retryCount);
-            }
-
-            @Override
-            public boolean onTimeout(Connection connection, long latency, int retryCount) {
-                QueryState queryState = queryStateRef.get();
-                if (!queryState.isInProgressAt(retryCount) ||
-                    !queryStateRef.compareAndSet(queryState, queryState.complete())) {
-                    logger.debug("onTimeout triggered but the response was completed by another thread, cancelling (retryCount = {}, queryState = {}, queryStateRef = {})",
-                                 retryCount, queryState, queryStateRef.get());
-                    return false;
-                }
-                logError(connection.address, new DriverException("Timeout waiting for response to prepare message"));
-                retry(false, null);
+                current = host;
+                write(connection, this);
                 return true;
-            }
-        };
-    }
-
-    @Override
-    public void onException(Connection connection, Exception exception, long latency, int retryCount) {
-        QueryState queryState = queryStateRef.get();
-        if (!queryState.isInProgressAt(retryCount) ||
-            !queryStateRef.compareAndSet(queryState, queryState.complete())) {
-            logger.debug("onException triggered but the response was completed by another thread, cancelling (retryCount = {}, queryState = {}, queryStateRef = {})",
-                         retryCount, queryState, queryStateRef.get());
-            return;
-        }
-
-        Host queriedHost = current;
-        try {
-            connection.release();
-
-            if (exception instanceof ConnectionException) {
+            } catch (ConnectionException e) {
+                // If we have any problem with the connection, move to the next node.
                 if (metricsEnabled())
                     metrics().getErrorMetrics().getConnectionErrors().inc();
-                ConnectionException ce = (ConnectionException)exception;
-                logError(ce.address, ce);
-                retry(false, null);
+                if (connection != null)
+                    connection.release();
+                logError(host.getSocketAddress(), e);
+                return false;
+            } catch (BusyConnectionException e) {
+                // The pool shouldn't have give us a busy connection unless we've maxed up the pool, so move on to the next host.
+                connection.release();
+                logError(host.getSocketAddress(), e);
+                return false;
+            } catch (TimeoutException e) {
+                // We timeout, log it but move to the next node.
+                logError(host.getSocketAddress(), new DriverException("Timeout while trying to acquire available connection (you may want to increase the driver number of per-host connections)"));
+                return false;
+            } catch (RuntimeException e) {
+                if (connection != null)
+                    connection.release();
+                logger.error("Unexpected error while querying " + host.getAddress(), e);
+                logError(host.getSocketAddress(), e);
+                return false;
+            }
+        }
+
+        private void write(Connection connection, Connection.ResponseCallback responseCallback) throws ConnectionException, BusyConnectionException {
+            // Make sure cancel() does not see a stale connectionHandler if it sees the new query state
+            // before connection.write has completed
+            connectionHandler = null;
+
+            // Ensure query state is "in progress" (can be already if connection.write failed on a previous node and we're retrying)
+            while (true) {
+                QueryState previous = queryStateRef.get();
+                if (previous.isCancelled()) {
+                    connection.release();
+                    return;
+                }
+                if (previous.inProgress || queryStateRef.compareAndSet(previous, previous.startNext()))
+                    break;
+            }
+
+            connectionHandler = connection.write(responseCallback, false);
+            // Only start the timeout when we're sure connectionHandler is set. This avoids an edge case where onTimeout() was triggered
+            // *before* the call to connection.write had returned.
+            connectionHandler.startTimeout();
+
+            // Note that we could have already received the response here (so onSet() / onException() would have been called). This is
+            // why we only test for CANCELLED_WHILE_IN_PROGRESS below.
+
+            // If cancel() was called after we set the state to "in progress", but before connection.write had completed, it might have
+            // missed the new value of connectionHandler. So make sure that cancelHandler() gets called here (we might call it twice,
+            // but it knows how to deal with it).
+            if (queryStateRef.get() == QueryState.CANCELLED_WHILE_IN_PROGRESS)
+                connectionHandler.cancelHandler();
+        }
+
+        private void retry(final boolean retryCurrent, ConsistencyLevel newConsistencyLevel) {
+            final Host h = current;
+            this.retryConsistencyLevel = newConsistencyLevel;
+
+            // We should not retry on the current thread as this will be an IO thread.
+            manager.executor().execute(new Runnable() {
+                @Override
+                public void run() {
+                    if (queryStateRef.get().isCancelled())
+                        return;
+                    try {
+                        if (retryCurrent) {
+                            if (query(h))
+                                return;
+                        }
+                        sendRequest();
+                    } catch (Exception e) {
+                        setFinalException(null, new DriverInternalError("Unexpected exception while retrying query", e));
+                    }
+                }
+            });
+        }
+
+        void cancel() {
+            // Atomically set a special QueryState, that will cause any further operation to abort.
+            // We want to remember whether a request was in progress when we did this, so there are two cancel states.
+            while (true) {
+                QueryState previous = queryStateRef.get();
+                if (previous.isCancelled()) {
+                    return;
+                } else if (previous.inProgress && queryStateRef.compareAndSet(previous, QueryState.CANCELLED_WHILE_IN_PROGRESS)) {
+                    if(logger.isTraceEnabled())
+                        logger.trace("[{}] Cancelled while in progress", id);
+                    // The connectionHandler should be non-null, but we might miss the update if we're racing with write().
+                    // If it's still null, this will be handled by re-checking queryStateRef at the end of write().
+                    if (connectionHandler != null)
+                        connectionHandler.cancelHandler();
+                    return;
+                } else if (!previous.inProgress && queryStateRef.compareAndSet(previous, QueryState.CANCELLED_WHILE_COMPLETE)) {
+                    if(logger.isTraceEnabled())
+                        logger.trace("[{}] Cancelled while complete", id);
+                    return;
+                }
+            }
+        }
+
+        @Override
+        public Message.Request request() {
+            if (retryConsistencyLevel != null && retryConsistencyLevel != request.consistency())
+                return manager.makeRequestMessage(statement, retryConsistencyLevel, request.consistency(), request.pagingState());
+            else
+                return request;
+        }
+
+        @Override
+        public void onSet(Connection connection, Message.Response response, long latency, int retryCount) {
+            QueryState queryState = queryStateRef.get();
+            if (!queryState.isInProgressAt(retryCount) ||
+                !queryStateRef.compareAndSet(queryState, queryState.complete())) {
+                logger.debug("onSet triggered but the response was completed by another thread, cancelling (retryCount = {}, queryState = {}, queryStateRef = {})",
+                    retryCount, queryState, queryStateRef.get());
                 return;
             }
-            setFinalException(connection, exception);
-        } catch (Exception e) {
-            // This shouldn't happen, but if it does, we want to signal the callback, not let it hang indefinitely
-            setFinalException(null, new DriverInternalError("An unexpected error happened while handling exception " + exception, e));
-        } finally {
-            if (queriedHost != null && statement != Statement.DEFAULT)
-                manager.cluster.manager.reportLatency(queriedHost, statement, exception, latency);
+
+            Host queriedHost = current;
+            Exception exceptionToReport = null;
+            try {
+                switch (response.type) {
+                    case RESULT:
+                        connection.release();
+                        setFinalResult(connection, response);
+                        break;
+                    case ERROR:
+                        Responses.Error err = (Responses.Error)response;
+                        exceptionToReport = err.asException(connection.address);
+                        RetryPolicy.RetryDecision retry = null;
+                        RetryPolicy retryPolicy = statement.getRetryPolicy() == null
+                            ? manager.configuration().getPolicies().getRetryPolicy()
+                            : statement.getRetryPolicy();
+                        switch (err.code) {
+                            case READ_TIMEOUT:
+                                connection.release();
+                                assert err.infos instanceof ReadTimeoutException;
+                                if (metricsEnabled())
+                                    metrics().getErrorMetrics().getReadTimeouts().inc();
+
+                                ReadTimeoutException rte = (ReadTimeoutException)err.infos;
+                                retry = retryPolicy.onReadTimeout(statement,
+                                    rte.getConsistencyLevel(),
+                                    rte.getRequiredAcknowledgements(),
+                                    rte.getReceivedAcknowledgements(),
+                                    rte.wasDataRetrieved(),
+                                    retriesByPolicy);
+
+                                if (metricsEnabled()) {
+                                    if (retry.getType() == Type.RETRY)
+                                        metrics().getErrorMetrics().getRetriesOnReadTimeout().inc();
+                                    if (retry.getType() == Type.IGNORE)
+                                        metrics().getErrorMetrics().getIgnoresOnReadTimeout().inc();
+                                }
+                                break;
+                            case WRITE_TIMEOUT:
+                                connection.release();
+                                assert err.infos instanceof WriteTimeoutException;
+                                if (metricsEnabled())
+                                    metrics().getErrorMetrics().getWriteTimeouts().inc();
+
+                                WriteTimeoutException wte = (WriteTimeoutException)err.infos;
+                                retry = retryPolicy.onWriteTimeout(statement,
+                                    wte.getConsistencyLevel(),
+                                    wte.getWriteType(),
+                                    wte.getRequiredAcknowledgements(),
+                                    wte.getReceivedAcknowledgements(),
+                                    retriesByPolicy);
+
+                                if (metricsEnabled()) {
+                                    if (retry.getType() == Type.RETRY)
+                                        metrics().getErrorMetrics().getRetriesOnWriteTimeout().inc();
+                                    if (retry.getType() == Type.IGNORE)
+                                        metrics().getErrorMetrics().getIgnoresOnWriteTimeout().inc();
+                                }
+                                break;
+                            case UNAVAILABLE:
+                                connection.release();
+                                assert err.infos instanceof UnavailableException;
+                                if (metricsEnabled())
+                                    metrics().getErrorMetrics().getUnavailables().inc();
+
+                                UnavailableException ue = (UnavailableException)err.infos;
+                                retry = retryPolicy.onUnavailable(statement,
+                                    ue.getConsistencyLevel(),
+                                    ue.getRequiredReplicas(),
+                                    ue.getAliveReplicas(),
+                                    retriesByPolicy);
+
+                                if (metricsEnabled()) {
+                                    if (retry.getType() == Type.RETRY)
+                                        metrics().getErrorMetrics().getRetriesOnUnavailable().inc();
+                                    if (retry.getType() == Type.IGNORE)
+                                        metrics().getErrorMetrics().getIgnoresOnUnavailable().inc();
+                                }
+                                break;
+                            case OVERLOADED:
+                                connection.release();
+                                // Try another node
+                                logger.warn("Host {} is overloaded, trying next host.", connection.address);
+                                DriverException overloaded = new DriverException("Host overloaded");
+                                logError(connection.address, overloaded);
+                                if (metricsEnabled())
+                                    metrics().getErrorMetrics().getOthers().inc();
+                                retry(false, null);
+                                return;
+                            case SERVER_ERROR:
+                                connection.release();
+                                // Defunct connection and try another node
+                                logger.warn("{} replied with server error ({}), trying next host.", connection.address, err.message);
+                                DriverException exception = new DriverException("Host replied with server error: " + err.message);
+                                logError(connection.address, exception);
+                                connection.defunct(exception);
+                                if (metricsEnabled())
+                                    metrics().getErrorMetrics().getOthers().inc();
+                                retry(false, null);
+                                return;
+                            case IS_BOOTSTRAPPING:
+                                connection.release();
+                                // Try another node
+                                logger.error("Query sent to {} but it is bootstrapping. This shouldn't happen but trying next host.", connection.address);
+                                DriverException bootstrapping = new DriverException("Host is bootstrapping");
+                                logError(connection.address, bootstrapping);
+                                if (metricsEnabled())
+                                    metrics().getErrorMetrics().getOthers().inc();
+                                retry(false, null);
+                                return;
+                            case UNPREPARED:
+                                // Do not release connection yet, because we might reuse it to send the PREPARE message (see write() call below)
+                                assert err.infos instanceof MD5Digest;
+                                MD5Digest id = (MD5Digest)err.infos;
+                                PreparedStatement toPrepare = manager.cluster.manager.preparedQueries.get(id);
+                                if (toPrepare == null) {
+                                    // This shouldn't happen
+                                    connection.release();
+                                    String msg = String.format("Tried to execute unknown prepared query %s", id);
+                                    logger.error(msg);
+                                    setFinalException(connection, new DriverInternalError(msg));
+                                    return;
+                                }
+
+                                String currentKeyspace = connection.keyspace();
+                                String prepareKeyspace = toPrepare.getQueryKeyspace();
+                                if (prepareKeyspace != null && (currentKeyspace == null || !currentKeyspace.equals(prepareKeyspace))) {
+                                    // This shouldn't happen in normal use, because a user shouldn't try to execute
+                                    // a prepared statement with the wrong keyspace set.
+                                    // Fail fast (we can't change the keyspace to reprepare, because we're using a pooled connection
+                                    // that's shared with other requests).
+                                    connection.release();
+                                    throw new IllegalStateException(String.format("Statement was prepared on keyspace %s, can't execute it on %s (%s)",
+                                        toPrepare.getQueryKeyspace(), connection.keyspace(), toPrepare.getQueryString()));
+                                }
+
+                                logger.info("Query {} is not prepared on {}, preparing before retrying executing. "
+                                        + "Seeing this message a few times is fine, but seeing it a lot may be source of performance problems",
+                                    toPrepare.getQueryString(), connection.address);
+
+                                write(connection, prepareAndRetry(toPrepare.getQueryString()));
+                                // we're done for now, the prepareAndRetry callback will handle the rest
+                                return;
+                            default:
+                                connection.release();
+                                if (metricsEnabled())
+                                    metrics().getErrorMetrics().getOthers().inc();
+                                break;
+                        }
+
+                        if (retry == null)
+                            setFinalResult(connection, response);
+                        else {
+                            switch (retry.getType()) {
+                                case RETRY:
+                                    ++retriesByPolicy;
+                                    if (logger.isDebugEnabled())
+                                        logger.debug("Doing retry {} for query {} at consistency {}", retriesByPolicy, statement, retry.getRetryConsistencyLevel());
+                                    if (metricsEnabled())
+                                        metrics().getErrorMetrics().getRetries().inc();
+                                    retry(true, retry.getRetryConsistencyLevel());
+                                    break;
+                                case RETHROW:
+                                    setFinalResult(connection, response);
+                                    break;
+                                case IGNORE:
+                                    if (metricsEnabled())
+                                        metrics().getErrorMetrics().getIgnores().inc();
+                                    setFinalResult(connection, new Responses.Result.Void());
+                                    break;
+                            }
+                        }
+                        break;
+                    default:
+                        connection.release();
+                        setFinalResult(connection, response);
+                        break;
+                }
+            } catch (Exception e) {
+                exceptionToReport = e;
+                setFinalException(connection, e);
+            } finally {
+                if (queriedHost != null && statement != Statement.DEFAULT)
+                    manager.cluster.manager.reportLatency(queriedHost, statement, exceptionToReport, latency);
+            }
+        }
+
+        private Connection.ResponseCallback prepareAndRetry(final String toPrepare) {
+            return new Connection.ResponseCallback() {
+
+                @Override
+                public Message.Request request() {
+                    return new Requests.Prepare(toPrepare);
+                }
+
+                @Override
+                public int retryCount() {
+                    return SpeculativeExecution.this.retryCount();
+                }
+
+                @Override
+                public void onSet(Connection connection, Message.Response response, long latency, int retryCount) {
+                    QueryState queryState = queryStateRef.get();
+                    if (!queryState.isInProgressAt(retryCount) ||
+                        !queryStateRef.compareAndSet(queryState, queryState.complete())) {
+                        logger.debug("onSet triggered but the response was completed by another thread, cancelling (retryCount = {}, queryState = {}, queryStateRef = {})",
+                            retryCount, queryState, queryStateRef.get());
+                        return;
+                    }
+
+                    connection.release();
+
+                    // TODO should we check the response ?
+                    switch (response.type) {
+                        case RESULT:
+                            if (((Responses.Result)response).kind == Responses.Result.Kind.PREPARED) {
+                                logger.debug("Scheduling retry now that query is prepared");
+                                retry(true, null);
+                            } else {
+                                logError(connection.address, new DriverException("Got unexpected response to prepare message: " + response));
+                                retry(false, null);
+                            }
+                            break;
+                        case ERROR:
+                            logError(connection.address, new DriverException("Error preparing query, got " + response));
+                            if (metricsEnabled())
+                                metrics().getErrorMetrics().getOthers().inc();
+                            retry(false, null);
+                            break;
+                        default:
+                            // Something's wrong, so we return but we let setFinalResult propagate the exception
+                            SpeculativeExecution.this.setFinalResult(connection, response);
+                            break;
+                    }
+                }
+
+                @Override
+                public void onException(Connection connection, Exception exception, long latency, int retryCount) {
+                    SpeculativeExecution.this.onException(connection, exception, latency, retryCount);
+                }
+
+                @Override
+                public boolean onTimeout(Connection connection, long latency, int retryCount) {
+                    QueryState queryState = queryStateRef.get();
+                    if (!queryState.isInProgressAt(retryCount) ||
+                        !queryStateRef.compareAndSet(queryState, queryState.complete())) {
+                        logger.debug("onTimeout triggered but the response was completed by another thread, cancelling (retryCount = {}, queryState = {}, queryStateRef = {})",
+                            retryCount, queryState, queryStateRef.get());
+                        return false;
+                    }
+                    logError(connection.address, new DriverException("Timeout waiting for response to prepare message"));
+                    retry(false, null);
+                    return true;
+                }
+            };
+        }
+
+        @Override
+        public void onException(Connection connection, Exception exception, long latency, int retryCount) {
+            QueryState queryState = queryStateRef.get();
+            if (!queryState.isInProgressAt(retryCount) ||
+                !queryStateRef.compareAndSet(queryState, queryState.complete())) {
+                logger.debug("onException triggered but the response was completed by another thread, cancelling (retryCount = {}, queryState = {}, queryStateRef = {})",
+                    retryCount, queryState, queryStateRef.get());
+                return;
+            }
+
+            Host queriedHost = current;
+            try {
+                connection.release();
+
+                if (exception instanceof ConnectionException) {
+                    if (metricsEnabled())
+                        metrics().getErrorMetrics().getConnectionErrors().inc();
+                    ConnectionException ce = (ConnectionException)exception;
+                    logError(ce.address, ce);
+                    retry(false, null);
+                    return;
+                }
+                setFinalException(connection, exception);
+            } catch (Exception e) {
+                // This shouldn't happen, but if it does, we want to signal the callback, not let it hang indefinitely
+                setFinalException(null, new DriverInternalError("An unexpected error happened while handling exception " + exception, e));
+            } finally {
+                if (queriedHost != null && statement != Statement.DEFAULT)
+                    manager.cluster.manager.reportLatency(queriedHost, statement, exception, latency);
+            }
+        }
+
+        @Override
+        public boolean onTimeout(Connection connection, long latency, int retryCount) {
+            QueryState queryState = queryStateRef.get();
+            if (!queryState.isInProgressAt(retryCount) ||
+                !queryStateRef.compareAndSet(queryState, queryState.complete())) {
+                logger.debug("onTimeout triggered but the response was completed by another thread, cancelling (retryCount = {}, queryState = {}, queryStateRef = {})",
+                    retryCount, queryState, queryStateRef.get());
+                return false;
+            }
+
+            Host queriedHost = current;
+            OperationTimedOutException timeoutException = new OperationTimedOutException(connection.address);
+            try {
+                logError(connection.address, timeoutException);
+                retry(false, null);
+            } catch (Exception e) {
+                // This shouldn't happen, but if it does, we want to signal the callback, not let it hang indefinitely
+                setFinalException(null, new DriverInternalError("An unexpected error happened while handling timeout", e));
+            } finally {
+                if (queriedHost != null && statement != Statement.DEFAULT)
+                    manager.cluster.manager.reportLatency(queriedHost, statement, timeoutException, latency);
+            }
+            return true;
+        }
+
+        @Override
+        public int retryCount() {
+            return queryStateRef.get().retryCount;
+        }
+
+        private void setFinalException(Connection connection, Exception exception) {
+            RequestHandler.this.setFinalException(this, connection, exception);
+        }
+
+        private void setFinalResult(Connection connection, Message.Response response) {
+            RequestHandler.this.setFinalResult(this, connection, response);
         }
     }
 
-    @Override
-    public boolean onTimeout(Connection connection, long latency, int retryCount) {
-        QueryState queryState = queryStateRef.get();
-        if (!queryState.isInProgressAt(retryCount) ||
-            !queryStateRef.compareAndSet(queryState, queryState.complete())) {
-            logger.debug("onTimeout triggered but the response was completed by another thread, cancelling (retryCount = {}, queryState = {}, queryStateRef = {})",
-                         retryCount, queryState, queryStateRef.get());
-            return false;
-        }
-
-        Host queriedHost = current;
-        OperationTimedOutException timeoutException = new OperationTimedOutException(connection.address);
-        try {
-            logError(connection.address, timeoutException);
-            retry(false, null);
-        } catch (Exception e) {
-            // This shouldn't happen, but if it does, we want to signal the callback, not let it hang indefinitely
-            setFinalException(null, new DriverInternalError("An unexpected error happened while handling timeout", e));
-        } finally {
-            if (queriedHost != null && statement != Statement.DEFAULT)
-                manager.cluster.manager.reportLatency(queriedHost, statement, timeoutException, latency);
-        }
-        return true;
-    }
-
-    @Override
-    public int retryCount() {
-        return queryStateRef.get().retryCount;
-    }
-
-    interface Callback extends Connection.ResponseCallback {
-        public void onSet(Connection connection, Message.Response response, ExecutionInfo info, Statement statement, long latency);
-        public void register(RequestHandler handler);
-    }
-
-    // This is used to prevent races between request completion (either success or error) and timeout.
-    // A retry is in progress once we have written the request to the connection and until we get back a response (see onSet
-    // or onException) or a timeout (see onTimeout).
-    // The count increments on each retry.
+    /**
+     * The state of a SpeculativeExecution.
+     *
+     * This is used to prevent races between request completion (either success or error) and timeout.
+     * A retry is in progress once we have written the request to the connection and until we get back a response (see onSet
+     * or onException) or a timeout (see onTimeout).
+     * The count increments on each retry.
+     */
     static class QueryState {
         static final QueryState INITIAL = new QueryState(-1, false);
         static final QueryState CANCELLED_WHILE_IN_PROGRESS = new QueryState(Integer.MIN_VALUE, false);
@@ -652,6 +789,23 @@ class RequestHandler implements Connection.ResponseCallback {
         @Override
         public String toString() {
             return String.format("QueryState(count=%d, inProgress=%s, cancelled=%s)", retryCount, inProgress, isCancelled());
+        }
+    }
+
+    /**
+     * Wraps the iterator return by {@link com.datastax.driver.core.policies.LoadBalancingPolicy} to make it safe for
+     * concurrent access by multiple threads.
+     */
+    static class QueryPlan {
+        private final Iterator<Host> iterator;
+
+        QueryPlan(Iterator<Host> iterator) {
+            this.iterator = iterator;
+        }
+
+        /** @return null if there are no more hosts */
+        synchronized Host next() {
+            return iterator.hasNext() ? iterator.next() : null;
         }
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -33,6 +33,7 @@ import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.datastax.driver.core.exceptions.UnsupportedFeatureException;
 import com.datastax.driver.core.policies.LoadBalancingPolicy;
 import com.datastax.driver.core.policies.ReconnectionPolicy;
+import com.datastax.driver.core.policies.SpeculativeExecutionPolicy;
 import com.datastax.driver.core.utils.MoreFutures;
 
 /**
@@ -177,6 +178,10 @@ class SessionManager extends AbstractSession {
 
     LoadBalancingPolicy loadBalancingPolicy() {
         return cluster.manager.loadBalancingPolicy();
+    }
+
+    SpeculativeExecutionPolicy speculativeRetryPolicy() {
+        return cluster.manager.speculativeRetryPolicy();
     }
 
     ReconnectionPolicy reconnectionPolicy() {
@@ -476,6 +481,9 @@ class SessionManager extends AbstractSession {
         if (pagingState == null) {
             usedPagingState = statement.getPagingState();
         }
+
+        if (statement instanceof StatementWrapper)
+            statement = ((StatementWrapper)statement).getWrappedStatement();
 
         if (statement instanceof RegularStatement) {
             RegularStatement rs = (RegularStatement)statement;

--- a/driver-core/src/main/java/com/datastax/driver/core/StatementWrapper.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/StatementWrapper.java
@@ -1,0 +1,152 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.nio.ByteBuffer;
+
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.RetryPolicy;
+import com.datastax.driver.core.policies.SpeculativeExecutionPolicy;
+
+/**
+ * Base class for custom {@link Statement} implementations that wrap another statement.
+ * <p>
+ * This is intended for use with a custom {@link RetryPolicy}, {@link LoadBalancingPolicy} or
+ * {@link SpeculativeExecutionPolicy}. The client code can wrap a statement to "mark" it, or
+ * add information that will lead to special handling in the policy.
+ * <p>
+ * Example:
+ * <pre>
+ * {@code
+ * // Define your own subclass
+ * public class MyCustomStatement extends StatementWrapper {
+ *     public MyCustomStatement(Statement wrapped) {
+ *         super(wrapped);
+ *     }
+ * }
+ *
+ * // In your load balancing policy, add a special case for that new type
+ * public class MyLoadBalancingPolicy implements LoadBalancingPolicy {
+ *     public Iterator<Host> newQueryPlan(String loggedKeyspace, Statement statement) {
+ *         if (statement instanceof MyCustomStatement) {
+ *             // return specially crafted plan
+ *         } else {
+ *             // return default plan
+ *         }
+ *     }
+ * }
+ *
+ * // The client wraps whenever it wants to trigger the special plan
+ * Statement s = new SimpleStatement("...");
+ * session.execute(s);                         // will use default plan
+ * session.execute(new MyCustomStatement(s));  // will use special plan
+ * }
+ * </pre>
+ */
+public abstract class StatementWrapper extends Statement {
+    private final Statement wrapped;
+
+    /**
+     * Builds a new instance.
+     *
+     * @param wrapped the wrapped statement.
+     */
+    protected StatementWrapper(Statement wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    Statement getWrappedStatement() {
+        // Protect against multiple levels of wrapping (even though there is no practical reason for that)
+        return (wrapped instanceof StatementWrapper)
+            ? ((StatementWrapper)wrapped).getWrappedStatement()
+            : wrapped;
+    }
+
+    @Override
+    public Statement setConsistencyLevel(ConsistencyLevel consistency) {
+        return wrapped.setConsistencyLevel(consistency);
+    }
+
+    @Override
+    public Statement disableTracing() {
+        return wrapped.disableTracing();
+    }
+
+    @Override
+    public Statement setSerialConsistencyLevel(ConsistencyLevel serialConsistency) {
+        return wrapped.setSerialConsistencyLevel(serialConsistency);
+    }
+
+    @Override
+    public Statement enableTracing() {
+        return wrapped.enableTracing();
+    }
+
+    @Override
+    public ByteBuffer getPagingState() {
+        return wrapped.getPagingState();
+    }
+
+    @Override
+    public boolean isTracing() {
+        return wrapped.isTracing();
+    }
+
+    @Override
+    public RetryPolicy getRetryPolicy() {
+        return wrapped.getRetryPolicy();
+    }
+
+    @Override
+    public ByteBuffer getRoutingKey() {
+        return wrapped.getRoutingKey();
+    }
+
+    @Override
+    public Statement setRetryPolicy(RetryPolicy policy) {
+        return wrapped.setRetryPolicy(policy);
+    }
+
+    @Override
+    public ConsistencyLevel getConsistencyLevel() {
+        return wrapped.getConsistencyLevel();
+    }
+
+    @Override
+    public Statement setPagingState(PagingState pagingState) {
+        return wrapped.setPagingState(pagingState);
+    }
+
+    @Override
+    public ConsistencyLevel getSerialConsistencyLevel() {
+        return wrapped.getSerialConsistencyLevel();
+    }
+
+    @Override
+    public String getKeyspace() {
+        return wrapped.getKeyspace();
+    }
+
+    @Override
+    public int getFetchSize() {
+        return wrapped.getFetchSize();
+    }
+
+    @Override
+    public Statement setFetchSize(int fetchSize) {
+        return wrapped.setFetchSize(fetchSize);
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/ConstantSpeculativeExecutionPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/ConstantSpeculativeExecutionPolicy.java
@@ -1,0 +1,71 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.policies;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.google.common.base.Preconditions;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.Statement;
+
+/**
+ * A {@link SpeculativeExecutionPolicy} that schedules a given number of speculative executions, separated by a fixed delay.
+ */
+public class ConstantSpeculativeExecutionPolicy implements SpeculativeExecutionPolicy {
+    private final int maxSpeculativeExecutions;
+    private final long constantDelayMillis;
+
+    /**
+     * Builds a new instance.
+     *
+     * @param maxSpeculativeExecutions the number of speculative executions. Must be strictly positive.
+     * @param constantDelayMillis the delay between each speculative execution. Must be strictly positive.
+     *
+     * @throws IllegalArgumentException if one of the arguments does not respect the preconditions above.
+     */
+    public ConstantSpeculativeExecutionPolicy(final int maxSpeculativeExecutions, final long constantDelayMillis) {
+        this.maxSpeculativeExecutions = maxSpeculativeExecutions;
+        this.constantDelayMillis = constantDelayMillis;
+        Preconditions.checkArgument(maxSpeculativeExecutions > 0,
+            "number of speculative executions must be strictly positive (was %d)", maxSpeculativeExecutions);
+        Preconditions.checkArgument(constantDelayMillis > 0,
+            "delay must be strictly positive (was %d)", constantDelayMillis);
+    }
+
+    @Override
+    public SpeculativeExecutionPlan newPlan(String loggedKeyspace, Statement statement) {
+        return new SpeculativeExecutionPlan() {
+            private final AtomicInteger remaining = new AtomicInteger(maxSpeculativeExecutions);
+
+            @Override
+            public long nextExecution(Host lastQueried) {
+                return (remaining.getAndDecrement() > 0) ? constantDelayMillis : -1;
+            }
+        };
+    }
+
+    @Override
+    public void init(Cluster cluster) {
+        // do nothing
+    }
+
+    @Override
+    public void close() {
+        // do nothing
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/NoSpeculativeExecutionPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/NoSpeculativeExecutionPolicy.java
@@ -1,0 +1,55 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.policies;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.Statement;
+
+/**
+ * A {@link SpeculativeExecutionPolicy} that never schedules speculative executions.
+ */
+public class NoSpeculativeExecutionPolicy implements SpeculativeExecutionPolicy {
+
+    /** The single instance (this class is stateless). */
+    public static final NoSpeculativeExecutionPolicy INSTANCE = new NoSpeculativeExecutionPolicy();
+
+    private static final SpeculativeExecutionPlan PLAN = new SpeculativeExecutionPlan() {
+        @Override
+        public long nextExecution(Host lastQueried) {
+            return -1;
+        }
+    };
+
+    @Override
+    public SpeculativeExecutionPlan newPlan(String loggedKeyspace, Statement statement) {
+        return PLAN;
+    }
+
+    private NoSpeculativeExecutionPolicy() {
+        // do nothing
+    }
+
+    @Override
+    public void init(Cluster cluster) {
+        // do nothing
+    }
+
+    @Override
+    public void close() {
+        // do nothing
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/Policies.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/Policies.java
@@ -23,14 +23,17 @@ public class Policies {
     private static final ReconnectionPolicy DEFAULT_RECONNECTION_POLICY = new ExponentialReconnectionPolicy(1000, 10 * 60 * 1000);
     private static final RetryPolicy DEFAULT_RETRY_POLICY = DefaultRetryPolicy.INSTANCE;
     private static final AddressTranslater DEFAULT_ADDRESS_TRANSLATER = new IdentityTranslater();
+    private static final SpeculativeExecutionPolicy DEFAULT_SPECULATIVE_EXECUTION_POLICY = NoSpeculativeExecutionPolicy.INSTANCE;
 
     private final LoadBalancingPolicy loadBalancingPolicy;
     private final ReconnectionPolicy reconnectionPolicy;
     private final RetryPolicy retryPolicy;
     private final AddressTranslater addressTranslater;
+    private final SpeculativeExecutionPolicy speculativeExecutionPolicy;
 
     public Policies() {
-        this(defaultLoadBalancingPolicy(), defaultReconnectionPolicy(), defaultRetryPolicy(), defaultAddressTranslater());
+        this(defaultLoadBalancingPolicy(), defaultReconnectionPolicy(), defaultRetryPolicy(),
+            defaultAddressTranslater(), defaultSpeculativeExecutionPolicy());
     }
 
     /**
@@ -44,8 +47,9 @@ public class Policies {
      */
     public Policies(LoadBalancingPolicy loadBalancingPolicy,
                     ReconnectionPolicy reconnectionPolicy,
-                    RetryPolicy retryPolicy) {
-        this(loadBalancingPolicy, reconnectionPolicy, retryPolicy, DEFAULT_ADDRESS_TRANSLATER);
+                    RetryPolicy retryPolicy,
+                    SpeculativeExecutionPolicy speculativeExecutionPolicy) {
+        this(loadBalancingPolicy, reconnectionPolicy, retryPolicy, DEFAULT_ADDRESS_TRANSLATER, speculativeExecutionPolicy);
     }
 
     /**
@@ -59,11 +63,13 @@ public class Policies {
     public Policies(LoadBalancingPolicy loadBalancingPolicy,
                     ReconnectionPolicy reconnectionPolicy,
                     RetryPolicy retryPolicy,
-                    AddressTranslater addressTranslater) {
+                    AddressTranslater addressTranslater,
+                    SpeculativeExecutionPolicy speculativeExecutionPolicy) {
         this.loadBalancingPolicy = loadBalancingPolicy;
         this.reconnectionPolicy = reconnectionPolicy;
         this.retryPolicy = retryPolicy;
         this.addressTranslater = addressTranslater;
+        this.speculativeExecutionPolicy = speculativeExecutionPolicy;
     }
 
     /**
@@ -110,12 +116,23 @@ public class Policies {
     /**
      * The default address translater.
      * <p>
-     * The default address tanslater is {@link IdentityTranslater}.
+     * The default address translater is {@link IdentityTranslater}.
      *
      * @return the default address translater.
      */
     public static AddressTranslater defaultAddressTranslater() {
         return DEFAULT_ADDRESS_TRANSLATER;
+    }
+
+    /**
+     * The default speculative retry policy.
+     * <p>
+     * The default speculative retry policy is a {@link NoSpeculativeExecutionPolicy}.
+     *
+     * @return the default speculative retry policy.
+     */
+    public static SpeculativeExecutionPolicy defaultSpeculativeExecutionPolicy() {
+        return DEFAULT_SPECULATIVE_EXECUTION_POLICY;
     }
 
     /**
@@ -159,5 +176,14 @@ public class Policies {
      */
     public AddressTranslater getAddressTranslater() {
         return addressTranslater;
+    }
+
+    /**
+     * The speculative execution policy in use.
+     *
+     * @return the speculative execution policy in use.
+     */
+    public SpeculativeExecutionPolicy getSpeculativeExecutionPolicy() {
+        return speculativeExecutionPolicy;
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/SpeculativeExecutionPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/SpeculativeExecutionPolicy.java
@@ -1,0 +1,72 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.policies;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.Statement;
+
+/**
+ * The policy that decides if the driver will send speculative queries to the next hosts when the current host takes too
+ * long to respond.
+ * <p>
+ * Note that only idempotent statements will be speculatively retried, see
+ * {@link com.datastax.driver.core.Statement#isIdempotent()} for more information.
+ */
+public interface SpeculativeExecutionPolicy {
+    /**
+     * Gets invoked at cluster startup.
+     *
+     * @param cluster the cluster that this policy is associated with.
+     */
+    void init(Cluster cluster);
+
+    /**
+     * Returns the plan to use for a new query.
+     *
+     * @param loggedKeyspace the currently logged keyspace (the one set through either
+     * {@link Cluster#connect(String)} or by manually doing a {@code USE} query) for
+     * the session on which this plan need to be built. This can be {@code null} if
+     * the corresponding session has no keyspace logged in.
+     * @param statement the query for which to build a plan.
+     * @return the plan.
+     */
+    SpeculativeExecutionPlan newPlan(String loggedKeyspace, Statement statement);
+
+    /**
+     * Gets invoked at cluster shutdown.
+     *
+     * This gives the policy the opportunity to perform some cleanup, for instance stop threads that it might have started.
+     */
+    void close();
+
+    /**
+     * A plan that governs speculative executions for a given query.
+     * <p>
+     * Each time a host is queried, {@link #nextExecution(Host)} is invoked to determine if and when a speculative query to
+     * the next host will be sent.
+     */
+    interface SpeculativeExecutionPlan {
+        /**
+         * Returns the time before the next speculative query.
+         *
+         * @param lastQueried the host that was just queried.
+         * @return the time (in milliseconds) before a speculative query is sent to the next host. If zero or negative,
+         * no speculative query will be sent.
+         */
+        long nextExecution(Host lastQueried);
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Assignment.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Assignment.java
@@ -29,6 +29,8 @@ public abstract class Assignment extends Utils.Appendeable {
         this.name = name;
     }
 
+    abstract boolean isIdempotent();
+
     static class SetAssignment extends Assignment {
 
         private final Object value;
@@ -48,6 +50,11 @@ public abstract class Assignment extends Utils.Appendeable {
         @Override
         boolean containsBindMarker() {
             return Utils.containsBindMarker(value);
+        }
+
+        @Override
+        boolean isIdempotent() {
+            return true;
         }
     }
 
@@ -78,6 +85,11 @@ public abstract class Assignment extends Utils.Appendeable {
         boolean containsBindMarker() {
             return Utils.containsBindMarker(value);
         }
+
+        @Override
+        boolean isIdempotent() {
+            return false;
+        }
     }
 
     static class ListPrependAssignment extends Assignment {
@@ -100,6 +112,11 @@ public abstract class Assignment extends Utils.Appendeable {
         @Override
         boolean containsBindMarker() {
             return Utils.containsBindMarker(value);
+        }
+
+        @Override
+        boolean isIdempotent() {
+            return false;
         }
     }
 
@@ -124,17 +141,28 @@ public abstract class Assignment extends Utils.Appendeable {
         boolean containsBindMarker() {
             return Utils.containsBindMarker(value);
         }
+
+        @Override
+        boolean isIdempotent() {
+            return true;
+        }
     }
 
     static class CollectionAssignment extends Assignment {
 
         private final Object collection;
         private final boolean isAdd;
+        private final boolean isIdempotent;
 
-        CollectionAssignment(String name, Object collection, boolean isAdd) {
+        CollectionAssignment(String name, Object collection, boolean isAdd, boolean isIdempotent) {
             super(name);
             this.collection = collection;
             this.isAdd = isAdd;
+            this.isIdempotent = isIdempotent;
+        }
+
+        CollectionAssignment(String name, Object collection, boolean isAdd) {
+            this(name, collection, isAdd, true);
         }
 
         @Override
@@ -147,6 +175,11 @@ public abstract class Assignment extends Utils.Appendeable {
         @Override
         boolean containsBindMarker() {
             return Utils.containsBindMarker(collection);
+        }
+
+        @Override
+        public boolean isIdempotent() {
+            return isIdempotent;
         }
     }
 
@@ -172,6 +205,11 @@ public abstract class Assignment extends Utils.Appendeable {
         @Override
         boolean containsBindMarker() {
             return Utils.containsBindMarker(key) || Utils.containsBindMarker(value);
+        }
+
+        @Override
+        boolean isIdempotent() {
+            return true;
         }
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
@@ -641,7 +641,7 @@ public final class QueryBuilder {
      */
     public static Assignment append(String name, Object value) {
         Object v = value instanceof BindMarker ? value : Collections.singletonList(value);
-        return new Assignment.CollectionAssignment(name, v, true);
+        return new Assignment.CollectionAssignment(name, v, true, false);
     }
 
     /**
@@ -654,7 +654,7 @@ public final class QueryBuilder {
      * @return the correspond assignment (to use in an update query)
      */
     public static Assignment appendAll(String name, List<?> list) {
-        return new Assignment.CollectionAssignment(name, list, true);
+        return new Assignment.CollectionAssignment(name, list, true, false);
     }
 
     /**
@@ -667,7 +667,7 @@ public final class QueryBuilder {
      * @return the correspond assignment (to use in an update query)
      */
     public static Assignment appendAll(String name, BindMarker list) {
-        return new Assignment.CollectionAssignment(name, list, true);
+        return new Assignment.CollectionAssignment(name, list, true, false);
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
@@ -175,6 +175,8 @@ public class Update extends BuiltStatement {
          */
         public Assignments and(Assignment assignment) {
             statement.setCounterOp(assignment instanceof CounterAssignment);
+            if (!assignment.isIdempotent())
+                statement.setNonIdempotentOps();
             assignments.add(assignment);
             checkForBindMarkers(assignment);
             return this;

--- a/driver-core/src/test/java/com/datastax/driver/core/ConnectionReleaseTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ConnectionReleaseTest.java
@@ -1,0 +1,129 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.AsyncFunction;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.scassandra.http.client.PrimingRequest;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
+
+public class ConnectionReleaseTest extends ScassandraTestBase {
+
+    /**
+     * <p>
+     * Validates that when a future is set that the stream associated with the future's request is released.
+     * This prevents situations where a user may not be specifying a separate executor on a callback/
+     * transform to a ResultSetFuture, which is not recommended, causing executeAsync to block in borrowConnection
+     * until stream ids become available.
+     *
+     * Executes the following:
+     *
+     * <ol>
+     *   <li>Sets # of connections per host to 1.</li>
+     *   <li>Sends MAX_STREAM_PER_CONNECTION-1 requests that take 10 seconds to execute.</li>
+     *   <li>Calls executeAsync to retrieve records from test1 with k=1.</li>
+     *   <li>Transforms executeAsync to take the 'c' column from the result and query test2.
+     *       This is done without an executor to ensure the netty worker is used and has to wait for the function
+     *       completion.</li>
+     *   <li>Asserts that the transformed future completes within pool timeout and the value is as expected.</li>
+     * </ol>
+     *
+     * @jira_ticket JAVA-666
+     * @expected_result Are able to transform a Future without hanging in executeAsync as connection should be freed
+     *   before the transform function is called.
+     * @test_category queries:async
+     * @since 2.0.10, 2.1.6
+     */
+    @SuppressWarnings("unchecked")
+    @Test(groups="short")
+    public void should_release_connection_before_completing_future() throws Exception {
+        Cluster cluster = null;
+        Collection<ResultSetFuture> mockFutures = Lists.newArrayList();
+        try {
+            primingClient.prime(
+                    PrimingRequest.queryBuilder()
+                            .withQuery("mock query")
+                            .withRows(ImmutableMap.of("key", 1))
+                            .withFixedDelay(10000)
+                            .build()
+            );
+            primingClient.prime(
+                    PrimingRequest.queryBuilder()
+                            .withQuery("select c from test1 where k=1")
+                            .withRows(ImmutableMap.of("c", "hello"))
+                            .build()
+            );
+            primingClient.prime(
+                    PrimingRequest.queryBuilder()
+                            .withQuery("select n from test2 where c='hello'")
+                            .withRows(ImmutableMap.of("n", "world"))
+                            .build()
+            );
+
+            cluster = Cluster.builder().addContactPointsWithPorts(Collections.singletonList(hostAddress))
+                    .withPoolingOptions(new PoolingOptions()
+                            .setCoreConnectionsPerHost(HostDistance.LOCAL, 1)
+                            .setMaxConnectionsPerHost(HostDistance.LOCAL, 1))
+                    .build();
+
+            final Session session = cluster.connect("ks");
+            // Consume all stream ids except one.
+            for(int i = 0; i < StreamIdGenerator.MAX_STREAM_PER_CONNECTION-1; i++)
+                mockFutures.add(session.executeAsync("mock query"));
+
+
+            ListenableFuture<ResultSet> future = Futures.transform(session.executeAsync("select c from test1 where k=1"),
+                    new AsyncFunction<ResultSet, ResultSet>() {
+                        @Override
+                        public ListenableFuture<ResultSet> apply(ResultSet result) {
+                            Row row = result.one();
+                            String c = row.getString("c");
+                            // Execute async might hang if no streams are available.  This happens if the connection
+                            // was not release.
+                            return session.executeAsync("select n from test2 where c='" + c + "'");
+                        }
+                    });
+
+            // Wait for up to pool timeout for response.  If future is not complete by then, we can assume
+            // that it is likely that the execute is hung because the connection wasn't released yet.
+            long waitTimeInMs = cluster.getConfiguration().getPoolingOptions().getPoolTimeoutMillis();
+            try {
+                ResultSet result = future.get(waitTimeInMs, TimeUnit.MILLISECONDS);
+                assertThat(result.one().getString("n")).isEqualTo("world");
+            }  catch (TimeoutException e) {
+                fail("Future timed out after " + waitTimeInMs + "ms.  " +
+                        "There is a strong possibility connection is not being released.");
+            }
+        } finally {
+            // Cancel all pending requests.
+            for(ResultSetFuture future : mockFutures)
+                future.cancel(true);
+            if(cluster != null)
+                cluster.close();
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/SCassandraCluster.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SCassandraCluster.java
@@ -1,0 +1,129 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import org.scassandra.Scassandra;
+import org.scassandra.ScassandraFactory;
+import org.scassandra.http.client.ColumnTypes;
+import org.scassandra.http.client.PrimingClient;
+import org.scassandra.http.client.PrimingRequest;
+
+/**
+ * Launches multiple SCassandra instances, and mocks the appropriate request to make the driver think
+ * that they belong to the same cluster.
+ *
+ * Note: this uses the same addresses as {@link CCMBridge}, so make sure IP aliases have been set up,
+ * and a CCM cluster is not running at the same time.
+ */
+public class SCassandraCluster {
+    private static final int BINARY_PORT = 9042;
+    private static final int ADMIN_PORT = 9052;
+
+    private final List<Scassandra> scassandras;
+    private final List<InetAddress> addresses;
+    private final List<PrimingClient> primingClients;
+
+    public SCassandraCluster(String ipPrefix, int nodeCount) {
+        scassandras = Lists.newArrayListWithCapacity(nodeCount);
+        addresses = Lists.newArrayListWithCapacity(nodeCount);
+        primingClients = Lists.newArrayListWithCapacity(nodeCount);
+
+        for (int i = 1; i <= nodeCount; i++) {
+            String ip = ipPrefix + i;
+            try {
+                addresses.add(InetAddress.getByName(ip));
+            } catch (UnknownHostException e) {
+                throw new AssertionError(e);
+            }
+            Scassandra scassandra = ScassandraFactory.createServer(ip, BINARY_PORT, ip, ADMIN_PORT);
+            scassandra.start();
+            scassandras.add(scassandra);
+
+            // Currently Scassandra#primingClient() uses localhost by default, so build manually:
+            primingClients.add(PrimingClient.builder()
+                .withHost(ip).withPort(scassandra.getAdminPort())
+                .build());
+        }
+        primePeers();
+    }
+
+    public List<InetAddress> addresses() {
+        return addresses;
+    }
+
+    public void stop() {
+        for (Scassandra scassandra : scassandras)
+            scassandra.stop();
+    }
+
+    public SCassandraCluster prime(int node, PrimingRequest request) {
+        primingClients.get(node - 1).prime(request);
+        return this;
+    }
+
+    public void clearAllPrimes() {
+        for (PrimingClient primingClient : primingClients)
+            primingClient.clearAllPrimes();
+        primePeers();
+    }
+
+    private void primePeers() {
+        for (int i = 0; i < scassandras.size(); i++)
+            primePeers(primingClients.get(i), scassandras.get(i));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void primePeers(PrimingClient primingClient, Scassandra toIgnore) {
+        List<Map<String, ?>> rows = Lists.newArrayListWithCapacity(scassandras.size());
+        for (int i = 0; i < scassandras.size(); i++) {
+            if (scassandras.get(i).equals(toIgnore))
+                continue;
+            InetAddress address = addresses.get(i);
+            rows.add(ImmutableMap.<String, Object>builder()
+                .put("peer", address)
+                .put("rpc_address", address)
+                .put("data_center", "datacenter1")
+                .put("rack", "rack1")
+                .put("release_version", "2.0.1")
+                .put("tokens", ImmutableSet.of(Long.toString(Long.MIN_VALUE + i)))
+                .build());
+        }
+        primingClient.prime(
+            PrimingRequest.queryBuilder()
+                .withQuery("SELECT * FROM system.peers")
+                .withColumnTypes(SELECT_PEERS_COLUMN_TYPES)
+                .withRows(rows)
+                .build());
+    }
+
+    private static final ImmutableMap<String, ColumnTypes> SELECT_PEERS_COLUMN_TYPES =
+        ImmutableMap.<String, ColumnTypes>builder()
+            .put("peer", ColumnTypes.Inet)
+            .put("rpc_address", ColumnTypes.Inet)
+            .put("data_center", ColumnTypes.Text)
+            .put("rack", ColumnTypes.Text)
+            .put("release_version", ColumnTypes.Text)
+            .put("tokens", ColumnTypes.TextSet)
+            .build();
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/SpeculativeExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SpeculativeExecutionTest.java
@@ -1,0 +1,270 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.UnsignedBytes;
+import org.scassandra.http.client.PrimingRequest;
+import org.testng.annotations.*;
+
+import com.datastax.driver.core.policies.ConstantSpeculativeExecutionPolicy;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.RetryPolicy;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+
+public class SpeculativeExecutionTest {
+    SCassandraCluster scassandras;
+
+    Cluster cluster = null;
+    SortingLoadBalancingPolicy loadBalancingPolicy;
+    Metrics.Errors errors;
+    Host host1, host2, host3;
+    Session session;
+
+    @BeforeClass(groups = "short")
+    public void beforeClass() {
+        scassandras = new SCassandraCluster(CCMBridge.IP_PREFIX, 3);
+    }
+
+    @BeforeMethod(groups = "short")
+    public void beforeMethod() {
+        int speculativeExecutionDelay = 200;
+
+        loadBalancingPolicy = new SortingLoadBalancingPolicy();
+        cluster = Cluster.builder()
+            .addContactPoint(CCMBridge.ipOfNode(2))
+            .withLoadBalancingPolicy(loadBalancingPolicy)
+            .withSpeculativeExecutionPolicy(new ConstantSpeculativeExecutionPolicy(1, speculativeExecutionDelay))
+            .withQueryOptions(new QueryOptions().setDefaultIdempotence(true))
+            .withRetryPolicy(new CustomRetryPolicy())
+            .build();
+
+        session = cluster.connect();
+
+        host1 = TestUtils.findHost(cluster, 1);
+        host2 = TestUtils.findHost(cluster, 2);
+        host3 = TestUtils.findHost(cluster, 3);
+
+        errors = cluster.getMetrics().getErrorMetrics();
+    }
+
+    @Test(groups = "short")
+    public void should_not_start_speculative_execution_if_first_execution_completes_successfully() {
+        scassandras.prime(1, PrimingRequest.queryBuilder()
+                .withQuery("mock query")
+                .withRows(row("result", "result1"))
+                .build()
+        );
+
+        long execStartCount = errors.getSpeculativeExecutions().getCount();
+
+        ResultSet rs = session.execute("mock query");
+        Row row = rs.one();
+
+        assertThat(row.getString("result")).isEqualTo("result1");
+        assertThat(errors.getSpeculativeExecutions().getCount()).isEqualTo(execStartCount);
+        assertThat(rs.getExecutionInfo().getQueriedHost()).isEqualTo(host1);
+    }
+
+    @Test(groups = "short")
+    public void should_not_start_speculative_execution_if_first_execution_retries_but_is_still_fast_enough() {
+        // will retry once on this node:
+        scassandras.prime(1, PrimingRequest.queryBuilder()
+                .withQuery("mock query")
+                .withConsistency(PrimingRequest.Consistency.TWO)
+                .withResult(PrimingRequest.Result.read_request_timeout)
+                .build()
+        ).prime(1, PrimingRequest.queryBuilder()
+                .withQuery("mock query")
+                .withConsistency(PrimingRequest.Consistency.ONE)
+                .withRows(row("result", "result1"))
+                .build()
+        );
+
+        long execStartCount = errors.getSpeculativeExecutions().getCount();
+        long retriesStartCount = errors.getRetriesOnUnavailable().getCount();
+
+        SimpleStatement statement = new SimpleStatement("mock query");
+        statement.setConsistencyLevel(ConsistencyLevel.TWO);
+        ResultSet rs = session.execute(statement);
+        Row row = rs.one();
+
+        assertThat(row.getString("result")).isEqualTo("result1");
+        assertThat(errors.getSpeculativeExecutions().getCount()).isEqualTo(execStartCount);
+        assertThat(errors.getRetriesOnReadTimeout().getCount()).isEqualTo(retriesStartCount + 1);
+        assertThat(rs.getExecutionInfo().getQueriedHost()).isEqualTo(host1);
+    }
+
+    @Test(groups = "short")
+    public void should_start_speculative_execution_if_first_execution_takes_too_long() {
+        scassandras.prime(1, PrimingRequest.queryBuilder()
+                .withQuery("mock query")
+                .withFixedDelay(400)
+                .withRows(row("result", "result1"))
+                .build()
+        ).prime(2, PrimingRequest.queryBuilder()
+                .withQuery("mock query")
+                .withRows(row("result", "result2"))
+                .build()
+        );
+        long execStartCount = errors.getSpeculativeExecutions().getCount();
+
+        ResultSet rs = session.execute("mock query");
+        Row row = rs.one();
+
+        assertThat(row.getString("result")).isEqualTo("result2");
+        assertThat(errors.getSpeculativeExecutions().getCount()).isEqualTo(execStartCount + 1);
+        assertThat(rs.getExecutionInfo().getQueriedHost()).isEqualTo(host2);
+    }
+
+    @Test(groups = "short")
+    public void should_wait_until_all_executions_have_finished() {
+        // Rely on read timeouts to trigger errors that cause an execution to move to the next node
+        cluster.getConfiguration().getSocketOptions().setReadTimeoutMillis(1000);
+
+        scassandras
+            // execution1 starts with host1, which will time out at t=1000
+            .prime(1, PrimingRequest.queryBuilder()
+                .withQuery("mock query")
+                .withFixedDelay(2000)
+                .withRows(row("result", "result1"))
+                .build())
+                // at t=1000, execution1 moves to host3, which eventually succeeds at t=1500
+            .prime(3, PrimingRequest.queryBuilder()
+                .withQuery("mock query")
+                .withFixedDelay(500)
+                .withRows(row("result", "result3"))
+                .build())
+                // meanwhile, execution2 starts at t=200, using host2 which times out at t=1200
+                // at that time, the query plan is empty so execution2 fails
+                // The goal of this test is to check that execution2 does not fail the query, since execution1 is still running
+            .prime(2, PrimingRequest.queryBuilder()
+                .withQuery("mock query")
+                .withFixedDelay(2000)
+                .withRows(row("result", "result2"))
+                .build());
+        long execStartCount = errors.getSpeculativeExecutions().getCount();
+
+        ResultSet rs = session.execute("mock query");
+        Row row = rs.one();
+
+        assertThat(row.getString("result")).isEqualTo("result3");
+        assertThat(errors.getSpeculativeExecutions().getCount()).isEqualTo(execStartCount + 1);
+        assertThat(rs.getExecutionInfo().getQueriedHost()).isEqualTo(host3);
+    }
+
+    @AfterMethod(groups = "short")
+    public void afterMethod() {
+        scassandras.clearAllPrimes();
+        if (cluster != null)
+            cluster.close();
+    }
+
+    @AfterClass(groups = "short")
+    public void afterClass() {
+        if (scassandras != null)
+            scassandras.stop();
+    }
+
+    /**
+     * A load balancing policy that sorts hosts on the last byte of the address,
+     * so that the query plan is always [host1, host2, host3].
+     */
+    static class SortingLoadBalancingPolicy implements LoadBalancingPolicy {
+
+        private final SortedSet<Host> hosts = new ConcurrentSkipListSet<Host>(new Comparator<Host>() {
+            @Override
+            public int compare(Host host1, Host host2) {
+                byte[] address1 = host1.getAddress().getAddress();
+                byte[] address2 = host2.getAddress().getAddress();
+                return UnsignedBytes.compare(
+                    address1[address1.length - 1],
+                    address2[address2.length - 1]);
+            }
+        });
+
+        @Override
+        public void init(Cluster cluster, Collection<Host> hosts) {
+            this.hosts.addAll(hosts);
+        }
+
+        @Override
+        public HostDistance distance(Host host) {
+            return HostDistance.LOCAL;
+        }
+
+        @Override
+        public Iterator<Host> newQueryPlan(String loggedKeyspace, Statement statement) {
+            return hosts.iterator();
+        }
+
+        @Override
+        public void onAdd(Host host) {
+            onUp(host);
+        }
+
+        @Override
+        public void onUp(Host host) {
+            hosts.add(host);
+        }
+
+        @Override
+        public void onDown(Host host) {
+            hosts.remove(host);
+        }
+
+        @Override
+        public void onRemove(Host host) {
+            onDown(host);
+        }
+
+        @Override
+        public void onSuspected(Host host) {
+        }
+    }
+
+    /**
+     * Custom retry policy that retries at ONE on read timeout.
+     * This deals with the fact that Scassandra only allows read timeouts with 0 replicas.
+     */
+    static class CustomRetryPolicy implements RetryPolicy {
+        @Override
+        public RetryDecision onReadTimeout(Statement statement, ConsistencyLevel cl, int requiredResponses, int receivedResponses, boolean dataRetrieved, int nbRetry) {
+            if (nbRetry != 0)
+                return RetryDecision.rethrow();
+            return RetryDecision.retry(ConsistencyLevel.ONE);
+        }
+
+        @Override
+        public RetryDecision onWriteTimeout(Statement statement, ConsistencyLevel cl, WriteType writeType, int requiredAcks, int receivedAcks, int nbRetry) {
+            return RetryDecision.rethrow();
+        }
+
+        @Override
+        public RetryDecision onUnavailable(Statement statement, ConsistencyLevel cl, int requiredReplica, int aliveReplica, int nbRetry) {
+            return RetryDecision.rethrow();
+        }
+    }
+
+    private static List<Map<String, ?>> row(String key, String value) {
+        return ImmutableList.<Map<String, ?>>of(ImmutableMap.of(key, value));
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/StatementIdempotenceTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StatementIdempotenceTest.java
@@ -1,0 +1,103 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.driver.core.querybuilder.BuiltStatement;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+
+public class StatementIdempotenceTest {
+    @Test(groups = "unit")
+    public void should_default_to_false_when_not_set_on_statement_nor_query_options() {
+        QueryOptions queryOptions = new QueryOptions();
+        SimpleStatement statement = new SimpleStatement("");
+
+        assertThat(statement.isIdempotentWithDefault(queryOptions)).isFalse();
+    }
+
+    @Test(groups = "unit")
+    public void should_use_query_options_when_not_set_on_statement() {
+        QueryOptions queryOptions = new QueryOptions();
+        SimpleStatement statement = new SimpleStatement("");
+
+        for (boolean valueInOptions : new boolean[]{ true, false }) {
+            queryOptions.setDefaultIdempotence(valueInOptions);
+            assertThat(statement.isIdempotentWithDefault(queryOptions)).isEqualTo(valueInOptions);
+        }
+    }
+
+    @Test(groups = "unit")
+    public void should_use_statement_when_set_on_statement() {
+        QueryOptions queryOptions = new QueryOptions();
+        SimpleStatement statement = new SimpleStatement("");
+
+        for (boolean valueInOptions : new boolean[]{ true, false })
+            for (boolean valueInStatement : new boolean[]{ true, false }) {
+                queryOptions.setDefaultIdempotence(valueInOptions);
+                statement.setIdempotent(valueInStatement);
+                assertThat(statement.isIdempotentWithDefault(queryOptions)).isEqualTo(valueInStatement);
+            }
+    }
+
+    @Test(groups = "unit")
+    public void should_infer_for_built_statement() {
+        for (BuiltStatement statement : idempotentBuiltStatements())
+            assertThat(statement.isIdempotent())
+                .as(statement.getQueryString())
+                .isTrue();
+
+        for (BuiltStatement statement : nonIdempotentBuiltStatements())
+            assertThat(statement.isIdempotent())
+                .as(statement.getQueryString())
+                .isFalse();
+    }
+
+    @Test(groups = "unit")
+    public void should_override_inferred_value_when_manually_set_on_built_statement() {
+        for (boolean manualValue : new boolean[]{ true, false }) {
+            for (BuiltStatement statement : idempotentBuiltStatements()) {
+                statement.setIdempotent(manualValue);
+                assertThat(statement.isIdempotent()).isEqualTo(manualValue);
+            }
+
+            for (BuiltStatement statement : nonIdempotentBuiltStatements()) {
+                statement.setIdempotent(manualValue);
+                assertThat(statement.isIdempotent()).isEqualTo(manualValue);
+            }
+        }
+    }
+
+    private static ImmutableList<BuiltStatement> idempotentBuiltStatements() {
+        return ImmutableList.<BuiltStatement>of(
+            update("foo").with(set("v", 1)).where(eq("k", 1)), // set simple value
+            update("foo").with(add("s", 1)).where(eq("k", 1)), // add to set
+            update("foo").with(put("m", "a", 1)).where(eq("k", 1)) // put in map
+        );
+    }
+
+    private static ImmutableList<BuiltStatement> nonIdempotentBuiltStatements() {
+        return ImmutableList.<BuiltStatement>of(
+            update("foo").with(append("l", 1)).where(eq("k", 1)), // append to list
+            update("foo").with(set("v", 1)).and(prepend("l", 1)).where(eq("k", 1)), // prepend to list
+            update("foo").with(incr("c")).where(eq("k", 1)) // counter update
+        );
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/StatementWrapperTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StatementWrapperTest.java
@@ -1,0 +1,147 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.google.common.collect.Lists;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.driver.core.policies.*;
+
+public class StatementWrapperTest extends CCMBridge.PerClassSingleNodeCluster {
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return Lists.newArrayList();
+    }
+
+    CustomLoadBalancingPolicy loadBalancingPolicy = new CustomLoadBalancingPolicy();
+    CustomSpeculativeExecutionPolicy speculativeExecutionPolicy = new CustomSpeculativeExecutionPolicy();
+    CustomRetryPolicy retryPolicy = new CustomRetryPolicy();
+
+    @Override
+    protected Cluster.Builder configure(Cluster.Builder builder) {
+        return builder
+            .withLoadBalancingPolicy(loadBalancingPolicy)
+            .withSpeculativeExecutionPolicy(speculativeExecutionPolicy)
+            .withRetryPolicy(retryPolicy);
+    }
+
+    @Test(groups = "short")
+    public void should_pass_wrapped_statement_to_load_balancing_policy() {
+        loadBalancingPolicy.customStatementsHandled.set(0);
+
+        SimpleStatement s = new SimpleStatement("select * from system.local");
+        session.execute(s);
+        assertThat(loadBalancingPolicy.customStatementsHandled.get()).isEqualTo(0);
+
+        session.execute(new CustomStatement(s));
+        assertThat(loadBalancingPolicy.customStatementsHandled.get()).isEqualTo(1);
+    }
+
+    @Test(groups = "short")
+    public void should_pass_wrapped_statement_to_speculative_execution_policy() {
+        speculativeExecutionPolicy.customStatementsHandled.set(0);
+
+        SimpleStatement s = new SimpleStatement("select * from system.local");
+        session.execute(s);
+        assertThat(speculativeExecutionPolicy.customStatementsHandled.get()).isEqualTo(0);
+
+        session.execute(new CustomStatement(s));
+        assertThat(speculativeExecutionPolicy.customStatementsHandled.get()).isEqualTo(1);
+    }
+
+    @Test(groups = "short")
+    public void should_pass_wrapped_statement_to_retry_policy() {
+        retryPolicy.customStatementsHandled.set(0);
+
+        // Set CL TWO with only one node, so the statement will always cause UNAVAILABLE,
+        // which our custom policy ignores.
+        Statement s = new SimpleStatement("select * from system.local")
+            .setConsistencyLevel(ConsistencyLevel.TWO);
+
+        session.execute(s);
+        assertThat(retryPolicy.customStatementsHandled.get()).isEqualTo(0);
+
+        session.execute(new CustomStatement(s));
+        assertThat(retryPolicy.customStatementsHandled.get()).isEqualTo(1);
+    }
+
+    /** A custom wrapper that's just used to mark statements. */
+    static class CustomStatement extends StatementWrapper {
+        protected CustomStatement(Statement wrapped) {
+            super(wrapped);
+        }
+    }
+
+    /** A load balancing policy that counts how many times it has seen the custom wrapper */
+    static class CustomLoadBalancingPolicy extends DelegatingLoadBalancingPolicy {
+        final AtomicInteger customStatementsHandled = new AtomicInteger();
+
+        public CustomLoadBalancingPolicy() {
+            super(new RoundRobinPolicy());
+        }
+
+        @Override
+        public Iterator<Host> newQueryPlan(String loggedKeyspace, Statement statement) {
+            if (statement instanceof CustomStatement)
+                customStatementsHandled.incrementAndGet();
+            return super.newQueryPlan(loggedKeyspace, statement);
+        }
+    }
+
+    /** A speculative execution policy that counts how many times it has seen the custom wrapper */
+    static class CustomSpeculativeExecutionPolicy extends DelegatingSpeculativeExecutionPolicy {
+        final AtomicInteger customStatementsHandled = new AtomicInteger();
+
+        protected CustomSpeculativeExecutionPolicy() {
+            super(NoSpeculativeExecutionPolicy.INSTANCE);
+        }
+
+        @Override
+        public SpeculativeExecutionPlan newPlan(String loggedKeyspace, Statement statement) {
+            if (statement instanceof CustomStatement)
+                customStatementsHandled.incrementAndGet();
+            return super.newPlan(loggedKeyspace, statement);
+        }
+    }
+
+    /** A retry policy that counts how many times it has seen the custom wrapper for UNAVAILABLE errors. */
+    static class CustomRetryPolicy implements RetryPolicy {
+        final AtomicInteger customStatementsHandled = new AtomicInteger();
+
+        @Override
+        public RetryDecision onUnavailable(Statement statement, ConsistencyLevel cl, int requiredReplica, int aliveReplica, int nbRetry) {
+            if (statement instanceof CustomStatement)
+                customStatementsHandled.incrementAndGet();
+            return RetryDecision.ignore();
+        }
+
+        @Override
+        public RetryDecision onReadTimeout(Statement statement, ConsistencyLevel cl, int requiredResponses, int receivedResponses, boolean dataRetrieved, int nbRetry) {
+            return RetryDecision.rethrow();
+        }
+
+        @Override
+        public RetryDecision onWriteTimeout(Statement statement, ConsistencyLevel cl, WriteType writeType, int requiredAcks, int receivedAcks, int nbRetry) {
+            return RetryDecision.rethrow();
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/DelegatingSpeculativeExecutionPolicy.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/DelegatingSpeculativeExecutionPolicy.java
@@ -1,0 +1,47 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.policies;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Statement;
+
+/**
+ * Base class for tests that want to wrap a policy to add some instrumentation.
+ *
+ * NB: this is currently only used in tests, but could be provided as a convenience in the production code.
+ */
+public abstract class DelegatingSpeculativeExecutionPolicy implements SpeculativeExecutionPolicy {
+    private final SpeculativeExecutionPolicy delegate;
+
+    protected DelegatingSpeculativeExecutionPolicy(SpeculativeExecutionPolicy delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void init(Cluster cluster) {
+        delegate.init(cluster);
+    }
+
+    @Override
+    public SpeculativeExecutionPlan newPlan(String loggedKeyspace, Statement statement) {
+        return delegate.newPlan(loggedKeyspace, statement);
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+}


### PR DESCRIPTION
Preemptively query the next host when the current one takes too long to respond. Introduces a new `SpeculativeExecutionPolicy` (I deliberately avoided the word "retry" which was already used in driver jargon).

Most of the `RequestHandler` logic was extracted in a `SpeculativeExecution` inner class. A RequestHandler starts multiple SpeculativeExecutions which compete for the same query plan. This allows:
- coherent integration with the retry logic: each SpeculativeExecution can still retry, as defined by the `RetryPolicy`.
- few changes to existing synchronization code. Each SpeculativeExecution manages its own requests with the existing `QueryState` mechanism, and the RequestHandler coordinates all SpeculativeExecutions.
