### PR TITLE
JAVA-825: Parse materialized views metadata.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
@@ -37,7 +37,7 @@ public class ColumnMetadata {
     static final String INDEX_OPTIONS = "index_options";
     static final String INDEX_NAME = "index_name";
 
-    private final TableMetadata table;
+    private final TableOrView parent;
     private final String name;
     private final DataType type;
     private final boolean isStatic;
@@ -46,14 +46,14 @@ public class ColumnMetadata {
     // between columns and indexes, and is updated only after the column is created
     final Map<String, IndexMetadata> indexes = new LinkedHashMap<String, IndexMetadata>();
 
-    private ColumnMetadata(TableMetadata table, String name, DataType type, boolean isStatic) {
-        this.table = table;
+    private ColumnMetadata(TableOrView parent, String name, DataType type, boolean isStatic) {
+        this.parent = parent;
         this.name = name;
         this.type = type;
         this.isStatic = isStatic;
     }
 
-    static ColumnMetadata fromRaw(TableMetadata tm, Raw raw) {
+    static ColumnMetadata fromRaw(TableOrView tm, Raw raw) {
         return new ColumnMetadata(tm, raw.name, raw.dataType, raw.kind == Raw.Kind.STATIC);
     }
 
@@ -71,12 +71,13 @@ public class ColumnMetadata {
     }
 
     /**
-     * Returns the metadata of the table this column is part of.
+     * Returns the parent object of this column. This can be a {@link TableMetadata}
+     * or a {@link MaterializedViewMetadata} object.
      *
-     * @return the {@code TableMetadata} for the table this column is part of.
+     * @return the parent object of this column.
      */
-    public TableMetadata getTable() {
-        return table;
+    public TableOrView getParent() {
+        return parent;
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/IndexMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/IndexMetadata.java
@@ -116,7 +116,7 @@ public class IndexMetadata {
         } else {
             options = SimpleJSONParser.parseStringMap(indexOptionsCol);
         }
-        return new IndexMetadata(column.getTable(), indexName, columns, indexType, TargetType.COLUMN, options);
+        return new IndexMetadata((TableMetadata)column.getParent(), indexName, columns, indexType, TargetType.COLUMN, options);
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/KeyspaceMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/KeyspaceMetadata.java
@@ -42,6 +42,7 @@ public class KeyspaceMetadata {
     private final Map<String, String> replication;
 
     private final Map<String, TableMetadata> tables = new ConcurrentHashMap<String, TableMetadata>();
+    private final Map<String, MaterializedViewMetadata> views = new ConcurrentHashMap<String, MaterializedViewMetadata>();
     private final Map<String, UserType> userTypes = new ConcurrentHashMap<String, UserType>();
     final Map<String, FunctionMetadata> functions = new ConcurrentHashMap<String, FunctionMetadata>();
     private final Map<String, AggregateMetadata> aggregates = new ConcurrentHashMap<String, AggregateMetadata>();
@@ -121,6 +122,31 @@ public class KeyspaceMetadata {
      */
     public Collection<TableMetadata> getTables() {
         return Collections.<TableMetadata>unmodifiableCollection(tables.values());
+    }
+
+    /**
+     * Returns the metadata for a materialized view contained in this keyspace.
+     *
+     * @param name the name of materialized view to retrieve
+     * @return the metadata for materialized view {@code name} if it exists in this keyspace,
+     * {@code null} otherwise.
+     */
+    public MaterializedViewMetadata getMaterializedView(String name) {
+        return views.get(Metadata.handleId(name));
+    }
+
+    void removeMaterializedView(String materializedView) {
+        views.remove(materializedView);
+    }
+
+    /**
+     * Returns the materialized views defined in this keyspace.
+     *
+     * @return a collection of the metadata for the materialized views defined in this
+     * keyspace.
+     */
+    public Collection<MaterializedViewMetadata> getMaterializedViews() {
+        return Collections.unmodifiableCollection(views.values());
     }
 
     /**
@@ -289,6 +315,10 @@ public class KeyspaceMetadata {
 
     void add(TableMetadata tm) {
         tables.put(tm.getName(), tm);
+    }
+
+    void add(MaterializedViewMetadata view) {
+        views.put(view.getName(), view);
     }
 
     void add(FunctionMetadata function) {

--- a/driver-core/src/main/java/com/datastax/driver/core/MaterializedViewMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/MaterializedViewMetadata.java
@@ -1,0 +1,218 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.*;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.collect.Iterables.transform;
+
+/**
+ *  An immutable representation of a materialized view.
+ *  Materialized views are available starting from Cassandra 3.0.
+ */
+public class MaterializedViewMetadata extends TableOrView {
+
+    private static final Logger logger = LoggerFactory.getLogger(MaterializedViewMetadata.class);
+
+    private final TableMetadata baseTable;
+
+    private final boolean includeAllColumns;
+
+    private MaterializedViewMetadata(
+        KeyspaceMetadata keyspace,
+        TableMetadata baseTable,
+        String name,
+        UUID id,
+        List<ColumnMetadata> partitionKey,
+        List<ColumnMetadata> clusteringColumns,
+        Map<String, ColumnMetadata> columns,
+        boolean includeAllColumns,
+        Options options,
+        List<Order> clusteringOrder,
+        VersionNumber cassandraVersion) {
+        super(keyspace, name, id, partitionKey, clusteringColumns, columns, options, clusteringOrder, cassandraVersion);
+        this.baseTable = baseTable;
+        this.includeAllColumns = includeAllColumns;
+    }
+
+    static MaterializedViewMetadata build(KeyspaceMetadata keyspace, Row row, Map<String, ColumnMetadata.Raw> rawCols, VersionNumber cassandraVersion) {
+
+        String name = row.getString("view_name");
+        String tableName = row.getString("base_table_name");
+        TableMetadata baseTable = keyspace.getTable(tableName);
+        if(baseTable == null) {
+            logger.trace(String.format("Cannot find base table %s for materialized view %s.%s: "
+                    + "Cluster.getMetadata().getKeyspace(\"%s\").getView(\"%s\") will return null",
+                tableName, keyspace.getName(), name, keyspace.getName(), name));
+            return null;
+        }
+
+        UUID id = row.getUUID("id");
+        boolean includeAllColumns = row.getBool("include_all_columns");
+
+        int partitionKeySize = findCollectionSize(rawCols.values(), ColumnMetadata.Raw.Kind.PARTITION_KEY);
+        int clusteringSize = findCollectionSize(rawCols.values(), ColumnMetadata.Raw.Kind.CLUSTERING_COLUMN);
+        List<ColumnMetadata> partitionKey = nullInitializedList(partitionKeySize);
+        List<ColumnMetadata> clusteringColumns = nullInitializedList(clusteringSize);
+        List<TableMetadata.Order> clusteringOrder = nullInitializedList(clusteringSize);
+
+        // We use a linked hashmap because we will keep this in the order of a 'SELECT * FROM ...'.
+        LinkedHashMap<String, ColumnMetadata> columns = new LinkedHashMap<String, ColumnMetadata>();
+
+        TableMetadata.Options options = null;
+        try {
+            options = new Options(row, false, cassandraVersion);
+        } catch (RuntimeException e) {
+            // See ControlConnection#refreshSchema for why we'd rather not probably this further. Since table options is one thing
+            // that tends to change often in Cassandra, it's worth special casing this.
+            logger.error(String.format("Error parsing schema options for view %s.%s: "
+                    + "Cluster.getMetadata().getKeyspace(\"%s\").getView(\"%s\").getOptions() will return null",
+                keyspace.getName(), name, keyspace.getName(), name), e);
+        }
+
+        MaterializedViewMetadata view = new MaterializedViewMetadata(
+            keyspace, baseTable, name, id, partitionKey, clusteringColumns, columns,
+            includeAllColumns, options, clusteringOrder, cassandraVersion);
+
+        // We use this temporary set just so non PK columns are added in lexicographical order, which is the one of a
+        // 'SELECT * FROM ...'
+        Set<ColumnMetadata> otherColumns = new TreeSet<ColumnMetadata>(columnMetadataComparator);
+        for (ColumnMetadata.Raw rawCol : rawCols.values()) {
+            ColumnMetadata col = ColumnMetadata.fromRaw(view, rawCol);
+            switch (rawCol.kind) {
+                case PARTITION_KEY:
+                    partitionKey.set(rawCol.position, col);
+                    break;
+                case CLUSTERING_COLUMN:
+                    clusteringColumns.set(rawCol.position, col);
+                    clusteringOrder.set(rawCol.position, rawCol.isReversed ? Order.DESC : Order.ASC);
+                    break;
+                default:
+                    otherColumns.add(col);
+                    break;
+            }
+        }
+        for (ColumnMetadata c : partitionKey)
+            columns.put(c.getName(), c);
+        for (ColumnMetadata c : clusteringColumns)
+            columns.put(c.getName(), c);
+        for (ColumnMetadata c : otherColumns)
+            columns.put(c.getName(), c);
+
+        baseTable.add(view);
+
+        return view;
+
+    }
+
+    private static int findCollectionSize(Collection<ColumnMetadata.Raw> cols, ColumnMetadata.Raw.Kind kind) {
+        int maxId = -1;
+        for (ColumnMetadata.Raw col : cols)
+            if (col.kind == kind)
+                maxId = Math.max(maxId, col.position);
+        return maxId + 1;
+    }
+
+    /**
+     * Return this materialized view's base table.
+     * @return this materialized view's base table.
+     */
+    public TableMetadata getBaseTable() {
+        return baseTable;
+    }
+
+    @Override
+    protected String asCQLQuery(boolean formatted) {
+
+        String keyspaceName = Metadata.escapeId(keyspace.getName());
+        String baseTableName = Metadata.escapeId(baseTable.getName());
+        String viewName = Metadata.escapeId(name);
+        String whereClause = Joiner.on(" AND ").join(transform(getPartitionKey(), new Function<ColumnMetadata, String>() {
+            @Override
+            public String apply(ColumnMetadata input) {
+                return Metadata.escapeId(input.getName()) + " IS NOT NULL";
+            }
+        }));
+
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("CREATE MATERIALIZED VIEW ")
+            .append(keyspaceName).append('.').append(viewName)
+            .append(" AS ");
+        newLine(sb, formatted);
+
+        // SELECT
+        sb.append("SELECT ");
+        if(includeAllColumns) {
+            sb.append(" * ");
+        } else {
+            Iterator<ColumnMetadata> it = columns.values().iterator();
+            while(it.hasNext()) {
+                ColumnMetadata column = it.next();
+                sb.append(spaces(4, formatted)).append(Metadata.escapeId(column.getName()));
+                if(it.hasNext()) sb.append(",");
+                sb.append(" ");
+                newLine(sb, formatted);
+            }
+        }
+
+        // FROM
+        newLine(sb.append("FROM ").append(keyspaceName).append('.').append(baseTableName).append(" "), formatted);
+
+        // WHERE
+        newLine(sb.append("WHERE "), formatted);
+        Iterator<ColumnMetadata> it = getPrimaryKey().iterator();
+        while(it.hasNext()) {
+            ColumnMetadata column = it.next();
+            sb.append(spaces(4, formatted)).append(Metadata.escapeId(column.getName()));
+            sb.append(" IS NOT NULL");
+            if(it.hasNext()) sb.append(" AND");
+            sb.append(" ");
+            newLine(sb, formatted);
+        }
+
+        // PK
+        sb.append("PRIMARY KEY (");
+        if (partitionKey.size() == 1) {
+            sb.append(partitionKey.get(0).getName());
+        } else {
+            sb.append('(');
+            boolean first = true;
+            for (ColumnMetadata cm : partitionKey) {
+                if (first)
+                    first = false;
+                else
+                    sb.append(", ");
+                sb.append(Metadata.escapeId(cm.getName()));
+            }
+            sb.append(')');
+        }
+        for (ColumnMetadata cm : clusteringColumns)
+            sb.append(", ").append(Metadata.escapeId(cm.getName()));
+        sb.append(')');
+        newLine(sb, formatted);
+
+        appendOptions(sb, formatted);
+        return sb.toString();
+
+    }
+
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/SchemaElement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SchemaElement.java
@@ -15,6 +15,11 @@
  */
 package com.datastax.driver.core;
 
+/**
+ * Values for a SCHEMA_CHANGE event.
+ * See protocol v4 section 4.2.6.
+ * Note that {@code VIEW} is not a valid string under protocol v4 or lower, but is included for internal use only.
+ */
 enum SchemaElement {
-    KEYSPACE, TABLE, TYPE, FUNCTION, AGGREGATE
+    KEYSPACE, TABLE, TYPE, FUNCTION, AGGREGATE, VIEW
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
@@ -225,11 +225,11 @@ public class TableMetadata {
             ColumnMetadata col = ColumnMetadata.fromRaw(tm, rawCol);
             switch (rawCol.kind) {
                 case PARTITION_KEY:
-                    partitionKey.set(rawCol.componentIndex, col);
+                    partitionKey.set(rawCol.position, col);
                     break;
                 case CLUSTERING_COLUMN:
-                    clusteringColumns.set(rawCol.componentIndex, col);
-                    clusteringOrder.set(rawCol.componentIndex, rawCol.isReversed ? Order.DESC : Order.ASC);
+                    clusteringColumns.set(rawCol.position, col);
+                    clusteringOrder.set(rawCol.position, rawCol.isReversed ? Order.DESC : Order.ASC);
                     break;
                 default:
                     otherColumns.add(col);
@@ -347,7 +347,7 @@ public class TableMetadata {
         int maxId = -1;
         for (ColumnMetadata.Raw col : cols)
             if (col.kind == ColumnMetadata.Raw.Kind.PARTITION_KEY)
-                maxId = Math.max(maxId, col.componentIndex);
+                maxId = Math.max(maxId, col.position);
         return maxId + 1;
     }
 
@@ -355,14 +355,14 @@ public class TableMetadata {
                                           Collection<ColumnMetadata.Raw> cols,
                                           List<String> columnAliases,
                                           VersionNumber cassandraVersion) {
-        // In 2.0 onwards, this is relatively easy, we just find the biggest 'componentIndex' amongst the clustering columns.
+        // In 2.0 onwards, this is relatively easy, we just find the biggest 'position' amongst the clustering columns.
         // For 1.2 however, this is slightly more subtle: we need to infer it based on whether the comparator is composite or not, and whether we have
         // regular columns or not.
         if (cassandraVersion.getMajor() >= 2) {
             int maxId = -1;
             for (ColumnMetadata.Raw col : cols)
                 if (col.kind == ColumnMetadata.Raw.Kind.CLUSTERING_COLUMN)
-                    maxId = Math.max(maxId, col.componentIndex);
+                    maxId = Math.max(maxId, col.position);
             return maxId + 1;
         } else {
             int size = comparator.types.size();

--- a/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
@@ -17,16 +17,13 @@ package com.datastax.driver.core;
 
 import java.util.*;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Describes a Table.
  */
-public class TableMetadata {
+public class TableMetadata extends TableOrView {
 
     private static final Logger logger = LoggerFactory.getLogger(TableMetadata.class);
 
@@ -52,40 +49,8 @@ public class TableMetadata {
 
     private static final String EMPTY_TYPE           = "org.apache.cassandra.db.marshal.EmptyType";
 
-    private static final Comparator<ColumnMetadata> columnMetadataComparator = new Comparator<ColumnMetadata>() {
-        public int compare(ColumnMetadata c1, ColumnMetadata c2) {
-            return c1.getName().compareTo(c2.getName());
-        }
-    };
-
-    private final KeyspaceMetadata keyspace;
-    private final String name;
-    private final UUID id;
-    private final List<ColumnMetadata> partitionKey;
-    private final List<ColumnMetadata> clusteringColumns;
-    private final Map<String, ColumnMetadata> columns;
     private final Map<String, IndexMetadata> indexes;
-    private final Options options;
-    private final List<Order> clusteringOrder;
-
-
-    private final VersionNumber cassandraVersion;
-
-    /**
-     * Clustering orders.
-     * <p>
-     * This is used by {@link #getClusteringOrder} to indicate the clustering
-     * order of a table.
-     */
-    public static enum Order {
-        ASC, DESC;
-
-        static final Predicate<Order> isAscending = new Predicate<Order>() {
-            public boolean apply(Order o) {
-                return o == ASC;
-            }
-        };
-    }
+    private final Map<String, MaterializedViewMetadata> views;
 
     private TableMetadata(KeyspaceMetadata keyspace,
                           String name,
@@ -97,16 +62,9 @@ public class TableMetadata {
                           Options options,
                           List<Order> clusteringOrder,
                           VersionNumber cassandraVersion) {
-        this.keyspace = keyspace;
-        this.name = name;
-        this.id = id;
-        this.partitionKey = partitionKey;
-        this.clusteringColumns = clusteringColumns;
-        this.columns = columns;
+        super(keyspace, name, id, partitionKey, clusteringColumns, columns, options, clusteringOrder, cassandraVersion);
         this.indexes = indexes;
-        this.options = options;
-        this.clusteringOrder = clusteringOrder;
-        this.cassandraVersion = cassandraVersion;
+        this.views = new HashMap<String, MaterializedViewMetadata>();
     }
 
     static TableMetadata build(KeyspaceMetadata ksm, Row row, Map<String, ColumnMetadata.Raw> rawCols, List<Row> indexRows, String nameColumn, VersionNumber cassandraVersion, ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
@@ -270,6 +228,7 @@ public class TableMetadata {
                 column.indexes.put(index.getName(), index);
             }
         }
+
         return tm;
     }
 
@@ -374,109 +333,6 @@ public class TableMetadata {
         }
     }
 
-    private static <T> List<T> nullInitializedList(int size) {
-        List<T> l = new ArrayList<T>(size);
-        for (int i = 0; i < size; ++i)
-            l.add(null);
-        return l;
-    }
-
-    /**
-     * Returns the name of this table.
-     *
-     * @return the name of this CQL table.
-     */
-    public String getName() {
-        return name;
-    }
-
-    /**
-     * Returns the unique id of this table.
-     * <p>
-     * Note: this id is available in Cassandra 2.1 and above. It will be
-     * {@code null} for earlier versions.
-     *
-     * @return the unique id of the table.
-     */
-    public UUID getId() {
-        return id;
-    }
-
-    /**
-     * Returns the keyspace this table belong to.
-     *
-     * @return the keyspace metadata of the keyspace this table belong to.
-     */
-    public KeyspaceMetadata getKeyspace() {
-        return keyspace;
-    }
-
-    /**
-     * Returns metadata on a column of this table.
-     *
-     * @param name the name of the column to retrieve ({@code name} will be
-     * interpreted as a case-insensitive identifier unless enclosed in double-quotes,
-     * see {@link Metadata#quote}).
-     * @return the metadata for the column if it exists, or
-     * {@code null} otherwise.
-     */
-    public ColumnMetadata getColumn(String name) {
-        return columns.get(Metadata.handleId(name));
-    }
-
-    /**
-     * Returns a list containing all the columns of this table.
-     *
-     * The order of the columns in the list is consistent with
-     * the order of the columns returned by a {@code SELECT * FROM thisTable}:
-     * the first column is the partition key, next are the clustering
-     * columns in their defined order, and then the rest of the
-     * columns follow in alphabetic order.
-     *
-     * @return a list containing the metadata for the columns of this table.
-     */
-    public List<ColumnMetadata> getColumns() {
-        return new ArrayList<ColumnMetadata>(columns.values());
-    }
-
-    /**
-     * Returns the list of columns composing the primary key for this table.
-     *
-     * A table will always at least have a partition key (that
-     * may itself be one or more columns), so the returned list at least
-     * has one element.
-     *
-     * @return the list of columns composing the primary key for this table.
-     */
-    public List<ColumnMetadata> getPrimaryKey() {
-        List<ColumnMetadata> pk = new ArrayList<ColumnMetadata>(partitionKey.size() + clusteringColumns.size());
-        pk.addAll(partitionKey);
-        pk.addAll(clusteringColumns);
-        return pk;
-    }
-
-    /**
-     * Returns the list of columns composing the partition key for this table.
-     *
-     * A table always has a partition key so the returned list has
-     * at least one element.
-     *
-     * @return the list of columns composing the partition key for this table.
-     */
-    public List<ColumnMetadata> getPartitionKey() {
-        return Collections.unmodifiableList(partitionKey);
-    }
-
-    /**
-     * Returns the list of clustering columns for this table.
-     *
-     * @return the list of clustering columns for this table.
-     * If there is no clustering columns, an empty list is returned.
-     */
-    public List<ColumnMetadata> getClusteringColumns() {
-        return Collections.unmodifiableList(clusteringColumns);
-    }
-
     /**
      * Returns metadata on a index of this table.
      *
@@ -500,32 +356,29 @@ public class TableMetadata {
     }
 
     /**
-     * Returns the clustering order for this table.
-     * <p>
-     * The returned contains the clustering order of each clustering column. The
-     * {@code i}th element of the result correspond to the order (ascending or
-     * descending) of the {@code i}th clustering column (see
-     * {@link #getClusteringColumns}). Note that a table defined without any
-     * particular clustering order is equivalent to one for which all the
-     * clustering key are in ascending order.
+     * Returns metadata on a view of this table.
      *
-     * @return a list with the clustering order for each clustering column.
+     * @param name the name of the view to retrieve ({@code name} will be
+     * interpreted as a case-insensitive identifier unless enclosed in double-quotes,
+     * see {@link Metadata#quote}).
+     * @return the metadata for the {@code name} view if it exists, or
+     * {@code null} otherwise.
      */
-    public List<Order> getClusteringOrder() {
-        return clusteringOrder;
+    public MaterializedViewMetadata getView(String name) {
+        return views.get(Metadata.handleId(name));
     }
 
     /**
-     * Returns the options for this table.
+     * Returns a list containing all the viewes of this table.
      *
-     * @return the options for this table.
+     * @return a list containing the metadata for the viewes of this table.
      */
-    public Options getOptions() {
-        return options;
+    public List<MaterializedViewMetadata> getViews() {
+        return new ArrayList<MaterializedViewMetadata>(views.values());
     }
 
-    void add(ColumnMetadata column) {
-        columns.put(column.getName(), column);
+    void add(MaterializedViewMetadata view) {
+        views.put(view.getName(), view);
     }
 
     /**
@@ -533,8 +386,8 @@ public class TableMetadata {
      * table and the index on it.
      * <p>
      * In other words, this method returns the queries that would allow you to
-     * recreate the schema of this table, along with the indexes defined on
-     * columns of this table.
+     * recreate the schema of this table, along with the indexes and views defined on
+     * this table, if any.
      * <p>
      * Note that the returned String is formatted to be human readable (for
      * some definition of human readable at least).
@@ -542,36 +395,25 @@ public class TableMetadata {
      * @return the CQL queries representing this table schema as a {code
      * String}.
      */
+    @Override
     public String exportAsString() {
         StringBuilder sb = new StringBuilder();
 
-        sb.append(asCQLQuery(true));
+        sb.append(super.exportAsString());
 
         for (IndexMetadata index : indexes.values()) {
             sb.append('\n').append(index.asCQLQuery());
         }
+
+        for (MaterializedViewMetadata index : views.values()) {
+            sb.append('\n').append(index.asCQLQuery());
+        }
+
         return sb.toString();
     }
 
-    /**
-     * Returns a CQL query representing this table.
-     * <p>
-     * This method returns a single 'CREATE TABLE' query with the options
-     * corresponding to this table definition.
-     * <p>
-     * Note that the returned string is a single line; the returned query
-     * is not formatted in any way.
-     *
-     * @return the 'CREATE TABLE' query corresponding to this table.
-     * @see #exportAsString
-     */
-    public String asCQLQuery() {
-        return asCQLQuery(false);
-    }
-
-    private String asCQLQuery(boolean formatted) {
+    protected String asCQLQuery(boolean formatted) {
         StringBuilder sb = new StringBuilder();
-
         sb.append("CREATE TABLE ").append(Metadata.escapeId(keyspace.getName())).append('.').append(Metadata.escapeId(name)).append(" (");
         newLine(sb, formatted);
         for (ColumnMetadata cm : columns.values())
@@ -585,7 +427,10 @@ public class TableMetadata {
             sb.append('(');
             boolean first = true;
             for (ColumnMetadata cm : partitionKey) {
-                if (first) first = false; else sb.append(", ");
+                if (first)
+                    first = false;
+                else
+                    sb.append(", ");
                 sb.append(Metadata.escapeId(cm.getName()));
             }
             sb.append(')');
@@ -596,397 +441,8 @@ public class TableMetadata {
         newLine(sb, formatted);
         // end PK
 
-        // Options
-        sb.append(") WITH ");
-
-        if (options.isCompactStorage)
-            and(sb.append("COMPACT STORAGE"), formatted);
-        if (!Iterables.all(clusteringOrder, Order.isAscending))
-            and(appendClusteringOrder(sb), formatted);
-        sb.append("read_repair_chance = ").append(options.readRepair);
-        and(sb, formatted).append("dclocal_read_repair_chance = ").append(options.localReadRepair);
-        if (cassandraVersion.getMajor() < 2 || (cassandraVersion.getMajor() == 2 && cassandraVersion.getMinor() == 0))
-            and(sb, formatted).append("replicate_on_write = ").append(options.replicateOnWrite);
-        and(sb, formatted).append("gc_grace_seconds = ").append(options.gcGrace);
-        and(sb, formatted).append("bloom_filter_fp_chance = ").append(options.bfFpChance);
-        if (cassandraVersion.getMajor() < 2 || cassandraVersion.getMajor() == 2 && cassandraVersion.getMinor() < 1)
-            and(sb, formatted).append("caching = '").append(options.caching.get("keys")).append('\'');
-        else
-            and(sb, formatted).append("caching = ").append(formatOptionMap(options.caching));
-        if (options.comment != null)
-            and(sb, formatted).append("comment = '").append(options.comment.replace("'","''")).append('\'');
-        and(sb, formatted).append("compaction = ").append(formatOptionMap(options.compaction));
-        and(sb, formatted).append("compression = ").append(formatOptionMap(options.compression));
-        if (cassandraVersion.getMajor() >= 2) {
-            and(sb, formatted).append("default_time_to_live = ").append(options.defaultTTL);
-            and(sb, formatted).append("speculative_retry = '").append(options.speculativeRetry).append('\'');
-            if (options.indexInterval != null)
-                and(sb, formatted).append("index_interval = ").append(options.indexInterval);
-        }
-        if (cassandraVersion.getMajor() > 2 || (cassandraVersion.getMajor() == 2 && cassandraVersion.getMinor() >= 1)) {
-            and(sb, formatted).append("min_index_interval = ").append(options.minIndexInterval);
-            and(sb, formatted).append("max_index_interval = ").append(options.maxIndexInterval);
-        }
-        sb.append(';');
+        sb.append(")");
+        appendOptions(sb, formatted);
         return sb.toString();
-    }
-
-    @Override
-    public String toString() {
-        return asCQLQuery();
-    }
-
-    private StringBuilder appendClusteringOrder(StringBuilder sb) {
-        sb.append("CLUSTERING ORDER BY (");
-        for (int i = 0; i < clusteringColumns.size(); i++) {
-            if (i > 0) sb.append(", ");
-            sb.append(clusteringColumns.get(i).getName()).append(' ').append(clusteringOrder.get(i));
-        }
-        return sb.append(')');
-    }
-
-    private static String formatOptionMap(Map<String, String> m) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{ ");
-        boolean first = true;
-        for (Map.Entry<String, String> entry : m.entrySet()) {
-            if (first) first = false; else sb.append(", ");
-            sb.append('\'').append(entry.getKey()).append('\'');
-            sb.append(" : ");
-            try {
-                sb.append(Integer.parseInt(entry.getValue()));
-            } catch (NumberFormatException e) {
-                sb.append('\'').append(entry.getValue()).append('\'');
-            }
-        }
-        sb.append(" }");
-        return sb.toString();
-    }
-
-    private StringBuilder and(StringBuilder sb, boolean formatted) {
-        return newLine(sb, formatted).append(spaces(2, formatted)).append(" AND ");
-    }
-
-    static String spaces(int n, boolean formatted) {
-        if (!formatted)
-            return "";
-
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < n; i++)
-            sb.append(' ');
-
-        return sb.toString();
-    }
-
-    static StringBuilder newLine(StringBuilder sb, boolean formatted) {
-        if (formatted)
-            sb.append('\n');
-        return sb;
-    }
-
-    static StringBuilder spaceOrNewLine(StringBuilder sb, boolean formatted) {
-        sb.append(formatted ? '\n' : ' ');
-        return sb;
-    }
-
-    public static class Options {
-
-        private static final String COMMENT                     = "comment";
-        private static final String READ_REPAIR                 = "read_repair_chance";
-        private static final String DCLOCAL_READ_REPAIR         = "dclocal_read_repair_chance";
-        private static final String LOCAL_READ_REPAIR           = "local_read_repair_chance";
-        private static final String REPLICATE_ON_WRITE          = "replicate_on_write";
-        private static final String GC_GRACE                    = "gc_grace_seconds";
-        private static final String BF_FP_CHANCE                = "bloom_filter_fp_chance";
-        private static final String CACHING                     = "caching";
-        private static final String COMPACTION                  = "compaction";
-        private static final String COMPACTION_CLASS            = "compaction_strategy_class";
-        private static final String COMPACTION_OPTIONS          = "compaction_strategy_options";
-        private static final String POPULATE_CACHE_ON_FLUSH     = "populate_io_cache_on_flush";
-        private static final String COMPRESSION                 = "compression";
-        private static final String COMPRESSION_PARAMS          = "compression_parameters";
-        private static final String MEMTABLE_FLUSH_PERIOD_MS    = "memtable_flush_period_in_ms";
-        private static final String DEFAULT_TTL                 = "default_time_to_live";
-        private static final String SPECULATIVE_RETRY           = "speculative_retry";
-        private static final String INDEX_INTERVAL              = "index_interval";
-        private static final String MIN_INDEX_INTERVAL          = "min_index_interval";
-        private static final String MAX_INDEX_INTERVAL          = "max_index_interval";
-
-        private static final boolean DEFAULT_REPLICATE_ON_WRITE = true;
-        private static final double DEFAULT_BF_FP_CHANCE = 0.01;
-        private static final boolean DEFAULT_POPULATE_CACHE_ON_FLUSH = false;
-        private static final int DEFAULT_MEMTABLE_FLUSH_PERIOD = 0;
-        private static final int DEFAULT_DEFAULT_TTL = 0;
-        private static final String DEFAULT_SPECULATIVE_RETRY = "NONE";
-        private static final int DEFAULT_INDEX_INTERVAL = 128;
-        private static final int DEFAULT_MIN_INDEX_INTERVAL = 128;
-        private static final int DEFAULT_MAX_INDEX_INTERVAL = 2048;
-
-        private final boolean isCompactStorage;
-
-        private final String comment;
-        private final double readRepair;
-        private final double localReadRepair;
-        private final boolean replicateOnWrite;
-        private final int gcGrace;
-        private final double bfFpChance;
-        private final Map<String, String> caching;
-        private final boolean populateCacheOnFlush;
-        private final int memtableFlushPeriodMs;
-        private final int defaultTTL;
-        private final String speculativeRetry;
-        private final Integer indexInterval;
-        private final Integer minIndexInterval;
-        private final Integer maxIndexInterval;
-        private final Map<String, String> compaction;
-        private final Map<String, String> compression;
-
-        Options(Row row, boolean isCompactStorage, VersionNumber version) {
-
-            boolean is120 = version.getMajor() < 2;
-            boolean is200 = version.getMajor() == 2 && version.getMinor() == 0;
-            boolean is210 = version.getMajor() == 2 && version.getMinor() >= 1;
-            boolean is300OrHigher = version.getMajor() > 2;
-            boolean is210OrHigher = is210 || is300OrHigher;
-
-            this.isCompactStorage = isCompactStorage;
-            this.comment = isNullOrAbsent(row, COMMENT) ? "" : row.getString(COMMENT);
-            this.readRepair = row.getDouble(READ_REPAIR);
-
-            if(is300OrHigher)
-                this.localReadRepair = row.getDouble(DCLOCAL_READ_REPAIR);
-            else
-                this.localReadRepair = row.getDouble(LOCAL_READ_REPAIR);
-
-            this.replicateOnWrite = is210OrHigher || isNullOrAbsent(row, REPLICATE_ON_WRITE) ? DEFAULT_REPLICATE_ON_WRITE : row.getBool(REPLICATE_ON_WRITE);
-            this.gcGrace = row.getInt(GC_GRACE);
-            this.bfFpChance = isNullOrAbsent(row, BF_FP_CHANCE) ? DEFAULT_BF_FP_CHANCE : row.getDouble(BF_FP_CHANCE);
-
-            this.populateCacheOnFlush = isNullOrAbsent(row, POPULATE_CACHE_ON_FLUSH) ? DEFAULT_POPULATE_CACHE_ON_FLUSH : row.getBool(POPULATE_CACHE_ON_FLUSH);
-            this.memtableFlushPeriodMs = is120 || isNullOrAbsent(row, MEMTABLE_FLUSH_PERIOD_MS) ? DEFAULT_MEMTABLE_FLUSH_PERIOD : row.getInt(MEMTABLE_FLUSH_PERIOD_MS);
-            this.defaultTTL = is120 || isNullOrAbsent(row, DEFAULT_TTL) ? DEFAULT_DEFAULT_TTL : row.getInt(DEFAULT_TTL);
-            this.speculativeRetry = is120 || isNullOrAbsent(row, SPECULATIVE_RETRY) ? DEFAULT_SPECULATIVE_RETRY : row.getString(SPECULATIVE_RETRY);
-
-            if (is200)
-                this.indexInterval = isNullOrAbsent(row, INDEX_INTERVAL) ? DEFAULT_INDEX_INTERVAL : row.getInt(INDEX_INTERVAL);
-            else
-                this.indexInterval = null;
-
-            if (is210OrHigher) {
-                this.minIndexInterval = isNullOrAbsent(row, MIN_INDEX_INTERVAL)
-                                      ? DEFAULT_MIN_INDEX_INTERVAL
-                                      : row.getInt(MIN_INDEX_INTERVAL);
-                this.maxIndexInterval = isNullOrAbsent(row, MAX_INDEX_INTERVAL)
-                                      ? DEFAULT_MAX_INDEX_INTERVAL
-                                      : row.getInt(MAX_INDEX_INTERVAL);
-            } else {
-                this.minIndexInterval = null;
-                this.maxIndexInterval = null;
-            }
-
-            if (is300OrHigher) {
-                this.caching = ImmutableMap.copyOf(row.getMap(CACHING, String.class, String.class));
-            } else if (is210) {
-                this.caching = ImmutableMap.copyOf(SimpleJSONParser.parseStringMap(row.getString(CACHING)));
-            } else {
-                this.caching = ImmutableMap.of("keys", row.getString(CACHING));
-            }
-
-            if (is300OrHigher)
-                this.compaction = ImmutableMap.copyOf(row.getMap(COMPACTION, String.class, String.class));
-            else {
-                this.compaction = ImmutableMap.<String, String>builder()
-                    .put("class", row.getString(COMPACTION_CLASS))
-                    .putAll(SimpleJSONParser.parseStringMap(row.getString(COMPACTION_OPTIONS)))
-                    .build();
-            }
-
-            if(is300OrHigher)
-                this.compression = ImmutableMap.copyOf(row.getMap(COMPRESSION, String.class, String.class));
-            else
-                this.compression = ImmutableMap.copyOf(SimpleJSONParser.parseStringMap(row.getString(COMPRESSION_PARAMS)));
-        }
-
-        private static boolean isNullOrAbsent(Row row, String name) {
-            return row.getColumnDefinitions().getIndexOf(name) < 0
-                   || row.isNull(name);
-        }
-
-        /**
-         * Returns whether the table uses the {@code COMPACT STORAGE} option.
-         *
-         * @return whether the table uses the {@code COMPACT STORAGE} option.
-         */
-        public boolean isCompactStorage() {
-            return isCompactStorage;
-        }
-
-        /**
-         * Returns the commentary set for this table.
-         *
-         * @return the commentary set for this table, or {@code null} if noe has been set.
-         */
-        public String getComment() {
-            return comment;
-        }
-
-        /**
-         * Returns the chance with which a read repair is triggered for this table.
-         *
-         * @return the read repair chance set for table (in [0.0, 1.0]).
-         */
-        public double getReadRepairChance() {
-            return readRepair;
-        }
-
-        /**
-         * Returns the cluster local read repair chance set for this table.
-         *
-         * @return the local read repair chance set for table (in [0.0, 1.0]).
-         */
-        public double getLocalReadRepairChance() {
-            return localReadRepair;
-        }
-
-        /**
-         * Returns whether replicateOnWrite is set for this table.
-         *
-         * This is only meaningful for tables holding counters.
-         *
-         * @return whether replicateOnWrite is set for this table.
-         */
-        public boolean getReplicateOnWrite() {
-            return replicateOnWrite;
-        }
-
-        /**
-         * Returns the tombstone garbage collection grace time in seconds for this table.
-         *
-         * @return the tombstone garbage collection grace time in seconds for this table.
-         */
-        public int getGcGraceInSeconds() {
-            return gcGrace;
-        }
-
-        /**
-         * Returns the false positive chance for the Bloom filter of this table.
-         *
-         * @return the Bloom filter false positive chance for this table (in [0.0, 1.0]).
-         */
-        public double getBloomFilterFalsePositiveChance() {
-            return bfFpChance;
-        }
-
-        /**
-         * Returns the caching options for this table.
-         *
-         * @return an immutable map containing the caching options for this table.
-         */
-        public Map<String, String> getCaching() {
-            return caching;
-        }
-
-        /**
-         * Whether the populate I/O cache on flush is set on this table.
-         *
-         * @return whether the populate I/O cache on flush is set on this table.
-         */
-        public boolean getPopulateIOCacheOnFlush() {
-            return populateCacheOnFlush;
-        }
-
-        /*
-         * Returns the memtable flush period (in milliseconds) option for this table.
-         * <p>
-         * Note: this option is not available in Cassandra 1.2 and will return 0 (no periodic
-         * flush) when connected to 1.2 nodes.
-         *
-         * @return the memtable flush period option for this table or 0 if no
-         * periodic flush is configured.
-         */
-        public int getMemtableFlushPeriodInMs() {
-            return memtableFlushPeriodMs;
-        }
-
-        /**
-         * Returns the default TTL for this table.
-         * <p>
-         * Note: this option is not available in Cassandra 1.2 and will return 0 (no default
-         * TTL) when connected to 1.2 nodes.
-         *
-         * @return the default TTL for this table or 0 if no default TTL is
-         * configured.
-         */
-        public int getDefaultTimeToLive() {
-            return defaultTTL;
-        }
-
-        /**
-         * Returns the speculative retry option for this table.
-         * <p>
-         * Note: this option is not available in Cassandra 1.2 and will return "NONE" (no
-         * speculative retry) when connected to 1.2 nodes.
-         *
-         * @return the speculative retry option this table.
-         */
-        public String getSpeculativeRetry() {
-            return speculativeRetry;
-        }
-
-        /**
-         * Returns the index interval option for this table.
-         * <p>
-         * Note: this option is not available in Cassandra 1.2 (more precisely, it is not
-         * configurable per-table) and will return 128 (the default index interval) when
-         * connected to 1.2 nodes. It is deprecated in Cassandra 2.1 and above, and will
-         * therefore return {@code null} for 2.1 nodes.
-         *
-         * @return the index interval option for this table.
-         */
-        public Integer getIndexInterval() {
-            return indexInterval;
-        }
-
-        /**
-         * Returns the minimum index interval option for this table.
-         * <p>
-         * Note: this option is available in Cassandra 2.1 and above, and will return
-         * {@code null} for earlier versions.
-         *
-         * @return the minimum index interval option for this table.
-         */
-        public Integer getMinIndexInterval() {
-            return minIndexInterval;
-        }
-
-        /**
-         * Returns the maximum index interval option for this table.
-         * <p>
-         * Note: this option is available in Cassandra 2.1 and above, and will return
-         * {@code null} for earlier versions.
-         *
-         * @return the maximum index interval option for this table.
-         */
-        public Integer getMaxIndexInterval() {
-            return maxIndexInterval;
-        }
-
-        /**
-         * Returns the compaction options for this table.
-         *
-         * @return an immutable map containing the compaction options for this table.
-         */
-        public Map<String, String> getCompaction() {
-            return compaction;
-        }
-
-        /**
-         * Returns the compression options for this table.
-         *
-         * @return an immutable map containing the compression options for this table.
-         */
-        public Map<String, String> getCompression() {
-            return compression;
-        }
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/TableOrView.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableOrView.java
@@ -1,0 +1,642 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.*;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+/**
+ * Base class for Tables and Materialized Views.
+ */
+abstract class TableOrView {
+
+    static final Comparator<ColumnMetadata> columnMetadataComparator = new Comparator<ColumnMetadata>() {
+        public int compare(ColumnMetadata c1, ColumnMetadata c2) {
+            return c1.getName().compareTo(c2.getName());
+        }
+    };
+
+    protected final KeyspaceMetadata keyspace;
+    protected final String name;
+    protected final UUID id;
+    protected final List<ColumnMetadata> partitionKey;
+    protected final List<ColumnMetadata> clusteringColumns;
+    protected final Map<String, ColumnMetadata> columns;
+    protected final Options options;
+    protected final List<Order> clusteringOrder;
+    protected final VersionNumber cassandraVersion;
+
+    /**
+     * Clustering orders.
+     * <p>
+     * This is used by {@link #getClusteringOrder} to indicate the clustering
+     * order of a table.
+     */
+    public enum Order {
+        ASC, DESC;
+
+        static final Predicate<Order> isAscending = new Predicate<Order>() {
+            public boolean apply(Order o) {
+                return o == ASC;
+            }
+        };
+    }
+
+    TableOrView(KeyspaceMetadata keyspace,
+                        String name,
+                        UUID id,
+                        List<ColumnMetadata> partitionKey,
+                        List<ColumnMetadata> clusteringColumns,
+                        Map<String, ColumnMetadata> columns,
+                        Options options,
+                        List<Order> clusteringOrder,
+                        VersionNumber cassandraVersion) {
+        this.keyspace = keyspace;
+        this.name = name;
+        this.id = id;
+        this.partitionKey = partitionKey;
+        this.clusteringColumns = clusteringColumns;
+        this.columns = columns;
+        this.options = options;
+        this.clusteringOrder = clusteringOrder;
+        this.cassandraVersion = cassandraVersion;
+    }
+
+    protected static <T> List<T> nullInitializedList(int size) {
+        List<T> l = new ArrayList<T>(size);
+        for (int i = 0; i < size; ++i)
+            l.add(null);
+        return l;
+    }
+
+    /**
+     * Returns the name of this table.
+     *
+     * @return the name of this CQL table.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the unique id of this table.
+     * <p>
+     * Note: this id is available in Cassandra 2.1 and above. It will be
+     * {@code null} for earlier versions.
+     *
+     * @return the unique id of the table.
+     */
+    public UUID getId() {
+        return id;
+    }
+
+    /**
+     * Returns the keyspace this table belong to.
+     *
+     * @return the keyspace metadata of the keyspace this table belong to.
+     */
+    public KeyspaceMetadata getKeyspace() {
+        return keyspace;
+    }
+
+    /**
+     * Returns metadata on a column of this table.
+     *
+     * @param name the name of the column to retrieve ({@code name} will be
+     * interpreted as a case-insensitive identifier unless enclosed in double-quotes,
+     * see {@link Metadata#quote}).
+     * @return the metadata for the column if it exists, or
+     * {@code null} otherwise.
+     */
+    public ColumnMetadata getColumn(String name) {
+        return columns.get(Metadata.handleId(name));
+    }
+
+    /**
+     * Returns a list containing all the columns of this table.
+     *
+     * The order of the columns in the list is consistent with
+     * the order of the columns returned by a {@code SELECT * FROM thisTable}:
+     * the first column is the partition key, next are the clustering
+     * columns in their defined order, and then the rest of the
+     * columns follow in alphabetic order.
+     *
+     * @return a list containing the metadata for the columns of this table.
+     */
+    public List<ColumnMetadata> getColumns() {
+        return new ArrayList<ColumnMetadata>(columns.values());
+    }
+
+    /**
+     * Returns the list of columns composing the primary key for this table.
+     *
+     * A table will always at least have a partition key (that
+     * may itself be one or more columns), so the returned list at least
+     * has one element.
+     *
+     * @return the list of columns composing the primary key for this table.
+     */
+    public List<ColumnMetadata> getPrimaryKey() {
+        List<ColumnMetadata> pk = new ArrayList<ColumnMetadata>(partitionKey.size() + clusteringColumns.size());
+        pk.addAll(partitionKey);
+        pk.addAll(clusteringColumns);
+        return pk;
+    }
+
+    /**
+     * Returns the list of columns composing the partition key for this table.
+     *
+     * A table always has a partition key so the returned list has
+     * at least one element.
+     *
+     * @return the list of columns composing the partition key for this table.
+     */
+    public List<ColumnMetadata> getPartitionKey() {
+        return Collections.unmodifiableList(partitionKey);
+    }
+
+    /**
+     * Returns the list of clustering columns for this table.
+     *
+     * @return the list of clustering columns for this table.
+     * If there is no clustering columns, an empty list is returned.
+     */
+    public List<ColumnMetadata> getClusteringColumns() {
+        return Collections.unmodifiableList(clusteringColumns);
+    }
+
+    /**
+     * Returns the clustering order for this table.
+     * <p>
+     * The returned contains the clustering order of each clustering column. The
+     * {@code i}th element of the result correspond to the order (ascending or
+     * descending) of the {@code i}th clustering column (see
+     * {@link #getClusteringColumns}). Note that a table defined without any
+     * particular clustering order is equivalent to one for which all the
+     * clustering key are in ascending order.
+     *
+     * @return a list with the clustering order for each clustering column.
+     */
+    public List<Order> getClusteringOrder() {
+        return clusteringOrder;
+    }
+
+    /**
+     * Returns the options for this table.
+     *
+     * @return the options for this table.
+     */
+    public Options getOptions() {
+        return options;
+    }
+
+    void add(ColumnMetadata column) {
+        columns.put(column.getName(), column);
+    }
+
+    /**
+     * Returns a {@code String} containing CQL queries representing this
+     * table and the index on it.
+     * <p>
+     * In other words, this method returns the queries that would allow you to
+     * recreate the schema of this table, along with the indexes and views defined on
+     * this table, if any.
+     * <p>
+     * Note that the returned String is formatted to be human readable (for
+     * some definition of human readable at least).
+     *
+     * @return the CQL queries representing this table schema as a {code
+     * String}.
+     */
+    public String exportAsString() {
+        return asCQLQuery(true);
+    }
+
+    /**
+     * Returns a CQL query representing this table.
+     * <p>
+     * This method returns a single 'CREATE TABLE' query with the options
+     * corresponding to this table definition.
+     * <p>
+     * Note that the returned string is a single line; the returned query
+     * is not formatted in any way.
+     *
+     * @return the 'CREATE TABLE' query corresponding to this table.
+     * @see #exportAsString
+     */
+    public String asCQLQuery() {
+        return asCQLQuery(false);
+    }
+
+    protected abstract String asCQLQuery(boolean formatted);
+
+    protected StringBuilder appendOptions(StringBuilder sb, boolean formatted){
+        // Options
+        sb.append(" WITH ");
+        if (options.isCompactStorage)
+            and(sb.append("COMPACT STORAGE"), formatted);
+        if (!Iterables.all(clusteringOrder, Order.isAscending))
+            and(appendClusteringOrder(sb), formatted);
+        sb.append("read_repair_chance = ").append(options.readRepair);
+        and(sb, formatted).append("dclocal_read_repair_chance = ").append(options.localReadRepair);
+        if (cassandraVersion.getMajor() < 2 || (cassandraVersion.getMajor() == 2 && cassandraVersion.getMinor() == 0))
+            and(sb, formatted).append("replicate_on_write = ").append(options.replicateOnWrite);
+        and(sb, formatted).append("gc_grace_seconds = ").append(options.gcGrace);
+        and(sb, formatted).append("bloom_filter_fp_chance = ").append(options.bfFpChance);
+        if (cassandraVersion.getMajor() < 2 || cassandraVersion.getMajor() == 2 && cassandraVersion.getMinor() < 1)
+            and(sb, formatted).append("caching = '").append(options.caching.get("keys")).append('\'');
+        else
+            and(sb, formatted).append("caching = ").append(formatOptionMap(options.caching));
+        if (options.comment != null)
+            and(sb, formatted).append("comment = '").append(options.comment.replace("'","''")).append('\'');
+        and(sb, formatted).append("compaction = ").append(formatOptionMap(options.compaction));
+        and(sb, formatted).append("compression = ").append(formatOptionMap(options.compression));
+        if (cassandraVersion.getMajor() >= 2) {
+            and(sb, formatted).append("default_time_to_live = ").append(options.defaultTTL);
+            and(sb, formatted).append("speculative_retry = '").append(options.speculativeRetry).append('\'');
+            if (options.indexInterval != null)
+                and(sb, formatted).append("index_interval = ").append(options.indexInterval);
+        }
+        if (cassandraVersion.getMajor() > 2 || (cassandraVersion.getMajor() == 2 && cassandraVersion.getMinor() >= 1)) {
+            and(sb, formatted).append("min_index_interval = ").append(options.minIndexInterval);
+            and(sb, formatted).append("max_index_interval = ").append(options.maxIndexInterval);
+        }
+        sb.append(';');
+        return sb;
+    }
+
+    @Override
+    public String toString() {
+        return asCQLQuery();
+    }
+
+    private StringBuilder appendClusteringOrder(StringBuilder sb) {
+        sb.append("CLUSTERING ORDER BY (");
+        for (int i = 0; i < clusteringColumns.size(); i++) {
+            if (i > 0) sb.append(", ");
+            sb.append(clusteringColumns.get(i).getName()).append(' ').append(clusteringOrder.get(i));
+        }
+        return sb.append(')');
+    }
+
+    private static String formatOptionMap(Map<String, String> m) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{ ");
+        boolean first = true;
+        for (Map.Entry<String, String> entry : m.entrySet()) {
+            if (first) first = false; else sb.append(", ");
+            sb.append('\'').append(entry.getKey()).append('\'');
+            sb.append(" : ");
+            try {
+                sb.append(Integer.parseInt(entry.getValue()));
+            } catch (NumberFormatException e) {
+                sb.append('\'').append(entry.getValue()).append('\'');
+            }
+        }
+        sb.append(" }");
+        return sb.toString();
+    }
+
+    private StringBuilder and(StringBuilder sb, boolean formatted) {
+        return newLine(sb, formatted).append(spaces(2, formatted)).append(" AND ");
+    }
+
+    static String spaces(int n, boolean formatted) {
+        if (!formatted)
+            return "";
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < n; i++)
+            sb.append(' ');
+
+        return sb.toString();
+    }
+
+    static StringBuilder newLine(StringBuilder sb, boolean formatted) {
+        if (formatted)
+            sb.append('\n');
+        return sb;
+    }
+
+    static StringBuilder spaceOrNewLine(StringBuilder sb, boolean formatted) {
+        sb.append(formatted ? '\n' : ' ');
+        return sb;
+    }
+
+    public static class Options {
+
+        private static final String COMMENT                     = "comment";
+        private static final String READ_REPAIR                 = "read_repair_chance";
+        private static final String DCLOCAL_READ_REPAIR         = "dclocal_read_repair_chance";
+        private static final String LOCAL_READ_REPAIR           = "local_read_repair_chance";
+        private static final String REPLICATE_ON_WRITE          = "replicate_on_write";
+        private static final String GC_GRACE                    = "gc_grace_seconds";
+        private static final String BF_FP_CHANCE                = "bloom_filter_fp_chance";
+        private static final String CACHING                     = "caching";
+        private static final String COMPACTION                  = "compaction";
+        private static final String COMPACTION_CLASS            = "compaction_strategy_class";
+        private static final String COMPACTION_OPTIONS          = "compaction_strategy_options";
+        private static final String POPULATE_CACHE_ON_FLUSH     = "populate_io_cache_on_flush";
+        private static final String COMPRESSION                 = "compression";
+        private static final String COMPRESSION_PARAMS          = "compression_parameters";
+        private static final String MEMTABLE_FLUSH_PERIOD_MS    = "memtable_flush_period_in_ms";
+        private static final String DEFAULT_TTL                 = "default_time_to_live";
+        private static final String SPECULATIVE_RETRY           = "speculative_retry";
+        private static final String INDEX_INTERVAL              = "index_interval";
+        private static final String MIN_INDEX_INTERVAL          = "min_index_interval";
+        private static final String MAX_INDEX_INTERVAL          = "max_index_interval";
+
+        private static final boolean DEFAULT_REPLICATE_ON_WRITE = true;
+        private static final double DEFAULT_BF_FP_CHANCE = 0.01;
+        private static final boolean DEFAULT_POPULATE_CACHE_ON_FLUSH = false;
+        private static final int DEFAULT_MEMTABLE_FLUSH_PERIOD = 0;
+        private static final int DEFAULT_DEFAULT_TTL = 0;
+        private static final String DEFAULT_SPECULATIVE_RETRY = "NONE";
+        private static final int DEFAULT_INDEX_INTERVAL = 128;
+        private static final int DEFAULT_MIN_INDEX_INTERVAL = 128;
+        private static final int DEFAULT_MAX_INDEX_INTERVAL = 2048;
+
+        private final boolean isCompactStorage;
+
+        private final String comment;
+        private final double readRepair;
+        private final double localReadRepair;
+        private final boolean replicateOnWrite;
+        private final int gcGrace;
+        private final double bfFpChance;
+        private final Map<String, String> caching;
+        private final boolean populateCacheOnFlush;
+        private final int memtableFlushPeriodMs;
+        private final int defaultTTL;
+        private final String speculativeRetry;
+        private final Integer indexInterval;
+        private final Integer minIndexInterval;
+        private final Integer maxIndexInterval;
+        private final Map<String, String> compaction;
+        private final Map<String, String> compression;
+
+        Options(Row row, boolean isCompactStorage, VersionNumber version) {
+
+            boolean is120 = version.getMajor() < 2;
+            boolean is200 = version.getMajor() == 2 && version.getMinor() == 0;
+            boolean is210 = version.getMajor() == 2 && version.getMinor() >= 1;
+            boolean is300OrHigher = version.getMajor() > 2;
+            boolean is210OrHigher = is210 || is300OrHigher;
+
+            this.isCompactStorage = isCompactStorage;
+            this.comment = isNullOrAbsent(row, COMMENT) ? "" : row.getString(COMMENT);
+            this.readRepair = row.getDouble(READ_REPAIR);
+
+            if(is300OrHigher)
+                this.localReadRepair = row.getDouble(DCLOCAL_READ_REPAIR);
+            else
+                this.localReadRepair = row.getDouble(LOCAL_READ_REPAIR);
+
+            this.replicateOnWrite = is210OrHigher || isNullOrAbsent(row, REPLICATE_ON_WRITE) ? DEFAULT_REPLICATE_ON_WRITE : row.getBool(REPLICATE_ON_WRITE);
+            this.gcGrace = row.getInt(GC_GRACE);
+            this.bfFpChance = isNullOrAbsent(row, BF_FP_CHANCE) ? DEFAULT_BF_FP_CHANCE : row.getDouble(BF_FP_CHANCE);
+
+            this.populateCacheOnFlush = isNullOrAbsent(row, POPULATE_CACHE_ON_FLUSH) ? DEFAULT_POPULATE_CACHE_ON_FLUSH : row.getBool(POPULATE_CACHE_ON_FLUSH);
+            this.memtableFlushPeriodMs = is120 || isNullOrAbsent(row, MEMTABLE_FLUSH_PERIOD_MS) ? DEFAULT_MEMTABLE_FLUSH_PERIOD : row.getInt(MEMTABLE_FLUSH_PERIOD_MS);
+            this.defaultTTL = is120 || isNullOrAbsent(row, DEFAULT_TTL) ? DEFAULT_DEFAULT_TTL : row.getInt(DEFAULT_TTL);
+            this.speculativeRetry = is120 || isNullOrAbsent(row, SPECULATIVE_RETRY) ? DEFAULT_SPECULATIVE_RETRY : row.getString(SPECULATIVE_RETRY);
+
+            if (is200)
+                this.indexInterval = isNullOrAbsent(row, INDEX_INTERVAL) ? DEFAULT_INDEX_INTERVAL : row.getInt(INDEX_INTERVAL);
+            else
+                this.indexInterval = null;
+
+            if (is210OrHigher) {
+                this.minIndexInterval = isNullOrAbsent(row, MIN_INDEX_INTERVAL)
+                                      ? DEFAULT_MIN_INDEX_INTERVAL
+                                      : row.getInt(MIN_INDEX_INTERVAL);
+                this.maxIndexInterval = isNullOrAbsent(row, MAX_INDEX_INTERVAL)
+                                      ? DEFAULT_MAX_INDEX_INTERVAL
+                                      : row.getInt(MAX_INDEX_INTERVAL);
+            } else {
+                this.minIndexInterval = null;
+                this.maxIndexInterval = null;
+            }
+
+            if (is300OrHigher) {
+                this.caching = ImmutableMap.copyOf(row.getMap(CACHING, String.class, String.class));
+            } else if (is210) {
+                this.caching = ImmutableMap.copyOf(SimpleJSONParser.parseStringMap(row.getString(CACHING)));
+            } else {
+                this.caching = ImmutableMap.of("keys", row.getString(CACHING));
+            }
+
+            if (is300OrHigher)
+                this.compaction = ImmutableMap.copyOf(row.getMap(COMPACTION, String.class, String.class));
+            else {
+                this.compaction = ImmutableMap.<String, String>builder()
+                    .put("class", row.getString(COMPACTION_CLASS))
+                    .putAll(SimpleJSONParser.parseStringMap(row.getString(COMPACTION_OPTIONS)))
+                    .build();
+            }
+
+            if(is300OrHigher)
+                this.compression = ImmutableMap.copyOf(row.getMap(COMPRESSION, String.class, String.class));
+            else
+                this.compression = ImmutableMap.copyOf(SimpleJSONParser.parseStringMap(row.getString(COMPRESSION_PARAMS)));
+        }
+
+        private static boolean isNullOrAbsent(Row row, String name) {
+            return row.getColumnDefinitions().getIndexOf(name) < 0
+                   || row.isNull(name);
+        }
+
+        /**
+         * Returns whether the table uses the {@code COMPACT STORAGE} option.
+         *
+         * @return whether the table uses the {@code COMPACT STORAGE} option.
+         */
+        public boolean isCompactStorage() {
+            return isCompactStorage;
+        }
+
+        /**
+         * Returns the commentary set for this table.
+         *
+         * @return the commentary set for this table, or {@code null} if noe has been set.
+         */
+        public String getComment() {
+            return comment;
+        }
+
+        /**
+         * Returns the chance with which a read repair is triggered for this table.
+         *
+         * @return the read repair chance set for table (in [0.0, 1.0]).
+         */
+        public double getReadRepairChance() {
+            return readRepair;
+        }
+
+        /**
+         * Returns the cluster local read repair chance set for this table.
+         *
+         * @return the local read repair chance set for table (in [0.0, 1.0]).
+         */
+        public double getLocalReadRepairChance() {
+            return localReadRepair;
+        }
+
+        /**
+         * Returns whether replicateOnWrite is set for this table.
+         *
+         * This is only meaningful for tables holding counters.
+         *
+         * @return whether replicateOnWrite is set for this table.
+         */
+        public boolean getReplicateOnWrite() {
+            return replicateOnWrite;
+        }
+
+        /**
+         * Returns the tombstone garbage collection grace time in seconds for this table.
+         *
+         * @return the tombstone garbage collection grace time in seconds for this table.
+         */
+        public int getGcGraceInSeconds() {
+            return gcGrace;
+        }
+
+        /**
+         * Returns the false positive chance for the Bloom filter of this table.
+         *
+         * @return the Bloom filter false positive chance for this table (in [0.0, 1.0]).
+         */
+        public double getBloomFilterFalsePositiveChance() {
+            return bfFpChance;
+        }
+
+        /**
+         * Returns the caching options for this table.
+         *
+         * @return an immutable map containing the caching options for this table.
+         */
+        public Map<String, String> getCaching() {
+            return caching;
+        }
+
+        /**
+         * Whether the populate I/O cache on flush is set on this table.
+         *
+         * @return whether the populate I/O cache on flush is set on this table.
+         */
+        public boolean getPopulateIOCacheOnFlush() {
+            return populateCacheOnFlush;
+        }
+
+        /*
+         * Returns the memtable flush period (in milliseconds) option for this table.
+         * <p>
+         * Note: this option is not available in Cassandra 1.2 and will return 0 (no periodic
+         * flush) when connected to 1.2 nodes.
+         *
+         * @return the memtable flush period option for this table or 0 if no
+         * periodic flush is configured.
+         */
+        public int getMemtableFlushPeriodInMs() {
+            return memtableFlushPeriodMs;
+        }
+
+        /**
+         * Returns the default TTL for this table.
+         * <p>
+         * Note: this option is not available in Cassandra 1.2 and will return 0 (no default
+         * TTL) when connected to 1.2 nodes.
+         *
+         * @return the default TTL for this table or 0 if no default TTL is
+         * configured.
+         */
+        public int getDefaultTimeToLive() {
+            return defaultTTL;
+        }
+
+        /**
+         * Returns the speculative retry option for this table.
+         * <p>
+         * Note: this option is not available in Cassandra 1.2 and will return "NONE" (no
+         * speculative retry) when connected to 1.2 nodes.
+         *
+         * @return the speculative retry option this table.
+         */
+        public String getSpeculativeRetry() {
+            return speculativeRetry;
+        }
+
+        /**
+         * Returns the index interval option for this table.
+         * <p>
+         * Note: this option is not available in Cassandra 1.2 (more precisely, it is not
+         * configurable per-table) and will return 128 (the default index interval) when
+         * connected to 1.2 nodes. It is deprecated in Cassandra 2.1 and above, and will
+         * therefore return {@code null} for 2.1 nodes.
+         *
+         * @return the index interval option for this table.
+         */
+        public Integer getIndexInterval() {
+            return indexInterval;
+        }
+
+        /**
+         * Returns the minimum index interval option for this table.
+         * <p>
+         * Note: this option is available in Cassandra 2.1 and above, and will return
+         * {@code null} for earlier versions.
+         *
+         * @return the minimum index interval option for this table.
+         */
+        public Integer getMinIndexInterval() {
+            return minIndexInterval;
+        }
+
+        /**
+         * Returns the maximum index interval option for this table.
+         * <p>
+         * Note: this option is available in Cassandra 2.1 and above, and will return
+         * {@code null} for earlier versions.
+         *
+         * @return the maximum index interval option for this table.
+         */
+        public Integer getMaxIndexInterval() {
+            return maxIndexInterval;
+        }
+
+        /**
+         * Returns the compaction options for this table.
+         *
+         * @return an immutable map containing the compaction options for this table.
+         */
+        public Map<String, String> getCompaction() {
+            return compaction;
+        }
+
+        /**
+         * Returns the compression options for this table.
+         *
+         * @return an immutable map containing the compression options for this table.
+         */
+        public Map<String, String> getCompression() {
+            return compression;
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
@@ -55,4 +55,8 @@ public class Assertions extends org.assertj.core.api.Assertions {
         return new TypeCodecAssert(codec);
     }
 
+    public static MaterializedViewMetadataAssert assertThat(MaterializedViewMetadata view) {
+        return new MaterializedViewMetadataAssert(view);
+    }
+
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/ColumnMetadataAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ColumnMetadataAssert.java
@@ -36,27 +36,27 @@ public class ColumnMetadataAssert extends AbstractAssert<ColumnMetadataAssert, C
     }
 
     public ColumnMetadataAssert isPrimaryKey() {
-        assertThat(actual.getTable().getPrimaryKey().contains(actual));
+        assertThat(actual.getParent().getPrimaryKey().contains(actual));
         return this;
     }
 
     public ColumnMetadataAssert isPartitionKey() {
-        assertThat(actual.getTable().getPartitionKey().contains(actual));
+        assertThat(actual.getParent().getPartitionKey().contains(actual));
         return this;
     }
 
     public ColumnMetadataAssert isClusteringColumn() {
-        assertThat(actual.getTable().getClusteringColumns().contains(actual));
+        assertThat(actual.getParent().getClusteringColumns().contains(actual));
         return this;
     }
 
     public ColumnMetadataAssert isRegularColumn() {
-        assertThat(!actual.getTable().getPrimaryKey().contains(actual));
+        assertThat(!actual.getParent().getPrimaryKey().contains(actual));
         return this;
     }
 
-    public ColumnMetadataAssert hasClusteringOrder(TableMetadata.Order order) {
-        assertThat(actual.getTable().getClusteringOrder().get(actual.getTable().getClusteringColumns().indexOf(actual))).isEqualTo(order);
+    public ColumnMetadataAssert hasClusteringOrder(TableOrView.Order order) {
+        assertThat(actual.getParent().getClusteringOrder().get(actual.getParent().getClusteringColumns().indexOf(actual))).isEqualTo(order);
         return this;
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
@@ -41,7 +41,7 @@ public class IndexMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
     private static final ColumnDefinitions defs = new ColumnDefinitions(new ColumnDefinitions.Definition[]{
         definition(COLUMN_NAME, text()),
         definition(COMPONENT_INDEX, cint()),
-        definition(KIND, text()),
+        definition(KIND_V2, text()),
         definition(INDEX_NAME, text()),
         definition(INDEX_TYPE, text()),
         definition(VALIDATOR, text()),

--- a/driver-core/src/test/java/com/datastax/driver/core/MaterializedViewMetadataAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MaterializedViewMetadataAssert.java
@@ -17,36 +17,27 @@ package com.datastax.driver.core;
 
 import org.assertj.core.api.AbstractAssert;
 
-import static com.datastax.driver.core.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class TableMetadataAssert extends AbstractAssert<TableMetadataAssert, TableMetadata> {
+public class MaterializedViewMetadataAssert extends AbstractAssert<MaterializedViewMetadataAssert, MaterializedViewMetadata> {
 
-    protected TableMetadataAssert(TableMetadata actual) {
-        super(actual, TableMetadataAssert.class);
+    public MaterializedViewMetadataAssert(MaterializedViewMetadata actual) {
+        super(actual, MaterializedViewMetadataAssert.class);
     }
 
-    public TableMetadataAssert hasName(String name) {
+    public MaterializedViewMetadataAssert hasName(String name) {
         assertThat(actual.getName()).isEqualTo(name);
         return this;
     }
 
-    public TableMetadataAssert isCompactStorage() {
-        assertThat(actual.getOptions().isCompactStorage()).isTrue();
+    public MaterializedViewMetadataAssert hasBaseTable(TableMetadata table) {
+        assertThat(actual.getBaseTable()).isEqualTo(table);
         return this;
     }
 
-    public TableMetadataAssert isNotCompactStorage() {
-        assertThat(actual.getOptions().isCompactStorage()).isFalse();
-        return this;
-    }
-
-    public TableMetadataAssert hasNumberOfColumns(int expected) {
+    public MaterializedViewMetadataAssert hasNumberOfColumns(int expected) {
         assertThat(actual.getColumns().size()).isEqualTo(expected);
         return this;
     }
 
-    public TableMetadataAssert hasMaterializedView(MaterializedViewMetadata expected) {
-        assertThat(actual.getView(expected.getName())).isNotNull().isEqualTo(expected);
-        return this;
-    }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/MaterializedViewMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MaterializedViewMetadataTest.java
@@ -1,0 +1,120 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.testng.annotations.Test;
+
+import com.datastax.driver.core.utils.CassandraVersion;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+import static com.datastax.driver.core.DataType.*;
+import static com.datastax.driver.core.TableOrView.Order.DESC;
+
+@CassandraVersion(major = 3)
+public class MaterializedViewMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
+
+    @Test(groups = "short")
+    public void should_create_view_metadata() {
+
+        // given
+        String createTable = String.format(
+            "CREATE TABLE %s.scores("
+                + "user TEXT,"
+                + "game TEXT,"
+                + "year INT,"
+                + "month INT,"
+                + "day INT,"
+                + "score INT,"
+                + "PRIMARY KEY (user, game, year, month, day)"
+                + ")",
+            keyspace);
+        String createMV = String.format(
+            "CREATE MATERIALIZED VIEW %s.monthlyhigh AS "
+                + "SELECT user FROM %s.scores "
+                + "WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL AND day IS NOT NULL "
+                + "PRIMARY KEY ((game, year, month), score, user, day) "
+                + "WITH CLUSTERING ORDER BY (score DESC)",
+            keyspace, keyspace);
+
+        // when
+        session.execute(createTable);
+        session.execute(createMV);
+
+        // then
+        TableMetadata table = cluster.getMetadata().getKeyspace(keyspace).getTable("scores");
+        MaterializedViewMetadata mv = cluster.getMetadata().getKeyspace(keyspace).getMaterializedView("monthlyhigh");
+
+        assertThat(table).isNotNull().hasName("scores").hasMaterializedView(mv).hasNumberOfColumns(6);
+        assertThat(table.getColumns().get(0)).isNotNull().hasName("user").isPartitionKey();
+        assertThat(table.getColumns().get(1)).isNotNull().hasName("game").isClusteringColumn();
+        assertThat(table.getColumns().get(2)).isNotNull().hasName("year").isClusteringColumn();
+        assertThat(table.getColumns().get(3)).isNotNull().hasName("month").isClusteringColumn();
+        assertThat(table.getColumns().get(4)).isNotNull().hasName("day").isClusteringColumn();
+        assertThat(table.getColumns().get(5)).isNotNull().hasName("score").isRegularColumn();
+
+        assertThat(mv).isNotNull().hasName("monthlyhigh").hasBaseTable(table).hasNumberOfColumns(6).isEqualTo(table.getView("monthlyhigh"));
+        assertThat(mv.getColumns().get(0)).isNotNull().hasName("game").isPartitionKey();
+        assertThat(mv.getColumns().get(1)).isNotNull().hasName("year").isPartitionKey();
+        assertThat(mv.getColumns().get(2)).isNotNull().hasName("month").isPartitionKey();
+        assertThat(mv.getColumns().get(3)).isNotNull().hasName("score").isClusteringColumn().hasClusteringOrder(DESC);
+        assertThat(mv.getColumns().get(4)).isNotNull().hasName("user").isClusteringColumn();
+        assertThat(mv.getColumns().get(5)).isNotNull().hasName("day").isClusteringColumn();
+
+        assertThat(mv.asCQLQuery(false)).contains(createMV);
+
+    }
+
+    @Test(groups = "short")
+    public void should_create_view_metadata_with_case_sensitive_column_names() {
+        // given
+        String createTable = String.format(
+            "CREATE TABLE %s.t1 ("
+                + "\"theKey\" int, "
+                + "\"theClustering\" int, "
+                + "\"theValue\" int, "
+                + "PRIMARY KEY (\"theKey\", \"theClustering\"))",
+            keyspace);
+        String createMV = String.format(
+            "CREATE MATERIALIZED VIEW %s.mv1 AS "
+                + "SELECT \"theKey\", \"theClustering\", \"theValue\" "
+                + "FROM %s.t1 "
+                + "WHERE \"theKey\" IS NOT NULL AND \"theClustering\" IS NOT NULL AND \"theValue\" IS NOT NULL "
+                + "PRIMARY KEY (\"theKey\", \"theClustering\")",
+            keyspace, keyspace);
+        // when
+        session.execute(createTable);
+        session.execute(createMV);
+        // then
+        TableMetadata table = cluster.getMetadata().getKeyspace(keyspace).getTable("t1");
+        MaterializedViewMetadata mv = cluster.getMetadata().getKeyspace(keyspace).getMaterializedView("mv1");
+        assertThat(table).isNotNull().hasName("t1").hasMaterializedView(mv).hasNumberOfColumns(3);
+        assertThat(table.getColumns().get(0)).isNotNull().hasName("theKey").isPartitionKey().hasType(cint());
+        assertThat(table.getColumns().get(1)).isNotNull().hasName("theClustering").isClusteringColumn().hasType(cint());
+        assertThat(table.getColumns().get(2)).isNotNull().hasName("theValue").isRegularColumn().hasType(cint());
+        assertThat(mv).isNotNull().hasName("mv1").hasBaseTable(table).hasNumberOfColumns(3);
+        assertThat(mv.getColumns().get(0)).isNotNull().hasName("theKey").isPartitionKey().hasType(cint());
+        assertThat(mv.getColumns().get(1)).isNotNull().hasName("theClustering").isClusteringColumn().hasType(cint());
+        assertThat(mv.getColumns().get(2)).isNotNull().hasName("theValue").isRegularColumn().hasType(cint());
+    }
+
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return Collections.emptyList();
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
@@ -18,15 +18,14 @@ package com.datastax.driver.core;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.entry;
 
 import static com.datastax.driver.core.Assertions.assertThat;
 import static com.datastax.driver.core.DataType.*;
-import static com.datastax.driver.core.TableMetadata.Order.ASC;
-import static com.datastax.driver.core.TableMetadata.Order.DESC;
+import static com.datastax.driver.core.TableOrView.Order.ASC;
+import static com.datastax.driver.core.TableOrView.Order.DESC;
 
 public class TableMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
 
@@ -61,7 +60,7 @@ public class TableMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
             + "    l list<text>,\n"
             + "    v int,\n"
             + "    PRIMARY KEY (k, c1, c2)\n"
-            + ");", keyspace);
+            + ") WITH CLUSTERING ORDER BY (c1 ASC, c2 DESC);", keyspace);
         // when
         session.execute(cql);
         TableMetadata table = cluster.getMetadata().getKeyspace(keyspace).getTable("sparse");
@@ -69,7 +68,7 @@ public class TableMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
         assertThat(table).isNotNull().hasName("sparse").hasNumberOfColumns(5).isNotCompactStorage();
         assertThat(table.getColumns().get(0)).isNotNull().hasName("k").isPartitionKey().hasType(text());
         assertThat(table.getColumns().get(1)).isNotNull().hasName("c1").isClusteringColumn().hasClusteringOrder(ASC).hasType(cint());
-        assertThat(table.getColumns().get(2)).isNotNull().hasName("c2").isClusteringColumn().hasClusteringOrder(ASC).hasType(cfloat());
+        assertThat(table.getColumns().get(2)).isNotNull().hasName("c2").isClusteringColumn().hasClusteringOrder(DESC).hasType(cfloat());
         assertThat(table.getColumns().get(3)).isNotNull().hasName("l").isRegularColumn().hasType(list(text()));
         assertThat(table.getColumns().get(4)).isNotNull().hasName("v").isRegularColumn().hasType(cint());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cassandra.version>3.0.0-beta1</cassandra.version>
+    <cassandra.version>3.0.0-rc1</cassandra.version>
     <java.version>1.6</java.version>
     <log4j.version>1.2.17</log4j.version>
     <slf4j-log4j12.version>1.7.6</slf4j-log4j12.version>


### PR DESCRIPTION
This also includes JAVA-912.

We have some tests failing:
- `HostConnectionPoolTest` fails because protocol v2 has been deprecated
- `MaterializedViewMetadataTest.should_create_view_metadata` fails because clustering order by is apparently not being taken into account

TODO: schema change events for materialized views.
