### PR TITLE
Make connection and pool creation fully async (JAVA-692).

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedResultSet.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedResultSet.java
@@ -21,7 +21,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingDeque;
 
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -29,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.datastax.driver.core.exceptions.DriverInternalError;
+import com.datastax.driver.core.utils.MoreFutures;
 
 /**
  * Default implementation of a result set, backed by an ArrayDeque of ArrayList.
@@ -178,7 +178,7 @@ abstract class ArrayBackedResultSet implements ResultSet {
         }
 
         public ListenableFuture<Void> fetchMoreResults() {
-            return Futures.immediateFuture(null);
+            return MoreFutures.VOID_SUCCESS;
         }
 
         public ExecutionInfo getExecutionInfo() {
@@ -287,7 +287,7 @@ abstract class ArrayBackedResultSet implements ResultSet {
 
         private ListenableFuture<Void> fetchMoreResults(FetchingState fetchState) {
             if (fetchState == null)
-                return Futures.immediateFuture(null);
+                return MoreFutures.VOID_SUCCESS;
 
             if (fetchState.inProgress != null)
                 return fetchState.inProgress;

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -2275,7 +2275,8 @@ public class Cluster implements Closeable {
         private static final int INTERVAL_MS = 15000;
 
         private final ScheduledExecutorService executor;
-        private final Map<Connection, Long> connections = new ConcurrentHashMap<Connection, Long>();
+        @VisibleForTesting
+        final Map<Connection, Long> connections = new ConcurrentHashMap<Connection, Long>();
 
         private volatile boolean shutdown;
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1474,7 +1474,7 @@ public class Cluster implements Closeable {
 
                 List<ListenableFuture<Boolean>> futures = Lists.newArrayListWithCapacity(sessions.size());
                 for (SessionManager s : sessions)
-                    futures.add(s.forceRenewPool(host, poolCreationExecutor));
+                    futures.add(s.forceRenewPool(host));
 
                 // Only mark the node up once all session have re-added their pool (if the load-balancing
                 // policy says it should), so that Host.isUp() don't return true before we're reconnected
@@ -1507,7 +1507,7 @@ public class Cluster implements Closeable {
                 // Now, check if there isn't pools to create/remove following the addition.
                 // We do that now only so that it's not called before we've set the node up.
                 for (SessionManager s : sessions)
-                    s.updateCreatedPools(blockingExecutor);
+                    s.updateCreatedPools();
 
             } finally {
                 host.notificationsLock.unlock();
@@ -1821,7 +1821,7 @@ public class Cluster implements Closeable {
 
                 List<ListenableFuture<Boolean>> futures = Lists.newArrayListWithCapacity(sessions.size());
                 for (SessionManager s : sessions)
-                    futures.add(s.maybeAddPool(host, blockingExecutor));
+                    futures.add(s.maybeAddPool(host));
 
                 // Only mark the node up once all session have added their pool (if the load-balancing
                 // policy says it should), so that Host.isUp() don't return true before we're reconnected
@@ -1854,7 +1854,7 @@ public class Cluster implements Closeable {
                 // Now, check if there isn't pools to create/remove following the addition.
                 // We do that now only so that it's not called before we've set the node up.
                 for (SessionManager s : sessions)
-                    s.updateCreatedPools(blockingExecutor);
+                    s.updateCreatedPools();
 
             } finally {
                 host.notificationsLock.unlock();
@@ -2203,7 +2203,7 @@ public class Cluster implements Closeable {
                 controlConnection.reconnect();
 
             for (SessionManager s : sessions)
-                s.updateCreatedPools(executor);
+                s.updateCreatedPools();
         }
 
         void refreshConnectedHost(Host host) {
@@ -2213,7 +2213,7 @@ public class Cluster implements Closeable {
                 controlConnection.reconnect();
 
             for (SessionManager s : sessions)
-                s.updateCreatedPools(host, executor);
+                s.updateCreatedPools(host);
         }
 
         private class ClusterCloseFuture extends CloseFuture.Forwarding {

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1819,16 +1819,23 @@ public class Cluster implements Closeable {
 
                 controlConnection.onAdd(host);
 
-                List<ListenableFuture<Void>> futures = Lists.newArrayListWithCapacity(sessions.size());
+                List<ListenableFuture<Boolean>> futures = Lists.newArrayListWithCapacity(sessions.size());
                 for (SessionManager s : sessions)
                     futures.add(s.maybeAddPool(host, blockingExecutor));
 
                 // Only mark the node up once all session have added their pool (if the load-balancing
                 // policy says it should), so that Host.isUp() don't return true before we're reconnected
                 // to the node.
-                ListenableFuture<List<Void>> f = Futures.allAsList(futures);
-                Futures.addCallback(f, new FutureCallback<List<Void>>() {
-                    public void onSuccess(List<Void> poolCreationResults) {
+                ListenableFuture<List<Boolean>> f = Futures.allAsList(futures);
+                Futures.addCallback(f, new FutureCallback<List<Boolean>>() {
+                    public void onSuccess(List<Boolean> poolCreationResults) {
+                        // If any of the creation failed, they will have signaled a connection failure
+                        // which will trigger a reconnection to the node. So don't bother marking UP.
+                        if (Iterables.any(poolCreationResults, Predicates.equalTo(false))) {
+                            logger.debug("Connection pool cannot be created, not marking {} UP", host);
+                            return;
+                        }
+
                         host.setUp();
 
                         for (Host.StateListener listener : listeners)
@@ -1836,7 +1843,9 @@ public class Cluster implements Closeable {
                     }
 
                     public void onFailure(Throwable t) {
-                        logger.debug("Connection pool cannot be created, not marking " + host + " UP", t);
+                        // That future is not really supposed to throw unexpected exceptions
+                        if (!(t instanceof InterruptedException))
+                            logger.error("Unexpected error while adding node: while this shouldn't happen, this shouldn't be critical", t);
                     }
                 });
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1472,16 +1472,23 @@ public class Cluster implements Closeable {
 
                 logger.trace("Adding/renewing host pools for newly UP host {}", host);
 
-                List<ListenableFuture<Void>> futures = Lists.newArrayListWithCapacity(sessions.size());
+                List<ListenableFuture<Boolean>> futures = Lists.newArrayListWithCapacity(sessions.size());
                 for (SessionManager s : sessions)
                     futures.add(s.forceRenewPool(host, poolCreationExecutor));
 
                 // Only mark the node up once all session have re-added their pool (if the load-balancing
                 // policy says it should), so that Host.isUp() don't return true before we're reconnected
                 // to the node.
-                ListenableFuture<List<Void>> f = Futures.allAsList(futures);
-                Futures.addCallback(f, new FutureCallback<List<Void>>() {
-                    public void onSuccess(List<Void> poolCreationResults) {
+                ListenableFuture<List<Boolean>> f = Futures.allAsList(futures);
+                Futures.addCallback(f, new FutureCallback<List<Boolean>>() {
+                    public void onSuccess(List<Boolean> poolCreationResults) {
+                        // If any of the creation failed, they will have signaled a connection failure
+                        // which will trigger a reconnection to the node. So don't bother marking UP.
+                        if (Iterables.any(poolCreationResults, Predicates.equalTo(false))) {
+                            logger.debug("Connection pool cannot be created, not marking {} UP", host);
+                            return;
+                        }
+
                         host.setUp();
 
                         for (Host.StateListener listener : listeners)
@@ -1489,7 +1496,9 @@ public class Cluster implements Closeable {
                     }
 
                     public void onFailure(Throwable t) {
-                        logger.debug("Connection pool cannot be created, not marking " + host + " UP", t);
+                        // That future is not really supposed to throw unexpected exceptions
+                        if (!(t instanceof InterruptedException))
+                            logger.error("Unexpected error while marking node UP: while this shouldn't happen, this shouldn't be critical", t);
                     }
                 });
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.driver.core;
 
+import java.lang.ref.WeakReference;
 import java.net.InetSocketAddress;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -27,6 +28,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
+import com.google.common.collect.MapMaker;
 import com.google.common.util.concurrent.*;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.*;
@@ -752,7 +754,7 @@ class Connection {
     }
 
     private static final class Flusher implements Runnable {
-        final EventLoop eventLoop;
+        final WeakReference<EventLoop> eventLoopRef;
         final Queue<FlushItem> queued = new ConcurrentLinkedQueue<FlushItem>();
         final AtomicBoolean running = new AtomicBoolean(false);
         final HashSet<Channel> channels = new HashSet<Channel>();
@@ -761,12 +763,17 @@ class Connection {
         int runsWithNoWork = 0;
 
         private Flusher(EventLoop eventLoop) {
-            this.eventLoop = eventLoop;
+            this.eventLoopRef = new WeakReference<EventLoop>(eventLoop);
         }
 
         void start() {
             if (!running.get() && running.compareAndSet(false, true)) {
-                this.eventLoop.execute(this);
+                EventLoop eventLoop = eventLoopRef.get();
+                if(eventLoop == null) {
+                    return;
+                } else {
+                    eventLoop.execute(this);
+                }
             }
         }
 
@@ -804,11 +811,17 @@ class Connection {
                 }
             }
 
-            eventLoop.schedule(this, 10000, TimeUnit.NANOSECONDS);
+            EventLoop eventLoop = eventLoopRef.get();
+            if(eventLoop != null) {
+                eventLoop.schedule(this, 10000, TimeUnit.NANOSECONDS);
+            }
         }
     }
 
-    private static final ConcurrentMap<EventLoop, Flusher> flusherLookup = new ConcurrentHashMap<EventLoop, Flusher>();
+    private static final ConcurrentMap<EventLoop, Flusher> flusherLookup = new MapMaker()
+            .concurrencyLevel(16)
+            .weakKeys()
+            .makeMap();
 
     private static class FlushItem {
         final Channel channel;

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -125,16 +125,17 @@ class Connection {
                                 channelReadyFuture.setException(new TransportException(Connection.this.address, "Connection closed during initialization."));
                             }
                         });
-                    }
-                    Connection.this.factory.allChannels.add(channel);
-                    if (!future.isSuccess()) {
-                        if (logger.isDebugEnabled())
-                            logger.debug(String.format("%s Error connecting to %s%s", Connection.this, Connection.this.address, extractMessage(future.cause())));
-                        channelReadyFuture.setException(new TransportException(Connection.this.address, "Cannot connect", future.cause()));
                     } else {
-                        logger.debug("{} Connection opened successfully", Connection.this);
-                        channel.closeFuture().addListener(new ChannelCloseListener());
-                        channelReadyFuture.set(null);
+                        Connection.this.factory.allChannels.add(channel);
+                        if (!future.isSuccess()) {
+                            if (logger.isDebugEnabled())
+                                logger.debug(String.format("%s Error connecting to %s%s", Connection.this, Connection.this.address, extractMessage(future.cause())));
+                            channelReadyFuture.setException(new TransportException(Connection.this.address, "Cannot connect", future.cause()));
+                        } else {
+                            logger.debug("{} Connection opened successfully", Connection.this);
+                            channel.closeFuture().addListener(new ChannelCloseListener());
+                            channelReadyFuture.set(null);
+                        }
                     }
                 }
             });

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -25,9 +25,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.google.common.base.Function;
 import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.AbstractFuture;
-import com.google.common.util.concurrent.Uninterruptibles;
+import com.google.common.util.concurrent.*;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.*;
 import io.netty.channel.group.ChannelGroup;
@@ -47,7 +47,8 @@ import org.slf4j.LoggerFactory;
 import static io.netty.handler.timeout.IdleState.ALL_IDLE;
 
 import com.datastax.driver.core.exceptions.AuthenticationException;
-import com.datastax.driver.core.exceptions.DriverInternalError;
+import com.datastax.driver.core.utils.MoreFutures;
+import com.datastax.driver.core.utils.MoreFutures.FailureCallback;
 
 // For LoggingHandler
 //import org.jboss.netty.handler.logging.LoggingHandler;
@@ -66,7 +67,7 @@ class Connection {
     public final InetSocketAddress address;
     private final String name;
 
-    private final Channel channel;
+    private volatile Channel channel;
     private final Factory factory;
 
     private final Dispatcher dispatcher = new Dispatcher();
@@ -77,28 +78,27 @@ class Connection {
     private final AtomicInteger writer = new AtomicInteger(0);
     private volatile String keyspace;
 
-    private volatile boolean isInitialized;
     private volatile boolean isDefunct;
 
+    final ListenableFuture<Void> initFuture;
     private final AtomicReference<ConnectionCloseFuture> closeFuture = new AtomicReference<ConnectionCloseFuture>();
 
     /**
      * Create a new connection to a Cassandra node.
      *
      * The connection is open and initialized by the constructor.
-     *
-     * @throws ConnectionException if the connection attempts fails or is
-     * refused by the server.
      */
