### PR TITLE
Reduce memory footprint by 2

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/CBUtil.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CBUtil.java
@@ -264,7 +264,9 @@ abstract class CBUtil {
         }
 
         cb.writeInt(bytes.remaining());
+        int oldPosition = bytes.position();
         cb.writeBytes(bytes.duplicate());
+        bytes.position(oldPosition);
     }
 
     public static int sizeOfValue(byte[] bytes) {

--- a/driver-core/src/main/java/com/datastax/driver/core/CBUtil.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CBUtil.java
@@ -265,7 +265,7 @@ abstract class CBUtil {
 
         cb.writeInt(bytes.remaining());
         int oldPosition = bytes.position();
-        cb.writeBytes(bytes.duplicate());
+        cb.writeBytes(bytes);
         bytes.position(oldPosition);
     }
 


### PR DESCRIPTION
Run my application under profiler and found that inserts consume a lot of memory. This memory will be garbage collected anyway, but would like to spent my CPU on useful stuff.

Looks like only buffer position is affected. Save and restore it to keep backward compatible with old code.
