### PR TITLE
JAVA-658 : Provide an option to cancel re-prepare all statements if onUp.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -32,6 +32,7 @@
 - [new feature] Make it possible to register for SchemaChange Events (JAVA-151)
 - [improvement] Downgrade "Asked to rebuild table" log from ERROR to INFO level (JAVA-861)
 - [improvement] Provide an option to prepare statements only on one node (JAVA-797)
+- [improvement] Provide an option to not re-prepare all statements in onUp (JAVA-658)
 
 Merged from 2.0.10_fixes branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1550,7 +1550,8 @@ public class Cluster implements Closeable {
                     }
 
                     try {
-                        reusedConnection = prepareAllQueries(host, reusedConnection);
+                        if (getCluster().getConfiguration().getQueryOptions().isReprepareOnUp())
+                            reusedConnection = prepareAllQueries(host, reusedConnection);
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                         // Don't propagate because we don't want to prevent other listener to run

--- a/driver-core/src/test/java/com/datastax/driver/core/SCassandraCluster.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SCassandraCluster.java
@@ -85,6 +85,16 @@ public class SCassandraCluster {
             scassandra.stop();
     }
 
+    public void start(int node) {
+        int i = node - 1;
+        scassandras.get(i).start();
+        primePeers(primingClients.get(i), scassandras.get(i));
+    }
+
+    public void stop(int node) {
+        scassandras.get(node - 1).stop();
+    }
+
     public SCassandraCluster prime(int node, PrimingRequest request) {
         primingClients.get(node - 1).prime(request);
         return this;


### PR DESCRIPTION
We have the same limitations as in #401 to write a deterministic test for this new option.
