### PR TITLE
JAVA-797 : Added option to prepare statements once

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -31,6 +31,7 @@
 - [improvement] Allow PlainTextAuthProvider to change its credentials at runtime (JAVA-719)
 - [new feature] Make it possible to register for SchemaChange Events (JAVA-151)
 - [improvement] Downgrade "Asked to rebuild table" log from ERROR to INFO level (JAVA-861)
+- [improvement] Provide an option to prepare statements only on one node (JAVA-797)
 
 Merged from 2.0.10_fixes branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -145,15 +145,17 @@ class SessionManager extends AbstractSession {
                                 Responses.Result.Prepared pmsg = (Responses.Result.Prepared)rm;
                                 PreparedStatement stmt = DefaultPreparedStatement.fromMessage(pmsg, cluster.getMetadata(), query, poolsState.keyspace);
                                 stmt = cluster.manager.addPrepared(stmt);
-                                try {
-                                    // All Sessions are connected to the same nodes so it's enough to prepare only the nodes of this session.
-                                    // If that changes, we'll have to make sure this propagate to other sessions too.
-                                    prepare(stmt.getQueryString(), future.getAddress());
-                                } catch (InterruptedException e) {
-                                    Thread.currentThread().interrupt();
-                                    // This method doesn't propagate interruption, at least not for now. However, if we've
-                                    // interrupted preparing queries on other node it's not a problem as we'll re-prepare
-                                    // later if need be. So just ignore.
+                                if (cluster.getConfiguration().getQueryOptions().isPrepareOnAllHosts()){
+                                    try {
+                                        // All Sessions are connected to the same nodes so it's enough to prepare only the nodes of this session.
+                                        // If that changes, we'll have to make sure this propagate to other sessions too.
+                                        prepare(stmt.getQueryString(), future.getAddress());
+                                    } catch (InterruptedException e) {
+                                        Thread.currentThread().interrupt();
+                                        // This method doesn't propagate interruption, at least not for now. However, if we've
+                                        // interrupted preparing queries on other node it's not a problem as we'll re-prepare
+                                        // later if need be. So just ignore.
+                                    }
                                 }
                                 return stmt;
                             default:

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryOptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryOptionsTest.java
@@ -1,0 +1,148 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.List;
+import com.google.common.collect.Lists;
+import org.scassandra.http.client.PreparedStatementPreparation;
+import org.testng.annotations.*;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+
+public class QueryOptionsTest {
+    SCassandraCluster scassandra;
+
+    QueryOptions queryOptions = new QueryOptions();
+
+    SortingLoadBalancingPolicy loadBalancingPolicy;
+
+    Cluster cluster = null;
+    Session session = null;
+    Host host1, host2, host3;
+
+
+    @BeforeClass(groups = "short")
+    public void beforeClass() {
+        scassandra = new SCassandraCluster(CCMBridge.IP_PREFIX, 3);
+    }
+
+    @BeforeMethod(groups = "short")
+    public void beforeMethod() {
+        loadBalancingPolicy = new SortingLoadBalancingPolicy();
+        cluster = Cluster.builder()
+            .addContactPoint(CCMBridge.ipOfNode(2))
+            .withLoadBalancingPolicy(loadBalancingPolicy)
+            .withQueryOptions(queryOptions)
+            .build();
+
+        session = cluster.connect();
+
+        host1 = TestUtils.findHost(cluster, 1);
+        host2 = TestUtils.findHost(cluster, 2);
+        host3 = TestUtils.findHost(cluster, 3);
+
+        // Make sure there are no prepares
+        for(int host : Lists.newArrayList(1, 2, 3)) {
+            assertThat(scassandra.retrievePreparedStatementPreparations(host)).hasSize(0);
+        }
+    }
+
+    public void validatePrepared(boolean expectAll) {
+        // Prepare the statement
+        String query = "select sansa_stark from the_known_world";
+        session.prepare(query);
+
+        // Ensure prepared properly based on expectation.
+        List<PreparedStatementPreparation> preparationOne = scassandra.retrievePreparedStatementPreparations(1);
+        List<PreparedStatementPreparation> preparationTwo = scassandra.retrievePreparedStatementPreparations(2);
+        List<PreparedStatementPreparation> preparationThree = scassandra.retrievePreparedStatementPreparations(3);
+
+        assertThat(preparationOne).hasSize(1);
+        assertThat(preparationOne.get(0).getPreparedStatementText()).isEqualTo(query);
+
+        if (expectAll) {
+            assertThat(preparationTwo).hasSize(1);
+            assertThat(preparationTwo.get(0).getPreparedStatementText()).isEqualTo(query);
+            assertThat(preparationThree).hasSize(1);
+            assertThat(preparationThree.get(0).getPreparedStatementText()).isEqualTo(query);
+        } else {
+            assertThat(preparationTwo).isEmpty();
+            assertThat(preparationThree).isEmpty();
+        }
+    }
+
+    /**
+     * <p>
+     * Validates that statements are only prepared on one node when
+     * {@link QueryOptions#setPrepareOnAllHosts(boolean)} is set to false.
+     * </p>
+     *
+     * @test_category prepared_statements:prepared
+     * @expected_result prepare query only on the first node.
+     * @jira_ticket JAVA-797
+     * @since 2.0.11, 2.1.8, 2.2.1
+     */
+    @Test(groups = "short")
+    public void should_prepare_once_when_prepare_on_all_hosts_false() {
+        queryOptions.setPrepareOnAllHosts(false);
+        validatePrepared(false);
+    }
+
+    /**
+     * <p>
+     * Validates that statements are prepared on one node when
+     * {@link QueryOptions#setPrepareOnAllHosts(boolean)} is set to true.
+     * </p>
+     *
+     * @test_category prepared_statements:prepared
+     * @expected_result all nodes prepared the query
+     * @jira_ticket JAVA-797
+     * @since 2.0.11, 2.1.8, 2.2.1
+     */
+    @Test(groups = "short")
+    public void should_prepare_everywhere_when_prepare_on_all_hosts_true() {
+        queryOptions.setPrepareOnAllHosts(true);
+        validatePrepared(true);
+    }
+
+    /**
+     * <p>
+     * Validates that statements are prepared on one node when
+     * {@link QueryOptions#setPrepareOnAllHosts(boolean)} is not set.
+     * </p>
+     *
+     * @test_category prepared_statements:prepared
+     * @expected_result all nodes prepared the query.
+     * @jira_ticket JAVA-797
+     * @since 2.0.11
+     */
+    @Test(groups = "short")
+    public void should_prepare_everywhere_when_not_configured() {
+        validatePrepared(true);
+    }
+
+    @AfterMethod(groups = "short")
+    public void afterMethod() {
+        scassandra.clearAllPrimes();
+        scassandra.clearAllRecordedActivity();
+    }
+
+    @AfterClass(groups = "short")
+    public void afterClass() {
+        if (scassandra != null)
+            scassandra.stop();
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/SCassandraCluster.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SCassandraCluster.java
@@ -94,6 +94,10 @@ public class SCassandraCluster {
         return activityClients.get(node - 1).retrieveQueries();
     }
 
+    public List<PreparedStatementExecution> retrievePreparedStatementExecutions(int node){
+        return activityClients.get(node - 1).retrievePreparedStatementExecutions();
+    }
+
     public void clearAllPrimes() {
         for (PrimingClient primingClient : primingClients)
             primingClient.clearAllPrimes();

--- a/driver-core/src/test/java/com/datastax/driver/core/SCassandraCluster.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SCassandraCluster.java
@@ -98,6 +98,10 @@ public class SCassandraCluster {
         return activityClients.get(node - 1).retrievePreparedStatementExecutions();
     }
 
+    public List<PreparedStatementPreparation> retrievePreparedStatementPreparations(int node) {
+        return activityClients.get(node - 1).retrievePreparedStatementPreparations();
+    }
+
     public void clearAllPrimes() {
         for (PrimingClient primingClient : primingClients)
             primingClient.clearAllPrimes();
@@ -121,14 +125,24 @@ public class SCassandraCluster {
             if (scassandras.get(i).equals(toIgnore))
                 continue;
             InetAddress address = addresses.get(i);
-            rows.add(ImmutableMap.<String, Object>builder()
+            Map<String, ?> row = ImmutableMap.<String, Object>builder()
                 .put("peer", address)
                 .put("rpc_address", address)
                 .put("data_center", "datacenter1")
                 .put("rack", "rack1")
                 .put("release_version", "2.0.1")
                 .put("tokens", ImmutableSet.of(Long.toString(Long.MIN_VALUE + i)))
-                .build());
+                .build();
+
+            rows.add(row);
+
+            String query = "SELECT * FROM system.peers WHERE peer='" + address.toString().substring(1) + "'";
+            primingClient.prime(
+                PrimingRequest.queryBuilder()
+                    .withQuery(query)
+                    .withColumnTypes(SELECT_PEERS_COLUMN_TYPES)
+                    .withRows(row)
+                    .build());
         }
         primingClient.prime(
             PrimingRequest.queryBuilder()

--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,7 @@
     <testng.version>6.8.8</testng.version>
     <assertj.version>1.7.0</assertj.version>
     <mockito.version>1.10.8</mockito.version>
-    <!--
-      There are more recent versions of Scassandra but they require JDK 7,
-      our build is still using JDK 6.
-    -->
-    <scassandra.version>0.4.1</scassandra.version>
+    <scassandra.version>0.9.1</scassandra.version>
     <main.basedir>${project.basedir}</main.basedir>
   </properties>
 


### PR DESCRIPTION
Writing a test for this option would need either adding a feature in SCassandra to be able to retrieve prepared statements in ActivityClients, because right now it only takes in accounts **executed** prepared statements. Or, having a ticket like [CASSANDRA-8831](https://issues.apache.org/jira/browse/CASSANDRA-8831) implemented in Cassandra.
