### PR TITLE
JAVA-899 Use isTraceEnabled in CodecRegistry where trace is used.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 2.2.0-rc4
+- [improvement] Use isTraceEnabled in CodecRegistry where trace is used. (JAVA-899)
+
 ### 2.2.0-rc3
 
 - [bug] Propagate CodecRegistry to nested UDTs (JAVA-847)

--- a/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
@@ -451,11 +451,13 @@ public final class CodecRegistry {
 
     private <T> TypeCodec<T> lookupCodec(DataType cqlType, TypeToken<T> javaType) {
         checkNotNull(cqlType, "Parameter cqlType cannot be null");
-        logger.trace("Querying cache for codec [{} <-> {}]", cqlType, javaType);
+        if(logger.isTraceEnabled())
+            logger.trace("Querying cache for codec [{} <-> {}]", cqlType, javaType);
         CacheKey cacheKey = new CacheKey(cqlType, javaType);
         try {
             TypeCodec<?> codec = cache.get(cacheKey);
-            logger.trace("Returning cached codec [{} <-> {}]", cqlType, javaType);
+            if(logger.isTraceEnabled())
+                logger.trace("Returning cached codec [{} <-> {}]", cqlType, javaType);
             return (TypeCodec<T>)codec;
         } catch (UncheckedExecutionException e) {
             if(e.getCause() instanceof CodecNotFoundException) {
@@ -469,12 +471,14 @@ public final class CodecRegistry {
 
     private <T> TypeCodec<T> findCodec(DataType cqlType, TypeToken<T> javaType) {
         checkNotNull(cqlType, "Parameter cqlType cannot be null");
-        logger.trace("Looking for codec [{} <-> {}]",
-            cqlType == null ? "ANY" : cqlType,
-            javaType == null ? "ANY" : javaType);
+        if(logger.isTraceEnabled())
+            logger.trace("Looking for codec [{} <-> {}]",
+                cqlType == null ? "ANY" : cqlType,
+                javaType == null ? "ANY" : javaType);
         for (TypeCodec<?> codec : codecs) {
             if ((cqlType == null || codec.accepts(cqlType)) && (javaType == null || codec.accepts(javaType))) {
-                logger.trace("Codec found: {}", codec);
+                if(logger.isTraceEnabled())
+                    logger.trace("Codec found: {}", codec);
                 return (TypeCodec<T>)codec;
             }
         }
@@ -483,10 +487,12 @@ public final class CodecRegistry {
 
     private <T> TypeCodec<T> findCodec(DataType cqlType, T value) {
         checkNotNull(value, "Parameter value cannot be null");
-        logger.trace("Looking for codec [{} <-> {}]", cqlType == null ? "ANY" : cqlType, value.getClass());
+        if(logger.isTraceEnabled())
+            logger.trace("Looking for codec [{} <-> {}]", cqlType == null ? "ANY" : cqlType, value.getClass());
         for (TypeCodec<?> codec : codecs) {
             if ((cqlType == null || codec.accepts(cqlType)) && codec.accepts(value)) {
-                logger.trace("Codec found: {}", codec);
+                if(logger.isTraceEnabled())
+                    logger.trace("Codec found: {}", codec);
                 return (TypeCodec<T>)codec;
             }
         }
@@ -500,7 +506,8 @@ public final class CodecRegistry {
         // double-check that the created codec satisfies the initial request
         if (!codec.accepts(cqlType) || (javaType != null && !codec.accepts(javaType)))
             throw newException(cqlType, javaType);
-        logger.trace("Codec created: {}", codec);
+        if(logger.isTraceEnabled())
+            logger.trace("Codec created: {}", codec);
         return codec;
     }
 
@@ -511,7 +518,8 @@ public final class CodecRegistry {
         // double-check that the created codec satisfies the initial request
         if((cqlType != null && !codec.accepts(cqlType)) || !codec.accepts(value))
             throw newException(cqlType, TypeToken.of(value.getClass()));
-        logger.trace("Codec created: {}", codec);
+        if(logger.isTraceEnabled())
+            logger.trace("Codec created: {}", codec);
         return codec;
     }
 


### PR DESCRIPTION
Minor change to use 'isTraceEnabled()' in CodecRegistry for [JAVA-899](https://datastax-oss.atlassian.net/browse/JAVA-899).  After some microbenchmarking this doesn't seem to have made any difference throughput-wise, but I still think it's worth checking.  There were 2 other trace calls in the driver in Connection.java that don't check isTraceEnabled that I will update on the 2.0 branch.
##### Without isTraceEnabled()

```
Benchmark                                                Mode  Cnt         Score        Error  Units
CodecRegistryBenchmark.codecForWithDataTypeAndClass     thrpt   40  10161877.234 ± 537363.267  ops/s
CodecRegistryBenchmark.codecForWithDataTypeAndToken     thrpt   40  10997595.418 ± 620316.110  ops/s
CodecRegistryBenchmark.codecForWithNoDataType           thrpt   40    856435.550 ±  43492.977  ops/s
CodecRegistryBenchmark.codecForWithNoDataTypeBestCase   thrpt   40   4286882.168 ± 191963.935  ops/s
CodecRegistryBenchmark.codecForWithNoDataTypeWorstCase  thrpt   40     68979.731 ±   3913.868  ops/s
RowBenchmark.getObject                                  thrpt   40   2528969.380 ± 172483.368  ops/s
RowBenchmark.getWithToken                               thrpt   40   2503465.997 ± 155421.694  ops/s
```
##### With isTraceEnabled()

```
Benchmark                                                Mode  Cnt         Score        Error  Units
CodecRegistryBenchmark.codecForWithDataTypeAndClass     thrpt   40   9593448.056 ± 430546.988  ops/s
CodecRegistryBenchmark.codecForWithDataTypeAndToken     thrpt   40  10965278.538 ± 523017.248  ops/s
CodecRegistryBenchmark.codecForWithNoDataType           thrpt   40    855637.588 ±  50067.211  ops/s
CodecRegistryBenchmark.codecForWithNoDataTypeBestCase   thrpt   40   4142871.211 ± 257956.479  ops/s
CodecRegistryBenchmark.codecForWithNoDataTypeWorstCase  thrpt   40     65764.214 ±   3059.630  ops/s
RowBenchmark.getObject                                  thrpt   40   2605139.928 ± 128551.449  ops/s
RowBenchmark.getWithToken                               thrpt   40   2411576.277 ± 113910.636  ops/s
```
