### PR TITLE
JAVA-765: Provide API to retrieve values of a Parameterized SimpleStatement

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -22,6 +22,7 @@
 - [bug] Preserve tracing across retries (JAVA-815)
 - [improvement] New RetryDecision.tryNextHost() (JAVA-709)
 - [bug] Handle function calls and raw strings as non-idempotent in QueryBuilder (JAVA-733)
+- [improvement] Provide API to retrieve values of a Parameterized SimpleStatement (JAVA-765)
 
 Merged from 2.0.10_fixes branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Assignment.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Assignment.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 
 import static com.datastax.driver.core.querybuilder.Utils.appendName;
@@ -41,7 +40,7 @@ public abstract class Assignment extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables) {
             appendName(name, sb);
             sb.append('=');
             appendValue(value, sb, variables);
@@ -75,7 +74,7 @@ public abstract class Assignment extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables) {
             appendName(name, sb).append('=');
             appendName(name, sb).append(isIncr ? "+" : "-");
             appendValue(value, sb, variables);
@@ -102,7 +101,7 @@ public abstract class Assignment extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables) {
             appendName(name, sb).append('=');
             appendValue(value, sb, variables);
             sb.append('+');
@@ -132,7 +131,7 @@ public abstract class Assignment extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables) {
             appendName(name, sb).append('[').append(idx).append("]=");
             appendValue(value, sb, variables);
         }
