### PR TITLE
JAVA-732 Expose KEYS and FULL indexing options in IndexMetadata

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
@@ -234,11 +234,10 @@ public class ColumnMetadata {
         }
 
         /**
-         * Builds a JSON object based on the index options map.
+         * Builds a string representation of the custom index options.
          * 
-         * @return String representation of the JSON object containing the index options,
-         *         similar to what Cassandra stores in the 'index_options' column of the 'schema_columns' table
-         *         in the 'system' keyspace.
+         * @return String representation of the custom index options, similar to what Cassandra stores in
+         *         the 'index_options' column of the 'schema_columns' table in the 'system' keyspace.
          */
         private String getOptionsAsCql() {
             StringBuilder builder = new StringBuilder();

--- a/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
@@ -1,5 +1,7 @@
 package com.datastax.driver.core;
 
+import com.datastax.driver.core.ColumnMetadata.IndexMetadata;
+
 /**
  * Augment AssertJ with custom assertions for the Java driver.
  */
@@ -18,5 +20,9 @@ public class Assertions extends org.assertj.core.api.Assertions{
 
     public static DataTypeAssert assertThat(DataType type) {
         return new DataTypeAssert(type);
+    }
+    
+    public static IndexMetadataAssert assertThat(IndexMetadata indexMetadata) {
+        return new IndexMetadataAssert(indexMetadata);
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -453,6 +453,8 @@ public class CCMBridge {
 
         protected static Cluster cluster;
         protected static Session session;
+        
+        protected final VersionNumber cassandraVersion = VersionNumber.parse(System.getProperty("cassandra.version"));
 
         protected abstract Collection<String> getTableDefinitions();
 

--- a/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataAssert.java
@@ -1,0 +1,70 @@
+package com.datastax.driver.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.AbstractAssert;
+
+import com.datastax.driver.core.ColumnMetadata.IndexMetadata;
+
+public class IndexMetadataAssert extends AbstractAssert<IndexMetadataAssert, IndexMetadata> {
+
+    public IndexMetadataAssert(IndexMetadata actual) {
+        super(actual, IndexMetadataAssert.class);
+    }
+
+    public IndexMetadataAssert hasName(String name) {
+        assertThat(actual.getName()).isEqualTo(name);
+        return this;
+    }
+    
+    public IndexMetadataAssert hasOption(String name, String value) {
+        assertThat(actual.getOption(name)).isEqualTo(value);
+        return this;
+    }
+    
+    public IndexMetadataAssert asCqlQuery(String cqlQuery) {
+        assertThat(actual.asCQLQuery()).isEqualTo(cqlQuery);
+        return this;
+    }
+    
+    public IndexMetadataAssert isKeys(){
+        assertThat(actual.isKeys()).isTrue();
+        return this;
+    }
+    
+    public IndexMetadataAssert isNotKeys(){
+        assertThat(actual.isKeys()).isFalse();
+        return this;
+    }
+    
+    public IndexMetadataAssert isFull() {
+        assertThat(actual.isFull()).isTrue();
+        return this;
+    }
+    
+    public IndexMetadataAssert isNotFull() {
+        assertThat(actual.isFull()).isFalse();
+        return this;
+    }
+    
+    public IndexMetadataAssert isEntries() {
+        assertThat(actual.isEntries()).isTrue();
+        return this;
+    }
+    
+    public IndexMetadataAssert isNotEntries() {
+        assertThat(actual.isEntries()).isFalse();
+        return this;
+    }
+    
+    public IndexMetadataAssert isCustomIndex() {
+        assertThat(actual.isCustomIndex()).isTrue();
+        return this;
+    }
+    
+    public IndexMetadataAssert isNotCustomIndex() {
+        assertThat(actual.isCustomIndex()).isFalse();
+        return this;
+    }
+    
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
@@ -194,8 +194,8 @@ public class IndexMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
             .isNotEntries()
             .isCustomIndex()
             .hasOption("foo", "bar")
-            .asCqlQuery("CREATE CUSTOM INDEX custom_index ON ks_1.indexing (text_column) "
-                + "USING 'dummy.DummyIndex' WITH OPTIONS = {'foo' : 'bar', 'class_name' : 'dummy.DummyIndex'};");
+            .asCqlQuery(String.format("CREATE CUSTOM INDEX custom_index ON %s.indexing (text_column) "
+                + "USING 'dummy.DummyIndex' WITH OPTIONS = {'foo' : 'bar', 'class_name' : 'dummy.DummyIndex'};", keyspace));
     }
 
     private ColumnDefinitions.Definition definition(String name, DataType type) {

--- a/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
@@ -1,0 +1,200 @@
+package com.datastax.driver.core;
+
+import static com.datastax.driver.core.ColumnMetadata.COLUMN_NAME;
+import static com.datastax.driver.core.ColumnMetadata.COMPONENT_INDEX;
+import static com.datastax.driver.core.ColumnMetadata.INDEX_NAME;
+import static com.datastax.driver.core.ColumnMetadata.INDEX_OPTIONS;
+import static com.datastax.driver.core.ColumnMetadata.INDEX_TYPE;
+import static com.datastax.driver.core.ColumnMetadata.KIND;
+import static com.datastax.driver.core.ColumnMetadata.VALIDATOR;
+import static com.datastax.driver.core.DataType.cint;
+import static com.datastax.driver.core.DataType.text;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.datastax.driver.core.ColumnMetadata.IndexMetadata;
+import com.datastax.driver.core.ColumnMetadata.Raw;
+import com.datastax.driver.core.Token.M3PToken;
+import com.datastax.driver.core.utils.CassandraVersion;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+
+@CassandraVersion(
+    major = 2.1)
+public class IndexMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
+
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        String createTable = "CREATE TABLE indexing ("
+            + "id int primary key,"
+            + "map_values map<text, int>,"
+            + "map_keys map<text, int>,"
+            + "map_entries map<text, int>,"
+            + "map_full frozen<map<text, int>>,"
+            + "set_full frozen<set<text>>,"
+            + "list_full frozen<list<text>>,"
+            + "custom text)";
+        return ImmutableList.of(createTable);
+    }
+
+    @Test(
+        groups = "short")
+    public void should_not_flag_map_index_type() {
+        String createValuesIndex = String.format("CREATE INDEX map_values_index ON %s.indexing (map_values);", keyspace);
+        session.execute(createValuesIndex);
+        IndexMetadata index = getIndexForColumn("map_values");
+        Assert.assertEquals(index.getName(), "map_values_index");
+        Assert.assertFalse(index.isKeys());
+        Assert.assertFalse(index.isFull());
+        Assert.assertFalse(index.isEntries());
+        Assert.assertFalse(index.isCustomIndex());
+        Assert.assertEquals(index.asCQLQuery(), createValuesIndex);
+    }
+
+    @Test(
+        groups = "short")
+    public void should_flag_map_index_type_as_keys() {
+        String createKeysIndex = String.format("CREATE INDEX map_keys_index ON %s.indexing (KEYS(map_keys));", keyspace);
+        session.execute(createKeysIndex);
+        IndexMetadata index = getIndexForColumn("map_keys");
+        Assert.assertEquals(index.getName(), "map_keys_index");
+        Assert.assertTrue(index.isKeys());
+        Assert.assertFalse(index.isFull());
+        Assert.assertFalse(index.isEntries());
+        Assert.assertFalse(index.isCustomIndex());
+        Assert.assertEquals(index.asCQLQuery(), createKeysIndex);
+    }
+
+    @Test(
+        groups = "short")
+    @CassandraVersion(
+        major = 2.1,
+        minor = 3)
+    public void should_flag_map_index_type_as_full() {
+        String createFullIndex = String.format("CREATE INDEX map_full_index ON %s.indexing (FULL(map_full));", keyspace);
+        session.execute(createFullIndex);
+        IndexMetadata index = getIndexForColumn("map_full");
+        Assert.assertEquals(index.getName(), "map_full_index");
+        Assert.assertFalse(index.isKeys());
+        Assert.assertTrue(index.isFull());
+        Assert.assertFalse(index.isEntries());
+        Assert.assertFalse(index.isCustomIndex());
+        Assert.assertEquals(index.asCQLQuery(), createFullIndex);
+    }
+
+    @Test(
+        groups = "short")
+    @CassandraVersion(
+        major = 2.1,
+        minor = 3)
+    public void should_flag_set_index_type_as_full() {
+        String createFullIndex = String.format("CREATE INDEX set_full_index ON %s.indexing (FULL(set_full));", keyspace);
+        session.execute(createFullIndex);
+        IndexMetadata index = getIndexForColumn("set_full");
+        Assert.assertEquals(index.getName(), "set_full_index");
+        Assert.assertFalse(index.isKeys());
+        Assert.assertTrue(index.isFull());
+        Assert.assertFalse(index.isEntries());
+        Assert.assertFalse(index.isCustomIndex());
+        Assert.assertEquals(index.asCQLQuery(), createFullIndex);
+    }
+
+    @Test(
+        groups = "short")
+    @CassandraVersion(
+        major = 2.1,
+        minor = 3)
+    public void should_flag_list_index_type_as_full() {
+        String createFullIndex = String.format("CREATE INDEX list_full_index ON %s.indexing (FULL(list_full));", keyspace);
+        session.execute(createFullIndex);
+        IndexMetadata index = getIndexForColumn("list_full");
+        Assert.assertEquals(index.getName(), "list_full_index");
+        Assert.assertFalse(index.isKeys());
+        Assert.assertTrue(index.isFull());
+        Assert.assertFalse(index.isEntries());
+        Assert.assertFalse(index.isCustomIndex());
+        Assert.assertEquals(index.asCQLQuery(), createFullIndex);
+    }
+
+    @Test(
+        groups = "short")
+    @CassandraVersion(
+        major = 3.0)
+    public void should_flag_map_index_type_as_entries() {
+        String createEntriesIndex = String.format("CREATE INDEX map_entries_index ON %s.indexing (ENTRIES(map_entries));", keyspace);
+        session.execute(createEntriesIndex);
+        IndexMetadata index = getIndexForColumn("map_entries");
+        Assert.assertEquals(index.getName(), "map_entries_index");
+        Assert.assertFalse(index.isKeys());
+        Assert.assertFalse(index.isFull());
+        Assert.assertTrue(index.isEntries());
+        Assert.assertFalse(index.isCustomIndex());
+        Assert.assertEquals(index.asCQLQuery(), createEntriesIndex);
+    }
+
+    @Test(
+        groups = "short",
+        description = "This test case builds a ColumnMetadata object programatically to test custom indices,"
+            + "otherwise, it would require deploying an actual custom index class into the C* test cluster")
+    public void should_parse_custom_index_options() {
+        TableMetadata table = getTable("indexing");
+        ColumnDefinitions defs = new ColumnDefinitions(new ColumnDefinitions.Definition[] {
+                definition(COLUMN_NAME, text()),
+                definition(COMPONENT_INDEX, cint()),
+                definition(KIND, text()),
+                definition(INDEX_NAME, text()),
+                definition(INDEX_TYPE, text()),
+                definition(VALIDATOR, text()),
+                definition(INDEX_OPTIONS, text())
+        });
+        List<ByteBuffer> data = ImmutableList.of(
+            wrap("custom"), // column name
+            wrap(0), // component index
+            wrap("regular"), // kind
+            wrap("custom_index"), // index name
+            wrap("CUSTOM"), // index type
+            wrap("org.apache.cassandra.db.marshal.UTF8Type"), // validator
+            wrap("{\"foo\" : \"bar\", \"class_name\" : \"dummy.DummyIndex\"}") // index options
+            );
+        Row row = ArrayBackedRow.fromData(defs, M3PToken.FACTORY, ProtocolVersion.V3, data);
+        ColumnMetadata column = ColumnMetadata.fromRaw(table, Raw.fromRow(row, VersionNumber.parse("2.1")));
+        IndexMetadata index = column.getIndex();
+        Assert.assertFalse(index.isKeys());
+        Assert.assertFalse(index.isFull());
+        Assert.assertFalse(index.isEntries());
+        Assert.assertTrue(index.isCustomIndex());
+        Assert.assertEquals(index.getOption("foo"), "bar");
+        Assert.assertEquals(index.asCQLQuery(), "CREATE CUSTOM INDEX custom_index ON ks_1.indexing (custom) "
+            + "USING 'dummy.DummyIndex' WITH OPTIONS = {'foo' : 'bar', 'class_name' : 'dummy.DummyIndex'};");
+    }
+
+    private ColumnDefinitions.Definition definition(String name, DataType type) {
+        return new ColumnDefinitions.Definition("ks", "table", name, type);
+    }
+
+    private ByteBuffer wrap(String value) {
+        return ByteBuffer.wrap(value.getBytes());
+    }
+
+    private ByteBuffer wrap(int number) {
+        return ByteBuffer.wrap(Ints.toByteArray(number));
+    }
+
+    private IndexMetadata getIndexForColumn(String columnName) {
+        return getColumn(columnName).getIndex();
+    }
+
+    private ColumnMetadata getColumn(String name) {
+        return getTable("indexing").getColumn(name);
+    }
+
+    private TableMetadata getTable(String name) {
+        return cluster.getMetadata().getKeyspace(keyspace).getTable(name);
+    }
+
+}


### PR DESCRIPTION
- Exposed the type of the index for a collection (KEYS, FULL or ENTRIES) through the following API: isKeys, isFull and isEntries;
- Also, exposed the index options that might be available for a custom index through the new "getOption(String)" method;
- Changed the asCQLQuery method to include the index functions, if necessary, and also
  to include the custom index options using the "WITH OPTIONS" keywords;
- Added tests, to the "short" TestNG group, to validate the changes in the IndexMetadata class. Please, note that one test case, "should_flag_map_index_type_as_entries", requires C\* 3.0 which is not released yet, hence, it's not available under the CCM infrastructure used by the driver, so the test will be skipped for now.
