### PR TITLE
Fix ClusterInitTest#should_wait_for_each_contact_point_at_most_once.

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
@@ -92,9 +92,7 @@ public class ClusterInitTest {
 
             // We have one live host so we expect 1 control connection + core connection count successful connections.
             // The other 5 hosts are unreachable, we should attempt to connect to each of them only once.
-            int coreConnections = cluster.getConfiguration()
-                    .getPoolingOptions()
-                    .getCoreConnectionsPerHost(HostDistance.LOCAL);
+            int coreConnections = TestUtils.numberOfLocalCoreConnections(cluster);
             verify(socketOptions, times(1 + coreConnections + 5)).getKeepAlive();
         } finally {
             if (cluster != null)


### PR DESCRIPTION
Use TestUtils.numberOfLocalCoreConnections to get correct number of core connections used based on protocol version.  Was failing on 2.1 running against a 2.1+ cassandra cluster.
