### PR TITLE
Allow hosts to remain partially up (JAVA-544).

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -38,6 +38,7 @@
 - [improvement] Debounce control connection queries (JAVA-657)
 - [bug] LoadBalancingPolicy.distance() called before init() (JAVA-784)
 - [new feature] Make driver-side metadata optional (JAVA-828)
+- [improvement] Allow hosts to remain partially up (JAVA-544)
 
 Merged from 2.0.10_fixes branch:
 

--- a/clirr-ignores.xml
+++ b/clirr-ignores.xml
@@ -6,4 +6,20 @@
   * check the reports in `<module>/target/site/clirr-report.html`
   * add new differences if needed. Difference types are explained at http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html
 -->
-<differences/>
+<differences>
+  <difference>
+    <differenceType>1001</differenceType> <!-- decreased visibility -->
+    <className>com/datastax/driver/core/ConvictionPolicy$Factory</className>
+    <justification>False positive, the enclosing class is package-private so this was never exposed</justification>
+  </difference>
+  <difference>
+    <differenceType>8001</differenceType> <!-- class removed -->
+    <className>com/datastax/driver/core/ConvictionPolicy$Simple</className>
+    <justification>False positive, the enclosing class is package-private so this was never exposed</justification>
+  </difference>
+  <difference>
+    <differenceType>8001</differenceType> <!-- class removed -->
+    <className>com/datastax/driver/core/ConvictionPolicy$Simple$Factory</className>
+    <justification>False positive, the enclosing class is package-private so this was never exposed</justification>
+  </difference>
+</differences>

--- a/driver-core/src/main/java/com/datastax/driver/core/ConvictionPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ConvictionPolicy.java
@@ -15,6 +15,13 @@
  */
 package com.datastax.driver.core;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import com.datastax.driver.core.policies.ReconnectionPolicy;
+
 /**
  * The policy with which to decide whether a host should be considered down.
  *
@@ -26,23 +33,35 @@ package com.datastax.driver.core;
 abstract class ConvictionPolicy {
 
     /**
+     * Called when a new connection to the host has been successfully opened.
+     */
+    abstract void signalConnectionCreated();
+
+    /**
+     * Called when a connection closed normally.
+     */
+    abstract void signalConnectionClosed();
+
+    /**
      * Called when a connection error occurs on a connection to the host this policy applies to.
      *
      * @param exception the connection error that occurred.
-     *
-     * @return {@code true} if the host should be considered down.
+     * @param connectionInitialized whether the connection was initialized.
+     * @return whether the host should be considered down.
      */
-    public abstract boolean addFailure(ConnectionException exception);
+    abstract boolean signalConnectionFailure(ConnectionException exception, boolean connectionInitialized);
+
+    abstract boolean canReconnectNow();
 
     /**
-     * Called when the host has been detected up.
+     * Called when the host goes down.
      */
-    public abstract void reset();
+    abstract void reset();
 
     /**
      * Simple factory interface to allow creating {@link ConvictionPolicy} instances.
      */
