### PR TITLE
Fix loop syntax

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -313,11 +313,12 @@ public abstract class TestUtils {
     }
 
     private static void waitFor(String node, Cluster cluster, int maxTry, boolean waitForDead, boolean waitForOut) {
-        if (waitForDead || waitForOut)
+        if (waitForDead || waitForOut) {
             if (waitForDead)
                 logger.info("Waiting for stopped node: " + node);
             else if (waitForOut)
                 logger.info("Waiting for decommissioned node: " + node);
+        }
         else
             logger.info("Waiting for upcoming node: " + node);
 


### PR DESCRIPTION
Without this fix, the message `waiting for upcoming node` is never displayed
