### PR TITLE
Prevent wrapping of Driver and InterruptedException in initAsync.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -182,12 +182,12 @@ class Connection {
                     future.setException(t);
                 } else {
                     // Defunct to ensure that the error will be signaled (marking the host down)
-                    ConnectionException ce = (t instanceof ConnectionException)
-                        ? (ConnectionException)t
+                    Exception e = (t instanceof ConnectionException || t instanceof DriverException || t instanceof InterruptedException)
+                        ? (Exception)t
                         : new ConnectionException(Connection.this.address,
                         String.format("Unexpected error during transport initialization (%s)", t),
                         t);
-                    future.setException(defunct(ce));
+                    future.setException(defunct(e));
                 }
                 return future;
             }


### PR DESCRIPTION
Minor issue noticed that `AuthenticationTest#testConnectionAttemptWithIncorrectCredentialsIsRefused` and `AuthenticationTest#testConnectionAttemptWithoutCredentialsIsRefused()` were failing because `Connection#initAsync` was throwing `AuthenticationException` wrapped in `ConnectionException` which caused `ControlConnection#connection` to fail with `NoHostAvailableException` instead of `AuthenticationException` which it previously did.
