### PR TITLE
JAVA-736 Forbid bind marker in QueryBuilder remove/discard.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
@@ -594,7 +594,7 @@ public final class QueryBuilder {
      *
      * @param name the column name (must be of type list).
      * @param value the value to prepend. Using a BindMarker here is not supported.
-     *              To use a BindMarker use {@code QueryBuilder#addAll} with a
+     *              To use a BindMarker use {@code QueryBuilder#prependAll} with a
      *              singleton list.
      * @return the correspond assignment (to use in an update query)
      */
@@ -602,7 +602,7 @@ public final class QueryBuilder {
         if (value instanceof BindMarker) {
             throw new InvalidQueryException("binding a value in prepend() is not supported, use prependAll() and bind a singleton list");
         }
-        return new Assignment.ListPrependAssignment(name, Collections.singletonList(value));
+        return prependAll(name, Collections.singletonList(value));
     }
 
     /**
@@ -638,7 +638,7 @@ public final class QueryBuilder {
      *
      * @param name the column name (must be of type list).
      * @param value the value to append. Using a BindMarker here is not supported.
-     *              To use a BindMarker use {@code QueryBuilder#addAll} with a
+     *              To use a BindMarker use {@code QueryBuilder#appendAll} with a
      *              singleton list.
      * @return the correspond assignment (to use in an update query)
      */
@@ -646,7 +646,7 @@ public final class QueryBuilder {
         if (value instanceof BindMarker) {
             throw new InvalidQueryException("Binding a value in append() is not supported, use appendAll() and bind a singleton list");
         }
-        return new Assignment.CollectionAssignment(name, Collections.singletonList(value), true, false);
+        return appendAll(name, Collections.singletonList(value));
     }
 
     /**
@@ -681,12 +681,15 @@ public final class QueryBuilder {
      * This will generate: {@code name = name - [value]}.
      *
      * @param name the column name (must be of type list).
-     * @param value the value to discard
+     * @param value the value to discard.  Using a BindMarker here is not supported.
+     *              To use a BindMarker use {@code QueryBuilder#discardAll} with a singleton list.
      * @return the correspond assignment (to use in an update query)
      */
     public static Assignment discard(String name, Object value) {
-        Object v = value instanceof BindMarker ? value : Collections.singletonList(value);
-        return new Assignment.CollectionAssignment(name, v, false);
+        if (value instanceof BindMarker) {
+            throw new InvalidQueryException("Binding a value in discard() is not supported, use discardAll() and bind a singleton list");
+        }
+        return discardAll(name, Collections.singletonList(value));
     }
 
     /**
@@ -737,14 +740,14 @@ public final class QueryBuilder {
      * @param name the column name (must be of type set).
      * @param value the value to add. Using a BindMarker here is not supported.
      *              To use a BindMarker use {@code QueryBuilder#addAll} with a
-     *              singleton list.
+     *              singleton set.
      * @return the correspond assignment (to use in an update query)
      */
     public static Assignment add(String name, Object value) {
         if (value instanceof BindMarker){
             throw new InvalidQueryException("Binding a value in add() is not supported, use addAll() and bind a singleton list");
         }
-        return new Assignment.CollectionAssignment(name, Collections.singleton(value), true);
+        return addAll(name, Collections.singleton(value));
     }
 
     /**
@@ -779,12 +782,15 @@ public final class QueryBuilder {
      * This will generate: {@code name = name - {value}}.
      *
      * @param name the column name (must be of type set).
-     * @param value the value to remove
+     * @param value the value to remove. Using a BindMarker here is not supported.
+     *              To use a BindMarker use {@code QueryBuilder#removeAll} with a singleton set.
      * @return the correspond assignment (to use in an update query)
      */
     public static Assignment remove(String name, Object value) {
-        Object v = value instanceof BindMarker ? value : Collections.singleton(value);
-        return new Assignment.CollectionAssignment(name, v, false);
+        if (value instanceof BindMarker) {
+            throw new InvalidQueryException("Binding a value in remove() is not supported, use removeAll() and bind a singleton set");
+        }
+        return removeAll(name, Collections.singleton(value));
     }
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -803,25 +803,30 @@ public class QueryBuilderTest {
         assertThat(statement.toString()).isEqualTo(query);
     }
 
-    @Test(groups = "unit")
-    public void should_not_allow_bind_marker_as_added_collection_item() {
-        try {
-            // This generates the query "UPDATE foo SET s = s + {?} WHERE k = 1", which is invalid in Cassandra
-            // (individual values in collections can't be bound)
-            update("foo").with(add("s", bindMarker())).where(eq("k", 1));
-            fail("Expected an exception");
-        } catch (InvalidQueryException e) { /*expected*/ }
+    @Test(groups = "unit", expectedExceptions = InvalidQueryException.class)
+    public void should_not_allow_bind_marker_for_add() {
+        // This generates the query "UPDATE foo SET s = s + {?} WHERE k = 1", which is invalid in Cassandra
+        update("foo").with(add("s", bindMarker())).where(eq("k", 1));
+    }
 
-        // Same for list append/prepend
-        try {
-            update("foo").with(prepend("l", bindMarker())).where(eq("k", 1));
-            fail("Expected an exception");
-        } catch (InvalidQueryException e) { /*expected*/ }
-        try {
-            update("foo").with(append("l", bindMarker())).where(eq("k", 1));
-            fail("Expected an exception");
-        } catch (InvalidQueryException e) { /*expected*/ }
+    @Test(groups = "unit", expectedExceptions = InvalidQueryException.class)
+    public void should_now_allow_bind_marker_for_prepend() {
+        update("foo").with(prepend("l", bindMarker())).where(eq("k", 1));
+    }
 
+    @Test(groups = "unit", expectedExceptions = InvalidQueryException.class)
+    public void should_not_allow_bind_marker_for_append() {
+        update("foo").with(append("l", bindMarker())).where(eq("k", 1));
+    }
+
+    @Test(groups = "unit", expectedExceptions = InvalidQueryException.class)
+    public void should_not_allow_bind_marker_for_remove() {
+        update("foo").with(remove("s", bindMarker())).where(eq("k", 1));
+    }
+
+    @Test(groups = "unit", expectedExceptions = InvalidQueryException.class)
+    public void should_not_allow_bind_marker_for_discard() {
+        update("foo").with(discard("l", bindMarker())).where(eq("k", 1));
     }
 
     @Test(groups = "unit")


### PR DESCRIPTION
This is an update for #364 to apply the same restriction on QueryBuilder.remove and discard.  There are also some slight javadoc updates and some small changes to call the *all methods with a singleton collection instead of calling the same method that the *all methods do for simplification (though this isn't necessary).
