### PR TITLE
JAVA-880: TupleCodec and UDTCodec should treat empty ByteBuffers as empty values, not null values.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -5,6 +5,8 @@
 - [bug] Propagate CodecRegistry to nested UDTs (JAVA-847)
 - [improvement] Ability to store a default, shareable CodecRegistry
   instance (JAVA-848)
+- [bug] Treat empty ByteBuffers as empty values in TupleCodec and
+  UDTCodec (JAVA-880)
 
 
 ### 2.2.0-rc2

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
@@ -2009,8 +2009,9 @@ public abstract class TypeCodec<T> {
 
         @Override
         public UDTValue deserialize(ByteBuffer bytes, ProtocolVersion protocolVersion) {
-            if (bytes == null || bytes.remaining() == 0)
+            if (bytes == null)
                 return null;
+            // empty byte buffers will result in empty UDTValues
             ByteBuffer input = bytes.duplicate();
             UDTValue value = definition.newValue();
 
@@ -2121,8 +2122,9 @@ public abstract class TypeCodec<T> {
 
         @Override
         public TupleValue deserialize(ByteBuffer bytes, ProtocolVersion protocolVersion) {
-            if (bytes == null || bytes.remaining() == 0)
+            if (bytes == null)
                 return null;
+            // empty byte buffers will result in empty TupleValues
             ByteBuffer input = bytes.duplicate();
             TupleValue value = definition.newValue();
 


### PR DESCRIPTION
See https://datastax-oss.atlassian.net/browse/JAVA-880
