### PR TITLE
Add DataType.allPrimitiveTypes(ProtocolVersion).

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
@@ -21,6 +21,7 @@ import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.*;
 
+import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 import org.testng.annotations.Test;
 
@@ -276,5 +277,23 @@ public class DataTypeTest {
             .canBeDeserializedAs(new TypeToken<Map<Integer, List<String>>>(){})
             .canBeDeserializedAs(new TypeToken<Map<Number, Collection<String>>>(){})
             .cannotBeDeserializedAs(new TypeToken<Map<Integer, Collection<Integer>>>(){});
+    }
+
+    @Test(groups = "unit")
+    public void should_not_return_v4_types_in_all_primitive_types_with_v3() {
+        Set<DataType> dataTypes = DataType.allPrimitiveTypes(ProtocolVersion.V3);
+
+        // Ensure it does not contain specific newer types tinyint and smallint.
+        assertThat(dataTypes).doesNotContainAnyElementsOf(Lists.newArrayList(DataType.tinyint(), DataType.smallint()));
+
+        // Ensure all values are <= V3.
+        for(DataType dataType : dataTypes) {
+            assertThat(dataType.getName().minProtocolVersion).isLessThanOrEqualTo(ProtocolVersion.V3);
+        }
+    }
+
+    @Test(groups = "unit")
+    public void should_return_same_elements_with_all_primitive_types_using_latest_protocol_version() {
+        assertThat(DataType.allPrimitiveTypes(ProtocolVersion.NEWEST_SUPPORTED)).isEqualTo(DataType.allPrimitiveTypes());
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
@@ -49,6 +49,8 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
     private static final String SIMPLE_TABLE = "test";
     private static final String SIMPLE_TABLE2 = "test2";
 
+    private final Collection<DataType> primitiveTypes = DataType.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion());
+
     private boolean exclude(DataType t) {
         return t.getName() == DataType.Name.COUNTER;
     }