@@ -166,7 +165,7 @@ public abstract class Assignment extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables) {
             appendName(name, sb).append('=');
             appendName(name, sb).append(isAdd ? "+" : "-");
             appendValue(collection, sb, variables);
@@ -195,7 +194,7 @@ public abstract class Assignment extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables) {
             appendName(name, sb).append('[');
             appendValue(key, sb, variables);
             sb.append("]=");

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Batch.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Batch.java
@@ -48,7 +48,7 @@ public class Batch extends BuiltStatement {
     }
 
     @Override
-    StringBuilder buildQueryString(List<ByteBuffer> variables) {
+    StringBuilder buildQueryString(List<Object> variables) {
         StringBuilder builder = new StringBuilder();
 
         builder.append(isCounterOp()

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Clause.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Clause.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 
 public abstract class Clause extends Utils.Appendeable {
@@ -48,7 +47,7 @@ public abstract class Clause extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables) {
             Utils.appendName(name, sb).append(op);
             Utils.appendValue(value, sb, variables);
         }
@@ -79,7 +78,7 @@ public abstract class Clause extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables) {
 
             // We special case the case of just one bind marker because there is little
             // reasons to do:
@@ -146,7 +145,7 @@ public abstract class Clause extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables) {
             sb.append("(");
             for (int i = 0; i < names.size(); i++) {
                 if (i > 0)

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -52,7 +51,7 @@ public class Delete extends BuiltStatement {
     }
 
     @Override
-    StringBuilder buildQueryString(List<ByteBuffer> variables) {
+    StringBuilder buildQueryString(List<Object> variables) {
         StringBuilder builder = new StringBuilder();
 
         builder.append("DELETE");
@@ -414,7 +413,7 @@ public class Delete extends BuiltStatement {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> values) {
+        void appendTo(StringBuilder sb, List<Object> values) {
             Utils.appendName(columnName, sb);
         }
 
@@ -426,7 +425,7 @@ public class Delete extends BuiltStatement {
         @Override
         public String toString() {
             StringBuilder sb = new StringBuilder();
-            appendTo(sb, new ArrayList<ByteBuffer>());
+            appendTo(sb, new ArrayList<Object>());
             return sb.toString();
         }
     }
@@ -444,7 +443,7 @@ public class Delete extends BuiltStatement {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> values) {
+        void appendTo(StringBuilder sb, List<Object> values) {
             super.appendTo(sb, values);
             sb.append('[');
             Utils.appendFlatValue(key, sb);

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
@@ -46,7 +46,7 @@ public class Insert extends BuiltStatement {
     }
 
     @Override
-    StringBuilder buildQueryString(List<ByteBuffer> variables) {
+    StringBuilder buildQueryString(List<Object> variables) {
         StringBuilder builder = new StringBuilder();
 
         builder.append("INSERT INTO ");

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Ordering.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Ordering.java
@@ -29,7 +29,7 @@ public class Ordering extends Utils.Appendeable {
     }
 
     @Override
-    void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+    void appendTo(StringBuilder sb, List<Object> variables) {
         Utils.appendName(name, sb);
         sb.append(isDesc ? " DESC" : " ASC");
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Select.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Select.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -55,7 +54,7 @@ public class Select extends BuiltStatement {
     }
 
     @Override
-    StringBuilder buildQueryString(List<ByteBuffer> variables) {
+    StringBuilder buildQueryString(List<Object> variables) {
         StringBuilder builder = new StringBuilder();
 
         builder.append("SELECT ");

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Truncate.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Truncate.java
@@ -38,7 +38,7 @@ public class Truncate extends BuiltStatement {
     }
 
     @Override
-    protected StringBuilder buildQueryString(List<ByteBuffer> variables) {
+    protected StringBuilder buildQueryString(List<Object> variables) {
         StringBuilder builder = new StringBuilder();
 
         builder.append("TRUNCATE ");

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
@@ -52,7 +52,7 @@ public class Update extends BuiltStatement {
     }
 
     @Override
-    StringBuilder buildQueryString(List<ByteBuffer> variables) {
+    StringBuilder buildQueryString(List<Object> variables) {
         StringBuilder builder = new StringBuilder();
 
         builder.append("UPDATE ");

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Using.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Using.java
@@ -35,7 +35,7 @@ public abstract class Using extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables) {
             sb.append(optionName).append(' ').append(value);
         }
 
@@ -54,7 +54,7 @@ public abstract class Using extends Utils.Appendeable {
         }
 
         @Override
-        void appendTo(StringBuilder sb, List<ByteBuffer> variables) {
+        void appendTo(StringBuilder sb, List<Object> variables) {
             sb.append(optionName).append(' ').append(marker);
         }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/SimpleStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SimpleStatementTest.java
@@ -20,10 +20,32 @@ import java.util.List;
 
 import org.testng.annotations.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class SimpleStatementTest {
+
     @Test(groups = "unit", expectedExceptions = { IllegalArgumentException.class })
     public void should_fail_if_too_many_variables() {
         List<Object> args = Collections.nCopies(1 << 16, (Object)1);
         new SimpleStatement("mock query", args.toArray());
     }
+
+    @Test(groups = "unit", expectedExceptions = { IllegalStateException.class })
+    public void should_throw_ISE_if_getObject_called_on_statement_without_values() {
+        new SimpleStatement("doesn't matter").getObject(0);
+    }
+
+
+    @Test(groups = "unit", expectedExceptions = { IndexOutOfBoundsException.class })
+    public void should_throw_IOOBE_if_getObject_called_with_wrong_index() {
+        new SimpleStatement("doesn't matter", new Object()).getObject(1);
+    }
+
+    @Test(groups = "unit")
+    public void should_return_object_at_ith_index() {
+        Object expected = new Object();
+        Object actual = new SimpleStatement("doesn't matter", expected).getObject(0);
+        assertThat(actual).isSameAs(expected);
+    }
+
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -18,7 +18,6 @@ package com.datastax.driver.core.querybuilder;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
-import java.nio.ByteBuffer;
 import java.util.*;
 
 import org.testng.annotations.Test;
@@ -28,7 +27,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-import com.datastax.driver.core.Assertions;
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.Statement;
@@ -776,4 +774,22 @@ public class QueryBuilderTest {
         assertThat(select.getQueryString()).doesNotContain("?");
         assertThat(select.getValues()).isNull();
     }
+
+    @Test(groups = "unit", expectedExceptions = { IllegalStateException.class })
+    public void should_throw_ISE_if_getObject_called_on_statement_without_values() {
+        select().from("test").where(eq("foo", 42)).getObject(0); // integers are appended to the CQL string
+    }
+
+    @Test(groups = "unit", expectedExceptions = { IndexOutOfBoundsException.class })
+    public void should_throw_IOOBE_if_getObject_called_with_wrong_index() {
+        select().from("test").where(eq("foo", new Object())).getObject(1);
+    }
+
+    @Test(groups = "unit")
+    public void should_return_object_at_ith_index() {
+        Object expected = new Object();
+        Object actual = select().from("test").where(eq("foo", expected)).getObject(0);
+        assertThat(actual).isSameAs(expected);
+    }
+
 }


### PR DESCRIPTION
The first commit introduces a`getObject(int)` method for `SimpleStatement`, the second the same method but for `BuiltStatement`.