-    public interface Factory {
+    interface Factory {
 
         /**
          * Creates a new ConvictionPolicy instance for {@code host}.
@@ -50,30 +69,89 @@ abstract class ConvictionPolicy {
          * @param host the host this policy applies to
          * @return the newly created {@link ConvictionPolicy} instance.
          */
-        public ConvictionPolicy create(Host host);
+        ConvictionPolicy create(Host host, ReconnectionPolicy reconnectionPolicy);
     }
 
-    public static class Simple extends ConvictionPolicy {
-        private Simple(Host host) {
+    static class DefaultConvictionPolicy extends ConvictionPolicy {
+        private final Host host;
+        private final ReconnectionPolicy reconnectionPolicy;
+        private final AtomicInteger openConnections = new AtomicInteger();
+
+        private volatile long nextReconnectionTime = Long.MIN_VALUE;
+        private ReconnectionPolicy.ReconnectionSchedule reconnectionSchedule;
+
+        private DefaultConvictionPolicy(Host host, ReconnectionPolicy reconnectionPolicy) {
+            this.host = host;
+            this.reconnectionPolicy = reconnectionPolicy;
         }
 
         @Override
-        public boolean addFailure(ConnectionException exception) {
-            return true;
-        }
-
-        public boolean addFailureFromExternalDetector() {
-            return true;
+        void signalConnectionCreated() {
+            int newCount = openConnections.incrementAndGet();
+            Host.statesLogger.debug("[{}] new connection created, total = {}", host, newCount);
+            resetReconnectionTime();
         }
 
         @Override
-        public void reset() {}
+        void signalConnectionClosed() {
+            if (host.state == Host.State.DOWN)
+                return;
+            int remaining = openConnections.decrementAndGet();
+            assert remaining >= 0;
+            Host.statesLogger.debug("[{}] connection closed, remaining = {}", host, remaining);
+        }
 
-        public static class Factory implements ConvictionPolicy.Factory {
+        @Override
+        boolean signalConnectionFailure(ConnectionException exception, boolean wasFullyInitialized) {
+            if (host.state == Host.State.DOWN)
+                return false;
+
+            updateReconnectionTime();
+            int remaining = (wasFullyInitialized)
+                ? openConnections.decrementAndGet()
+                : openConnections.get();
+
+            assert remaining >= 0;
+            Host.statesLogger.debug("[{}] remaining connections = {}", host, remaining);
+            return remaining == 0;
+        }
+
+        private synchronized void updateReconnectionTime() {
+            long now = System.nanoTime();
+            if (nextReconnectionTime > now)
+                // Someone else updated the time before us
+                return;
+
+            if (reconnectionSchedule == null)
+                reconnectionSchedule = reconnectionPolicy.newSchedule();
+
+            long nextDelayMs = reconnectionSchedule.nextDelayMs();
+            Host.statesLogger.debug("[{}] preventing new connections for the next {} ms", host, nextDelayMs);
+            nextReconnectionTime = now + NANOSECONDS.convert(nextDelayMs, MILLISECONDS);
+        }
+
+        private synchronized void resetReconnectionTime() {
+            reconnectionSchedule = null;
+            nextReconnectionTime = Long.MIN_VALUE;
+        }
+
+        @Override
+        boolean canReconnectNow() {
+            return nextReconnectionTime == Long.MIN_VALUE ||
+                System.nanoTime() >= nextReconnectionTime;
+        }
+
+        @Override
+        synchronized void reset() {
+            openConnections.set(0);
+            resetReconnectionTime();
+        }
+
+        static class Factory implements ConvictionPolicy.Factory {
 
             @Override
-            public ConvictionPolicy create(Host host) {
-                return new Simple(host);
+            public ConvictionPolicy create(Host host, ReconnectionPolicy reconnectionPolicy) {
+                return new DefaultConvictionPolicy(host, reconnectionPolicy);
             }
         }
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/Host.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Host.java
@@ -27,8 +27,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.datastax.driver.core.utils.MoreFutures;
-
 /**
  * A Cassandra node.
  *
@@ -38,6 +36,7 @@ public class Host {
 
     private static final Logger logger = LoggerFactory.getLogger(Host.class);
 
+    static final Logger statesLogger = LoggerFactory.getLogger(Host.class.getName() + ".STATES");
 
     private final InetSocketAddress address;
 
@@ -46,7 +45,7 @@ public class Host {
     /** Ensures state change notifications for that host are handled serially */
     final ReentrantLock notificationsLock = new ReentrantLock(true);
 
-    private final ConvictionPolicy policy;
+    final ConvictionPolicy convictionPolicy;
     private final Cluster.Manager manager;
 
     // Tracks later reconnection attempts to that host so we avoid adding multiple tasks.
@@ -69,12 +68,12 @@ public class Host {
     // ClusterMetadata keeps one Host object per inet address and we rely on this (more precisely,
     // we rely on the fact that we can use Object equality as a valid equality), so don't use
     // that constructor but ClusterMetadata.getHost instead.
-    Host(InetSocketAddress address, ConvictionPolicy.Factory policy, Cluster.Manager manager) {
-        if (address == null || policy == null)
+    Host(InetSocketAddress address, ConvictionPolicy.Factory convictionPolicyFactory, Cluster.Manager manager) {
+        if (address == null || convictionPolicyFactory == null)
             throw new NullPointerException();
 
         this.address = address;
-        this.policy = policy.create(this);
+        this.convictionPolicy = convictionPolicyFactory.create(this, manager.reconnectionPolicy());
         this.manager = manager;
         this.defaultExecutionInfo = new ExecutionInfo(ImmutableList.of(this));
         this.state = State.ADDED;
@@ -276,15 +275,11 @@ public class Host {
 
     void setDown() {
         state = State.DOWN;
+        convictionPolicy.reset();
     }
 
     void setUp() {
-        policy.reset();
         state = State.UP;
-    }
-
-    boolean signalConnectionFailure(ConnectionException exception) {
-        return policy.addFailure(exception);
     }
 
     /**
@@ -314,26 +309,7 @@ public class Host {
         public void onUp(Host host);
 
         /**
-         * Called when a node is suspected to be dead.
-         * <p>
-         * A node is suspected to be dead when an error occurs on one of it's
-         * opened connection. As soon as an host is suspected, a connection attempt
-         * to that host is immediately tried. If this succeed, then it means that
-         * the connection was disfunctional but that the node was not really down.
-         * If this fails however, this means the node is truly dead, onDown() is
-         * called and further reconnection attempts are scheduled according to the
-         * {@link ReconnectionPolicy} in place.
-         * <p>
-         * When this event is triggered, it is possible to call the host
-         * {@link getInitialReconnectionAttemptFuture} method to wait until the
-         * initial and immediate reconnection attempt succeed or fail.
-         * <p>
-         * Note that some StateListener may ignore that event. If a node that
-         * that is suspected down turns out to be truly down (that is, the driver
-         * cannot successfully connect to it right away), then {@link onDown} will
-         * be called.
-         *
-         * @deprecated the suspicion mechanism has been disabled. This will never
+         * @deprecated the "suspicion" mechanism has been deprecated. This will never
          * get called.
          */
         @Deprecated

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -313,7 +313,7 @@ class RequestHandler {
                 return false;
             } catch (TimeoutException e) {
                 // We timeout, log it but move to the next node.
-                logError(host.getSocketAddress(), new DriverException("Timeout while trying to acquire available connection (you may want to increase the driver number of per-host connections)"));
+                logError(host.getSocketAddress(), new DriverException("Timeout while trying to acquire available connection (you may want to increase the driver number of per-host connections)", e));
                 return false;
             } catch (RuntimeException e) {
                 if (connection != null)

--- a/driver-core/src/test/java/com/datastax/driver/core/AbstractReconnectionHandlerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AbstractReconnectionHandlerTest.java
@@ -52,7 +52,7 @@ public class AbstractReconnectionHandlerTest {
         schedule = new MockReconnectionSchedule();
         work = new MockReconnectionWork();
         future.set(null);
-        handler = new AbstractReconnectionHandler(executor, schedule, future) {
+        handler = new AbstractReconnectionHandler("test", executor, schedule, future) {
             @Override
             protected Connection tryReconnect() throws ConnectionException, InterruptedException, UnsupportedProtocolVersionException, ClusterNameMismatchException {
                 return work.tryReconnect();
@@ -330,7 +330,7 @@ public class AbstractReconnectionHandlerTest {
     private void waitForCompletion() {
         executor.shutdown();
         try {
-            boolean shutdown = executor.awaitTermination(10, TimeUnit.SECONDS);
+            boolean shutdown = executor.awaitTermination(30, TimeUnit.SECONDS);
             if (!shutdown)
                 fail("executor ran for longer than expected");
         } catch (InterruptedException e) {

--- a/driver-core/src/test/java/com/datastax/driver/core/AbstractReplicationStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AbstractReplicationStrategyTest.java
@@ -25,7 +25,12 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.*;
+
+import com.datastax.driver.core.policies.ExponentialReconnectionPolicy;
 
 /**
  * Base class for replication strategy tests. Currently only supports testing
@@ -38,13 +43,13 @@ public class AbstractReplicationStrategyTest {
     protected static class HostMock extends Host {
         private final String address;
 
-        private HostMock(String address) throws UnknownHostException {
-            super(new InetSocketAddress(InetAddress.getByName(address), 9042), new ConvictionPolicy.Simple.Factory(), null);
+        private HostMock(String address, Cluster.Manager manager) throws UnknownHostException {
+            super(new InetSocketAddress(InetAddress.getByName(address), 9042), new ConvictionPolicy.DefaultConvictionPolicy.Factory(), manager);
             this.address = address;
         }
 
-        private HostMock(String address, String dc, String rack) throws UnknownHostException {
-            this(address);
+        private HostMock(String address, String dc, String rack, Cluster.Manager manager) throws UnknownHostException {
+            this(address, manager);
             this.setLocationInfo(dc, rack);
         }
 
@@ -81,7 +86,7 @@ public class AbstractReplicationStrategyTest {
      */
     protected static HostMock host(String address) {
         try {
-            return new HostMock(address);
+            return new HostMock(address, mock(Cluster.Manager.class));
         } catch (UnknownHostException ex) {
             throw new RuntimeException(ex); //wrap to avoid declarations
         }
@@ -93,7 +98,7 @@ public class AbstractReplicationStrategyTest {
      */
     protected static HostMock host(String address, String dc, String rack) {
         try {
-            return new HostMock(address, dc, rack);
+            return new HostMock(address, dc, rack, mock(Cluster.Manager.class));
         } catch (UnknownHostException ex) {
             throw new RuntimeException(ex); //wrap to avoid declarations
         }

--- a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
@@ -22,14 +22,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.datastax.driver.core.Assertions.assertThat;
+import static com.datastax.driver.core.TestUtils.nonDebouncingQueryOptions;
 
 import com.datastax.driver.core.policies.DelegatingLoadBalancingPolicy;
 import com.datastax.driver.core.policies.LoadBalancingPolicy;
@@ -111,6 +111,7 @@ public class ControlConnectionTest {
 
             cluster = Cluster.builder()
                     .addContactPoint(CCMBridge.ipOfNode(1))
+                    .withQueryOptions(nonDebouncingQueryOptions())
                     .build();
             cluster.init();
 

--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
@@ -299,47 +299,6 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
         }
     }
 
-    private void reprepareOnNewlyUpNodeTest(String ks, Session session) throws Exception {
-
-        ks = ks == null ? "" : ks + '.';
-
-        session.execute("INSERT INTO " + ks + "test (k, i) VALUES ('123', 17)");
-        session.execute("INSERT INTO " + ks + "test (k, i) VALUES ('124', 18)");
-
-        PreparedStatement ps = session.prepare("SELECT * FROM " + ks + "test WHERE k = ?");
-
-        assertEquals(session.execute(ps.bind("123")).one().getInt("i"), 17);
-
-        ccmBridge.stop();
-        waitForDown(CCMBridge.IP_PREFIX + '1', cluster);
-
-        ccmBridge.start();
-        waitFor(CCMBridge.IP_PREFIX + '1', cluster, 120);
-
-        try
-        {
-            assertEquals(session.execute(ps.bind("124")).one().getInt("i"), 18);
-        }
-        catch (NoHostAvailableException e)
-        {
-            System.out.println(">> " + e.getErrors());
-            throw e;
-        }
-    }
-
-    @Test(groups = "long", priority = Integer.MAX_VALUE)
-    public void reprepareOnNewlyUpNodeTest() throws Exception {
-        reprepareOnNewlyUpNodeTest(null, session);
-    }
-
-    @Test(groups = "long", priority = Integer.MAX_VALUE)
-    public void reprepareOnNewlyUpNodeNoKeyspaceTest() throws Exception {
-
-        // This is the same test than reprepareOnNewlyUpNodeTest, except that the
-        // prepared statement is prepared while no current keyspace is used
-        reprepareOnNewlyUpNodeTest(keyspace, cluster.connect());
-    }
-
     @Test(groups = "short")
     public void prepareWithNullValuesTest() throws Exception {
 

--- a/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
@@ -143,6 +144,14 @@ public class RecommissionedNodeTest {
             .isNotReconnectingFromDown();
     }
 
+    @BeforeMethod(groups = "long")
+    public void clearFields() {
+        // Clear cluster and ccm instances between tests.
+        mainCluster = null;
+        mainCcm = null;
+        otherCcm = null;
+    }
+
     @AfterMethod(groups = "long")
     public void teardown() {
         if (mainCluster != null)
@@ -164,8 +173,8 @@ public class RecommissionedNodeTest {
     }
 
     private static void waitForCountUpHosts(Cluster cluster, int expectedCount) throws InterruptedException {
-        int maxRetries = 30;
-        int interval = 10;
+        int maxRetries = 10;
+        int interval = 6;
 
         for (int i = 0; i <= maxRetries; i++) {
             int actualCount = countUpHosts(cluster);


### PR DESCRIPTION
When a connection fails, don't mark the host down immediately: keep going with the remaining connections, and periodically try to reopen the missing ones. Only mark the host down when the last connection goes down.

This expands `ConvictionPolicy` to track the number of connections per host.

Missing connections are reopened by the connection pool. This means it requires activity (borrow / return), so a completely inactive pool might not recreate its connections, even stay below its core size. I think that's a reasonable tradeoff, given that a separate reconnection process à la `AbstractReconnectionHandler` would add a lot of complexity.

On a side note, I've introduced a dedicated `Host.statesLogger`, in an attempt to centralize all logs related to host states.
