### PR TITLE
User-defined functions in 2.2

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@
 - [new feature] Expose server-side warnings on ExecutionInfo (JAVA-780)
 - [new feature] Expose new read/write failure exceptions (JAVA-749)
 - [new feature] Expose function and aggregate metadata (JAVA-747)
+- [new feature] Add new client exception for CQL function failure (JAVA-778)
 
 Merged from 2.1 branch:
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -7,6 +7,7 @@
 - [new feature] Distinguish NULL and UNSET values (JAVA-777)
 - [new feature] Expose server-side warnings on ExecutionInfo (JAVA-780)
 - [new feature] Expose new read/write failure exceptions (JAVA-749)
+- [new feature] Expose function and aggregate metadata (JAVA-747)
 
 Merged from 2.1 branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/AggregateMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AggregateMetadata.java
@@ -1,0 +1,288 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+/**
+ * Describes a CQL aggregate function (created with {@code CREATE AGGREGATE...}).
+ */
+public class AggregateMetadata {
+
+    private final KeyspaceMetadata keyspace;
+    private final String fullName;
+    private final String simpleName;
+    private final List<DataType> argumentTypes;
+    private final String finalFuncSimpleName;
+    private final String finalFuncFullName;
+    private final Object initCond;
+    private final DataType returnType;
+    private final String stateFuncSimpleName;
+    private final String stateFuncFullName;
+    private final DataType stateType;
+
+    public AggregateMetadata(KeyspaceMetadata keyspace, String fullName, String simpleName, List<DataType> argumentTypes,
+                             String finalFuncSimpleName, String finalFuncFullName, Object initCond, DataType returnType,
+                             String stateFuncSimpleName, String stateFuncFullName, DataType stateType) {
+        this.keyspace = keyspace;
+        this.fullName = fullName;
+        this.simpleName = simpleName;
+        this.argumentTypes = argumentTypes;
+        this.finalFuncSimpleName = finalFuncSimpleName;
+        this.finalFuncFullName = finalFuncFullName;
+        this.initCond = initCond;
+        this.returnType = returnType;
+        this.stateFuncSimpleName = stateFuncSimpleName;
+        this.stateFuncFullName = stateFuncFullName;
+        this.stateType = stateType;
+    }
+
+    // CREATE TABLE system.schema_aggregates (
+    //     keyspace_name text,
+    //     aggregate_name text,
+    //     signature frozen<list<text>>,
+    //     argument_types list<text>,
+    //     final_func text,
+    //     initcond blob,
+    //     return_type text,
+    //     state_func text,
+    //     state_type text,
+    //     PRIMARY KEY (keyspace_name, aggregate_name, signature)
+    // ) WITH CLUSTERING ORDER BY (aggregate_name ASC, signature ASC)
+    static AggregateMetadata build(KeyspaceMetadata ksm, Row row, ProtocolVersion protocolVersion) {
+        String simpleName = row.getString("aggregate_name");
+        List<String> signature = row.getList("signature", String.class);
+        String fullName = Metadata.fullFunctionName(simpleName, signature);
+        List<DataType> argumentTypes = parseTypes(row.getList("argument_types", String.class));
+        String finalFuncSimpleName = row.getString("final_func");
+        DataType returnType = CassandraTypeParser.parseOne(row.getString("return_type"));
+        String stateFuncSimpleName = row.getString("state_func");
+        String stateTypeName = row.getString("state_type");
+        DataType stateType = CassandraTypeParser.parseOne(stateTypeName);
+        ByteBuffer rawInitCond = row.getBytes("initcond");
+        Object initCond = rawInitCond == null ? null : stateType.deserialize(rawInitCond, protocolVersion);
+
+        String finalFuncFullName = finalFuncSimpleName == null ? null : String.format("%s(%s)", finalFuncSimpleName, stateType);
+        String stateFuncFullName = makeStateFuncFullName(stateFuncSimpleName, stateType.toString(), signature);
+
+        AggregateMetadata aggregate = new AggregateMetadata(ksm, fullName, simpleName, argumentTypes,
+            finalFuncSimpleName, finalFuncFullName, initCond, returnType, stateFuncSimpleName,
+            stateFuncFullName, stateType);
+        ksm.add(aggregate);
+        return aggregate;
+    }
+
+    private static String makeStateFuncFullName(String stateFuncSimpleName, String stateTypeName, List<String> typeNames) {
+        List<String> args = Lists.newArrayList(stateTypeName);
+        args.addAll(typeNames);
+        return Metadata.fullFunctionName(stateFuncSimpleName, args);
+    }
+
+    private static List<DataType> parseTypes(List<String> names) {
+        if (names.isEmpty())
+            return Collections.emptyList();
+
+        ImmutableList.Builder<DataType> builder = ImmutableList.builder();
+        for (String name : names)
+            builder.add(CassandraTypeParser.parseOne(name));
+        return builder.build();
+    }
+
+    /**
+     * Returns a CQL query representing this function in human readable form.
+     * <p>
+     * This method is equivalent to {@link #asCQLQuery} but the output is formatted.
+     *
+     * @return the CQL query representing this function.
+     */
+    public String exportAsString() {
+        return asCQLQuery(true);
+    }
+
+    /**
+     * Returns a CQL query representing this function.
+     *
+     * This method returns a single 'CREATE FUNCTION' query corresponding to
+     * this function definition.
+     *
+     * @return the 'CREATE FUNCTION' query corresponding to this function.
+     */
+    public String asCQLQuery() {
+        return asCQLQuery(false);
+    }
+
+    @Override
+    public String toString() {
+        return asCQLQuery(false);
+    }
+
+    private String asCQLQuery(boolean formatted) {
+        //create aggregate test.prettysum(int) SFUNC plus STYPE int FINALFUNC announce INITCOND 0;
+
+        StringBuilder sb = new StringBuilder();
+
+        sb
+            .append("CREATE AGGREGATE ")
+            .append(Metadata.escapeId(keyspace.getName()))
+            .append('.')
+            .append(Metadata.escapeId(simpleName))
+            .append('(');
+
+        boolean first = true;
+        for (DataType type : argumentTypes) {
+            if (first)
+                first = false;
+            else
+                sb.append(',');
+            sb.append(type);
+        }
+        sb.append(')');
+
+        TableMetadata.spaceOrNewLine(sb, formatted)
+            .append("SFUNC ")
+            .append(stateFuncSimpleName)
+            .append(" STYPE ")
+            .append(stateType);
+
+        if (finalFuncSimpleName != null)
+            TableMetadata.spaceOrNewLine(sb, formatted)
+                .append("FINALFUNC ")
+                .append(finalFuncSimpleName);
+
+        if (initCond != null)
+            TableMetadata.spaceOrNewLine(sb, formatted)
+                .append("INITCOND ")
+                .append(stateType.format(initCond));
+
+        sb.append(';');
+
+        return sb.toString();
+    }
+
+    /**
+     * Returns the keyspace this aggregate belongs to.
+     *
+     * @return the keyspace metadata of the keyspace this aggregate belongs to.
+     */
+    public KeyspaceMetadata getKeyspace() {
+        return keyspace;
+    }
+
+    /**
+     * Returns the full name of this aggregate.
+     * <p>
+     * This is the name of the aggregate, followed by the names of the argument types between parentheses,
+     * like it was specified in the {@code CREATE AGGREGATE...} statement, for example {@code sum(int)}.
+     *
+     * @return the full name.
+     */
+    public String getFullName() {
+        return fullName;
+    }
+
+    /**
+     * Returns the simple name of this aggregate.
+     * <p>
+     * This is the name of the aggregate, without arguments. Note that aggregates can be overloaded with
+     * different argument lists, therefore the simple name may not be unique. For example,
+     * {@code sum(int)} and {@code sum(int,int)} both have the simple name {@code sum}.
+     *
+     * @return the simple name.
+     *
+     * @see #getFullName()
+     */
+    public String getSimpleName() {
+        return simpleName;
+    }
+
+    /**
+     * Returns the types of this aggregate's arguments.
+     *
+     * @return the types.
+     */
+    public List<DataType> getArgumentTypes() {
+        return argumentTypes;
+    }
+
+    /**
+     * Returns the final function of this aggregate.
+     * <p>
+     * This is the function specified with {@code FINALFUNC} in the {@code CREATE AGGREGATE...}
+     * statement. It transforms the final value after the aggregation is complete.
+     *
+     * @return the metadata of the final function, or {@code null} if there is none.
+     */
+    public FunctionMetadata getFinalFunc() {
+        return (finalFuncFullName == null)
+            ? null
+            : keyspace.functions.get(finalFuncFullName);
+    }
+
+    /**
+     * Returns the initial state value of this aggregate.
+     * <p>
+     * This is the value specified with {@code INITCOND} in the {@code CREATE AGGREGATE...}
+     * statement. It's passed to the initial invocation of the state function (if that function
+     * does not accept null arguments).
+     *
+     * @return the initial state, or {@code null} if there is none.
+     */
+    public Object getInitCond() {
+        return initCond;
+    }
+
+    /**
+     * Returns the return type of this aggregate.
+     * <p>
+     * This is the final type of the value computed by this aggregate; in other words, the return
+     * type of the final function if it is defined, or the state type otherwise.
+     *
+     * @return the return type.
+     */
+    public DataType getReturnType() {
+        return returnType;
+    }
+
+    /**
+     * Returns the state function of this aggregate.
+     * <p>
+     * This is the function specified with {@code SFUNC} in the {@code CREATE AGGREGATE...}
+     * statement. It aggregates the current state with each row to produce a new state.
+     *
+     * @return the metadata of the state function.
+     */
+    public FunctionMetadata getStateFunc() {
+        return keyspace.functions.get(stateFuncFullName);
+    }
+
+    /**
+     * Returns the state type of this aggregate.
+     * <p>
+     * This is the type specified with {@code STYPE} in the {@code CREATE AGGREGATE...}
+     * statement. It defines the type of the value that is accumulated as the aggregate
+     * iterates through the rows.
+     *
+     * @return the state type.
+     */
+    public DataType getStateType() {
+        return stateType;
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -2007,31 +2007,31 @@ public class Cluster implements Closeable {
             }
         }
 
-        public void submitSchemaRefresh(final SchemaElement targetType, final String targetKeyspace, final String targetName) {
+        public void submitSchemaRefresh(final SchemaElement targetType, final String targetKeyspace, final String targetName, final String signature) {
             logger.trace("Submitting schema refresh");
             executor.submit(new ExceptionCatchingRunnable() {
                 @Override
                 public void runMayThrow() throws InterruptedException, ExecutionException {
-                    controlConnection.refreshSchema(targetType, targetKeyspace, targetName);
+                    controlConnection.refreshSchema(targetType, targetKeyspace, targetName, signature);
                 }
             });
         }
 
         // refresh the schema using the provided connection, and notice the future with the provided resultset once done
-        public void refreshSchemaAndSignal(final Connection connection, final DefaultResultSetFuture future, final ResultSet rs, final SchemaElement target, final String keyspace, final String name) {
+        public void refreshSchemaAndSignal(final Connection connection, final DefaultResultSetFuture future, final ResultSet rs, final SchemaElement target, final String keyspace, final String name, final String signature) {
             if (logger.isDebugEnabled())
                 logger.debug("Refreshing schema for {}{}",
                     target == null ? "everything" : keyspace,
                     (target == KEYSPACE) ? "" : "." + name + " (" + target + ")");
 
-            maybeRefreshSchemaAndSignal(connection, future, rs, target, keyspace, name);
+            maybeRefreshSchemaAndSignal(connection, future, rs, target, keyspace, name, signature);
         }
 
         public void waitForSchemaAgreementAndSignal(final Connection connection, final DefaultResultSetFuture future, final ResultSet rs) {
-            maybeRefreshSchemaAndSignal(connection, future, rs, null, null, null);
+            maybeRefreshSchemaAndSignal(connection, future, rs, null, null, null, null);
         }
 
-        private void maybeRefreshSchemaAndSignal(final Connection connection, final DefaultResultSetFuture future, final ResultSet rs, final SchemaElement targetType, final String targetKeyspace, final String targetName) {
+        private void maybeRefreshSchemaAndSignal(final Connection connection, final DefaultResultSetFuture future, final ResultSet rs, final SchemaElement targetType, final String targetKeyspace, final String targetName, final String signature) {
             final boolean refreshSchema = (targetKeyspace != null); // if false, only wait for schema agreement
 
             executor.submit(new Runnable() {
@@ -2045,11 +2045,11 @@ public class Cluster implements Closeable {
                         if (!schemaInAgreement)
                             logger.warn("No schema agreement from live replicas after {} s. The schema may not be up to date on some nodes.", configuration.getProtocolOptions().getMaxSchemaAgreementWaitSeconds());
                         if (refreshSchema)
-                            ControlConnection.refreshSchema(connection, targetType, targetKeyspace, targetName, Manager.this, false);
+                            ControlConnection.refreshSchema(connection, targetType, targetKeyspace, targetName, signature, Manager.this, false);
                     } catch (Exception e) {
                         if (refreshSchema) {
                             logger.error("Error during schema refresh ({}). The schema from Cluster.getMetadata() might appear stale. Asynchronously submitting job to fix.", e.getMessage());
-                            submitSchemaRefresh(targetType, targetKeyspace, targetName);
+                            submitSchemaRefresh(targetType, targetKeyspace, targetName, signature);
                         } else {
                             logger.warn("Error while waiting for schema agreement", e);
                         }
@@ -2173,7 +2173,10 @@ public class Cluster implements Closeable {
                     switch (scc.change) {
                         case CREATED:
                         case UPDATED:
-                            submitSchemaRefresh(scc.targetType, scc.targetKeyspace, scc.targetName);
+                            // TODO generate signature for function/aggregate events
+                            String signature = null;
+
+                            submitSchemaRefresh(scc.targetType, scc.targetKeyspace, scc.targetName, signature);
                             break;
                         case DROPPED:
                             KeyspaceMetadata keyspace;

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -2007,31 +2007,31 @@ public class Cluster implements Closeable {
             }
         }
 
-        public void submitSchemaRefresh(final SchemaElement targetType, final String targetKeyspace, final String targetName, final String signature) {
+        public void submitSchemaRefresh(final SchemaElement targetType, final String targetKeyspace, final String targetName, final List<String> targetSignature) {
             logger.trace("Submitting schema refresh");
             executor.submit(new ExceptionCatchingRunnable() {
                 @Override
                 public void runMayThrow() throws InterruptedException, ExecutionException {
-                    controlConnection.refreshSchema(targetType, targetKeyspace, targetName, signature);
+                    controlConnection.refreshSchema(targetType, targetKeyspace, targetName, targetSignature);
                 }
             });
         }
 
         // refresh the schema using the provided connection, and notice the future with the provided resultset once done
-        public void refreshSchemaAndSignal(final Connection connection, final DefaultResultSetFuture future, final ResultSet rs, final SchemaElement target, final String keyspace, final String name, final String signature) {
+        public void refreshSchemaAndSignal(final Connection connection, final DefaultResultSetFuture future, final ResultSet rs, final SchemaElement targetType, final String targetKeyspace, final String targetName, final List<String> targetSignature) {
             if (logger.isDebugEnabled())
                 logger.debug("Refreshing schema for {}{}",
-                    target == null ? "everything" : keyspace,
-                    (target == KEYSPACE) ? "" : "." + name + " (" + target + ")");
+                    targetType == null ? "everything" : targetKeyspace,
+                    (targetType == KEYSPACE) ? "" : "." + targetName + " (" + targetType + ")");
 
-            maybeRefreshSchemaAndSignal(connection, future, rs, target, keyspace, name, signature);
+            maybeRefreshSchemaAndSignal(connection, future, rs, targetType, targetKeyspace, targetName, targetSignature);
         }
 
         public void waitForSchemaAgreementAndSignal(final Connection connection, final DefaultResultSetFuture future, final ResultSet rs) {
             maybeRefreshSchemaAndSignal(connection, future, rs, null, null, null, null);
         }
 
-        private void maybeRefreshSchemaAndSignal(final Connection connection, final DefaultResultSetFuture future, final ResultSet rs, final SchemaElement targetType, final String targetKeyspace, final String targetName, final String signature) {
+        private void maybeRefreshSchemaAndSignal(final Connection connection, final DefaultResultSetFuture future, final ResultSet rs, final SchemaElement targetType, final String targetKeyspace, final String targetName, final List<String> targetSignature) {
             final boolean refreshSchema = (targetKeyspace != null); // if false, only wait for schema agreement
 
             executor.submit(new Runnable() {
@@ -2045,11 +2045,11 @@ public class Cluster implements Closeable {
                         if (!schemaInAgreement)
                             logger.warn("No schema agreement from live replicas after {} s. The schema may not be up to date on some nodes.", configuration.getProtocolOptions().getMaxSchemaAgreementWaitSeconds());
                         if (refreshSchema)
-                            ControlConnection.refreshSchema(connection, targetType, targetKeyspace, targetName, signature, Manager.this, false);
+                            ControlConnection.refreshSchema(connection, targetType, targetKeyspace, targetName, targetSignature, Manager.this, false);
                     } catch (Exception e) {
                         if (refreshSchema) {
                             logger.error("Error during schema refresh ({}). The schema from Cluster.getMetadata() might appear stale. Asynchronously submitting job to fix.", e.getMessage());
-                            submitSchemaRefresh(targetType, targetKeyspace, targetName, signature);
+                            submitSchemaRefresh(targetType, targetKeyspace, targetName, targetSignature);
                         } else {
                             logger.warn("Error while waiting for schema agreement", e);
                         }
@@ -2173,33 +2173,32 @@ public class Cluster implements Closeable {
                     switch (scc.change) {
                         case CREATED:
                         case UPDATED:
-                            // TODO generate signature for function/aggregate events
-                            String signature = null;
-
-                            submitSchemaRefresh(scc.targetType, scc.targetKeyspace, scc.targetName, signature);
+                            submitSchemaRefresh(scc.targetType, scc.targetKeyspace, scc.targetName, scc.targetSignature);
                             break;
                         case DROPPED:
-                            KeyspaceMetadata keyspace;
-                            switch (scc.targetType) {
-                                case KEYSPACE:
-                                    manager.metadata.removeKeyspace(scc.targetKeyspace);
-                                    break;
-                                case TABLE:
-                                    keyspace = manager.metadata.getKeyspaceInternal(scc.targetKeyspace);
-                                    if (keyspace == null)
-                                        logger.warn("Received a DROPPED notification for table {}.{}, but this keyspace is unknown in our metadata",
-                                            scc.targetKeyspace, scc.targetName);
-                                    else
-                                        keyspace.removeTable(scc.targetName);
-                                    break;
-                                case TYPE:
-                                    keyspace = manager.metadata.getKeyspaceInternal(scc.targetKeyspace);
-                                    if (keyspace == null)
-                                        logger.warn("Received a DROPPED notification for UDT {}.{}, but this keyspace is unknown in our metadata",
-                                            scc.targetKeyspace, scc.targetName);
-                                    else
-                                        keyspace.removeUserType(scc.targetName);
-                                    break;
+                            if (scc.targetType == KEYSPACE) {
+                                manager.metadata.removeKeyspace(scc.targetKeyspace);
+                            } else {
+                                KeyspaceMetadata keyspace = manager.metadata.getKeyspaceInternal(scc.targetKeyspace);
+                                if (keyspace == null) {
+                                    logger.warn("Received a DROPPED notification for {} {}.{}, but this keyspace is unknown in our metadata",
+                                        scc.targetType, scc.targetKeyspace, scc.targetName);
+                                } else {
+                                    switch (scc.targetType) {
+                                        case TABLE:
+                                            keyspace.removeTable(scc.targetName);
+                                            break;
+                                        case TYPE:
+                                            keyspace.removeUserType(scc.targetName);
+                                            break;
+                                        case FUNCTION:
+                                            keyspace.removeFunction(Metadata.fullFunctionName(scc.targetName, scc.targetSignature));
+                                            break;
+                                        case AGGREGATE:
+                                            keyspace.removeAggregate(Metadata.fullFunctionName(scc.targetName, scc.targetSignature));
+                                            break;
+                                    }
+                                }
                             }
                             break;
                     }

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -288,7 +288,7 @@ class ControlConnection implements Host.StateListener {
         }
     }
 
-    public void refreshSchema(SchemaElement targetType, String targetKeyspace, String targetName, String signature) throws InterruptedException {
+    public void refreshSchema(SchemaElement targetType, String targetKeyspace, String targetName, List<String> signature) throws InterruptedException {
         logger.debug("[Control connection] Refreshing schema for {}{}",
             targetType == null ? "everything" : targetKeyspace,
             (targetType == KEYSPACE) ? "" : "." + targetName + " (" + targetType + ")");
@@ -312,7 +312,7 @@ class ControlConnection implements Host.StateListener {
         }
     }
 
-    static void refreshSchema(Connection connection, SchemaElement targetType, String targetKeyspace, String targetName, String signature, Cluster.Manager cluster, boolean isInitialConnection) throws ConnectionException, BusyConnectionException, ExecutionException, InterruptedException {
+    static void refreshSchema(Connection connection, SchemaElement targetType, String targetKeyspace, String targetName, List<String> targetSignature, Cluster.Manager cluster, boolean isInitialConnection) throws ConnectionException, BusyConnectionException, ExecutionException, InterruptedException {
         Host host = cluster.metadata.getHost(connection.address);
         // Neither host, nor it's version should be null. But instead of dying if there is a race or something, we can kind of try to infer
         // a Cassandra version from the protocol version (this is not full proof, we can have the protocol 1 against C* 2.0+, but it's worth
@@ -335,9 +335,9 @@ class ControlConnection implements Host.StateListener {
             else if (targetType == TYPE)
                 whereClause += " AND type_name = '" + targetName + '\'';
             else if (targetType == FUNCTION)
-                whereClause += " AND function_name = '" + targetName + "' AND signature = '" + signature + '\'';
+                whereClause += " AND function_name = '" + targetName + "' AND signature = " + DataType.LIST_OF_TEXT.format(targetSignature);
             else if (targetType == AGGREGATE)
-                whereClause += " AND aggregate_name = '" + targetName + "' AND signature = '" + signature + '\'';
+                whereClause += " AND aggregate_name = '" + targetName + "' AND signature = " + DataType.LIST_OF_TEXT.format(targetSignature);
         }
 
         boolean isSchemaOrKeyspace = (targetType == null || targetType == KEYSPACE);

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -32,9 +32,7 @@ import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.exceptions.DriverInternalError;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 
-import static com.datastax.driver.core.SchemaElement.KEYSPACE;
-import static com.datastax.driver.core.SchemaElement.TABLE;
-import static com.datastax.driver.core.SchemaElement.TYPE;
+import static com.datastax.driver.core.SchemaElement.*;
 
 class ControlConnection implements Host.StateListener {
 
@@ -54,6 +52,8 @@ class ControlConnection implements Host.StateListener {
     private static final String SELECT_COLUMN_FAMILIES = "SELECT * FROM system.schema_columnfamilies";
     private static final String SELECT_COLUMNS = "SELECT * FROM system.schema_columns";
     private static final String SELECT_USERTYPES = "SELECT * FROM system.schema_usertypes";
+    private static final String SELECT_FUNCTIONS = "SELECT * FROM system.schema_functions";
+    private static final String SELECT_AGGREGATES = "SELECT * FROM system.schema_aggregates";
 
     private static final String SELECT_PEERS = "SELECT * FROM system.peers";
     private static final String SELECT_LOCAL = "SELECT * FROM system.local WHERE key='local'";
@@ -268,7 +268,7 @@ class ControlConnection implements Host.StateListener {
             // We want that because the token map was not properly initialized by the first call above, since it requires the list of keyspaces
             // to be loaded.
             logger.debug("[Control connection] Refreshing schema");
-            refreshSchema(connection, null, null, null, cluster, isInitialConnection);
+            refreshSchema(connection, null, null, null, null, cluster, isInitialConnection);
             return connection;
         } catch (BusyConnectionException e) {
             connection.closeAsync().force();
@@ -288,7 +288,7 @@ class ControlConnection implements Host.StateListener {
         }
     }
 
-    public void refreshSchema(SchemaElement targetType, String targetKeyspace, String targetName) throws InterruptedException {
+    public void refreshSchema(SchemaElement targetType, String targetKeyspace, String targetName, String signature) throws InterruptedException {
         logger.debug("[Control connection] Refreshing schema for {}{}",
             targetType == null ? "everything" : targetKeyspace,
             (targetType == KEYSPACE) ? "" : "." + targetName + " (" + targetType + ")");
@@ -297,7 +297,7 @@ class ControlConnection implements Host.StateListener {
             // At startup, when we add the initial nodes, this will be null, which is ok
             if (c == null)
                 return;
-            refreshSchema(c, targetType, targetKeyspace, targetName, cluster, false);
+            refreshSchema(c, targetType, targetKeyspace, targetName, signature, cluster, false);
         } catch (ConnectionException e) {
             logger.debug("[Control connection] Connection error while refreshing schema ({})", e.getMessage());
             signalError();
@@ -312,7 +312,7 @@ class ControlConnection implements Host.StateListener {
         }
     }
 
-    static void refreshSchema(Connection connection, SchemaElement targetType, String targetKeyspace, String targetName, Cluster.Manager cluster, boolean isInitialConnection) throws ConnectionException, BusyConnectionException, ExecutionException, InterruptedException {
+    static void refreshSchema(Connection connection, SchemaElement targetType, String targetKeyspace, String targetName, String signature, Cluster.Manager cluster, boolean isInitialConnection) throws ConnectionException, BusyConnectionException, ExecutionException, InterruptedException {
         Host host = cluster.metadata.getHost(connection.address);
         // Neither host, nor it's version should be null. But instead of dying if there is a race or something, we can kind of try to infer
         // a Cassandra version from the protocol version (this is not full proof, we can have the protocol 1 against C* 2.0+, but it's worth
@@ -334,21 +334,31 @@ class ControlConnection implements Host.StateListener {
                 whereClause += " AND columnfamily_name = '" + targetName + '\'';
             else if (targetType == TYPE)
                 whereClause += " AND type_name = '" + targetName + '\'';
+            else if (targetType == FUNCTION)
+                whereClause += " AND function_name = '" + targetName + "' AND signature = '" + signature + '\'';
+            else if (targetType == AGGREGATE)
+                whereClause += " AND aggregate_name = '" + targetName + "' AND signature = '" + signature + '\'';
         }
 
         boolean isSchemaOrKeyspace = (targetType == null || targetType == KEYSPACE);
         DefaultResultSetFuture ksFuture = isSchemaOrKeyspace
-                                        ? new DefaultResultSetFuture(null, cluster.protocolVersion(), new Requests.Query(SELECT_KEYSPACES + whereClause))
-                                        : null;
+            ? new DefaultResultSetFuture(null, cluster.protocolVersion(), new Requests.Query(SELECT_KEYSPACES + whereClause))
+            : null;
         DefaultResultSetFuture udtFuture = (isSchemaOrKeyspace && supportsUdts(cassandraVersion) || targetType == TYPE)
-                                         ? new DefaultResultSetFuture(null, cluster.protocolVersion(), new Requests.Query(SELECT_USERTYPES + whereClause))
-                                         : null;
+            ? new DefaultResultSetFuture(null, cluster.protocolVersion(), new Requests.Query(SELECT_USERTYPES + whereClause))
+            : null;
         DefaultResultSetFuture cfFuture = (isSchemaOrKeyspace || targetType == TABLE)
-                                        ? new DefaultResultSetFuture(null, cluster.protocolVersion(), new Requests.Query(SELECT_COLUMN_FAMILIES + whereClause))
-                                        : null;
+            ? new DefaultResultSetFuture(null, cluster.protocolVersion(), new Requests.Query(SELECT_COLUMN_FAMILIES + whereClause))
+            : null;
         DefaultResultSetFuture colsFuture = (isSchemaOrKeyspace || targetType == TABLE)
-                                          ? new DefaultResultSetFuture(null, cluster.protocolVersion(), new Requests.Query(SELECT_COLUMNS + whereClause))
-                                          : null;
+            ? new DefaultResultSetFuture(null, cluster.protocolVersion(), new Requests.Query(SELECT_COLUMNS + whereClause))
+            : null;
+        DefaultResultSetFuture functionsFuture = (isSchemaOrKeyspace && supportsUdfs(cassandraVersion) || targetType == FUNCTION)
+            ? new DefaultResultSetFuture(null, cluster.protocolVersion(), new Requests.Query(SELECT_FUNCTIONS + whereClause))
+            : null;
+        DefaultResultSetFuture aggregatesFuture = (isSchemaOrKeyspace && supportsUdfs(cassandraVersion) || targetType == AGGREGATE)
+            ? new DefaultResultSetFuture(null, cluster.protocolVersion(), new Requests.Query(SELECT_AGGREGATES + whereClause))
+            : null;
 
         if (ksFuture != null)
             connection.write(ksFuture);
@@ -358,14 +368,20 @@ class ControlConnection implements Host.StateListener {
             connection.write(cfFuture);
         if (colsFuture != null)
             connection.write(colsFuture);
+        if (functionsFuture != null)
+            connection.write(functionsFuture);
+        if (aggregatesFuture != null)
+            connection.write(aggregatesFuture);
 
         try {
             cluster.metadata.rebuildSchema(targetType, targetKeyspace, targetName,
-                                           ksFuture == null ? null : ksFuture.get(),
-                                           udtFuture == null ? null : udtFuture.get(),
-                                           cfFuture == null ? null : cfFuture.get(),
-                                           colsFuture == null ? null : colsFuture.get(),
-                                           cassandraVersion);
+                ksFuture == null ? null : ksFuture.get(),
+                udtFuture == null ? null : udtFuture.get(),
+                cfFuture == null ? null : cfFuture.get(),
+                colsFuture == null ? null : colsFuture.get(),
+                functionsFuture == null ? null : functionsFuture.get(),
+                aggregatesFuture == null ? null : aggregatesFuture.get(),
+                cassandraVersion);
         } catch (RuntimeException e) {
             // Failure to parse the schema is definitively wrong so log a full-on error, but this won't generally prevent queries to
             // work and this can happen when new Cassandra versions modify stuff in the schema and the driver hasn't yet be modified.
@@ -381,6 +397,10 @@ class ControlConnection implements Host.StateListener {
 
     private static boolean supportsUdts(VersionNumber cassandraVersion) {
         return cassandraVersion.getMajor() > 2 || (cassandraVersion.getMajor() == 2 && cassandraVersion.getMinor() >= 1);
+    }
+
+    private static boolean supportsUdfs(VersionNumber cassandraVersion) {
+        return cassandraVersion.getMajor() > 2 || (cassandraVersion.getMajor() == 2 && cassandraVersion.getMinor() >= 2);
     }
 
     public void refreshNodeListAndTokenMap() {

--- a/driver-core/src/main/java/com/datastax/driver/core/DataType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataType.java
@@ -176,6 +176,8 @@ public abstract class DataType {
     }
     private static final Set<DataType> primitiveTypeSet = ImmutableSet.copyOf(primitiveTypeMap.values());
 
+    static final DataType LIST_OF_TEXT = DataType.list(DataType.text());
+
     protected DataType(DataType.Name name) {
         this.name = name;
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
@@ -72,7 +72,10 @@ class DefaultResultSetFuture extends AbstractFuture<ResultSet> implements Result
                             switch (scc.change) {
                                 case CREATED:
                                 case UPDATED:
-                                    session.cluster.manager.refreshSchemaAndSignal(connection, this, rs, scc.targetType, scc.targetKeyspace, scc.targetName);
+                                    // TODO generate signature for function/aggregate events
+                                    String signature = null;
+
+                                    session.cluster.manager.refreshSchemaAndSignal(connection, this, rs, scc.targetType, scc.targetKeyspace, scc.targetName, signature);
                                     break;
                                 case DROPPED:
                                     KeyspaceMetadata keyspace;

--- a/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DefaultResultSetFuture.java
@@ -26,6 +26,10 @@ import org.slf4j.LoggerFactory;
 
 import com.datastax.driver.core.exceptions.*;
 
+import static com.datastax.driver.core.SchemaElement.KEYSPACE;
+import static com.datastax.driver.core.SchemaElement.TABLE;
+import static com.datastax.driver.core.SchemaElement.TYPE;
+
 /**
  * Internal implementation of ResultSetFuture.
  */
@@ -68,42 +72,37 @@ class DefaultResultSetFuture extends AbstractFuture<ResultSet> implements Result
                             break;
                         case SCHEMA_CHANGE:
                             Responses.Result.SchemaChange scc = (Responses.Result.SchemaChange)rm;
+                            logger.debug("Applying {}", scc);
                             ResultSet rs = ArrayBackedResultSet.fromMessage(rm, session, protocolVersion, info, statement);
                             switch (scc.change) {
                                 case CREATED:
                                 case UPDATED:
-                                    // TODO generate signature for function/aggregate events
-                                    String signature = null;
-
-                                    session.cluster.manager.refreshSchemaAndSignal(connection, this, rs, scc.targetType, scc.targetKeyspace, scc.targetName, signature);
+                                    session.cluster.manager.refreshSchemaAndSignal(connection, this, rs, scc.targetType, scc.targetKeyspace, scc.targetName, scc.targetSignature);
                                     break;
                                 case DROPPED:
-                                    KeyspaceMetadata keyspace;
-                                    switch (scc.targetType) {
-                                        case KEYSPACE:
-                                            // If that the one keyspace we are logged in, reset to null (it shouldn't really happen but ...)
-                                            // Note: Actually, Cassandra doesn't do that so we don't either as this could confuse prepared statements.
-                                            // We'll add it back if CASSANDRA-5358 changes that behavior
-                                            //if (scc.keyspace.equals(session.poolsState.keyspace))
-                                            //    session.poolsState.setKeyspace(null);
-                                            session.cluster.manager.metadata.removeKeyspace(scc.targetKeyspace);
-                                            break;
-                                        case TABLE:
-                                            keyspace = session.cluster.manager.metadata.getKeyspaceInternal(scc.targetKeyspace);
-                                            if (keyspace == null)
-                                                logger.warn("Received a DROPPED notification for table {}.{}, but this keyspace is unknown in our metadata",
-                                                    scc.targetKeyspace, scc.targetName);
-                                            else
-                                                keyspace.removeTable(scc.targetName);
-                                            break;
-                                        case TYPE:
-                                            keyspace = session.cluster.manager.metadata.getKeyspaceInternal(scc.targetKeyspace);
-                                            if (keyspace == null)
-                                                logger.warn("Received a DROPPED notification for UDT {}.{}, but this keyspace is unknown in our metadata",
-                                                    scc.targetKeyspace, scc.targetName);
-                                            else
-                                                keyspace.removeUserType(scc.targetName);
-                                            break;
+                                    if (scc.targetType == KEYSPACE) {
+                                        session.cluster.manager.metadata.removeKeyspace(scc.targetKeyspace);
+                                    } else {
+                                        KeyspaceMetadata keyspace = session.cluster.manager.metadata.getKeyspaceInternal(scc.targetKeyspace);
+                                        if (keyspace == null) {
+                                            logger.warn("Received a DROPPED notification for {} {}.{}, but this keyspace is unknown in our metadata",
+                                                scc.targetType, scc.targetKeyspace, scc.targetName);
+                                        } else {
+                                            switch (scc.targetType) {
+                                                case TABLE:
+                                                    keyspace.removeTable(scc.targetName);
+                                                    break;
+                                                case TYPE:
+                                                    keyspace.removeUserType(scc.targetName);
+                                                    break;
+                                                case FUNCTION:
+                                                    keyspace.removeFunction(Metadata.fullFunctionName(scc.targetName, scc.targetSignature));
+                                                    break;
+                                                case AGGREGATE:
+                                                    keyspace.removeAggregate(Metadata.fullFunctionName(scc.targetName, scc.targetSignature));
+                                                    break;
+                                            }
+                                        }
                                     }
                                     session.cluster.manager.waitForSchemaAgreementAndSignal(connection, this, rs);
                                     break;

--- a/driver-core/src/main/java/com/datastax/driver/core/ExceptionCode.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ExceptionCode.java
@@ -38,6 +38,7 @@ enum ExceptionCode {
     WRITE_TIMEOUT   (0x1100),
     READ_TIMEOUT    (0x1200),
     READ_FAILURE    (0x1300),
+    FUNCTION_FAILURE(0x1400),
     WRITE_FAILURE   (0x1500),
 
     // 2xx: problem validating the request

--- a/driver-core/src/main/java/com/datastax/driver/core/FunctionMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/FunctionMetadata.java
@@ -1,0 +1,272 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Describes a CQL function (created with {@code CREATE FUNCTION...}).
+ */
+public class FunctionMetadata {
+    private static final Logger logger = LoggerFactory.getLogger(FunctionMetadata.class);
+
+    private final KeyspaceMetadata keyspace;
+    private final String fullName;
+    private final String simpleName;
+    private final Map<String, DataType> arguments;
+    private final String body;
+    private final boolean calledOnNullInput;
+    private final String language;
+    private final DataType returnType;
+
+    private FunctionMetadata(KeyspaceMetadata keyspace,
+                             String fullName,
+                             String simpleName,
+                             Map<String, DataType> arguments,
+                             String body,
+                             boolean calledOnNullInput,
+                             String language,
+                             DataType returnType) {
+        this.keyspace = keyspace;
+        this.fullName = fullName;
+        this.simpleName = simpleName;
+        this.arguments = arguments;
+        this.body = body;
+        this.calledOnNullInput = calledOnNullInput;
+        this.language = language;
+        this.returnType = returnType;
+    }
+
+    // CREATE TABLE system.schema_functions (
+    //     keyspace_name text,
+    //     function_name text,
+    //     signature frozen<list<text>>,
+    //     argument_names list<text>,
+    //     argument_types list<text>,
+    //     body text,
+    //     called_on_null_input boolean,
+    //     language text,
+    //     return_type text,
+    //     PRIMARY KEY (keyspace_name, function_name, signature)
+    // ) WITH CLUSTERING ORDER BY (function_name ASC, signature ASC)
+    static FunctionMetadata build(KeyspaceMetadata ksm, Row row) {
+        String simpleName = row.getString("function_name");
+        List<String> signature = row.getList("signature", String.class);
+        String fullName = Metadata.fullFunctionName(simpleName, signature);
+
+        List<String> argumentNames = row.getList("argument_names", String.class);
+        List<String> argumentTypes = row.getList("argument_types", String.class);
+        if (argumentNames.size() != argumentTypes.size()) {
+            logger.error(String.format("Error parsing definition of function %1$s.%2$s: the number of argument names and types don't match."
+                    + "Cluster.getMetadata().getKeyspace(\"%1$s\").getFunction(\"%2$s\") will be missing.",
+                ksm.getName(), fullName));
+            return null;
+        }
+        Map<String, DataType> arguments = buildArguments(argumentNames, argumentTypes);
+
+        String body = row.getString("body");
+        boolean calledOnNullInput = row.getBool("called_on_null_input");
+        String language = row.getString("language");
+        DataType returnType = CassandraTypeParser.parseOne(row.getString("return_type"));
+
+        FunctionMetadata function = new FunctionMetadata(ksm, fullName, simpleName, arguments, body,
+            calledOnNullInput, language, returnType);
+        ksm.add(function);
+        return function;
+    }
+
+    // Note: the caller ensures that names and types have the same size
+    private static Map<String, DataType> buildArguments(List<String> names, List<String> types) {
+        if (names.isEmpty())
+            return Collections.emptyMap();
+
+        ImmutableMap.Builder<String, DataType> builder = ImmutableMap.builder();
+        Iterator<String> iterTypes = types.iterator();
+        for (String name : names) {
+            DataType type = CassandraTypeParser.parseOne(iterTypes.next());
+            builder.put(name, type);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Returns a CQL query representing this function in human readable form.
+     * <p>
+     * This method is equivalent to {@link #asCQLQuery} but the output is formatted.
+     *
+     * @return the CQL query representing this function.
+     */
+    public String exportAsString() {
+        return asCQLQuery(true);
+    }
+
+    /**
+     * Returns a CQL query representing this function.
+     *
+     * This method returns a single 'CREATE FUNCTION' query corresponding to
+     * this function definition.
+     *
+     * @return the 'CREATE FUNCTION' query corresponding to this function.
+     */
+    public String asCQLQuery() {
+        return asCQLQuery(false);
+    }
+
+    @Override
+    public String toString() {
+        return asCQLQuery(false);
+    }
+
+    private String asCQLQuery(boolean formatted) {
+        // create function test.sum(a int, b int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java as 'return a+b;';
+
+        StringBuilder sb = new StringBuilder();
+
+        sb
+            .append("CREATE FUNCTION ")
+            .append(Metadata.escapeId(keyspace.getName()))
+            .append('.')
+            .append(Metadata.escapeId(simpleName))
+            .append('(');
+
+        boolean first = true;
+        for (Map.Entry<String, DataType> entry : arguments.entrySet()) {
+            if (first)
+                first = false;
+            else
+                sb.append(',');
+            TableMetadata.newLine(sb, formatted);
+            String name = entry.getKey();
+            DataType type = entry.getValue();
+            sb
+                .append(TableMetadata.spaces(4, formatted))
+                .append(Metadata.escapeId(name))
+                .append(' ')
+                .append(type);
+        }
+        sb.append(')');
+
+        TableMetadata.spaceOrNewLine(sb, formatted)
+            .append(calledOnNullInput ? "CALLED ON NULL INPUT" : "RETURNS NULL ON NULL INPUT");
+
+        TableMetadata.spaceOrNewLine(sb, formatted)
+            .append("RETURNS ")
+            .append(returnType);
+
+        TableMetadata.spaceOrNewLine(sb, formatted)
+            .append("LANGUAGE ")
+            .append(language);
+
+        TableMetadata.spaceOrNewLine(sb, formatted)
+            .append("AS '")
+            .append(body)
+            .append("';");
+
+        return sb.toString();
+    }
+
+    /**
+     * Returns the keyspace this function belongs to.
+     *
+     * @return the keyspace metadata of the keyspace this function belongs to.
+     */
+    public KeyspaceMetadata getKeyspace() {
+        return keyspace;
+    }
+
+    /**
+     * Returns the full name of this function.
+     * <p>
+     * This is the name of the function, followed by the names of the argument types between parentheses,
+     * for example {@code sum(int,int)}.
+     *
+     * @return the full name.
+     */
+    public String getFullName() {
+        return fullName;
+    }
+
+    /**
+     * Returns the simple name of this function.
+     * <p>
+     * This is the name of the function, without arguments. Note that functions can be overloaded with
+     * different argument lists, therefore the simple name may not be unique. For example,
+     * {@code sum(int,int)} and {@code sum(int,int,int)} both have the simple name {@code sum}.
+     *
+     * @return the simple name.
+     *
+     * @see #getFullName()
+     */
+    public String getSimpleName() {
+        return simpleName;
+    }
+
+    /**
+     * Returns the names and types of this function's arguments.
+     *
+     * @return a map from argument name to argument type.
+     */
+    public Map<String, DataType> getArguments() {
+        return arguments;
+    }
+
+    /**
+     * Returns the body of this function.
+     *
+     * @return the body.
+     */
+    public String getBody() {
+        return body;
+    }
+
+    /**
+     * Indicates whether this function's body gets called on null input.
+     * <p>
+     * This is {@code true} if the function was created with {@code CALLED ON NULL INPUT},
+     * and {@code false} if it was created with {@code RETURNS NULL ON NULL INPUT}.
+     *
+     * @return whether this function's body gets called on null input.
+     */
+    public boolean isCalledOnNullInput() {
+        return calledOnNullInput;
+    }
+
+    /**
+     * Returns the programming language in which this function's body is written.
+     *
+     * @return the language.
+     */
+    public String getLanguage() {
+        return language;
+    }
+
+    /**
+     * Returns the return type of this function.
+     *
+     * @return the return type.
+     */
+    public DataType getReturnType() {
+        return returnType;
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/Responses.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Responses.java
@@ -119,6 +119,7 @@ class Responses {
                 case READ_TIMEOUT:     return ((ReadTimeoutException)infos).copy();
                 case WRITE_FAILURE:    return ((WriteFailureException)infos).copy();
                 case READ_FAILURE:     return ((ReadFailureException)infos).copy();
+                case FUNCTION_FAILURE: return new FunctionExecutionException(message);
                 case SYNTAX_ERROR:     return new SyntaxError(message);
                 case UNAUTHORIZED:     return new UnauthorizedException(message);
                 case INVALID:          return new InvalidQueryException(message);

--- a/driver-core/src/main/java/com/datastax/driver/core/SchemaElement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SchemaElement.java
@@ -16,5 +16,5 @@
 package com.datastax.driver.core;
 
 enum SchemaElement {
-    KEYSPACE, TABLE, TYPE
+    KEYSPACE, TABLE, TYPE, FUNCTION, AGGREGATE
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
@@ -506,6 +506,11 @@ public class TableMetadata {
         return sb;
     }
 
+    static StringBuilder spaceOrNewLine(StringBuilder sb, boolean formatted) {
+        sb.append(formatted ? '\n' : ' ');
+        return sb;
+    }
+
     public static class Options {
 
         private static final String COMMENT                     = "comment";

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/FunctionExecutionException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/FunctionExecutionException.java
@@ -1,0 +1,37 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.exceptions;
+
+/**
+ * Error during the execution of a function.
+ */
+public class FunctionExecutionException extends QueryExecutionException {
+
+    private static final long serialVersionUID = 0;
+
+    public FunctionExecutionException(String msg) {
+        super(msg);
+    }
+
+    private FunctionExecutionException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+    @Override
+    public DriverException copy() {
+        return new FunctionExecutionException(getMessage(), this);
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/AggregateMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AggregateMetadataTest.java
@@ -1,0 +1,180 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+
+public class AggregateMetadataTest {
+
+    // These tests needs a protocol version to (de)serialize INITCONDs. Since we're using basic types, I don't think the binary format
+    // is going to change at any time in the future, so the actual version does not matter.
+    private static final ProtocolVersion PROTOCOL_VERSION = ProtocolVersion.NEWEST_SUPPORTED;
+
+    KeyspaceMetadata keyspace;
+
+    @BeforeMethod(groups = "unit")
+    public void setup() {
+        keyspace = new KeyspaceMetadata("ks", false, Collections.<String, String>emptyMap());
+    }
+
+    @Test(groups = "unit")
+    public void should_parse_and_format_aggregate_with_initcond_and_no_finalfunc() {
+        FunctionMetadata stateFunc = mock(FunctionMetadata.class);
+        keyspace.functions.put("cat(text,int)", stateFunc);
+
+        AggregateMetadata aggregate = AggregateMetadata.build(keyspace, SYSTEM_ROW_CAT_TOS, PROTOCOL_VERSION);
+
+        assertThat(aggregate).isNotNull();
+        assertThat(aggregate.getFullName()).isEqualTo("cat_tos(int)");
+        assertThat(aggregate.getSimpleName()).isEqualTo("cat_tos");
+        assertThat(aggregate.getArgumentTypes()).containsExactly(DataType.cint());
+        assertThat(aggregate.getFinalFunc()).isNull();
+        assertThat(aggregate.getInitCond()).isEqualTo("0");
+        assertThat(aggregate.getReturnType()).isEqualTo(DataType.text());
+        assertThat(aggregate.getStateFunc()).isEqualTo(stateFunc);
+        assertThat(aggregate.getStateType()).isEqualTo(DataType.text());
+
+        assertThat(keyspace.getAggregate("cat_tos", DataType.cint())).isEqualTo(aggregate);
+
+        assertThat(aggregate.toString()).isEqualTo("CREATE AGGREGATE ks.cat_tos(int) SFUNC cat STYPE text INITCOND '0';");
+
+        assertThat(aggregate.exportAsString()).isEqualTo("CREATE AGGREGATE ks.cat_tos(int)\n"
+            + "SFUNC cat STYPE text\n"
+            + "INITCOND '0';");
+    }
+
+    @Test(groups = "unit")
+    public void should_parse_and_format_aggregate_with_no_arguments() {
+        FunctionMetadata stateFunc = mock(FunctionMetadata.class);
+        keyspace.functions.put("inc(int)", stateFunc);
+
+        AggregateMetadata aggregate = AggregateMetadata.build(keyspace, SYSTEM_ROW_MYCOUNT, PROTOCOL_VERSION);
+
+        assertThat(aggregate).isNotNull();
+        assertThat(aggregate.getFullName()).isEqualTo("mycount()");
+        assertThat(aggregate.getSimpleName()).isEqualTo("mycount");
+        assertThat(aggregate.getArgumentTypes()).isEmpty();
+        assertThat(aggregate.getFinalFunc()).isNull();
+        assertThat(aggregate.getInitCond()).isEqualTo(0);
+        assertThat(aggregate.getReturnType()).isEqualTo(DataType.cint());
+        assertThat(aggregate.getStateFunc()).isEqualTo(stateFunc);
+        assertThat(aggregate.getStateType()).isEqualTo(DataType.cint());
+
+        assertThat(keyspace.getAggregate("mycount")).isEqualTo(aggregate);
+
+        assertThat(aggregate.toString()).isEqualTo("CREATE AGGREGATE ks.mycount() SFUNC inc STYPE int INITCOND 0;");
+
+        assertThat(aggregate.exportAsString()).isEqualTo("CREATE AGGREGATE ks.mycount()\n"
+            + "SFUNC inc STYPE int\n"
+            + "INITCOND 0;");
+    }
+
+    @Test(groups = "unit")
+    public void should_parse_and_format_aggregate_with_final_function() {
+        FunctionMetadata stateFunc = mock(FunctionMetadata.class);
+        keyspace.functions.put("plus(int,int)", stateFunc);
+        FunctionMetadata finalFunc = mock(FunctionMetadata.class);
+        keyspace.functions.put("announce(int)", finalFunc);
+
+        AggregateMetadata aggregate = AggregateMetadata.build(keyspace, SYSTEM_ROW_PRETTYSUM, PROTOCOL_VERSION);
+
+        assertThat(aggregate).isNotNull();
+        assertThat(aggregate.getFullName()).isEqualTo("prettysum(int)");
+        assertThat(aggregate.getSimpleName()).isEqualTo("prettysum");
+        assertThat(aggregate.getArgumentTypes()).containsExactly(DataType.cint());
+        assertThat(aggregate.getFinalFunc()).isEqualTo(finalFunc);
+        assertThat(aggregate.getInitCond()).isEqualTo(0);
+        assertThat(aggregate.getReturnType()).isEqualTo(DataType.text());
+        assertThat(aggregate.getStateFunc()).isEqualTo(stateFunc);
+        assertThat(aggregate.getStateType()).isEqualTo(DataType.cint());
+
+        assertThat(keyspace.getAggregate("prettysum", DataType.cint())).isEqualTo(aggregate);
+
+        assertThat(aggregate.toString()).isEqualTo("CREATE AGGREGATE ks.prettysum(int) SFUNC plus STYPE int FINALFUNC announce INITCOND 0;");
+
+        assertThat(aggregate.exportAsString()).isEqualTo("CREATE AGGREGATE ks.prettysum(int)\n"
+            + "SFUNC plus STYPE int\n"
+            + "FINALFUNC announce\n"
+            + "INITCOND 0;");
+    }
+
+    @Test(groups = "unit")
+    public void should_parse_and_format_aggregate_with_no_initcond() {
+        FunctionMetadata stateFunc = mock(FunctionMetadata.class);
+        keyspace.functions.put("plus(int,int)", stateFunc);
+
+        AggregateMetadata aggregate = AggregateMetadata.build(keyspace, SYSTEM_ROW_SUM, PROTOCOL_VERSION);
+
+        assertThat(aggregate).isNotNull();
+        assertThat(aggregate.getFullName()).isEqualTo("sum(int)");
+        assertThat(aggregate.getSimpleName()).isEqualTo("sum");
+        assertThat(aggregate.getArgumentTypes()).containsExactly(DataType.cint());
+        assertThat(aggregate.getFinalFunc()).isNull();
+        assertThat(aggregate.getInitCond()).isNull();
+        assertThat(aggregate.getReturnType()).isEqualTo(DataType.cint());
+        assertThat(aggregate.getStateFunc()).isEqualTo(stateFunc);
+        assertThat(aggregate.getStateType()).isEqualTo(DataType.cint());
+
+        assertThat(keyspace.getAggregate("sum", DataType.cint())).isEqualTo(aggregate);
+
+        assertThat(aggregate.toString()).isEqualTo("CREATE AGGREGATE ks.sum(int) SFUNC plus STYPE int;");
+
+        assertThat(aggregate.exportAsString()).isEqualTo("CREATE AGGREGATE ks.sum(int)\n"
+            + "SFUNC plus STYPE int;");
+    }
+
+    private static final String INT = "org.apache.cassandra.db.marshal.Int32Type";
+    private static final String TEXT = "org.apache.cassandra.db.marshal.UTF8Type";
+
+    private static final Row SYSTEM_ROW_CAT_TOS = mockRow("cat_tos", ImmutableList.of("int"), ImmutableList.of(INT),
+        null, DataType.text().serialize("0", PROTOCOL_VERSION), TEXT, "cat", TEXT);
+
+    private static final Row SYSTEM_ROW_MYCOUNT = mockRow("mycount", Collections.<String>emptyList(), Collections.<String>emptyList(),
+        null, DataType.cint().serialize(0, PROTOCOL_VERSION), INT, "inc", INT);
+
+    private static final Row SYSTEM_ROW_PRETTYSUM = mockRow("prettysum", ImmutableList.of("int"), ImmutableList.of(INT),
+        "announce", DataType.cint().serialize(0, PROTOCOL_VERSION), TEXT, "plus", INT);
+
+    private static final Row SYSTEM_ROW_SUM = mockRow("sum", ImmutableList.of("int"), ImmutableList.of(INT),
+        null, null, INT, "plus", INT);
+
+    private static Row mockRow(String aggregateName, List<String> signature, List<String> argumentTypes, String finalFunc,
+                               ByteBuffer initCond, String returnType, String stateFunc, String stateType) {
+        Row row = mock(Row.class);
+
+        when(row.getString("aggregate_name")).thenReturn(aggregateName);
+        when(row.getList("signature", String.class)).thenReturn(signature);
+        when(row.getList("argument_types", String.class)).thenReturn(argumentTypes);
+        when(row.getString("final_func")).thenReturn(finalFunc);
+        when(row.getBytes("initcond")).thenReturn(initCond);
+        when(row.getString("return_type")).thenReturn(returnType);
+        when(row.getString("state_func")).thenReturn(stateFunc);
+        when(row.getString("state_type")).thenReturn(stateType);
+
+        return row;
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -165,6 +165,7 @@ public class CCMBridge {
         return f;
     }
 
+    /** Note that this method does not start CCM */
     public static CCMBridge create(String name, String... options) {
         // This leads to a confusing CCM error message so check explicitly:
         checkArgument(!"current".equals(name.toLowerCase()),
@@ -486,6 +487,7 @@ public class CCMBridge {
                 try {
                     //launch ccm cluster
                     ccmBridge = CCMBridge.create("test-class");
+                    ccmBridge.updateConfig("enable_user_defined_functions", "true");
 
                     ports = new int[5];
                     for (int i = 0; i < 5; i++) {

--- a/driver-core/src/test/java/com/datastax/driver/core/FunctionMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/FunctionMetadataTest.java
@@ -1,0 +1,123 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+
+public class FunctionMetadataTest {
+    KeyspaceMetadata keyspace;
+
+    @BeforeMethod(groups = "unit")
+    public void setup() {
+        keyspace = new KeyspaceMetadata("ks", false, Collections.<String, String>emptyMap());
+    }
+
+    @Test(groups = "unit")
+    public void should_parse_and_format_simple_function() {
+        FunctionMetadata function = FunctionMetadata.build(keyspace, SYSTEM_ROW_PLUS);
+
+        assertThat(function).isNotNull();
+        assertThat(function.getKeyspace()).isEqualTo(keyspace);
+        assertThat(function.getFullName()).isEqualTo("plus(int,int)");
+        assertThat(function.getSimpleName()).isEqualTo("plus");
+        assertThat(function.getReturnType()).isEqualTo(DataType.cint());
+        assertThat(function.getArguments())
+            .containsEntry("s", DataType.cint())
+            .containsEntry("v", DataType.cint());
+        assertThat(function.getLanguage()).isEqualTo("java");
+        assertThat(function.getBody()).isEqualTo("return s+v;");
+        assertThat(function.isCalledOnNullInput()).isFalse();
+
+        assertThat(keyspace.getFunction("plus", DataType.cint(), DataType.cint())).isEqualTo(function);
+
+        assertThat(function.toString())
+            .isEqualTo("CREATE FUNCTION ks.plus(s int,v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return s+v;';");
+
+        assertThat(function.exportAsString())
+            .isEqualTo("CREATE FUNCTION ks.plus(\n"
+                + "    s int,\n"
+                + "    v int)\n"
+                + "RETURNS NULL ON NULL INPUT\n"
+                + "RETURNS int\n"
+                + "LANGUAGE java\n"
+                + "AS 'return s+v;';");
+    }
+
+    @Test(groups = "unit")
+    public void should_parse_and_format_function_with_no_arguments() {
+        FunctionMetadata function = FunctionMetadata.build(keyspace, SYSTEM_ROW_PI);
+
+        assertThat(function).isNotNull();
+        assertThat(function.getKeyspace()).isEqualTo(keyspace);
+        assertThat(function.getFullName()).isEqualTo("pi()");
+        assertThat(function.getSimpleName()).isEqualTo("pi");
+        assertThat(function.getReturnType()).isEqualTo(DataType.cdouble());
+        assertThat(function.getArguments()).isEmpty();
+        assertThat(function.getLanguage()).isEqualTo("java");
+        assertThat(function.getBody()).isEqualTo("return Math.PI;");
+        assertThat(function.isCalledOnNullInput()).isTrue();
+
+        assertThat(keyspace.getFunction("pi")).isEqualTo(function);
+
+        assertThat(function.toString())
+            .isEqualTo("CREATE FUNCTION ks.pi() CALLED ON NULL INPUT RETURNS double LANGUAGE java AS 'return Math.PI;';");
+
+        assertThat(function.exportAsString())
+            .isEqualTo("CREATE FUNCTION ks.pi()\n"
+                + "CALLED ON NULL INPUT\n"
+                + "RETURNS double\n"
+                + "LANGUAGE java\n"
+                + "AS 'return Math.PI;';");
+    }
+
+    private static final String INT = "org.apache.cassandra.db.marshal.Int32Type";
+    private static final String DOUBLE = "org.apache.cassandra.db.marshal.DoubleType";
+
+    private static final Row SYSTEM_ROW_PLUS = mockRow("plus",
+        ImmutableList.of("int", "int"), ImmutableList.of("s", "v"), ImmutableList.of(INT, INT),
+        "return s+v;", false, "java", INT
+    );
+
+    private static final Row SYSTEM_ROW_PI = mockRow("pi",
+        Collections.<String>emptyList(), Collections.<String>emptyList(), Collections.<String>emptyList(),
+        "return Math.PI;", true, "java", DOUBLE);
+
+    private static Row mockRow(String functionName, List<String> signature, List<String> argumentNames, List<String> argumentTypes,
+                               String body, boolean calledOnNullInput, String language, String returnType) {
+        Row row = mock(Row.class);
+
+        when(row.getString("function_name")).thenReturn(functionName);
+        when(row.getList("signature", String.class)).thenReturn(signature);
+        when(row.getList("argument_names", String.class)).thenReturn(argumentNames);
+        when(row.getList("argument_types", String.class)).thenReturn(argumentTypes);
+        when(row.getString("body")).thenReturn(body);
+        when(row.getBool("called_on_null_input")).thenReturn(calledOnNullInput);
+        when(row.getString("language")).thenReturn(language);
+        when(row.getString("return_type")).thenReturn(returnType);
+
+        return row;
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -344,7 +344,7 @@ public abstract class TestUtils {
         // keep alive kicks in, but that's a fairly long time. So we cheat and trigger a force
         // the detection by forcing a request.
         if (waitForDead || waitForOut)
-            cluster.manager.submitSchemaRefresh(null, null, null);
+            cluster.manager.submitSchemaRefresh(null, null, null, null);
 
         InetAddress address;
         try {

--- a/driver-core/src/test/java/com/datastax/driver/core/exceptions/FunctionExecutionExceptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/exceptions/FunctionExecutionExceptionTest.java
@@ -1,0 +1,42 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.exceptions;
+
+import java.util.Collection;
+
+import com.google.common.collect.Lists;
+import org.testng.annotations.Test;
+
+import com.datastax.driver.core.CCMBridge;
+import com.datastax.driver.core.utils.CassandraVersion;
+
+public class FunctionExecutionExceptionTest extends CCMBridge.PerClassSingleNodeCluster {
+
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return Lists.newArrayList(
+            "CREATE TABLE foo (k int primary key)",
+            "INSERT INTO foo (k) VALUES (0)",
+            "CREATE FUNCTION inverse(i int) RETURNS NULL ON NULL INPUT RETURNS double LANGUAGE java AS 'return 1.0/i;'"
+        );
+    }
+
+    @Test(groups = "short", expectedExceptions = FunctionExecutionException.class)
+    @CassandraVersion(major = 2.2)
+    public void should_throw_when_function_execution_fails() {
+        session.execute("SELECT inverse(k) FROM foo");
+    }
+}


### PR DESCRIPTION
This branch is currently based on `java783`, once that's merged I'll rebase on 2.2.

https://github.com/datastax/java-driver/compare/java783...udf

The first commit (JAVA-747) adds functions and aggregates to the metadata, they get loaded on a full refresh or keyspace refresh.

What's missing for now is individual reloads/removes on notifications, I'll add that once protocol v4 support is more advanced.
