### PR TITLE
Support cassandra.directory and cassandra.branch props for CCMBridge.

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/TestListener.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestListener.java
@@ -30,7 +30,7 @@ public class TestListener extends TestListenerAdapter implements IInvokedMethodL
     private int test_index = 0;
 
     static {
-        System.out.println("[CCMBridge] Using Cassandra version: " + CCMBridge.CASSANDRA_VERSION);
+        System.out.println("[CCMBridge] Using Cassandra version: " + CCMBridge.CASSANDRA_VERSION + " (install arguments: " + CCMBridge.CASSANDRA_INSTALL_ARGS + ")");
     }
 
     @Override


### PR DESCRIPTION
As I was testing #453, I enhanced CCMBridge in such a way that I could use a custom install, figured I'd create a PR for this.

Adds optional cassandra.directory and cassandra.branch properties as
a means of running cassandra with CCM beyond deployed cassandra
versions.

The order of precedence for what is used is:
1. cassandra.directory
2. cassandra.branch
3. cassandra.version

cassandra.version is still required for `@CassandraVersion` annotation
checks for tests, but won't be used to launch CCM if either
cassandra.directory or cassandra.branch is present.
