### PR TITLE
Expose an API that tells if the schemas agree on all the peers (JAVA-669)

### DIFF
--- a/driver-core/CHANGELOG.rst
+++ b/driver-core/CHANGELOG.rst
@@ -36,6 +36,8 @@ CHANGELOG
 - [improvement] Log keyspace xxx does not exist at WARN level (JAVA-534)
 - [improvement] Allow Cluster subclasses to delegate to another instance
   (JAVA-619)
+- [new feature] Expose an API to check for schema agreement after a
+  schema-altering statement (JAVA-669)
 
 Merged from 2.0.9_fixes branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -2037,20 +2037,38 @@ public class Cluster implements Closeable {
             if (logger.isDebugEnabled())
                 logger.debug("Refreshing schema for {}{}", keyspace == null ? "" : keyspace, table == null ? "" : '.' + table);
 
+            maybeRefreshSchemaAndSignal(connection, future, rs, keyspace, table);
+        }
+
+        public void waitForSchemaAgreementAndSignal(final Connection connection, final DefaultResultSetFuture future, final ResultSet rs) {
+            maybeRefreshSchemaAndSignal(connection, future, rs, null, null);
+        }
+
+        private void maybeRefreshSchemaAndSignal(final Connection connection, final DefaultResultSetFuture future, final ResultSet rs, final String keyspace, final String table) {
+            final boolean refreshSchema = (keyspace != null); // if false, only wait for schema agreement
+
             executor.submit(new Runnable() {
                 @Override
                 public void run() {
+                    boolean schemaInAgreement = false;
                     try {
                         // Before refreshing the schema, wait for schema agreement so
                         // that querying a table just after having created it don't fail.
-                        if (!ControlConnection.waitForSchemaAgreement(connection, Cluster.Manager.this))
+                        schemaInAgreement = ControlConnection.waitForSchemaAgreement(connection, Manager.this);
+                        if (!schemaInAgreement)
                             logger.warn("No schema agreement from live replicas after {} s. The schema may not be up to date on some nodes.", configuration.getProtocolOptions().getMaxSchemaAgreementWaitSeconds());
-                        ControlConnection.refreshSchema(connection, keyspace, table, Cluster.Manager.this, false);
+                        if (refreshSchema)
+                            ControlConnection.refreshSchema(connection, keyspace, table, Manager.this, false);
                     } catch (Exception e) {
-                        logger.error("Error during schema refresh ({}). The schema from Cluster.getMetadata() might appear stale. Asynchronously submitting job to fix.", e.getMessage());
-                        submitSchemaRefresh(keyspace, table);
+                        if (refreshSchema) {
+                            logger.error("Error during schema refresh ({}). The schema from Cluster.getMetadata() might appear stale. Asynchronously submitting job to fix.", e.getMessage());
+                            submitSchemaRefresh(keyspace, table);
+                        } else {
+                            logger.warn("Error while waiting for schema agreement", e);
+                        }
                     } finally {
-                        // Always sets the result
+                        // Always sets the result, but remember if we reached schema agreement
+                        rs.getExecutionInfo().setSchemaInAgreement(schemaInAgreement);
                         future.setResult(rs);
                     }
                 }

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -595,31 +595,7 @@ class ControlConnection implements Host.StateListener {
         int maxSchemaAgreementWaitSeconds = cluster.configuration.getProtocolOptions().getMaxSchemaAgreementWaitSeconds();
         while (elapsed < maxSchemaAgreementWaitSeconds * 1000) {
 
-            DefaultResultSetFuture peersFuture = new DefaultResultSetFuture(null, new Requests.Query(SELECT_SCHEMA_PEERS));
-            DefaultResultSetFuture localFuture = new DefaultResultSetFuture(null, new Requests.Query(SELECT_SCHEMA_LOCAL));
-            connection.write(peersFuture);
-            connection.write(localFuture);
-
-            Set<UUID> versions = new HashSet<UUID>();
-
-            Row localRow = localFuture.get().one();
-            if (localRow != null && !localRow.isNull("schema_version"))
-                versions.add(localRow.getUUID("schema_version"));
-
-            for (Row row : peersFuture.get()) {
-
-                InetSocketAddress addr = addressToUseForPeerHost(row, connection.address, cluster, true);
-                if (addr == null || row.isNull("schema_version"))
-                    continue;
-
-                Host peer = cluster.metadata.getHost(addr);
-                if (peer != null && peer.isUp())
-                    versions.add(row.getUUID("schema_version"));
-            }
-
-            logger.debug("Checking for schema agreement: versions are {}", versions);
-
-            if (versions.size() <= 1)
+            if (checkSchemaAgreement(connection, cluster))
                 return true;
 
             // let's not flood the node too much
@@ -629,6 +605,42 @@ class ControlConnection implements Host.StateListener {
         }
 
         return false;
+    }
+
+    private static boolean checkSchemaAgreement(Connection connection, Cluster.Manager cluster) throws ConnectionException, BusyConnectionException, InterruptedException, ExecutionException {
+        DefaultResultSetFuture peersFuture = new DefaultResultSetFuture(null, new Requests.Query(SELECT_SCHEMA_PEERS));
+        DefaultResultSetFuture localFuture = new DefaultResultSetFuture(null, new Requests.Query(SELECT_SCHEMA_LOCAL));
+        connection.write(peersFuture);
+        connection.write(localFuture);
+
+        Set<UUID> versions = new HashSet<UUID>();
+
+        Row localRow = localFuture.get().one();
+        if (localRow != null && !localRow.isNull("schema_version"))
+            versions.add(localRow.getUUID("schema_version"));
+
+        for (Row row : peersFuture.get()) {
+
+            InetSocketAddress addr = addressToUseForPeerHost(row, connection.address, cluster, true);
+            if (addr == null || row.isNull("schema_version"))
+                continue;
+
+            Host peer = cluster.metadata.getHost(addr);
+            if (peer != null && peer.isUp())
+                versions.add(row.getUUID("schema_version"));
+        }
+        logger.debug("Checking for schema agreement: versions are {}", versions);
+        return versions.size() <= 1;
+    }
+
+    boolean checkSchemaAgreement() {
+        Connection c = connectionRef.get();
+        try {
+            return c != null && checkSchemaAgreement(c, cluster);
+        } catch (Exception e) {
+            logger.warn("Error while checking schema agreement", e);
+            return false;
+        }
     }
 
     boolean isOpen() {

--- a/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
@@ -91,7 +91,7 @@ class DefaultResultSetFuture extends AbstractFuture<ResultSet> implements Result
                                         else
                                             keyspace.removeTable(scc.columnFamily);
                                     }
-                                    this.setResult(rs);
+                                    session.cluster.manager.waitForSchemaAgreementAndSignal(connection, this, rs);
                                     break;
                                 case UPDATED:
                                     if (scc.columnFamily.isEmpty()) {

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -354,6 +354,19 @@ public class Metadata {
     }
 
     /**
+     * Checks whether hosts that are currently up agree on the schema definition.
+     * <p>
+     * This method performs a one-time check only, without any form of retry; therefore {@link Cluster.Builder#withMaxSchemaAgreementWaitSeconds(int)}
+     * does not apply in this case.
+     *
+     * @return {@code true} if all hosts agree on the schema; {@code false} if they don't agree, or if the check could not be performed
+     * (for example, if the control connection is down).
+     */
+    public boolean checkSchemaAgreement() {
+        return cluster.controlConnection.checkSchemaAgreement();
+    }
+
+    /**
      * Returns the metadata of a keyspace given its name.
      *
      * @param keyspace the name of the keyspace for which metadata should be

--- a/driver-core/src/main/java/com/datastax/driver/core/ProtocolOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ProtocolOptions.java
@@ -15,6 +15,8 @@
  */
 package com.datastax.driver.core;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * Options of the Cassandra native binary protocol.
  */
@@ -83,7 +85,8 @@ public class ProtocolOptions {
     private final int port;
     final int initialProtocolVersion; // What the user asked us. Will be -1 by default.
 
-    private final int maxSchemaAgreementWaitSeconds;
+    @VisibleForTesting
+    volatile int maxSchemaAgreementWaitSeconds;
 
     private final SSLOptions sslOptions; // null if no SSL
     private final AuthProvider authProvider;

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaAgreementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaAgreementTest.java
@@ -1,0 +1,124 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.net.InetAddress;
+import java.util.UUID;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.driver.core.exceptions.DriverException;
+import com.datastax.driver.core.utils.UUIDs;
+
+public class SchemaAgreementTest {
+
+    // Don't use "IF EXISTS" to remain compatible with older C* versions
+    static final String CREATE_TABLE = "CREATE TABLE foo (k int primary key, v int)";
+    static final String DROP_TABLE = "DROP TABLE foo";
+
+    CCMBridge ccm;
+    Cluster cluster;
+    Session session;
+    ProtocolOptions protocolOptions;
+
+    @BeforeClass(groups = "short")
+    public void setup() {
+        ccm = CCMBridge.create("schema_agreement", 2);
+        cluster = Cluster.builder().addContactPoint(CCMBridge.ipOfNode(1)).build();
+        session = cluster.connect();
+        session.execute("create keyspace test with replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+        session.execute("use test");
+        protocolOptions = cluster.getConfiguration().getProtocolOptions();
+    }
+
+    @Test(groups = "short")
+    public void should_set_flag_on_successful_agreement() {
+        protocolOptions.maxSchemaAgreementWaitSeconds = 10;
+        ResultSet rs = session.execute(CREATE_TABLE);
+        assertThat(rs.getExecutionInfo().isSchemaInAgreement()).isTrue();
+    }
+
+    @Test(groups = "short")
+    public void should_set_flag_on_non_schema_altering_statement() {
+        protocolOptions.maxSchemaAgreementWaitSeconds = 10;
+        ResultSet rs = session.execute("select release_version from system.local");
+        assertThat(rs.getExecutionInfo().isSchemaInAgreement()).isTrue();
+    }
+
+    @Test(groups = "short")
+    public void should_unset_flag_on_failed_agreement() {
+        // Setting to 0 results in no query being set, so agreement fails
+        protocolOptions.maxSchemaAgreementWaitSeconds = 0;
+        ResultSet rs = session.execute(CREATE_TABLE);
+        assertThat(rs.getExecutionInfo().isSchemaInAgreement()).isFalse();
+    }
+
+    @Test(groups = "short")
+    public void should_check_agreement_through_cluster_metadata() {
+        Cluster controlCluster = null;
+        try {
+            controlCluster = TestUtils.buildControlCluster(cluster);
+            Session controlSession = controlCluster.connect();
+
+            Row localRow = controlSession.execute("SELECT schema_version FROM system.local").one();
+            UUID localVersion = localRow.getUUID("schema_version");
+            Row peerRow = controlSession.execute("SELECT peer, schema_version FROM system.peers").one();
+            InetAddress peerAddress = peerRow.getInet("peer");
+            UUID peerVersion = peerRow.getUUID("schema_version");
+            // The two nodes should be in agreement at this point, but check just in case:
+            assertThat(localVersion).isEqualTo(peerVersion);
+
+            // Now check the method under test:
+            assertThat(cluster.getMetadata().checkSchemaAgreement()).isTrue();
+
+            // Insert a fake version to simulate a disagreement:
+            forceSchemaVersion(controlSession, peerAddress, UUIDs.random());
+            assertThat(cluster.getMetadata().checkSchemaAgreement()).isFalse();
+
+            forceSchemaVersion(controlSession, peerAddress, peerVersion);
+        } finally {
+            if (controlCluster != null)
+                controlCluster.close();
+        }
+    }
+
+    private static void forceSchemaVersion(Session session, InetAddress peerAddress, UUID schemaVersion) {
+        session.execute(String.format("UPDATE system.peers SET schema_version = %s WHERE peer = %s",
+            DataType.uuid().format(schemaVersion), DataType.inet().format(peerAddress)));
+    }
+
+    @AfterMethod(groups = "short")
+    public void cleanupSchema() {
+        protocolOptions.maxSchemaAgreementWaitSeconds = 10;
+        try {
+            session.execute(DROP_TABLE);
+        } catch (DriverException e) { /*ignore*/ }
+    }
+
+    @AfterClass(groups = "short")
+    public void teardown() {
+        if (cluster != null)
+            cluster.close();
+        if (ccm != null)
+            ccm.remove();
+    }
+}
+

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.ByteBuffer;
 import java.util.*;
@@ -30,6 +31,9 @@ import org.scassandra.ScassandraFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.SkipException;
+
+import com.datastax.driver.core.policies.RoundRobinPolicy;
+import com.datastax.driver.core.policies.WhiteListPolicy;
 
 /**
  * A number of static fields/methods handy for tests.
@@ -431,5 +435,17 @@ public abstract class TestUtils {
         } else {
             return 2;
         }
+    }
+
+    /**
+     * @return a {@Cluster} instance that connects only to the control host of the given cluster.
+     */
+    public static Cluster buildControlCluster(Cluster cluster) {
+        Host controlHost = cluster.manager.controlConnection.connectedHost();
+        List<InetSocketAddress> singleAddress = Collections.singletonList(controlHost.getSocketAddress());
+        return Cluster.builder()
+            .addContactPointsWithPorts(singleAddress)
+            .withLoadBalancingPolicy(new WhiteListPolicy(new RoundRobinPolicy(), singleAddress))
+            .build();
     }
 }


### PR DESCRIPTION
This adds two methods:
- one on ExecutionInfo to check if the peers agreed after the last statement
- one on Cluster.Metadata to trigger a manual one-time check
