### PR TITLE
Driver integration module [wip - Do not merge]

### DIFF
--- a/driver-integration/README.rst
+++ b/driver-integration/README.rst
@@ -1,0 +1,28 @@
+Driver Integration Tests
+========================
+
+A set of modules representing possible packaging configurations that
+the driver and tests to exercise these configurations.
+
+This is not an exhaustive set of tests, it is merely to cover a set
+of functionality that can not easily be exercised in the base test
+cases since they require a very particular classpath configuration.
+
+Usage
+-----
+
+To run all of these tests, execute the following:
+
+    mvn integration-test -P short
+
+Modules
+-------
+
+* integration-core - contains base test cases that are shared among
+  other modules.
+* integration-bare - a 'bare' configuration, meaning just the driver
+  with no other optional dependencies such as compression libraries.
+* integration-epoll - uses the netty-transport-native-epoll library
+  to provide epoll for I/O.
+* integration-shaded - uses the 'shaded' driver-core jar for using
+  an embedded netty library.

--- a/driver-integration/integration-bare/pom.xml
+++ b/driver-integration/integration-bare/pom.xml
@@ -1,0 +1,201 @@
+<!--
+
+         Copyright (C) 2012-2015 DataStax Inc.
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.datastax.cassandra</groupId>
+        <artifactId>cassandra-driver-integration-parent</artifactId>
+        <version>2.0.11-SNAPSHOT</version>
+    </parent>
+    <artifactId>cassandra-driver-integration-bare</artifactId>
+    <packaging>jar</packaging>
+
+    <name>DataStax Java Driver Integration Suite - Bare Configuration</name>
+    <description>A suite of integration tests to be executed with a bare (driver only) configuration.</description>
+    <url>https://github.com/datastax/java-driver</url>
+
+    <properties>
+        <main.basedir>${project.parent.parent.basedir}</main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>cassandra-driver-integration-core</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${testng.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-exec</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.18.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <!-- Skip test by default, short or long is required to run unit tests since pax-exam will throw exception if it encounters a
+                 test with no matching methods. -->
+            <id>default</id>
+            <properties>
+                <env>default</env>
+            </properties>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.14</version>
+                        <configuration>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.18.1</version>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgument>-Xlint:all</compilerArgument>
+                            <showWarnings>true</showWarnings>
+                            <showDeprecation>true</showDeprecation>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>short</id>
+            <properties>
+                <env>default</env>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.14</version>
+                        <configuration>
+                            <groups>unit,short</groups>
+                            <useFile>false</useFile>
+                            <systemPropertyVariables>
+                                <cassandra.version>${cassandra.version}</cassandra.version>
+                                <ipprefix>${ipprefix}</ipprefix>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.18.1</version>
+                        <configuration>
+                            <groups>unit,short</groups>
+                            <useFile>false</useFile>
+                            <systemPropertyVariables>
+                                <cassandra.version>${cassandra.version}</cassandra.version>
+                                <ipprefix>${ipprefix}</ipprefix>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>long</id>
+            <properties>
+                <env>default</env>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.16</version>
+                        <configuration>
+                            <groups>unit,short,long</groups>
+                            <useFile>false</useFile>
+                            <systemPropertyVariables>
+                                <cassandra.version>${cassandra.version}</cassandra.version>
+                                <ipprefix>${ipprefix}</ipprefix>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.18.1</version>
+                        <configuration>
+                            <groups>unit,short,long</groups>
+                            <useFile>false</useFile>
+                            <systemPropertyVariables>
+                                <cassandra.version>${cassandra.version}</cassandra.version>
+                                <ipprefix>${ipprefix}</ipprefix>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/driver-integration/integration-bare/src/test/java/BareConfigurationIT.java
+++ b/driver-integration/integration-bare/src/test/java/BareConfigurationIT.java
@@ -1,0 +1,84 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.NettyOptions;
+import com.datastax.driver.core.ProtocolOptions;
+import com.datastax.driver.integration.BaseIntegrationTest;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BareConfigurationIT extends BaseIntegrationTest {
+
+    /**
+     * <p>
+     * Ensures that if LZ4 is not in the classpath that it cannot be used for compression.
+     *
+     * @test_category packaging, connection:compression
+     * @expected_result An exception is thrown at the time the cluster is built.
+     */
+    @Test(groups="unit", expectedExceptions=IllegalStateException.class,
+            expectedExceptionsMessageRegExp = "The requested compression is not available.*")
+    public void should_not_be_able_to_use_lz4() {
+        configure(Cluster.builder())
+                .addContactPointsWithPorts(Collections.singletonList(hostAddress)).
+                withCompression(ProtocolOptions.Compression.LZ4).build();
+    }
+
+    /**
+     * <p>
+     * Ensures that if Snappy is not in the classpath that it cannot be used for compression.
+     *
+     * @test_category packaging, connection:compression
+     * @expected_result An exception is thrown at the time the cluster is built.
+     */
+    @Test(groups="unit", expectedExceptions=IllegalStateException.class,
+            expectedExceptionsMessageRegExp = "The requested compression is not available.*")
+    public void should_not_be_able_to_use_snappy() {
+        configure(Cluster.builder())
+                .addContactPointsWithPorts(Collections.singletonList(hostAddress)).
+                withCompression(ProtocolOptions.Compression.SNAPPY).build();
+    }
+
+    /**
+     * <p>
+     * Ensures that by default NIO is used for I/O for the underlying netty instance used by the driver.
+     *
+     * @test_category packaging
+     * @expected_result NioEventLoopGroup is used as the EventLoopGroup instance, NioSocketChannel is used as the
+     *                  Channel instance.
+     * @jira_ticket JAVA-676
+     * @since 2.0.10, 2.1.6
+     */
+    @Test(groups="unit")
+    public void should_use_nio_for_netty() {
+        NettyOptions nettyOptions = new NettyOptions();
+        assertThat(nettyOptions.channelClass()).isEqualTo(NioSocketChannel.class);
+        EventLoopGroup eventLoopGroup = nettyOptions.eventLoopGroup(new DefaultThreadFactory("test"));
+        try {
+            assertThat(eventLoopGroup).isInstanceOf(NioEventLoopGroup.class);
+        } finally {
+            eventLoopGroup.shutdownGracefully(0, 5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/driver-integration/integration-bare/src/test/resources/log4j.properties
+++ b/driver-integration/integration-bare/src/test/resources/log4j.properties
@@ -1,0 +1,28 @@
+#
+#      Copyright (C) 2012-2015 DataStax Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=INFO, A1
+
+# Scassandra's info log is a bit verbose
+log4j.logger.org.scassandra=WARN
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=\    %-6r [%t] %-5p %c %x - %m%n

--- a/driver-integration/integration-core/pom.xml
+++ b/driver-integration/integration-core/pom.xml
@@ -1,0 +1,67 @@
+<!--
+
+         Copyright (C) 2012-2015 DataStax Inc.
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.datastax.cassandra</groupId>
+        <artifactId>cassandra-driver-integration-parent</artifactId>
+        <version>2.0.11-SNAPSHOT</version>
+    </parent>
+    <artifactId>cassandra-driver-integration-core</artifactId>
+    <packaging>jar</packaging>
+
+    <name>DataStax Java Driver Integration Suite - Core</name>
+    <description>A suite of integration tests to be executed under multiple driver configurations.</description>
+    <url>https://github.com/datastax/java-driver</url>
+
+    <properties>
+        <main.basedir>${project.parent.parent.basedir}</main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <version>${project.parent.version}</version>
+            <!-- optional dependency as a different classifier may be pulled in -->
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${testng.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-exec</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/driver-integration/integration-core/src/main/java/com/datastax/driver/integration/BaseIntegrationTest.java
+++ b/driver-integration/integration-core/src/main/java/com/datastax/driver/integration/BaseIntegrationTest.java
@@ -1,0 +1,309 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.integration;
+
+import com.datastax.driver.core.*;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+
+/**
+ * A 'BaseIntegrationTest' that uses a single node CCM cluster and runs a test that exercises basic functionality.
+ *
+ * The intent of this is test is to be extended in other modules to exercise logic in different packaging
+ * configurations that would not be covered by integration tests in driver-core.
+ */
+public abstract class BaseIntegrationTest extends CCMBridge.PerClassSingleNodeCluster{
+
+    private static final Logger logger = LoggerFactory.getLogger(BaseIntegrationTest.class);
+
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * <p>
+     * Executes a basic integration test that does the following:
+     *
+     * <ol>
+     *     <li>Creates a table.</li>
+     *     <li>Prepares statements for inserting, reading and deleting data.</li>
+     *     <li>Inserts 1000 rows into a table in 100 different partitions.</li>
+     *     <li>Reads data from each partition.</li>
+     *     <li>Reads all data with a range query in a paged fashion.</li>
+     *     <li>Deletes the data.</li>
+     *     <li>Deletes the table.</li>
+     * </ol>
+     */
+    @Test(groups="short")
+    public void should_perform_basic_functionality() throws Exception {
+        String tableName = "spbf";
+        basicLifecycle(session, tableName, 100, 10).call();
+    }
+
+    public Callable<Void> basicLifecycle(Session session, String tableName, int partitions, int keysPerPartition) {
+        return new BasicLifecycle(session, tableName, partitions, keysPerPartition);
+    }
+
+    protected static class BasicLifecycle implements Callable<Void> {
+
+        private final Session session;
+        private final String tableName;
+        private final int partitions;
+        private final int rowsPerPartition;
+
+        PreparedStatement updateStmt;
+        PreparedStatement readStmt;
+        PreparedStatement rangeStmt;
+        PreparedStatement deleteStmt;
+
+        protected BasicLifecycle(Session session, String tableName, int partitions, int rowsPerPartition) {
+            this.session = session;
+            this.tableName = tableName;
+            this.partitions = partitions;
+            this.rowsPerPartition = rowsPerPartition;
+        }
+
+        @Override
+        public Void call() {
+            createTable();
+            prepare();
+            insertData();
+            readData();
+            readDataRange();
+            deleteData();
+            dropData();
+            return null;
+        }
+
+        public void createTable() {
+            // TODO: Check if schema agrees / wait until it does.
+            logger.debug("Creating {} table.", tableName);
+            ResultSet tableResults = session.execute(
+                    String.format("create table %s (k1 int, k2 int, v int, primary key (k1,k2))", tableName));
+        }
+
+        public void prepare() {
+            updateStmt = session.prepare(QueryBuilder.update(tableName)
+                    .with(set("v", bindMarker("v1")))
+                    .where(eq("k1", bindMarker("k1"))).and(eq("k2", bindMarker("k2"))));
+
+            readStmt = session.prepare(QueryBuilder.select().from(tableName)
+                    .where(eq("k1", bindMarker("k1"))));
+
+            rangeStmt = session.prepare(QueryBuilder.select().from(tableName));
+
+            deleteStmt = session.prepare(QueryBuilder.delete().from(tableName)
+                    .where(eq("k1", bindMarker("k1"))));
+        }
+
+        /**
+         * Loads data into {@link #tableName} for {@link #partitions} with {@link #rowsPerPartition} rows per
+         * partition.  Data from each partition is loaded as a {@link BatchStatement} and each statement is
+         * executed concurrently using {@link Session#executeAsync}.  Will throw an exception if any insert fails.
+         */
+        public void insertData() {
+            // Insert data.
+            final CountDownLatch latch = new CountDownLatch(partitions);
+            final AtomicReference<Throwable> failure = new AtomicReference<Throwable>(null);
+            logger.debug("Performing {} batches with {} updates per batch.", partitions, rowsPerPartition);
+            long startTime = System.currentTimeMillis();
+            for(int k1 = 0; k1 < partitions; k1++) {
+                BatchStatement batch = new BatchStatement();
+                for(int k2 = 0; k2 < rowsPerPartition; k2++) {
+                    batch.add(updateStmt.bind(k1+k2, k1, k2));
+                }
+                ResultSetFuture future = session.executeAsync(batch);
+                Futures.addCallback(future, new FutureCallback<ResultSet>() {
+
+                    @Override
+                    public void onSuccess(ResultSet result) {
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        // Complete the latch on any failure and record the error.
+                        if(failure.compareAndSet(null, t)) {
+                            for (int i = 0; i < partitions; i++) {
+                                latch.countDown();
+                            }
+                        }
+                    }
+                });
+            }
+
+            Uninterruptibles.awaitUninterruptibly(latch, 5, TimeUnit.SECONDS);
+            Assertions.assertThat(latch.getCount()).isEqualTo(0);
+            // Check to make sure no inserts failed.
+            Throwable failureEx = failure.get();
+            if(failureEx != null) {
+                Assertions.fail("Error raised while inserting data.", failureEx);
+            }
+            logger.debug("Took {} ms to write data.", System.currentTimeMillis() - startTime);
+        }
+
+        /**
+         * Reads data from {@link #tableName} for each of {@link #partitions}.  Each partition is queried individually
+         * and all queries are made concurrently using {@link Session#executeAsync}.  Will throw an exception if any
+         * read fails *or* the data returned is not expected.
+         */
+        public void readData() {
+            // Read the data back.
+            logger.debug("Performing {} reads.", partitions);
+            final CountDownLatch readLatch = new CountDownLatch(partitions);
+            final AtomicReference<Throwable> readFailure = new AtomicReference<Throwable>(null);
+            long startTime = System.currentTimeMillis();
+            for(int k1 = 0; k1 < partitions; k1++) {
+                ResultSetFuture future = session.executeAsync(readStmt.bind(k1));
+                Futures.addCallback(future, new FutureCallback<ResultSet>() {
+
+                    private void setException(Throwable t) {
+                        // Complete the latch on any failure and record the error.
+                        if(readFailure.compareAndSet(null, t)) {
+                            for (int i = 0; i < partitions; i++) {
+                                readLatch.countDown();
+                            }
+                        }
+                    }
+
+                    @Override
+                    public void onSuccess(ResultSet result) {
+                        int expectedk2 = 0;
+                        for(Row row : result) {
+                            int k1 = row.getInt("k1");
+                            int k2 = row.getInt("k2");
+                            int v = row.getInt("v");
+
+                            if(k2 != expectedk2) {
+                                setException(new Exception(String.format("Expected k2 to be %d for %d:%d:%d", expectedk2, k1, k2, v)));
+                                return;
+                            }
+                            if(v != k1+k2) {
+                                setException(new Exception(String.format("Expected v to be %d for %d:%d:%d", k1+k2, k1, k2, v)));
+                                return;
+                            }
+                            expectedk2++;
+                        }
+                        readLatch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        setException(t);
+                    }
+                });
+            }
+
+            Uninterruptibles.awaitUninterruptibly(readLatch, 5, TimeUnit.SECONDS);
+            Assertions.assertThat(readLatch.getCount()).isEqualTo(0);
+            // Check to make sure no inserts failed.
+            Throwable failureEx = readFailure.get();
+            if(failureEx != null) {
+                Assertions.fail("Error raised while reading data.", failureEx);
+            }
+            logger.debug("Took {} ms to read data.", System.currentTimeMillis() - startTime);
+        }
+
+        /**
+         * Reads data from {@link #tableName} as a range query.  Will throw an exception if the query fails *or* the
+         * data returned is not expected.
+         */
+        public void readDataRange() {
+            long startTime = System.currentTimeMillis();
+            ResultSet rangeResults = session.execute(rangeStmt.bind());
+            int count = 0;
+            int expectedk2 = 0;
+            int previousk1 = -1;
+            logger.debug("Performing range query.");
+            for(Row row : rangeResults) {
+                int k1 = row.getInt("k1");
+                if(k1 != previousk1) {
+                    expectedk2 = 0;
+                    previousk1 = k1;
+                }
+                int k2 = row.getInt("k2");
+                Assertions.assertThat(k2).isEqualTo(expectedk2++);
+                int v = row.getInt("v");
+                Assertions.assertThat(v).isEqualTo(k1+k2);
+                count++;
+            }
+            Assertions.assertThat(count).isEqualTo(partitions* rowsPerPartition);
+            logger.debug("Took {} ms to read data from range query.", System.currentTimeMillis() - startTime);
+
+        }
+
+        /**
+         * Deletes all data from {@link #tableName}.  Each partition is deleted individually and all deletes are done
+         * asynchronously.  Will throw an exception if any delete fails.
+         */
+        public void deleteData() {
+            // Delete the data.
+            logger.debug("Performing {} deletes.", partitions);
+            final CountDownLatch deleteLatch = new CountDownLatch(partitions);
+            final AtomicReference<Throwable> deleteFailure = new AtomicReference<Throwable>(null);
+            long startTime = System.currentTimeMillis();
+            for(int k1 = 0; k1 < partitions; k1++) {
+                ResultSetFuture future = session.executeAsync(deleteStmt.bind(k1));
+                Futures.addCallback(future, new FutureCallback<ResultSet>() {
+                    @Override
+                    public void onSuccess(ResultSet result) {
+                        deleteLatch.countDown();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        // Complete the latch on any failure and record the error.
+                        if(deleteFailure.compareAndSet(null, t)) {
+                            for (int i = 0; i < partitions; i++) {
+                                deleteLatch.countDown();
+                            }
+                        }
+                    }
+                });
+            }
+
+            Uninterruptibles.awaitUninterruptibly(deleteLatch, 5, TimeUnit.SECONDS);
+            Assertions.assertThat(deleteLatch.getCount()).isEqualTo(0);
+            // Check to make sure no inserts failed.
+            Throwable failureEx = deleteFailure.get();
+            if(failureEx != null) {
+                Assertions.fail("Error raised while deleting data.", failureEx);
+            }
+            logger.debug("Took {} ms to delete data.", System.currentTimeMillis() - startTime);
+        }
+
+        public void dropData() {
+            logger.debug("Dropping {} table.", tableName);
+            // TODO assert schema agreement.
+            ResultSet dropResults = session.execute(String.format("drop table %s", tableName));
+        }
+    }
+}

--- a/driver-integration/integration-epoll/pom.xml
+++ b/driver-integration/integration-epoll/pom.xml
@@ -1,0 +1,209 @@
+<!--
+
+         Copyright (C) 2012-2015 DataStax Inc.
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.datastax.cassandra</groupId>
+        <artifactId>cassandra-driver-integration-parent</artifactId>
+        <version>2.0.11-SNAPSHOT</version>
+    </parent>
+    <artifactId>cassandra-driver-integration-epoll</artifactId>
+    <packaging>jar</packaging>
+
+    <name>DataStax Java Driver Integration Suite - Epoll Configuration</name>
+    <description>A suite of integration tests to be executed using netty with epoll.</description>
+    <url>https://github.com/datastax/java-driver</url>
+
+    <properties>
+        <main.basedir>${project.parent.parent.basedir}</main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>${netty.version}</version>
+            <!-- Explicitly bring in the linux classifier, test may fail on 32-bit linux -->
+            <classifier>linux-x86_64</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>cassandra-driver-integration-core</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${testng.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-exec</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.18.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <!-- Skip test by default, short or long is required to run unit tests since pax-exam will throw exception if it encounters a
+                 test with no matching methods. -->
+            <id>default</id>
+            <properties>
+                <env>default</env>
+            </properties>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.14</version>
+                        <configuration>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.18.1</version>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgument>-Xlint:all</compilerArgument>
+                            <showWarnings>true</showWarnings>
+                            <showDeprecation>true</showDeprecation>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>short</id>
+            <properties>
+                <env>default</env>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.14</version>
+                        <configuration>
+                            <groups>unit,short</groups>
+                            <useFile>false</useFile>
+                            <systemPropertyVariables>
+                                <cassandra.version>${cassandra.version}</cassandra.version>
+                                <ipprefix>${ipprefix}</ipprefix>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.18.1</version>
+                        <configuration>
+                            <groups>unit,short</groups>
+                            <useFile>false</useFile>
+                            <systemPropertyVariables>
+                                <cassandra.version>${cassandra.version}</cassandra.version>
+                                <ipprefix>${ipprefix}</ipprefix>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>long</id>
+            <properties>
+                <env>default</env>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.16</version>
+                        <configuration>
+                            <groups>unit,short,long</groups>
+                            <useFile>false</useFile>
+                            <systemPropertyVariables>
+                                <cassandra.version>${cassandra.version}</cassandra.version>
+                                <ipprefix>${ipprefix}</ipprefix>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.18.1</version>
+                        <configuration>
+                            <groups>unit,short,long</groups>
+                            <useFile>false</useFile>
+                            <systemPropertyVariables>
+                                <cassandra.version>${cassandra.version}</cassandra.version>
+                                <ipprefix>${ipprefix}</ipprefix>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/driver-integration/integration-epoll/src/test/java/EpollConfigurationIT.java
+++ b/driver-integration/integration-epoll/src/test/java/EpollConfigurationIT.java
@@ -1,0 +1,68 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+import com.datastax.driver.core.NettyOptions;
+import com.datastax.driver.integration.BaseIntegrationTest;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EpollConfigurationIT extends BaseIntegrationTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(EpollConfigurationIT.class);
+
+    /**
+     * <p>
+     * Ensures that Epoll is used for I/O for the underlying netty instance used by the driver if
+     * netty-transport-native-epoll is present in the classpath.
+     *
+     * @test_category packaging
+     * @expected_result EpollEventLoopGroup is used as the EventLoopGroup instance, EpollSocketChannel is used as the
+     *                  Channel instance.
+     * @jira_ticket JAVA-676
+     * @since 2.0.10, 2.1.6
+     */
+    @Test(groups="unit")
+    public void should_use_epoll_for_netty_on_linux_only() {
+        boolean isLinux = System.getProperty("os.name", "").toLowerCase(Locale.US).equals("linux");
+        if(isLinux) {
+            logger.debug("Detected os was Linux, expecting Epoll configuration.");
+        } else {
+            logger.warn("Did not detect Linux OS, so NIO configuration should be used.");
+        }
+        NettyOptions nettyOptions = new NettyOptions();
+        Class<? extends SocketChannel> channelClass = isLinux ? EpollSocketChannel.class : NioSocketChannel.class;
+        Class<? extends EventLoopGroup> eventLoopClass = isLinux ? EpollEventLoopGroup.class : NioEventLoopGroup.class;
+        assertThat(nettyOptions.channelClass()).isEqualTo(channelClass);
+        EventLoopGroup eventLoopGroup = nettyOptions.eventLoopGroup(new DefaultThreadFactory("test"));
+        try {
+            assertThat(eventLoopGroup).isInstanceOf(eventLoopClass);
+        } finally {
+            eventLoopGroup.shutdownGracefully(0, 5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/driver-integration/integration-epoll/src/test/resources/log4j.properties
+++ b/driver-integration/integration-epoll/src/test/resources/log4j.properties
@@ -1,0 +1,28 @@
+#
+#      Copyright (C) 2012-2015 DataStax Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=INFO, A1
+
+# Scassandra's info log is a bit verbose
+log4j.logger.org.scassandra=WARN
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=\    %-6r [%t] %-5p %c %x - %m%n

--- a/driver-integration/integration-shaded/pom.xml
+++ b/driver-integration/integration-shaded/pom.xml
@@ -1,0 +1,211 @@
+<!--
+
+         Copyright (C) 2012-2015 DataStax Inc.
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.datastax.cassandra</groupId>
+        <artifactId>cassandra-driver-integration-parent</artifactId>
+        <version>2.0.11-SNAPSHOT</version>
+    </parent>
+    <artifactId>cassandra-driver-integration-shaded</artifactId>
+    <packaging>jar</packaging>
+
+    <name>DataStax Java Driver Integration Suite - Shaded Configuration</name>
+    <description>A suite of integration tests to be executed using the shaded jar.</description>
+    <url>https://github.com/datastax/java-driver</url>
+
+    <properties>
+        <main.basedir>${project.parent.parent.basedir}</main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+            <classifier>shaded</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>cassandra-driver-integration-core</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${testng.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-exec</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <!-- Bring in a different version of netty to ensure we can support this in the shaded configuration. -->
+            <version>4.0.20.Final</version>
+            <!-- Explicitly bring in the linux classifier, test may fail on 32-bit linux -->
+            <classifier>linux-x86_64</classifier>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.18.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <!-- Skip test by default, short or long is required to run unit tests since pax-exam will throw exception if it encounters a
+                 test with no matching methods. -->
+            <id>default</id>
+            <properties>
+                <env>default</env>
+            </properties>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.14</version>
+                        <configuration>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.18.1</version>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgument>-Xlint:all</compilerArgument>
+                            <showWarnings>true</showWarnings>
+                            <showDeprecation>true</showDeprecation>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>short</id>
+            <properties>
+                <env>default</env>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.14</version>
+                        <configuration>
+                            <groups>unit,short</groups>
+                            <useFile>false</useFile>
+                            <systemPropertyVariables>
+                                <cassandra.version>${cassandra.version}</cassandra.version>
+                                <ipprefix>${ipprefix}</ipprefix>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.18.1</version>
+                        <configuration>
+                            <groups>unit,short</groups>
+                            <useFile>false</useFile>
+                            <systemPropertyVariables>
+                                <cassandra.version>${cassandra.version}</cassandra.version>
+                                <ipprefix>${ipprefix}</ipprefix>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>long</id>
+            <properties>
+                <env>default</env>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.16</version>
+                        <configuration>
+                            <groups>unit,short,long</groups>
+                            <useFile>false</useFile>
+                            <systemPropertyVariables>
+                                <cassandra.version>${cassandra.version}</cassandra.version>
+                                <ipprefix>${ipprefix}</ipprefix>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.18.1</version>
+                        <configuration>
+                            <groups>unit,short,long</groups>
+                            <useFile>false</useFile>
+                            <systemPropertyVariables>
+                                <cassandra.version>${cassandra.version}</cassandra.version>
+                                <ipprefix>${ipprefix}</ipprefix>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/driver-integration/integration-shaded/src/test/java/ShadedConfigurationIT.java
+++ b/driver-integration/integration-shaded/src/test/java/ShadedConfigurationIT.java
@@ -1,0 +1,153 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+import java.util.Collections;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.datastax.shaded.netty.channel.ChannelDuplexHandler;
+import com.datastax.shaded.netty.channel.ChannelHandlerContext;
+import com.datastax.shaded.netty.channel.EventLoopGroup;
+import com.datastax.shaded.netty.channel.nio.NioEventLoopGroup;
+import com.datastax.shaded.netty.channel.socket.SocketChannel;
+import com.datastax.shaded.netty.channel.socket.nio.NioSocketChannel;
+import com.datastax.shaded.netty.util.concurrent.DefaultThreadFactory;
+import com.google.common.util.concurrent.*;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertFalse;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.NettyOptions;
+import com.datastax.driver.integration.BaseIntegrationTest;
+
+public class ShadedConfigurationIT extends BaseIntegrationTest {
+
+    /**
+     * <p>
+     * Validates that NIO is used unconditionally when using the shaded jar.  Additionally
+     * ensures that the shaded netty components are used instead of the alternative io.netty
+     * classes when present in the classpath.
+     *
+     * @test_category packaging
+     * @expected_result Shaded Netty components are used.
+     * @jira_ticket JAVA-676
+     * @since 2.0.10, 2.1.6
+     */
+    @Test(groups = "unit")
+    public void should_use_nio_for_shaded_netty() {
+        NettyOptions nettyOptions = new NettyOptions();
+        assertThat(nettyOptions.channelClass()).isEqualTo(NioSocketChannel.class);
+        EventLoopGroup eventLoopGroup = nettyOptions.eventLoopGroup(new DefaultThreadFactory("test"));
+        try {
+            assertThat(eventLoopGroup).isInstanceOf(NioEventLoopGroup.class);
+        } finally {
+            eventLoopGroup.shutdownGracefully(0, 5, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * <p>
+     * Validates that netty components can be customized via {@link NettyOptions} when using
+     * the shaded jar configuration.
+     *
+     * <p>
+     * This is not a comprehensive test as it just ensures {@link NettyOptions} can be customized,
+     * but does not exhaustively test {@link NettyOptions} as
+     * {@link com.datastax.driver.core.NettyOptionsTest} provides this test coverage.
+     *
+     * @test_category packaging
+     * @expected_result custom {@link NettyOptions} is used.
+     * @jira_ticket JAVA-676
+     * @since 2.0.10, 2.1.6
+     */
+    @Test(groups = "short")
+    public void should_be_able_to_customize_netty_options() throws Exception {
+        // A simple configuration where all Clusters share the same EventLoopGroup.
+        final EventLoopGroup eventLoop = new NioEventLoopGroup();
+        final AtomicInteger readCount = new AtomicInteger(0);
+
+        ListeningExecutorService executor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(3));
+
+        NettyOptions nettyOptions = new NettyOptions() {
+            @Override
+            public EventLoopGroup eventLoopGroup(ThreadFactory threadFactory) {
+                return eventLoop;
+            }
+
+            @Override
+            public void onClusterClose(EventLoopGroup eventLoopGroup) {
+                // NO-OP, we want to reuse the event loop.
+            }
+
+            @Override
+            public void afterChannelInitialized(SocketChannel channel) throws Exception {
+                // Add a simple handler that counts number of read calls.
+                channel.pipeline().addFirst(new ChannelDuplexHandler() {
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                        readCount.incrementAndGet();
+                        ctx.fireChannelRead(msg);
+                    }
+                });
+            }
+        };
+
+        try {
+            Cluster.Builder builder = Cluster.builder().withNettyOptions(nettyOptions)
+                .addContactPointsWithPorts(Collections.singletonList(hostAddress));
+
+            // Create a cluster and exercise it, then close it
+            // this is mostly to ensure onClusterClose is called and the event loop is not closed.
+            Cluster cluster0 = builder.build();
+            try {
+                ListenableFuture<Void> future = executor.submit(basicLifecycle(cluster0.connect(keyspace), "cluster0", 100, 10));
+                Uninterruptibles.getUninterruptibly(future, 5, TimeUnit.SECONDS);
+                cluster0.close();
+                assertFalse(eventLoop.isShutdown() || eventLoop.isShuttingDown());
+                assertThat(readCount.get()).isGreaterThan(0);
+                readCount.set(0);
+            } finally {
+                cluster0.close();
+            }
+
+            // Create 3 clusters and simultaneously exercise them.
+            Cluster cluster1 = builder.build();
+            Cluster cluster2 = builder.build();
+            Cluster cluster3 = builder.build();
+            try {
+                ListenableFuture[] futures = new ListenableFuture[]{
+                        executor.submit(basicLifecycle(cluster1.connect(keyspace), "cluster1", 100, 10)),
+                        executor.submit(basicLifecycle(cluster2.connect(keyspace), "cluster2", 100, 10)),
+                        executor.submit(basicLifecycle(cluster3.connect(keyspace), "cluster3", 100, 10))
+                };
+
+                // Waits for all futures to complete, if any errors encountered this test fails.
+                Uninterruptibles.getUninterruptibly(Futures.allAsList(futures), 10, TimeUnit.SECONDS);
+                assertThat(readCount.get()).isGreaterThan(0);
+            } finally {
+                cluster1.close();
+                cluster2.close();
+                cluster3.close();
+            }
+        } finally {
+            eventLoop.shutdownGracefully(0, 5, TimeUnit.SECONDS);
+            executor.shutdown();
+        }
+    }
+}

--- a/driver-integration/integration-shaded/src/test/resources/log4j.properties
+++ b/driver-integration/integration-shaded/src/test/resources/log4j.properties
@@ -1,0 +1,28 @@
+#
+#      Copyright (C) 2012-2015 DataStax Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=INFO, A1
+
+# Scassandra's info log is a bit verbose
+log4j.logger.org.scassandra=WARN
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=\    %-6r [%t] %-5p %c %x - %m%n

--- a/driver-integration/pom.xml
+++ b/driver-integration/pom.xml
@@ -1,0 +1,65 @@
+<!--
+
+         Copyright (C) 2012-2015 DataStax Inc.
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.datastax.cassandra</groupId>
+        <artifactId>cassandra-driver-parent</artifactId>
+        <version>2.0.11-SNAPSHOT</version>
+    </parent>
+    <artifactId>cassandra-driver-integration-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>DataStax Java Driver Integration Suite</name>
+    <description>A suite of integration tests composed of different configurations to test with.</description>
+    <url>https://github.com/datastax/java-driver</url>
+
+    <properties>
+        <main.basedir>${project.parent.basedir}</main.basedir>
+    </properties>
+
+    <modules>
+        <module>integration-core</module>
+        <module>integration-bare</module>
+        <module>integration-epoll</module>
+        <module>integration-shaded</module>
+    </modules>
+
+    <licenses>
+        <license>
+            <name>Apache 2</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>Apache License Version 2.0</comments>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git@github.com:datastax/java-driver.git</connection>
+        <developerConnection>scm:git:git@github.com:datastax/java-driver.git</developerConnection>
+        <url>https://github.com/datastax/java-driver</url>
+    </scm>
+
+    <developers>
+        <developer>
+            <name>Various</name>
+            <organization>DataStax</organization>
+        </developer>
+    </developers>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
   <modules>
     <module>driver-core</module>
+    <module>driver-integration</module>
     <module>driver-examples</module>
     <module>driver-dse</module>
     <module>driver-dist</module>


### PR DESCRIPTION
(Reopening against 2.0 as java640 has been merged.)

Since the behavior of the driver may be altered based on libraries that are present we need a mechanism for testing with these configurations in an automated fashion. The 'osgi' example provides most of this functionality as it loads up OSGi containers with different library configurations, but this is not adequate in some cases, particularly the 'shaded' case where some classes use a different packaging namespace.

This is a first attempt and is far from perfect, but wanted to get this opened up to get some feedback with regards to whether i'm on the right path here.

Some concerns/questions:
1. Is this the right place for something like this?  Does it need to be in the java-driver repository proper, or should it be a separate project?
2. Is the module name 'driver-integration' appropriate?  Can you think of a better name?
3. Can you think of a better way of testing different library configurations other than creating a separate module for each config?
4. The integration-shaded module uses the netty shaded package structure which is problematic at least in IntelliJ.  I think this may be annoying for those who like to keep clean environments.  You can work around it by adding driver-integration/integration-shaded/pom.xml as an [Ignored File](https://www.jetbrains.com/idea/help/maven-ignored-files.html).
5. Another thought I had was that maybe we could customize our existing tests in driver-core to have a base Cluster.Builder that can be configured on a per-module basis, that way we can run all tests under these different configurations.  That may be too exhaustive, but may uncover some unknown issues.

The timeline for review on this is not urgent, this can be something should wait to look at until after release.
