### PR TITLE
Fix two links in Javadoc.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/TableOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/TableOptions.java
@@ -30,7 +30,7 @@ import com.google.common.base.Strings;
  *
  * @param <T> the concrete sub-class of {@link com.datastax.driver.core.schemabuilder.TableOptions}
  *
- * @see <a href="http://www.datastax.com/documentation/cql/3.1/cql/cql_reference/tabProp.html" target="_blank">details on table options</a>
+ * @see <a href="http://docs.datastax.com/en/cql/3.1/cql/cql_reference/tabProp.html" target="_blank">details on table options</a>
  */
 public abstract class TableOptions<T extends TableOptions> extends SchemaStatement {
 
@@ -295,7 +295,7 @@ public abstract class TableOptions<T extends TableOptions> extends SchemaStateme
      * @param populateIOOnCacheFlush whether to populate IO cache on flush of sstables.
      * @return this {@code TableOptions} object.
      *
-     * @see <a href="http://www.datastax.com/documentation/cassandra/2.0/cassandra/configuration/configCassandra_yaml_r.html?scroll=reference_ds_qfg_n1r_1k__compaction_preheat_key_cache">the global option compaction_preheat_key_cache</a>
+     * @see <a href="http://docs.datastax.com/en/cassandra/2.0/cassandra/configuration/configCassandra_yaml_r.html?scroll=reference_ds_qfg_n1r_1k__compaction_preheat_key_cache">the global option compaction_preheat_key_cache</a>
      */
     public T populateIOCacheOnFlush(Boolean populateIOOnCacheFlush) {
         this.populateIOOnCacheFlush = Optional.fromNullable(populateIOOnCacheFlush);

--- a/driver-dse/src/main/java/com/datastax/driver/auth/DseAuthProvider.java
+++ b/driver-dse/src/main/java/com/datastax/driver/auth/DseAuthProvider.java
@@ -34,9 +34,9 @@ import java.net.InetSocketAddress;
  * <code>login.config.url.n</code> entry in the <code>java.security</code> properties
  * file.
  * <p>
- * See <a href="http://docs.oracle.com/javase/1.4.2/docs/guide/security/jaas/tutorials/LoginConfigFile.html">http://docs.oracle.com/javase/1.4.2/docs/guide/security/jaas/tutorials/LoginConfigFile.html</a>
- * for further details on the Login configuration file and
- * <a href="http://docs.oracle.com/javase/6/docs/technotes/guides/security/jaas/tutorials/GeneralAcnOnly.html">http://docs.oracle.com/javase/6/docs/technotes/guides/security/jaas/tutorials/GeneralAcnOnly.html</a>
+ * See the following documents for further details on the 
+ * <a href="https://docs.oracle.com/javase/6/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html">JAAS Login Configuration File</a> and the
+ * <a href="http://docs.oracle.com/javase/6/docs/technotes/guides/security/jaas/tutorials/GeneralAcnOnly.html">JAAS Authentication Tutorial</a>
  * for more on JAAS in general.
  *
  * <h1>Authentication using ticket cache</h1>


### PR DESCRIPTION
Changed URL for a couple of links.

www.datastax.com/documentation ==> docs.datastax.com/en
