### PR TITLE
Propogate tracing flag across all subsequent requests

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,7 @@
 
 ### 2.0.11 (in progress)
 
+- [bug] Propogate tracing for retry requests (JAVA-815)
 - [bug] Fix SpeculativeExecutionPolicy.init() and close() are never called (JAVA-796)
 - [improvement] Suppress unnecessary warning at shutdown (JAVA-710)
 - [improvement] Allow DNS name with multiple A-records as contact point (#340)

--- a/driver-core/src/main/java/com/datastax/driver/core/Message.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Message.java
@@ -96,6 +96,11 @@ abstract class Message {
             this.type = type;
         }
 
+        protected Request(Type type, boolean tracingRequested) {
+            this.type = type;
+            this.tracingRequested = tracingRequested;
+        }
+
         public void setTracingRequested() {
             this.tracingRequested = true;
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/Requests.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Requests.java
@@ -139,7 +139,11 @@ class Requests {
         }
 
         public Query(String query, QueryProtocolOptions options) {
-            super(Type.QUERY);
+            this(query, options, false);
+       }
+
+        public Query(String query, QueryProtocolOptions options, boolean tracing) {
+            super(Type.QUERY, tracing);
             this.query = query;
             this.options = options;
         }
@@ -182,7 +186,11 @@ class Requests {
         public final QueryProtocolOptions options;
 
         public Execute(MD5Digest statementId, QueryProtocolOptions options) {
-            super(Message.Request.Type.EXECUTE);
+            this(statementId, options, false);
+        }
+
+        public Execute(MD5Digest statementId, QueryProtocolOptions options, boolean tracing) {
+            super(Message.Request.Type.EXECUTE, tracing);
             this.statementId = statementId;
             this.options = options;
         }
@@ -352,8 +360,8 @@ class Requests {
         public final List<List<ByteBuffer>> values;
         public final ConsistencyLevel consistency;
 
-        public Batch(BatchStatement.Type type, List<Object> queryOrIdList, List<List<ByteBuffer>> values, ConsistencyLevel consistency) {
-            super(Message.Request.Type.BATCH);
+        public Batch(BatchStatement.Type type, List<Object> queryOrIdList, List<List<ByteBuffer>> values, ConsistencyLevel consistency, boolean tracing) {
+            super(Message.Request.Type.BATCH, tracing);
             this.type = type;
             this.queryOrIdList = queryOrIdList;
             this.values = values;


### PR DESCRIPTION
Refactor the code so that when new statements are constructed from
old statements, the 'tracing' flag is preserved.

Relates to: JAVA-815
