### PR TITLE
Handle contact points removed during init (JAVA-792).

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -27,6 +27,7 @@
 - [improvement] implement UPDATE ... IF EXISTS in QueryBuilder (JAVA-827)
 - [improvement] Randomize contact points list to prevent hotspots (JAVA-618)
 - [improvement] Surface the coordinator used on query failure (JAVA-720)
+- [bug] Handle contact points removed during init (JAVA-792)
 
 Merged from 2.0.10_fixes branch:
 

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterAssert.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.driver.core;
 
+import java.net.InetSocketAddress;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.TreeSet;
@@ -44,9 +45,17 @@ public class ClusterAssert extends AbstractAssert<ClusterAssert, Cluster> {
     public HostAssert host(int hostNumber) {
         // TODO at some point this won't work anymore if we have assertions that wait for a node to
         // join the cluster, e.g. assertThat(cluster).node(3).comesUp().
-        Host host = TestUtils.findHost(actual, hostNumber);
+        return new HostAssert(
+            TestUtils.findHost(actual, hostNumber),
+            actual);
+    }
 
-        return new HostAssert(host, actual);
+    public HostAssert host(String hostAddress) {
+        // TODO at some point this won't work anymore if we have assertions that wait for a node to
+        // join the cluster, e.g. assertThat(cluster).node(3).comesUp().
+        return new HostAssert(
+            TestUtils.findHost(actual, hostAddress),
+            actual);
     }
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
@@ -17,28 +17,36 @@ package com.datastax.driver.core;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import org.scassandra.Scassandra;
+import org.scassandra.http.client.PrimingClient;
+import org.scassandra.http.client.PrimingRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
-import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.datastax.driver.core.policies.ConstantReconnectionPolicy;
-import com.datastax.driver.core.querybuilder.Insert;
-import com.datastax.driver.core.utils.UUIDs;
 
+import static com.datastax.driver.core.Assertions.*;
 import static com.datastax.driver.core.FakeHost.Behavior.THROWING_CONNECT_TIMEOUTS;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.Host.State.DOWN;
+import static com.datastax.driver.core.Host.State.UP;
+import static com.datastax.driver.core.HostDistance.LOCAL;
 
 public class ClusterInitTest {
     private static final Logger logger = LoggerFactory.getLogger(ClusterInitTest.class);
@@ -47,44 +55,58 @@ public class ClusterInitTest {
      * Test for JAVA-522: when the cluster and session initialize, if some contact points are behaving badly and
      * causing timeouts, we want to ensure that the driver does not wait multiple times on the same host.
      */
-
     @Test(groups = "short")
-    public void should_wait_for_each_contact_point_at_most_once() {
-        CCMBridge ccm = null;
+    public void should_handle_failing_or_missing_contact_points() throws UnknownHostException {
         Cluster cluster = null;
-        List<FakeHost> fakeHosts = Lists.newArrayList();
+        Scassandra scassandra = null;
+        List<FakeHost> failingHosts = Lists.newArrayList();
         try {
-            // Obtaining connect timeouts is not trivial: we create a 6-host cluster but only start one of them,
-            // then simulate the other 5.
-            ccm = CCMBridge.builder("test").withNodes(6).notStarted().build();
-            ccm.start(1);
+            // Simulate a cluster of 5 hosts.
 
-            for (int i = 0; i < 5; i++) {
-                FakeHost fakeHost = new FakeHost(CCMBridge.ipOfNode(i + 2), 9042, THROWING_CONNECT_TIMEOUTS);
-                fakeHosts.add(fakeHost);
-                fakeHost.start();
+            // - 1 is an actual Scassandra instance that will accept connections:
+            scassandra = TestUtils.createScassandraServer();
+            scassandra.start();
+            String realHostAddress = "localhost";
+            int port = scassandra.getBinaryPort();
+
+            // - the remaining 4 are fake servers that will throw connect timeouts:
+            for (int i = 2; i <= 5; i++) {
+                FakeHost failingHost = new FakeHost(CCMBridge.ipOfNode(i), port, THROWING_CONNECT_TIMEOUTS);
+                failingHosts.add(failingHost);
+                failingHost.start();
             }
 
-            // Our real instance has no rows in its system.peers table. That would cause the driver to ignore our fake
-            // hosts when the control connection refreshes the host list.
-            // So we also insert fake rows in system.peers:
-            fakePeerRowsInNode1();
+            // - we also have a "missing" contact point, i.e. there's no server listening at this address,
+            //   and the address is not listed in the live host's system.peers
+            String missingHostAddress = CCMBridge.ipOfNode(6);
+
+            primePeerRows(scassandra, failingHosts);
 
             logger.info("Environment is set up, starting test");
             long start = System.nanoTime();
 
-            // We want to count how many connections were attempted. For that, we rely on the fact that SocketOptions.getKeepAlive is called in Connection.Factory.newBoostrap()
-            // each time we prepare to open a new connection. This is a bit of a hack, but this is what we have.
+            // We want to count how many connections were attempted. For that, we rely on the fact that SocketOptions.getKeepAlive
+            // is called in Connection.Factory.newBoostrap() each time we prepare to open a new connection.
             SocketOptions socketOptions = spy(new SocketOptions());
 
-            // Set an enormous delay so that reconnection attempts don't pollute our observations
+            // Set an "infinite" reconnection delay so that reconnection attempts don't pollute our observations
             ConstantReconnectionPolicy reconnectionPolicy = new ConstantReconnectionPolicy(3600 * 1000);
 
-            cluster = Cluster.builder().addContactPoints(
-                CCMBridge.ipOfNode(1), CCMBridge.ipOfNode(2), CCMBridge.ipOfNode(3),
-                CCMBridge.ipOfNode(4), CCMBridge.ipOfNode(5), CCMBridge.ipOfNode(6))
+            // Force 1 connection per pool. Otherwise we can't distinguish a failed pool creation from multiple connection
+            // attempts, because pools create their connections in parallel (so 1 pool failure equals multiple connection failures).
+            PoolingOptions poolingOptions = new PoolingOptions().setConnectionsPerHost(LOCAL, 1, 1);
+
+            cluster = Cluster.builder()
+                .withPort(scassandra.getBinaryPort())
+                .addContactPoints(
+                    realHostAddress,
+                    failingHosts.get(0).address, failingHosts.get(1).address,
+                    failingHosts.get(2).address, failingHosts.get(3).address,
+                    missingHostAddress
+                )
                 .withSocketOptions(socketOptions)
                 .withReconnectionPolicy(reconnectionPolicy)
+                .withPoolingOptions(poolingOptions)
                 .withProtocolVersion(TestUtils.getDesiredProtocolVersion())
                 .build();
             cluster.connect();
@@ -93,72 +115,80 @@ public class ClusterInitTest {
             long initTimeMs = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS);
             logger.info("Cluster and session initialized in {} ms", initTimeMs);
 
-            // We have one live host so we expect 1 control connection + core connection count successful connections.
-            // The other 5 hosts are unreachable, we should attempt to connect to each of them only once.
-            int coreConnections = cluster.getConfiguration()
-                    .getPoolingOptions()
-                    .getCoreConnectionsPerHost(HostDistance.LOCAL);
-            verify(socketOptions, times(1 + coreConnections + 5)).getKeepAlive();
+            // Expect :
+            // - 2 connections for the live host (1 control connection + 1 pooled connection)
+            // - 1 attempt per failing host (either a control connection attempt or a failed pool creation)
+            // - 0 or 1 for the missing host. We can't know for sure because contact points are randomized. If it's tried
+            //   before the live host there will be a connection attempt, otherwise it will be removed directly because
+            //   it's not in the live host's system.peers.
+            verify(socketOptions, atLeast(6)).getKeepAlive();
+            verify(socketOptions, atMost(7)).getKeepAlive();
+
+            assertThat(cluster).host(realHostAddress).hasState(UP);
+            for (FakeHost failingHost : failingHosts)
+                assertThat(cluster).host(failingHost.address).hasState(DOWN);
+            assertThat(cluster).host(missingHostAddress).isNull();
+
         } finally {
             if (cluster != null)
                 cluster.close();
-            for (FakeHost fakeHost : fakeHosts)
+            for (FakeHost fakeHost : failingHosts)
                 fakeHost.stop();
-            if (ccm != null)
-                ccm.remove();
+            if (scassandra != null)
+                scassandra.stop();
         }
     }
 
     /**
-     * <p>
      * Validates that a Cluster that was never able to successfully establish connection a session can be closed
      * properly.
      *
      * @test_category connection
      * @expected_result Cluster closes within 1 second.
      */
-    @Test(groups="unit")
+    @Test(groups = "unit")
     public void should_be_able_to_close_cluster_that_never_successfully_connected() throws Exception {
         Cluster cluster = Cluster.builder()
-                .addContactPointsWithPorts(Collections.singleton(new InetSocketAddress("127.0.0.1", 65534)))
-                .build();
+            .addContactPointsWithPorts(Collections.singleton(new InetSocketAddress("127.0.0.1", 65534)))
+            .build();
         try {
             cluster.connect();
             fail("Should not have been able to connect.");
-        } catch(NoHostAvailableException e) {} // Expected.
+        } catch (NoHostAvailableException e) {
+        } // Expected.
         CloseFuture closeFuture = cluster.closeAsync();
         try {
             closeFuture.get(1, TimeUnit.SECONDS);
-        } catch(TimeoutException e) {
+        } catch (TimeoutException e) {
             fail("Close Future did not complete quickly.");
         }
     }
 
-    private void fakePeerRowsInNode1() {
-        Cluster cluster = null;
-        try {
-            cluster = Cluster.builder().addContactPoint(CCMBridge.ipOfNode(1)).build();
-            Session session = cluster.connect("system");
+    private void primePeerRows(Scassandra scassandra, List<FakeHost> otherHosts) throws UnknownHostException {
+        PrimingClient primingClient = PrimingClient.builder()
+            .withHost("localhost").withPort(scassandra.getAdminPort())
+            .build();
 
-            String releaseVersion = session.execute("SELECT release_version FROM local")
-                .one().getString("release_version");
+        List<Map<String, ?>> rows = Lists.newArrayListWithCapacity(5);
 
-            for (int i = 2; i <= 6; i++) {
-                Insert insertStmt = insertInto("peers")
-                    .value("peer", InetAddress.getByName(CCMBridge.ipOfNode(i)))
-                    .value("data_center", "datacenter1")
-                    .value("host_id", UUIDs.random())
-                    .value("rack", "rack1")
-                    .value("release_version", releaseVersion)
-                    .value("rpc_address", InetAddress.getByName(CCMBridge.ipOfNode(i)))
-                    .value("schema_version", UUIDs.random());
-                session.execute(insertStmt);
-            }
-        } catch (Exception e) {
-            fail("Error while inserting fake peer rows", e);
-        } finally {
-            if (cluster != null)
-                cluster.close();
+        int i = 0;
+        for (FakeHost otherHost : otherHosts) {
+            InetAddress address = InetAddress.getByName(otherHost.address);
+            rows.add(ImmutableMap.<String, Object>builder()
+                .put("peer", address)
+                .put("rpc_address", address)
+                .put("data_center", "datacenter1")
+                .put("rack", "rack1")
+                .put("release_version", "2.0.1")
+                .put("tokens", ImmutableSet.of(Long.toString(Long.MIN_VALUE + i++)))
+                .build());
         }
+
+        primingClient.prime(
+            PrimingRequest.queryBuilder()
+                .withQuery("SELECT * FROM system.peers")
+                .withColumnTypes(SCassandraCluster.SELECT_PEERS_COLUMN_TYPES)
+                .withRows(rows)
+                .build());
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/FakeHost.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/FakeHost.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.fail;
 public class FakeHost {
     public enum Behavior {THROWING_CONNECT_TIMEOUTS, THROWING_OPERATION_TIMEOUTS}
 
-    private final String address;
+    final String address;
     private final int port;
     private final Behavior behavior;
     private final ExecutorService executor;

--- a/driver-core/src/test/java/com/datastax/driver/core/SCassandraCluster.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SCassandraCluster.java
@@ -134,7 +134,7 @@ public class SCassandraCluster {
                 .build());
     }
 
-    private static final ImmutableMap<String, ColumnTypes> SELECT_PEERS_COLUMN_TYPES =
+    static final ImmutableMap<String, ColumnTypes> SELECT_PEERS_COLUMN_TYPES =
         ImmutableMap.<String, ColumnTypes>builder()
             .put("peer", ColumnTypes.Inet)
             .put("rpc_address", ColumnTypes.Inet)

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -24,8 +24,6 @@ import java.net.ServerSocket;
 import java.nio.ByteBuffer;
 import java.util.*;
 
-import static org.testng.Assert.fail;
-
 import org.scassandra.Scassandra;
 import org.scassandra.ScassandraFactory;
 import org.slf4j.Logger;
@@ -382,15 +380,19 @@ public abstract class TestUtils {
         }
     }
 
-    /** Utility method to find the {@code Host} object corresponding to a node in a cluster. */
     public static Host findHost(Cluster cluster, int hostNumber) {
-        String address = CCMBridge.ipOfNode(hostNumber);
-        for (Host host : cluster.getMetadata().getAllHosts()) {
+        return findHost(cluster, CCMBridge.ipOfNode(hostNumber));
+    }
+
+    public static Host findHost(Cluster cluster, String address) {
+        // Note: we can't rely on ProtocolOptions.getPort() to build an InetSocketAddress and call metadata.getHost,
+        // because the port doesn't have the correct value if addContactPointsWithPorts was used to create the Cluster
+        // (JAVA-860 will solve that)
+        for (Host host : cluster.getMetadata().allHosts()) {
             if (host.getAddress().getHostAddress().equals(address))
                 return host;
         }
-        fail(address + " not found in cluster metadata");
-        return null; // never reached
+        return null;
     }
 
     public static int numberOfLocalCoreConnections(Cluster cluster) {


### PR DESCRIPTION
Also refactored `ClusterInitTest` to use SCassandra, handle parallel pool creation and randomized contact points, and test for removed contact points.
