### PR TITLE
Add note that by default null fields are saved.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -28,8 +28,6 @@ import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.datastax.driver.core.exceptions.DriverInternalError;
-
 import static com.datastax.driver.core.SchemaElement.KEYSPACE;
 import static com.datastax.driver.core.SchemaElement.TABLE;
 import static com.datastax.driver.core.SchemaElement.TYPE;
@@ -88,7 +86,7 @@ public class Metadata {
                 return;
             }
             if (udtRows.containsKey(targetKeyspace)) {
-                Map<String, UserType> userTypes = buildUserTypes(keyspace, udtRows.get(targetKeyspace), cassandraVersion);
+                Map<String, UserType> userTypes = buildUserTypes(udtRows.get(targetKeyspace));
                 updateUserTypes(keyspace.userTypes, userTypes, targetName);
             }
         }
@@ -147,7 +145,7 @@ public class Metadata {
             for (TableMetadata table : tables.values()) {
                 keyspace.add(table);
             }
-            Map<String, UserType> userTypes = buildUserTypes(keyspace, udtRows.get(keyspace.getName()), cassandraVersion);
+            Map<String, UserType> userTypes = buildUserTypes(udtRows.get(keyspace.getName()));
             for (UserType userType : userTypes.values()) {
                 keyspace.add(userType);
             }
@@ -195,7 +193,7 @@ public class Metadata {
         return tables;
     }
 
-    private Map<String, UserType> buildUserTypes(KeyspaceMetadata keyspace, List<Row> udtRows, VersionNumber cassandraVersion) {
+    private Map<String, UserType> buildUserTypes(List<Row> udtRows) {
         Map<String, UserType> userTypes = new LinkedHashMap<String, UserType>();
         if (udtRows != null) {
             for (Row udtRow : udtRows) {
@@ -237,8 +235,9 @@ public class Metadata {
                 triggerOnKeyspaceChanged(newKeyspace, oldKeyspace);
             }
             Map<String, TableMetadata> oldTables = oldKeyspace == null ? new HashMap<String, TableMetadata>() : oldKeyspace.tables;
-            Map<String, TableMetadata> newTables = newKeyspace.tables;
-            updateTables(oldTables, newTables, null);
+            updateTables(oldTables, newKeyspace.tables, null);
+            Map<String, UserType> oldTypes = oldKeyspace == null ? new HashMap<String, UserType>() : oldKeyspace.userTypes;
+            updateUserTypes(oldTypes, newKeyspace.userTypes, null);
         }
     }
 

--- a/driver-core/src/test/resources/log4j.properties
+++ b/driver-core/src/test/resources/log4j.properties
@@ -16,7 +16,6 @@
 
 # Set root logger level to DEBUG and its only appender to A1.
 log4j.rootLogger=INFO, A1
-log4j.logger.com.datastax.driver.core.Host.STATES=DEBUG
 
 # Adjust Scassandra's log level
 # (it seems some messages are conditioned by log4j.properties and others by reference.conf, so we need both)

--- a/features/object_mapper/using/README.md
+++ b/features/object_mapper/using/README.md
@@ -86,9 +86,10 @@ underlying query:
 - `consistencyLevel`: specify a consistency level.
 - `tracing`: set tracing flag for the query.
 - `saveNullFields`: if set to true, fields with value `null` in an
-  instance that is to be persisted, will be explicitly written as `null`
+  instance that is to be persisted will be explicitly written as `null`
   in the query. If set to false, fields with null value won't be included
-  in the write query (thus avoiding tombstones).
+  in the write query (thus avoiding tombstones).  If not specified, the 
+  default behavior is to persist `null` fields.
 
 To use options, add them to the mapper call after regular parameters:
 


### PR DESCRIPTION
Just a simple doc update to make it more apparent that if 'saveNullFields' is not explicitly specified, the default behavior is to save null fields.
