### PR TITLE
Suppress Unexpected error in onFailure if cancelled. (JAVA-710)

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1497,7 +1497,7 @@ public class Cluster implements Closeable {
 
                     public void onFailure(Throwable t) {
                         // That future is not really supposed to throw unexpected exceptions
-                        if (!(t instanceof InterruptedException))
+                        if (!(t instanceof InterruptedException) && !(t instanceof CancellationException))
                             logger.error("Unexpected error while marking node UP: while this shouldn't happen, this shouldn't be critical", t);
                     }
                 });
@@ -1844,7 +1844,7 @@ public class Cluster implements Closeable {
 
                     public void onFailure(Throwable t) {
                         // That future is not really supposed to throw unexpected exceptions
-                        if (!(t instanceof InterruptedException))
+                        if (!(t instanceof InterruptedException) && !(t instanceof CancellationException))
                             logger.error("Unexpected error while adding node: while this shouldn't happen, this shouldn't be critical", t);
                     }
                 });


### PR DESCRIPTION
Trivial change to suppress logging `Unexpected error while ...: while this shouldn't happen, this shouldn't be critical` if the Future(s) were cancelled as a result of `Cluster` being closed.
