### PR TITLE
Keep SocketOptions#getTcpNoDelay() defaulting to false.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/SocketOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SocketOptions.java
@@ -45,7 +45,7 @@ public class SocketOptions {
     private volatile Boolean keepAlive;
     private volatile Boolean reuseAddress;
     private volatile Integer soLinger;
-    private volatile Boolean tcpNoDelay = Boolean.TRUE;
+    private volatile Boolean tcpNoDelay = Boolean.FALSE;
     private volatile Integer receiveBufferSize;
     private volatile Integer sendBufferSize;
 


### PR DESCRIPTION
In Netty 4.0 the default behavior of TCP_NODELAY was changed to be enabled rather than using nagle (https://github.com/netty/netty/issues/939).  We should keep TCP_NODELAY as disabled until we do our next major release similar to how netty waited for a major release.
