### PR TITLE
Configure which hosts are managed in inner Policy (including DCAwareRoundRobinPolicy)

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/policies/HostFilterPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/HostFilterPolicy.java
@@ -1,0 +1,224 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.policies;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.base.Predicate;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.HostDistance;
+import com.datastax.driver.core.Statement;
+
+/**
+ * A load balancing policy wrapper that ensure that only hosts matching the predicate
+ * will ever be returned.
+ * <p>
+ * This policy wraps another load balancing policy and will delegate the choice
+ * of hosts to the wrapped policy with the exception that only hosts matching 
+ * the predicate provided when constructing this policy will ever be
+ * returned. Any host not matching the predicate will be considered {@code IGNORED}
+ * and thus will not be connected to.
+ * <p>
+ * This policy can be useful to ensure that the driver only connects to a
+ * predefined set of hosts. Keep in mind however that this policy defeats
+ * somewhat the host auto-detection of the driver. As such, this policy is only
+ * useful in a few special cases or for testing, but is not optimal in general.
+ * If all you want to do is limiting connections to hosts of the local
+ * data-center then you should use DCAwareRoundRobinPolicy and *not* this policy
+ * in particular.
+ */
+public class HostFilterPolicy implements ChainableLoadBalancingPolicy, CloseableLoadBalancingPolicy {
+    private final LoadBalancingPolicy childPolicy;
+    private final Predicate<Host> predicate;
+
+    /**
+     * Create a new policy that wraps the provided child policy but only "allow" hosts
+     * matching the predicate.
+     *
+     * @param childPolicy the wrapped policy.
+     * @param predicate the host predicate. Only hosts matching this predicate may get connected
+     * to (whether they will get connected to or not depends on the child policy).
+     */
+    public HostFilterPolicy(LoadBalancingPolicy childPolicy, Predicate<Host> predicate) {
+        this.childPolicy = childPolicy;
+        this.predicate = predicate;
+    }
+
+    @Override
+    public LoadBalancingPolicy getChildPolicy() {
+        return childPolicy;
+    }
+
+    /**
+     * Initialize this load balancing policy.
+     *
+     * @param cluster the {@code Cluster} instance for which the policy is created.
+     * @param hosts the initial hosts to use.
+     *
+     * @throws IllegalArgumentException if none of the host in {@code hosts}
+     * (which will correspond to the contact points) matches the predicate.
+     */
+    @Override
+    public void init(Cluster cluster, Collection<Host> hosts) {
+        List<Host> whiteHosts = new ArrayList<Host>(hosts.size());
+        for (Host host : hosts)
+            if (predicate.apply(host))
+                whiteHosts.add(host);
+
+        if (whiteHosts.isEmpty())
+            throw new IllegalArgumentException(String.format("Cannot use HostFilterPolicy where the filter allows none of the contacts points (%s)", hosts));
+
+        childPolicy.init(cluster, whiteHosts);
+    }
+
+    /**
+     * Return the HostDistance for the provided host.
+     *
+     * @param host the host of which to return the distance of.
+     * @return {@link HostDistance#IGNORED} if {@code host} is not matching the predicate, the HostDistance
+     * as returned by the wrapped policy otherwise.
+     */
+    @Override
+    public HostDistance distance(Host host) {
+        return predicate.apply(host)
+             ? childPolicy.distance(host)
+             : HostDistance.IGNORED;
+    }
+
+    /**
+     * Returns the hosts to use for a new query.
+     * <p>
+     * It is guaranteed that only hosts matching the predicate will be returned.
+     *
+     * @param loggedKeyspace the currently logged keyspace (the one set through either
+     * {@link Cluster#connect(String)} or by manually doing a {@code USE} query) for
+     * the session on which this plan need to be built. This can be {@code null} if
+     * the corresponding session has no keyspace logged in.
+     * @param statement the query for which to build a plan.
+     */
+    @Override
+    public Iterator<Host> newQueryPlan(String loggedKeyspace, Statement statement) {
+        // Just delegate to the child policy, since we filter the hosts not white
+        // listed upfront, the child policy will never see a host that is not white
+        // listed and thus can't return one.
+        return childPolicy.newQueryPlan(loggedKeyspace, statement);
+    }
+
+    @Override
+    public void onUp(Host host) {
+        if (predicate.apply(host))
+            childPolicy.onUp(host);
+    }
+
+    @Override
+    public void onSuspected(Host host) {
+        if (predicate.apply(host))
+            childPolicy.onSuspected(host);
+    }
+
+    @Override
+    public void onDown(Host host) {
+        if (predicate.apply(host))
+            childPolicy.onDown(host);
+    }
+
+    @Override
+    public void onAdd(Host host) {
+        if (predicate.apply(host))
+            childPolicy.onAdd(host);
+    }
+
+    @Override
+    public void onRemove(Host host) {
+        if (predicate.apply(host))
+            childPolicy.onRemove(host);
+    }
+
+    @Override
+    public void close() {
+        if (childPolicy instanceof CloseableLoadBalancingPolicy)
+            ((CloseableLoadBalancingPolicy)childPolicy).close();
+    }
+    
+    /**
+     * Create a new policy that wraps the provided child policy but only "allow/forbids" hosts
+     * from the provided list.
+     *
+     * @param childPolicy the wrapped policy.
+     * @param hosts the hosts.
+     * @param allow when true allow hosts from the provided list to be connected to 
+     * (whether they will get connected to or not depends on the child policy), otherwise forbids these hosts
+     */
+    public static HostFilterPolicy mkHostAddressListPolicy( LoadBalancingPolicy childPolicy, Collection<InetSocketAddress> hosts, boolean allow) {
+        Predicate<Host> predicate = mkHostAddressPredicate(hosts);
+        return new HostFilterPolicy(childPolicy, allow ? predicate : Predicates.not(predicate));
+    }
+    
+    /**
+     * Create a new policy that wraps the provided child policy but only "allow/forbids" hosts
+     * whose DC belongs to the provided list.
+     *
+     * @param childPolicy the wrapped policy.
+     * @param dcs the DCs.
+     * @param allow when true allow hosts whose DC from the provided list to be connected to 
+     * (whether they will get connected to or not depends on the child policy), otherwise forbids these hosts
+     */
+    public static HostFilterPolicy mkDCListPolicy( LoadBalancingPolicy childPolicy, Collection<String> dcs, boolean allow) {
+        Predicate<Host> predicate = mkHostDCPredicate(dcs, allow);
+        return new HostFilterPolicy(childPolicy, allow ? predicate : Predicates.not(predicate));
+    }
+    
+    /**
+     * Create a predicate based on membership to a list of addresses
+     * @param hosts the host addresses
+     * @return the predicate
+     */
+    public static Predicate<Host> mkHostAddressPredicate( Collection<InetSocketAddress> hosts) {
+        final ImmutableSet<InetSocketAddress> _hosts = ImmutableSet.copyOf(hosts);
+        return new Predicate<Host>() {
+            @Override
+            public boolean apply(Host host) {
+                return _hosts.contains(host.getSocketAddress());
+            }
+        };
+    }
+    
+    /**
+     * Create a predicate based on membership to a list of DCs
+     * @param dcs the data centers
+     * @param onNull the predicate value when host's DC is undefined
+     * @return the predicate
+     */
+    public static Predicate<Host> mkHostDCPredicate( Collection<String> dcs, final boolean onNull) {
+        final ImmutableSet<String> _dcs = ImmutableSet.copyOf(dcs);
+        return new Predicate<Host>() {
+            @Override
+            public boolean apply(Host host) {
+                String hdc = host.getDatacenter();
+                return (hdc == null) ? onNull : _dcs.contains(hdc);
+            }
+        };
+    }
+
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/HostFilterPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/HostFilterPolicy.java
@@ -13,6 +13,7 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
+
 package com.datastax.driver.core.policies;
 
 import java.net.InetSocketAddress;
@@ -131,6 +132,7 @@ public class HostFilterPolicy implements ChainableLoadBalancingPolicy, Closeable
             childPolicy.onUp(host);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void onSuspected(Host host) {
         if (predicate.apply(host))

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/WhiteListPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/WhiteListPolicy.java
@@ -46,10 +46,9 @@ import com.datastax.driver.core.Statement;
  * If all you want to do is limiting connections to hosts of the local
  * data-center then you should use DCAwareRoundRobinPolicy and *not* this policy
  * in particular.
+ * @see HostFilterPolicy
  */
-public class WhiteListPolicy implements ChainableLoadBalancingPolicy, CloseableLoadBalancingPolicy {
-    private final LoadBalancingPolicy childPolicy;
-    private final Set<InetSocketAddress> whiteList;
+public class WhiteListPolicy extends HostFilterPolicy {
 
     /**
      * Create a new policy that wraps the provided child policy but only "allow" hosts
@@ -60,103 +59,7 @@ public class WhiteListPolicy implements ChainableLoadBalancingPolicy, CloseableL
      * to (whether they will get connected to or not depends on the child policy).
      */
     public WhiteListPolicy(LoadBalancingPolicy childPolicy, Collection<InetSocketAddress> whiteList) {
-        this.childPolicy = childPolicy;
-        this.whiteList = ImmutableSet.copyOf(whiteList);
+        super( childPolicy, HostFilterPolicy.mkHostAddressPredicate(whiteList));
     }
 
-    @Override
-    public LoadBalancingPolicy getChildPolicy() {
-        return childPolicy;
-    }
-
-    /**
-     * Initialize this load balancing policy.
-     *
-     * @param cluster the {@code Cluster} instance for which the policy is created.
-     * @param hosts the initial hosts to use.
-     *
-     * @throws IllegalArgumentException if none of the host in {@code hosts}
-     * (which will correspond to the contact points) are part of the white list.
-     */
-    @Override
-    public void init(Cluster cluster, Collection<Host> hosts) {
-        List<Host> whiteHosts = new ArrayList<Host>(hosts.size());
-        for (Host host : hosts)
-            if (whiteList.contains(host.getSocketAddress()))
-                whiteHosts.add(host);
-
-        if (whiteHosts.isEmpty())
-            throw new IllegalArgumentException(String.format("Cannot use WhiteListPolicy where the white list (%s) contains none of the contacts points (%s)", whiteList, hosts));
-
-        childPolicy.init(cluster, whiteHosts);
-    }
-
-    /**
-     * Return the HostDistance for the provided host.
-     *
-     * @param host the host of which to return the distance of.
-     * @return {@link HostDistance#IGNORED} if {@code host} is not part of the white list, the HostDistance
-     * as returned by the wrapped policy otherwise.
-     */
-    @Override
-    public HostDistance distance(Host host) {
-        return whiteList.contains(host.getSocketAddress())
-             ? childPolicy.distance(host)
-             : HostDistance.IGNORED;
-    }
-
-    /**
-     * Returns the hosts to use for a new query.
-     * <p>
-     * It is guaranteed that only hosts from the white list will be returned.
-     *
-     * @param loggedKeyspace the currently logged keyspace (the one set through either
-     * {@link Cluster#connect(String)} or by manually doing a {@code USE} query) for
-     * the session on which this plan need to be built. This can be {@code null} if
-     * the corresponding session has no keyspace logged in.
-     * @param statement the query for which to build a plan.
-     */
-    @Override
-    public Iterator<Host> newQueryPlan(String loggedKeyspace, Statement statement) {
-        // Just delegate to the child policy, since we filter the hosts not white
-        // listed upfront, the child policy will never see a host that is not white
-        // listed and thus can't return one.
-        return childPolicy.newQueryPlan(loggedKeyspace, statement);
-    }
-
-    @Override
-    public void onUp(Host host) {
-        if (whiteList.contains(host.getSocketAddress()))
-            childPolicy.onUp(host);
-    }
-
-    @Override
-    public void onSuspected(Host host) {
-        if (whiteList.contains(host.getSocketAddress()))
-            childPolicy.onSuspected(host);
-    }
-
-    @Override
-    public void onDown(Host host) {
-        if (whiteList.contains(host.getSocketAddress()))
-            childPolicy.onDown(host);
-    }
-
-    @Override
-    public void onAdd(Host host) {
-        if (whiteList.contains(host.getSocketAddress()))
-            childPolicy.onAdd(host);
-    }
-
-    @Override
-    public void onRemove(Host host) {
-        if (whiteList.contains(host.getSocketAddress()))
-            childPolicy.onRemove(host);
-    }
-
-    @Override
-    public void close() {
-        if (childPolicy instanceof CloseableLoadBalancingPolicy)
-            ((CloseableLoadBalancingPolicy)childPolicy).close();
-    }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/HostFilterPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/HostFilterPolicyTest.java
@@ -1,0 +1,346 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.datastax.driver.core.policies;
+
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.mockito.Matchers;
+import com.google.common.base.Predicates;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import org.mockito.Mockito;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import static com.datastax.driver.core.TestUtils.*;
+
+import com.datastax.driver.core.AbstractPoliciesTest;
+import com.datastax.driver.core.CCMBridge;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.HostDistance;
+import com.datastax.driver.core.MemoryAppender;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+
+import org.testng.annotations.Test;
+
+public class HostFilterPolicyTest extends AbstractPoliciesTest {
+
+    private final InetSocketAddress host0 = InetSocketAddress.createUnresolved("192.168.1.1", 2345);
+    private final InetSocketAddress host1 = InetSocketAddress.createUnresolved("192.168.1.2", 9876);
+    private final InetSocketAddress host2 = InetSocketAddress.createUnresolved("192.168.1.3", 6666);
+    
+    private final List<InetSocketAddress> hosts = ImmutableList.of(host0, host1);
+
+    private final List<String> dcs = ImmutableList.of("dc0", "dc1");
+
+    Logger policyLogger = Logger.getLogger(DCAwareRoundRobinPolicy.class);
+    MemoryAppender logs;
+    CCMBridge ccm;
+
+    @BeforeClass(groups = "short")
+    public void createCcm() {
+        // Two-DC cluster with one host in each DC
+        ccm = CCMBridge.builder("test").withNodes(1, 1).build();
+    }
+
+    @AfterClass(groups = "short")
+    public void deleteCcm() {
+        if (ccm != null)
+            ccm.remove();
+    }
+
+    @Test(groups = "unit")
+    public void testHostFilterPolicy() {
+        
+        Cluster cluster = Mockito.mock(Cluster.class);
+        List<Host> hosts = ImmutableList.of(Mockito.mock(Host.class), Mockito.mock(Host.class));
+
+        // Check that when the predicate returns true for a given host the policy acts as a pass through
+        {
+            Predicate<Host> predicate = Predicates.<Host>alwaysTrue();
+            
+            LoadBalancingPolicy ipolicy = Mockito.mock(LoadBalancingPolicy.class);
+            when(ipolicy.distance(any(Host.class))).thenReturn(HostDistance.LOCAL);
+            
+            HostFilterPolicy policy = new HostFilterPolicy(ipolicy, predicate);
+            
+            Host host = Mockito.mock(Host.class);
+
+            policy.onAdd(host);
+            Mockito.verify(ipolicy, times(1)).onAdd(host);
+            
+            policy.onDown(host);
+            Mockito.verify(ipolicy, times(1)).onDown(host);
+
+            policy.onUp(host);
+            Mockito.verify(ipolicy, times(1)).onUp(host);
+
+            policy.onRemove(host);
+            Mockito.verify(ipolicy, times(1)).onRemove(host);
+
+            policy.onSuspected(host);
+            Mockito.verify(ipolicy, times(1)).onSuspected(host);
+
+            assertThat(policy.distance(host)).isSameAs(HostDistance.LOCAL);
+            
+            policy.init(cluster, hosts);
+            Mockito.verify(ipolicy, times(1)).init(eq(cluster), eq(hosts));
+        }
+        
+        // Check that when the predicate returns false for a given host the policy filters out every action
+        {
+            Predicate<Host> predicate = Predicates.<Host>alwaysFalse();
+            
+            LoadBalancingPolicy ipolicy = Mockito.mock(LoadBalancingPolicy.class);
+            when(ipolicy.distance(any(Host.class))).thenReturn(HostDistance.LOCAL);
+
+            HostFilterPolicy policy = new HostFilterPolicy(ipolicy, predicate);
+            
+            Host host = Mockito.mock(Host.class);
+            
+            policy.onAdd(host);
+            Mockito.verify(ipolicy, never()).onAdd(host);
+            
+            policy.onDown(host);
+            Mockito.verify(ipolicy, never()).onDown(host);
+
+            policy.onUp(host);
+            Mockito.verify(ipolicy, never()).onUp(host);
+
+            policy.onRemove(host);
+            Mockito.verify(ipolicy, never()).onRemove(host);
+
+            policy.onSuspected(host);
+            Mockito.verify(ipolicy, never()).onSuspected(host);
+
+            assertThat(policy.distance(host)).isSameAs(HostDistance.IGNORED);
+            
+            try {
+                policy.init(cluster, hosts);
+                fail("should throw since no host can be passed to child policy");
+            }
+            catch( IllegalArgumentException e){
+                Mockito.verify(ipolicy, never()).init(any(Cluster.class), Matchers.anyCollectionOf(Host.class));
+            }
+        }
+    }
+    
+    @Test(groups = "unit")
+    public void testNewQueryPlan() {
+        
+        List<Host> hosts = ImmutableList.of(Mockito.mock(Host.class), Mockito.mock(Host.class));
+        
+        LoadBalancingPolicy ipolicy = Mockito.mock(LoadBalancingPolicy.class);
+        when(ipolicy.newQueryPlan(any(String.class), any(Statement.class))).thenReturn(hosts.iterator());
+        
+        HostFilterPolicy policy = new HostFilterPolicy(ipolicy, null);
+
+        assertThat(policy.newQueryPlan("keyspace", Mockito.mock(Statement.class)).next()).isSameAs(hosts.get(0));
+    }
+    
+    @Test(groups = "unit")
+    public void testClose() {
+        
+        new HostFilterPolicy(null, null).close();
+
+        CloseableLoadBalancingPolicy ipolicy = Mockito.mock(CloseableLoadBalancingPolicy.class);
+        new HostFilterPolicy(ipolicy, null).close();
+        Mockito.verify(ipolicy, times(1)).close();
+    }
+    
+    @Test(groups = "unit")
+    public void testMkHostAddressListPolicy() {
+        
+        LoadBalancingPolicy ipolicy = Mockito.mock(LoadBalancingPolicy.class);
+        when(ipolicy.distance(any(Host.class))).thenReturn(HostDistance.LOCAL);
+
+        Host hostInList = Mockito.mock(Host.class);
+        when(hostInList.getSocketAddress()).thenReturn(host0);
+        
+        Host hostOutList = Mockito.mock(Host.class);
+        when(hostOutList.getSocketAddress()).thenReturn(host2);
+        
+        // black list policy
+        {
+            HostFilterPolicy policy = HostFilterPolicy.mkHostAddressListPolicy(ipolicy, hosts, false);
+            
+            assertThat(policy.distance(hostInList)).isSameAs(HostDistance.IGNORED);
+            assertThat(policy.distance(hostOutList)).isSameAs(HostDistance.LOCAL);
+        }
+
+        // white list policy
+        {
+            HostFilterPolicy policy = HostFilterPolicy.mkHostAddressListPolicy(ipolicy, hosts, true);
+            
+            assertThat(policy.distance(hostInList)).isSameAs(HostDistance.LOCAL);
+            assertThat(policy.distance(hostOutList)).isSameAs(HostDistance.IGNORED);
+        }
+
+    }
+    
+    @Test(groups = "unit")
+    public void testMkDCListPolicy() {
+                
+        LoadBalancingPolicy ipolicy = Mockito.mock(LoadBalancingPolicy.class);
+        when(ipolicy.distance(any(Host.class))).thenReturn(HostDistance.LOCAL);
+
+        Host hostInList = Mockito.mock(Host.class);
+        when(hostInList.getDatacenter()).thenReturn("dc0");
+        
+        Host hostOutList = Mockito.mock(Host.class);
+        when(hostOutList.getDatacenter()).thenReturn("dc2");
+        
+        Host hostNoDC = Mockito.mock(Host.class);
+        when(hostNoDC.getDatacenter()).thenReturn(null);
+        
+        // black list policy
+        {
+            HostFilterPolicy policy = HostFilterPolicy.mkDCListPolicy(ipolicy, dcs, false);
+            
+            assertThat(policy.distance(hostInList)).isSameAs(HostDistance.IGNORED);
+            assertThat(policy.distance(hostOutList)).isSameAs(HostDistance.LOCAL);
+            assertThat(policy.distance(hostNoDC)).isSameAs(HostDistance.LOCAL);
+        }
+
+        // white list policy
+        {
+            HostFilterPolicy policy = HostFilterPolicy.mkDCListPolicy(ipolicy, dcs, true);
+            
+            assertThat(policy.distance(hostInList)).isSameAs(HostDistance.LOCAL);
+            assertThat(policy.distance(hostOutList)).isSameAs(HostDistance.IGNORED);
+            assertThat(policy.distance(hostNoDC)).isSameAs(HostDistance.LOCAL);
+        }
+
+    }
+    
+    @Test(groups = "unit")
+    public void testMkHostAddressPredicate() {
+        
+        Predicate<Host> predicate = HostFilterPolicy.mkHostAddressPredicate(ImmutableList.of(host0, host1));
+
+        {
+            Host host = Mockito.mock(Host.class);
+            Mockito.when( host.getSocketAddress()).thenReturn(host0);
+            
+            assertThat(predicate.apply(host)).isTrue();
+        }
+
+        {
+            Host host = Mockito.mock(Host.class);
+            Mockito.when( host.getSocketAddress()).thenReturn(host2);
+            
+            assertThat(predicate.apply(host)).isFalse();
+        }
+    }
+
+    @Test(groups = "unit")
+    public void testMkHostDCPredicate() {
+        
+        Predicate<Host> predicate = HostFilterPolicy.mkHostDCPredicate(dcs, true);
+
+        {
+            Host host = Mockito.mock(Host.class);
+            Mockito.when( host.getDatacenter()).thenReturn("dc0");
+            
+            assertThat(predicate.apply(host)).isTrue();
+        }
+
+        {
+            Host host = Mockito.mock(Host.class);
+            Mockito.when( host.getDatacenter()).thenReturn("dc2");
+            
+            assertThat(predicate.apply(host)).isFalse();
+        }
+
+        {
+            Host host = Mockito.mock(Host.class);
+            Mockito.when( host.getDatacenter()).thenReturn(null);
+            
+            assertThat(predicate.apply(host)).isTrue();
+            
+            Predicate<Host> predicateFalse = HostFilterPolicy.mkHostDCPredicate(dcs, false);
+            assertThat(predicateFalse.apply(host)).isFalse();
+        }
+    }
+
+    @Test(groups = "long")
+    public void DCAwareRoundRobinWithOneRemoteHostInForbiddenDCTest() throws Throwable {
+
+        HostFilterPolicy policy = HostFilterPolicy.mkDCListPolicy(new DCAwareRoundRobinPolicy("dc2", 1, false), Arrays.asList("dc1"), false);
+
+        Cluster.Builder builder = Cluster.builder().withLoadBalancingPolicy(policy);
+        
+        CCMBridge.CCMCluster c = CCMBridge.buildCluster(1, 1, builder);
+        try {
+
+            createMultiDCSchema(c.session);
+            init(c, 12);
+            query(c, 12);
+
+            assertQueried(CCMBridge.IP_PREFIX + '1', 0);
+            assertQueried(CCMBridge.IP_PREFIX + '2', 12);
+
+            resetCoordinators();
+            c.cassandraCluster.bootstrapNode(3, "dc3");
+            waitFor(CCMBridge.IP_PREFIX + '3', c.cluster);
+
+            query(c, 12);
+
+            assertQueried(CCMBridge.IP_PREFIX + '1', 0);
+            assertQueried(CCMBridge.IP_PREFIX + '2', 12);
+            assertQueried(CCMBridge.IP_PREFIX + '3', 0);
+
+            resetCoordinators();
+            c.cassandraCluster.decommissionNode(2);
+            waitForDecommission(CCMBridge.IP_PREFIX + '2', c.cluster);
+
+            query(c, 12);
+
+            assertQueried(CCMBridge.IP_PREFIX + '1', 0);
+            assertQueried(CCMBridge.IP_PREFIX + '2', 0);
+            assertQueried(CCMBridge.IP_PREFIX + '3', 12);
+
+            resetCoordinators();
+            c.cassandraCluster.forceStop(3);
+            waitForDown(CCMBridge.IP_PREFIX + '3', c.cluster);
+
+            try {
+                query(c, 12);
+                fail("");
+            } catch (NoHostAvailableException e) {
+                // No more nodes so ...
+            }
+
+        } catch (Throwable e) {
+            c.errorOut();
+            throw e;
+        } finally {
+            resetCoordinators();
+            c.discard();
+        }
+    }
+
+
+
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/HostFilterPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/HostFilterPolicyTest.java
@@ -20,9 +20,6 @@ import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.log4j.Logger;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.mockito.Matchers;
 import com.google.common.base.Predicates;
 import com.google.common.base.Predicate;
@@ -38,7 +35,6 @@ import com.datastax.driver.core.CCMBridge;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Host;
 import com.datastax.driver.core.HostDistance;
-import com.datastax.driver.core.MemoryAppender;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 
@@ -54,22 +50,7 @@ public class HostFilterPolicyTest extends AbstractPoliciesTest {
 
     private final List<String> dcs = ImmutableList.of("dc0", "dc1");
 
-    Logger policyLogger = Logger.getLogger(DCAwareRoundRobinPolicy.class);
-    MemoryAppender logs;
-    CCMBridge ccm;
-
-    @BeforeClass(groups = "short")
-    public void createCcm() {
-        // Two-DC cluster with one host in each DC
-        ccm = CCMBridge.builder("test").withNodes(1, 1).build();
-    }
-
-    @AfterClass(groups = "short")
-    public void deleteCcm() {
-        if (ccm != null)
-            ccm.remove();
-    }
-
+    @SuppressWarnings("deprecation")
     @Test(groups = "unit")
     public void testHostFilterPolicy() {
         

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/PoliciesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/PoliciesTest.java
@@ -1,0 +1,86 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.datastax.driver.core.policies;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.mockito.Mockito;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.HostDistance;
+import com.datastax.driver.core.policies.Policies.Builder;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+public class PoliciesTest {
+
+    @Test(groups = "unit")
+    public void testBuildLoadBalancingWithFilters() {
+        
+        LoadBalancingPolicy ipolicy = Mockito.mock(LoadBalancingPolicy.class);
+        when(ipolicy.distance(any(Host.class))).thenReturn(HostDistance.LOCAL);
+
+        InetSocketAddress addr0 = InetSocketAddress.createUnresolved("192.168.1.1", 2345);
+        InetSocketAddress addr1 = InetSocketAddress.createUnresolved("192.168.1.2", 9876);
+
+        List<InetSocketAddress> okAddresses = ImmutableList.of(addr0);
+        List<InetSocketAddress> koAddresses = ImmutableList.of(addr1);
+
+        List<String> okDCs = ImmutableList.of("dc0");
+        List<String> koDCs = ImmutableList.of("dc1");
+
+        Builder builder = Policies.builder()
+                        .withLoadBalancingPolicy(ipolicy)
+                        .withBlackListedDCs(koDCs)
+                        .withWhiteListedDCs(okDCs)
+                        .withBlackListedHosts(koAddresses)
+                        .withWhiteListedHosts(okAddresses);
+        
+        Policies policies = builder.build();
+
+        LoadBalancingPolicy policy = policies.getLoadBalancingPolicy();
+        
+        // OK: white listed address and data center
+        assertThat(policy.distance(mkHost(addr0, "dc0"))).isSameAs(HostDistance.LOCAL);
+        
+        // KO: black listed host and white listed data center
+        assertThat(policy.distance(mkHost(addr1, "dc0"))).isSameAs(HostDistance.IGNORED);
+
+        // KO: white listed host and black listed data center
+        assertThat(policy.distance(mkHost(addr0, "dc1"))).isSameAs(HostDistance.IGNORED);
+
+        // KO: black listed host and black listed data center
+        assertThat(policy.distance(mkHost(addr1, "dc1"))).isSameAs(HostDistance.IGNORED);
+
+        // OK: white listed host and undefined data center
+        assertThat(policy.distance(mkHost(addr0, null))).isSameAs(HostDistance.LOCAL);
+    }
+    
+    private static Host mkHost( InetSocketAddress addr, String dc ){
+        Host host = Mockito.mock(Host.class);
+        when(host.getSocketAddress()).thenReturn(addr);
+        when(host.getDatacenter()).thenReturn(dc);
+
+        return host;
+    }
+}


### PR DESCRIPTION
Add a filtering policy to prevent some host to be queried
(such as a the ones belonging to a dedicated DC).

Update from #439
