### PR TITLE
JAVA-679: Support bind marker in QueryBuilder DELETE's list index.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
@@ -344,7 +344,7 @@ public class Delete extends BuiltStatement {
          * @return this in-build DELETE Selection
          */
         public Selection listElt(String columnName, int idx) {
-            columns.add(new IndexedSelector(columnName, idx));
+            columns.add(new CollectionElementSelector(columnName, idx));
             return this;
         }
 
@@ -357,7 +357,32 @@ public class Delete extends BuiltStatement {
          * @return this in-build DELETE Selection
          */
         public Selection listElt(String columnName, BindMarker idx) {
-            columns.add(new IndexedSelector(columnName, idx));
+            columns.add(new CollectionElementSelector(columnName, idx));
+            return this;
+        }
+
+        /**
+         * Deletes the provided set element.
+         *
+         * @param columnName the name of the set column.
+         * @param element the element to delete.
+         * @return this in-build DELETE Selection
+         */
+        public Selection setElt(String columnName, Object element) {
+            columns.add(new CollectionElementSelector(columnName, element));
+            return this;
+        }
+
+        /**
+         * Deletes the provided set element,
+         * specified as a bind marker.
+         *
+         * @param columnName the name of the set column.
+         * @param element the element to delete.
+         * @return this in-build DELETE Selection
+         */
+        public Selection setElt(String columnName, BindMarker element) {
+            columns.add(new CollectionElementSelector(columnName, element));
             return this;
         }
 
@@ -369,7 +394,7 @@ public class Delete extends BuiltStatement {
          * @return this in-build DELETE Selection
          */
         public Selection mapElt(String columnName, Object key) {
-            columns.add(new IndexedSelector(columnName, key));
+            columns.add(new CollectionElementSelector(columnName, key));
             return this;
         }
     }
@@ -377,7 +402,7 @@ public class Delete extends BuiltStatement {
     /**
      * A selector in a DELETE selection clause.
      * A selector can be either a column name,
-     * a list element or a map entry.
+     * a list element, a set element or a map entry.
      */
     static class Selector extends Utils.Appendeable {
 
@@ -406,13 +431,13 @@ public class Delete extends BuiltStatement {
     }
 
     /**
-     * A list element or a map entry in a DELETE selection clause.
+     * A selector representing a list index, a set element or a map key in a DELETE selection clause.
      */
-    static class IndexedSelector extends Selector {
+    static class CollectionElementSelector extends Selector {
 
         private final Object key;
 
-        IndexedSelector(String columnName, Object key) {
+        CollectionElementSelector(String columnName, Object key) {
             super(columnName);
             this.key = key;
         }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
@@ -38,7 +38,7 @@ public class QueryBuilderExecutionTest extends CCMBridge.PerClassSingleNodeClust
         return Arrays.asList(
             String.format(TestUtils.CREATE_TABLE_SIMPLE_FORMAT, TABLE1),
             "CREATE TABLE dateTest (t timestamp PRIMARY KEY)",
-            "CREATE TABLE test_coll (k int PRIMARY KEY, a list<int>, b map<int,text>)");
+            "CREATE TABLE test_coll (k int PRIMARY KEY, a list<int>, b map<int,text>, c set<text>)");
     }
 
     @Test(groups = "short")
@@ -124,7 +124,7 @@ public class QueryBuilderExecutionTest extends CCMBridge.PerClassSingleNodeClust
     @Test(groups = "short")
     public void should_delete_list_element_with_bind_marker() throws Exception {
         //given
-        session.execute("INSERT INTO test_coll (k, a, b) VALUES (1, [1,2,3], null)");
+        session.execute("INSERT INTO test_coll (k, a) VALUES (1, [1,2,3])");
         //when
         BuiltStatement statement = delete().listElt("a", bindMarker()).from("test_coll").where(eq("k", 1));
         PreparedStatement ps = session.prepare(statement);
@@ -135,9 +135,34 @@ public class QueryBuilderExecutionTest extends CCMBridge.PerClassSingleNodeClust
     }
 
     @Test(groups = "short")
+    public void should_delete_set_element() throws Exception {
+        //given
+        session.execute("INSERT INTO test_coll (k, c) VALUES (1, {'foo','bar','qix'})");
+        //when
+        BuiltStatement statement = delete().setElt("c", "foo").from("test_coll").where(eq("k", 1));
+        session.execute(statement);
+        //then
+        Set<String> actual = session.execute("SELECT c FROM test_coll WHERE k = 1").one().getSet("c", String.class);
+        assertThat(actual).containsOnly("bar", "qix");
+    }
+
+    @Test(groups = "short")
+    public void should_delete_set_element_with_bind_marker() throws Exception {
+        //given
+        session.execute("INSERT INTO test_coll (k, c) VALUES (1, {'foo','bar','qix'})");
+        //when
+        BuiltStatement statement = delete().setElt("c", bindMarker()).from("test_coll").where(eq("k", 1));
+        PreparedStatement ps = session.prepare(statement);
+        session.execute(ps.bind("foo"));
+        //then
+        Set<String> actual = session.execute("SELECT c FROM test_coll WHERE k = 1").one().getSet("c", String.class);
+        assertThat(actual).containsOnly("bar", "qix");
+    }
+
+    @Test(groups = "short")
     public void should_delete_map_entry() throws Exception {
         //given
-        session.execute("INSERT INTO test_coll (k, a, b) VALUES (1, null, {1:'foo', 2:'bar'})");
+        session.execute("INSERT INTO test_coll (k, b) VALUES (1, {1:'foo', 2:'bar'})");
         //when
         BuiltStatement statement = delete().mapElt("b", 1).from("test_coll").where(eq("k", 1));
         session.execute(statement);


### PR DESCRIPTION
This commit adds support for deletion of set elements.
