### PR TITLE
Fix for JAVA-854 including test case

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1347,7 +1347,7 @@ public class Cluster implements Closeable {
 
                     if (!connectionFactory.protocolVersion.isSupportedBy(host)) {
                         logUnsupportedVersionProtocol(host, connectionFactory.protocolVersion);
-                        return;
+                        continue;
                     }
                     
                     if (!contactPointHosts.contains(host))

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -279,6 +279,10 @@ public class CCMBridge {
         execute(CCM_COMMAND + " updateconf " + confStr);
     }
 
+    public void setNodeVersion(int n, String version) {
+        execute(CCM_COMMAND + " setdir -v %s -n node%d", version, n);
+    }
+    
     private void execute(String command, Object... args) {
 
         String fullCommand = String.format(command, args) + " --config-dir=" + ccmDir;


### PR DESCRIPTION
This PR is adding a test for the rather trivial to fix [JAVA-854](https://datastax-oss.atlassian.net/browse/JAVA-854). 
There are probably more places where an integration test for mixed protocol versions could be useful, but I started to write a test for `TokenAwarePolicy` as I wondered how it would deal with incompatible nodes. 

Please note this PR depends on https://github.com/pcmanus/ccm/pull/345 to allow changing the version of individual nodes. 
