### PR TITLE
JAVA-618: Randomize contact points list to prevent hotspots.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -25,6 +25,7 @@
 - [bug] Handle function calls and raw strings as non-idempotent in QueryBuilder (JAVA-733)
 - [improvement] Provide API to retrieve values of a Parameterized SimpleStatement (JAVA-765)
 - [improvement] implement UPDATE ... IF EXISTS in QueryBuilder (JAVA-827)
+- [improvement] Randomize contact points list to prevent hotspots (JAVA-618)
 
 Merged from 2.0.10_fixes branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -74,7 +74,10 @@ class ControlConnection implements Host.StateListener {
             return;
 
         // NB: at this stage, allHosts() only contains the initial contact points
-        setNewConnection(reconnectInternal(cluster.metadata.allHosts().iterator(), true));
+        List<Host> hosts = new ArrayList<Host>(cluster.metadata.allHosts());
+        // shuffle so that multiple clients with the same contact points don't all pick the same control host
+        Collections.shuffle(hosts);
+        setNewConnection(reconnectInternal(hosts.iterator(), true));
     }
 
     public CloseFuture closeAsync() {

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicy.java
@@ -19,9 +19,6 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -210,6 +207,9 @@ public class DCAwareRoundRobinPolicy implements LoadBalancingPolicy, CloseableLo
             String nonLocalHosts = Joiner.on(",").join(notInLocalDC);
             logger.warn("Some contact points don't match local data center. Local DC = {}. Non-conforming contact points: {}", localDc, nonLocalHosts);
         }
+
+        this.index.set(new Random().nextInt(Math.max(hosts.size(), 1)));
+
     }
 
     private String dc(Host host) {

--- a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
@@ -15,10 +15,18 @@
  */
 package com.datastax.driver.core;
 
+import java.net.InetAddress;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,6 +37,9 @@ import com.datastax.driver.core.policies.Policies;
 import com.datastax.driver.core.policies.ReconnectionPolicy;
 
 public class ControlConnectionTest {
+
+    static final Logger logger = LoggerFactory.getLogger(ControlConnectionTest.class);
+
     @Test(groups = "short")
     public void should_prevent_simultaneous_reconnection_attempts() throws InterruptedException {
         CCMBridge ccm = null;
@@ -120,6 +131,61 @@ public class ControlConnectionTest {
             if (ccm != null)
                 ccm.remove();
         }
+    }
+
+    /**
+     * <p>
+     * Ensures that contact points are randomized when determining the initial control connection
+     * by default.  Initializes a cluster with 5 contact points 100 times and ensures that all 5
+     * were used.
+     * </p>
+     *
+     * @jira_ticket JAVA-618
+     * @expected_result All 5 hosts were chosen within 100 attempts.  There is a very small possibility
+     *  that this may not be the case and this is not actually an error.
+     * @test_category control_connection
+     * @since 2.0.11, 2.1.8, 2.2.0
+     */
+    @Test(groups = "short")
+    public void should_randomize_contact_points_when_determining_control_connection() {
+        int hostCount = 5;
+        int iterations = 100;
+        SCassandraCluster scassandras = new SCassandraCluster(hostCount);
+
+        try {
+            final HashMultiset<InetAddress> occurrencesByHost = HashMultiset.create(hostCount);
+            for(int i = 0; i < iterations; i++) {
+                Cluster cluster = Cluster.builder()
+                    .addContactPoints(scassandras.addresses())
+                    .build();
+
+                try {
+                    cluster.init();
+                    occurrencesByHost.add(cluster.manager.controlConnection.connectedHost().getAddress());
+                } finally {
+                    cluster.close();
+                }
+            }
+            if(logger.isDebugEnabled()) {
+                Map<InetAddress, Integer> hostCounts = Maps.toMap(occurrencesByHost.elementSet(), new Function<InetAddress, Integer>() {
+                    @Override
+                    public Integer apply(InetAddress input) {
+                        return occurrencesByHost.count(input);
+                    }
+                });
+                logger.debug("Control Connection Use Counts by Host: {}", hostCounts);
+            }
+            // There is an incredibly low chance that a host may not be used based on randomness.
+            // This probability is very low however.
+            assertThat(occurrencesByHost.elementSet().size())
+                .as("Not all hosts were used as contact points.  There is a very small chance"
+                    + " of this happening based on randomness, investigate whether or not this"
+                    + " is a bug.")
+                .isEqualTo(hostCount);
+        } finally {
+            scassandras.stop();
+        }
+
     }
 
     static class QueryPlanCountingPolicy extends DelegatingLoadBalancingPolicy {

--- a/driver-core/src/test/java/com/datastax/driver/core/SCassandraCluster.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SCassandraCluster.java
@@ -43,6 +43,10 @@ public class SCassandraCluster {
     private final List<PrimingClient> primingClients;
     private final List<ActivityClient> activityClients;
 
+    public SCassandraCluster(int nodeCount) {
+        this(CCMBridge.IP_PREFIX, nodeCount);
+    }
+
     public SCassandraCluster(String ipPrefix, int nodeCount) {
         scassandras = Lists.newArrayListWithCapacity(nodeCount);
         addresses = Lists.newArrayListWithCapacity(nodeCount);

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicyTest.java
@@ -191,7 +191,6 @@ public class DCAwareRoundRobinPolicyTest {
         }
 
         @Override public void init(Cluster cluster, Collection<Host> hosts) {
-            System.out.println("init " + hosts);
             initHosts.addAll(hosts);
             super.init(cluster, hosts);
         }

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -5,6 +5,9 @@ versions of the Java driver.
 
 ### 2.0.11
 
+2.0.11 preserves binary compatibility with previous versions. There are a few
+changes in the driver's behavior:
+
 1. The `DefaultRetryPolicy`'s behaviour has changed in the case of an Unavailable
    exception received from a request. The new behaviour will cause the driver to
    process a Retry on a different node at most once, otherwise an exception will
@@ -13,10 +16,19 @@ versions of the Java driver.
    because of a network partition) but can still answer to the client normally.
    In this case, trying another node has a chance of success.
    The previous behaviour was to always throw an exception.
+
 2. A `BuiltStatement` is now considered non-idempotent whenever a `fcall()`
    or `raw()` is used to build a value to be inserted in the database.
    If you know that the CQL functions or expressions are safe, use
    `setIdempotent(true)` on the statement.
+
+3. The list of contact points provided at startup is now shuffled before trying
+   to open the control connection, so that multiple clients with the same contact
+   points don't all pick the same control host. As a result, you can't assume that
+   the driver will try contact points in a deterministic order. In particular, if
+   you use the `DCAwareRoundRobinPolicy` without specifying a primary datacenter
+   name, make sure that you only provide local hosts as contact points.
+
 
 ### 2.0.x to 2.0.10
 


### PR DESCRIPTION
This commit introduces the following enhancements:
- Randomize Cluster's initial contact points list;
- Randomize initial host index in DCAwareRoundRobinPolicy;
- Randomize returned rows from system.peers table in ControlConnection.
