### PR TITLE
Record error if RetryDecision.tryNextHost

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -579,6 +579,8 @@ class RequestHandler {
                                         logger.debug("Doing retry {} for query {} at consistency {}", retriesByPolicy, statement, retry.getRetryConsistencyLevel());
                                     if (metricsEnabled())
                                         metrics().getErrorMetrics().getRetries().inc();
+                                    if (!retry.isRetryCurrent())
+                                        logError(connection.address, exceptionToReport);
                                     retry(retry.isRetryCurrent(), retry.getRetryConsistencyLevel());
                                     break;
                                 case RETHROW:

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerErrorsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerErrorsTest.java
@@ -214,11 +214,15 @@ public class QueryLoggerErrorsTest extends ScassandraTestBase.PerClassCluster {
                 .build()
         );
         // when
+        // when
         try {
             session.execute(query);
-            fail("Should have thrown UnavailableException");
-        } catch (UnavailableException e) {
+            fail("Should have thrown NoHostAvailableException");
+        } catch(NoHostAvailableException e) {
             // ok
+            Throwable error = e.getErrors().get(hostAddress);
+            assertThat(error).isNotNull();
+            assertThat(error).isInstanceOf(UnavailableException.class);
         }
         // then
         String line = errorAppender.waitAndGet(5000);

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/AbstractRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/AbstractRetryPolicyIntegrationTest.java
@@ -105,6 +105,10 @@ public class AbstractRetryPolicyIntegrationTest {
     }
 
     protected ResultSet query() {
+        return query(session);
+    }
+
+    protected ResultSet query(Session session) {
         return session.execute("mock query");
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/LatencyAwarePolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/LatencyAwarePolicyTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.CountDownLatch;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -111,9 +112,12 @@ public class LatencyAwarePolicyTest extends ScassandraTestBase {
         // when
         try {
             session.execute(query);
-            fail("Should have thrown UnavailableException");
-        } catch(UnavailableException e) {
+            fail("Should have thrown NoHostAvailableException");
+        } catch(NoHostAvailableException e) {
             // ok
+            Throwable error = e.getErrors().get(hostAddress);
+            assertThat(error).isNotNull();
+            assertThat(error).isInstanceOf(UnavailableException.class);
         }
         // then
         // wait until trackers have been notified


### PR DESCRIPTION
JAVA-709 (#372) added the capability for a RetryDecision to specify that a request may be retried on different host by using RetryDecision.tryNextHost.  In the case where tryNextHost is used and there are no more available hosts a NoHostAvailableException (no hosts were tried) is surfaced to the user.   This change instead surfaces the response that initiated the RetryDecision instead of NoHostAvailableException.

Added #should_rethrow_on_first_unavailable_if_there_are_no_more_hosts() to demonstrate this change.
