### PR TITLE
Fix 2.1 specific Integration Test issues.

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/DynamicConnectionPoolTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DynamicConnectionPoolTest.java
@@ -45,7 +45,10 @@ public class DynamicConnectionPoolTest extends CCMBridge.PerClassSingleNodeClust
 
     @Override
     protected Cluster.Builder configure(Cluster.Builder builder) {
-        return builder.withProtocolVersion(ProtocolVersion.V2);
+        // Use version 2 at highest.
+        ProtocolVersion versionToUse = TestUtils.getDesiredProtocolVersion();
+        versionToUse = versionToUse == ProtocolVersion.V3 ? ProtocolVersion.V2 : versionToUse;
+        return builder.withProtocolVersion(versionToUse);
     }
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -434,14 +434,16 @@ public abstract class TestUtils {
     /**
      * @return The desired target protocol version based on the 'cassandra.version' System property.
      */
-    public static int getDesiredProtocolVersion() {
+    public static ProtocolVersion getDesiredProtocolVersion() {
         String version = System.getProperty("cassandra.version");
         String[] versionArray = version.split("\\.|-");
         double major = Double.parseDouble(versionArray[0] + "." + versionArray[1]);
         if(major < 2.0) {
-            return 1;
+            return ProtocolVersion.V1;
+        } else if (major < 2.1) {
+            return ProtocolVersion.V2;
         } else {
-            return 2;
+            return ProtocolVersion.V3;
         }
     }
 


### PR DESCRIPTION
Fixes DynamicConnectionPoolTest by not explicitly settings Protocol Version 2, which breaks when running 1.2 clusters.

Updates getDesiredProtocolVersion to return ProtocolVersion and also return V3.
