### PR TITLE
Allow Cluster subclasses to delegate to another instance (JAVA-619).

### DIFF
--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -34,6 +34,8 @@ CHANGELOG
 - [bug] Fix issue when executing a PreparedStatement from another cluster
   (JAVA-641)
 - [improvement] Log keyspace xxx does not exist at WARN level (JAVA-534)
+- [improvement] Allow Cluster subclasses to delegate to another instance
+  (JAVA-619)
 
 Merged from 2.0.9_fixes branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/DelegatingCluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DelegatingCluster.java
@@ -1,0 +1,111 @@
+package com.datastax.driver.core;
+
+import java.net.InetSocketAddress;
+import java.util.Collections;
+
+/**
+ * Base class for custom {@link Cluster} implementations that wrap another instance (delegate / decorator pattern).
+ */
+public abstract class DelegatingCluster extends Cluster {
+    /**
+     * Builds a new instance.
+     */
+    protected DelegatingCluster() {
+        // Implementation notes:
+        // If Cluster was an interface, delegates would be trivial to write. But, for historical reasons, it's a class,
+        // and changing that would break backward compatibility. That makes delegates rather convoluted and error-prone
+        // to write, so we provide DelegatingCluster to abstract the details.
+        // This class ensures that:
+        // - init() is never called on the parent class, because that would initialize the Cluster.Manager instance and
+        //   create a lot of internal state (thread pools, etc.) that we don't need, since another Cluster instance is
+        //   already handling the calls.
+        // - all public methods are properly forwarded to the delegate (otherwise they would call the parent class and
+        //   return inconsistent results).
+        // These two goals are closely related, since a lot of public methods call init(), so accidentally calling a
+        // parent method could initialize the parent state.
+
+        // Construct parent class with dummy parameters that will never get used (since super.init() is never called).
+        super("delegating_cluster", Collections.<InetSocketAddress>emptyList(), null);
+
+        // Immediately close the parent class's internal Manager, to make sure that it will fail fast if it's ever
+        // accidentally invoked.
+        super.closeAsync();
+    }
+
+    /**
+     * Returns the delegate instance where all calls will be forwarded.
+     *
+     * @return the delegate.
+     */
+    protected abstract Cluster delegate();
+
+    @Override
+    public Cluster init() {
+        return delegate().init();
+    }
+
+    @Override
+    public Session newSession() {
+        return delegate().newSession();
+    }
+
+    @Override
+    public Session connect() {
+        return delegate().connect();
+    }
+
+    @Override
+    public Session connect(String keyspace) {
+        return delegate().connect(keyspace);
+    }
+
+    @Override
+    public Metadata getMetadata() {
+        return delegate().getMetadata();
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        return delegate().getConfiguration();
+    }
+
+    @Override
+    public Metrics getMetrics() {
+        return delegate().getMetrics();
+    }
+
+    @Override
+    public Cluster register(Host.StateListener listener) {
+        return delegate().register(listener);
+    }
+
+    @Override
+    public Cluster unregister(Host.StateListener listener) {
+        return delegate().unregister(listener);
+    }
+
+    @Override
+    public Cluster register(LatencyTracker tracker) {
+        return delegate().register(tracker);
+    }
+
+    @Override
+    public Cluster unregister(LatencyTracker tracker) {
+        return delegate().unregister(tracker);
+    }
+
+    @Override
+    public CloseFuture closeAsync() {
+        return delegate().closeAsync();
+    }
+
+    @Override
+    public void close() {
+        delegate().close();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return delegate().isClosed();
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterDelegateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterDelegateTest.java
@@ -1,0 +1,38 @@
+package com.datastax.driver.core;
+
+import java.util.Collection;
+
+import com.google.common.collect.Lists;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClusterDelegateTest extends CCMBridge.PerClassSingleNodeCluster {
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return Lists.newArrayList();
+    }
+
+    @Test(groups = "short")
+    public void should_allow_subclass_to_delegate_to_other_instance() {
+        SimpleDelegatingCluster delegatingCluster = new SimpleDelegatingCluster(cluster);
+
+        ResultSet rs = delegatingCluster.connect().execute("select * from system.local");
+
+        assertThat(rs.all()).hasSize(1);
+    }
+
+    static class SimpleDelegatingCluster extends DelegatingCluster {
+
+        private final Cluster delegate;
+
+        public SimpleDelegatingCluster(Cluster delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        protected Cluster delegate() {
+            return delegate;
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
@@ -15,43 +15,38 @@ public class SessionLeakTest {
         // Checking for JAVA-342
         CCMBridge ccmBridge;
         ccmBridge = CCMBridge.create("test", 1);
-
-        // give the driver time to close other sessions in this class
-        //Thread.sleep(10);
-
-        // create a new cluster object and ensure 0 sessions and connections
-        Cluster cluster = Cluster.builder().addContactPoints(CCMBridge.IP_PREFIX + '1').build();
-
-        int corePoolSize = cluster.getConfiguration()
-                .getPoolingOptions()
-                .getCoreConnectionsPerHost(HostDistance.LOCAL);
-
-        assertEquals(cluster.manager.sessions.size(), 0);
-        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 0);
-
-        // ensure sessions.size() returns with 1 control connection + core pool size.
-        Session session = cluster.connect();
-        assertEquals(cluster.manager.sessions.size(), 1);
-        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1 + corePoolSize);
-
-        // ensure sessions.size() returns to 0 with only 1 active connection (the control connection)
-        session.close();
-        assertEquals(cluster.manager.sessions.size(), 0);
-        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
-
+        Cluster cluster = null;
         try {
-            Session thisSession;
+            // create a new cluster object and ensure 0 sessions and connections
+            cluster = Cluster.builder().addContactPoints(CCMBridge.IP_PREFIX + '1').build();
+            cluster.init();
+
+            int corePoolSize = cluster.getConfiguration()
+                    .getPoolingOptions()
+                    .getCoreConnectionsPerHost(HostDistance.LOCAL);
+
+            assertEquals(cluster.manager.sessions.size(), 0);
+            // Should be 1 control connection after initialization.
+            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
+
+            // ensure sessions.size() returns with 1 control connection + core pool size.
+            Session session = cluster.connect();
+            assertEquals(cluster.manager.sessions.size(), 1);
+            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1 + corePoolSize);
+
+            // ensure sessions.size() returns to 0 with only 1 active connection (the control connection)
+            session.close();
+            assertEquals(cluster.manager.sessions.size(), 0);
+            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
 
             // ensure bootstrapping a node does not create additional connections
-
-
             ccmBridge.bootstrapNode(2);
             assertEquals(cluster.manager.sessions.size(), 0);
             assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
 
             // ensure a new session gets registered and core connections are established
             // there should be corePoolSize more connections to accommodate for the new host.
-            thisSession = cluster.connect();
+            Session thisSession = cluster.connect();
             assertEquals(cluster.manager.sessions.size(), 1);
 
             assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1 + (corePoolSize * 2));
@@ -60,26 +55,14 @@ public class SessionLeakTest {
             thisSession.close();
 
             assertEquals(cluster.manager.sessions.size(), 0);
-
             assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
-
-
         } finally {
-            // ensure we decommission node2 for the rest of the tests
-
-            assertEquals(cluster.manager.sessions.size(), 0);
-            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
-
             if(cluster != null){
                 cluster.close();
-
             }
-
             if (ccmBridge != null) {
                 ccmBridge.remove();
             }
-
-
         }
     }
 }


### PR DESCRIPTION
This moves all significant work to Cluster.Manager.init(). A delegating
subclass must ensure that init() is never called in the parent class, so
that extra ressources like thread pools are not created unnecessarily.

This is a workaround for the fact that Cluster should be an interface,
which would be a better way to address this use case, but can't be done
for compatibility reasons.
