### PR TITLE
Update license headers for 2015 (JAVA-704)

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -26,6 +26,10 @@
   <description>A driver for Apache Cassandra 1.2+ that works exclusively with the Cassandra Query Language version 3 (CQL3) and Cassandra's binary protocol.</description>
   <url>https://github.com/datastax/java-driver</url>
 
+  <properties>
+    <main.basedir>${project.parent.basedir}</main.basedir>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.netty</groupId>

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -1,17 +1,19 @@
 <!--
-        Copyright (C) 2012 DataStax Inc.
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
+         Copyright (C) 2012-2015 DataStax Inc.
 
-        http://www.apache.org/licenses/LICENSE-2.0
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
 
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+         http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractGettableData.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractGettableData.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractReconnectionHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractReconnectionHandler.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractSession.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractSession.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedResultSet.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedResultSet.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedRow.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedRow.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/AuthProvider.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AuthProvider.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/Authenticator.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Authenticator.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/BusyConnectionException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BusyConnectionException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/CBUtil.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CBUtil.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/CassandraTypeParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CassandraTypeParser.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/CloseFuture.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CloseFuture.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ClusterNameMismatchException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ClusterNameMismatchException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ColumnDefinitions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ColumnDefinitions.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/Configuration.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Configuration.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ConnectionException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ConnectionException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ConsistencyLevel.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ConsistencyLevel.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ConvictionPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ConvictionPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/DataType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataType.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/DefaultPreparedStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DefaultPreparedStatement.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ExceptionCatchingRunnable.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ExceptionCatchingRunnable.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ExceptionCode.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ExceptionCode.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ExecutionInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ExecutionInfo.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/Frame.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Frame.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/FrameCompressor.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/FrameCompressor.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/GettableData.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/GettableData.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.math.BigDecimal;

--- a/driver-core/src/main/java/com/datastax/driver/core/Host.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Host.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/HostDistance.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostDistance.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/KeyspaceMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/KeyspaceMetadata.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/LatencyTracker.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/LatencyTracker.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/MD5Digest.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/MD5Digest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/Message.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Message.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/Metrics.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metrics.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/MetricsOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/MetricsOptions.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/OperationTimedOutException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/OperationTimedOutException.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.net.InetSocketAddress;

--- a/driver-core/src/main/java/com/datastax/driver/core/PlainTextAuthProvider.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PlainTextAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/PooledConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PooledConnection.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/PoolingOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PoolingOptions.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/PreparedId.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PreparedId.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/PreparedStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PreparedStatement.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ProtocolEvent.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ProtocolEvent.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ProtocolOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ProtocolOptions.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ProtocolV1Authenticator.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ProtocolV1Authenticator.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/QueryLogger.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/QueryLogger.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/QueryOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/QueryOptions.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/QueryTrace.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/QueryTrace.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/RegularStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RegularStatement.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ReplicationStategy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ReplicationStategy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/Requests.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Requests.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/Responses.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Responses.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ResultSet.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ResultSet.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/ResultSetFuture.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ResultSetFuture.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/Row.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Row.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/SSLOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SSLOptions.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/Session.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Session.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/SimpleJSONParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SimpleJSONParser.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/SimpleStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SimpleStatement.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/SocketOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SocketOptions.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/Statement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Statement.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/StreamIdGenerator.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/StreamIdGenerator.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/SystemProperties.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SystemProperties.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import org.slf4j.Logger;

