### PR TITLE
Allow user to register custom type codecs (JAVA-721).

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -125,6 +125,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.5.3</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractGettableData.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractGettableData.java
@@ -21,16 +21,22 @@ import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.*;
 
-import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
 
-import com.datastax.driver.core.exceptions.InvalidTypeException;
+import static com.datastax.driver.core.CodecUtils.listOf;
+import static com.datastax.driver.core.CodecUtils.mapOf;
+import static com.datastax.driver.core.CodecUtils.setOf;
+import static com.datastax.driver.core.DataType.Name.*;
 
 abstract class AbstractGettableData implements GettableData {
 
     protected final ColumnDefinitions metadata;
 
-    protected AbstractGettableData(ColumnDefinitions metadata) {
+    protected final CodecRegistry codecRegistry;
+
+    protected AbstractGettableData(ColumnDefinitions metadata, CodecRegistry codecRegistry) {
         this.metadata = metadata;
+        this.codecRegistry = codecRegistry;
     }
 
     protected abstract ByteBuffer getValue(int i);
@@ -45,13 +51,13 @@ abstract class AbstractGettableData implements GettableData {
     }
 
     public boolean getBool(int i) {
-        metadata.checkType(i, DataType.Name.BOOLEAN);
+        metadata.checkType(i, BOOLEAN);
 
         ByteBuffer value = getValue(i);
         if (value == null || value.remaining() == 0)
             return false;
 
-        return TypeCodec.BooleanCodec.instance.deserializeNoBoxing(value);
+        return codecFor(i, Boolean.class).deserialize(value);
     }
 
     public boolean getBool(String name) {
@@ -59,13 +65,13 @@ abstract class AbstractGettableData implements GettableData {
     }
 
     public int getInt(int i) {
-        metadata.checkType(i, DataType.Name.INT);
+        metadata.checkType(i, INT);
 
         ByteBuffer value = getValue(i);
         if (value == null || value.remaining() == 0)
             return 0;
 
-        return TypeCodec.IntCodec.instance.deserializeNoBoxing(value);
+        return codecFor(i, Integer.class).deserialize(value);
     }
 
     public int getInt(String name) {
@@ -73,13 +79,13 @@ abstract class AbstractGettableData implements GettableData {
     }
 
     public long getLong(int i) {
-        metadata.checkType(i, DataType.Name.BIGINT, DataType.Name.COUNTER);
+        metadata.checkType(i, BIGINT, COUNTER);
 
         ByteBuffer value = getValue(i);
         if (value == null || value.remaining() == 0)
             return 0L;
 
-        return TypeCodec.LongCodec.instance.deserializeNoBoxing(value);
+        return codecFor(i, Long.class).deserialize(value);
     }
 
     public long getLong(String name) {
@@ -87,13 +93,13 @@ abstract class AbstractGettableData implements GettableData {
     }
 
     public Date getDate(int i) {
-        metadata.checkType(i, DataType.Name.TIMESTAMP);
+        metadata.checkType(i, TIMESTAMP);
 
         ByteBuffer value = getValue(i);
         if (value == null || value.remaining() == 0)
             return null;
 
-        return TypeCodec.DateCodec.instance.deserialize(value);
+        return codecFor(i, Date.class).deserialize(value);
     }
 
     public Date getDate(String name) {
@@ -101,13 +107,13 @@ abstract class AbstractGettableData implements GettableData {
     }
 
     public float getFloat(int i) {
-        metadata.checkType(i, DataType.Name.FLOAT);
+        metadata.checkType(i, FLOAT);
 
         ByteBuffer value = getValue(i);
         if (value == null || value.remaining() == 0)
             return 0.0f;
 
-        return TypeCodec.FloatCodec.instance.deserializeNoBoxing(value);
+        return codecFor(i, Float.class).deserialize(value);
     }
 
     public float getFloat(String name) {
@@ -115,13 +121,13 @@ abstract class AbstractGettableData implements GettableData {
     }
 
     public double getDouble(int i) {
-        metadata.checkType(i, DataType.Name.DOUBLE);
+        metadata.checkType(i, DOUBLE);
 
         ByteBuffer value = getValue(i);
         if (value == null || value.remaining() == 0)
             return 0.0;
 
-        return TypeCodec.DoubleCodec.instance.deserializeNoBoxing(value);
+        return codecFor(i, Double.class).deserialize(value);
     }
 
     public double getDouble(String name) {
@@ -143,8 +149,13 @@ abstract class AbstractGettableData implements GettableData {
     }
 
     public ByteBuffer getBytes(int i) {
-        metadata.checkType(i, DataType.Name.BLOB);
-        return getBytesUnsafe(i);
+        metadata.checkType(i, BLOB);
+
+        ByteBuffer value = getValue(i);
+        if (value == null)
+            return null;
+
+        return codecFor(i, ByteBuffer.class).deserialize(value);
     }
 
     public ByteBuffer getBytes(String name) {
@@ -152,17 +163,13 @@ abstract class AbstractGettableData implements GettableData {
     }
 
     public String getString(int i) {
-        DataType.Name type = metadata.checkType(i, DataType.Name.VARCHAR,
-            DataType.Name.TEXT,
-            DataType.Name.ASCII);
+        metadata.checkType(i, VARCHAR, TEXT, ASCII);
 
         ByteBuffer value = getValue(i);
         if (value == null)
             return null;
 
-        return type == DataType.Name.ASCII
-            ? TypeCodec.StringCodec.asciiInstance.deserialize(value)
-            : TypeCodec.StringCodec.utf8Instance.deserialize(value);
+        return codecFor(i, String.class).deserialize(value);
     }
 
     public String getString(String name) {
@@ -170,13 +177,13 @@ abstract class AbstractGettableData implements GettableData {
     }
 
     public BigInteger getVarint(int i) {
-        metadata.checkType(i, DataType.Name.VARINT);
+        metadata.checkType(i, VARINT);
 
         ByteBuffer value = getValue(i);
         if (value == null || value.remaining() == 0)
             return null;
 
-        return TypeCodec.BigIntegerCodec.instance.deserialize(value);
+        return codecFor(i, BigInteger.class).deserialize(value);
     }
 
     public BigInteger getVarint(String name) {
@@ -184,13 +191,13 @@ abstract class AbstractGettableData implements GettableData {
     }
 
     public BigDecimal getDecimal(int i) {
-        metadata.checkType(i, DataType.Name.DECIMAL);
+        metadata.checkType(i, DECIMAL);
 
         ByteBuffer value = getValue(i);
         if (value == null || value.remaining() == 0)
             return null;
 
-        return TypeCodec.DecimalCodec.instance.deserialize(value);
+        return codecFor(i, BigDecimal.class).deserialize(value);
     }
 
     public BigDecimal getDecimal(String name) {
@@ -198,15 +205,13 @@ abstract class AbstractGettableData implements GettableData {
     }
 
     public UUID getUUID(int i) {
-        DataType.Name type = metadata.checkType(i, DataType.Name.UUID, DataType.Name.TIMEUUID);
+        metadata.checkType(i, UUID, TIMEUUID);
 
         ByteBuffer value = getValue(i);
         if (value == null || value.remaining() == 0)
             return null;
 
-        return type == DataType.Name.UUID
-            ? TypeCodec.UUIDCodec.instance.deserialize(value)
-            : TypeCodec.TimeUUIDCodec.instance.deserialize(value);
+        return codecFor(i, UUID.class).deserialize(value);
     }
 
     public UUID getUUID(String name) {
@@ -214,13 +219,13 @@ abstract class AbstractGettableData implements GettableData {
     }
 
     public InetAddress getInet(int i) {
-        metadata.checkType(i, DataType.Name.INET);
+        metadata.checkType(i, INET);
 
         ByteBuffer value = getValue(i);
         if (value == null || value.remaining() == 0)
             return null;
 
-        return TypeCodec.InetCodec.instance.deserialize(value);
+        return codecFor(i, InetAddress.class).deserialize(value);
     }
 
     public InetAddress getInet(String name) {
@@ -229,19 +234,15 @@ abstract class AbstractGettableData implements GettableData {
 
     @SuppressWarnings("unchecked")
     public <T> List<T> getList(int i, Class<T> elementsClass) {
-        DataType type = metadata.getType(i);
-        if (type.getName() != DataType.Name.LIST)
-            throw new InvalidTypeException(String.format("Column %s is not of list type", metadata.getName(i)));
-
-        Class<?> expectedClass = type.getTypeArguments().get(0).getName().javaType;
-        if (!elementsClass.isAssignableFrom(expectedClass))
-            throw new InvalidTypeException(String.format("Column %s is a list of %s (CQL type %s), cannot be retrieve as a list of %s", metadata.getName(i), expectedClass, type, elementsClass));
+        metadata.checkType(i, LIST);
 
         ByteBuffer value = getValue(i);
         if (value == null)
-            return Collections.<T>emptyList();
+            return Collections.emptyList();
 
-        return Collections.unmodifiableList((List<T>)type.codec().deserialize(value));
+        TypeToken<List<T>> javaType = listOf(elementsClass);
+        List<T> list = codecFor(i, javaType).deserialize(value);
+        return Collections.unmodifiableList(list);
     }
 
     public <T> List<T> getList(String name, Class<T> elementsClass) {
@@ -250,19 +251,15 @@ abstract class AbstractGettableData implements GettableData {
 
     @SuppressWarnings("unchecked")
     public <T> Set<T> getSet(int i, Class<T> elementsClass) {
-        DataType type = metadata.getType(i);
-        if (type.getName() != DataType.Name.SET)
-            throw new InvalidTypeException(String.format("Column %s is not of set type", metadata.getName(i)));
-
-        Class<?> expectedClass = type.getTypeArguments().get(0).getName().javaType;
-        if (!elementsClass.isAssignableFrom(expectedClass))
-            throw new InvalidTypeException(String.format("Column %s is a set of %s (CQL type %s), cannot be retrieve as a set of %s", metadata.getName(i), expectedClass, type, elementsClass));
+        metadata.checkType(i, SET);
 
         ByteBuffer value = getValue(i);
         if (value == null)
-            return Collections.<T>emptySet();
+            return Collections.emptySet();
 
-        return Collections.unmodifiableSet((Set<T>)type.codec().deserialize(value));
+        TypeToken<Set<T>> javaType = setOf(elementsClass);
+        Set<T> set = codecFor(i, javaType).deserialize(value);
+        return Collections.unmodifiableSet(set);
     }
 
     public <T> Set<T> getSet(String name, Class<T> elementsClass) {
@@ -271,20 +268,15 @@ abstract class AbstractGettableData implements GettableData {
 
     @SuppressWarnings("unchecked")
     public <K, V> Map<K, V> getMap(int i, Class<K> keysClass, Class<V> valuesClass) {
-        DataType type = metadata.getType(i);
-        if (type.getName() != DataType.Name.MAP)
-            throw new InvalidTypeException(String.format("Column %s is not of map type", metadata.getName(i)));
-
-        Class<?> expectedKeysClass = type.getTypeArguments().get(0).getName().javaType;
-        Class<?> expectedValuesClass = type.getTypeArguments().get(1).getName().javaType;
-        if (!keysClass.isAssignableFrom(expectedKeysClass) || !valuesClass.isAssignableFrom(expectedValuesClass))
-            throw new InvalidTypeException(String.format("Column %s is a map of %s->%s (CQL type %s), cannot be retrieve as a map of %s->%s", metadata.getName(i), expectedKeysClass, expectedValuesClass, type, keysClass, valuesClass));
+        metadata.checkType(i, MAP);
 
         ByteBuffer value = getValue(i);
         if (value == null)
-            return Collections.<K, V>emptyMap();
+            return Collections.emptyMap();
 
-        return Collections.unmodifiableMap((Map<K, V>)type.codec().deserialize(value));
+        TypeToken<Map<K, V>> javaType = mapOf(keysClass, valuesClass);
+        Map<K, V> map = codecFor(i, javaType).deserialize(value);
+        return Collections.unmodifiableMap(map);
     }
 
     public <K, V> Map<K, V> getMap(String name, Class<K> keysClass, Class<V> valuesClass) {
@@ -306,10 +298,66 @@ abstract class AbstractGettableData implements GettableData {
                     return null;
             }
         else
-            return type.deserialize(raw);
+            return codecFor(i).deserialize(raw);
     }
 
     public Object getObject(String name) {
         return getObject(metadata.getFirstIdx(name));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T getObject(int i, Class<T> targetClass) {
+       return getObject(i, TypeToken.of(targetClass));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T getObject(int i, TypeToken<T> targetType) {
+        ByteBuffer raw = getValue(i);
+        if(raw == null)
+            return null;
+        TypeCodec<T> codec = codecFor(i, targetType);
+        return codec.deserialize(raw);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T getObject(String name, Class<T> targetClass) {
+        return getObject(metadata.findFirstIdx(name), targetClass);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T getObject(String name, TypeToken<T> targetType) {
+        return getObject(metadata.findFirstIdx(name), targetType);
+    }
+
+    protected CodecRegistry getCodecRegistry() {
+        return codecRegistry;
+    }
+
+    protected <T> TypeCodec<T> codecFor(int i){
+        return getCodecRegistry().codecFor(metadata.getType(i), metadata.getKeyspace(i), metadata.getTable(i), metadata.getName(i));
+    }
+
+    protected <T> TypeCodec<T> codecFor(int i, T value){
+        return getCodecRegistry().codecFor(metadata.getType(i), value, metadata.getKeyspace(i), metadata.getTable(i), metadata.getName(i));
+    }
+
+    protected <T> TypeCodec<T> codecFor(int i, Class<T> javaClass){
+        return codecFor(i, TypeToken.of(javaClass));
+    }
+
+    protected <T> TypeCodec<T> codecFor(int i, TypeToken<T> javaType){
+        return getCodecRegistry().codecFor(metadata.getType(i), javaType, metadata.getKeyspace(i), metadata.getTable(i), metadata.getName(i));
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedRow.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedRow.java
@@ -28,17 +28,17 @@ class ArrayBackedRow extends AbstractGettableData implements Row {
     private final Token.Factory tokenFactory;
     private final List<ByteBuffer> data;
 
-    private ArrayBackedRow(ColumnDefinitions metadata, Token.Factory tokenFactory, List<ByteBuffer> data) {
-        super(metadata);
+    private ArrayBackedRow(ColumnDefinitions metadata, CodecRegistry codecRegistry, Token.Factory tokenFactory, List<ByteBuffer> data) {
+        super(metadata, codecRegistry);
         this.tokenFactory = tokenFactory;
         this.data = data;
     }
 
-    static Row fromData(ColumnDefinitions metadata, Token.Factory tokenFactory, List<ByteBuffer> data) {
+    static Row fromData(ColumnDefinitions metadata, CodecRegistry codecRegistry, Token.Factory tokenFactory, List<ByteBuffer> data) {
         if (data == null)
             return null;
 
-        return new ArrayBackedRow(metadata, tokenFactory, data);
+        return new ArrayBackedRow(metadata, codecRegistry, tokenFactory, data);
     }
 
     public ColumnDefinitions getColumnDefinitions() {
@@ -88,9 +88,10 @@ class ArrayBackedRow extends AbstractGettableData implements Row {
             if (bb == null)
                 sb.append("NULL");
             else
-                sb.append(metadata.getType(i).codec().deserialize(bb).toString());
+                sb.append(getCodecRegistry().codecFor(metadata.getType(i)).deserialize(bb).toString());
         }
         sb.append(']');
         return sb.toString();
     }
+
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
@@ -80,14 +80,17 @@ public class BatchStatement extends Statement {
         this.batchType = batchType;
     }
 
-    IdAndValues getIdAndValues() {
+    IdAndValues getIdAndValues(CodecRegistry codecRegistry) {
         IdAndValues idAndVals = new IdAndValues(statements.size());
         for (Statement statement : statements) {
             if (statement instanceof RegularStatement) {
                 RegularStatement st = (RegularStatement)statement;
-                ByteBuffer[] vals = st.getValues();
-                idAndVals.ids.add(st.getQueryString());
-                idAndVals.values.add(vals == null ? Collections.<ByteBuffer>emptyList() : Arrays.asList(vals));
+                Object[] vals = st.getValues(codecRegistry);
+                idAndVals.ids.add(st.getQueryString(codecRegistry));
+                idAndVals.values.add(
+                    vals == null ?
+                        Collections.<ByteBuffer>emptyList() :
+                        Arrays.asList(CodecUtils.convert(vals, codecRegistry)));
             } else {
                 // We handle BatchStatement in add() so ...
                 assert statement instanceof BoundStatement;

--- a/driver-core/src/main/java/com/datastax/driver/core/CassandraTypeParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CassandraTypeParser.java
@@ -256,7 +256,7 @@ class CassandraTypeParser {
                 String bbHex = readNextIdentifier();
                 String name = null;
                 try {
-                    name = TypeCodec.StringCodec.utf8Instance.deserialize(Bytes.fromHexString("0x" + bbHex));
+                    name = TypeCodec.VarcharCodec.instance.deserialize(Bytes.fromHexString("0x" + bbHex));
                 } catch (NumberFormatException e) {
                     throwSyntaxError(e.getMessage());
                 }

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -585,8 +585,9 @@ public class Cluster implements Closeable {
 
         private NettyOptions nettyOptions = NettyOptions.DEFAULT_INSTANCE;
 
-        private Collection<Host.StateListener> listeners;
+        private CodecRegistry codecRegistry = CodecRegistry.DEFAULT_INSTANCE;
 
+        private Collection<Host.StateListener> listeners;
 
         @Override
         public String getClusterName() {
@@ -898,6 +899,21 @@ public class Cluster implements Closeable {
             return this;
         }
 
+
+        /**
+         * Configures the {@link CodecRegistry} instance to use for the new cluster.
+         * <p>
+         * If no codec registry is set through this method, {@link CodecRegistry#DEFAULT_INSTANCE}
+         * will be used instead.
+         *
+         * @param codecRegistry the codec registry to use.
+         * @return this Builder.
+         */
+        public Builder withCodecRegistry(CodecRegistry codecRegistry) {
+            this.codecRegistry = codecRegistry;
+            return this;
+        }
+
         /**
          * Uses the provided credentials when connecting to Cassandra hosts.
          * <p>
@@ -1094,7 +1110,8 @@ public class Cluster implements Closeable {
                                      socketOptions == null ? new SocketOptions() : socketOptions,
                                      metricsEnabled ? new MetricsOptions(jmxEnabled) : null,
                                      queryOptions == null ? new QueryOptions() : queryOptions,
-                                     nettyOptions);
+                                     nettyOptions,
+                                     codecRegistry);
         }
 
         @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
@@ -1,0 +1,711 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import com.google.common.base.Objects;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.TypeToken;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.datastax.driver.core.TypeCodec.*;
+import com.datastax.driver.core.exceptions.CodecNotFoundException;
+
+/**
+ * A registry for {@link TypeCodec}s.
+ * <p>
+ * {@link CodecRegistry} instances can be created via the {@link #builder()} method:
+ * <pre>
+ * CodecRegistry registry = CodecRegistry.builder().withCodecs(codec1, codec2).build();
+ * </pre>
+ * Note that the order in which codecs are added to the registry matters;
+ * when looking for a matching codec, the registry will consider all known codecs in
+ * the order they have been provided and will return the first matching candidate,
+ * even if another codec would be a better match.
+ * <p>
+ * To build a {@link CodecRegistry} instance with all the default codecs used
+ * by the Java driver, simply use the following:
+ * <pre>
+ * CodecRegistry registry = CodecRegistry.builder().withDefaultCodecs().build();
+ * </pre>
+ * Note that the default set of codecs has no support for
+ * <a href="https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/db/marshal/AbstractType.java">Cassandra custom types</a>;
+ * to be able to deserialize values of such types, you need to manually register an appropriate codec:
+ * <pre>
+ * CodecRegistry registry = CodecRegistry.builder().withCustomType(myCustomTypeCodec).build();
+ * </pre>
+ * {@link CodecRegistry} instances must then be associated with a {@link Cluster} instance:
+ * <pre>
+ * Cluster cluster = new Cluster.builder().withCodecRegistry(myCodecRegistry).build();
+ * </pre>
+ * The default {@link CodecRegistry} instance is {@link CodecRegistry#DEFAULT_INSTANCE}.
+ * To retrieve the {@link CodecRegistry} instance associated with a Cluster, do the
+ * following:
+ * <pre>
+ * CodecRegistry registry = cluster.getConfiguration().getCodecRegistry();
+ * </pre>
+ * {@link CodecRegistry} instances are immutable and can be safely shared accross threads.
+ *
+ */
+public class CodecRegistry {
+
+    private static final Logger logger = LoggerFactory.getLogger(CodecRegistry.class);
+
+    private static final ImmutableSet<TypeCodec<?>> PRIMITIVE_CODECS = ImmutableSet.of(
+        BlobCodec.instance,
+        BooleanCodec.instance,
+        IntCodec.instance,
+        BigintCodec.instance,
+        CounterCodec.instance,
+        DoubleCodec.instance,
+        FloatCodec.instance,
+        VarintCodec.instance,
+        DecimalCodec.instance,
+        VarcharCodec.instance,
+        AsciiCodec.instance,
+        TimestampCodec.instance,
+        UUIDCodec.instance,
+        TimeUUIDCodec.instance,
+        InetCodec.instance
+    );
+
+    /**
+     * The default set of codecs used by the Java driver.
+     * They contain codecs to handle native types, and collections
+     * of all native types (lists, sets and maps).
+     *
+     * Note that the default set of codecs has no support for
+     * <a href="https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/db/marshal/AbstractType.java">Cassandra custom types</a>;
+     * to be able to deserialize values of such types, you need to manually register an appropriate codec.
+     */
+    private static final ImmutableList<TypeCodec<?>> DEFAULT_CODECS;
+
+    static {
+        ImmutableList.Builder<TypeCodec<?>> builder = new ImmutableList.Builder<TypeCodec<?>>();
+        builder.addAll(PRIMITIVE_CODECS);
+        for (TypeCodec<?> primitiveCodec1 : PRIMITIVE_CODECS) {
+            builder.add(new ListCodec(primitiveCodec1));
+            builder.add(new SetCodec(primitiveCodec1));
+            for (TypeCodec<?> primitiveCodec2 : PRIMITIVE_CODECS) {
+                builder.add(new MapCodec(primitiveCodec1, primitiveCodec2));
+            }
+        }
+        DEFAULT_CODECS = builder.build();
+    }
+
+    /**
+     * The default {@link CodecRegistry} instance.
+     */
+    public static final CodecRegistry DEFAULT_INSTANCE = new CodecRegistry(DEFAULT_CODECS, ImmutableMap.<OverrideKey, TypeCodec<?>>of());
+
+    /**
+     * A builder to build {@link CodecRegistry} instances.
+     */
+    public static class Builder {
+
+        private ImmutableList.Builder<TypeCodec<?>> builder = ImmutableList.builder();
+
+        private ImmutableMap.Builder<OverrideKey, TypeCodec<?>> overrides = ImmutableMap.builder();
+
+        /**
+         * Add the {@link #DEFAULT_CODECS default set of codecs} to the registry.
+         *
+         * @return this Builder (for method chaining)
+         */
+        public Builder withDefaultCodecs() {
+            builder.addAll(DEFAULT_CODECS);
+            return this;
+        }
+
+        /**
+         * Add the given codec to the list of known codecs of this registry.
+         * Note that the order in which codecs are added to the registry matters;
+         * when looking for a matching codec, the registry will consider all known codecs in
+         * the order they have been provided and will return the first matching candidate,
+         * even if another codec would be a better match.
+         *
+         * @param codec The codec to add to the registry.
+         * @return this Builder (for method chaining).
+         */
+        public Builder withCodec(TypeCodec<?> codec) {
+            return withCodec(codec, false);
+        }
+
+        /**
+         * Add the given codec to the list of known codecs of this registry.
+         * Note that the order in which codecs are added to the registry matters;
+         * when looking for a matching codec, the registry will consider all known codecs in
+         * the order they have been provided and will return the first matching candidate,
+         * even if another codec would be a better match.
+         *
+         * @param codec The codec to add to the registry.
+         * @param includeDerivedCollectionCodecs If {@code true}, register not only the given codec
+         * but also collection codecs whose element types are handled by the given codec.
+         * @return this Builder (for method chaining).
+         */
+        public Builder withCodec(TypeCodec<?> codec, boolean includeDerivedCollectionCodecs) {
+            return withCodecs(Collections.singleton(codec), includeDerivedCollectionCodecs);
+        }
+
+        /**
+         * Add the given codecs to the list of known codecs of this registry.
+         * Note that the order in which codecs are added to the registry matters;
+         * when looking for a matching codec, the registry will consider all known codecs in
+         * the order they have been provided and will return the first matching candidate,
+         * even if another codec would be a better match.
+         *
+         * @param codecs The codecs to add to the registry.
+         * @return this Builder (for method chaining).
+         */
+        public Builder withCodecs(TypeCodec<?>... codecs) {
+            return withCodecs(Arrays.asList(codecs), false);
+        }
+
+        /**
+         * Add the given codecs to the list of known codecs of this registry.
+         * Note that the order in which codecs are added to the registry matters;
+         * when looking for a matching codec, the registry will consider all known codecs in
+         * the order they have been provided and will return the first matching candidate,
+         * even if another codec would be a better match.
+         *
+         * @param codecs The codecs to add to the registry.
+         * @return this Builder (for method chaining).
+         */
+        public Builder withCodecs(Iterable<? extends TypeCodec<?>> codecs) {
+            return withCodecs(codecs, false);
+        }
+
+        /**
+         * Add the given codecs to the list of known codecs of this registry.
+         * Note that the order in which codecs are added to the registry matters;
+         * when looking for a matching codec, the registry will consider all known codecs in
+         * the order they have been provided and will return the first matching candidate,
+         * even if another codec would be a better match.
+         *
+         * @param codecs The codecs to add to the registry.
+         * @param includeDerivedCollectionCodecs If {@code true}, register not only the given codecs
+         * but also collection codecs whose element types are handled by the given codecs.
+         * @return this Builder (for method chaining).
+         */
+        public Builder withCodecs(Iterable<? extends TypeCodec<?>> codecs, boolean includeDerivedCollectionCodecs) {
+            for (TypeCodec<?> codec : codecs) {
+                if(includeDerivedCollectionCodecs) addCodecAndDerivedCollectionCodecs(codec);
+                else builder.add(codec);
+            }
+            return this;
+        }
+
+        /**
+         * Add the given codec to the registry as an "overriding" codec.
+         * <p>
+         * This codec will only be used if the value being serialized or deserialized
+         * belongs to the specified keyspace, table and column.
+         * <p>
+         * <strong>IMPORTANT</strong>: Overriding codecs can only be used in conjunction with {@link GettableData} instances,
+         * such as{@link BoundStatement}s and {@link Row}s.
+         * It <em>cannot</em> be used with other instances of {@link Statement}, such
+         * as {@link SimpleStatement} or with the {@link com.datastax.driver.core.querybuilder.QueryBuilder query builder}.
+         * <p>
+         * <em>For this reason, if you plan to use overriding codecs, be sure to only use {@link PreparedStatement}s.</em>
+         *
+         * @param keyspace The keyspace name to which the overriding codec applies; must not be {@code null}.
+         * @param table The table name to which the overriding codec applies; must not be {@code null}.
+         * @param column The column name to which the overriding codec applies; must not be {@code null}.
+         * @param codec The overriding codec.
+         * @return this Builder (for method chaining).
+         */
+        public Builder withOverridingCodec(String keyspace, String table, String column, TypeCodec<?> codec) {
+            checkNotNull(keyspace, "Parameter keyspace cannot be null");
+            checkNotNull(table, "Parameter table cannot be null");
+            checkNotNull(column, "Parameter column cannot be null");
+            overrides.put(new OverrideKey(keyspace, table, column), codec);
+            return this;
+        }
+
+        /**
+         * Builds the registry.
+         * @return the newly-created {@link CodecRegistry}.
+         */
+        public CodecRegistry build() {
+            // reverse to make the last codecs override the first ones
+            // if their scope overlap
+            return new CodecRegistry(builder.build(), overrides.build());
+        }
+
+        private <T> void addCodecAndDerivedCollectionCodecs(TypeCodec<T> customCodec) {
+            builder.add(customCodec);
+            builder.add(new ListCodec<T>(customCodec));
+            builder.add(new SetCodec<T>(customCodec));
+            for (TypeCodec<?> primitiveCodec : PRIMITIVE_CODECS) {
+                builder.add(new MapCodec(primitiveCodec, customCodec));
+                builder.add(new MapCodec(customCodec, primitiveCodec));
+            }
+        }
+
+
+    }
+
+    /**
+     * Create a new instance of {@link com.datastax.driver.core.CodecRegistry.Builder}
+     * @return an instance of {@link com.datastax.driver.core.CodecRegistry.Builder}
+     * to build {@link CodecRegistry} instances.
+     */
+    public static CodecRegistry.Builder builder() {
+        return new Builder();
+    }
+
+    private static final class OverrideKey {
+
+        private final String keysapce;
+
+        private final String table;
+
+        private final String column;
+
+        public OverrideKey(String keysapce, String table, String column) {
+            this.keysapce = keysapce;
+            this.table = table;
+            this.column = column;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            OverrideKey override = (OverrideKey)o;
+            return Objects.equal(keysapce, override.keysapce) &&
+                Objects.equal(table, override.table) &&
+                Objects.equal(column, override.column);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(keysapce, table, column);
+        }
+    }
+
+    private static final class CacheKey {
+
+        private final TypeToken<?> javaType;
+
+        private final DataType cqlType;
+
+        public CacheKey(TypeToken<?> javaType, DataType cqlType) {
+            this.javaType = javaType;
+            this.cqlType = cqlType;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            CacheKey cacheKey = (CacheKey)o;
+            return Objects.equal(javaType, cacheKey.javaType) && Objects.equal(cqlType, cacheKey.cqlType);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(javaType, cqlType);
+        }
+    }
+
+    private final ImmutableList<TypeCodec<?>> codecs;
+
+    private final ImmutableMap<OverrideKey, TypeCodec<?>> overrides;
+
+    private final LoadingCache<CacheKey, TypeCodec<?>> cache;
+
+    private CodecRegistry(ImmutableList<TypeCodec<?>> codecs, ImmutableMap<OverrideKey, TypeCodec<?>> overrides) {
+        this.codecs = codecs;
+        this.overrides = overrides;
+        this.cache = CacheBuilder.newBuilder()
+            .initialCapacity(400)
+            .build(
+                new CacheLoader<CacheKey, TypeCodec<?>>() {
+                    public TypeCodec<?> load(CacheKey cacheKey) {
+                        return findCodec(cacheKey.cqlType, cacheKey.javaType);
+                    }
+                });
+    }
+
+    /**
+     * Returns a {@link TypeCodec codec} that accepts the given value.
+     * <p>
+     * This method takes an actual Java object and tries to locate a suitable codec for it.
+     * For this reason, codecs must perform a {@link TypeCodec#accepts(Object) "manual" inspection}
+     * of the object to determine if they can accept it or not, which, depending on the implementations,
+     * can be an expensive operation; besides, the resulting codec cannot be cached.
+     * Therefore there might be a performance penalty when using this method.
+     * <p>
+     * Furthermore, this method would return the first matching codec, regardless of its accepted {@link DataType CQL type}.
+     * For this reason, this method might not return the most accurate codec and should be
+     * reserved for situations where the runtime object to be serialized is not available or unknown.
+     * In the Java driver, this happens mainly when serializing a value in a {@link SimpleStatement}
+     * or in the {@link com.datastax.driver.core.querybuilder.QueryBuilder}, where no CQL type information
+     * is available.
+     * <p>
+     * Regular users should avoid using this method.
+     * <p>
+     * Codecs returned by this method are NOT cached.
+     *
+     * @param value The value the codec should accept; must not be {@code null}.
+     * @return A suitable codec.
+     * @throws CodecNotFoundException if a suitable codec cannot be found.
+     */
+    public <T> TypeCodec<T> codecFor(T value) {
+        checkNotNull(value, "Parameter value cannot be null");
+        return findCodec(null, value);
+    }
+
+    /**
+     * Returns a {@link TypeCodec codec} that accepts the given {@link DataType CQL type}.
+     * <p>
+     * This method would return the first matching codec, regardless of its accepted Java type.
+     * For this reason, this method might not return the most accurate codec and should be
+     * reserved for situations where the runtime type is not available or unknown.
+     * In the Java driver, this happens mainly when deserializing a value using the
+     * {@link AbstractGettableData#getObject(int)} method.
+     * <p>
+     * Codecs returned by this method are cached.
+     *
+     * @param cqlType The {@link DataType CQL type} the codec should accept; must not be {@code null}.
+     * @return A suitable codec.
+     * @throws CodecNotFoundException if a suitable codec cannot be found.
+     */
+    public <T> TypeCodec<T> codecFor(DataType cqlType) throws CodecNotFoundException {
+        return lookupCache(cqlType, null);
+    }
+
+    /**
+     * Returns a {@link TypeCodec codec} that accepts the given {@link DataType CQL type}
+     * and the given Java class.
+     * <p>
+     * This method can only handle raw (non-parameterized) Java types.
+     * For parameterized types, use {@link #codecFor(DataType, TypeToken)} instead.
+     * <p>
+     * Note that type inheritance needs special care.
+     * If a codec accepts a Java type that is assignable to the
+     * given Java type, that codec may be returned if it is found first
+     * in the registry, <em>even if another codec is a better match</em>.
+     * <p>
+     * Codecs returned by this method are cached.
+     *
+     * @param cqlType The {@link DataType CQL type} the codec should accept; must not be {@code null}.
+     * @param javaType The Java type the codec should accept; must not be {@code null}.
+     * @return A suitable codec.
+     * @throws CodecNotFoundException if a suitable codec cannot be found.
+     */
+    public <T> TypeCodec<T> codecFor(DataType cqlType, Class<T> javaType) throws CodecNotFoundException {
+        return codecFor(cqlType, TypeToken.of(javaType));
+    }
+
+    /**
+     * Returns a {@link TypeCodec codec} that accepts the given {@link DataType CQL type}
+     * and the given Java type.
+     * <p>
+     * This method handles parameterized types thanks to Guava's {@link TypeToken} API, and should
+     * therefore be preferred over {@link #codecFor(DataType, Class)}.
+     * <p>
+     * Note that type inheritance needs special care.
+     * If a codec accepts a Java type that is assignable to the
+     * given Java type, that codec may be returned if it is found first
+     * in the registry, <em>even if another codec is a better match</em>.
+     * <p>
+     * Codecs returned by this method are cached.
+     *
+     * @param cqlType The {@link DataType CQL type} the codec should accept; must not be {@code null}.
+     * @param javaType The {@link TypeToken Java type} the codec should accept; must not be {@code null}.
+     * @return A suitable codec.
+     * @throws CodecNotFoundException if a suitable codec cannot be found.
+     */
+    public <T> TypeCodec<T> codecFor(DataType cqlType, TypeToken<T> javaType) throws CodecNotFoundException {
+        checkNotNull(cqlType, "Parameter cqlType cannot be null");
+        checkNotNull(javaType, "Parameter javaType cannot be null");
+        return lookupCache(cqlType, javaType);
+    }
+
+    /**
+     * Returns a {@link TypeCodec codec} that accepts the given {@link DataType CQL type}
+     * and the given value.
+     * <p>
+     * This method takes an actual Java object and tries to locate a suitable codec for it.
+     * For this reason, codecs must perform a {@link TypeCodec#accepts(Object) "manual" inspection}
+     * of the object to determine if they can accept it or not, which, depending on the implementations,
+     * can be an expensive operation; besides, the resulting codec cannot be cached.
+     * Therefore there might be a performance penalty when using this method.
+     * <p>
+     * Codecs returned by this method are NOT cached.
+     *
+     * @param cqlType The {@link DataType CQL type} the codec should accept; must not be {@code null}.
+     * @param value The value the codec should accept; must not be {@code null}.
+     * @return A suitable codec.
+     * @throws CodecNotFoundException if a suitable codec cannot be found.
+     */
+    public <T> TypeCodec<T> codecFor(DataType cqlType, T value) {
+        checkNotNull(cqlType, "Parameter cqlType cannot be null");
+        checkNotNull(value, "Parameter value cannot be null");
+        return findCodec(cqlType, value);
+    }
+
+    // Methods accepting codec overrides
+
+    /**
+     * Return an overriding {@link TypeCodec codec} that accepts the given {@link DataType CQL type}
+     * and applies only to the given keyspace, table and column.
+     * <p>
+     * If such an overriding codec cannot be found, the registry attempts to find
+     * a globally-registered one and returns it instead.
+     * <p>
+     * This method would return the first matching codec, regardless of its accepted Java type.
+     * For this reason, this method might not return the most accurate codec and should be
+     * reserved for situations where the runtime object to be serialized is not available or unknown.
+     * In the Java driver, this happens mainly when deserializing a value using the
+     * {@link AbstractGettableData#getObject(int)} method.
+     * <p>
+     * Codecs returned by this method are cached.
+     *
+     * @param cqlType The {@link DataType CQL type} the codec should accept; must not be {@code null}.
+     * @param keyspace The keyspace name to which the overriding codec applies;
+     * if {@code null}, no overriding codec will be located and the globally-registered codec will be returned instead.
+     * @param table The table name to which the overriding codec applies;
+     * if {@code null}, no overriding codec will be located and the globally-registered codec will be returned instead.
+     * @param column The column name to which the overriding codec applies;
+     * if {@code null}, no overriding codec will be located and the globally-registered codec will be returned instead.
+     * @return An overriding codec for the given keyspace, table and column, if any; otherwise, a globally-registered suitable codec.
+     * @throws CodecNotFoundException if an overriding codec is found but does not accept the given {@link DataType CQL type};
+     * or if no suitable codec could be found at all.
+     */
+    public <T> TypeCodec<T> codecFor(DataType cqlType, String keyspace, String table, String column) throws CodecNotFoundException {
+        checkNotNull(cqlType, "Parameter cqlType cannot be null");
+        TypeCodec<T> codec = findOverridingCodec(cqlType, null, keyspace, table, column);
+        if (codec != null)
+            return codec;
+        return codecFor(cqlType);
+    }
+
+    /**
+     * Return an overriding {@link TypeCodec codec} that accepts the given {@link DataType CQL type}
+     * and the given Java class, and that applies only to the given keyspace, table and column.
+     * <p>
+     * If such an overriding codec cannot be found, the registry attempts to find
+     * a globally-registered one and returns it instead.
+     * <p>
+     * This method can only handle raw (non-parameterized) Java types.
+     * For parameterized types, use {@link #codecFor(DataType, TypeToken, String, String, String)} instead.
+     * <p>
+     * Note that type inheritance needs special care.
+     * If a codec accepts a Java type that is assignable to the
+     * given Java type, that codec may be returned if it is found first
+     * in the registry, <em>even if another codec is a better match</em>.
+     * <p>
+     * Codecs returned by this method are cached.
+     *
+     * @param cqlType The {@link DataType CQL type} the codec should accept; must not be {@code null}.
+     * @param javaType The Java type the codec should accept; must not be {@code null}.
+     * @param keyspace The keyspace name to which the overriding codec applies;
+     * if {@code null}, no overriding codec will be located and the globally-registered codec will be returned instead.
+     * @param table The table name to which the overriding codec applies;
+     * if {@code null}, no overriding codec will be located and the globally-registered codec will be returned instead.
+     * @param column The column name to which the overriding codec applies;
+     * if {@code null}, no overriding codec will be located and the globally-registered codec will be returned instead.
+     * @return An overriding codec for the given keyspace, table and column, if any; otherwise, a globally-registered suitable codec.
+     * @throws CodecNotFoundException if an overriding codec is found but does not accept the given {@link DataType CQL type}
+     * and the given Java class; or if no suitable codec could be found at all.
+     */
+    public <T> TypeCodec<T> codecFor(DataType cqlType, Class<T> javaType, String keyspace, String table, String column) throws CodecNotFoundException {
+        return codecFor(cqlType, TypeToken.of(javaType), keyspace, table, column);
+    }
+
+    /**
+     * Return an overriding {@link TypeCodec codec} that accepts the given {@link DataType CQL type}
+     * and the given Java type, and that applies only to the given keyspace, table and column.
+     * <p>
+     * If such an overriding codec cannot be found, the registry attempts to find
+     * a globally-registered one and returns it instead.
+     * <p>
+     * This method handles parameterized types thanks to Guava's {@link TypeToken} API, and should
+     * therefore be preferred over {@link #codecFor(DataType, Class, String, String, String)}.
+     * <p>
+     * Note that type inheritance needs special care.
+     * If a codec accepts a Java type that is assignable to the
+     * given Java type, that codec may be returned if it is found first
+     * in the registry, <em>even if another codec is a better match</em>.
+     * <p>
+     * Codecs returned by this method are cached.
+     *
+     * @param cqlType The {@link DataType CQL type} the codec should accept; must not be {@code null}.
+     * @param javaType The {@link TypeToken Java type} the codec should accept; must not be {@code null}.
+     * @param keyspace The keyspace name to which the overriding codec applies;
+     * if {@code null}, no overriding codec will be located and the globally-registered codec will be returned instead.
+     * @param table The table name to which the overriding codec applies;
+     * if {@code null}, no overriding codec will be located and the globally-registered codec will be returned instead.
+     * @param column The column name to which the overriding codec applies;
+     * if {@code null}, no overriding codec will be located and the globally-registered codec will be returned instead.
+     * @return An overriding codec for the given keyspace, table and column, if any; otherwise, a globally-registered suitable codec.
+     * @throws CodecNotFoundException if an overriding codec is found but does not accept the given {@link DataType CQL type}
+     * and the given Java type; or if no suitable codec could be found at all.
+     */
+    public <T> TypeCodec<T> codecFor(DataType cqlType, TypeToken<T> javaType, String keyspace, String table, String column) throws CodecNotFoundException {
+        checkNotNull(cqlType, "Parameter cqlType cannot be null");
+        checkNotNull(javaType, "Parameter javaType cannot be null");
+        TypeCodec<T> codec = findOverridingCodec(cqlType, javaType, keyspace, table, column);
+        if (codec != null)
+            return codec;
+        return codecFor(cqlType, javaType);
+    }
+
+    /**
+     * Return an overriding {@link TypeCodec codec} that accepts the given {@link DataType CQL type}
+     * and the given value, and that applies only to the given keyspace, table and column.
+     * <p>
+     * If such an overriding codec cannot be found, the registry attempts to find
+     * a globally-registered one and returns it instead.
+     * <p>
+     * This method takes an actual Java object and tries to locate a suitable codec for it.
+     * For this reason, codecs must perform a {@link TypeCodec#accepts(Object) "manual" inspection}
+     * of the object to determine if they can accept it or not, which, depending on the implementations,
+     * can be an expensive operation; besides, the resulting codec cannot be cached.
+     * Therefore there might be a performance penalty when using this method.
+     * <p>
+     * Codecs returned by this method are NOT cached.
+     *
+     * @param cqlType The {@link DataType CQL type} the codec should accept; must not be {@code null}.
+     * @param value The value the codec should accept; must not be {@code null}.
+     * @param keyspace The keyspace name to which the overriding codec applies;
+     * if {@code null}, no overriding codec will be located and the globally-registered codec will be returned instead.
+     * @param table The table name to which the overriding codec applies;
+     * if {@code null}, no overriding codec will be located and the globally-registered codec will be returned instead.
+     * @param column The column name to which the overriding codec applies;
+     * if {@code null}, no overriding codec will be located and the globally-registered codec will be returned instead.
+     * @return An overriding codec for the given keyspace, table and column, if any, otherwise, a globally-registered suitable codec.
+     * @throws CodecNotFoundException if an overriding codec is found but does not accept the given value;
+     * or if no suitable codec could be found at all.
+     */
+    public <T> TypeCodec<T> codecFor(DataType cqlType, T value, String keyspace, String table, String column) {
+        checkNotNull(cqlType, "Parameter cqlType cannot be null");
+        checkNotNull(value, "Parameter value cannot be null");
+        TypeCodec<T> codec = findOverridingCodec(cqlType, value, keyspace, table, column);
+        if (codec != null)
+            return codec;
+        return codecFor(cqlType, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> TypeCodec<T> lookupCache(DataType cqlType, TypeToken<T> javaType) {
+        logger.debug("Looking up overriding codec for {} <-> {}", cqlType, javaType);
+        CacheKey cacheKey = new CacheKey(javaType, cqlType);
+        try {
+            return (TypeCodec<T>)cache.getUnchecked(cacheKey);
+        } catch (UncheckedExecutionException e) {
+            throw (CodecNotFoundException)e.getCause();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> TypeCodec<T> findCodec(DataType cqlType, TypeToken<T> javaType) {
+        logger.debug("Looking for codec [{} <-> {}]", cqlType, javaType);
+        for (TypeCodec<?> codec : codecs) {
+            if ((cqlType == null || codec.accepts(cqlType)) && (javaType == null || codec.accepts(javaType))) {
+                logger.debug("Codec found: {}", codec);
+                return (TypeCodec<T>)codec;
+            }
+        }
+        return logErrorAndThrow(cqlType, javaType);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> TypeCodec<T> findCodec(DataType cqlType, T value) {
+        TypeToken<?> javaType = TypeToken.of(value.getClass());
+        logger.debug("Looking for codec [{} <-> {}]", cqlType, javaType);
+        for (TypeCodec<?> codec : codecs) {
+            if ((cqlType == null || codec.accepts(cqlType)) && codec.accepts(value)) {
+                logger.debug("Codec found: {}", codec);
+                return (TypeCodec<T>)codec;
+            }
+        }
+        return logErrorAndThrow(cqlType, javaType);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> TypeCodec<T> findOverridingCodec(DataType cqlType, TypeToken<T> javaType, String keyspace, String table, String column) {
+        if (keyspace != null && table != null && column != null) {
+            logger.debug("Looking for overriding codec for {}.{}.{}", keyspace, table, column);
+            OverrideKey overrideKey = new OverrideKey(keyspace, table, column);
+            if (overrides.containsKey(overrideKey)) {
+                TypeCodec<?> codec = overrides.get(overrideKey);
+                if ((cqlType == null || codec.accepts(cqlType)) && (javaType == null || codec.accepts(javaType))) {
+                    logger.debug("Overriding codec found for {}.{}.{}: {}", keyspace, table, column, codec);
+                    return (TypeCodec<T>)codec;
+                } else {
+                    return logErrorAndThrow(codec, cqlType, javaType, keyspace, table, column);
+                }
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> TypeCodec<T> findOverridingCodec(DataType cqlType, T value, String keyspace, String table, String column) {
+        if (keyspace != null && table != null && column != null) {
+            logger.debug("Looking for overriding codec for {}.{}.{}", keyspace, table, column);
+            OverrideKey overrideKey = new OverrideKey(keyspace, table, column);
+            if (overrides.containsKey(overrideKey)) {
+                TypeCodec<?> codec = overrides.get(overrideKey);
+                if ((cqlType == null || codec.accepts(cqlType)) && codec.accepts(value)) { // value cannot be null
+                    logger.debug("Overriding codec found for {}.{}.{}: {}", keyspace, table, column, codec);
+                    return (TypeCodec<T>)codec;
+                } else {
+                    return logErrorAndThrow(codec, cqlType, TypeToken.of((Class<T>)value.getClass()), keyspace, table, column);
+                }
+            }
+        }
+        return null;
+    }
+
+    private <T> TypeCodec<T> logErrorAndThrow(DataType cqlType, TypeToken<?> javaType) {
+        String msg = String.format("Codec not found for required pair: [%s <-> %s]",
+            cqlType == null ? "ANY" : cqlType,
+            javaType == null ? "ANY" : javaType);
+        logger.error(msg);
+        throw new CodecNotFoundException(msg, cqlType, javaType);
+    }
+
+    private <T> TypeCodec<T> logErrorAndThrow(TypeCodec<?> codec, DataType cqlType, TypeToken<T> javaType, String keyspace, String table, String column) {
+        String msg = String.format("Found overriding codec %s for %s.%s.%s but it does not accept required pair: [%s <-> %s]",
+            codec,
+            keyspace, table, column,
+            cqlType == null ? "ANY" : cqlType,
+            javaType == null ? "ANY" : javaType);
+        logger.error(msg);
+        throw new CodecNotFoundException(msg, cqlType, javaType);
+    }
+
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/CodecUtils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CodecUtils.java
@@ -1,0 +1,125 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.reflect.TypeParameter;
+import com.google.common.reflect.TypeToken;
+
+/**
+ * A set of utility methods to deal with type conversion,
+ * serialization, and to create {@link TypeToken} instances.
+ */
+public class CodecUtils {
+
+    public static <T> TypeToken<List<T>> listOf(Class<T> eltType) {
+        return new TypeToken<List<T>>(){}.where(new TypeParameter<T>(){}, eltType);
+    }
+
+    public static <T> TypeToken<List<T>> listOf(TypeToken<T> eltType) {
+        return new TypeToken<List<T>>(){}.where(new TypeParameter<T>(){}, eltType);
+    }
+
+    public static <T> TypeToken<Set<T>> setOf(Class<T> eltType) {
+        return new TypeToken<Set<T>>(){}.where(new TypeParameter<T>(){}, eltType);
+    }
+
+    public static <T> TypeToken<Set<T>> setOf(TypeToken<T> eltType) {
+        return new TypeToken<Set<T>>(){}.where(new TypeParameter<T>(){}, eltType);
+    }
+
+    public static <K, V> TypeToken<Map<K, V>> mapOf(Class<K> keyType, Class<V> valueType) {
+        return new TypeToken<Map<K, V>>(){}
+            .where(new TypeParameter<K>(){}, keyType)
+            .where(new TypeParameter<V>(){}, valueType);
+    }
+
+    public static <K, V> TypeToken<Map<K, V>> mapOf(TypeToken<K> keyType, TypeToken<V> valueType) {
+        return new TypeToken<Map<K, V>>(){}
+            .where(new TypeParameter<K>(){}, keyType)
+            .where(new TypeParameter<V>(){}, valueType);
+    }
+
+    public static ByteBuffer[] convert(Object[] values, CodecRegistry codecRegistry) {
+        ByteBuffer[] serializedValues = new ByteBuffer[values.length];
+        for (int i = 0; i < values.length; i++) {
+            Object value = values[i];
+                if (value == null) {
+                    serializedValues[i] = null;
+                } else {
+                    if (value instanceof Token)
+                        value = ((Token)value).getValue();
+                    try {
+                        TypeCodec<Object> codec = codecRegistry.codecFor(value);
+                        serializedValues[i] = codec.serialize(value);
+                    } catch (Exception e) {
+                        // Catch and rethrow to provide a more helpful error message (one that include which value is bad)
+                        throw new IllegalArgumentException(String.format("Value %d of type %s does not correspond to any CQL3 type", i, value.getClass()), e);
+                    }
+                }
+        }
+        return serializedValues;
+    }
+
+    // Utility method for collections
+    public static ByteBuffer pack(List<ByteBuffer> buffers, int elements, int size) {
+        if (elements > 65535)
+            throw new IllegalArgumentException("Native protocol version 2 supports up to 65535 elements in any collection - but collection contains " + elements + " elements");
+        ByteBuffer result = ByteBuffer.allocate(2 + size);
+        result.putShort((short)elements);
+        for (ByteBuffer bb : buffers) {
+            int elemSize = bb.remaining();
+            if (elemSize > 65535)
+                throw new IllegalArgumentException("Native protocol version 2 supports only elements with size up to 65535 bytes - but element size is " + elemSize + " bytes");
+            result.putShort((short)elemSize);
+            result.put(bb.duplicate());
+        }
+        return (ByteBuffer)result.flip();
+    }
+
+    // Utility method for collections
+    public static int getUnsignedShort(ByteBuffer bb) {
+        int length = (bb.get() & 0xFF) << 8;
+        return length | (bb.get() & 0xFF);
+    }
+
+    public static ByteBuffer compose(ByteBuffer... buffers) {
+        if(buffers.length == 1) return buffers[0];
+
+        int totalLength = 0;
+        for (ByteBuffer bb : buffers)
+            totalLength += 2 + bb.remaining() + 1;
+
+        ByteBuffer out = ByteBuffer.allocate(totalLength);
+        for (ByteBuffer buffer : buffers) {
+            ByteBuffer bb = buffer.duplicate();
+            putShortLength(out, bb.remaining());
+            out.put(bb);
+            out.put((byte)0);
+        }
+        out.flip();
+        return out;
+    }
+
+    private static void putShortLength(ByteBuffer bb, int length) {
+        bb.put((byte)((length >> 8) & 0xFF));
+        bb.put((byte)(length & 0xFF));
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/Configuration.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Configuration.java
@@ -41,6 +41,7 @@ public class Configuration {
     private final MetricsOptions metricsOptions;
     private final QueryOptions queryOptions;
     private final NettyOptions nettyOptions;
+    private final CodecRegistry codecRegistry;
 
     /*
      * Creates a configuration object.
@@ -52,7 +53,9 @@ public class Configuration {
              new SocketOptions(),
              new MetricsOptions(),
              new QueryOptions(),
-             NettyOptions.DEFAULT_INSTANCE);
+             NettyOptions.DEFAULT_INSTANCE,
+             CodecRegistry.DEFAULT_INSTANCE
+        );
     }
 
     /**
@@ -65,6 +68,7 @@ public class Configuration {
      * @param metricsOptions the metrics options, or null to disable metrics.
      * @param queryOptions defaults related to queries.
      * @param nettyOptions the {@link NettyOptions} instance to use
+     * @param codecRegistry the {@link CodecRegistry} instance to use
      */
     public Configuration(Policies policies,
                          ProtocolOptions protocolOptions,
@@ -72,7 +76,8 @@ public class Configuration {
                          SocketOptions socketOptions,
                          MetricsOptions metricsOptions,
                          QueryOptions queryOptions,
-                         NettyOptions nettyOptions) {
+                         NettyOptions nettyOptions,
+                         CodecRegistry codecRegistry) {
         this.policies = policies;
         this.protocolOptions = protocolOptions;
         this.poolingOptions = poolingOptions;
@@ -80,6 +85,7 @@ public class Configuration {
         this.metricsOptions = metricsOptions;
         this.queryOptions = queryOptions;
         this.nettyOptions = nettyOptions;
+        this.codecRegistry = codecRegistry;
     }
 
     void register(Cluster.Manager manager) {
@@ -152,4 +158,13 @@ public class Configuration {
     public NettyOptions getNettyOptions() {
         return nettyOptions;
     }
+
+    /**
+     * Returns the {@link CodecRegistry} instance for this configuration.
+     * @return the {@link CodecRegistry} instance for this configuration.
+     */
+    public CodecRegistry getCodecRegistry() {
+        return codecRegistry;
+    }
+
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/GettableData.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/GettableData.java
@@ -21,6 +21,8 @@ import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.*;
 
+import com.google.common.reflect.TypeToken;
+
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 
 /**
@@ -512,4 +514,69 @@ public interface GettableData {
      * @throws IllegalArgumentException if {@code name} is not a valid name for this object.
      */
     Object getObject(String name);
+
+    // Methods providing dynamic serialization/deserialization
+
+    /**
+     * Returns the the {@code i}th value converted to the given Java type.
+     * A suitable {@link TypeCodec} instance for {@code targetClass} must
+     * have been previously registered with the {@link CodecRegistry} currently in use.
+     *
+     * @param i the index to retrieve.
+     * @param targetClass The Java type the value should be converted to.
+     * @return the value of the {@code i}th value converted to the given Java type.
+     * If the CQL value is {@code NULL}, then {@code null} is returned.
+     * @throws com.datastax.driver.core.exceptions.CodecNotFoundException
+     * if no {@link TypeCodec} instance for {@code targetClass} could be found
+     * by the {@link CodecRegistry} currently in use.
+     */
+    <T> T getObject(int i, Class<T> targetClass);
+
+    /**
+     * Returns the the {@code i}th value converted to the given Java type.
+     * A suitable {@link TypeCodec} instance for {@code targetType} must
+     * have been previously registered with the {@link CodecRegistry} currently in use.
+     *
+     * @param i the index to retrieve.
+     * @param targetType The Java type the value should be converted to.
+     * @return the value of the {@code i}th value converted to the given Java type.
+     * If the CQL value is {@code NULL}, then {@code null} is returned.
+     * @throws com.datastax.driver.core.exceptions.CodecNotFoundException
+     * if no {@link TypeCodec} instance for {@code targetType} could be found
+     * by the {@link CodecRegistry} currently in use.
+     */
+    <T> T getObject(int i, TypeToken<T> targetType);
+
+    /**
+     * Returns the value for {@code name} converted to the given Java type.
+     * A suitable {@link TypeCodec} instance for {@code targetClass} must
+     * have been previously registered with the {@link CodecRegistry} currently in use.
+     *
+     * @param name the name to retrieve.
+     * @param targetClass The Java type the value should be converted to.
+     * @return the value for {@code name} value converted to the given Java type.
+     * If the CQL value is {@code NULL}, then {@code null} is returned.
+     * @throws IllegalArgumentException if {@code name} is not a valid name for this object.
+     * @throws com.datastax.driver.core.exceptions.CodecNotFoundException
+     * if no {@link TypeCodec} instance for {@code targetClass} could be found
+     * by the {@link CodecRegistry} currently in use.
+     */
+    <T> T getObject(String name, Class<T> targetClass);
+
+    /**
+     * Returns the value for {@code name} converted to the given Java type.
+     * A suitable {@link TypeCodec} instance for {@code targetType} must
+     * have been previously registered with the {@link CodecRegistry} currently in use.
+     *
+     * @param name the name to retrieve.
+     * @param targetType The Java type the value should be converted to.
+     * @return the value for {@code name} value converted to the given Java type.
+     * If the CQL value is {@code NULL}, then {@code null} is returned.
+     * @throws IllegalArgumentException if {@code name} is not a valid name for this object.
+     * @throws com.datastax.driver.core.exceptions.CodecNotFoundException
+     * if no {@link TypeCodec} instance for {@code targetType} could be found
+     * by the {@link CodecRegistry} currently in use.
+     */
+    <T> T getObject(String name, TypeToken<T> targetType);
+
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/PreparedStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PreparedStatement.java
@@ -268,4 +268,5 @@ public interface PreparedStatement {
      * @return the PreparedId corresponding to this statement.
      */
     public PreparedId getPreparedId();
+
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/QueryLogger.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/QueryLogger.java
@@ -720,6 +720,8 @@ public abstract class QueryLogger implements LatencyTracker {
         } else {
             DataType type = definition.getType();
             int maxParameterValueLength = this.maxParameterValueLength;
+            CodecRegistry codecRegistry = cluster.getConfiguration().getCodecRegistry();
+            TypeCodec<Object> codec = codecRegistry.codecFor(type);
             if (type.equals(DataType.blob()) && maxParameterValueLength != -1) {
                 // prevent large blobs from being converted to strings
                 int maxBufferLength = Math.max(2, (maxParameterValueLength - 2) / 2);
@@ -727,14 +729,14 @@ public abstract class QueryLogger implements LatencyTracker {
                 if (bufferTooLarge) {
                     raw = (ByteBuffer)raw.duplicate().limit(maxBufferLength);
                 }
-                Object value = type.deserialize(raw);
-                valueStr = type.format(value);
+                Object value = codec.deserialize(raw);
+                valueStr = codec.format(value);
                 if (bufferTooLarge) {
                     valueStr = valueStr + TRUNCATED_OUTPUT;
                 }
             } else {
-                Object value = type.deserialize(raw);
-                valueStr = type.format(value);
+                Object value = codec.deserialize(raw);
+                valueStr = codec.format(value);
                 if (maxParameterValueLength != -1 && valueStr.length() > maxParameterValueLength) {
                     valueStr = valueStr.substring(0, maxParameterValueLength) + TRUNCATED_OUTPUT;
                 }

--- a/driver-core/src/main/java/com/datastax/driver/core/RegularStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RegularStatement.java
@@ -35,9 +35,21 @@ public abstract class RegularStatement extends Statement {
     /**
      * Returns the query string for this statement.
      *
+     * @deprecated Use {@link #getQueryString(CodecRegistry)} instead.
      * @return a valid CQL query string.
      */
+    @Deprecated
     public abstract String getQueryString();
+
+    /**
+     * Returns the query string for this statement.
+     * If there are values that need to be inserted
+     * in the string, these will be formatted
+     * with the given {@link CodecRegistry} instance.
+     *
+     * @return a valid CQL query string.
+     */
+    public abstract String getQueryString(CodecRegistry codecRegistry);
 
     /**
      * The values to use for this statement.
@@ -49,15 +61,37 @@ public abstract class RegularStatement extends Statement {
      * 1 through {@link Cluster.Builder#withProtocolVersion} or you use
      * Cassandra 1.2).
      *
+     * @deprecated Use {@link #getValues(CodecRegistry)} instead.
      * @return the values to use for this statement or {@code null} if there is
      * no such values.
-     *
+     * @throws IllegalArgumentException if one of the values is not of a type
+     * that can be serialized to a CQL3 type
      * @see SimpleStatement#SimpleStatement(String, Object...)
      */
+    @Deprecated
     public abstract ByteBuffer[] getValues();
+
+    /**
+     * Return the values to use for this statement, converted using the given
+     * {@link CodecRegistry instance}.
+     * <p>
+     * Note: Values for a RegularStatement (i.e. if this method does not return
+     * {@code null}) are not supported with the native protocol version 1: you
+     * will get an {@link UnsupportedProtocolVersionException} when submitting
+     * one if version 1 of the protocol is in use (i.e. if you've force version
+     * 1 through {@link Cluster.Builder#withProtocolVersion} or you use
+     * Cassandra 1.2).
+     *
+     * @return the values to use for this statement or {@code null} if there is
+     * no such values.
+     * @throws IllegalArgumentException if one of the values is not of a type
+     * that can be serialized to a CQL3 type
+     * @see SimpleStatement#SimpleStatement(String, Object...)
+     */
+    public abstract ByteBuffer[] getValues(CodecRegistry codecRegistry);
 
     @Override
     public String toString() {
-        return getQueryString();
+        return getQueryString(CodecRegistry.DEFAULT_INSTANCE);
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/Responses.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Responses.java
@@ -421,8 +421,10 @@ class Responses {
                             sb.append(" | ");
                             if (metadata.columns == null)
                                 sb.append(Bytes.toHexString(v));
-                            else
-                                sb.append(metadata.columns.getType(i).deserialize(v));
+                            else {
+                                // using default codec registry as this is only intended for debugging purposes
+                                sb.append(CodecRegistry.DEFAULT_INSTANCE.codecFor(metadata.columns.getType(i)).deserialize(v));
+                            }
                         }
                     }
                     sb.append('\n');

--- a/driver-core/src/main/java/com/datastax/driver/core/Statement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Statement.java
@@ -158,7 +158,7 @@ public abstract class Statement {
     }
 
     /**
-     * Returns the routing key (in binary raw form) to use for token aware 
+     * Returns the routing key (in binary raw form) to use for token aware
      * routing of this query.
      * <p>
      * The routing key is optional in that implementers are free to

--- a/driver-core/src/main/java/com/datastax/driver/core/Token.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Token.java
@@ -19,7 +19,6 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
 import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -213,7 +212,7 @@ public abstract class Token implements Comparable<Token> {
 
             @Override
             Token deserialize(ByteBuffer buffer) {
-                return new M3PToken((Long) getTokenType().deserialize(buffer));
+                return new M3PToken(TypeCodec.BigintCodec.instance.deserialize(buffer));
             }
 
             @Override
@@ -532,7 +531,7 @@ public abstract class Token implements Comparable<Token> {
 
             @Override
             Token deserialize(ByteBuffer buffer) {
-                return new RPToken((BigInteger)getTokenType().deserialize(buffer));
+                return new RPToken(TypeCodec.VarintCodec.instance.deserialize(buffer));
             }
 
             @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/CodecNotFoundException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/CodecNotFoundException.java
@@ -15,20 +15,32 @@
  */
 package com.datastax.driver.core.exceptions;
 
-public class InvalidTypeException extends DriverException {
+import com.google.common.reflect.TypeToken;
 
-    private static final long serialVersionUID = 0;
+import com.datastax.driver.core.DataType;
 
-    public InvalidTypeException(String msg) {
+/**
+ * Thrown when a suitable {@link com.datastax.driver.core.TypeCodec} cannot be found by
+ * {@link com.datastax.driver.core.CodecRegistry} instances.
+ */
+@SuppressWarnings("serial")
+public class CodecNotFoundException extends DriverException {
+
+    private final DataType cqlType;
+
+    private final TypeToken<?> javaType;
+
+    public CodecNotFoundException(String msg, DataType cqlType, TypeToken<?> javaType) {
         super(msg);
+        this.cqlType = cqlType;
+        this.javaType = javaType;
     }
 
-    public InvalidTypeException(String msg, Throwable cause) {
-        super(msg, cause);
+    public DataType getCqlType() {
+        return cqlType;
     }
 
-    @Override
-    public DriverException copy() {
-        return new InvalidTypeException(getMessage(), this);
+    public TypeToken<?> getJavaType() {
+        return javaType;
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Assignment.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Assignment.java
@@ -15,8 +15,9 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import java.nio.ByteBuffer;
 import java.util.List;
+
+import com.datastax.driver.core.CodecRegistry;
 
 import static com.datastax.driver.core.querybuilder.Utils.appendName;
 import static com.datastax.driver.core.querybuilder.Utils.appendValue;
@@ -41,10 +42,10 @@ public abstract class Assignment extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables, CodecRegistry codecRegistry) {
             appendName(name, sb);
             sb.append('=');
-            appendValue(value, sb, variables);
+            appendValue(value, codecRegistry, sb, variables);
         }
 
         @Override
@@ -75,10 +76,10 @@ public abstract class Assignment extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables, CodecRegistry codecRegistry) {
             appendName(name, sb).append('=');
             appendName(name, sb).append(isIncr ? "+" : "-");
-            appendValue(value, sb, variables);
+            appendValue(value, codecRegistry, sb, variables);
         }
 
         @Override
@@ -102,9 +103,9 @@ public abstract class Assignment extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables, CodecRegistry codecRegistry) {
             appendName(name, sb).append('=');
-            appendValue(value, sb, variables);
+            appendValue(value, codecRegistry, sb, variables);
             sb.append('+');
             appendName(name, sb);
         }
@@ -132,9 +133,9 @@ public abstract class Assignment extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables, CodecRegistry codecRegistry) {
             appendName(name, sb).append('[').append(idx).append("]=");
-            appendValue(value, sb, variables);
+            appendValue(value, codecRegistry, sb, variables);
         }
 
         @Override
@@ -166,10 +167,10 @@ public abstract class Assignment extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables, CodecRegistry codecRegistry) {
             appendName(name, sb).append('=');
             appendName(name, sb).append(isAdd ? "+" : "-");
-            appendValue(collection, sb, variables);
+            appendValue(collection, codecRegistry, sb, variables);
         }
 
         @Override
@@ -195,11 +196,11 @@ public abstract class Assignment extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables, CodecRegistry codecRegistry) {
             appendName(name, sb).append('[');
-            appendValue(key, sb, variables);
+            appendValue(key, codecRegistry, sb, variables);
             sb.append("]=");
-            appendValue(value, sb, variables);
+            appendValue(value, codecRegistry, sb, variables);
         }
 
         @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Clause.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Clause.java
@@ -15,8 +15,9 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import java.nio.ByteBuffer;
 import java.util.List;
+
+import com.datastax.driver.core.CodecRegistry;
 
 public abstract class Clause extends Utils.Appendeable {
 
@@ -48,9 +49,9 @@ public abstract class Clause extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables, CodecRegistry codecRegistry) {
             Utils.appendName(name, sb).append(op);
-            Utils.appendValue(value, sb, variables);
+            Utils.appendValue(value, codecRegistry, sb, variables);
         }
 
         @Override
@@ -79,7 +80,7 @@ public abstract class Clause extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables, CodecRegistry codecRegistry) {
 
             // We special case the case of just one bind marker because there is little
             // reasons to do:
@@ -94,7 +95,7 @@ public abstract class Clause extends Utils.Appendeable {
             }
 
             Utils.appendName(name, sb).append(" IN (");
-            Utils.joinAndAppendValues(sb, ",", values, variables).append(')');
+            Utils.joinAndAppendValues(sb, codecRegistry, ",", values, variables).append(')');
         }
 
         @Override
@@ -139,14 +140,14 @@ public abstract class Clause extends Utils.Appendeable {
 
         @Override
         boolean containsBindMarker() {
-            for (int i = 0; i < values.size(); i++)
-                if (Utils.containsBindMarker(values.get(i)))
+            for (Object value : values)
+                if (Utils.containsBindMarker(value))
                     return true;
             return false;
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables, CodecRegistry codecRegistry) {
             sb.append("(");
             for (int i = 0; i < names.size(); i++) {
                 if (i > 0)
@@ -157,7 +158,7 @@ public abstract class Clause extends Utils.Appendeable {
             for (int i = 0; i < values.size(); i++) {
                 if (i > 0)
                     sb.append(",");
-                Utils.appendValue(values.get(i), sb, variables);
+                Utils.appendValue(values.get(i), codecRegistry, sb, variables);
             }
             sb.append(")");
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
@@ -15,11 +15,11 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.TableMetadata;
 
 /**
@@ -46,7 +46,7 @@ public class Insert extends BuiltStatement {
     }
 
     @Override
-    StringBuilder buildQueryString(List<ByteBuffer> variables) {
+    StringBuilder buildQueryString(List<Object> variables, CodecRegistry codecRegistry) {
         StringBuilder builder = new StringBuilder();
 
         builder.append("INSERT INTO ");
@@ -54,9 +54,9 @@ public class Insert extends BuiltStatement {
             Utils.appendName(keyspace, builder).append('.');
         Utils.appendName(table, builder);
         builder.append('(');
-        Utils.joinAndAppendNames(builder, ",", names);
+        Utils.joinAndAppendNames(builder, codecRegistry, ",", names);
         builder.append(") VALUES (");
-        Utils.joinAndAppendValues(builder, ",", values, variables);
+        Utils.joinAndAppendValues(builder, codecRegistry, ",", values, variables);
         builder.append(')');
 
         if (ifNotExists)
@@ -64,7 +64,7 @@ public class Insert extends BuiltStatement {
 
         if (!usings.usings.isEmpty()) {
             builder.append(" USING ");
-            Utils.joinAndAppend(builder, " AND ", usings.usings, variables);
+            Utils.joinAndAppend(builder, codecRegistry, " AND ", usings.usings, variables);
         }
         return builder;
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Ordering.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Ordering.java
@@ -15,8 +15,9 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import java.nio.ByteBuffer;
 import java.util.List;
+
+import com.datastax.driver.core.CodecRegistry;
 
 public class Ordering extends Utils.Appendeable {
 
@@ -29,7 +30,7 @@ public class Ordering extends Utils.Appendeable {
     }
 
     @Override
-    void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+    void appendTo(StringBuilder sb, List<Object> variables, CodecRegistry codecRegistry) {
         Utils.appendName(name, sb);
         sb.append(isDesc ? " DESC" : " ASC");
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
@@ -17,6 +17,7 @@ package com.datastax.driver.core.querybuilder;
 
 import java.util.*;
 
+import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.TableMetadata;
 
@@ -258,7 +259,9 @@ public final class QueryBuilder {
     public static String token(String... columnNames) {
         StringBuilder sb = new StringBuilder();
         sb.append("token(");
-        Utils.joinAndAppendNames(sb, ",", Arrays.asList((Object[])columnNames));
+        // FIXME use configured CodecRegistry
+        CodecRegistry codecRegistry = CodecRegistry.DEFAULT_INSTANCE;
+        Utils.joinAndAppendNames(sb, codecRegistry, ",", Arrays.asList((Object[])columnNames));
         sb.append(')');
         return sb.toString();
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Truncate.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Truncate.java
@@ -18,6 +18,7 @@ package com.datastax.driver.core.querybuilder;
 import java.nio.ByteBuffer;
 import java.util.List;
 
+import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.TableMetadata;
 
 /**
@@ -38,7 +39,7 @@ public class Truncate extends BuiltStatement {
     }
 
     @Override
-    protected StringBuilder buildQueryString(List<ByteBuffer> variables) {
+    protected StringBuilder buildQueryString(List<Object> variables, CodecRegistry codecRegistry) {
         StringBuilder builder = new StringBuilder();
 
         builder.append("TRUNCATE ");

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
@@ -15,10 +15,10 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.TableMetadata;
 import com.datastax.driver.core.querybuilder.Assignment.CounterAssignment;
 
@@ -52,7 +52,7 @@ public class Update extends BuiltStatement {
     }
 
     @Override
-    StringBuilder buildQueryString(List<ByteBuffer> variables) {
+    StringBuilder buildQueryString(List<Object> variables, CodecRegistry codecRegistry) {
         StringBuilder builder = new StringBuilder();
 
         builder.append("UPDATE ");
@@ -62,22 +62,22 @@ public class Update extends BuiltStatement {
 
         if (!usings.usings.isEmpty()) {
             builder.append(" USING ");
-            Utils.joinAndAppend(builder, " AND ", usings.usings, variables);
+            Utils.joinAndAppend(builder, codecRegistry, " AND ", usings.usings, variables);
         }
 
         if (!assignments.assignments.isEmpty()) {
             builder.append(" SET ");
-            Utils.joinAndAppend(builder, ",", assignments.assignments, variables);
+            Utils.joinAndAppend(builder, codecRegistry, ",", assignments.assignments, variables);
         }
 
         if (!where.clauses.isEmpty()) {
             builder.append(" WHERE ");
-            Utils.joinAndAppend(builder, " AND ", where.clauses, variables);
+            Utils.joinAndAppend(builder, codecRegistry, " AND ", where.clauses, variables);
         }
 
         if (!conditions.conditions.isEmpty()) {
             builder.append(" IF ");
-            Utils.joinAndAppend(builder, " AND ", conditions.conditions, variables);
+            Utils.joinAndAppend(builder, codecRegistry, " AND ", conditions.conditions, variables);
         }
 
         return builder;

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Using.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Using.java
@@ -15,8 +15,9 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import java.nio.ByteBuffer;
 import java.util.List;
+
+import com.datastax.driver.core.CodecRegistry;
 
 public abstract class Using extends Utils.Appendeable {
 
@@ -35,7 +36,7 @@ public abstract class Using extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables, CodecRegistry codecRegistry) {
             sb.append(optionName).append(' ').append(value);
         }
 
@@ -54,7 +55,7 @@ public abstract class Using extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables, CodecRegistry codecRegistry) {
             sb.append(optionName).append(' ').append(marker);
         }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
@@ -17,217 +17,56 @@ package com.datastax.driver.core.querybuilder;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.net.InetAddress;
-import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.List;
 import java.util.regex.Pattern;
 
-import com.datastax.driver.core.DataType;
-import com.datastax.driver.core.utils.Bytes;
+import com.datastax.driver.core.CodecRegistry;
+import com.datastax.driver.core.TypeCodec;
 
 // Static utilities private to the query builder
 abstract class Utils {
 
     private static final Pattern cnamePattern = Pattern.compile("\\w+(?:\\[.+\\])?");
 
-
-    static StringBuilder joinAndAppend(StringBuilder sb, String separator, List<? extends Appendeable> values, List<ByteBuffer> variables) {
+    static StringBuilder joinAndAppend(StringBuilder sb, CodecRegistry codecRegistry, String separator, List<? extends Appendeable> values, List<Object> variables) {
         for (int i = 0; i < values.size(); i++) {
             if (i > 0)
                 sb.append(separator);
-            values.get(i).appendTo(sb, variables);
+            values.get(i).appendTo(sb, variables, codecRegistry);
         }
         return sb;
     }
 
-    static StringBuilder joinAndAppendNames(StringBuilder sb, String separator, List<?> values) {
+    static StringBuilder joinAndAppendNames(StringBuilder sb, CodecRegistry codecRegistry, String separator, List<?> values) {
         for (int i = 0; i < values.size(); i++) {
             if (i > 0)
                 sb.append(separator);
-            appendName(values.get(i), sb);
+            appendName(values.get(i), codecRegistry, sb);
         }
         return sb;
     }
 
-    static StringBuilder joinAndAppendValues(StringBuilder sb, String separator, List<?> values, List<ByteBuffer> variables) {
+    static StringBuilder joinAndAppendValues(StringBuilder sb, CodecRegistry codecRegistry, String separator, List<?> values, List<Object> variables) {
         for (int i = 0; i < values.size(); i++) {
             if (i > 0)
                 sb.append(separator);
-            appendValue(values.get(i), sb, variables);
+            appendValue(values.get(i), codecRegistry, sb, variables);
         }
         return sb;
     }
 
     // Returns null if it's not really serializable (function call, bind markers, ...)
-    static ByteBuffer serializeValue(Object value) {
-        if (value == QueryBuilder.bindMarker() || value instanceof FCall || value instanceof CName)
-            return null;
+    static boolean shouldInsertBindMarker(Object value) {
+        if (value instanceof BindMarker || value instanceof FCall || value instanceof CName)
+            return true;
 
         // We also don't serialize fixed size number types. The reason is that if we do it, we will
         // force a particular size (4 bytes for ints, ...) and for the query builder, we don't want
         // users to have to bother with that.
         if (value instanceof Number && !(value instanceof BigInteger || value instanceof BigDecimal))
-            return null;
-
-        try {
-            return DataType.serializeValue(value);
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
-    }
-
-    static StringBuilder appendValue(Object value, StringBuilder sb, List<ByteBuffer> variables) {
-        if (variables == null)
-            return appendValue(value, sb, false);
-
-        ByteBuffer bb = serializeValue(value);
-        if (bb == null)
-            return appendValue(value, sb, false);
-
-        sb.append('?');
-        variables.add(bb);
-        return sb;
-    }
-
-    static StringBuilder appendFlatValue(Object value, StringBuilder sb) {
-        appendFlatValue(value, sb, false);
-        return sb;
-    }
-
-    private static StringBuilder appendValue(Object value, StringBuilder sb, boolean rawValue) {
-        // That is kind of lame but lacking a better solution
-        if (appendValueIfLiteral(value, sb))
-            return sb;
-
-        if (appendValueIfCollection(value, sb, rawValue))
-            return sb;
-
-        appendStringIfValid(value, sb, rawValue);
-        return sb;
-    }
-
-    private static void appendFlatValue(Object value, StringBuilder sb, boolean rawValue) {
-        if (appendValueIfLiteral(value, sb))
-            return;
-
-        appendStringIfValid(value, sb, rawValue);
-    }
-
-    private static void appendStringIfValid(Object value, StringBuilder sb, boolean rawValue) {
-        if (value instanceof RawString) {
-            sb.append(value.toString());
-        } else {
-            if (!(value instanceof String)) {
-                String msg = String.format("Invalid value %s of type unknown to the query builder", value);
-                if (value instanceof byte[])
-                    msg += " (for blob values, make sure to use a ByteBuffer)";
-                throw new IllegalArgumentException(msg);
-            }
-
-            if (rawValue)
-                sb.append((String)value);
-            else
-                appendValueString((String)value, sb);
-        }
-    }
-
-    private static boolean appendValueIfLiteral(Object value, StringBuilder sb) {
-        if (value instanceof Number || value instanceof UUID || value instanceof Boolean) {
-            sb.append(value);
             return true;
-        } else if (value instanceof InetAddress) {
-            sb.append('\'').append(((InetAddress)value).getHostAddress()).append('\'');
-            return true;
-        } else if (value instanceof Date) {
-            sb.append(((Date)value).getTime());
-            return true;
-        } else if (value instanceof ByteBuffer) {
-            sb.append(Bytes.toHexString((ByteBuffer) value));
-            return true;
-        } else if (value instanceof BindMarker) {
-            sb.append(value);
-            return true;
-        } else if (value instanceof FCall) {
-            FCall fcall = (FCall)value;
-            sb.append(fcall.name).append('(');
-            for (int i = 0; i < fcall.parameters.length; i++) {
-                if (i > 0)
-                    sb.append(',');
-                appendValue(fcall.parameters[i], sb, null);
-            }
-            sb.append(')');
-            return true;
-        } else if (value instanceof CName) {
-            appendName(((CName)value).name, sb);
-            return true;
-        } else if (value == null) {
-            sb.append("null");
-            return true;
-        } else {
-            return false;
-        }
-    }
 
-    @SuppressWarnings("rawtypes")
-    private static boolean appendValueIfCollection(Object value, StringBuilder sb, boolean rawValue) {
-        if (value instanceof List) {
-            appendList((List) value, sb, rawValue);
-            return true;
-        } else if (value instanceof Set) {
-            appendSet((Set)value, sb, rawValue);
-            return true;
-        } else if (value instanceof Map) {
-            appendMap((Map)value, sb, rawValue);
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    static StringBuilder appendCollection(Object value, StringBuilder sb, List<ByteBuffer> variables) {
-        ByteBuffer bb = variables == null ? null : serializeValue(value);
-        if (bb == null) {
-            boolean wasCollection = appendValueIfCollection(value, sb, false);
-            assert wasCollection;
-        } else {
-            sb.append('?');
-            variables.add(bb);
-        }
-        return sb;
-    }
-
-    static StringBuilder appendList(List<?> l, StringBuilder sb) {
-        return appendList(l, sb, false);
-    }
-
-    private static StringBuilder appendList(List<?> l, StringBuilder sb, boolean rawValue) {
-        sb.append('[');
-        for (int i = 0; i < l.size(); i++) {
-            if (i > 0)
-                sb.append(',');
-            appendFlatValue(l.get(i), sb, rawValue);
-        }
-        sb.append(']');
-        return sb;
-    }
-
-    static StringBuilder appendSet(Set<?> s, StringBuilder sb) {
-        return appendSet(s, sb, false);
-    }
-
-    private static StringBuilder appendSet(Set<?> s, StringBuilder sb, boolean rawValue) {
-        sb.append('{');
-        boolean first = true;
-        for (Object elt : s) {
-            if (first) first = false; else sb.append(',');
-            appendFlatValue(elt, sb, rawValue);
-        }
-        sb.append('}');
-        return sb;
-    }
-
-    static StringBuilder appendMap(Map<?, ?> m, StringBuilder sb) {
-        return appendMap(m, sb, false);
+        return false;
     }
 
     static boolean containsBindMarker(Object value) {
@@ -244,35 +83,46 @@ abstract class Utils {
         return false;
     }
 
-    private static StringBuilder appendMap(Map<?, ?> m, StringBuilder sb, boolean rawValue) {
-        sb.append('{');
-        boolean first = true;
-        for (Map.Entry<?, ?> entry : m.entrySet()) {
-            if (first)
-                first = false;
-            else
-                sb.append(',');
-            appendFlatValue(entry.getKey(), sb, rawValue);
-            sb.append(':');
-            appendFlatValue(entry.getValue(), sb, rawValue);
-        }
-        sb.append('}');
+    static StringBuilder appendValue(Object value, CodecRegistry codecRegistry, StringBuilder sb, List<Object> variables) {
+        if (variables == null || !shouldInsertBindMarker(value))
+            return appendValue(value, codecRegistry, sb);
+
+        sb.append('?');
+        variables.add(value);
         return sb;
     }
 
-    private static StringBuilder appendValueString(String value, StringBuilder sb) {
-        return sb.append('\'').append(replace(value, '\'', "''")).append('\'');
+    static StringBuilder appendValue(Object value, CodecRegistry codecRegistry, StringBuilder sb) {
+        if (value == null) {
+            sb.append("null");
+        } else if (value instanceof BindMarker) {
+            sb.append(value);
+        } else if (value instanceof FCall) {
+            FCall fcall = (FCall)value;
+            sb.append(fcall.name).append('(');
+            for (int i = 0; i < fcall.parameters.length; i++) {
+                if (i > 0)
+                    sb.append(',');
+                appendValue(fcall.parameters[i], codecRegistry, sb, null);
+            }
+            sb.append(')');
+        } else if (value instanceof CName) {
+            appendName(((CName)value).name, sb);
+        } else if (value instanceof RawString) {
+            sb.append(value.toString());
+        } else {
+            TypeCodec<Object> codec = codecRegistry.codecFor(value);
+            sb.append(codec.format(value));
+        }
+        return sb;
     }
+
 
     static boolean isRawValue(Object value) {
         return value != null
             && !(value instanceof FCall)
             && !(value instanceof CName)
             && !(value instanceof BindMarker);
-    }
-
-    static String toRawString(Object value) {
-        return appendValue(value, new StringBuilder(), true).toString();
     }
 
     static StringBuilder appendName(String name, StringBuilder sb) {
@@ -285,7 +135,7 @@ abstract class Utils {
         return sb;
     }
 
-    static StringBuilder appendName(Object name, StringBuilder sb) {
+    static StringBuilder appendName(Object name, CodecRegistry codecRegistry, StringBuilder sb) {
         if (name instanceof String) {
             appendName((String)name, sb);
         } else if (name instanceof CName) {
@@ -296,12 +146,12 @@ abstract class Utils {
             for (int i = 0; i < fcall.parameters.length; i++) {
                 if (i > 0)
                     sb.append(',');
-                appendValue(fcall.parameters[i], sb, null);
+                appendValue(fcall.parameters[i], codecRegistry, sb, null);
             }
             sb.append(')');
         } else if (name instanceof Alias) {
             Alias alias = (Alias)name;
-            appendName(alias.column, sb);
+            appendName(alias.column, codecRegistry, sb);
             sb.append(" AS ").append(alias.alias);
         } else {
             throw new IllegalArgumentException(String.format("Invalid column %s of type unknown of the query builder", name));
@@ -310,40 +160,8 @@ abstract class Utils {
     }
 
     static abstract class Appendeable {
-        abstract void appendTo(StringBuilder sb, List<ByteBuffer> values);
+        abstract void appendTo(StringBuilder sb, List<Object> values, CodecRegistry codecRegistry);
         abstract boolean containsBindMarker();
-    }
-
-    // Simple method to replace a single character. String.replace is a bit too
-    // inefficient (see JAVA-67)
-    static String replace(String text, char search, String replacement) {
-        if (text == null || text.isEmpty())
-            return text;
-
-        int nbMatch = 0;
-        int start = -1;
-        do {
-            start = text.indexOf(search, start+1);
-            if (start != -1)
-                ++nbMatch;
-        } while (start != -1);
-
-        if (nbMatch == 0)
-            return text;
-
-        int newLength = text.length() + nbMatch * (replacement.length() - 1);
-        char[] result = new char[newLength];
-        int newIdx = 0;
-        for (int i = 0; i < text.length(); i++) {
-            char c = text.charAt(i);
-            if (c == search) {
-                for (int r = 0; r < replacement.length(); r++)
-                    result[newIdx++] = replacement.charAt(r);
-            } else {
-                result[newIdx++] = c;
-            }
-        }
-        return new String(result);
     }
 
     static class RawString {

--- a/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
@@ -30,4 +30,9 @@ public class Assertions extends org.assertj.core.api.Assertions{
     public static TokenRangeAssert assertThat(TokenRange range) {
         return new TokenRangeAssert(range);
     }
+
+    public static TypeCodecAssert assertThat(TypeCodec codec) {
+        return new TypeCodecAssert(codec);
+    }
+
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/BoundStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/BoundStatementTest.java
@@ -68,4 +68,5 @@ public class BoundStatementTest extends CCMBridge.PerClassSingleNodeCluster {
             fail("Expected index error");
         } catch (IndexOutOfBoundsException e) { /* expected */ }
     }
+
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/CodecRegistryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CodecRegistryTest.java
@@ -1,0 +1,256 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.reflect.TypeToken;
+import org.testng.annotations.Test;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.reflect.TypeToken.of;
+
+import com.datastax.driver.core.TypeCodec.DoubleCodec;
+import com.datastax.driver.core.TypeCodec.ListCodec;
+import com.datastax.driver.core.TypeCodec.VarcharCodec;
+import com.datastax.driver.core.exceptions.CodecNotFoundException;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+import static com.datastax.driver.core.Assertions.fail;
+import static com.datastax.driver.core.CodecUtils.listOf;
+import static com.datastax.driver.core.CodecUtils.setOf;
+import static com.datastax.driver.core.DataType.*;
+
+public class CodecRegistryTest {
+
+    @Test(groups = "unit")
+    public void should_retrieve_codec_by_java_and_cql_when_simple_type(){
+        CodecRegistry registry = CodecRegistry.builder().withCodecs(VarcharCodec.instance).build();
+        assertThat(registry.codecFor(varchar(), String.class)).isSameAs(VarcharCodec.instance);
+        assertThat(registry.codecFor(text(), String.class)).isSameAs(VarcharCodec.instance); // just an alias
+    }
+
+    @Test(groups = "unit")
+    public void should_retrieve_codec_by_java_and_cql_when_parameterized_type(){
+        ListCodec<Double> codec = new ListCodec<Double>(DoubleCodec.instance);
+        CodecRegistry registry = CodecRegistry.builder().withCodecs(codec).build();
+        assertThat(registry.codecFor(list(cdouble()), listOf(Double.class))).isSameAs(codec);
+    }
+
+    @Test(groups = "unit")
+    public void should_override_codec_when_overlapping_scope(){
+        TypeCodec<?> codec1 = new FakeCodec<Integer>(bigint(), of(Integer.class));
+        TypeCodec<?> codec2 = new FakeCodec<Integer>(cint(), of(Integer.class));
+        TypeCodec<?> codec3 = new FakeCodec<Integer>(cint(), of(Integer.class));
+        TypeCodec<?> codec4 = new FakeCodec<BigInteger>(cint(), of(BigInteger.class));
+        CodecRegistry registry = CodecRegistry.builder().withCodecs(codec1, codec2, codec3, codec4).build();
+        assertThat(registry.codecFor(cint())).isSameAs(codec2); // first wins
+        assertThat(registry.codecFor(1234)).isSameAs(codec1); // first wins
+        assertThat(registry.codecFor(cint(), of(Integer.class))).isSameAs(codec2); // first exact match wins
+        assertThat(registry.codecFor(cint(), of(BigInteger.class))).isSameAs(codec4); // only matching codec
+    }
+
+    @Test(groups = "unit")
+    public void should_override_codec_per_column(){
+        TypeCodec<?> codec1 = new FakeCodec<Integer>(cint(), of(Integer.class));
+        TypeCodec<?> codec2 = new FakeCodec<Integer>(cint(), of(Integer.class));
+        CodecRegistry registry = CodecRegistry.builder()
+            .withCodecs(codec1)
+            .withOverridingCodec("myKeyspace", "myTable", "myColumn", codec2)
+            .build();
+        assertThat(registry.codecFor(cint(), of(Integer.class))).isSameAs(codec1);
+        assertThat(registry.codecFor(cint(), of(Integer.class), "myKeyspace", "myTable", "myColumn")).isSameAs(codec2);
+    }
+
+    @Test(groups = "unit")
+    public void test_raw_type_covariance(){
+        CodecRegistry registry = CodecRegistry.builder().withCodecs(new NumberCodec()).build();
+        assertThat(registry.codecFor(decimal())).isInstanceOf(NumberCodec.class);
+        assertThat(registry.codecFor(decimal(), Integer.class)).isInstanceOf(NumberCodec.class);
+        assertThat(registry.codecFor(1234)).isInstanceOf(NumberCodec.class);
+    }
+
+    @Test(groups = "unit", expectedExceptions = CodecNotFoundException.class)
+    public void test_parameterized_type_covariance(){
+        // List<? extends Number>
+        TypeCodec<?> codec = new AnyNumberListCodec();
+        CodecRegistry registry = CodecRegistry.builder().withCodecs(codec).build();
+        assertThat(registry.codecFor(list(decimal()))).isSameAs(codec);
+        assertThat(registry.codecFor(list(decimal()), listOf(Integer.class))).isSameAs(codec); // List<Integer> instance of List<? extends Number>
+        // List<Number>
+        codec = new NumberListCodec();
+        registry = CodecRegistry.builder().withCodecs(codec).build();
+        assertThat(registry.codecFor(list(decimal()))).isSameAs(codec);
+        registry.codecFor(list(decimal()), listOf(Integer.class)); // List<Integer> not instance of List<Number> -> CodecNotFoundException
+    }
+
+    @Test(groups = "unit", expectedExceptions = CodecNotFoundException.class)
+    public void test_interface_vs_implementation(){
+        // List<String>
+        TypeCodec<?> codec = new ListCodec<String>(VarcharCodec.instance);
+        CodecRegistry registry = CodecRegistry.builder().withCodecs(codec).build();
+        assertThat(registry.codecFor(list(text()))).isSameAs(codec);
+        assertThat(registry.codecFor(newArrayList("a", "b", "c"))).isSameAs(codec);
+        assertThat(registry.codecFor(list(text()), new TypeToken<ArrayList<String>>(){})).isSameAs(codec); // ArrayList<String> instance of List<String>
+        // ArrayList<String>
+        codec = new ArrayListOfStringsCodec();
+        registry = CodecRegistry.builder().withCodecs(codec).build();
+        assertThat(registry.codecFor(list(text()))).isSameAs(codec);
+        assertThat(registry.codecFor(newArrayList("a", "b", "c"))).isSameAs(codec);
+        registry.codecFor(list(text()), listOf(String.class)); // List<String> not instance of ArrayList<String>
+    }
+
+    @Test(groups = "unit", expectedExceptions = CodecNotFoundException.class)
+    public void native_to_collection(){
+        TypeCodec<?> codec = new TextToListOfStringsCodec();
+        CodecRegistry registry = CodecRegistry.builder().withCodecs(codec).build();
+        assertThat(registry.codecFor(text())).isSameAs(codec);
+        assertThat(registry.codecFor(text(), listOf(String.class))).isSameAs(codec);
+        assertThat(registry.codecFor(newArrayList("a", "b", "c"))).isSameAs(codec);
+    }
+
+    @Test(groups = "unit")
+    public void collection_to_native(){
+        TypeCodec<?> codec = new ListOfIntsToStringCodec();
+        CodecRegistry registry = CodecRegistry.builder().withCodecs(codec).build();
+        assertThat(registry.codecFor(list(cint()))).isSameAs(codec);
+        assertThat(registry.codecFor(list(cint()), String.class)).isSameAs(codec);
+        assertThat(registry.codecFor("123")).isSameAs(codec);
+    }
+
+    @Test(groups = "unit")
+    public void collection_to_nested_collection(){
+        TypeCodec<?> codec = new ListOfVarcharsToSetOfListOfIntegersCodec();
+        CodecRegistry registry = CodecRegistry.builder().withCodecs(codec).build();
+        assertThat(registry.codecFor(list(varchar()))).isSameAs(codec);
+        assertThat(registry.codecFor(list(varchar()), setOf(listOf(Integer.class)))).isSameAs(codec);
+        try {
+            registry.codecFor(list(varchar()), listOf(listOf(Integer.class)));
+            fail("should not have found codec for List<List<Integer>");
+        } catch (CodecNotFoundException e) {
+            //ok
+        }
+        try {
+            assertThat(registry.codecFor(newArrayList(newArrayList(1, 2, 3)))).isSameAs(codec);
+            fail("should not have found codec for [[1,2,3]]");
+        } catch (CodecNotFoundException e) {
+            //ok
+        }
+    }
+
+    private class FakeCodec<T> extends TypeCodec<T> {
+
+        protected FakeCodec(DataType cqlType, TypeToken<T> javaType) {
+            super(cqlType, javaType);
+        }
+
+        @Override
+        public ByteBuffer serialize(T value) {
+            return null;
+        }
+
+        @Override
+        public T deserialize(ByteBuffer bytes) {
+            return null;
+        }
+
+        @Override
+        public T parse(String value) {
+            return null;
+        }
+
+        @Override
+        public String format(T value) {
+            return null;
+        }
+    }
+
+    private class ArrayListOfStringsCodec extends TypeCodec.CollectionCodec<String, ArrayList<String>> {
+
+        public ArrayListOfStringsCodec() {
+            super(list(text()), new TypeToken<ArrayList<String>>(){}, VarcharCodec.instance);
+        }
+
+        @Override
+        protected ArrayList<String> newInstance(int capacity) {
+            return new ArrayList<String>(capacity);
+        }
+
+        @Override
+        protected char getOpeningChar() {
+            return '[';
+        }
+
+        @Override
+        protected char getClosingChar() {
+            return ']';
+        }
+
+    }
+
+    private class NumberCodec extends FakeCodec<Number> {
+
+        protected NumberCodec() {
+            super(decimal(), of(Number.class));
+        }
+
+    }
+
+    private class TextToListOfStringsCodec extends FakeCodec<List<String>> {
+
+        protected TextToListOfStringsCodec() {
+            super(text(), listOf(String.class));
+        }
+
+    }
+
+    private class ListOfIntsToStringCodec extends FakeCodec<String> {
+
+        protected ListOfIntsToStringCodec() {
+            super(list(cint()), of(String.class));
+        }
+
+    }
+
+    private class NumberListCodec extends ListCodec<Number> {
+
+        protected NumberListCodec() {
+            super(new NumberCodec());
+        }
+
+    }
+
+    private class AnyNumberListCodec extends FakeCodec<List<? extends Number>> {
+
+        protected AnyNumberListCodec() {
+            super(list(decimal()), new TypeToken<List<? extends Number>>(){});
+        }
+
+    }
+
+    private class ListOfVarcharsToSetOfListOfIntegersCodec extends FakeCodec<Set<List<Integer>>> {
+
+        protected ListOfVarcharsToSetOfListOfIntegersCodec() {
+            super(list(varchar()), setOf(listOf(Integer.class)));
+        }
+
+    }
+
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/JsonCodec.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/JsonCodec.java
@@ -1,0 +1,57 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+
+import static com.datastax.driver.core.DataType.text;
+
+/**
+ * A simple Json codec for TypeCodec tests.
+ */
+public class JsonCodec<T> extends TypeCodec.ParsingTypeCodec<T> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public JsonCodec(Class<T> javaType) {
+        super(javaType);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T parse(String value) {
+        try {
+            return (T) objectMapper.readValue(value, getJavaType().getRawType());
+        } catch (IOException e) {
+            throw new InvalidTypeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String format(T value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new InvalidTypeException(e.getMessage(), e);
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
@@ -87,6 +87,8 @@ public class QueryLoggerTest extends CCMBridge.PerClassSingleNodeCluster {
         )
     );
 
+    private CodecRegistry codecRegistry = CodecRegistry.DEFAULT_INSTANCE;
+
     private Logger normal = Logger.getLogger(NORMAL_LOGGER.getName());
     private Logger slow = Logger.getLogger(SLOW_LOGGER.getName());
     private Logger error = Logger.getLogger(ERROR_LOGGER.getName());
@@ -491,7 +493,7 @@ public class QueryLoggerTest extends CCMBridge.PerClassSingleNodeCluster {
             .contains(ipOfNode(1))
             .contains(query);
         for (DataType type : dataTypes) {
-            assertThat(line).contains(type.format(getFixedValue(type)));
+            assertThat(line).contains(codecRegistry.codecFor(type).format((getFixedValue(type))));
         }
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaAgreementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaAgreementTest.java
@@ -102,7 +102,7 @@ public class SchemaAgreementTest {
 
     private static void forceSchemaVersion(Session session, InetAddress peerAddress, UUID schemaVersion) {
         session.execute(String.format("UPDATE system.peers SET schema_version = %s WHERE peer = %s",
-            DataType.uuid().format(schemaVersion), DataType.inet().format(peerAddress)));
+            TypeCodec.UUIDCodec.instance.format(schemaVersion), TypeCodec.InetCodec.instance.format(peerAddress)));
     }
 
     @AfterMethod(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -156,11 +156,15 @@ public abstract class TestUtils {
             case TIMEUUID:
                 return row.getUUID(name);
             case LIST:
-                return row.getList(name, type.getTypeArguments().get(0).asJavaClass());
+                Class<?> listEltClass = CodecRegistry.DEFAULT_INSTANCE.codecFor(type.getTypeArguments().get(0)).getJavaType().getRawType();
+                return row.getList(name, listEltClass);
             case SET:
-                return row.getSet(name, type.getTypeArguments().get(0).asJavaClass());
+                Class<?> setEltClass = CodecRegistry.DEFAULT_INSTANCE.codecFor(type.getTypeArguments().get(0)).getJavaType().getRawType();
+                return row.getSet(name, setEltClass);
             case MAP:
-                return row.getMap(name, type.getTypeArguments().get(0).asJavaClass(), type.getTypeArguments().get(1).asJavaClass());
+                Class<?> keyClass = CodecRegistry.DEFAULT_INSTANCE.codecFor(type.getTypeArguments().get(0)).getJavaType().getRawType();
+                Class<?> valueClass = CodecRegistry.DEFAULT_INSTANCE.codecFor(type.getTypeArguments().get(1)).getJavaType().getRawType();
+                return row.getMap(name, keyClass, valueClass);
         }
         throw new RuntimeException("Missing handling of " + type);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
@@ -16,7 +16,9 @@
 package com.datastax.driver.core;
 
 import java.net.InetSocketAddress;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
@@ -114,7 +116,7 @@ public abstract class TokenIntegrationTest {
 
         // Find the replica for a given partition key
         int testKey = 1;
-        Set<Host> replicas = metadata.getReplicas("test", DataType.cint().serialize(testKey));
+        Set<Host> replicas = metadata.getReplicas("test", TypeCodec.IntCodec.instance.serialize(testKey));
         assertThat(replicas).hasSize(1);
         Host replica = replicas.iterator().next();
 

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecAssert.java
@@ -1,0 +1,88 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.nio.ByteBuffer;
+
+import com.google.common.reflect.TypeToken;
+import org.assertj.core.api.AbstractAssert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+
+/**
+ */
+@SuppressWarnings("unused")
+public class TypeCodecAssert extends AbstractAssert<TypeCodecAssert, TypeCodec> {
+
+    protected TypeCodecAssert(TypeCodec<?> actual) {
+        super(actual, TypeCodecAssert.class);
+    }
+
+    public TypeCodecAssert accepts(Class<?> clazz) {
+        return accepts(TypeToken.of(clazz));
+    }
+
+    public TypeCodecAssert accepts(TypeToken<?> javaType) {
+        assertThat(actual.accepts(javaType)).isTrue();
+        return this;
+    }
+
+    public TypeCodecAssert doesNotAccept(TypeToken<?> javaType) {
+        assertThat(actual.accepts(javaType)).isFalse();
+        return this;
+    }
+
+    public TypeCodecAssert accepts(Object value) {
+        assertThat(actual.accepts(value)).isTrue();
+        return this;
+    }
+
+    public TypeCodecAssert doesNotAccept(Object value) {
+        assertThat(actual.accepts(value)).isFalse();
+        return this;
+    }
+
+    public TypeCodecAssert accepts(DataType cqlType) {
+        assertThat(actual.accepts(cqlType)).isTrue();
+        return this;
+    }
+
+    public TypeCodecAssert doesNotAccept(DataType cqlType) {
+        assertThat(actual.accepts(cqlType)).isFalse();
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public TypeCodecAssert canSerialize(Object value) {
+        assertThat(actual.deserialize(actual.serialize(value))).isEqualTo(value);
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public TypeCodecAssert cannotSerialize(Object value) {
+        try {
+            assertThat(actual.deserialize(actual.serialize(value)))
+                .describedAs(String.format("Codec is not supposed to serialize this value but it actually does: %s", value))
+                .isNotEqualTo(value);
+        } catch (Exception e) {
+            //ok
+        }
+        return this;
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecCollectionsIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecCollectionsIntegrationTest.java
@@ -1,0 +1,236 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static com.datastax.driver.core.CodecUtils.listOf;
+import static com.datastax.driver.core.CodecUtils.mapOf;
+import static com.datastax.driver.core.CodecUtils.setOf;
+
+public class TypeCodecCollectionsIntegrationTest {
+
+    private CCMBridge ccm;
+    private Cluster cluster;
+    private Session session;
+
+    private List<String> schema = newArrayList(
+        "CREATE KEYSPACE IF NOT EXISTS test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+        "USE test",
+        "CREATE TABLE IF NOT EXISTS \"myTable2\" ("
+            + "c_int int PRIMARY KEY, "
+            + "l_int list<int>, "
+            + "l_bigint list<bigint>, "
+            + "s_float set<float>, "
+            + "s_double set<double>, "
+            + "m_varint map<int,varint>, "
+            + "m_decimal map<int,decimal>"
+            + ")"
+    );
+
+    private final String insertQuery = "INSERT INTO \"myTable2\" (c_int, l_int, l_bigint, s_float, s_double, m_varint, m_decimal) VALUES (?, ?, ?, ?, ?, ?, ?)";
+
+    private final String selectQuery = "SELECT c_int, l_int, l_bigint, s_float, s_double, m_varint, m_decimal FROM \"myTable2\" WHERE c_int = ?";
+
+    private int n_int = 42;
+    private List<Integer> l_int = newArrayList(42, 43);
+    private List<Long> l_bigint = newArrayList(42l, 43l);
+    private Set<Float> s_float = newHashSet(42.42f, 43.43f);
+    private Set<Double> s_double = newHashSet(42.42d, 43.43d);
+    private Map<Integer, BigInteger> m_varint = ImmutableMap.of(42, new BigInteger("424242"), 43, new BigInteger("434343"));
+    private Map<Integer, BigDecimal> m_decimal = ImmutableMap.of(42, new BigDecimal("424242.42"), 43, new BigDecimal("434343.43"));
+
+    @BeforeClass(groups = "short")
+    public void setupCcm() {
+        ccm = CCMBridge.create("test", 1);
+    }
+
+    @AfterMethod(groups = "short", alwaysRun = true)
+    public void teardown() {
+        if (cluster != null)
+            cluster.close();
+    }
+
+    @AfterClass(groups = "short", alwaysRun = true)
+    public void teardownCcm() {
+        if (ccm != null)
+            ccm.remove();
+    }
+
+    @Test(groups = "short")
+    public void should_use_collection_codecs_with_simple_statements() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(new SimpleStatement(insertQuery, n_int, l_int, l_bigint, s_float, s_double, m_varint, m_decimal));
+        ResultSet rows = session.execute(new SimpleStatement(selectQuery, n_int));
+        Row row = rows.one();
+        assertRow(row);
+    }
+
+    @Test(groups = "short")
+    public void should_use_collection_codecs_with_prepared_statements_1() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(session.prepare(insertQuery).bind(n_int, l_int, l_bigint, s_float, s_double, m_varint, m_decimal));
+        PreparedStatement ps = session.prepare(selectQuery);
+        ResultSet rows = session.execute(ps.bind(n_int));
+        Row row = rows.one();
+        assertRow(row);
+    }
+
+    @Test(groups = "short")
+    public void should_use_collection_codecs_with_prepared_statements_2() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(session.prepare(insertQuery).bind()
+                .setInt(0, n_int)
+                .setList(1, l_int)
+                .setList(2, l_bigint)
+                .setSet(3, s_float)
+                .setSet(4, s_double)
+                .setMap(5, m_varint)
+                .setMap(6, m_decimal)
+        );
+        PreparedStatement ps = session.prepare(selectQuery);
+        ResultSet rows = session.execute(ps.bind()
+                .setInt(0, n_int)
+        );
+        Row row = rows.one();
+        assertRow(row);
+    }
+
+    @Test(groups = "short")
+    public void should_use_collection_codecs_with_prepared_statements_3() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(session.prepare(insertQuery).bind()
+                .setInt(0, n_int)
+                .setObject(1, l_int)
+                .setObject(2, l_bigint)
+                .setObject(3, s_float)
+                .setObject(4, s_double)
+                .setObject(5, m_varint)
+                .setObject(6, m_decimal)
+        );
+        PreparedStatement ps = session.prepare(selectQuery);
+        ResultSet rows = session.execute(ps.bind()
+                .setInt(0, n_int)
+        );
+        Row row = rows.one();
+        assertRow(row);
+    }
+
+    @Test(groups = "short")
+    public void should_use_collection_codecs_with_prepared_statements_4() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(session.prepare(insertQuery).bind()
+                .setInt(0, n_int)
+                .setObject(1, l_int, listOf(Integer.class))
+                .setObject(2, l_bigint, listOf(Long.class))
+                .setObject(3, s_float, setOf(Float.class))
+                .setObject(4, s_double, setOf(Double.class))
+                .setObject(5, m_varint, mapOf(Integer.class, BigInteger.class))
+                .setObject(6, m_decimal, mapOf(Integer.class, BigDecimal.class))
+        );
+        PreparedStatement ps = session.prepare(selectQuery);
+        ResultSet rows = session.execute(ps.bind()
+                .setInt(0, n_int)
+        );
+        Row row = rows.one();
+        assertRow(row);
+    }
+
+    private void assertRow(Row row) {
+        assertThat(row.getInt(0)).isEqualTo(n_int);
+        assertThat(row.getList(1, Integer.class)).isEqualTo(l_int);
+        assertThat(row.getList(2, Long.class)).isEqualTo(l_bigint);
+        assertThat(row.getSet(3, Float.class)).isEqualTo(s_float);
+        assertThat(row.getSet(4, Double.class)).isEqualTo(s_double);
+        assertThat(row.getMap(5, Integer.class, BigInteger.class)).isEqualTo(m_varint);
+        assertThat(row.getMap(6, Integer.class, BigDecimal.class)).isEqualTo(m_decimal);
+        // with getObject + type
+        assertThat(row.getObject(1, listOf(Integer.class))).isEqualTo(l_int);
+        assertThat(row.getObject(2, listOf(Long.class))).isEqualTo(l_bigint);
+        assertThat(row.getObject(3, setOf(Float.class))).isEqualTo(s_float);
+        assertThat(row.getObject(4, setOf(Double.class))).isEqualTo(s_double);
+        assertThat(row.getObject(5, mapOf(Integer.class, BigInteger.class))).isEqualTo(m_varint);
+        assertThat(row.getObject(6, mapOf(Integer.class, BigDecimal.class))).isEqualTo(m_decimal);
+        // with getObject
+        assertThat(row.getObject(1)).isEqualTo(l_int);
+        assertThat(row.getObject(2)).isEqualTo(l_bigint);
+        assertThat(row.getObject(3)).isEqualTo(s_float);
+        assertThat(row.getObject(4)).isEqualTo(s_double);
+        assertThat(row.getObject(5)).isEqualTo(m_varint);
+        assertThat(row.getObject(6)).isEqualTo(m_decimal);
+    }
+
+    private void createSession() {
+        cluster.init();
+        session = cluster.connect();
+        for (String statement : schema)
+            session.execute(statement);
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecEncapsulationIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecEncapsulationIntegrationTest.java
@@ -1,0 +1,325 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import com.google.common.base.Objects;
+import com.google.common.reflect.TypeParameter;
+import com.google.common.reflect.TypeToken;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.driver.core.TypeCodec.*;
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+
+public class TypeCodecEncapsulationIntegrationTest {
+
+    private CCMBridge ccm;
+    private Cluster cluster;
+    private Session session;
+
+    private List<String> schema = newArrayList(
+        "CREATE KEYSPACE IF NOT EXISTS test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+        "USE test",
+        "CREATE TABLE IF NOT EXISTS \"myTable\" ("
+            + "c_int int, "
+            + "c_bigint bigint, "
+            + "c_float float, "
+            + "c_double double, "
+            + "c_varint varint, "
+            + "c_decimal decimal, "
+            + "PRIMARY KEY (c_int, c_bigint)"
+            + ")"
+    );
+
+    private final String insertQuery = "INSERT INTO \"myTable\" (c_int, c_bigint, c_float, c_double, c_varint, c_decimal) VALUES (?, ?, ?, ?, ?, ?)";
+
+    private final String selectQuery = "SELECT c_int, c_bigint, c_float, c_double, c_varint, c_decimal FROM \"myTable\" WHERE c_int = ? and c_bigint = ?";
+
+    private int n_int = 42;
+    private long n_bigint = 4242;
+    private float n_float = 42.42f;
+    private double n_double = 4242.42d;
+    private BigInteger n_varint = new BigInteger("424242");
+    private BigDecimal n_decimal = new BigDecimal("424242.42");
+
+    @BeforeClass(groups = "short")
+    public void setupCcm() {
+        ccm = CCMBridge.create("test", 1);
+    }
+
+    @AfterMethod(groups = "short", alwaysRun = true)
+    public void teardown() {
+        if (cluster != null)
+            cluster.close();
+    }
+
+    @AfterClass(groups = "short", alwaysRun = true)
+    public void teardownCcm() {
+        if (ccm != null)
+            ccm.remove();
+    }
+
+    @Test(groups = "short")
+    public void should_use_custom_codecs_with_simple_statements() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withCodecs(
+                        new NumberBoxCodec<Integer>(IntCodec.instance),
+                        new NumberBoxCodec<Long>(BigintCodec.instance),
+                        new NumberBoxCodec<Float>(FloatCodec.instance),
+                        new NumberBoxCodec<Double>(DoubleCodec.instance),
+                        new NumberBoxCodec<BigInteger>(VarintCodec.instance),
+                        new NumberBoxCodec<BigDecimal>(DecimalCodec.instance)
+                    )
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(new SimpleStatement(insertQuery,
+            n_int,
+            new NumberBox<Long>(n_bigint),
+            new NumberBox<Float>(n_float),
+            new NumberBox<Double>(n_double),
+            new NumberBox<BigInteger>(n_varint),
+            new NumberBox<BigDecimal>(n_decimal)));
+        ResultSet rows = session.execute(new SimpleStatement(selectQuery, n_int, new NumberBox<Long>(n_bigint)));
+        Row row = rows.one();
+        assertRow(row);
+    }
+
+    @Test(groups = "short")
+    public void should_use_custom_codecs_with_prepared_statements_1() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withCodecs(
+                        new NumberBoxCodec<Integer>(IntCodec.instance),
+                        new NumberBoxCodec<Long>(BigintCodec.instance),
+                        new NumberBoxCodec<Float>(FloatCodec.instance),
+                        new NumberBoxCodec<Double>(DoubleCodec.instance),
+                        new NumberBoxCodec<BigInteger>(VarintCodec.instance),
+                        new NumberBoxCodec<BigDecimal>(DecimalCodec.instance)
+                    )
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(session.prepare(insertQuery).bind(
+            n_int,
+            new NumberBox<Long>(n_bigint),
+            new NumberBox<Float>(n_float),
+            new NumberBox<Double>(n_double),
+            new NumberBox<BigInteger>(n_varint),
+            new NumberBox<BigDecimal>(n_decimal)));
+        PreparedStatement ps = session.prepare(selectQuery);
+        ResultSet rows = session.execute(ps.bind(n_int, new NumberBox<Long>(n_bigint)));
+        Row row = rows.one();
+        assertRow(row);
+    }
+
+    @Test(groups = "short")
+    public void should_use_custom_codecs_with_prepared_statements_2() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withCodecs(
+                        new NumberBoxCodec<Integer>(IntCodec.instance),
+                        new NumberBoxCodec<Long>(BigintCodec.instance),
+                        new NumberBoxCodec<Float>(FloatCodec.instance),
+                        new NumberBoxCodec<Double>(DoubleCodec.instance),
+                        new NumberBoxCodec<BigInteger>(VarintCodec.instance),
+                        new NumberBoxCodec<BigDecimal>(DecimalCodec.instance)
+                    )
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(session.prepare(insertQuery).bind()
+                .setObject(0, new NumberBox<Integer>(n_int))
+                .setObject(1, new NumberBox<Long>(n_bigint))
+                .setObject(2, new NumberBox<Float>(n_float))
+                .setObject(3, new NumberBox<Double>(n_double))
+                .setObject(4, new NumberBox<BigInteger>(n_varint))
+                .setObject(5, new NumberBox<BigDecimal>(n_decimal))
+        );
+        PreparedStatement ps = session.prepare(selectQuery);
+        ResultSet rows = session.execute(ps.bind()
+                .setObject(0, new NumberBox<Integer>(n_int))
+                .setObject(1, new NumberBox<Long>(n_bigint))
+        );
+        Row row = rows.one();
+        assertRow(row);
+    }
+
+    @Test(groups = "short")
+    public void should_use_custom_codecs_with_prepared_statements_3() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withCodecs(
+                        new NumberBoxCodec<Integer>(IntCodec.instance),
+                        new NumberBoxCodec<Long>(BigintCodec.instance),
+                        new NumberBoxCodec<Float>(FloatCodec.instance),
+                        new NumberBoxCodec<Double>(DoubleCodec.instance),
+                        new NumberBoxCodec<BigInteger>(VarintCodec.instance),
+                        new NumberBoxCodec<BigDecimal>(DecimalCodec.instance)
+                    )
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(session.prepare(insertQuery).bind()
+                .setObject(0, new NumberBox<Integer>(n_int), new TypeToken<NumberBox<Integer>>(){})
+                .setObject(1, new NumberBox<Long>(n_bigint), new TypeToken<NumberBox<Long>>(){})
+                .setObject(2, new NumberBox<Float>(n_float), new TypeToken<NumberBox<Float>>(){})
+                .setObject(3, new NumberBox<Double>(n_double), new TypeToken<NumberBox<Double>>(){})
+                .setObject(4, new NumberBox<BigInteger>(n_varint), new TypeToken<NumberBox<BigInteger>>(){})
+                .setObject(5, new NumberBox<BigDecimal>(n_decimal), new TypeToken<NumberBox<BigDecimal>>(){})
+        );
+        PreparedStatement ps = session.prepare(selectQuery);
+        ResultSet rows = session.execute(ps.bind()
+                .setObject(0, new NumberBox<Integer>(n_int), new TypeToken<NumberBox<Integer>>(){})
+                .setObject(1, new NumberBox<Long>(n_bigint), new TypeToken<NumberBox<Long>>(){})
+        );
+        Row row = rows.one();
+        assertRow(row);
+    }
+
+    private void assertRow(Row row) {
+        // using getInt, etc: the default codecs are used
+        // and values are deserialized the traditional way
+        assertThat(row.getInt(0)).isEqualTo(n_int);
+        assertThat(row.getLong(1)).isEqualTo(n_bigint);
+        assertThat(row.getFloat(2)).isEqualTo(n_float);
+        assertThat(row.getDouble(3)).isEqualTo(n_double);
+        assertThat(row.getVarint(4)).isEqualTo(n_varint);
+        assertThat(row.getDecimal(5)).isEqualTo(n_decimal);
+        // with getObject, the first matching codec for the CQL type is used
+        // here it will be the NumberBox codecs because they were registered
+        // first
+        assertThat(row.getObject(0)).isEqualTo(new NumberBox<Integer>(n_int));
+        assertThat(row.getObject(1)).isEqualTo(new NumberBox<Long>(n_bigint));
+        assertThat(row.getObject(2)).isEqualTo(new NumberBox<Float>(n_float));
+        assertThat(row.getObject(3)).isEqualTo(new NumberBox<Double>(n_double));
+        assertThat(row.getObject(4)).isEqualTo(new NumberBox<BigInteger>(n_varint));
+        assertThat(row.getObject(5)).isEqualTo(new NumberBox<BigDecimal>(n_decimal));
+        // with getObject + type
+        // we go back to the default codecs
+        assertThat(row.getObject(0, Integer.class)).isEqualTo(n_int);
+        assertThat(row.getObject(1, Long.class)).isEqualTo(n_bigint);
+        assertThat(row.getObject(2, Float.class)).isEqualTo(n_float);
+        assertThat(row.getObject(3, Double.class)).isEqualTo(n_double);
+        assertThat(row.getObject(4, BigInteger.class)).isEqualTo(n_varint);
+        assertThat(row.getObject(5, BigDecimal.class)).isEqualTo(n_decimal);
+        // with getObject + type, but enforcing NumberBox types
+        // we get the NumberBox codecs instead
+        assertThat(row.getObject(0, new TypeToken<NumberBox<Integer>>(){})).isEqualTo(new NumberBox<Integer>(n_int));
+        assertThat(row.getObject(1, new TypeToken<NumberBox<Long>>(){})).isEqualTo(new NumberBox<Long>(n_bigint));
+        assertThat(row.getObject(2, new TypeToken<NumberBox<Float>>(){})).isEqualTo(new NumberBox<Float>(n_float));
+        assertThat(row.getObject(3, new TypeToken<NumberBox<Double>>(){})).isEqualTo(new NumberBox<Double>(n_double));
+        assertThat(row.getObject(4, new TypeToken<NumberBox<BigInteger>>(){})).isEqualTo(new NumberBox<BigInteger>(n_varint));
+        assertThat(row.getObject(5, new TypeToken<NumberBox<BigDecimal>>(){})).isEqualTo(new NumberBox<BigDecimal>(n_decimal));
+    }
+
+    private void createSession() {
+        cluster.init();
+        session = cluster.connect();
+        for (String statement : schema)
+            session.execute(statement);
+    }
+
+    private class NumberBoxCodec<T extends Number> extends TypeCodec<NumberBox<T>> {
+
+        private final TypeCodec<T> numberCodec;
+
+        protected NumberBoxCodec(TypeCodec<T> numberCodec) {
+            super(numberCodec.getCqlType(), new TypeToken<NumberBox<T>>(){}.where(new TypeParameter<T>(){}, numberCodec.getJavaType()));
+            this.numberCodec = numberCodec;
+        }
+
+        public boolean accepts(Object value) {
+            return value instanceof NumberBox && numberCodec.accepts(((NumberBox)value).getNumber());
+        }
+
+        @Override
+        public ByteBuffer serialize(NumberBox<T> value) throws InvalidTypeException {
+            return numberCodec.serialize(value.getNumber());
+        }
+
+        @Override
+        public NumberBox<T> deserialize(ByteBuffer bytes) throws InvalidTypeException {
+            return new NumberBox<T>(numberCodec.deserialize(bytes));
+        }
+
+        @Override
+        public NumberBox<T> parse(String value) throws InvalidTypeException {
+            return new NumberBox<T>(numberCodec.parse(value));
+        }
+
+        @Override
+        public String format(NumberBox<T> value) throws InvalidTypeException {
+            return numberCodec.format(value.getNumber());
+        }
+
+    }
+
+    private class NumberBox<T extends Number> {
+
+        private final T number;
+
+        private NumberBox(T number) {
+            this.number = number;
+        }
+
+        public T getNumber() {
+            return number;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            NumberBox numberBox = (NumberBox)o;
+            return Objects.equal(number, numberBox.number);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(number);
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecJsonIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecJsonIntegrationTest.java
@@ -1,0 +1,254 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+import com.datastax.driver.core.TypeCodecTest.User;
+import com.datastax.driver.core.exceptions.CodecNotFoundException;
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+
+public class TypeCodecJsonIntegrationTest {
+
+    private CCMBridge ccm;
+    private Cluster cluster;
+    private Session session;
+
+    private List<String> schema = Lists.newArrayList(
+        "CREATE KEYSPACE IF NOT EXISTS test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+        "USE test",
+        "CREATE TABLE IF NOT EXISTS \"myTable\" (c1 text, c2 text, c3 list<text>, PRIMARY KEY (c1, c2))"
+    );
+
+    private final JsonCodec<User> jsonCodec = new JsonCodec<User>(User.class);
+
+    private final User alice = new User(1, "Alice");
+    private final User bob = new User(2, "Bob");
+    private final User charlie = new User(3, "Charlie");
+
+    private final String bobJson = "{\"id\":2,\"name\":\"Bob\"}";
+    private final String charlieJson = "{\"id\":3,\"name\":\"Charlie\"}";
+    private final String aliceJson = "{\"id\":1,\"name\":\"Alice\"}";
+
+    private final ArrayList<User> bobAndCharlie = Lists.newArrayList(bob, charlie);
+
+    private final String insertQuery = "INSERT INTO \"myTable\" (c1, c2, c3) VALUES (?, ?, ?)";
+    private final String selectQuery = "SELECT c1, c2, c3 FROM \"myTable\" WHERE c1 = ? and c2 = ?";
+    private final String notAJsonString = "this text is not json";
+
+    @BeforeClass(groups = "short")
+    public void setupCcm() {
+        ccm = CCMBridge.create("test", 1);
+    }
+
+    @AfterMethod(groups = "short", alwaysRun = true)
+    public void teardown() {
+        if (cluster != null)
+            cluster.close();
+    }
+
+    @AfterClass(groups = "short", alwaysRun = true)
+    public void teardownCcm() {
+        if (ccm != null)
+            ccm.remove();
+    }
+
+    @Test(groups = "short")
+    public void should_use_globally_registered_custom_codec_with_simple_statements() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withCodec(jsonCodec, true) // global User <-> varchar codec
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(new SimpleStatement(insertQuery, notAJsonString, alice, bobAndCharlie));
+        ResultSet rows = session.execute(new SimpleStatement(selectQuery, notAJsonString, alice));
+        Row row = rows.one();
+        assertRow(row);
+    }
+
+    @Test(groups = "short")
+    public void should_use_globally_registered_custom_codec_with_prepared_statements_1() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withCodec(jsonCodec, true) // global User <-> varchar codec
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(session.prepare(insertQuery).bind(notAJsonString, alice, bobAndCharlie));
+        PreparedStatement ps = session.prepare(selectQuery);
+        // this bind() method does not convey information about the java type of alice
+        // so the registry will look for a codec accepting varchar <-> ANY
+        // and will find jsonCodec because it is the first registered
+        ResultSet rows = session.execute(ps.bind(notAJsonString, alice));
+        Row row = rows.one();
+        assertRow(row);
+    }
+
+    @Test(groups = "short")
+    public void should_use_globally_registered_custom_codec_with_prepared_statements_2() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withCodec(jsonCodec, true) // global User <-> varchar codec
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(session.prepare(insertQuery).bind()
+                .setString(0, notAJsonString)
+                .setObject(1, alice, User.class)
+                .setList(2, bobAndCharlie)
+        );
+        PreparedStatement ps = session.prepare(selectQuery);
+        ResultSet rows = session.execute(ps.bind()
+                .setString(0, notAJsonString)
+                // this setObject() method conveys information about the java type of alice
+                // so the registry will look for a codec accepting varchar <-> User
+                // and will find jsonCodec because it is the only matching one
+                .setObject(1, alice, User.class)
+        );
+        Row row = rows.one();
+        assertRow(row);
+        rows = session.execute(ps.bind()
+                .setString(0, notAJsonString)
+                // here we lost information about the java type of alice
+                // so the registry will look for a codec accepting varchar <-> ANY
+                // and will find jsonCodec because it is the only matching one
+                .setObject(1, alice)
+        );
+        row = rows.one();
+        assertRow(row);
+    }
+
+    @Test(groups = "short")
+    public void should_use_overriding_codec() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withOverridingCodec("test", "myTable", "c2", jsonCodec) // only test."myTable".c2 uses User <-> varchar codec
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        try {
+            session.execute(new SimpleStatement(insertQuery, notAJsonString, alice, bobAndCharlie));
+            fail("Cannot use overriding codecs with simple statements");
+        } catch (Exception e) {
+            //ok
+        }
+        try {
+            session.execute(session.prepare(insertQuery).bind()
+                    .setString(0, notAJsonString)
+                    .setObject(1, alice) // no Java type information so this would use VarcharCodec, but jsonCodec is overriding
+                    .setList(2, bobAndCharlie)
+            );
+            fail("Column c3 should not use overriding codec");
+        } catch (Exception e) {
+            //ok
+        }
+        session.execute(session.prepare(insertQuery).bind()
+                .setString(0, notAJsonString)
+                .setObject(1, alice) // no Java type information so this would use VarcharCodec, but jsonCodec is overriding
+                .setList(2, Lists.newArrayList(bobJson, charlieJson))
+        );
+        PreparedStatement ps = session.prepare(selectQuery);
+        ResultSet rows = session.execute(ps.bind()
+            .setString(0, notAJsonString)
+            .setObject(1, alice) // no Java type information so this would use VarcharCodec, but jsonCodec is overriding
+        );
+        Row row = rows.one();
+        // getString requires a codec accepting varchar <-> String, so VarcharCodec is used
+        assertThat(row.getString(0)).isEqualTo(notAJsonString);
+        // getObject requires a codec accepting varchar <-> ANY;
+        // the first codec that accepts that is jsonCodec, so it is used
+        assertThat(row.getObject(1)).isEqualTo(alice);
+        // getObject requires a codec accepting varchar <-> User;
+        // jsonCodec is the only codec that accepts varchar <-> User, so it is used
+        assertThat(row.getObject(1, User.class)).isEqualTo(alice);
+        // we still can get the column as a string using VarcharCodec.instance behind the scenes
+        try {
+            // will find an overriding codec jsonCodec that does not accept varchar <-> String
+            row.getString(1);
+            fail("Should not deserialize c2 as a String because of overriding codec");
+        } catch (CodecNotFoundException e) {
+            // ok
+        }
+        try {
+            // will not found codec for list<varchar> <-> List<User> because jsonCodec is not registered globally
+            assertThat(row.getList(2, User.class)).containsExactly(bob, charlie);
+            fail("Should not deserialize c3 as a List<User> because jsonCodec is not globally registered");
+        } catch (CodecNotFoundException e) {
+            // ok
+        }
+        // we still can get the column as a List<String>
+        assertThat(row.getList(2, String.class)).containsExactly(bobJson, charlieJson);
+    }
+
+    private void assertRow(Row row) {
+        // getString requires a codec accepting varchar <-> String, so VarcharCodec is used
+        assertThat(row.getString(0)).isEqualTo(notAJsonString);
+        // getObject requires a codec accepting varchar <-> ANY;
+        // the first codec that accepts that is jsonCodec, so it is used
+        assertThat(row.getObject(1)).isEqualTo(alice);
+        // getObject requires a codec accepting varchar <-> User;
+        // jsonCodec is the only codec that accepts varchar <-> User, so it is used
+        assertThat(row.getObject(1, User.class)).isEqualTo(alice);
+        // we still can get the column as a string using VarcharCodec.instance behind the scenes
+        assertThat(row.getString(1)).isEqualTo(aliceJson);
+        assertThat(row.getList(2, User.class)).containsExactly(bob, charlie);
+        // we still can get the column as a List<String>
+        assertThat(row.getList(2, String.class)).containsExactly(bobJson, charlieJson);
+        try {
+            // getObject requires a codec accepting varchar <-> ANY;
+            // the first codec that accepts that is jsonCodec, so it is used
+            // but the value is not JSON -> InvalidTypeException
+            row.getObject(0);
+            fail("This should not have worked");
+        } catch (InvalidTypeException e) {
+            // ok
+        }
+    }
+
+    private void createSession() {
+        cluster.init();
+        session = cluster.connect();
+        for (String statement : schema)
+            session.execute(statement);
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNumbersIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNumbersIntegrationTest.java
@@ -1,0 +1,296 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import com.google.common.base.Objects;
+import com.google.common.reflect.TypeParameter;
+import com.google.common.reflect.TypeToken;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.driver.core.TypeCodec.*;
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+
+public class TypeCodecNumbersIntegrationTest {
+
+    private CCMBridge ccm;
+    private Cluster cluster;
+    private Session session;
+
+    private List<String> schema = newArrayList(
+        "CREATE KEYSPACE IF NOT EXISTS test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+        "USE test",
+        "CREATE TABLE IF NOT EXISTS \"myTable\" ("
+            + "c_int int, "
+            + "c_bigint bigint, "
+            + "c_float float, "
+            + "c_double double, "
+            + "c_varint varint, "
+            + "c_decimal decimal, "
+            + "PRIMARY KEY (c_int, c_bigint)"
+            + ")"
+    );
+
+    private final String insertQuery = "INSERT INTO \"myTable\" (c_int, c_bigint, c_float, c_double, c_varint, c_decimal) VALUES (?, ?, ?, ?, ?, ?)";
+
+    private final String selectQuery = "SELECT c_int, c_bigint, c_float, c_double, c_varint, c_decimal FROM \"myTable\" WHERE c_int = ? and c_bigint = ?";
+
+    private int n_int = 42;
+    private long n_bigint = 4242;
+    private float n_float = 42.42f;
+    private double n_double = 4242.42d;
+    private BigInteger n_varint = new BigInteger("424242");
+    private BigDecimal n_decimal = new BigDecimal("424242.42");
+
+    @BeforeClass(groups = "short")
+    public void setupCcm() {
+        ccm = CCMBridge.create("test", 1);
+    }
+
+    @AfterMethod(groups = "short", alwaysRun = true)
+    public void teardown() {
+        if (cluster != null)
+            cluster.close();
+    }
+
+    @AfterClass(groups = "short", alwaysRun = true)
+    public void teardownCcm() {
+        if (ccm != null)
+            ccm.remove();
+    }
+
+    @Test(groups = "short")
+    public void should_use_defaut_codecs_with_simple_statements() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(new SimpleStatement(insertQuery, n_int, n_bigint, n_float, n_double, n_varint, n_decimal));
+        ResultSet rows = session.execute(new SimpleStatement(selectQuery, n_int, n_bigint));
+        Row row = rows.one();
+        assertRow(row);
+    }
+
+    @Test(groups = "short")
+    public void should_use_defaut_codecs_with_prepared_statements_1() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(session.prepare(insertQuery).bind(n_int, n_bigint, n_float, n_double, n_varint, n_decimal));
+        PreparedStatement ps = session.prepare(selectQuery);
+        ResultSet rows = session.execute(ps.bind(n_int, n_bigint));
+        Row row = rows.one();
+        assertRow(row);
+    }
+
+    @Test(groups = "short")
+    public void should_use_default_codecs_with_prepared_statements_2() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(session.prepare(insertQuery).bind()
+                .setInt(0, n_int)
+                .setLong(1, n_bigint)
+                .setFloat(2, n_float)
+                .setDouble(3, n_double)
+                .setVarint(4, n_varint)
+                .setDecimal(5, n_decimal)
+        );
+        PreparedStatement ps = session.prepare(selectQuery);
+        ResultSet rows = session.execute(ps.bind()
+                .setInt(0, n_int)
+                .setLong(1, n_bigint)
+        );
+        Row row = rows.one();
+        assertRow(row);
+    }
+
+    @Test(groups = "short")
+    public void should_use_default_codecs_with_prepared_statements_3() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(session.prepare(insertQuery).bind()
+                .setObject(0, n_int)
+                .setObject(1, n_bigint)
+                .setObject(2, n_float)
+                .setObject(3, n_double)
+                .setObject(4, n_varint)
+                .setObject(5, n_decimal)
+        );
+        PreparedStatement ps = session.prepare(selectQuery);
+        ResultSet rows = session.execute(ps.bind()
+                .setInt(0, n_int)
+                .setLong(1, n_bigint)
+        );
+        Row row = rows.one();
+        assertRow(row);
+    }
+
+    @Test(groups = "short")
+    public void should_use_default_codecs_with_prepared_statements_4() {
+        cluster = Cluster.builder()
+            .addContactPoints(CCMBridge.ipOfNode(1))
+            .withCodecRegistry(
+                CodecRegistry.builder()
+                    .withDefaultCodecs()
+                    .build()
+            )
+            .build();
+        createSession();
+        session.execute(session.prepare(insertQuery).bind()
+                .setObject(0, n_int, Integer.class)
+                .setObject(1, n_bigint, Long.class)
+                .setObject(2, n_float, Float.class)
+                .setObject(3, n_double, Double.class)
+                .setObject(4, n_varint, BigInteger.class)
+                .setObject(5, n_decimal, BigDecimal.class)
+        );
+        PreparedStatement ps = session.prepare(selectQuery);
+        ResultSet rows = session.execute(ps.bind()
+                .setInt(0, n_int)
+                .setLong(1, n_bigint)
+        );
+        Row row = rows.one();
+        assertRow(row);
+    }
+
+    private void assertRow(Row row) {
+        assertThat(row.getInt(0)).isEqualTo(n_int);
+        assertThat(row.getLong(1)).isEqualTo(n_bigint);
+        assertThat(row.getFloat(2)).isEqualTo(n_float);
+        assertThat(row.getDouble(3)).isEqualTo(n_double);
+        assertThat(row.getVarint(4)).isEqualTo(n_varint);
+        assertThat(row.getDecimal(5)).isEqualTo(n_decimal);
+        // with getObject
+        assertThat(row.getObject(0)).isEqualTo(n_int);
+        assertThat(row.getObject(1)).isEqualTo(n_bigint);
+        assertThat(row.getObject(2)).isEqualTo(n_float);
+        assertThat(row.getObject(3)).isEqualTo(n_double);
+        assertThat(row.getObject(4)).isEqualTo(n_varint);
+        assertThat(row.getObject(5)).isEqualTo(n_decimal);
+        // with getObject + type
+        assertThat(row.getObject(0, Integer.class)).isEqualTo(n_int);
+        assertThat(row.getObject(1, Long.class)).isEqualTo(n_bigint);
+        assertThat(row.getObject(2, Float.class)).isEqualTo(n_float);
+        assertThat(row.getObject(3, Double.class)).isEqualTo(n_double);
+        assertThat(row.getObject(4, BigInteger.class)).isEqualTo(n_varint);
+        assertThat(row.getObject(5, BigDecimal.class)).isEqualTo(n_decimal);
+    }
+
+    private void createSession() {
+        cluster.init();
+        session = cluster.connect();
+        for (String statement : schema)
+            session.execute(statement);
+    }
+
+    private class NumberBoxCodec<T extends Number> extends TypeCodec<NumberBox<T>> {
+
+        private final TypeCodec<T> numberCodec;
+
+        protected NumberBoxCodec(TypeCodec<T> numberCodec) {
+            super(numberCodec.getCqlType(), new TypeToken<NumberBox<T>>(){}.where(new TypeParameter<T>(){}, numberCodec.getJavaType()));
+            this.numberCodec = numberCodec;
+        }
+
+        public boolean accepts(Object value) {
+            return value instanceof NumberBox && numberCodec.accepts(((NumberBox)value).getNumber());
+        }
+
+        @Override
+        public ByteBuffer serialize(NumberBox<T> value) throws InvalidTypeException {
+            return numberCodec.serialize(value.getNumber());
+        }
+
+        @Override
+        public NumberBox<T> deserialize(ByteBuffer bytes) throws InvalidTypeException {
+            return new NumberBox<T>(numberCodec.deserialize(bytes));
+        }
+
+        @Override
+        public NumberBox<T> parse(String value) throws InvalidTypeException {
+            return new NumberBox<T>(numberCodec.parse(value));
+        }
+
+        @Override
+        public String format(NumberBox<T> value) throws InvalidTypeException {
+            return numberCodec.format(value.getNumber());
+        }
+
+    }
+
+    private class NumberBox<T extends Number> {
+
+        private final T number;
+
+        private NumberBox(T number) {
+            this.number = number;
+        }
+
+        public T getNumber() {
+            return number;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            NumberBox numberBox = (NumberBox)o;
+            return Objects.equal(number, numberBox.number);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(number);
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
@@ -15,58 +15,208 @@
  */
 package com.datastax.driver.core;
 
-import java.util.Collections;
-import java.util.List;
+import java.nio.ByteBuffer;
+import java.util.*;
 
-import org.testng.collections.Lists;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.Objects;
 import com.google.common.base.Strings;
-import org.testng.Assert;
+import com.google.common.collect.Lists;
 import org.testng.annotations.Test;
 
-import static com.datastax.driver.core.DataType.text;
+import static com.datastax.driver.core.Assertions.assertThat;
+import static com.datastax.driver.core.CodecUtils.listOf;
+import static com.datastax.driver.core.DataType.*;
 
 public class TypeCodecTest {
 
     public static final DataType CUSTOM_FOO = DataType.custom("com.example.FooBar");
 
+    public static final TypeCodec.CustomCodec CUSTOM_FOO_CODEC = new TypeCodec.CustomCodec(CUSTOM_FOO);
+
+    private CodecRegistry codecRegistry = CodecRegistry.builder()
+        .withDefaultCodecs()
+        .withCodec(CUSTOM_FOO_CODEC, true).build();
+
     @Test(groups = "unit")
     public void testCustomList() throws Exception {
-        TypeCodec<?> listType = TypeCodec.listOf(CUSTOM_FOO);
-        Assert.assertNotNull(listType);
+        DataType cqlType = list(CUSTOM_FOO);
+        TypeCodec<List<?>> codec = codecRegistry.codecFor(cqlType);
+        assertThat(codec).isNotNull().accepts(cqlType);
     }
 
     @Test(groups = "unit")
     public void testCustomSet() throws Exception {
-        TypeCodec<?> setType = TypeCodec.setOf(CUSTOM_FOO);
-        Assert.assertNotNull(setType);
+        DataType cqlType = set(CUSTOM_FOO);
+        TypeCodec<Set<?>> codec = codecRegistry.codecFor(cqlType);
+        assertThat(codec).isNotNull().accepts(cqlType);
     }
 
     @Test(groups = "unit")
     public void testCustomKeyMap() throws Exception {
-        TypeCodec mapType = TypeCodec.mapOf(CUSTOM_FOO, text());
-        Assert.assertNotNull(mapType);
+        DataType cqlType = map(CUSTOM_FOO, text());
+        TypeCodec<Map<?, ?>> codec = codecRegistry.codecFor(cqlType);
+        assertThat(codec).isNotNull().accepts(cqlType);
     }
 
     @Test(groups = "unit")
     public void testCustomValueMap() throws Exception {
-        TypeCodec mapType = TypeCodec.mapOf(text(), CUSTOM_FOO);
-        Assert.assertNotNull(mapType);
+        DataType cqlType = map(text(), CUSTOM_FOO);
+        TypeCodec<Map<?, ?>> codec = codecRegistry.codecFor(cqlType);
+        assertThat(codec).isNotNull().accepts(cqlType);
     }
 
     @Test(groups = "unit", expectedExceptions = { IllegalArgumentException.class })
     public void collectionTooLargeTest() throws Exception {
-        TypeCodec<List<Integer>> listType = TypeCodec.listOf(DataType.cint());
+        DataType cqlType = DataType.list(DataType.cint());
         List<Integer> list = Collections.nCopies(65536, 1);
-
-        listType.serialize(list);
+        TypeCodec<List<?>> codec = codecRegistry.codecFor(cqlType);
+        codec.serialize(list);
     }
 
     @Test(groups = "unit", expectedExceptions = { IllegalArgumentException.class })
     public void collectionElementTooLargeTest() throws Exception {
-        TypeCodec<List<String>> listType = TypeCodec.listOf(DataType.text());
+        DataType cqlType = DataType.list(DataType.text());
         List<String> list = Lists.newArrayList(Strings.repeat("a", 65536));
+        TypeCodec<List<?>> codec = codecRegistry.codecFor(cqlType);
+        codec.serialize(list);
+    }
 
-        listType.serialize(list);
+    @Test(groups = "unit")
+    public void test_cql_text_to_json() {
+        JsonCodec<User> codec = new JsonCodec<User>(User.class);
+        String json = "{\"id\":1,\"name\":\"John Doe\"}";
+        User user = new User(1, "John Doe");
+        assertThat(codec.format(user)).isEqualTo(json);
+        assertThat(codec.parse(json)).isEqualToComparingFieldByField(user);
+        assertThat(codec).canSerialize(user);
+    }
+
+    @Test(groups = "unit")
+    public void test_cql_list_varchar_to_list_list_integer() {
+        ListVarcharToListListInteger codec = new ListVarcharToListListInteger();
+        List<List<Integer>> list = new ArrayList<List<Integer>>();
+        list.add(Lists.newArrayList(1, 2, 3));
+        list.add(Lists.newArrayList(4, 5, 6));
+        assertThat(codec).canSerialize(list);
+    }
+
+    @Test(groups = "unit")
+    public void test_ascii_vs_utf8() {
+        TypeCodec.AsciiCodec asciiCodec = TypeCodec.AsciiCodec.instance;
+        TypeCodec.VarcharCodec utf8Codec = TypeCodec.VarcharCodec.instance;
+        String ascii = "The quick brown fox jumps over the lazy dog!";
+        String utf8 = "Dès Noël, où un zéphyr haï me vêt de glaçons würmiens, je dîne d’exquis rôtis de bœuf au kir à l’aÿ d’âge mûr & cætera!";
+        assertThat(asciiCodec)
+            .accepts(String.class)
+            .accepts(ascii())
+            .doesNotAccept(varchar())
+            .doesNotAccept(text())
+            .accepts(ascii)
+            .doesNotAccept(utf8)
+            .canSerialize(ascii)
+            .cannotSerialize(utf8);
+        assertThat(utf8Codec)
+            .accepts(String.class)
+            .doesNotAccept(ascii())
+            .accepts(varchar())
+            .accepts(text())
+            .accepts(ascii)
+            .accepts(utf8)
+            .canSerialize(ascii)
+            .canSerialize(utf8);
+    }
+
+    private class ListVarcharToListListInteger extends TypeCodec<List<List<Integer>>> {
+
+        private final ListCodec<String> codec = new ListCodec<String>(VarcharCodec.instance);
+
+        protected ListVarcharToListListInteger() {
+            super(list(varchar()), listOf(listOf(Integer.class)));
+        }
+
+        @Override
+        public ByteBuffer serialize(List<List<Integer>> value) {
+            return codec.serialize(Lists.transform(value, new Function<List<Integer>, String>() {
+                @Override
+                public String apply(List<Integer> input) {
+                    return Joiner.on(",").join(input);
+                }
+            }));
+        }
+
+        @Override
+        public List<List<Integer>> deserialize(ByteBuffer bytes) {
+            return Lists.transform(codec.deserialize(bytes), new Function<String, List<Integer>>() {
+                @Override
+                public List<Integer> apply(String input) {
+                    return Lists.transform(Arrays.asList(input.split(",")), new Function<String, Integer>() {
+                        @Override
+                        public Integer apply(String input) {
+                            return Integer.parseInt(input);
+                        }
+                    });
+                }
+            });
+        }
+
+        @Override
+        public List<List<Integer>> parse(String value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String format(List<List<Integer>> value) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class User {
+
+        private int id;
+
+        private String name;
+
+        @JsonCreator
+        public User(@JsonProperty("id") int id, @JsonProperty("name") String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            User user = (User)o;
+            return com.google.common.base.Objects.equal(id, user.id) &&
+                Objects.equal(name, user.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(id, name);
+        }
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderCodecTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderCodecTest.java
@@ -21,21 +21,27 @@ import java.net.InetAddress;
 import java.util.*;
 
 import org.testng.annotations.Test;
-import static org.testng.Assert.*;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.exceptions.CodecNotFoundException;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 
-public class QueryBuilderTest {
+public class QueryBuilderCodecTest {
+
+    private CodecRegistry registry = CodecRegistry.builder().withCodecs().build();
 
     @Test(groups = "unit")
     public void selectTest() throws Exception {
 
         String query;
-        Statement select;
+        BuiltStatement select;
 
         query = "SELECT * FROM foo WHERE k=4 AND c>'a' AND c<='z';";
         select = select().all().from("foo").where(eq("k", 4)).and(gt("c", "a")).and(lte("c", "z"));

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
@@ -40,7 +40,7 @@ public class QueryBuilderExecutionTest extends CCMBridge.PerClassSingleNodeClust
     @Test(groups = "short")
     public void executeTest() throws Exception {
 
-        session.execute(insertInto(TABLE1).value("k", "k1").value("t", "This is a test").value("i", 3).value("f", 0.42));
+        session.execute(insertInto(TABLE1).value("k", "k1").value("t", "This is a test").value("i", 3).value("f", 0.42f));
         session.execute(update(TABLE1).with(set("t", "Another test")).where(eq("k", "k2")));
 
         List<Row> rows = session.execute(select().from(TABLE1).where(in("k", "k1", "k2"))).all();

--- a/driver-core/src/test/java/com/datastax/driver/core/utils/UUIDsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/utils/UUIDsTest.java
@@ -23,10 +23,11 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentSkipListSet;
 
 import org.testng.annotations.Test;
+
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.TypeCodec;
 
 public class UUIDsTest {
 
@@ -111,9 +112,10 @@ public class UUIDsTest {
     }
 
     private static void assertWithin(UUID uuid, UUID lowerBound, UUID upperBound) {
-        ByteBuffer uuidBytes = DataType.uuid().serialize(uuid);
-        ByteBuffer lb = DataType.uuid().serialize(lowerBound);
-        ByteBuffer ub = DataType.uuid().serialize(upperBound);
+        TypeCodec.UUIDCodec codec = TypeCodec.UUIDCodec.instance;
+        ByteBuffer uuidBytes = codec.serialize(uuid);
+        ByteBuffer lb = codec.serialize(lowerBound);
+        ByteBuffer ub = codec.serialize(upperBound);
         assertTrue(compareTimestampBytes(lb, uuidBytes) <= 0);
         assertTrue(compareTimestampBytes(ub, uuidBytes) >= 0);
     }

--- a/driver-examples/osgi/src/main/java/com/datastax/driver/osgi/impl/MailboxImpl.java
+++ b/driver-examples/osgi/src/main/java/com/datastax/driver/osgi/impl/MailboxImpl.java
@@ -91,7 +91,7 @@ public class MailboxImpl implements MailboxService {
 
     @Override public Collection<MailboxMessage> getMessages(String recipient) throws MailboxException {
         try {
-            BoundStatement statement = new BoundStatement(retrieveStatement);
+            BoundStatement statement = new BoundStatement(retrieveStatement, session.getCluster());
             statement.setString(0, recipient);
             ResultSet result = session.execute(statement);
 
@@ -113,7 +113,7 @@ public class MailboxImpl implements MailboxService {
         try {
             UUID time = UUIDs.startOf(message.getDate().getTime());
 
-            BoundStatement statement = new BoundStatement(insertStatement);
+            BoundStatement statement = new BoundStatement(insertStatement, session.getCluster());
             statement.setString(0, message.getRecipient());
             statement.setUUID(1, time);
             statement.setString(2, message.getSender());
@@ -128,7 +128,7 @@ public class MailboxImpl implements MailboxService {
 
     @Override public void clearMailbox(String recipient) throws MailboxException {
         try {
-            BoundStatement statement = new BoundStatement(deleteStatement);
+            BoundStatement statement = new BoundStatement(deleteStatement, session.getCluster());
             statement.setString(0, recipient);
             session.execute(statement);
         } catch(Exception e) {

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,12 @@
     <!--
       We use an old version of Guava to be compatible with Spark 1.1.
       Check with the spark-cassandra-connector team before upgrading this.
+      Warning: since JAVA-721, Guava version MUST be >= 16.0.1
+      https://code.google.com/p/guava-libraries/issues/detail?id=1635
+      https://code.google.com/p/guava-libraries/issues/detail?id=1637
+      https://bugs.openjdk.java.net/browse/JDK-8031984
     -->
-    <guava.version>14.0.1</guava.version>
+    <guava.version>16.0.1</guava.version>
     <netty.version>4.0.27.Final</netty.version>
     <metrics.version>3.0.2</metrics.version>
     <snappy.version>1.0.5</snappy.version>


### PR DESCRIPTION
Use cases are:
- global (per cluster): use a CodecRegistry class to retrieve codecs, configurable on a per-cluster basis (e.g. to deserialize CQL timestamps as Joda or Java 8 classes)
- particular (per table/column): override the global codec on a per table/column basis (e.g. to deserialize a text CQL type as a JSON object)

The 2nd use case will only be possible for `GettableData` instances (`BoundStatement`s and `Row`s basically). It will not be available for `SimpleStatement`s nor `BuiltStatement`s (because these do not have any information about types). In other words, customizing serialization on a per-column basis will only be feasible when using prepared statements.

Summary of changes:

Maven
- Guava HAS to be 16.0.1 or higher, see [this](https://code.google.com/p/guava-libraries/issues/detail?id=1635) for details.

TypeCodec
- Now public API, most static methods moved to `CodecRegistry`;
- Now a codec can only handle one Java type and one CQL type, so some existing codecs have been refactored;
- New inspection methods to verify if a codec can handle specific types (`accepts(X)`).

DataType
- No more references to `TypeCodec`, the logic is transferred to `CodecRegistry` (because it's now dynamic);
- Most static methods that serialize and deserialize have been removed;
- The `javaClass` attribute has been removed;

CodecRegistry
- New class that contains all the known codecs;
- Has a builder;
- Has a cache for Java/CQL types to codecs;
- Can be associated with a Cluster: `builder.withCodecRegistry()`;
- Can be retrieved in a Cluster: `cluster.getConfiguration().getCodecRegistry()`;
- The default registry is `CodecRegistry.DEFAULT_INSTANCE`;
- Throws `CodecNotFoundException`.

Serializing values
- `SimpleStatement` and `BuiltStatement` versions of `getValues()`: now use a unified `convert()` method in `CodecUtils`;
- `BoundStatement.bind()`: guesses the best codec;
- `BoundStatement` methods `setBool()`, `setInt()` etc: retrieve the exact codec as implied by the method contract (i.e. `setBool()` will look for a codec that handles `Boolean <-> cbool` exclusively). _These methods can only be used if appropriate codecs are available (e.g. the default ones)_.
- Alternatively, `BoundStatement` has new `setObject(Object, X)` methods that accept a Java type as a second parameter.

Deserializing values
- New methods `getObjec(int, X)` and `getObject(String, X)` in `GettableData`: retrieve and object using the provided java type; the appropriate codec is looked up in the cluster's `CodecRegistry`;
- Methods `getBool()`, `getInt()`, etc. in `AbstractGettableData`: deserialize with exact codec as implied by the method contract. _These methods can only be used if appropriate codecs are available (e.g. the default ones), otherwise they would throw `ClassCastException`s_.
- All methods in GettableData instances will try to find an overriding codec for a particular table/column

Tests
- See `TypeCodecXXXTest` and `CodecRegistryTest` for examples of JSON serialization and fancy codecs

TODO
- Routing Keys: check if they can work with custom codecs
- Tokens: check if they can work with custom codecs
