### PR TITLE
JAVA-806: Session leak using connect() with wrong keyspace name

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -280,14 +280,16 @@ public class Cluster implements Closeable {
         long timeout = getConfiguration().getSocketOptions().getConnectTimeoutMillis();
         Session session = connect();
         try {
-            ResultSetFuture future = session.executeAsync("USE " + keyspace);
-            // Note: using the connection timeout isn't perfectly correct, we should probably change that someday
-            Uninterruptibles.getUninterruptibly(future, timeout, TimeUnit.MILLISECONDS);
-            return session;
-        } catch (TimeoutException e) {
-            throw new DriverInternalError(String.format("No responses after %d milliseconds while setting current keyspace. This should not happen, unless you have setup a very low connection timeout.", timeout));
-        } catch (ExecutionException e) {
-            throw DefaultResultSetFuture.extractCauseFromExecutionException(e);
+            try {
+                ResultSetFuture future = session.executeAsync("USE " + keyspace);
+                // Note: using the connection timeout isn't perfectly correct, we should probably change that someday
+                Uninterruptibles.getUninterruptibly(future, timeout, TimeUnit.MILLISECONDS);
+                return session;
+            } catch (TimeoutException e) {
+                throw new DriverInternalError(String.format("No responses after %d milliseconds while setting current keyspace. This should not happen, unless you have setup a very low connection timeout.", timeout));
+            } catch (ExecutionException e) {
+                throw DefaultResultSetFuture.extractCauseFromExecutionException(e);
+            }
         } catch (RuntimeException e) {
             session.close();
             throw e;

--- a/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
@@ -25,72 +25,76 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.testng.Assert.assertEquals;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+import com.google.common.collect.Lists;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.fail;
+
+import com.datastax.driver.core.exceptions.InvalidQueryException;
+import com.datastax.driver.core.utils.SocketChannelMonitor;
+
+import static com.datastax.driver.core.Assertions.assertThat;
 
 
 public class SessionLeakTest {
 
+    Cluster cluster;
+    List<InetSocketAddress> nodes = Lists.newArrayList(
+            new InetSocketAddress(CCMBridge.IP_PREFIX + '1', 9042),
+            new InetSocketAddress(CCMBridge.IP_PREFIX + '2', 9042));
+    SocketChannelMonitor channelMonitor;
 
     @Test(groups = "short")
     public void connectionLeakTest() throws Exception {
         // Checking for JAVA-342
         CCMBridge ccmBridge;
         ccmBridge = CCMBridge.create("test", 1);
-        Cluster cluster = null;
-        SocketChannelMonitor channelMonitor = new SocketChannelMonitor();
+        channelMonitor = new SocketChannelMonitor();
         channelMonitor.reportAtFixedInterval(1, TimeUnit.SECONDS);
-
-        List<InetSocketAddress> nodes = Lists.newArrayList(
-                new InetSocketAddress(CCMBridge.IP_PREFIX + '1', 9042),
-                new InetSocketAddress(CCMBridge.IP_PREFIX + '2', 9042));
         try {
-            // create a new cluster object and ensure 0 sessions and connections
             cluster = Cluster.builder()
                     .addContactPointsWithPorts(Collections.singletonList(
                             new InetSocketAddress(CCMBridge.IP_PREFIX + '1', 9042)))
                     .withNettyOptions(channelMonitor.nettyOptions()).build();
+
             cluster.init();
 
-            int corePoolSize = cluster.getConfiguration()
-                    .getPoolingOptions()
-                    .getCoreConnectionsPerHost(HostDistance.LOCAL);
-
-            assertEquals(cluster.manager.sessions.size(), 0);
+            assertThat(cluster.manager.sessions.size()).isEqualTo(0);
             // Should be 1 control connection after initialization.
-            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
-            assertEquals(channelMonitor.openChannels(nodes).size(), 1);
+            assertOpenConnections(1);
 
             // ensure sessions.size() returns with 1 control connection + core pool size.
+            int corePoolSize = TestUtils.numberOfLocalCoreConnections(cluster);
             Session session = cluster.connect();
-            assertEquals(cluster.manager.sessions.size(), 1);
-            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1 + corePoolSize);
-            assertEquals(channelMonitor.openChannels(nodes).size(), 1 + corePoolSize);
+
+            assertThat(cluster.manager.sessions.size()).isEqualTo(1);
+            assertOpenConnections(1 + corePoolSize);
 
             // ensure sessions.size() returns to 0 with only 1 active connection (the control connection)
             session.close();
-            assertEquals(cluster.manager.sessions.size(), 0);
-            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
-            assertEquals(channelMonitor.openChannels(nodes).size(), 1);
+            assertThat(cluster.manager.sessions.size()).isEqualTo(0);
+            assertOpenConnections(1);
 
             // ensure bootstrapping a node does not create additional connections
             ccmBridge.bootstrapNode(2);
-            assertEquals(cluster.manager.sessions.size(), 0);
-            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
-            assertEquals(channelMonitor.openChannels(nodes).size(), 1);
+            assertThat(cluster).host(2).comesUpWithin(2, MINUTES);
+
+            assertThat(cluster.manager.sessions.size()).isEqualTo(0);
+            assertOpenConnections(1);
 
             // ensure a new session gets registered and core connections are established
             // there should be corePoolSize more connections to accommodate for the new host.
             Session thisSession = cluster.connect();
-            assertEquals(cluster.manager.sessions.size(), 1);
-
-            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1 + (corePoolSize * 2));
-            assertEquals(channelMonitor.openChannels(nodes).size(), 1 + (corePoolSize * 2));
+            assertThat(cluster.manager.sessions.size()).isEqualTo(1);
+            assertOpenConnections(1 + (corePoolSize * 2));
 
             // ensure bootstrapping a node does not create additional connections that won't get cleaned up
             thisSession.close();
 
-            assertEquals(cluster.manager.sessions.size(), 0);
-            assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
-            assertEquals(channelMonitor.openChannels(nodes).size(), 1);
+            assertThat(cluster.manager.sessions.size()).isEqualTo(0);
+            assertOpenConnections(1);
         } finally {
             if(cluster != null){
                 cluster.close();
@@ -101,7 +105,58 @@ public class SessionLeakTest {
             // Ensure no channels remain open.
             channelMonitor.stop();
             channelMonitor.report();
-            assertEquals(channelMonitor.openChannels(nodes).size(), 0);
+            assertThat(channelMonitor.openChannels(nodes).size()).isEqualTo(0);
         }
+    }
+
+    @Test(groups = "short")
+    public void should_not_leak_session_when_wrong_keyspace() throws Exception {
+        // Checking for JAVA-806
+        CCMBridge ccmBridge;
+        ccmBridge = CCMBridge.create("test", 1);
+        channelMonitor = new SocketChannelMonitor();
+        channelMonitor.reportAtFixedInterval(1, TimeUnit.SECONDS);
+        try {
+            cluster = Cluster.builder()
+                .addContactPointsWithPorts(Collections.singletonList(
+                    new InetSocketAddress(CCMBridge.IP_PREFIX + '1', 9042)))
+                .withNettyOptions(channelMonitor.nettyOptions()).build();
+
+            cluster.init();
+
+            assertThat(cluster.manager.sessions.size()).isEqualTo(0);
+            // Should be 1 control connection after initialization.
+            assertOpenConnections(1);
+
+            // ensure sessions.size() returns with 1 control connection + core pool size.
+            int corePoolSize = TestUtils.numberOfLocalCoreConnections(cluster);
+            cluster.connect("wrong_keyspace");
+
+            fail("Should not have connected to a wrong keyspace");
+
+        } catch(InvalidQueryException e) {
+
+            // ok
+
+        } finally {
+
+            assertThat(cluster.manager.sessions.size()).isEqualTo(0);
+
+            if(cluster != null){
+                cluster.close();
+            }
+            if (ccmBridge != null) {
+                ccmBridge.remove();
+            }
+            // Ensure no channels remain open.
+            channelMonitor.stop();
+            channelMonitor.report();
+            assertThat(channelMonitor.openChannels(nodes).size()).isEqualTo(0);
+        }
+    }
+
+    private void assertOpenConnections(int expected) {
+        assertThat((cluster.getMetrics().getOpenConnections().getValue())).isEqualTo(expected);
+        assertThat(channelMonitor.openChannels(nodes).size()).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
This is a pull request against 2.0 that reuses the commit by @fbaro + additional unit test.
