### PR TITLE
Enable jenkins builds.

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,21 @@
+java:
+  - openjdk6
+  - oraclejdk7
+  - oraclejdk8
+os:
+  - ubuntu/trusty64
+cassandra:
+  - 1.2
+  - 2.0
+build:
+  - type: maven
+    version: 3.2.5
+    goals: clean compile test --fail-never -Plong
+    properties: |
+      com.datastax.driver.TEST_BASE_NODE_WAIT=120
+      com.datastax.driver.NEW_NODE_DELAY_SECONDS=100
+      cassandra.version=$CCM_CASSANDRA_VERSION
+      ccm.java.home=$CCM_JAVA_HOME
+  - xunit:
+    - "**/target/surefire-reports/TEST-*.xml"
+    - "**/target/failsafe-reports/TEST-*.xml" 


### PR DESCRIPTION
Adds build.yaml for jenkins builds.  Creates a job in jenkins for each branch with build.yaml present that does the following:

For each jdk (openjdk6, oraclejdk7, oraclejdk8) and cassandra (latest major of 1.2, 2.0 and 2.1) combination runs 'long' integration tests and records the test results.