-    protected Connection(String name, InetSocketAddress address, Factory factory) throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException, ClusterNameMismatchException {
+    protected Connection(String name, InetSocketAddress address, Factory factory) {
         this.address = address;
         this.factory = factory;
         this.name = name;
 
+        int protocolVersion = factory.protocolVersion == 1 ? 1 : 2;
+        final SettableFuture<Void> channelReadyFuture = SettableFuture.create();
+
         try {
             Bootstrap bootstrap = factory.newBootstrap();
             ProtocolOptions protocolOptions = factory.configuration.getProtocolOptions();
-            int protocolVersion = factory.protocolVersion == 1 ? 1 : 2;
             bootstrap.handler(
                 new Initializer(this, protocolVersion, protocolOptions.getCompression().compressor(), protocolOptions.getSSLOptions(),
                     factory.configuration.getPoolingOptions().getHeartbeatIntervalSeconds(),
@@ -107,41 +107,40 @@ class Connection {
             ChannelFuture future = bootstrap.connect(address);
 
             writer.incrementAndGet();
-            try {
-                // Wait until the connection attempt succeeds or fails.
-                this.channel = future.awaitUninterruptibly().channel();
-                this.factory.allChannels.add(this.channel);
-                if (!future.isSuccess()) {
-                    if (logger.isDebugEnabled())
-                        logger.debug(String.format("%s Error connecting to %s%s", this, address, extractMessage(future.cause())));
-                    throw defunct(new TransportException(address, "Cannot connect", future.cause()));
+            future.addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture future) throws Exception {
+                    writer.decrementAndGet();
+                    channel = future.channel();
+                    Connection.this.factory.allChannels.add(channel);
+                    if (!future.isSuccess()) {
+                        if (logger.isDebugEnabled())
+                            logger.debug(String.format("%s Error connecting to %s%s", Connection.this, Connection.this.address, extractMessage(future.cause())));
+                        channelReadyFuture.setException(defunct(new TransportException(Connection.this.address, "Cannot connect", future.cause())));
+                    } else {
+                        logger.trace("{} Connection opened successfully", Connection.this);
+                        channel.closeFuture().addListener(new ChannelCloseListener());
+                        channelReadyFuture.set(null);
+                    }
                 }
-                channel.closeFuture().addListener(new ChannelCloseListener());
-            } finally {
-                writer.decrementAndGet();
-            }
-
-            logger.trace("{} Connection opened successfully", this);
-            initializeTransport(protocolVersion, factory.manager.metadata.clusterName);
-            logger.debug("{} Transport initialized and ready", this);
-            isInitialized = true;
-
-        } catch (ConnectionException e) {
-            closeAsync().force();
-            throw e;
-        } catch (ClusterNameMismatchException e) {
-            closeAsync().force();
-            throw e;
-        } catch (UnsupportedProtocolVersionException e) {
-            closeAsync().force();
-            throw e;
-        } catch (InterruptedException e) {
-            closeAsync().force();
-            throw e;
+            });
         } catch (RuntimeException e) {
             closeAsync().force();
             throw e;
         }
+
+        ListeningExecutorService executor = factory.manager.executor;
+        this.initFuture = Futures.transform(channelReadyFuture,
+            onChannelReady(protocolVersion, executor),
+            executor);
+
+        // Make sure the connection gets properly closed if we get an exception during initialization
+        Futures.addCallback(this.initFuture, new FailureCallback<Void>() {
+            @Override
+            public void onFailure(Throwable t) {
+                closeAsync().force();
+            }
+        }, executor);
     }
 
     private static String extractMessage(Throwable t) {
@@ -153,119 +152,165 @@ class Connection {
         return " (" + msg + ')';
     }
 
-    private void initializeTransport(int version, String clusterName) throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException, ClusterNameMismatchException {
-        try {
-            ProtocolOptions.Compression compression = factory.configuration.getProtocolOptions().getCompression();
-            Message.Response response = write(new Requests.Startup(compression)).get();
-            switch (response.type) {
-                case READY:
-                    break;
-                case ERROR:
-                    Responses.Error error = (Responses.Error)response;
-                    // Testing for a specific string is a tad fragile but well, we don't have much choice
-                    if (error.code == ExceptionCode.PROTOCOL_ERROR && error.message.contains("Invalid or unsupported protocol version"))
-                        throw unsupportedProtocolVersionException(version);
-                    throw defunct(new TransportException(address, String.format("Error initializing connection: %s", error.message)));
-                case AUTHENTICATE:
-                    Authenticator authenticator = factory.authProvider.newAuthenticator(address);
-                    if (version == 1)
-                    {
-                        if (authenticator instanceof ProtocolV1Authenticator)
-                            authenticateV1(authenticator);
-                        else
-                            // DSE 3.x always uses SASL authentication backported from protocol v2
-                            authenticateV2(authenticator);
-                    }
-                    else
-                        authenticateV2(authenticator);
-                    break;
-                default:
-                    throw defunct(new TransportException(address, String.format("Unexpected %s response message from server to a STARTUP message", response.type)));
+    private AsyncFunction<Void, Void> onChannelReady(final int protocolVersion, final ListeningExecutorService executor) {
+        return new AsyncFunction<Void, Void>() {
+            @Override
+            public ListenableFuture<Void> apply(Void input) throws Exception {
+                ProtocolOptions.Compression compression = factory.configuration.getProtocolOptions().getCompression();
+                Future startupResponseFuture = write(new Requests.Startup(compression));
+                return Futures.transform(startupResponseFuture,
+                    onStartupResponse(protocolVersion, executor),
+                    executor);
             }
-
-            checkClusterName(clusterName);
-        } catch (BusyConnectionException e) {
-            throw defunct(new DriverInternalError("Newly created connection should not be busy"));
-        } catch (ExecutionException e) {
-            throw defunct(new ConnectionException(address, String.format("Unexpected error during transport initialization (%s)", e.getCause()), e.getCause()));
-        }
+        };
     }
 
-    private UnsupportedProtocolVersionException unsupportedProtocolVersionException(int triedVersion) {
-        logger.debug("Got unsupported protocol version error from {} for version {}", address, triedVersion);
-        return new UnsupportedProtocolVersionException(address, triedVersion);
-    }
-
-    private void authenticateV1(Authenticator authenticator) throws ConnectionException, BusyConnectionException, ExecutionException, InterruptedException {
-        Requests.Credentials creds = new Requests.Credentials(((ProtocolV1Authenticator)authenticator).getCredentials());
-        Message.Response authResponse = write(creds).get();
-        switch (authResponse.type) {
-            case READY:
-                break;
-            case ERROR:
-                throw defunct(new AuthenticationException(address, ((Responses.Error)authResponse).message));
-            default:
-                throw defunct(new TransportException(address, String.format("Unexpected %s response message from server to a CREDENTIALS message", authResponse.type)));
-        }
-    }
-
-    private void authenticateV2(Authenticator authenticator) throws ConnectionException, BusyConnectionException, ExecutionException, InterruptedException {
-        byte[] initialResponse = authenticator.initialResponse();
-        if (null == initialResponse)
-            initialResponse = EMPTY_BYTE_ARRAY;
-
-        Message.Response authResponse = write(new Requests.AuthResponse(initialResponse)).get();
-        waitForAuthCompletion(authResponse, authenticator);
-    }
-
-    private void waitForAuthCompletion(Message.Response authResponse, Authenticator authenticator) throws ConnectionException, BusyConnectionException, ExecutionException, InterruptedException {
-        switch (authResponse.type) {
-            case AUTH_SUCCESS:
-                logger.trace("{} Authentication complete", this);
-                authenticator.onAuthenticationSuccess(((Responses.AuthSuccess)authResponse).token);
-                break;
-            case AUTH_CHALLENGE:
-                byte[] responseToServer = authenticator.evaluateChallenge(((Responses.AuthChallenge)authResponse).token);
-                if (responseToServer == null) {
-                    // If we generate a null response, then authentication has completed, return without
-                    // sending a further response back to the server.
-                    logger.trace("{} Authentication complete (No response to server)", this);
-                    return;
-                } else {
-                    // Otherwise, send the challenge response back to the server
-                    logger.trace("{} Sending Auth response to challenge", this);
-                    waitForAuthCompletion(write(new Requests.AuthResponse(responseToServer)).get(), authenticator);
+    private AsyncFunction<Message.Response, Void> onStartupResponse(final int protocolVersion, final ListeningExecutorService executor) {
+        return new AsyncFunction<Message.Response, Void>() {
+            @Override
+            public ListenableFuture<Void> apply(Message.Response response) throws Exception {
+                switch (response.type) {
+                    case READY:
+                        return checkClusterName(executor);
+                    case ERROR:
+                        Responses.Error error = (Responses.Error)response;
+                        // Testing for a specific string is a tad fragile but well, we don't have much choice
+                        if (error.code == ExceptionCode.PROTOCOL_ERROR && error.message.contains("Invalid or unsupported protocol version"))
+                            throw unsupportedProtocolVersionException(protocolVersion);
+                        throw defunct(new TransportException(address, String.format("Error initializing connection: %s", error.message)));
+                    case AUTHENTICATE:
+                        Authenticator authenticator = factory.authProvider.newAuthenticator(address);
+                        if (protocolVersion == 1)
+                        {
+                            if (authenticator instanceof ProtocolV1Authenticator)
+                                return authenticateV1(authenticator, executor);
+                            else
+                                // DSE 3.x always uses SASL authentication backported from protocol v2
+                                return authenticateV2(authenticator, executor);
+                        }
+                        else
+                            return authenticateV2(authenticator, executor);
+                    default:
+                        throw defunct(new TransportException(address, String.format("Unexpected %s response message from server to a STARTUP message", response.type)));
                 }
-                break;
-            case ERROR:
-                // This is not very nice, but we're trying to identify if we
-                // attempted v2 auth against a server which only supports v1
-                // The AIOOBE indicates that the server didn't recognise the
-                // initial AuthResponse message
-                String message = ((Responses.Error)authResponse).message;
-                if (message.startsWith("java.lang.ArrayIndexOutOfBoundsException: 15"))
-                    message = String.format("Cannot use authenticator %s with protocol version 1, "
-                                  + "only plain text authentication is supported with this protocol version", authenticator);
-                throw defunct(new AuthenticationException(address, message));
-            default:
-                throw defunct(new TransportException(address, String.format("Unexpected %s response message from server to authentication message", authResponse.type)));
-        }
+            }
+        };
     }
 
     // Due to C* gossip bugs, system.peers may report nodes that are gone from the cluster.
     // If these nodes have been recommissionned to another cluster and are up, nothing prevents the driver from connecting
     // to them. So we check that the cluster the node thinks it belongs to is our cluster (JAVA-397).
-    private void checkClusterName(String expected) throws ClusterNameMismatchException, ConnectionException, BusyConnectionException, ExecutionException, InterruptedException {
+    private ListenableFuture<Void> checkClusterName(final ListeningExecutorService executor) {
+        final String expected = factory.manager.metadata.clusterName;
+
         // At initialization, the cluster is not known yet
         if (expected == null)
-            return;
+            return MoreFutures.VOID_SUCCESS;
 
-        DefaultResultSetFuture future = new DefaultResultSetFuture(null,new Requests.Query("select cluster_name from system.local"));
-        write(future);
-        Row row = future.get().one();
-        String actual = row.getString("cluster_name");
-        if (!expected.equals(actual))
-            throw new ClusterNameMismatchException(address, actual, expected);
+        DefaultResultSetFuture clusterNameFuture = new DefaultResultSetFuture(null,new Requests.Query("select cluster_name from system.local"));
+        try {
+            write(clusterNameFuture);
+            return Futures.transform(clusterNameFuture,
+                new AsyncFunction<ResultSet, Void>() {
+                    @Override
+                    public ListenableFuture<Void> apply(ResultSet rs) throws Exception {
+                        Row row = rs.one();
+                        String actual = row.getString("cluster_name");
+                        if (!expected.equals(actual))
+                            throw new ClusterNameMismatchException(address, actual, expected);
+                        return MoreFutures.VOID_SUCCESS;
+                    }
+                },
+                executor);
+        } catch (Exception e) {
+            return Futures.immediateFailedFuture(e);
+        }
+    }
+
+    private ListenableFuture<Void> authenticateV1(Authenticator authenticator, final ListeningExecutorService executor) {
+        Requests.Credentials creds = new Requests.Credentials(((ProtocolV1Authenticator)authenticator).getCredentials());
+        try {
+            Future authResponseFuture = write(creds);
+            return Futures.transform(authResponseFuture,
+                new AsyncFunction<Message.Response, Void>() {
+                    @Override
+                    public ListenableFuture<Void> apply(Message.Response authResponse) throws Exception {
+                        switch (authResponse.type) {
+                            case READY:
+                                return MoreFutures.VOID_SUCCESS;
+                            case ERROR:
+                                throw defunct(new AuthenticationException(address, ((Responses.Error)authResponse).message));
+                            default:
+                                throw defunct(new TransportException(address, String.format("Unexpected %s response message from server to a CREDENTIALS message", authResponse.type)));
+                        }
+                    }
+                },
+                executor);
+        } catch (Exception e) {
+            return Futures.immediateFailedFuture(e);
+        }
+    }
+
+    private ListenableFuture<Void> authenticateV2(final Authenticator authenticator, final ListeningExecutorService executor) {
+        byte[] initialResponse = authenticator.initialResponse();
+        if (null == initialResponse)
+            initialResponse = EMPTY_BYTE_ARRAY;
+
+        try {
+            Future authResponseFuture = write(new Requests.AuthResponse(initialResponse));
+            return Futures.transform(authResponseFuture,
+                onV2AuthResponse(authenticator, executor),
+                executor
+            );
+        } catch (Exception e) {
+            return Futures.immediateFailedFuture(e);
+        }
+    }
+
+    private AsyncFunction<Message.Response, Void> onV2AuthResponse(final Authenticator authenticator, final ListeningExecutorService executor) {
+        return new AsyncFunction<Message.Response, Void>() {
+            @Override
+            public ListenableFuture<Void> apply(Message.Response authResponse) throws Exception {
+                switch (authResponse.type) {
+                    case AUTH_SUCCESS:
+                        logger.trace("{} Authentication complete", this);
+                        authenticator.onAuthenticationSuccess(((Responses.AuthSuccess)authResponse).token);
+                        return MoreFutures.VOID_SUCCESS;
+                    case AUTH_CHALLENGE:
+                        byte[] responseToServer = authenticator.evaluateChallenge(((Responses.AuthChallenge)authResponse).token);
+                        if (responseToServer == null) {
+                            // If we generate a null response, then authentication has completed, return without
+                            // sending a further response back to the server.
+                            logger.trace("{} Authentication complete (No response to server)", this);
+                            return MoreFutures.VOID_SUCCESS;
+                        } else {
+                            // Otherwise, send the challenge response back to the server
+                            logger.trace("{} Sending Auth response to challenge", this);
+                            Future nextResponseFuture = write(new Requests.AuthResponse(responseToServer));
+                            return Futures.transform(nextResponseFuture,
+                                onV2AuthResponse(authenticator, executor),
+                                executor);
+                        }
+                    case ERROR:
+                        // This is not very nice, but we're trying to identify if we
+                        // attempted v2 auth against a server which only supports v1
+                        // The AIOOBE indicates that the server didn't recognise the
+                        // initial AuthResponse message
+                        String message = ((Responses.Error)authResponse).message;
+                        if (message.startsWith("java.lang.ArrayIndexOutOfBoundsException: 15"))
+                            message = String.format("Cannot use authenticator %s with protocol version 1, "
+                                + "only plain text authentication is supported with this protocol version", authenticator);
+                        throw defunct(new AuthenticationException(address, message));
+                    default:
+                        throw defunct(new TransportException(address, String.format("Unexpected %s response message from server to authentication message", authResponse.type)));
+                }
+            }
+        };
+    }
+
+    private UnsupportedProtocolVersionException unsupportedProtocolVersionException(int triedVersion) {
+        logger.debug("Got unsupported protocol version error from {} for version {}", address, triedVersion);
+        return new UnsupportedProtocolVersionException(address, triedVersion);
     }
 
     public boolean isDefunct() {
@@ -297,7 +342,7 @@ class Connection {
                 this instanceof PooledConnection &&
                 (((PooledConnection)this).pool == null || !((PooledConnection)this).pool.isClosed());
 
-            boolean markSuspected = isInitialized && !belongsToReconnectingPool;
+            boolean markSuspected = initFuture.isDone() && !belongsToReconnectingPool;
 
             // This will trigger onDown, including when the defunct Connection is part of a reconnection attempt, which is redundant.
             // This is not too much of a problem since calling onDown on a node that is already down has no effect.
@@ -585,20 +630,59 @@ class Connection {
                 throw new ConnectionException(address, "Connection factory is shut down");
 
             String name = address.toString() + '-' + getIdGenerator(host).getAndIncrement();
-            return new Connection(name, address, this);
+            Connection connection = new Connection(name, address, this);
+            // This method opens the connection synchronously, so wait until it's initialized
+            try {
+                connection.initFuture.get();
+                return connection;
+            } catch (ExecutionException e) {
+                throw launderAsyncInitException(e);
+            }
         }
 
         /**
          * Same as open, but associate the created connection to the provided connection pool.
          */
         public PooledConnection open(HostConnectionPool pool) throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException, ClusterNameMismatchException {
+            try {
+                return openAsync(pool).get();
+            } catch (ExecutionException e) {
+                throw launderAsyncInitException(e);
+            }
+        }
+
+        /**
+         * Same as open, but initializes the connection asynchronously.
+         */
+        public ListenableFuture<PooledConnection> openAsync(HostConnectionPool pool) {
             InetSocketAddress address = pool.host.getSocketAddress();
 
             if (isShutdown)
-                throw new ConnectionException(address, "Connection factory is shut down");
+                return Futures.immediateFailedFuture(new ConnectionException(address, "Connection factory is shut down"));
 
             String name = address.toString() + '-' + getIdGenerator(pool.host).getAndIncrement();
-            return new PooledConnection(name, address, this, pool);
+
+            final PooledConnection connection = new PooledConnection(name, address, this, pool);
+            return Futures.transform(connection.initFuture, new Function<Void, PooledConnection>() {
+                @Override
+                public PooledConnection apply(Void input) {
+                    return connection;
+                }
+            });
+        }
+
+        static RuntimeException launderAsyncInitException(ExecutionException e) throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException, ClusterNameMismatchException {
+            Throwable t = e.getCause();
+            if (t instanceof ConnectionException)
+                throw ((ConnectionException)t);
+            if (t instanceof InterruptedException)
+                throw ((InterruptedException)t);
+            if (t instanceof UnsupportedProtocolVersionException)
+                throw ((UnsupportedProtocolVersionException)t);
+            if (t instanceof ClusterNameMismatchException)
+                throw ((ClusterNameMismatchException)t);
+
+            return new RuntimeException("Unexpected exception during connection initialization", t);
         }
 
         private AtomicInteger getIdGenerator(Host host) {
@@ -871,7 +955,7 @@ class Connection {
         public void operationComplete(ChannelFuture future) throws Exception {
             // If we've closed the channel client side then we don't really want to defunct the connection, but
             // if there is remaining thread waiting on us, we still want to wake them up
-            if (!isInitialized || isClosed()) {
+            if (!initFuture.isDone() || isClosed()) {
                 dispatcher.errorOutAllHandler(new TransportException(address, "Channel has been closed"));
                 // we still want to force so that the future completes
                 Connection.this.closeAsync().force();
@@ -925,7 +1009,7 @@ class Connection {
         public ConnectionCloseFuture force() {
             // Note: we must not call releaseExternalResources on the bootstrap, because this shutdown the executors, which are shared
 
-            // This method can be thrown during Connection ctor, at which point channel is not yet set. This is ok.
+            // This method can be thrown during initialization, at which point channel is not yet set. This is ok.
             if (channel == null) {
                 set(null);
                 return this;

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.google.common.collect.MapMaker;
 import com.google.common.util.concurrent.*;
@@ -107,9 +106,9 @@ class Connection {
             Bootstrap bootstrap = factory.newBootstrap();
             ProtocolOptions protocolOptions = factory.configuration.getProtocolOptions();
             bootstrap.handler(
-                    new Initializer(this, protocolVersion, protocolOptions.getCompression().compressor(), protocolOptions.getSSLOptions(),
-                            factory.configuration.getPoolingOptions().getHeartbeatIntervalSeconds(),
-                            factory.configuration.getNettyOptions()));
+                new Initializer(this, protocolVersion, protocolOptions.getCompression().compressor(), protocolOptions.getSSLOptions(),
+                    factory.configuration.getPoolingOptions().getHeartbeatIntervalSeconds(),
+                    factory.configuration.getNettyOptions()));
 
             ChannelFuture future = bootstrap.connect(address);
 
@@ -119,7 +118,7 @@ class Connection {
                 public void operationComplete(ChannelFuture future) throws Exception {
                     writer.decrementAndGet();
                     channel = future.channel();
-                    if(isClosed()) {
+                    if (isClosed()) {
                         channel.close().addListener(new ChannelFutureListener() {
                             @Override
                             public void operationComplete(ChannelFuture future) throws Exception {
@@ -145,7 +144,7 @@ class Connection {
         }
 
         ListenableFuture<Void> initializeTransportFuture = Futures.transform(channelReadyFuture,
-                onChannelReady(protocolVersion));
+            onChannelReady(protocolVersion));
 
         // Fallback on initializeTransportFuture so we can properly propagate specific exceptions.
         ListenableFuture<Void> initFuture = Futures.withFallback(initializeTransportFuture, new FutureFallback<Void>() {
@@ -160,10 +159,10 @@ class Connection {
                 } else {
                     // Defunct to ensure that the error will be signaled (marking the host down)
                     ConnectionException ce = (t instanceof ConnectionException)
-                            ? (ConnectionException)t
-                            : new ConnectionException(Connection.this.address,
-                            String.format("Unexpected error during transport initialization (%s)", t),
-                            t);
+                        ? (ConnectionException)t
+                        : new ConnectionException(Connection.this.address,
+                        String.format("Unexpected error during transport initialization (%s)", t),
+                        t);
                     future.setException(defunct(ce));
                 }
                 return future;
@@ -179,7 +178,7 @@ class Connection {
 
             @Override
             public void onFailure(Throwable t) {
-                if(!isClosed()) {
+                if (!isClosed()) {
                     closeAsync().force();
                 }
             }
@@ -797,11 +796,8 @@ class Connection {
         void start() {
             if (!running.get() && running.compareAndSet(false, true)) {
                 EventLoop eventLoop = eventLoopRef.get();
-                if(eventLoop == null) {
-                    return;
-                } else {
+                if (eventLoop != null)
                     eventLoop.execute(this);
-                }
             }
         }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 import static io.netty.handler.timeout.IdleState.ALL_IDLE;
 
 import com.datastax.driver.core.exceptions.AuthenticationException;
+import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.utils.MoreFutures;
 import com.datastax.driver.core.utils.MoreFutures.FailureCallback;
 
@@ -674,13 +675,15 @@ class Connection {
         static RuntimeException launderAsyncInitException(ExecutionException e) throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException, ClusterNameMismatchException {
             Throwable t = e.getCause();
             if (t instanceof ConnectionException)
-                throw ((ConnectionException)t);
+                throw (ConnectionException)t;
             if (t instanceof InterruptedException)
-                throw ((InterruptedException)t);
+                throw (InterruptedException)t;
             if (t instanceof UnsupportedProtocolVersionException)
-                throw ((UnsupportedProtocolVersionException)t);
+                throw (UnsupportedProtocolVersionException)t;
             if (t instanceof ClusterNameMismatchException)
-                throw ((ClusterNameMismatchException)t);
+                throw (ClusterNameMismatchException)t;
+            if (t instanceof DriverException)
+                throw (DriverException)t;
 
             return new RuntimeException("Unexpected exception during connection initialization", t);
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -237,7 +237,7 @@ class Connection {
                     public ListenableFuture<Void> apply(Message.Response authResponse) throws Exception {
                         switch (authResponse.type) {
                             case READY:
-                                return MoreFutures.VOID_SUCCESS;
+                                return checkClusterName(executor);
                             case ERROR:
                                 throw defunct(new AuthenticationException(address, ((Responses.Error)authResponse).message));
                             default:
@@ -275,14 +275,14 @@ class Connection {
                     case AUTH_SUCCESS:
                         logger.trace("{} Authentication complete", this);
                         authenticator.onAuthenticationSuccess(((Responses.AuthSuccess)authResponse).token);
-                        return MoreFutures.VOID_SUCCESS;
+                        return checkClusterName(executor);
                     case AUTH_CHALLENGE:
                         byte[] responseToServer = authenticator.evaluateChallenge(((Responses.AuthChallenge)authResponse).token);
                         if (responseToServer == null) {
-                            // If we generate a null response, then authentication has completed, return without
+                            // If we generate a null response, then authentication has completed, proceed without
                             // sending a further response back to the server.
                             logger.trace("{} Authentication complete (No response to server)", this);
-                            return MoreFutures.VOID_SUCCESS;
+                            return checkClusterName(executor);
                         } else {
                             // Otherwise, send the challenge response back to the server
                             logger.trace("{} Sending Auth response to challenge", this);

--- a/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
@@ -249,7 +249,9 @@ class DefaultResultSetFuture extends AbstractFuture<ResultSet> implements Result
         if (!super.cancel(mayInterruptIfRunning))
             return false;
 
-        handler.cancel();
+        if(handler != null) {
+            handler.cancel();
+        }
         return true;
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Host.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Host.java
@@ -27,6 +27,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.datastax.driver.core.utils.MoreFutures;
+
 /**
  * A Cassandra node.
  *
@@ -48,7 +50,7 @@ public class Host {
     private final Cluster.Manager manager;
 
     // Tracks the first "immediate" reconnection attempt when a node get suspected.
-    final AtomicReference<ListenableFuture<?>> initialReconnectionAttempt = new AtomicReference<ListenableFuture<?>>(Futures.immediateFuture(null));
+    final AtomicReference<ListenableFuture<?>> initialReconnectionAttempt = new AtomicReference<ListenableFuture<?>>(MoreFutures.VOID_SUCCESS);
 
     // Tracks later reconnection attempts to that host so we avoid adding multiple tasks.
     final AtomicReference<ListenableFuture<?>> reconnectionAttempt = new AtomicReference<ListenableFuture<?>>();

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -119,7 +119,6 @@ class HostConnectionPool {
 
                 @Override
                 public void onFailure(Throwable t) {
-                    isClosing = true;
                     initFuture.setException(t);
                     forceClose(connectionFutures, manager.executor());
                 }

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -94,7 +94,10 @@ class HostConnectionPool {
 
         this.connections = new CopyOnWriteArrayList<PooledConnection>();
         this.open = new AtomicInteger();
+        this.initFuture = SettableFuture.create();
+    }
 
+    public void initAsync() {
         // Create initial core connections
         final List<ListenableFuture<PooledConnection>> connectionFutures =
             Lists.newArrayListWithCapacity(options().getCoreConnectionsPerHost(hostDistance));
@@ -106,7 +109,6 @@ class HostConnectionPool {
         // We could expose allConnectionsFuture directly so this is a bit superfluous, but it avoids
         // leaking the list of connections.  We also don't want to mark initialization as complete until open
         // has been set.
-        initFuture = SettableFuture.create();
         Futures.addCallback(allConnectionsFuture,
             new FutureCallback<List<PooledConnection>>() {
                 @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -126,16 +126,14 @@ class HostConnectionPool {
                 public void onFailure(Throwable t) {
                     initializationStatus = InitializationStatus.INIT_FAILED;
                     initFuture.setException(t);
-                    forceClose(connectionFutures, manager.executor());
+                    forceClose(connectionFutures);
                 }
-            },
-            manager.executor()
-        );
+            });
 
     }
 
     // Clean up if we got an error at construction time but still created part of the core connections
-    private void forceClose(List<ListenableFuture<PooledConnection>> l, ListeningExecutorService executor) {
+    private void forceClose(List<ListenableFuture<PooledConnection>> l) {
         for (ListenableFuture<PooledConnection> future : l) {
             if (!future.isDone())
                 future.cancel(true);
@@ -144,7 +142,7 @@ class HostConnectionPool {
                 public void onSuccess(PooledConnection connection) {
                     connection.closeAsync().force();
                 }
-            }, executor);
+            });
         }
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -18,10 +18,7 @@ package com.datastax.driver.core;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
@@ -105,6 +102,8 @@ class HostConnectionPool {
             connectionFutures.add(connection.initAsync());
         }
 
+        Executor initExecutor = manager.cluster.manager.configuration.getPoolingOptions().getInitializationExecutor();
+
         ListenableFuture<List<Void>> allConnectionsFuture = Futures.allAsList(connectionFutures);
 
         final SettableFuture<Void> initFuture = SettableFuture.create();
@@ -131,7 +130,7 @@ class HostConnectionPool {
                 forceClose(connections);
                 initFuture.setException(t);
             }
-        });
+        }, initExecutor);
         return initFuture;
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/PooledConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PooledConnection.java
@@ -31,7 +31,7 @@ class PooledConnection extends Connection {
 
     volatile long maxIdleTime;
 
-    PooledConnection(String name, InetSocketAddress address, Factory factory, HostConnectionPool pool) throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException, ClusterNameMismatchException {
+    PooledConnection(String name, InetSocketAddress address, Factory factory, HostConnectionPool pool) {
         super(name, address, factory);
         this.pool = pool;
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -206,11 +206,11 @@ class SessionManager extends AbstractSession {
             return Futures.immediateFuture(false);
 
         final HostConnectionPool newPool = new HostConnectionPool(host, distance, SessionManager.this);
-        newPool.initAsync();
+        ListenableFuture<Void> poolInitFuture = newPool.initAsync();
 
         final SettableFuture<Boolean> future = SettableFuture.create();
 
-        Futures.addCallback(newPool.initFuture, new FutureCallback<Void>() {
+        Futures.addCallback(poolInitFuture, new FutureCallback<Void>() {
             @Override
             public void onSuccess(Void result) {
                 // If we raced with a session shutdown, ensure that the pool will be closed.
@@ -261,9 +261,9 @@ class SessionManager extends AbstractSession {
             }
         }
 
-        newPool.initAsync();
+        ListenableFuture<Void> poolInitFuture = newPool.initAsync();
 
-        Futures.addCallback(newPool.initFuture, new FutureCallback<Void>() {
+        Futures.addCallback(poolInitFuture, new FutureCallback<Void>() {
             @Override
             public void onSuccess(Void result) {
                 // If we raced with a session shutdown, ensure that the pool will be closed.
@@ -278,7 +278,7 @@ class SessionManager extends AbstractSession {
                 pools.remove(host);
             }
         });
-        return newPool.initFuture;
+        return poolInitFuture;
     }
 
     // Returns whether there was problem creating the pool

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -24,6 +24,7 @@ import java.util.concurrent.locks.Lock;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +34,8 @@ import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.datastax.driver.core.exceptions.UnsupportedFeatureException;
 import com.datastax.driver.core.policies.LoadBalancingPolicy;
 import com.datastax.driver.core.policies.ReconnectionPolicy;
+import com.datastax.driver.core.utils.MoreFutures;
+import com.datastax.driver.core.utils.MoreFutures.FailureCallback;
 
 /**
  * Driver implementation of the Session interface.
@@ -67,14 +70,7 @@ class SessionManager extends AbstractSession {
 
         // Create pools to initial nodes (and wait for them to be created)
         Collection<Host> hosts = cluster.getMetadata().allHosts();
-        if (cluster.manager.sessions.size() == 1) {
-            // We only do it in parallel if this is the first session (meaning that the cluster just initialized).
-            createPoolsInParallel(hosts);
-        } else {
-            // Otherwise, we don't want to fill executor() because this is also where up/down notifications are processed,
-            // it's important that existing sessions get them in a timely manner. So we create the pools one by one:
-            createPoolsSequentially(hosts);
-        }
+        createPoolsInParallel(hosts);
 
         isInit = true;
         updateCreatedPools(executor());
@@ -82,32 +78,17 @@ class SessionManager extends AbstractSession {
     }
 
     private void createPoolsInParallel(Collection<Host> hosts) {
-        List<ListenableFuture<Boolean>> futures = new ArrayList<ListenableFuture<Boolean>>(hosts.size());
+        List<ListenableFuture<Void>> futures = Lists.newArrayListWithCapacity(hosts.size());
         for (Host host : hosts)
             if (host.state != Host.State.DOWN)
                 futures.add(maybeAddPool(host, executor()));
-        ListenableFuture<List<Boolean>> f = Futures.allAsList(futures);
         try {
-            f.get();
+            Futures.successfulAsList(futures).get();
         } catch (ExecutionException e) {
-            // This is not supposed to happen
-            throw new DriverInternalError(e);
+            // Won't happen because we used successfulAsList
+            // And if a particular pool failed, maybeAddPool already handled it
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-        }
-    }
-
-    private void createPoolsSequentially(Collection<Host> hosts) {
-        for (Host host : cluster.getMetadata().allHosts()) {
-            try {
-                if (host.state != Host.State.DOWN)
-                    maybeAddPool(host, executor()).get();
-            } catch (ExecutionException e) {
-                // This is not supposed to happen
-                throw new DriverInternalError(e);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
         }
     }
 
@@ -214,41 +195,36 @@ class SessionManager extends AbstractSession {
         return cluster.manager.blockingExecutor;
     }
 
-    // Returns whether there was problem creating the pool
-    ListenableFuture<Boolean> forceRenewPool(final Host host, ListeningExecutorService executor) {
+    // Returns a failed future if there was problem creating the pool
+    ListenableFuture<Void> forceRenewPool(final Host host, ListeningExecutorService executor) {
         final HostDistance distance = cluster.manager.loadBalancingPolicy().distance(host);
         if (distance == HostDistance.IGNORED)
-            return Futures.immediateFuture(true);
+            return MoreFutures.VOID_SUCCESS;
 
-        // Creating a pool is somewhat long since it has to create the connection, so do it asynchronously.
-        return executor.submit(new Callable<Boolean>() {
-            public Boolean call() {
-                while (true) {
-                    try {
-                        if (isClosing)
-                            return true;
+        if (isClosing)
+            return MoreFutures.VOID_SUCCESS;
 
-                        HostConnectionPool newPool = new HostConnectionPool(host, distance, SessionManager.this);
-                        HostConnectionPool previous = pools.put(host, newPool);
-                        if (previous == null) {
-                            logger.debug("Added connection pool for {}", host);
-                        } else {
-                            logger.debug("Renewed connection pool for {}", host);
-                            previous.closeAsync();
-                        }
+        HostConnectionPool newPool = new HostConnectionPool(host, distance, SessionManager.this);
+        HostConnectionPool previous = pools.put(host, newPool);
+        if (previous == null) {
+            logger.debug("Added connection pool for {}", host);
+        } else {
+            logger.debug("Renewed connection pool for {}", host);
+            previous.closeAsync();
+        }
 
-                        // If we raced with a session shutdown, ensure that the pool will be closed.
-                        if (isClosing)
-                            newPool.closeAsync();
+        // If we raced with a session shutdown, ensure that the pool will be closed.
+        if (isClosing)
+            newPool.closeAsync();
 
-                        return true;
-                    } catch (Exception e) {
-                        logger.error("Error creating pool to " + host, e);
-                        return false;
-                    }
-                }
+        Futures.addCallback(newPool.initFuture, new FailureCallback<Void>() {
+            @Override
+            public void onFailure(Throwable t) {
+                logger.error("Error creating pool to " + host, t);
             }
         });
+
+        return newPool.initFuture;
     }
 
     // Replace pool for a given only if it's the given previous value (which can be null)
@@ -256,16 +232,17 @@ class SessionManager extends AbstractSession {
     // maybeAddPool don't end up creating 2 HostConnectionPool. We can't rely on the pools
     // ConcurrentMap only for that since it's the duplicate HostConnectionPool creation we
     // want to avoid
-    private boolean replacePool(Host host, HostDistance distance, HostConnectionPool condition) throws ConnectionException, UnsupportedProtocolVersionException, ClusterNameMismatchException {
+    // This returns a future if the replacement was successful, or null if we raced.
+    private ListenableFuture<Void> replacePool(Host host, HostDistance distance, HostConnectionPool condition) {
         if (isClosing)
-            return true;
+            return MoreFutures.VOID_SUCCESS;
 
         Lock l = poolCreationLocks.get(host);
         l.lock();
         try {
             HostConnectionPool previous = pools.get(host);
             if (previous != condition)
-                return false;
+                return null;
 
             HostConnectionPool newPool = new HostConnectionPool(host, distance, this);
             previous = pools.put(host, newPool);
@@ -275,53 +252,53 @@ class SessionManager extends AbstractSession {
             }
 
             // If we raced with a session shutdown, ensure that the pool will be closed.
-            if (isClosing)
+            if (isClosing) {
                 newPool.closeAsync();
+                return MoreFutures.VOID_SUCCESS;
+            }
 
-            return true;
+            return newPool.initFuture;
         } finally {
             l.unlock();
         }
     }
 
-    // Returns whether there was problem creating the pool
-    ListenableFuture<Boolean> maybeAddPool(final Host host, ListeningExecutorService executor) {
+    // Returns a failed future if there was problem creating the pool
+    ListenableFuture<Void> maybeAddPool(final Host host, ListeningExecutorService executor) {
         final HostDistance distance = cluster.manager.loadBalancingPolicy().distance(host);
         if (distance == HostDistance.IGNORED)
-            return Futures.immediateFuture(true);
+            return MoreFutures.VOID_SUCCESS;
 
         HostConnectionPool previous = pools.get(host);
         if (previous != null && !previous.isClosed())
-            return Futures.immediateFuture(true);
+            return MoreFutures.VOID_SUCCESS;
 
-        // Creating a pool is somewhat long since it has to create the connection, so do it asynchronously.
-        return executor.submit(new Callable<Boolean>() {
-            public Boolean call() {
-                try {
-                    while (true) {
-                        HostConnectionPool previous = pools.get(host);
-                        if (previous != null && !previous.isClosed())
-                            return true;
+        while (true) {
+            previous = pools.get(host);
+            if (previous != null && !previous.isClosed())
+                return MoreFutures.VOID_SUCCESS;
 
-                        if (replacePool(host, distance, previous)) {
-                            logger.debug("Added connection pool for {}", host);
-                            return true;
+            ListenableFuture<Void> newPoolInit = replacePool(host, distance, previous);
+            if (newPoolInit != null) {
+                logger.debug("Added connection pool for {}", host);
+                Futures.addCallback(newPoolInit, new FailureCallback<Void>() {
+                    @Override
+                    public void onFailure(Throwable t) {
+                        if (t instanceof UnsupportedProtocolVersionException) {
+                            cluster.manager.logUnsupportedVersionProtocol(host);
+                            cluster.manager.triggerOnDown(host, false);
+                        } else if (t instanceof ClusterNameMismatchException) {
+                            ClusterNameMismatchException e = (ClusterNameMismatchException)t;
+                            cluster.manager.logClusterNameMismatch(host, e.expectedClusterName, e.actualClusterName);
+                            cluster.manager.triggerOnDown(host, false);
+                        } else {
+                            logger.error("Error creating pool to " + host, t);
                         }
                     }
-                } catch (UnsupportedProtocolVersionException e) {
-                    cluster.manager.logUnsupportedVersionProtocol(host);
-                    cluster.manager.triggerOnDown(host, false);
-                    return false;
-                } catch (ClusterNameMismatchException e) {
-                    cluster.manager.logClusterNameMismatch(host, e.expectedClusterName, e.actualClusterName);
-                    cluster.manager.triggerOnDown(host, false);
-                    return false;
-                } catch (Exception e) {
-                    logger.error("Error creating pool to " + host, e);
-                    return false;
-                }
+                }, executor);
+                return newPoolInit;
             }
-        });
+        }
     }
 
     CloseFuture removePool(Host host) {
@@ -371,7 +348,12 @@ class SessionManager extends AbstractSession {
             }
 
             // Wait pool creation before removing, so we don't lose connectivity
-            Futures.allAsList(poolCreationFutures).get();
+            try {
+                Futures.successfulAsList(poolCreationFutures).get();
+            } catch (ExecutionException e) {
+                // Won't happen because we used successfulAsList
+                // And if a particular pool failed, maybeAddPool already handled it
+            }
 
             List<ListenableFuture<?>> poolRemovalFutures = new ArrayList<ListenableFuture<?>>(toRemove.size());
             for (Host h : toRemove)
@@ -392,7 +374,11 @@ class SessionManager extends AbstractSession {
         try {
             if (pool == null) {
                 if (dist != HostDistance.IGNORED && h.state == Host.State.UP)
-                    maybeAddPool(h, executor).get();
+                    try {
+                        maybeAddPool(h, executor).get();
+                    } catch (ExecutionException e) {
+                        // Ignore, maybeAddPool has already handled the error
+                    }
             } else if (dist != pool.hostDistance) {
                 if (dist == HostDistance.IGNORED) {
                     removePool(h).get();

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -74,7 +74,7 @@ class SessionManager extends AbstractSession {
         createPoolsInParallel(hosts);
 
         isInit = true;
-        updateCreatedPools(executor());
+        updateCreatedPools();
         return this;
     }
 
@@ -82,7 +82,7 @@ class SessionManager extends AbstractSession {
         List<ListenableFuture<Boolean>> futures = Lists.newArrayListWithCapacity(hosts.size());
         for (Host host : hosts)
             if (host.state != Host.State.DOWN)
-                futures.add(maybeAddPool(host, executor()));
+                futures.add(maybeAddPool(host));
         try {
             Futures.successfulAsList(futures).get();
         } catch (ExecutionException e) {
@@ -197,7 +197,7 @@ class SessionManager extends AbstractSession {
     }
 
     // Returns whether there was problem creating the pool
-    ListenableFuture<Boolean> forceRenewPool(final Host host, ListeningExecutorService executor) {
+    ListenableFuture<Boolean> forceRenewPool(final Host host) {
         final HostDistance distance = cluster.manager.loadBalancingPolicy().distance(host);
         if (distance == HostDistance.IGNORED)
             return Futures.immediateFuture(true);
@@ -282,7 +282,7 @@ class SessionManager extends AbstractSession {
     }
 
     // Returns whether there was problem creating the pool
-    ListenableFuture<Boolean> maybeAddPool(final Host host, ListeningExecutorService executor) {
+    ListenableFuture<Boolean> maybeAddPool(final Host host) {
         final HostDistance distance = cluster.manager.loadBalancingPolicy().distance(host);
         if (distance == HostDistance.IGNORED)
             return Futures.immediateFuture(true);
@@ -320,7 +320,7 @@ class SessionManager extends AbstractSession {
                         }
                         future.set(false);
                     }
-                }, executor);
+                });
                 return future;
             }
         }
@@ -342,7 +342,7 @@ class SessionManager extends AbstractSession {
      * This method ensures that all hosts for which a pool should exist
      * have one, and hosts that shouldn't don't.
      */
-    void updateCreatedPools(ListeningExecutorService executor) {
+    void updateCreatedPools() {
         // This method does nothing during initialization. Some hosts may be non-responsive but not yet marked DOWN; if
         // we execute the code below we would try to create their pool over and over again.
         // It's called explicitly at the end of init(), once isInit has been set to true.
@@ -361,7 +361,7 @@ class SessionManager extends AbstractSession {
 
                 if (pool == null) {
                     if (dist != HostDistance.IGNORED && h.state == Host.State.UP)
-                        poolCreationFutures.add(maybeAddPool(h, executor));
+                        poolCreationFutures.add(maybeAddPool(h));
                 } else if (dist != pool.hostDistance) {
                     if (dist == HostDistance.IGNORED) {
                         toRemove.add(h);
@@ -392,7 +392,7 @@ class SessionManager extends AbstractSession {
         }
     }
 
-    void updateCreatedPools(Host h, ListeningExecutorService executor) {
+    void updateCreatedPools(Host h) {
         HostDistance dist = loadBalancingPolicy().distance(h);
         HostConnectionPool pool = pools.get(h);
 
@@ -400,7 +400,7 @@ class SessionManager extends AbstractSession {
             if (pool == null) {
                 if (dist != HostDistance.IGNORED && h.state == Host.State.UP)
                     try {
-                        maybeAddPool(h, executor).get();
+                        maybeAddPool(h).get();
                     } catch (ExecutionException e) {
                         // Ignore, maybeAddPool has already handled the error
                     }
@@ -423,7 +423,7 @@ class SessionManager extends AbstractSession {
         // Note that with well behaved balancing policy (that ignore dead nodes), the removePool call is not necessary
         // since updateCreatedPools should take care of it. But better protect against non well behaving policies.
         removePool(host).force().get();
-        updateCreatedPools(MoreExecutors.sameThreadExecutor());
+        updateCreatedPools();
     }
 
     void onSuspected(Host host) {

--- a/driver-core/src/main/java/com/datastax/driver/core/utils/MoreFutures.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/utils/MoreFutures.java
@@ -1,3 +1,18 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package com.datastax.driver.core.utils;
 
 import com.google.common.util.concurrent.FutureCallback;

--- a/driver-core/src/main/java/com/datastax/driver/core/utils/MoreFutures.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/utils/MoreFutures.java
@@ -1,0 +1,31 @@
+package com.datastax.driver.core.utils;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
+/**
+ * Helpers to work with Guava's {@link ListenableFuture}.
+ */
+public class MoreFutures {
+    /**
+     * An immediate successful {@code ListenableFuture<Void>}.
+     */
+    public static final ListenableFuture<Void> VOID_SUCCESS = Futures.immediateFuture(null);
+
+    /**
+     * A {@link FutureCallback} that does nothing on failure.
+     */
+    public static abstract class SuccessCallback<V> implements FutureCallback<V> {
+        @Override
+        public void onFailure(Throwable t) { /* nothing */ }
+    }
+
+    /**
+     * A {@link FutureCallback} that does nothing on success.
+     */
+    public static abstract class FailureCallback<V> implements FutureCallback<V> {
+        @Override
+        public void onSuccess(V result) { /* nothing */ }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -489,7 +489,7 @@ public class CCMBridge {
 
                     ports = new int[5];
                     for (int i = 0; i < 5; i++) {
-                        ports[i] = TestUtils.findAvailablePort(10000 + i);
+                        ports[i] = TestUtils.findAvailablePort(11000 + i);
                     }
 
                     ccmBridge.bootstrapNodeWithPorts(1, ports[0], ports[1], ports[2], ports[3], ports[4]);

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
@@ -1,0 +1,228 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.utils.SocketChannelMonitor;
+import com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.testng.Assert.assertEquals;
+
+public class ClusterStressTest extends CCMBridge.PerClassSingleNodeCluster {
+    private static final Logger logger = LoggerFactory.getLogger(ClusterStressTest.class);
+
+    private ExecutorService executorService;
+
+    public ClusterStressTest() {
+        // 8 threads should be enough so that we stress the driver and not the OS thread scheduler
+        executorService = Executors.newFixedThreadPool(8);
+    }
+
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return new ArrayList<String>(0);
+    }
+
+    @Test(groups = "long")
+    public void clusters_should_not_leak_connections() {
+        int numberOfClusters = 10;
+        int numberOfIterations = 500;
+        for (int i = 1; i < numberOfIterations; i++) {
+            logger.info("On iteration {}/{}.", i, numberOfIterations);
+            logger.info("Creating {} clusters", numberOfClusters);
+            List<CreateClusterAndCheckConnections> actions =
+                    waitForCreates(createClustersConcurrently(numberOfClusters));
+            waitForCloses(closeClustersConcurrently(actions));
+            logger.debug("# {} threads currently running", Thread.getAllStackTraces().keySet().size());
+        }
+    }
+
+    private List<Future<CreateClusterAndCheckConnections>> createClustersConcurrently(int numberOfClusters) {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        return createClustersConcurrently(numberOfClusters, countDownLatch);
+    }
+
+    private List<Future<CreateClusterAndCheckConnections>> createClustersConcurrently(int numberOfClusters,
+                                                                                      CountDownLatch countDownLatch) {
+        List<Future<CreateClusterAndCheckConnections>> clusterFutures =
+                Lists.newArrayListWithCapacity(numberOfClusters);
+        for (int i = 0; i < numberOfClusters; i++) {
+            clusterFutures.add(executorService.submit(new CreateClusterAndCheckConnections(countDownLatch)));
+        }
+        countDownLatch.countDown();
+        return clusterFutures;
+    }
+
+    private List<Future<Void>> closeClustersConcurrently(List<CreateClusterAndCheckConnections> actions) {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        return closeClustersConcurrently(actions, countDownLatch);
+    }
+
+    private List<Future<Void>> closeClustersConcurrently(List<CreateClusterAndCheckConnections> actions,
+                                                         CountDownLatch startSignal) {
+        List<Future<Void>> closeFutures = Lists.newArrayListWithCapacity(actions.size());
+        for (CreateClusterAndCheckConnections action : actions) {
+            closeFutures.add(executorService.submit(new CloseCluster(action.cluster, action.channelMonitor,
+                    startSignal)));
+        }
+        startSignal.countDown();
+        return closeFutures;
+    }
+
+    private List<CreateClusterAndCheckConnections> waitForCreates(
+            List<Future<CreateClusterAndCheckConnections>> futures) {
+        List<CreateClusterAndCheckConnections> actions = Lists.newArrayListWithCapacity(futures.size());
+        // If an error occurs, we will abort the test, but we still want to close all the clusters
+        // that were opened successfully, so we iterate over the whole list no matter what.
+        AssertionError error = null;
+        for (Future<CreateClusterAndCheckConnections> future : futures) {
+            try {
+                actions.add(future.get());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                if (error == null)
+                    error = assertionError("Interrupted while waiting for future creation", e);
+            } catch (ExecutionException e) {
+                if (error == null) {
+                    Throwable cause = e.getCause();
+                    if (cause instanceof AssertionError)
+                        error = (AssertionError)cause;
+                    else
+                        error = assertionError("Error while creating a cluster", cause);
+                }
+            }
+        }
+        if (error != null) {
+            for (CreateClusterAndCheckConnections action : actions)
+                action.cluster.close();
+            throw error;
+        } else
+            return actions;
+    }
+
+    private List<Void> waitForCloses(List<Future<Void>> futures) {
+        List<Void> result = new ArrayList<Void>(futures.size());
+        AssertionError error = null;
+        for (Future<Void> future : futures) {
+            try {
+                result.add(future.get());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                if (error == null)
+                    error = assertionError("Interrupted while waiting for future", e);
+            } catch (ExecutionException e) {
+                if (error == null) {
+                    Throwable cause = e.getCause();
+                    if (cause instanceof AssertionError)
+                        error = (AssertionError)cause;
+                    else
+                        error = assertionError("Error while closing a cluster", cause);
+                }
+            }
+        }
+        if (error != null)
+            throw error;
+        else
+            return result;
+    }
+
+    private static class CreateClusterAndCheckConnections implements Callable<CreateClusterAndCheckConnections> {
+        private final CountDownLatch startSignal;
+        private final Cluster cluster;
+        private final SocketChannelMonitor channelMonitor = new SocketChannelMonitor();
+        private final List<InetSocketAddress> contactPoints = Collections.singletonList(hostAddress);
+
+        CreateClusterAndCheckConnections(CountDownLatch startSignal) {
+            this.startSignal = startSignal;
+            this.cluster = Cluster.builder().addContactPointsWithPorts(contactPoints)
+                    .withPoolingOptions(new PoolingOptions().setCoreConnectionsPerHost(HostDistance.LOCAL, 1))
+                    .withNettyOptions(channelMonitor.nettyOptions()).build();
+        }
+
+        @Override
+        public CreateClusterAndCheckConnections call() throws Exception {
+            startSignal.await();
+
+            try {
+                // There should be 1 control connection after initializing.
+                cluster.init();
+                assertEquals(cluster.manager.sessions.size(), 0);
+                assertEquals((int)cluster.getMetrics().getOpenConnections().getValue(), 1);
+                assertEquals(channelMonitor.openChannels(contactPoints).size(), 1);
+
+                // The first session initializes the cluster and its control connection
+                Session session = cluster.connect();
+                assertEquals(cluster.manager.sessions.size(), 1);
+                assertEquals((int)cluster.getMetrics().getOpenConnections().getValue(), 1 + TestUtils.numberOfLocalCoreConnections(cluster));
+                assertEquals(channelMonitor.openChannels(contactPoints).size(), 1 + TestUtils.numberOfLocalCoreConnections(cluster));
+
+                // Closing the session keeps the control connection opened
+                session.close();
+                assertEquals(cluster.manager.sessions.size(), 0);
+                assertEquals((int)cluster.getMetrics().getOpenConnections().getValue(), 1);
+                assertEquals(channelMonitor.openChannels(contactPoints).size(), 1);
+
+                return this;
+            } catch (AssertionError e) {
+                // If an assertion fails, close the cluster now, because it's the last time we
+                // have a reference to it.
+                cluster.close();
+                throw e;
+            } finally {
+                channelMonitor.stop();
+            }
+        }
+    }
+
+    private static class CloseCluster implements Callable<Void> {
+        private final Cluster cluster;
+        private final SocketChannelMonitor channelMonitor;
+        private final CountDownLatch startSignal;
+
+        CloseCluster(Cluster cluster, SocketChannelMonitor channelMonitor, CountDownLatch startSignal) {
+            this.cluster = cluster;
+            this.channelMonitor = channelMonitor;
+            this.startSignal = startSignal;
+        }
+
+        @Override
+        public Void call() throws Exception {
+            startSignal.await();
+
+            cluster.close();
+            assertEquals(cluster.manager.sessions.size(), 0);
+            assertEquals(channelMonitor.openChannels(Collections.singletonList(hostAddress)).size(), 0);
+            channelMonitor.stop();
+
+            return null;
+        }
+    }
+
+    private static AssertionError assertionError(String message, Throwable cause) {
+        AssertionError error = new AssertionError(message);
+        error.initCause(cause);
+        return error;
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/PoolingOptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PoolingOptionsTest.java
@@ -15,98 +15,73 @@
  */
 package com.datastax.driver.core;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-
-import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
-import com.datastax.driver.core.Host.State;
-import com.datastax.driver.core.policies.ConstantReconnectionPolicy;
-import com.datastax.driver.core.policies.LimitingLoadBalancingPolicy;
-import com.datastax.driver.core.policies.RoundRobinPolicy;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.*;
 
-import static com.datastax.driver.core.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
 
-public class PoolingOptionsTest {
+public class PoolingOptionsTest extends CCMBridge.PerClassSingleNodeCluster {
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return Collections.emptyList();
+    }
 
     /**
-     * Tests {@link PoolingOptions#refreshConnectedHost(Host)} through a custom load balancing policy.
+     * <p>
+     * Validates that if a custom executor is provided via {@link PoolingOptions#setInitializationExecutor} that it
+     * is used to create and tear down connections.
+     * </p>
+     *
+     * @test_category connection:connection_pool
+     * @expected_result executor is used and successfully able to connect and tear down connections.
+     * @jira_ticket JAVA-692
+     * @since 2.0.10, 2.1.6
      */
-    @Test(groups = "long")
-    public void should_refresh_single_connected_host() {
-        CCMBridge ccm = null;
-        Cluster cluster = null;
+    @Test(groups = "short")
+    public void should_be_able_to_use_custom_initialization_executor() {
+        ThreadPoolExecutor executor = spy(new ThreadPoolExecutor(1, 1, 60, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<Runnable>()));
+
+        PoolingOptions poolingOptions = new PoolingOptions();
+        poolingOptions.setInitializationExecutor(executor);
+
+        Cluster cluster = Cluster.builder()
+                .addContactPointsWithPorts(Collections.singletonList(hostAddress))
+                .withPoolingOptions(poolingOptions).build();
         try {
-            // This will make the driver use at most 2 hosts, the others will be ignored
-            LimitingLoadBalancingPolicy loadBalancingPolicy = new LimitingLoadBalancingPolicy(new RoundRobinPolicy(), 2, 1);
+            cluster.init();
+            // Ensure executor used.
+            verify(executor, atLeastOnce()).execute(any(Runnable.class));
 
-            // Setup a 3-host cluster, start only two hosts so that we know in advance which ones the policy will use
-            ccm = CCMBridge.create("test");
-            ccm.populate(3);
-            ccm.start(1);
-            ccm.start(2);
-            ccm.waitForUp(1);
-            ccm.waitForUp(2);
-
-            PoolingOptions poolingOptions = Mockito.spy(new PoolingOptions());
-            cluster = Cluster.builder()
-                             .addContactPoint(CCMBridge.ipOfNode(1))
-                             .withPoolingOptions(poolingOptions)
-                             .withLoadBalancingPolicy(loadBalancingPolicy)
-                             .withReconnectionPolicy(new ConstantReconnectionPolicy(1000))
-                             .build();
+            // Reset invocation count.
+            reset();
 
             Session session = cluster.connect();
 
-            assertThat(cluster).usesControlHost(1);
-            assertThat(cluster).host(1)
-                               .hasState(State.UP)
-                               .isAtDistance(HostDistance.LOCAL);
-            // Wait for the node to be up, because apparently on Jenkins it's still only ADDED when we reach this line
-            // Waiting for NEW_NODE_DELAY_SECONDS+1 allows the driver to create a connection pool and mark the node up
-            assertThat(cluster).host(2)
-                               .comesUpWithin(Cluster.NEW_NODE_DELAY_SECONDS+1, SECONDS)
-                               .isAtDistance(HostDistance.LOCAL);
+            // Ensure executor used again to establish core connections.
+            verify(executor, atLeastOnce()).execute(any(Runnable.class));
 
-            // Bring host 3 up, its presence should be acknowledged but it should be ignored
-            ccm.start(3);
-            ccm.waitForUp(3);
+            // Expect core connections + control connection.
+            assertThat(cluster.getMetrics().getOpenConnections().getValue()).isEqualTo(
+                    TestUtils.numberOfLocalCoreConnections(cluster) + 1);
 
-            assertThat(cluster).host(1)
-                               .hasState(State.UP)
-                               .isAtDistance(HostDistance.LOCAL);
-            assertThat(cluster).host(2)
-                               .hasState(State.UP)
-                               .isAtDistance(HostDistance.LOCAL);
-            assertThat(cluster).host(3)
-                               .comesUpWithin(Cluster.NEW_NODE_DELAY_SECONDS+1, SECONDS)
-                               .isAtDistance(HostDistance.IGNORED);
-            assertThat(session).hasNoPoolFor(3);
+            reset();
 
-            // Kill host 2, host 3 should take its place
-            ccm.stop(2);
-            TestUtils.waitFor(CCMBridge.ipOfNode(3), cluster);
+            session.close();
 
-            assertThat(cluster).host(1)
-                               .hasState(State.UP)
-                               .isAtDistance(HostDistance.LOCAL);
-            assertThat(cluster).host(2)
-                               .hasState(State.DOWN);
-            assertThat(cluster).host(3)
-                               .hasState(State.UP)
-                               .isAtDistance(HostDistance.LOCAL);
-            assertThat(session).hasPoolFor(3);
+            // Executor should have been used to close connections associated with the session.
+            verify(executor, atLeastOnce()).execute(any(Runnable.class));
 
-            // This is when refreshConnectedHost should have been invoked, it triggers pool creation when
-            // we switch the node from IGNORED to UP:
-            Mockito.verify(poolingOptions)
-                   .refreshConnectedHost(TestUtils.findHost(cluster, 3));
-
+            // Only the control connection should remain.
+            assertThat(cluster.getMetrics().getOpenConnections().getValue()).isEqualTo(1);
         } finally {
-            if (cluster != null)
-                cluster.close();
-            if (ccm != null)
-                ccm.remove();
+            cluster.close();
+            executor.shutdown();
         }
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/RefreshConnectedHostTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RefreshConnectedHostTest.java
@@ -1,0 +1,112 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import com.datastax.driver.core.Host.State;
+import com.datastax.driver.core.policies.ConstantReconnectionPolicy;
+import com.datastax.driver.core.policies.LimitingLoadBalancingPolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+
+public class RefreshConnectedHostTest {
+
+    /**
+     * Tests {@link PoolingOptions#refreshConnectedHost(Host)} through a custom load balancing policy.
+     */
+    @Test(groups = "long")
+    public void should_refresh_single_connected_host() {
+        CCMBridge ccm = null;
+        Cluster cluster = null;
+        try {
+            // This will make the driver use at most 2 hosts, the others will be ignored
+            LimitingLoadBalancingPolicy loadBalancingPolicy = new LimitingLoadBalancingPolicy(new RoundRobinPolicy(), 2, 1);
+
+            // Setup a 3-host cluster, start only two hosts so that we know in advance which ones the policy will use
+            ccm = CCMBridge.create("test");
+            ccm.populate(3);
+            ccm.start(1);
+            ccm.start(2);
+            ccm.waitForUp(1);
+            ccm.waitForUp(2);
+
+            PoolingOptions poolingOptions = Mockito.spy(new PoolingOptions());
+            cluster = Cluster.builder()
+                             .addContactPoint(CCMBridge.ipOfNode(1))
+                             .withPoolingOptions(poolingOptions)
+                             .withLoadBalancingPolicy(loadBalancingPolicy)
+                             .withReconnectionPolicy(new ConstantReconnectionPolicy(1000))
+                             .build();
+
+            Session session = cluster.connect();
+
+            assertThat(cluster).usesControlHost(1);
+            assertThat(cluster).host(1)
+                               .hasState(State.UP)
+                               .isAtDistance(HostDistance.LOCAL);
+            // Wait for the node to be up, because apparently on Jenkins it's still only ADDED when we reach this line
+            // Waiting for NEW_NODE_DELAY_SECONDS+1 allows the driver to create a connection pool and mark the node up
+            assertThat(cluster).host(2)
+                               .comesUpWithin(Cluster.NEW_NODE_DELAY_SECONDS+1, SECONDS)
+                               .isAtDistance(HostDistance.LOCAL);
+
+            // Bring host 3 up, its presence should be acknowledged but it should be ignored
+            ccm.start(3);
+            ccm.waitForUp(3);
+
+            assertThat(cluster).host(1)
+                               .hasState(State.UP)
+                               .isAtDistance(HostDistance.LOCAL);
+            assertThat(cluster).host(2)
+                               .hasState(State.UP)
+                               .isAtDistance(HostDistance.LOCAL);
+            assertThat(cluster).host(3)
+                               .comesUpWithin(Cluster.NEW_NODE_DELAY_SECONDS+1, SECONDS)
+                               .isAtDistance(HostDistance.IGNORED);
+            assertThat(session).hasNoPoolFor(3);
+
+            // Kill host 2, host 3 should take its place
+            ccm.stop(2);
+            TestUtils.waitFor(CCMBridge.ipOfNode(3), cluster);
+
+            assertThat(cluster).host(1)
+                               .hasState(State.UP)
+                               .isAtDistance(HostDistance.LOCAL);
+            assertThat(cluster).host(2)
+                               .hasState(State.DOWN);
+            assertThat(cluster).host(3)
+                               .hasState(State.UP)
+                               .isAtDistance(HostDistance.LOCAL);
+            assertThat(session).hasPoolFor(3);
+
+            // This is when refreshConnectedHost should have been invoked, it triggers pool creation when
+            // we switch the node from IGNORED to UP:
+            Mockito.verify(poolingOptions)
+                   .refreshConnectedHost(TestUtils.findHost(cluster, 3));
+
+        } finally {
+            if (cluster != null)
+                cluster.close();
+            if (ccm != null)
+                ccm.remove();
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
@@ -15,9 +15,14 @@
  */
 package com.datastax.driver.core;
 
+import com.datastax.driver.core.utils.SocketChannelMonitor;
+import com.google.common.collect.Lists;
 import org.testng.annotations.Test;
 
+import java.net.InetSocketAddress;
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.testng.Assert.assertEquals;
 
@@ -31,9 +36,18 @@ public class SessionLeakTest {
         CCMBridge ccmBridge;
         ccmBridge = CCMBridge.create("test", 1);
         Cluster cluster = null;
+        SocketChannelMonitor channelMonitor = new SocketChannelMonitor();
+        channelMonitor.reportAtFixedInterval(1, TimeUnit.SECONDS);
+
+        List<InetSocketAddress> nodes = Lists.newArrayList(
+                new InetSocketAddress(CCMBridge.IP_PREFIX + '1', 9042),
+                new InetSocketAddress(CCMBridge.IP_PREFIX + '2', 9042));
         try {
             // create a new cluster object and ensure 0 sessions and connections
-            cluster = Cluster.builder().addContactPoints(CCMBridge.IP_PREFIX + '1').build();
+            cluster = Cluster.builder()
+                    .addContactPointsWithPorts(Collections.singletonList(
+                            new InetSocketAddress(CCMBridge.IP_PREFIX + '1', 9042)))
+                    .withNettyOptions(channelMonitor.nettyOptions()).build();
             cluster.init();
 
             int corePoolSize = cluster.getConfiguration()
@@ -43,21 +57,25 @@ public class SessionLeakTest {
             assertEquals(cluster.manager.sessions.size(), 0);
             // Should be 1 control connection after initialization.
             assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
+            assertEquals(channelMonitor.openChannels(nodes).size(), 1);
 
             // ensure sessions.size() returns with 1 control connection + core pool size.
             Session session = cluster.connect();
             assertEquals(cluster.manager.sessions.size(), 1);
             assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1 + corePoolSize);
+            assertEquals(channelMonitor.openChannels(nodes).size(), 1 + corePoolSize);
 
             // ensure sessions.size() returns to 0 with only 1 active connection (the control connection)
             session.close();
             assertEquals(cluster.manager.sessions.size(), 0);
             assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
+            assertEquals(channelMonitor.openChannels(nodes).size(), 1);
 
             // ensure bootstrapping a node does not create additional connections
             ccmBridge.bootstrapNode(2);
             assertEquals(cluster.manager.sessions.size(), 0);
             assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
+            assertEquals(channelMonitor.openChannels(nodes).size(), 1);
 
             // ensure a new session gets registered and core connections are established
             // there should be corePoolSize more connections to accommodate for the new host.
@@ -65,12 +83,14 @@ public class SessionLeakTest {
             assertEquals(cluster.manager.sessions.size(), 1);
 
             assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1 + (corePoolSize * 2));
+            assertEquals(channelMonitor.openChannels(nodes).size(), 1 + (corePoolSize * 2));
 
             // ensure bootstrapping a node does not create additional connections that won't get cleaned up
             thisSession.close();
 
             assertEquals(cluster.manager.sessions.size(), 0);
             assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
+            assertEquals(channelMonitor.openChannels(nodes).size(), 1);
         } finally {
             if(cluster != null){
                 cluster.close();
@@ -78,6 +98,10 @@ public class SessionLeakTest {
             if (ccmBridge != null) {
                 ccmBridge.remove();
             }
+            // Ensure no channels remain open.
+            channelMonitor.stop();
+            channelMonitor.report();
+            assertEquals(channelMonitor.openChannels(nodes).size(), 0);
         }
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionStressTest.java
@@ -1,0 +1,262 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.utils.SocketChannelMonitor;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import java.net.InetSocketAddress;
+import java.util.*;
+import java.util.concurrent.*;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class SessionStressTest extends CCMBridge.PerClassSingleNodeCluster {
+
+    private static final Logger logger = LoggerFactory.getLogger(SessionStressTest.class);
+
+    private ListeningExecutorService executorService;
+
+    public SessionStressTest() {
+        // 8 threads should be enough so that we stress the driver and not the OS thread scheduler
+        executorService = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(8));
+    }
+
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return new ArrayList<String>(0);
+    }
+
+
+    /**
+     * Stress test on opening/closing sessions.
+     * <p/>
+     * This test opens and closes {@code Session} in a multithreaded environment and makes sure that there is not
+     * connection leak. More specifically, this test performs the following steps:
+     * <p/>
+     * <ul>
+     * <li>Open 2000 {@code Session} concurrently</li>
+     * <li>Verify that 2000 sessions are reported as open by the {@code Cluster}</li>
+     * <li>Verify that 4001 connections are reported as open by the {@code Cluster}</li>
+     * <li>Close 1000 {@code Session} concurrently</li>
+     * <li>Verify that 1000 sessions are reported as open by the {@code Cluster}</li>
+     * <li>Verify that 2001 connections are reported as open by the {@code Cluster}</li>
+     * <li>Open concurrently 1000 {@code Session} while 1000 other {@code Session} are closed concurrently</li>
+     * <li>Verify that 1000 sessions are reported as open by the {@code Cluster}</li>
+     * <li>Verify that 2001 connections are reported as open by the {@code Cluster}</li>
+     * <li>Close 1000 {@code Session} concurrently</li>
+     * <li>Verify that 0 sessions are reported as open by the {@code Cluster}</li>
+     * <li>Verify that 1 connection is reported as open by the {@code Cluster}</li>
+     * </ul>
+     * <p/>
+     * This test is linked to JAVA-432.
+     */
+    @Test(groups = "long")
+    public void sessions_should_not_leak_connections() {
+        // override inherited field with a new cluster object and ensure 0 sessions and connections
+        SocketChannelMonitor channelMonitor = new SocketChannelMonitor();
+        channelMonitor.reportAtFixedInterval(1, TimeUnit.SECONDS);
+        List<InetSocketAddress> contactPoints = Collections.singletonList(hostAddress);
+        cluster = Cluster.builder().addContactPointsWithPorts(contactPoints)
+                .withPoolingOptions(new PoolingOptions().setCoreConnectionsPerHost(HostDistance.LOCAL, 1))
+                .withNettyOptions(channelMonitor.nettyOptions()).build();
+        cluster.init();
+
+        // The cluster has been initialized, we should have 1 connection.
+        assertEquals(cluster.manager.sessions.size(), 0);
+        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
+
+        // The first session initializes the cluster and its control connection
+        // This is a local cluster so we also have 2 connections per session
+        Session session = cluster.connect();
+        assertEquals(cluster.manager.sessions.size(), 1);
+        int coreConnections = TestUtils.numberOfLocalCoreConnections(cluster);
+        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1 + coreConnections);
+        assertEquals(channelMonitor.openChannels(contactPoints).size(), 1 + coreConnections);
+
+        // Closing the session keeps the control connection opened
+        session.close();
+        assertEquals(cluster.manager.sessions.size(), 0);
+        assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
+        assertEquals(channelMonitor.openChannels(contactPoints).size(), 1);
+
+        try {
+            int nbOfSessions = 2000;
+            int halfOfTheSessions = nbOfSessions / 2;
+            int nbOfIterations = 5;
+            int sleepTime = 20;
+
+            for (int iteration = 1; iteration <= nbOfIterations; iteration++) {
+                logger.info("On iteration {}/{}.", iteration, nbOfIterations);
+                logger.info("Creating {} sessions.", nbOfSessions);
+                waitFor(openSessionsConcurrently(nbOfSessions));
+
+                // We should see the exact number of opened sessions
+                // Since we have 2 connections per session, we should see 2 * sessions + control connection
+                assertEquals(cluster.manager.sessions.size(), nbOfSessions);
+                assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(),
+                        coreConnections * nbOfSessions + 1);
+                assertEquals(channelMonitor.openChannels(contactPoints).size(), coreConnections * nbOfSessions + 1);
+
+                // Close half of the sessions asynchronously
+                logger.info("Closing {}/{} sessions.", halfOfTheSessions, nbOfSessions);
+                waitFor(closeSessionsConcurrently(halfOfTheSessions));
+
+                // Check that we have the right number of sessions and connections
+                assertEquals(cluster.manager.sessions.size(), halfOfTheSessions);
+                assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(),
+                        coreConnections * (nbOfSessions / 2) + 1);
+                assertEquals(channelMonitor.openChannels(contactPoints).size(),
+                        coreConnections * (nbOfSessions / 2) + 1);
+
+                // Close and open the same number of sessions concurrently
+                logger.info("Closing and Opening {} sessions concurrently.", halfOfTheSessions);
+                CountDownLatch startSignal = new CountDownLatch(2);
+                List<ListenableFuture<Session>> openSessionFutures =
+                        openSessionsConcurrently(halfOfTheSessions, startSignal);
+                List<ListenableFuture<Void>> closeSessionsFutures = closeSessionsConcurrently(halfOfTheSessions,
+                        startSignal);
+                startSignal.countDown();
+                waitFor(openSessionFutures);
+                waitFor(closeSessionsFutures);
+
+                // Check that we have the same number of sessions and connections
+                assertEquals(cluster.manager.sessions.size(), halfOfTheSessions);
+                assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(),
+                        coreConnections * (nbOfSessions / 2) + 1);
+                assertEquals(channelMonitor.openChannels(contactPoints).size(),
+                        coreConnections * (nbOfSessions / 2) + 1);
+
+                // Close the remaining sessions
+                logger.info("Closing remaining {} sessions.", halfOfTheSessions);
+                waitFor(closeSessionsConcurrently(halfOfTheSessions));
+
+                // Check that we have a clean state
+                assertEquals(cluster.manager.sessions.size(), 0);
+                assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
+                assertEquals(channelMonitor.openChannels(contactPoints).size(), 1);
+
+                // On OSX, the TCP connections are released after 15s by default (sysctl -a net.inet.tcp.msl)
+                logger.info("Sleeping {} seconds so that TCP connections are released by the OS", sleepTime);
+                Uninterruptibles.sleepUninterruptibly(sleepTime, TimeUnit.SECONDS);
+            }
+        } finally {
+            cluster.close();
+
+            // Ensure no channels remain open.
+            channelMonitor.stop();
+            channelMonitor.report();
+            assertEquals(channelMonitor.openChannels(contactPoints).size(), 0);
+        }
+    }
+
+    private List<ListenableFuture<Session>> openSessionsConcurrently(int iterations) {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        return openSessionsConcurrently(iterations, countDownLatch);
+    }
+
+    private List<ListenableFuture<Session>> openSessionsConcurrently(int iterations, CountDownLatch countDownLatch) {
+        // Open new sessions once all tasks have been created
+        List<ListenableFuture<Session>> sessionFutures = Lists.newArrayListWithCapacity(iterations);
+        for (int i = 0; i < iterations; i++) {
+            sessionFutures.add(executorService.submit(new OpenSession(cluster, countDownLatch)));
+        }
+        countDownLatch.countDown();
+        return sessionFutures;
+    }
+
+    private List<ListenableFuture<Void>> closeSessionsConcurrently(int iterations) {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        return closeSessionsConcurrently(iterations, countDownLatch);
+    }
+
+    private List<ListenableFuture<Void>> closeSessionsConcurrently(int iterations, CountDownLatch countDownLatch) {
+        // Get a reference to every session we want to close
+        Stack<Session> sessionsToClose = new Stack<Session>();
+        Iterator<? extends Session> iterator = cluster.manager.sessions.iterator();
+        for (int i = 0; i < iterations; i++) {
+            sessionsToClose.push(iterator.next());
+        }
+
+        // Close sessions asynchronously once all tasks have been created
+        List<ListenableFuture<CloseFuture>> closeFutures = Lists.newArrayListWithCapacity(iterations);
+        for (int i = 0; i < iterations; i++) {
+            closeFutures.add(executorService.submit(new CloseSession(sessionsToClose.pop(), countDownLatch)));
+        }
+        countDownLatch.countDown();
+
+        // Immediately wait for CloseFutures, this should be very quick since all this work does is call closeAsync.
+        List<ListenableFuture<Void>> futures = Lists.newArrayListWithCapacity(iterations);
+        for(ListenableFuture<CloseFuture> closeFuture : closeFutures) {
+            try {
+                futures.add(closeFuture.get());
+            } catch(Exception e) {
+                logger.error("Got interrupted exception while waiting on closeFuture.", e);
+            }
+        }
+        return futures;
+    }
+
+    private <E> void waitFor(List<ListenableFuture<E>> futures) {
+        for (Future<E> future : futures) {
+            try {
+                future.get();
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Interrupted while waiting for future", e);
+            } catch (ExecutionException e) {
+                e.printStackTrace();
+                fail(e.getMessage());
+            }
+        }
+    }
+
+    private static class OpenSession implements Callable<Session> {
+        private final Cluster cluster;
+        private final CountDownLatch startSignal;
+
+        OpenSession(Cluster cluster, CountDownLatch startSignal) {
+            this.cluster = cluster;
+            this.startSignal = startSignal;
+        }
+
+        @Override
+        public Session call() throws Exception {
+            startSignal.await();
+            return cluster.connect();
+        }
+    }
+
+    private static class CloseSession implements Callable<CloseFuture> {
+        private final Session session;
+        private final CountDownLatch startSignal;
+
+        CloseSession(Session session, CountDownLatch startSignal) {
+            this.session = session;
+            this.startSignal = startSignal;
+        }
+
+        @Override
+        public CloseFuture call() throws Exception {
+            startSignal.await();
+            return session.closeAsync();
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -389,6 +389,10 @@ public abstract class TestUtils {
         return null; // never reached
     }
 
+    public static int numberOfLocalCoreConnections(Cluster cluster) {
+        Configuration configuration = cluster.getConfiguration();
+        return configuration.getPoolingOptions().getCoreConnectionsPerHost(HostDistance.LOCAL);
+    }
     /**
      * @return A Scassandra instance with an arbitrarily chosen binary port from 8042-8142 and admin port from
      * 8052-8152.

--- a/driver-core/src/test/java/com/datastax/driver/core/TimeoutStressTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TimeoutStressTest.java
@@ -1,0 +1,261 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import com.datastax.driver.core.utils.SocketChannelMonitor;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.common.util.concurrent.Uninterruptibles;
+import io.netty.channel.socket.SocketChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.google.common.collect.Iterables.filter;
+import static com.google.common.collect.Iterables.size;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TimeoutStressTest {
+
+    static final Logger logger = LoggerFactory.getLogger(TimeoutStressTest.class);
+
+    // Maximum number of concurrent queries running at a given time.
+    static final int CONCURRENT_QUERIES = 25;
+
+    // How long the test should run for, may want to consider running for longer periods to time to check for leaks
+    // that could occur over very tiny timing windows.
+    static final long DURATION = 240000;
+
+    // Configured read timeout - this may need to be tuned to the host system running the test.
+    static final int READ_TIMEOUT_IN_MS = 50;
+
+    // Configured connection timeout - this may need to be tuned to the host system running the test.
+    static final int CONNECTION_TIMEOUT_IN_MS = 20;
+
+    // Keyspace to use.
+    static final String KEYSPACE = "testks";
+
+    static Cluster cluster;
+
+    static CCMBridge ccmBridge;
+
+    static SocketChannelMonitor channelMonitor;
+
+    static AtomicInteger executedQueries = new AtomicInteger(0);
+
+    static List<InetSocketAddress> nodes;
+
+    static final Predicate<Connection> OPEN_CONNECTIONS = new Predicate<Connection>() {
+        @Override
+        public boolean apply(Connection input) {
+            // Capture Connections that have inFlight requests.  These will be eventually closed
+            // but potentially remain open.
+            return input.inFlight.get() > 0;
+        }
+    };
+
+    @BeforeClass(groups = "long")
+    public void beforeClass() throws Exception {
+        ccmBridge = CCMBridge.create("test", 3);
+        channelMonitor = new SocketChannelMonitor();
+        nodes = Lists.newArrayList(
+                new InetSocketAddress(CCMBridge.IP_PREFIX + '1', 9042),
+                new InetSocketAddress(CCMBridge.IP_PREFIX + '2', 9042),
+                new InetSocketAddress(CCMBridge.IP_PREFIX + '3', 9042)
+        );
+
+        PoolingOptions poolingOptions = new PoolingOptions().setCoreConnectionsPerHost(HostDistance.LOCAL, 8);
+
+        cluster = Cluster.builder()
+                .addContactPointsWithPorts(nodes)
+                .withPoolingOptions(poolingOptions)
+                .withNettyOptions(channelMonitor.nettyOptions())
+                .build();
+        Session session = cluster.connect();
+        setupSchema(session);
+        session.close();
+    }
+
+    @AfterClass(groups = "long")
+    public void afterClass() {
+        if(ccmBridge != null) {
+            ccmBridge.stop();
+        }
+        if(channelMonitor != null) {
+            channelMonitor.stop();
+        }
+        if(cluster != null) {
+            cluster.close();
+        }
+    }
+
+    @Test(groups = "long")
+    public void host_state_should_be_maintained_with_timeouts() {
+        // Set very low timeouts.
+        cluster.getConfiguration().getSocketOptions().setConnectTimeoutMillis(CONNECTION_TIMEOUT_IN_MS);
+        cluster.getConfiguration().getSocketOptions().setReadTimeoutMillis(READ_TIMEOUT_IN_MS);
+        Session session = cluster.connect();
+
+        int workers = Runtime.getRuntime().availableProcessors();
+        ExecutorService workerPool = Executors.newFixedThreadPool(workers,
+                new ThreadFactoryBuilder().setNameFormat("timeout-stress-test-worker-%d").setDaemon(true).build());
+
+        AtomicBoolean stopped = new AtomicBoolean(false);
+
+        // Ensure that we never exceed MaxConnectionsPerHost * nodes + 1 control connection.
+        int maxConnections = cluster.getConfiguration()
+                .getPoolingOptions().getMaxConnectionsPerHost(HostDistance.LOCAL) * nodes.size() + 1;
+
+        try {
+            Semaphore concurrentQueries = new Semaphore(CONCURRENT_QUERIES);
+            for (int i = 0; i < workers; i++) {
+                workerPool.submit(new TimeoutStressWorker(session, concurrentQueries, stopped));
+            }
+
+            long startTime = System.currentTimeMillis();
+            while (System.currentTimeMillis() - startTime < DURATION) {
+                Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+                channelMonitor.report();
+                // Some connections that are being closed may have had active requests which are delegated to the
+                // reaper for cleanup later.
+                Collection<SocketChannel> openChannels = channelMonitor.openChannels(nodes);
+
+                int maximumExpected = maxConnections + openConnectionsInReaper();
+                // Ensure that we don't exceed maximum connections.  Log as warning as there will be a bit of a timing
+                // factor between retrieving open connections and checking the reaper.
+                if(openChannels.size() > maximumExpected) {
+                    logger.warn("{} of open channels: {} exceeds maximum expected: {}: {}", openChannels.size(),
+                            maximumExpected, openChannels);
+                }
+            }
+        } finally {
+            stopped.set(true);
+
+            logger.debug("Sleeping 20 seconds to allow connection reaper to clean up connections.");
+            Uninterruptibles.sleepUninterruptibly(20, TimeUnit.SECONDS);
+
+            Collection<SocketChannel> openChannels = channelMonitor.openChannels(nodes);
+            assertThat(openChannels.size())
+                    .as("Number of open connections does not meet expected: %s", openChannels)
+                    .isLessThanOrEqualTo(maxConnections);
+
+            session.close();
+
+            logger.debug("Sleeping 20 seconds to allow connection reaper to clean up connections.");
+            Uninterruptibles.sleepUninterruptibly(20, TimeUnit.SECONDS);
+
+            openChannels = channelMonitor.openChannels(nodes);
+            assertThat(openChannels.size())
+                    .as("Number of open connections does not meet expected: %s", openChannels)
+                    .isEqualTo(1);
+
+            workerPool.shutdown();
+        }
+    }
+
+    private int openConnectionsInReaper() {
+        return size(filter(Lists.newArrayList(cluster.manager.reaper.connections.keySet()), OPEN_CONNECTIONS));
+    }
+
+    /**
+     * Creates the testks schema with a 'record' table and preloads 30k records.
+     */
+    private static void setupSchema(Session session) throws InterruptedException, ExecutionException, TimeoutException {
+        logger.info("Creating keyspace");
+        session.execute("create KEYSPACE if not exists " + KEYSPACE +
+                " WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}");
+        session.execute("use " + KEYSPACE);
+
+        logger.info("Creating table");
+        session.execute("create table if NOT EXISTS record (\n"
+                + "  name text,\n"
+                + "  phone text,\n"
+                + "  PRIMARY KEY ((name))\n"
+                + ");");
+
+        int records = 30000;
+        List<ResultSetFuture> futures = Lists.newArrayListWithExpectedSize(records);
+
+        for (int i = 0; i < records; i++) {
+            if (i % 1000 == 0)
+                logger.info("Inserting record {}.", i);
+            futures.add(session.executeAsync(
+                    "insert into record (name, phone) values (?, ?)", Integer.toString(i), "test"));
+        }
+
+        logger.info("Completed inserting data.  Waiting up to 30 for inserts to complete seconds before proceeding.");
+        Futures.allAsList(futures).get(30, TimeUnit.SECONDS);
+        logger.info("Inserts complete.");
+    }
+
+    public static class TimeoutStressWorker implements Runnable {
+
+        private final Semaphore concurrentQueries;
+        private final AtomicBoolean stopped;
+        private final Session session;
+
+        public TimeoutStressWorker(Session session, Semaphore concurrentQueries, AtomicBoolean stopped) {
+            this.session = session;
+            this.concurrentQueries = concurrentQueries;
+            this.stopped = stopped;
+        }
+
+
+        @Override
+        public void run() {
+            while(!stopped.get()) {
+                executedQueries.incrementAndGet();
+                try {
+                    concurrentQueries.acquire();
+                    ResultSetFuture future = session.executeAsync("select * from record limit 1000;");
+                    Futures.addCallback(future, new FutureCallback<ResultSet>() {
+
+                        @Override
+                        public void onSuccess(ResultSet result) {
+                            concurrentQueries.release();
+                        }
+
+                        @Override
+                        public void onFailure(Throwable t) {
+                            concurrentQueries.release();
+                            if(t instanceof NoHostAvailableException) {
+                                //logger.error("NHAE: {}", t.getMessage());
+                            } else {
+                                //logger.error("Exception", t);
+                            }
+                        }
+                    });
+                } catch(Exception e) {
+                    logger.error("Failure while submitting query.", e);
+                }
+            }
+
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/utils/SocketChannelMonitor.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/utils/SocketChannelMonitor.java
@@ -1,0 +1,160 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.utils;
+
+import com.datastax.driver.core.NettyOptions;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.MapMaker;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.netty.channel.socket.SocketChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Utility that observes {@link SocketChannel}s.  Helpful for ensuring that Sockets are actually closed
+ * when they should be.  Utilizes {@link NettyOptions} to monitor created {@link SocketChannel}s.
+ */
+public class SocketChannelMonitor implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(SocketChannelMonitor.class);
+
+    private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1,
+            new ThreadFactoryBuilder().setDaemon(true).setNameFormat("SocketMonitor-%d").build());
+
+    // use a weak set so channels may be garbage collected.
+    private final Collection<SocketChannel> channels = Collections.newSetFromMap(
+            new MapMaker().weakKeys().<SocketChannel, Boolean>makeMap());
+
+    private final AtomicLong channelsCreated = new AtomicLong(0);
+
+    private final NettyOptions nettyOptions = new NettyOptions() {
+        public void afterChannelInitialized(SocketChannel channel) throws Exception {
+            channels.add(channel);
+            channelsCreated.incrementAndGet();
+        }
+    };
+
+    @Override
+    public void run() {
+        try {
+            report();
+        } catch(Exception e) {
+            logger.error("Error countered.", e);
+        }
+    }
+
+    public void stop() {
+        executor.shutdown();
+        try {
+            executor.awaitTermination(1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+        }
+    }
+
+    /**
+     * @return A custom {@link NettyOptions} instance that hooks into afterChannelInitialized added channels may be
+     *         monitored.
+     */
+    public NettyOptions nettyOptions() {
+        return nettyOptions;
+    }
+
+    public static Predicate<SocketChannel> openChannels = new Predicate<SocketChannel>() {
+        @Override
+        public boolean apply(SocketChannel input) {
+            return input.isOpen();
+        }
+    };
+
+    /**
+     * Schedules a {@link #report()} to be called every configured interval.
+     * @param interval how often to report.
+     * @param timeUnit at what time precision to report at.
+     */
+    public void reportAtFixedInterval(int interval, TimeUnit timeUnit) {
+        executor.scheduleAtFixedRate(this, interval, interval, timeUnit);
+    }
+
+    /**
+     * Reports for all sockets.
+     */
+    public void report() {
+        report(Predicates.<SocketChannel>alwaysTrue());
+    }
+
+    /**
+     * <p>
+     * Report for all sockets matching the given predicate.  The report format reflects the number of open, closed,
+     * live and total sockets created.  This is logged at DEBUG if enabled.
+     *
+     * <p>
+     * If TRACE is enabled, each individual socket will be logged as well.
+     *
+     * @param channelFilter used to determine which sockets to report on.
+     */
+    public void report(Predicate<SocketChannel> channelFilter) {
+        if(logger.isDebugEnabled()) {
+            Iterable<SocketChannel> channels = matchingChannels(channelFilter);
+            Iterable<SocketChannel> open = Iterables.filter(channels, openChannels);
+            Iterable<SocketChannel> closed = Iterables.filter(channels, Predicates.not(openChannels));
+
+            logger.debug("Channel states: {} open, {} closed, live {}, total sockets created " +
+                            "(including those that don't match filter) {}.",
+                    Iterables.size(open),
+                    Iterables.size(closed),
+                    Iterables.size(channels),
+                    channelsCreated.get());
+
+            if(logger.isTraceEnabled()) {
+                logger.trace("Open channels {}.", open);
+                logger.trace("Closed channels {}.", closed);
+            }
+        }
+    }
+
+    /**
+     * @param addresses The addresses to include.
+     * @return Open channels matching the given socket addresses.
+     */
+    public Collection<SocketChannel> openChannels(final Collection<InetSocketAddress> addresses) {
+        return Lists.newArrayList(matchingChannels(new Predicate<SocketChannel>() {
+            @Override
+            public boolean apply(SocketChannel input) {
+                return input.isOpen() && input.remoteAddress() != null && addresses.contains(input.remoteAddress());
+            }
+        }));
+    }
+
+    /**
+     * @param channelFilter {@link Predicate} to use to determine whether or not a socket shall be considered.
+     * @return Channels matching the given {@link Predicate}.
+     */
+    public Iterable<SocketChannel> matchingChannels(final Predicate<SocketChannel> channelFilter) {
+        return Iterables.filter(Lists.newArrayList(channels), Predicates.and(Predicates.notNull(), channelFilter));
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/utils/SocketChannelMonitor.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/utils/SocketChannelMonitor.java
@@ -137,17 +137,31 @@ public class SocketChannelMonitor implements Runnable {
         }
     }
 
+    private static Comparator<SocketChannel> BY_REMOTE_ADDRESS = new Comparator<SocketChannel>() {
+        @Override
+        public int compare(SocketChannel t0, SocketChannel t1) {
+            // Should not be null as these are filtered previously in matchingChannels.
+            assert t0 != null && t0.remoteAddress() != null;
+            assert t1 != null && t1.remoteAddress() != null;;
+            return t0.remoteAddress().toString().compareTo(t1.remoteAddress().toString());
+        }
+    };
+
     /**
      * @param addresses The addresses to include.
      * @return Open channels matching the given socket addresses.
      */
     public Collection<SocketChannel> openChannels(final Collection<InetSocketAddress> addresses) {
-        return Lists.newArrayList(matchingChannels(new Predicate<SocketChannel>() {
+        List<SocketChannel> channels = Lists.newArrayList(matchingChannels(new Predicate<SocketChannel>() {
             @Override
             public boolean apply(SocketChannel input) {
                 return input.isOpen() && input.remoteAddress() != null && addresses.contains(input.remoteAddress());
             }
         }));
+
+        Collections.sort(channels, BY_REMOTE_ADDRESS);
+
+        return channels;
     }
 
     /**


### PR DESCRIPTION
Connection and HostConnectionPool constructors don't block anymore, both classes have a new initFuture that clients must wait on.

Hint for reviewers: start in Connection and make your way up.
