### PR TITLE
JAVA-724 : makeRequestMessage without generating new timestamp

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Message.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Message.java
@@ -114,11 +114,11 @@ abstract class Message {
             }
         }
 
-        long defaultTimestamp() {
+        long timestamp() {
             switch (this.type) {
-                case QUERY:   return ((Requests.Query)this).options.defaultTimestamp;
-                case EXECUTE: return ((Requests.Execute)this).options.defaultTimestamp;
-                case BATCH:   return ((Requests.Batch)this).options.defaultTimestamp;
+                case QUERY:   return ((Requests.Query)this).options.timestamp;
+                case EXECUTE: return ((Requests.Execute)this).options.timestamp;
+                case BATCH:   return ((Requests.Batch)this).options.timestamp;
                 default:      return 0;
             }
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -68,6 +68,9 @@ class RequestHandler {
     private final AtomicBoolean isDone = new AtomicBoolean();
     private AtomicInteger executionCount = new AtomicInteger();
 
+    // Timestamp common to all Speculative Executions of a same request
+    private long commonTimestamp = 0;
+
     public RequestHandler(SessionManager manager, Callback callback, Statement statement) {
         this.id = Long.toString(System.identityHashCode(this));
         if(logger.isTraceEnabled())
@@ -111,7 +114,10 @@ class RequestHandler {
         // Clone the request after the first execution, since we set the streamId on it later and we
         // don't want to share that across executions.
         if (position > 1)
-            request = manager.makeRequestMessage(statement, request.pagingState()) ;
+            request = manager.makeRequestMessage(statement, request.pagingState(), commonTimestamp) ;
+        else
+            // Set timestamp for future speculative executions
+            commonTimestamp = request.timestamp();
 
         SpeculativeExecution execution = new SpeculativeExecution(request, position);
         runningExecutions.add(execution);
@@ -405,7 +411,7 @@ class RequestHandler {
         @Override
         public Message.Request request() {
             if (retryConsistencyLevel != null && retryConsistencyLevel != request.consistency())
-                return manager.makeRequestMessage(statement, retryConsistencyLevel, request.serialConsistency(), request.pagingState(), request.defaultTimestamp());
+                return manager.makeRequestMessage(statement, retryConsistencyLevel, request.serialConsistency(), request.pagingState(), request.timestamp());
             else
                 return request;
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -69,7 +69,7 @@ class RequestHandler {
     private AtomicInteger executionCount = new AtomicInteger();
 
     // Timestamp common to all Speculative Executions of a same request
-    private long commonTimestamp = 0;
+    private volatile long commonTimestamp = 0;
 
     public RequestHandler(SessionManager manager, Callback callback, Statement statement) {
         this.id = Long.toString(System.identityHashCode(this));

--- a/driver-core/src/main/java/com/datastax/driver/core/Requests.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Requests.java
@@ -176,7 +176,7 @@ class Requests {
         PAGE_SIZE,
         PAGING_STATE,
         SERIAL_CONSISTENCY,
-        DEFAULT_TIMESTAMP,
+        TIMESTAMP,
         VALUE_NAMES;
 
         public static EnumSet<QueryFlag> deserialize(int flags) {
@@ -215,7 +215,7 @@ class Requests {
         public final int pageSize;
         public final ByteBuffer pagingState;
         public final ConsistencyLevel serialConsistency;
-        public final long defaultTimestamp;
+        public final long timestamp;
 
         public QueryProtocolOptions(ConsistencyLevel consistency,
                                     List<ByteBuffer> values,
@@ -223,7 +223,7 @@ class Requests {
                                     int pageSize,
                                     ByteBuffer pagingState,
                                     ConsistencyLevel serialConsistency,
-                                    long defaultTimestamp) {
+                                    long timestamp) {
 
             this.consistency = consistency;
             this.values = values;
@@ -231,7 +231,7 @@ class Requests {
             this.pageSize = pageSize;
             this.pagingState = pagingState;
             this.serialConsistency = serialConsistency;
-            this.defaultTimestamp = defaultTimestamp;
+            this.timestamp = timestamp;
 
             // Populate flags
             if (!values.isEmpty())
@@ -244,8 +244,8 @@ class Requests {
                 flags.add(QueryFlag.PAGING_STATE);
             if (serialConsistency != ConsistencyLevel.SERIAL)
                 flags.add(QueryFlag.SERIAL_CONSISTENCY);
-            if (defaultTimestamp != Long.MIN_VALUE)
-                flags.add(QueryFlag.DEFAULT_TIMESTAMP);
+            if (timestamp != Long.MIN_VALUE)
+                flags.add(QueryFlag.TIMESTAMP);
         }
 
         public void encode(ByteBuf dest, ProtocolVersion version) {
@@ -267,8 +267,8 @@ class Requests {
                         CBUtil.writeValue(pagingState, dest);
                     if (flags.contains(QueryFlag.SERIAL_CONSISTENCY))
                         CBUtil.writeConsistencyLevel(serialConsistency, dest);
-                    if (version == ProtocolVersion.V3 && flags.contains(QueryFlag.DEFAULT_TIMESTAMP))
-                        dest.writeLong(defaultTimestamp);
+                    if (version == ProtocolVersion.V3 && flags.contains(QueryFlag.TIMESTAMP))
+                        dest.writeLong(timestamp);
                     break;
                 default:
                     throw version.unsupported();
@@ -293,7 +293,7 @@ class Requests {
                         size += CBUtil.sizeOfValue(pagingState);
                     if (flags.contains(QueryFlag.SERIAL_CONSISTENCY))
                         size += CBUtil.sizeOfConsistencyLevel(serialConsistency);
-                    if (version == ProtocolVersion.V3 && flags.contains(QueryFlag.DEFAULT_TIMESTAMP))
+                    if (version == ProtocolVersion.V3 && flags.contains(QueryFlag.TIMESTAMP))
                         size += 8;
                     return size;
                 default:
@@ -385,17 +385,17 @@ class Requests {
         private final EnumSet<QueryFlag> flags = EnumSet.noneOf(QueryFlag.class);
         public final ConsistencyLevel consistency;
         public final ConsistencyLevel serialConsistency;
-        public final long defaultTimestamp;
+        public final long timestamp;
 
-        public BatchProtocolOptions(ConsistencyLevel consistency, ConsistencyLevel serialConsistency, long defaultTimestamp) {
+        public BatchProtocolOptions(ConsistencyLevel consistency, ConsistencyLevel serialConsistency, long timestamp) {
             this.consistency = consistency;
             this.serialConsistency = serialConsistency;
-            this.defaultTimestamp = defaultTimestamp;
+            this.timestamp = timestamp;
 
             if (serialConsistency != ConsistencyLevel.SERIAL)
                 flags.add(QueryFlag.SERIAL_CONSISTENCY);
-            if (defaultTimestamp != Long.MIN_VALUE)
-                flags.add(QueryFlag.DEFAULT_TIMESTAMP);
+            if (timestamp != Long.MIN_VALUE)
+                flags.add(QueryFlag.TIMESTAMP);
         }
 
         public void encode(ByteBuf dest, ProtocolVersion version) {
@@ -408,8 +408,8 @@ class Requests {
                     dest.writeByte((byte)QueryFlag.serialize(flags));
                     if (flags.contains(QueryFlag.SERIAL_CONSISTENCY))
                         CBUtil.writeConsistencyLevel(serialConsistency, dest);
-                    if (flags.contains(QueryFlag.DEFAULT_TIMESTAMP))
-                        dest.writeLong(defaultTimestamp);
+                    if (flags.contains(QueryFlag.TIMESTAMP))
+                        dest.writeLong(timestamp);
                     break;
                 default:
                     throw version.unsupported();
@@ -426,7 +426,7 @@ class Requests {
                     size += 1; // flags
                     if (flags.contains(QueryFlag.SERIAL_CONSISTENCY))
                         size += CBUtil.sizeOfConsistencyLevel(serialConsistency);
-                    if (flags.contains(QueryFlag.DEFAULT_TIMESTAMP))
+                    if (flags.contains(QueryFlag.TIMESTAMP))
                         size += 8;
                     return size;
                 default:
@@ -437,7 +437,7 @@ class Requests {
         @Override
         public String toString() {
             return String.format("[cl=%s, serialCl=%s, defaultTs=%d]",
-                                 consistency, serialConsistency, defaultTimestamp);
+                                 consistency, serialConsistency, timestamp);
         }
     }
 


### PR DESCRIPTION
New method `SessionManager#makeRequestMessage` with a timestamp argument which doesn't generate a new timestamp but uses the one in argument to create the Request.
 Use of the new `makeRequestMessage` method in case we create a new SpeculativeExecution for the same, the timestamp must not change otherwise it could break idempotence of writes.

A test for this change would require a scenario involving `SpeculativeExecutions` and ensure that for a new `SpeculativeExecution` executed, the driver doesn't generate a new timestamp using `TimestampGenerator.next()`, and uses the previously generated timestamp. `SpeculativeExecutions` are only reliably tested with Scassandra.
The problem is Scassandra only works with `ProtocolVersion` <= V2, also, custom `TimestampGenerator` is only effective using `ProtocolVersion` >= 3.
There is an incompatibility issue resulting from those two points.