@@ -60,7 +62,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
 
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE TABLE ").append(ALL_NATIVE_TABLE).append(" (k text PRIMARY KEY");
-        for (DataType type : DataType.allPrimitiveTypes()) {
+        for (DataType type : primitiveTypes) {
             if (exclude(type))
                 continue;
             sb.append(", c_").append(type).append(' ').append(type);
@@ -70,7 +72,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
 
         sb = new StringBuilder();
         sb.append("CREATE TABLE ").append(ALL_LIST_TABLE).append(" (k text PRIMARY KEY");
-        for (DataType type : DataType.allPrimitiveTypes()) {
+        for (DataType type : primitiveTypes) {
             if (exclude(type))
                 continue;
             sb.append(", c_list_").append(type).append(" list<").append(type).append('>');
@@ -80,7 +82,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
 
         sb = new StringBuilder();
         sb.append("CREATE TABLE ").append(ALL_SET_TABLE).append(" (k text PRIMARY KEY");
-        for (DataType type : DataType.allPrimitiveTypes()) {
+        for (DataType type : primitiveTypes) {
             // This must be handled separatly
             if (exclude(type))
                 continue;
@@ -91,12 +93,12 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
 
         sb = new StringBuilder();
         sb.append("CREATE TABLE ").append(ALL_MAP_TABLE).append(" (k text PRIMARY KEY");
-        for (DataType keyType : DataType.allPrimitiveTypes()) {
+        for (DataType keyType : primitiveTypes) {
             // This must be handled separatly
             if (exclude(keyType))
                 continue;
 
-            for (DataType valueType : DataType.allPrimitiveTypes()) {
+            for (DataType valueType : primitiveTypes) {
                 // This must be handled separatly
                 if (exclude(valueType))
                     continue;
@@ -115,7 +117,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
     @Test(groups = "short")
     public void preparedNativeTest() {
         // Test preparing/bounding for all native types
-        for (DataType type : DataType.allPrimitiveTypes()) {
+        for (DataType type : primitiveTypes) {
             // This must be handled separatly
             if (exclude(type))
                 continue;
@@ -136,7 +138,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
     @Test(groups = "short")
     public void preparedNativeTest2() {
         // Test preparing/bounding for all native types
-        for (DataType type : DataType.allPrimitiveTypes()) {
+        for (DataType type : primitiveTypes) {
             // This must be handled separatly
             if (exclude(type))
                 continue;
@@ -155,7 +157,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
     @SuppressWarnings("unchecked")
     public void prepareListTest() {
         // Test preparing/bounding for all possible list types
-        for (DataType rawType : DataType.allPrimitiveTypes()) {
+        for (DataType rawType : primitiveTypes) {
             // This must be handled separatly
             if (exclude(rawType))
                 continue;
@@ -179,7 +181,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
     @SuppressWarnings("unchecked")
     public void prepareListTest2() {
         // Test preparing/bounding for all possible list types
-        for (DataType rawType : DataType.allPrimitiveTypes()) {
+        for (DataType rawType : primitiveTypes) {
             // This must be handled separatly
             if (exclude(rawType))
                 continue;
@@ -200,7 +202,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
     @SuppressWarnings("unchecked")
     public void prepareSetTest() {
         // Test preparing/bounding for all possible set types
-        for (DataType rawType : DataType.allPrimitiveTypes()) {
+        for (DataType rawType : primitiveTypes) {
             // This must be handled separatly
             if (exclude(rawType))
                 continue;
@@ -224,7 +226,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
     @SuppressWarnings("unchecked")
     public void prepareSetTest2() {
         // Test preparing/bounding for all possible set types
-        for (DataType rawType : DataType.allPrimitiveTypes()) {
+        for (DataType rawType : primitiveTypes) {
             // This must be handled separatly
             if (exclude(rawType))
                 continue;
@@ -245,12 +247,12 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
     @SuppressWarnings("unchecked")
     public void prepareMapTest() {
         // Test preparing/bounding for all possible map types
-        for (DataType rawKeyType : DataType.allPrimitiveTypes()) {
+        for (DataType rawKeyType : primitiveTypes) {
             // This must be handled separatly
             if (exclude(rawKeyType))
                 continue;
 
-            for (DataType rawValueType : DataType.allPrimitiveTypes()) {
+            for (DataType rawValueType : primitiveTypes) {
                 // This must be handled separatly
                 if (exclude(rawValueType))
                     continue;
@@ -275,12 +277,12 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
     @SuppressWarnings("unchecked")
     public void prepareMapTest2() {
         // Test preparing/bounding for all possible map types
-        for (DataType rawKeyType : DataType.allPrimitiveTypes()) {
+        for (DataType rawKeyType : primitiveTypes) {
             // This must be handled separatly
             if (exclude(rawKeyType))
                 continue;
 
-            for (DataType rawValueType : DataType.allPrimitiveTypes()) {
+            for (DataType rawValueType : primitiveTypes) {
                 // This must be handled separatly
                 if (exclude(rawValueType))
                     continue;

--- a/driver-core/src/test/java/com/datastax/driver/core/PrimitiveTypeSamples.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PrimitiveTypeSamples.java
@@ -19,17 +19,16 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.driver.core.utils.Bytes;
+import com.google.common.collect.Maps;
 
 /**
  * This class provides sample values for each primitive data type.
@@ -42,7 +41,8 @@ public class PrimitiveTypeSamples {
 
     private static Map<DataType, Object> generateAll() {
         try {
-            ImmutableMap<DataType, Object> result = ImmutableMap.<DataType, Object>builder()
+            final Collection<DataType> primitiveTypes = DataType.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion());
+            ImmutableMap<DataType, Object> data = ImmutableMap.<DataType, Object>builder()
                 .put(DataType.ascii(), "ascii")
                 .put(DataType.bigint(), Long.MAX_VALUE)
                 .put(DataType.blob(), Bytes.fromHexString("0xCAFE"))
@@ -61,8 +61,16 @@ public class PrimitiveTypeSamples {
                 .put(DataType.varint(), new BigInteger(Integer.toString(Integer.MAX_VALUE) + "000"))
                 .build();
 
+            // Only include data types that support the desired protocol version.
+            Map<DataType, Object> result = Maps.filterKeys(data, new Predicate<DataType>() {
+                @Override
+                public boolean apply(DataType input) {
+                    return primitiveTypes.contains(input);
+                }
+            });
+
             // Check that we cover all types (except counter)
-            List<DataType> tmp = Lists.newArrayList(DataType.allPrimitiveTypes());
+            List<DataType> tmp = Lists.newArrayList(primitiveTypes);
             tmp.removeAll(result.keySet());
             assertThat(tmp)
                 .as("new datatype not covered in test")

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
@@ -52,7 +52,8 @@ import static com.datastax.driver.core.TestUtils.getFixedValue;
  */
 public class QueryLoggerTest extends CCMBridge.PerClassSingleNodeCluster {
 
-    private static final List<DataType> dataTypes = new ArrayList<DataType>(Sets.filter(DataType.allPrimitiveTypes(), new Predicate<DataType>() {
+    private static final List<DataType> dataTypes = new ArrayList<DataType>(
+            Sets.filter(DataType.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion()), new Predicate<DataType>() {
         @Override
         public boolean apply(DataType type) {
             return type != DataType.counter();

--- a/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
@@ -39,7 +39,7 @@ import com.datastax.driver.core.utils.CassandraVersion;
 @CassandraVersion(major=2.1)
 public class UserTypesTest extends CCMBridge.PerClassSingleNodeCluster {
 
-    private final static List<DataType> DATA_TYPE_PRIMITIVES = new ArrayList<DataType>(DataType.allPrimitiveTypes());
+    private final static List<DataType> DATA_TYPE_PRIMITIVES = new ArrayList<DataType>(DataType.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion()));
     private final static List<DataType.Name> DATA_TYPE_NON_PRIMITIVE_NAMES =
             new ArrayList<DataType.Name>(EnumSet.of(DataType.Name.LIST, DataType.Name.SET, DataType.Name.MAP, DataType.Name.TUPLE));
 


### PR DESCRIPTION
With the addition of tinyint, smallint, date and time we now have a case where some primitive types are not supported in all native protocol versions.  Therefore it seems useful to be able to request primitive types by version.

This method is currently only exposed as package private for internal use.  Updated tests to use this method in favor of DataType.allPrimitiveTypes() where applicable.

We will also need to make updates when we merge with #355 
