### PR TITLE
JAVA-885 Pass server authenticator class through to new authenticator

### DIFF
--- a/clirr-ignores.xml
+++ b/clirr-ignores.xml
@@ -9,4 +9,24 @@
   * add new differences if needed. Difference types are explained at http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html
 -->
 <differences>
+  <difference>
+    <differenceType>7004</differenceType> <!-- api change -->
+    <className>com/datastax/driver/core/AuthProvider</className>
+    <method>com.datastax.driver.core.Authenticator newAuthenticator(java.net.InetSocketAddress)</method>
+    <justification>A change to the newAuthenticator method to allow passing the configured server authenticator</justification>
+  </difference>
+
+  <difference>
+    <differenceType>7004</differenceType> <!-- api change -->
+    <className>com/datastax/driver/core/PlainTextAuthProvider</className>
+    <method>com.datastax.driver.core.Authenticator newAuthenticator(java.net.InetSocketAddress)</method>
+    <justification>A change to the newAuthenticator method to allow passing the configured server authenticator</justification>
+  </difference>
+
+  <difference>
+    <differenceType>7004</differenceType> <!-- api change -->
+    <className>com/datastax/driver/auth/DseAuthProvider</className>
+    <method>com.datastax.driver.core.Authenticator newAuthenticator(java.net.InetSocketAddress)</method>
+    <justification>A change to the newAuthenticator method to allow passing the configured server authenticator</justification>
+  </difference>
 </differences>

--- a/driver-core/src/main/java/com/datastax/driver/core/AuthProvider.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AuthProvider.java
@@ -34,7 +34,7 @@ public interface AuthProvider {
      * This is only useful as a placeholder when no authentication is to be used.
      */
     public static final AuthProvider NONE = new AuthProvider() {
-        public Authenticator newAuthenticator(InetSocketAddress host) {
+        public Authenticator newAuthenticator(InetSocketAddress host, String authenticator) {
             throw new AuthenticationException(host,
                 String.format("Host %s requires authentication, but no authenticator found in Cluster configuration", host));
         }
@@ -44,7 +44,8 @@ public interface AuthProvider {
      * The {@code Authenticator} to use when connecting to {@code host}
      *
      * @param host the Cassandra host to connect to.
+     * @param authenticator the configured authenticator on the host.
      * @return The authentication implementation to use.
      */
-    public Authenticator newAuthenticator(InetSocketAddress host) throws AuthenticationException;
+    public Authenticator newAuthenticator(InetSocketAddress host, String authenticator) throws AuthenticationException;
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -250,7 +250,8 @@ class Connection {
                             throw unsupportedProtocolVersionException(protocolVersion, error.serverProtocolVersion);
                         throw new TransportException(address, String.format("Error initializing connection: %s", error.message));
                     case AUTHENTICATE:
-                        Authenticator authenticator = factory.authProvider.newAuthenticator(address);
+                        Responses.Authenticate authenticate = (Responses.Authenticate)response;
+                        Authenticator authenticator = factory.authProvider.newAuthenticator(address, authenticate.authenticator);
                         switch (protocolVersion) {
                             case V1:
                                 if (authenticator instanceof ProtocolV1Authenticator)

--- a/driver-core/src/main/java/com/datastax/driver/core/PlainTextAuthProvider.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PlainTextAuthProvider.java
@@ -52,10 +52,11 @@ public class PlainTextAuthProvider implements AuthProvider {
      * to the server.
      *
      * @param host the Cassandra host with which we want to authenticate
+     * @param authenticator the configured authenticator on the host
      * @return an Authenticator instance which can be used to perform
      * authentication negotiations on behalf of the client
      */
-    public Authenticator newAuthenticator(InetSocketAddress host) {
+    public Authenticator newAuthenticator(InetSocketAddress host, String authenticator) {
         return new PlainTextAuthenticator(username, password);
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/ReconnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReconnectionTest.java
@@ -316,7 +316,7 @@ public class ReconnectionTest {
             this.password = password;
         }
 
-        public Authenticator newAuthenticator(InetSocketAddress host) {
+        public Authenticator newAuthenticator(InetSocketAddress host, String authenticator) {
             return new PlainTextAuthenticator();
         }
 

--- a/driver-dse/src/main/java/com/datastax/driver/auth/DseAuthProvider.java
+++ b/driver-dse/src/main/java/com/datastax/driver/auth/DseAuthProvider.java
@@ -80,7 +80,7 @@ import java.net.InetSocketAddress;
 public class DseAuthProvider implements AuthProvider
 {
     @Override
-    public Authenticator newAuthenticator(InetSocketAddress host) throws AuthenticationException
+    public Authenticator newAuthenticator(InetSocketAddress host, String authenticator) throws AuthenticationException
     {
         return new KerberosAuthenticator(host);
     }


### PR DESCRIPTION
This takes the server side authenticator class name that is passed in with the `AUTHENTICATE` message and passes it on the `newAuthenticator` method so that authenticators can make runtime decisions about how to authenticate.