--- a/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/Token.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Token.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/TokenRange.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TokenRange.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/TransportException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TransportException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/UnsupportedProtocolVersionException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/UnsupportedProtocolVersionException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/VersionNumber.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/VersionNumber.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/WriteType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/WriteType.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/AlreadyExistsException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/AlreadyExistsException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/AuthenticationException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/AuthenticationException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/BootstrappingException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/BootstrappingException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/DriverException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/DriverException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/DriverInternalError.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/DriverInternalError.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/InvalidConfigurationInQueryException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/InvalidConfigurationInQueryException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/InvalidQueryException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/InvalidQueryException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/InvalidTypeException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/InvalidTypeException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/NoHostAvailableException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/NoHostAvailableException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/OverloadedException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/OverloadedException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/PagingStateException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/PagingStateException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
 package com.datastax.driver.core.exceptions;
 
 public class PagingStateException extends DriverException {

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/QueryExecutionException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/QueryExecutionException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/QueryTimeoutException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/QueryTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/QueryValidationException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/QueryValidationException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/ReadTimeoutException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/ReadTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/SyntaxError.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/SyntaxError.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/TraceRetrievalException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/TraceRetrievalException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/TruncateException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/TruncateException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnauthorizedException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnauthorizedException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnavailableException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnavailableException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnpreparedException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnpreparedException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnsupportedFeatureException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnsupportedFeatureException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/WriteTimeoutException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/WriteTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/package-info.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/package-info.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/package-info.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/package-info.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/AddressTranslater.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/AddressTranslater.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/ChainableLoadBalancingPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/ChainableLoadBalancingPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/CloseableAddressTranslater.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/CloseableAddressTranslater.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/CloseableLoadBalancingPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/CloseableLoadBalancingPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/ConstantReconnectionPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/ConstantReconnectionPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/DefaultRetryPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/DefaultRetryPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/EC2MultiRegionAddressTranslater.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/EC2MultiRegionAddressTranslater.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/ExponentialReconnectionPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/ExponentialReconnectionPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/FallthroughRetryPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/FallthroughRetryPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/IdentityTranslater.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/IdentityTranslater.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/LatencyAwarePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/LatencyAwarePolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/LoadBalancingPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/LoadBalancingPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/LoggingRetryPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/LoggingRetryPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/Policies.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/Policies.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/ReconnectionPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/ReconnectionPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/RetryPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/RetryPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/RoundRobinPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/RoundRobinPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/TokenAwarePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/TokenAwarePolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/WhiteListPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/WhiteListPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/package-info.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/package-info.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Assignment.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Assignment.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Batch.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Batch.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BindMarker.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BindMarker.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Clause.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Clause.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Ordering.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Ordering.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Select.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Select.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Truncate.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Truncate.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Using.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Using.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/package-info.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/package-info.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/utils/Bytes.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/utils/Bytes.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/java/com/datastax/driver/core/utils/UUIDs.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/utils/UUIDs.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/main/resources/com/datastax/driver/core/Driver.properties
+++ b/driver-core/src/main/resources/com/datastax/driver/core/Driver.properties
@@ -1,1 +1,17 @@
+#
+#      Copyright (C) 2012-2015 DataStax Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
 driver.version=${project.version}

--- a/driver-core/src/test/java/com/datastax/driver/core/AbstractPoliciesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AbstractPoliciesTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/AbstractReconnectionHandlerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AbstractReconnectionHandlerTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.net.InetSocketAddress;

--- a/driver-core/src/test/java/com/datastax/driver/core/AbstractReplicationStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AbstractReplicationStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 /**

--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/AuthenticationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AuthenticationTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/BatchStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/BatchStatementTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/BoundStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/BoundStatementTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.Collection;

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/CaseSensitivityTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CaseSensitivityTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/CassandraTypeParserTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CassandraTypeParserTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterAssert.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.Iterator;

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.net.InetAddress;

--- a/driver-core/src/test/java/com/datastax/driver/core/ColumnDefinitionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ColumnDefinitionsTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/ConditionalUpdateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ConditionalUpdateTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.Collection;

--- a/driver-core/src/test/java/com/datastax/driver/core/ConsistencyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ConsistencyTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.Iterator;

--- a/driver-core/src/test/java/com/datastax/driver/core/CustomTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CustomTypeTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/ExceptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ExceptionsTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/FakeHost.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/FakeHost.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.io.IOException;

--- a/driver-core/src/test/java/com/datastax/driver/core/FetchingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/FetchingTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/HeartbeatTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HeartbeatTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import static java.util.concurrent.TimeUnit.SECONDS;

--- a/driver-core/src/test/java/com/datastax/driver/core/HostAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostAssert.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.concurrent.CountDownLatch;

--- a/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.Collection;

--- a/driver-core/src/test/java/com/datastax/driver/core/LargeDataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LargeDataTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyBootstrapTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyBootstrapTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyRefreshTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyRefreshTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/M3PTokenFactoryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/M3PTokenFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.List;

--- a/driver-core/src/test/java/com/datastax/driver/core/M3PTokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/M3PTokenIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import com.datastax.driver.core.Token.M3PToken;

--- a/driver-core/src/test/java/com/datastax/driver/core/M3PTokenVnodeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/M3PTokenVnodeIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 public class M3PTokenVnodeIntegrationTest extends TokenIntegrationTest {

--- a/driver-core/src/test/java/com/datastax/driver/core/MemoryAppender.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MemoryAppender.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.io.StringWriter;

--- a/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.Map;

--- a/driver-core/src/test/java/com/datastax/driver/core/MetricsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MetricsTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.Collection;

--- a/driver-core/src/test/java/com/datastax/driver/core/MissingRpcAddressTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MissingRpcAddressTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.net.InetAddress;

--- a/driver-core/src/test/java/com/datastax/driver/core/NetworkTopologyStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/NetworkTopologyStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/OPPTokenFactoryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/OPPTokenFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.math.BigInteger;

--- a/driver-core/src/test/java/com/datastax/driver/core/OPPTokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/OPPTokenIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import com.datastax.driver.core.Token.OPPToken;

--- a/driver-core/src/test/java/com/datastax/driver/core/OPPTokenVnodeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/OPPTokenVnodeIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 public class OPPTokenVnodeIntegrationTest extends TokenIntegrationTest {

--- a/driver-core/src/test/java/com/datastax/driver/core/PagingStateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PagingStateTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.Collection;

--- a/driver-core/src/test/java/com/datastax/driver/core/PoolingOptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PoolingOptionsTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import static java.util.concurrent.TimeUnit.SECONDS;

--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/PrimitiveTypeSamples.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PrimitiveTypeSamples.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerErrorsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerErrorsTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/RPTokenFactoryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RPTokenFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.List;

--- a/driver-core/src/test/java/com/datastax/driver/core/RPTokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RPTokenIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import com.datastax.driver.core.Token.RPToken;

--- a/driver-core/src/test/java/com/datastax/driver/core/RPTokenVnodeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RPTokenVnodeIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 public class RPTokenVnodeIntegrationTest extends TokenIntegrationTest {

--- a/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.concurrent.TimeUnit;

--- a/driver-core/src/test/java/com/datastax/driver/core/ReconnectionPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReconnectionPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/ReconnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReconnectionTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.io.IOException;

--- a/driver-core/src/test/java/com/datastax/driver/core/ReplicationStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReplicationStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/RequestHandlerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RequestHandlerTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.concurrent.TimeUnit;

--- a/driver-core/src/test/java/com/datastax/driver/core/RetryPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RetryPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/SSLAuthenticatedEncryptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLAuthenticatedEncryptionTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import com.google.common.base.Optional;

--- a/driver-core/src/test/java/com/datastax/driver/core/SSLEncryptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLEncryptionTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.concurrent.TimeUnit;

--- a/driver-core/src/test/java/com/datastax/driver/core/SSLTestBase.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLTestBase.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.security.KeyStore;

--- a/driver-core/src/test/java/com/datastax/driver/core/ScassandraTestBase.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ScassandraTestBase.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.net.InetSocketAddress;

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.List;

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/SessionAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionAssert.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import org.assertj.core.api.AbstractAssert;

--- a/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import org.testng.annotations.Test;

--- a/driver-core/src/test/java/com/datastax/driver/core/SessionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/SimpleJSONParserTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SimpleJSONParserTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/SimpleStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SimpleStatementTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.Collections;

--- a/driver-core/src/test/java/com/datastax/driver/core/SimpleStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SimpleStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/SingleTokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SingleTokenIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/StateListenerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StateListenerTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/StreamIdGeneratorTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StreamIdGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.Collection;

--- a/driver-core/src/test/java/com/datastax/driver/core/TestListener.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestListener.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.net.InetSocketAddress;

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenRangeAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenRangeAssert.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.Iterator;

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenRangeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenRangeTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import java.util.List;

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/VersionNumberTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/VersionNumberTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/exceptions/NoHostAvailableExceptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/exceptions/NoHostAvailableExceptionTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core.exceptions;
 
 import java.io.PrintWriter;

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/AlwaysIgnoreRetryPolicy.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/AlwaysIgnoreRetryPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/AlwaysRetryRetryPolicy.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/AlwaysRetryRetryPolicy.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/CloseableLoadBalancingPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/CloseableLoadBalancingPolicyTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core.policies;
 
 import org.testng.annotations.Test;

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicyTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core.policies;
 
 import java.util.Collection;

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/DelegatingLoadBalancingPolicy.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/DelegatingLoadBalancingPolicy.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core.policies;
 
 import java.util.Collection;

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/EC2MultiRegionAddressTranslaterTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/EC2MultiRegionAddressTranslaterTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core.policies;
 
 import org.testng.annotations.Test;

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/LatencyAwarePolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/LatencyAwarePolicyTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/LimitingLoadBalancingPolicy.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/LimitingLoadBalancingPolicy.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core.policies;
 
 import java.util.*;

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core.policies;
 
 import java.nio.ByteBuffer;

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderRoutingKeyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderRoutingKeyTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/java/com/datastax/driver/core/utils/CassandraVersion.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/utils/CassandraVersion.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core.utils;
 
 import java.lang.annotation.Retention;

--- a/driver-core/src/test/java/com/datastax/driver/core/utils/UUIDsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/utils/UUIDsTest.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-core/src/test/resources/log4j.properties
+++ b/driver-core/src/test/resources/log4j.properties
@@ -1,3 +1,19 @@
+#
+#      Copyright (C) 2012-2015 DataStax Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
 # Set root logger level to DEBUG and its only appender to A1.
 log4j.rootLogger=INFO, A1
 

--- a/driver-dist/pom.xml
+++ b/driver-dist/pom.xml
@@ -22,6 +22,10 @@
   </parent>
   <artifactId>cassandra-driver-dist</artifactId>
 
+  <properties>
+    <main.basedir>${project.parent.basedir}</main.basedir>
+  </properties>
+
   <!-- Should be pom but Javadoc generation requires a "classpath-capable" package -->
   <packaging>jar</packaging>
 

--- a/driver-dist/pom.xml
+++ b/driver-dist/pom.xml
@@ -1,17 +1,19 @@
 <!--
-        Copyright (C) 2012 DataStax Inc.
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
+         Copyright (C) 2012-2015 DataStax Inc.
 
-        http://www.apache.org/licenses/LICENSE-2.0
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
 
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+         http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/driver-dist/src/assembly/binary-tarball.xml
+++ b/driver-dist/src/assembly/binary-tarball.xml
@@ -1,3 +1,20 @@
+<!--
+
+         Copyright (C) 2012-2015 DataStax Inc.
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+-->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
   <id>binary-tarball</id>

--- a/driver-dse/pom.xml
+++ b/driver-dse/pom.xml
@@ -1,17 +1,19 @@
 <!--
-        Copyright (C) 2014 DataStax Inc.
 
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
+         Copyright (C) 2012-2015 DataStax Inc.
 
-        http://www.apache.org/licenses/LICENSE-2.0
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
 
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+         http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/driver-dse/pom.xml
+++ b/driver-dse/pom.xml
@@ -26,6 +26,10 @@
   <description>Extensions to the CQL driver for use with DataStax Enterprise.</description>
   <url>https://github.com/datastax/java-driver</url>
 
+  <properties>
+    <main.basedir>${project.parent.basedir}</main.basedir>
+  </properties>
+
   <dependencies>
     <dependency>
         <groupId>com.datastax.cassandra</groupId>

--- a/driver-dse/src/main/java/com/datastax/driver/auth/DseAuthProvider.java
+++ b/driver-dse/src/main/java/com/datastax/driver/auth/DseAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-dse/src/main/java/com/datastax/driver/auth/KerberosAuthenticator.java
+++ b/driver-dse/src/main/java/com/datastax/driver/auth/KerberosAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-dse/src/main/java/com/datastax/driver/auth/PrivilegedSaslClient.java
+++ b/driver-dse/src/main/java/com/datastax/driver/auth/PrivilegedSaslClient.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-examples/osgi/pom.xml
+++ b/driver-examples/osgi/pom.xml
@@ -1,15 +1,19 @@
 <!--
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+         Copyright (C) 2012-2015 DataStax Inc.
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License. See accompanying LICENSE file.
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/driver-examples/osgi/pom.xml
+++ b/driver-examples/osgi/pom.xml
@@ -27,6 +27,7 @@
   <properties>
     <felix.version>4.6.0</felix.version>
     <pax-exam.version>3.6.0</pax-exam.version>
+    <main.basedir>${project.parent.parent.basedir}</main.basedir>
   </properties>
 
   <dependencies>

--- a/driver-examples/osgi/src/test/resources/log4j.properties
+++ b/driver-examples/osgi/src/test/resources/log4j.properties
@@ -1,3 +1,19 @@
+#
+#      Copyright (C) 2012-2015 DataStax Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
 # Set root logger level to DEBUG and its only appender to A1.
 log4j.rootLogger=INFO, A1
 

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -1,15 +1,19 @@
 <!--
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+         Copyright (C) 2012-2015 DataStax Inc.
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License. See accompanying LICENSE file.
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -24,6 +24,10 @@
   <description>A collection of examples to demonstrate DataStax Java Driver for Apache Cassandra.</description>
   <url>https://github.com/datastax/java-driver</url>
 
+  <properties>
+    <main.basedir>${project.parent.basedir}</main.basedir>
+  </properties>
+
   <modules>
     <module>stress</module>
     <module>osgi</module>

--- a/driver-examples/stress/pom.xml
+++ b/driver-examples/stress/pom.xml
@@ -24,6 +24,10 @@
   <description>A stress test example for DataStax Java Driver for Apache Cassandra.</description>
   <url>https://github.com/datastax/java-driver</url>
 
+  <properties>
+    <main.basedir>${project.parent.parent.basedir}</main.basedir>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.datastax.cassandra</groupId>

--- a/driver-examples/stress/pom.xml
+++ b/driver-examples/stress/pom.xml
@@ -1,15 +1,19 @@
 <!--
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+         Copyright (C) 2012-2015 DataStax Inc.
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License. See accompanying LICENSE file.
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/driver-examples/stress/src/main/java/com/datastax/driver/stress/AsynchronousConsumer.java
+++ b/driver-examples/stress/src/main/java/com/datastax/driver/stress/AsynchronousConsumer.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-examples/stress/src/main/java/com/datastax/driver/stress/BlockingConsumer.java
+++ b/driver-examples/stress/src/main/java/com/datastax/driver/stress/BlockingConsumer.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-examples/stress/src/main/java/com/datastax/driver/stress/Consumer.java
+++ b/driver-examples/stress/src/main/java/com/datastax/driver/stress/Consumer.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-examples/stress/src/main/java/com/datastax/driver/stress/Generators.java
+++ b/driver-examples/stress/src/main/java/com/datastax/driver/stress/Generators.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-examples/stress/src/main/java/com/datastax/driver/stress/QueryGenerator.java
+++ b/driver-examples/stress/src/main/java/com/datastax/driver/stress/QueryGenerator.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-examples/stress/src/main/java/com/datastax/driver/stress/Reporter.java
+++ b/driver-examples/stress/src/main/java/com/datastax/driver/stress/Reporter.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/driver-examples/stress/src/main/java/com/datastax/driver/stress/Stress.java
+++ b/driver-examples/stress/src/main/java/com/datastax/driver/stress/Stress.java
@@ -1,5 +1,5 @@
 /*
- *      Copyright (C) 2012-2014 DataStax Inc.
+ *      Copyright (C) 2012-2015 DataStax Inc.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
     <version>7</version>
-    <relativePath />
+    <relativePath/>
   </parent>
-  
+
   <groupId>com.datastax.cassandra</groupId>
   <artifactId>cassandra-driver-parent</artifactId>
   <version>2.0.10-SNAPSHOT</version>
@@ -27,6 +27,7 @@
   <name>DataStax Java Driver for Apache Cassandra</name>
   <description>A driver for Apache Cassandra 1.2+ that works exclusively with the Cassandra Query Language version 3 (CQL3) and Cassandra's binary protocol.</description>
   <url>https://github.com/datastax/java-driver</url>
+  <inceptionYear>2012</inceptionYear>
 
   <modules>
     <module>driver-core</module>
@@ -59,6 +60,7 @@
       our build is still using JDK 6.
     -->
     <scassandra.version>0.4.1</scassandra.version>
+    <main.basedir>${project.basedir}</main.basedir>
   </properties>
 
   <dependencies>
@@ -95,63 +97,122 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-            <source>${java.version}</source>
-            <target>${java.version}</target>
-            <optimize>true</optimize>
-            <showDeprecation>true</showDeprecation>
-            <showWarnings>true</showWarnings>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <optimize>true</optimize>
+          <showDeprecation>true</showDeprecation>
+          <showWarnings>true</showWarnings>
         </configuration>
       </plugin>
       <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-source-plugin</artifactId>
-          <version>2.2.1</version>
-          <executions>
-            <execution>
-              <id>attach-sources</id>
-              <goals>
-                <goal>jar</goal>
-              </goals>
-            </execution>
-          </executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.9.1</version>
-          <configuration>
-            <!-- I can haz math in my javadoc (see http://zverovich.net/2012/01/14/beautiful-math-in-javadoc.html) -->
-            <additionalparam>-header '&lt;script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"&gt;&lt;/script&gt;'</additionalparam>
-          </configuration>
-          <executions>
-            <execution>
-              <id>attach-javadocs</id>
-              <goals>
-                <goal>jar</goal>
-              </goals>
-              <configuration>
-                <additionalparam>${javadoc.opts}</additionalparam>
-              </configuration>
-            </execution>
-          </executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <configuration>
+          <!-- I can haz math in my javadoc (see http://zverovich.net/2012/01/14/beautiful-math-in-javadoc.html) -->
+          <additionalparam>-header '&lt;script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"&gt;&lt;/script&gt;'</additionalparam>
+        </configuration>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <additionalparam>${javadoc.opts}</additionalparam>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
-      <artifactId>maven-assembly-plugin</artifactId>
-      <version>2.4</version>
-      <configuration>
-        <descriptorRefs>
-          <descriptorRef>jar-with-dependencies</descriptorRef>
-        </descriptorRefs>
-      </configuration>
-    </plugin>
-    <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-release-plugin</artifactId>
-      <version>2.5</version>
-      <configuration>
-        <tagNameFormat>@{project.version}</tagNameFormat>
-      </configuration>
-    </plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.4</version>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5</version>
+        <configuration>
+          <tagNameFormat>@{project.version}</tagNameFormat>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.9.1</version>
+        <executions>
+          <execution>
+            <id>timestamp-property</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>timestamp-property</goal>
+            </goals>
+            <configuration>
+              <name>currentYear</name>
+              <pattern>yyyy</pattern>
+              <locale>en_US</locale>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!--
+      To update license headers run:
+      mvn license:format -DcurrentYear=XXXX
+      -->
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>2.8</version>
+        <configuration>
+          <header>${main.basedir}/src/license/header.txt</header>
+          <includes>
+            <include>src/**/*.java</include>
+            <include>src/**/*.xml</include>
+            <include>src/**/*.properties</include>
+            <include>**/pom.xml</include>
+          </includes>
+          <excludes>
+            <exclude>**/src/main/config/ide/**</exclude>
+          </excludes>
+          <mapping>
+            <java>SLASHSTAR_STYLE</java>
+            <properties>SCRIPT_STYLE</properties>
+          </mapping>
+          <strictCheck>true</strictCheck>
+        </configuration>
+        <executions>
+          <execution>
+            <id>check-license</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <currentYear>${currentYear}</currentYear>
+              </properties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,19 @@
 <!--
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+         Copyright (C) 2012-2015 DataStax Inc.
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License. See accompanying LICENSE file.
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/src/license/header.txt
+++ b/src/license/header.txt
@@ -1,0 +1,13 @@
+     Copyright (C) ${project.inceptionYear}-${currentYear} DataStax Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.


### PR DESCRIPTION
This is un update + introduction of license-maven-plugin.
Since this PR modifies hundreds of files, look at just the first commit for real modifications. All the rest are just license headers being updated.
