### PR TITLE
Fix some timing and protocol version issues in Integration Tests.

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
@@ -110,6 +110,7 @@ public class RecommissionedNodeTest {
 
         // Node 1 should now be DOWN with no reconnection attempt
         assertThat(mainCluster).host(1)
+            .goesDownWithin(10, TimeUnit.SECONDS)
             .hasState(DOWN)
             .isNotReconnectingFromDown();
     }
@@ -133,6 +134,7 @@ public class RecommissionedNodeTest {
 
         // Node 1 should now be DOWN with no reconnection attempt
         assertThat(mainCluster).host(1)
+            .goesDownWithin(10, TimeUnit.SECONDS)
             .hasState(DOWN)
             .isNotReconnectingFromDown();
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/ReconnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReconnectionTest.java
@@ -262,6 +262,7 @@ public class ReconnectionTest {
                 .withReconnectionPolicy(new ConstantReconnectionPolicy(5000))
                 .withLoadBalancingPolicy(loadBalancingPolicy)
                 .withSocketOptions(socketOptions)
+                .withProtocolVersion(TestUtils.getDesiredProtocolVersion())
                 .build();
             // Create two sessions to have multiple pools
             cluster.connect();


### PR DESCRIPTION
Fixes timing issue in RecommissionedNodeTest by giving the Driver time to mark a node down as it is additionally in an 'ADDED' state on connect and will be marked down as soon as we detect invalid cluster name/version.

Sets protocol version explicitly in ReconnectionTest#should_use_connection_from_reconnection_in_pool so we do not need to account for a possible reconnection(s) to demote the protocol version.

Can this be merged to 2.1 shortly after as well?
