### PR TITLE
JAVA-912: Use native CQL names to store data types in schema 'columns' table.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
@@ -33,6 +33,9 @@ public class ColumnMetadata {
     static final String KIND_V2 = "type"; // v2 only
     static final String KIND_V3 = "kind"; // replaces type, v3 onwards
 
+    static final String CLUSTERING_ORDER = "clustering_order";
+    static final String DESC = "desc";
+
     static final String INDEX_TYPE = "index_type";
     static final String INDEX_OPTIONS = "index_options";
     static final String INDEX_NAME = "index_name";
@@ -129,6 +132,7 @@ public class ColumnMetadata {
     // exposed publicly at all.
     static class Raw {
 
+
         public enum Kind {
 
             PARTITION_KEY     ("PARTITION_KEY" , "PARTITION_KEY"),
@@ -178,7 +182,7 @@ public class ColumnMetadata {
             this.isReversed = isReversed;
         }
 
-        static Raw fromRow(Row row, VersionNumber version, ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
+        static Raw fromRow(Row row, VersionNumber version, Cluster cluster) {
             String name = row.getString(COLUMN_NAME);
 
             Kind kind;
@@ -198,14 +202,20 @@ public class ColumnMetadata {
                 position = row.isNull(COMPONENT_INDEX) ? 0 : row.getInt(COMPONENT_INDEX);
             }
 
-            String dataTypeStr;
+            DataType dataType;
+            boolean reversed;
             if(version.getMajor() >= 3) {
-                dataTypeStr = row.getString(TYPE);
+                String dataTypeStr = row.getString(TYPE);
+                dataType = DataTypeParser.parse(dataTypeStr, cluster.getMetadata());
+                String clusteringOrderStr = row.getString(CLUSTERING_ORDER);
+                reversed = clusteringOrderStr.equals(DESC);
             } else {
-                dataTypeStr = row.getString(VALIDATOR);
+                String dataTypeStr = row.getString(VALIDATOR);
+                ProtocolVersion protocolVersion = cluster.getConfiguration().getProtocolOptions().getProtocolVersion();
+                CodecRegistry codecRegistry = cluster.getConfiguration().getCodecRegistry();
+                dataType = CassandraTypeParser.parseOne(dataTypeStr, protocolVersion, codecRegistry);
+                reversed = CassandraTypeParser.isReversed(dataTypeStr);
             }
-            DataType dataType = CassandraTypeParser.parseOne(dataTypeStr, protocolVersion, codecRegistry);
-            boolean reversed = CassandraTypeParser.isReversed(dataTypeStr);
 
             Raw c = new Raw(name, kind, position, dataType, reversed);
 

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -320,7 +320,7 @@ class ControlConnection {
         }
 
         SchemaParser.forVersion(cassandraVersion)
-            .refresh(cluster.metadata,
+            .refresh(cluster.getCluster(),
                 targetType, targetKeyspace, targetName, targetSignature,
                 connection, cassandraVersion);
 

--- a/driver-core/src/main/java/com/datastax/driver/core/DataTypeParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataTypeParser.java
@@ -1,0 +1,258 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.ImmutableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datastax.driver.core.exceptions.DriverInternalError;
+
+/*
+ * Helps transforming CQL types (as read in the schema tables) to
+ * DataTypes, starting from Cassandra 3.0.
+ *
+ * Note that those methods all throw DriverInternalError when there is a parsing
+ * problem because in theory we'll only parse class names coming from Cassandra and
+ * so there shouldn't be anything wrong with them.
+ */
+class DataTypeParser {
+
+    private static final Logger logger = LoggerFactory.getLogger(DataTypeParser.class);
+
+    private static final String FROZEN = "frozen";
+    private static final String LIST = "list";
+    private static final String SET = "set";
+    private static final String MAP = "map";
+    private static final String TUPLE = "tuple";
+
+    private static ImmutableMap<String, DataType> nativeTypesMap =
+        new ImmutableMap.Builder<String, DataType>()
+            .put("ascii",     DataType.ascii())
+            .put("bigint",    DataType.bigint())
+            .put("blob",      DataType.blob())
+            .put("boolean",   DataType.cboolean())
+            .put("counter",   DataType.counter())
+            .put("decimal",   DataType.decimal())
+            .put("double",    DataType.cdouble())
+            .put("float",     DataType.cfloat())
+            .put("inet",      DataType.inet())
+            .put("int",       DataType.cint())
+            .put("text",      DataType.text())
+            .put("varchar",   DataType.varchar())
+            .put("timestamp", DataType.timestamp())
+            .put("date",      DataType.date())
+            .put("time",      DataType.time())
+            .put("uuid",      DataType.uuid())
+            .put("varint",    DataType.varint())
+            .put("timeuuid",  DataType.timeuuid())
+            .put("tinyint",   DataType.tinyint())
+            .put("smallint",  DataType.smallint())
+            .build();
+
+    static DataType parse(String type, Metadata metadata) {
+        boolean frozen = false;
+
+        if (type.startsWith(FROZEN)) {
+            frozen = true;
+            type = extractNestedType(type);
+        }
+
+        Parser parser = new Parser(type, 0);
+        String next = parser.parseNextName();
+
+        if (next.startsWith(LIST))
+            return DataType.list(parse(parser.getTypeParameters().get(0), metadata), frozen);
+
+        if (next.startsWith(SET))
+            return DataType.set(parse(parser.getTypeParameters().get(0), metadata), frozen);
+
+        if (next.startsWith(MAP)) {
+            List<String> params = parser.getTypeParameters();
+            return DataType.map(parse(params.get(0), metadata), parse(params.get(1), metadata), frozen);
+        }
+
+        if (frozen)
+            logger.warn("Got frozen keyword for something else than a collection, "
+                + "this driver version might be too old for your version of Cassandra");
+
+        if (type.startsWith(TUPLE)) {
+            List<String> rawTypes = parser.getTypeParameters();
+            List<DataType> types = new ArrayList<DataType>(rawTypes.size());
+            for (String rawType : rawTypes) {
+                types.add(parse(rawType, metadata));
+            }
+            return metadata.newTupleType(types);
+        }
+
+        // TODO User Defined Types
+
+        DataType dataType = nativeTypesMap.get(next);
+
+        if(dataType == null)
+            dataType = DataType.custom(type);
+
+        return dataType;
+    }
+
+    private static String extractNestedType(String typeName) {
+        Parser p = new Parser(typeName, 0);
+        p.parseNextName();
+        List<String> l = p.getTypeParameters();
+        if (l.size() != 1)
+            throw new IllegalStateException();
+        typeName = l.get(0);
+        return typeName;
+    }
+
+    private static class Parser {
+
+        private final String str;
+        private int idx;
+
+        private Parser(String str, int idx) {
+            this.str = str;
+            this.idx = idx;
+        }
+
+        public String parseNextName() {
+            skipBlank();
+            return readNextIdentifier();
+        }
+
+        public String readOne() {
+            String name = parseNextName();
+            String args = readRawArguments();
+            return name + args;
+        }
+
+        // Assumes we have just read a type name and read it's potential arguments
+        // blindly. I.e. it assume that either parsing is done or that we're on a '<'
+        // and this reads everything up until the corresponding closing '>'. It
+        // returns everything read, including the enclosing parenthesis.
+        private String readRawArguments() {
+            skipBlank();
+
+            if (isEOS() || str.charAt(idx) == '>' || str.charAt(idx) == ',')
+                return "";
+
+            if (str.charAt(idx) != '<')
+                throw new IllegalStateException(String.format("Expecting char %d of %s to be '<' but '%c' found", idx, str, str.charAt(idx)));
+
+            int i = idx;
+            int open = 1;
+            while (open > 0) {
+                ++idx;
+
+                if (isEOS())
+                    throw new IllegalStateException("Non closed angle brackets");
+
+                if (str.charAt(idx) == '<') {
+                    open++;
+                } else if (str.charAt(idx) == '>') {
+                    open--;
+                }
+            }
+            // we've stopped at the last closing ')' so move past that
+            ++idx;
+            return str.substring(i, idx);
+        }
+
+        private List<String> getTypeParameters() {
+            List<String> list = new ArrayList<String>();
+
+            if (isEOS())
+                return list;
+
+            skipBlankAndComma();
+
+            if (str.charAt(idx) != '<')
+                throw new IllegalStateException();
+
+            ++idx; // skipping '<'
+
+            while (skipBlankAndComma()) {
+                if (str.charAt(idx) == '>') {
+                    ++idx;
+                    return list;
+                }
+
+                try {
+                    list.add(readOne());
+                } catch (DriverInternalError e) {
+                    DriverInternalError ex = new DriverInternalError(String.format("Exception while parsing '%s' around char %d", str, idx));
+                    ex.initCause(e);
+                    throw ex;
+                }
+            }
+            throw new DriverInternalError(String.format("Syntax error parsing '%s' at char %d: unexpected end of string", str, idx));
+        }
+
+        private boolean isEOS() {
+            return isEOS(str, idx);
+        }
+
+        private static boolean isEOS(String str, int i) {
+            return i >= str.length();
+        }
+
+        private void skipBlank() {
+            idx = skipBlank(str, idx);
+        }
+
+        private static int skipBlank(String str, int i) {
+            while (!isEOS(str, i) && ParseUtils.isBlank(str.charAt(i)))
+                ++i;
+
+            return i;
+        }
+
+        // skip all blank and at best one comma, return true if there not EOS
+        private boolean skipBlankAndComma() {
+            boolean commaFound = false;
+            while (!isEOS()) {
+                int c = str.charAt(idx);
+                if (c == ',') {
+                    if (commaFound)
+                        return true;
+                    else
+                        commaFound = true;
+                } else if (!ParseUtils.isBlank(c)) {
+                    return true;
+                }
+                ++idx;
+            }
+            return false;
+        }
+
+        // left idx positioned on the character stopping the read
+        public String readNextIdentifier() {
+            int i = idx;
+            while (!isEOS() && ParseUtils.isIdentifierChar(str.charAt(idx)))
+                ++idx;
+
+            return str.substring(i, idx);
+        }
+
+        @Override
+        public String toString() {
+            return str.substring(0, idx) + "[" + (idx == str.length() ? "" : str.charAt(idx)) + "]" + str.substring(idx+1);
+        }
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -327,7 +327,17 @@ public class Metadata {
      * @return the newly created tuple type.
      */
     public TupleType newTupleType(DataType... types) {
-        return new TupleType(Arrays.asList(types), cluster.protocolVersion(), cluster.configuration.getCodecRegistry());
+        return newTupleType(Arrays.asList(types));
+    }
+
+    /**
+     * Creates a tuple type given a list of types.
+     *
+     * @param types the types for the tuple type.
+     * @return the newly created tuple type.
+     */
+    public TupleType newTupleType(List<DataType> types) {
+        return new TupleType(types, cluster.protocolVersion(), cluster.configuration.getCodecRegistry());
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
@@ -50,7 +50,7 @@ public class TableMetadata {
     private static final String SUPER                = "super";
     private static final String COMPOUND             = "compound";
 
-    private static final String EMPTY_TYPE           = "org.apache.cassandra.db.marshal.EmptyType";
+    private static final String EMPTY_TYPE           = "empty";
 
     private static final Comparator<ColumnMetadata> columnMetadataComparator = new Comparator<ColumnMetadata>() {
         public int compare(ColumnMetadata c1, ColumnMetadata c2) {
@@ -318,7 +318,9 @@ public class TableMetadata {
         Iterator<ColumnMetadata.Raw> it = cols.iterator();
         while(it.hasNext()) {
             ColumnMetadata.Raw col = it.next();
-            if(col.kind == ColumnMetadata.Raw.Kind.REGULAR && col.dataType instanceof DataType.CustomType && EMPTY_TYPE.equals(((DataType.CustomType)col.dataType).getCustomTypeClassName())) {
+            if (col.kind == ColumnMetadata.Raw.Kind.REGULAR
+                && col.dataType instanceof DataType.CustomType
+                && ((DataType.CustomType)col.dataType).getCustomTypeClassName().equals(EMPTY_TYPE)) {
                 // remove "value EmptyType" regular column
                 it.remove();
             }

--- a/driver-core/src/test/java/com/datastax/driver/core/AggregateMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AggregateMetadataTest.java
@@ -15,167 +15,131 @@
  */
 package com.datastax.driver.core;
 
-import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 
-import com.google.common.collect.ImmutableList;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import static com.datastax.driver.core.Assertions.assertThat;
+import static com.datastax.driver.core.DataType.cint;
+import static com.datastax.driver.core.DataType.text;
 
-public class AggregateMetadataTest {
+public class AggregateMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
 
-    // These tests needs a protocol version to (de)serialize INITCONDs. Since we're using basic types, I don't think the binary format
-    // is going to change at any time in the future, so the actual version does not matter.
-    private static final ProtocolVersion PROTOCOL_VERSION = ProtocolVersion.NEWEST_SUPPORTED;
-    private CodecRegistry codecRegistry = new CodecRegistry();
-
-    KeyspaceMetadata keyspace;
-
-    @BeforeMethod(groups = "unit")
-    public void setup() {
-        keyspace = new KeyspaceMetadata("ks", false, Collections.<String, String>emptyMap());
-    }
-
-    @Test(groups = "unit")
+    @Test(groups = "short")
     public void should_parse_and_format_aggregate_with_initcond_and_no_finalfunc() {
-        FunctionMetadata stateFunc = mock(FunctionMetadata.class);
-        keyspace.functions.put("cat(text,int)", stateFunc);
-
-        AggregateMetadata aggregate = AggregateMetadata.build(keyspace, SYSTEM_ROW_CAT_TOS, PROTOCOL_VERSION, codecRegistry);
-
+        // given
+        String cqlFunction = String.format("CREATE FUNCTION %s.cat(s text,v int) RETURNS NULL ON NULL INPUT RETURNS text LANGUAGE java AS 'return s;';", keyspace);
+        String cqlAggregate = String.format("CREATE AGGREGATE %s.cat_tos(int) SFUNC cat STYPE text INITCOND '0';", keyspace);
+        // when
+        session.execute(cqlFunction);
+        session.execute(cqlAggregate);
+        // then
+        KeyspaceMetadata keyspace = cluster.getMetadata().getKeyspace(this.keyspace);
+        FunctionMetadata stateFunc = keyspace.getFunction("cat", text(), cint());
+        AggregateMetadata aggregate = keyspace.getAggregate("cat_tos", cint());
         assertThat(aggregate).isNotNull();
         assertThat(aggregate.getFullName()).isEqualTo("cat_tos(int)");
         assertThat(aggregate.getSimpleName()).isEqualTo("cat_tos");
-        assertThat(aggregate.getArgumentTypes()).containsExactly(DataType.cint());
+        assertThat(aggregate.getArgumentTypes()).containsExactly(cint());
         assertThat(aggregate.getFinalFunc()).isNull();
         assertThat(aggregate.getInitCond()).isEqualTo("0");
-        assertThat(aggregate.getReturnType()).isEqualTo(DataType.text());
+        assertThat(aggregate.getReturnType()).isEqualTo(text());
         assertThat(aggregate.getStateFunc()).isEqualTo(stateFunc);
-        assertThat(aggregate.getStateType()).isEqualTo(DataType.text());
-
-        assertThat(keyspace.getAggregate("cat_tos", DataType.cint())).isEqualTo(aggregate);
-
-        assertThat(aggregate.toString()).isEqualTo("CREATE AGGREGATE ks.cat_tos(int) SFUNC cat STYPE text INITCOND '0';");
-
-        assertThat(aggregate.exportAsString()).isEqualTo("CREATE AGGREGATE ks.cat_tos(int)\n"
+        assertThat(aggregate.getStateType()).isEqualTo(text());
+        assertThat(aggregate.toString()).isEqualTo(cqlAggregate);
+        assertThat(aggregate.exportAsString()).isEqualTo(String.format("CREATE AGGREGATE %s.cat_tos(int)\n"
             + "SFUNC cat STYPE text\n"
-            + "INITCOND '0';");
+            + "INITCOND '0';", this.keyspace));
     }
 
-    @Test(groups = "unit")
+    @Test(groups = "short")
     public void should_parse_and_format_aggregate_with_no_arguments() {
-        FunctionMetadata stateFunc = mock(FunctionMetadata.class);
-        keyspace.functions.put("inc(int)", stateFunc);
-
-        AggregateMetadata aggregate = AggregateMetadata.build(keyspace, SYSTEM_ROW_MYCOUNT, PROTOCOL_VERSION, codecRegistry);
-
+        // given
+        String cqlFunction = String.format("CREATE FUNCTION %s.inc(i int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return i+1;';", keyspace);
+        String cqlAggregate = String.format("CREATE AGGREGATE %s.mycount() SFUNC inc STYPE int INITCOND 0;", keyspace);
+        // when
+        session.execute(cqlFunction);
+        session.execute(cqlAggregate);
+        // then
+        KeyspaceMetadata keyspace = cluster.getMetadata().getKeyspace(this.keyspace);
+        FunctionMetadata stateFunc = keyspace.getFunction("inc", cint());
+        AggregateMetadata aggregate = keyspace.getAggregate("mycount");
         assertThat(aggregate).isNotNull();
         assertThat(aggregate.getFullName()).isEqualTo("mycount()");
         assertThat(aggregate.getSimpleName()).isEqualTo("mycount");
         assertThat(aggregate.getArgumentTypes()).isEmpty();
         assertThat(aggregate.getFinalFunc()).isNull();
         assertThat(aggregate.getInitCond()).isEqualTo(0);
-        assertThat(aggregate.getReturnType()).isEqualTo(DataType.cint());
+        assertThat(aggregate.getReturnType()).isEqualTo(cint());
         assertThat(aggregate.getStateFunc()).isEqualTo(stateFunc);
-        assertThat(aggregate.getStateType()).isEqualTo(DataType.cint());
-
-        assertThat(keyspace.getAggregate("mycount")).isEqualTo(aggregate);
-
-        assertThat(aggregate.toString()).isEqualTo("CREATE AGGREGATE ks.mycount() SFUNC inc STYPE int INITCOND 0;");
-
-        assertThat(aggregate.exportAsString()).isEqualTo("CREATE AGGREGATE ks.mycount()\n"
+        assertThat(aggregate.getStateType()).isEqualTo(cint());
+        assertThat(aggregate.toString()).isEqualTo(cqlAggregate);
+        assertThat(aggregate.exportAsString()).isEqualTo(String.format("CREATE AGGREGATE %s.mycount()\n"
             + "SFUNC inc STYPE int\n"
-            + "INITCOND 0;");
+            + "INITCOND 0;", this.keyspace));
     }
 
-    @Test(groups = "unit")
+    @Test(groups = "short")
     public void should_parse_and_format_aggregate_with_final_function() {
-        FunctionMetadata stateFunc = mock(FunctionMetadata.class);
-        keyspace.functions.put("plus(int,int)", stateFunc);
-        FunctionMetadata finalFunc = mock(FunctionMetadata.class);
-        keyspace.functions.put("announce(int)", finalFunc);
-
-        AggregateMetadata aggregate = AggregateMetadata.build(keyspace, SYSTEM_ROW_PRETTYSUM, PROTOCOL_VERSION, codecRegistry);
-
+        // given
+        String cqlFunction1 = String.format("CREATE FUNCTION %s.plus(i int, j int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return i+j;';", keyspace);
+        String cqlFunction2 = String.format("CREATE FUNCTION %s.announce(i int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return i;';", keyspace);
+        String cqlAggregate = String.format("CREATE AGGREGATE %s.prettysum(int) SFUNC plus STYPE int FINALFUNC announce INITCOND 0;", keyspace);
+        // when
+        session.execute(cqlFunction1);
+        session.execute(cqlFunction2);
+        session.execute(cqlAggregate);
+        // then
+        KeyspaceMetadata keyspace = cluster.getMetadata().getKeyspace(this.keyspace);
+        FunctionMetadata stateFunc = keyspace.getFunction("plus", cint(), cint());
+        FunctionMetadata finalFunc = keyspace.getFunction("announce", cint());
+        AggregateMetadata aggregate = keyspace.getAggregate("prettysum", cint());
         assertThat(aggregate).isNotNull();
         assertThat(aggregate.getFullName()).isEqualTo("prettysum(int)");
         assertThat(aggregate.getSimpleName()).isEqualTo("prettysum");
-        assertThat(aggregate.getArgumentTypes()).containsExactly(DataType.cint());
+        assertThat(aggregate.getArgumentTypes()).containsExactly(cint());
         assertThat(aggregate.getFinalFunc()).isEqualTo(finalFunc);
         assertThat(aggregate.getInitCond()).isEqualTo(0);
-        assertThat(aggregate.getReturnType()).isEqualTo(DataType.text());
+        assertThat(aggregate.getReturnType()).isEqualTo(cint());
         assertThat(aggregate.getStateFunc()).isEqualTo(stateFunc);
-        assertThat(aggregate.getStateType()).isEqualTo(DataType.cint());
-
-        assertThat(keyspace.getAggregate("prettysum", DataType.cint())).isEqualTo(aggregate);
-
-        assertThat(aggregate.toString()).isEqualTo("CREATE AGGREGATE ks.prettysum(int) SFUNC plus STYPE int FINALFUNC announce INITCOND 0;");
-
-        assertThat(aggregate.exportAsString()).isEqualTo("CREATE AGGREGATE ks.prettysum(int)\n"
+        assertThat(aggregate.getStateType()).isEqualTo(cint());
+        assertThat(aggregate.toString()).isEqualTo(cqlAggregate);
+        assertThat(aggregate.exportAsString()).isEqualTo(String.format("CREATE AGGREGATE %s.prettysum(int)\n"
             + "SFUNC plus STYPE int\n"
             + "FINALFUNC announce\n"
-            + "INITCOND 0;");
+            + "INITCOND 0;", this.keyspace));
     }
 
-    @Test(groups = "unit")
+    @Test(groups = "short")
     public void should_parse_and_format_aggregate_with_no_initcond() {
-        FunctionMetadata stateFunc = mock(FunctionMetadata.class);
-        keyspace.functions.put("plus(int,int)", stateFunc);
-
-        AggregateMetadata aggregate = AggregateMetadata.build(keyspace, SYSTEM_ROW_SUM, PROTOCOL_VERSION, codecRegistry);
-
+        // given
+        String cqlFunction = String.format("CREATE FUNCTION %s.plus2(i int, j int) CALLED ON NULL INPUT RETURNS int LANGUAGE java AS 'return i+j;';", keyspace);
+        String cqlAggregate = String.format("CREATE AGGREGATE %s.sum(int) SFUNC plus2 STYPE int;", keyspace);
+        // when
+        session.execute(cqlFunction);
+        session.execute(cqlAggregate);
+        // then
+        KeyspaceMetadata keyspace = cluster.getMetadata().getKeyspace(this.keyspace);
+        FunctionMetadata stateFunc = keyspace.getFunction("plus2", cint(), cint());
+        AggregateMetadata aggregate = keyspace.getAggregate("sum", cint());
         assertThat(aggregate).isNotNull();
         assertThat(aggregate.getFullName()).isEqualTo("sum(int)");
         assertThat(aggregate.getSimpleName()).isEqualTo("sum");
-        assertThat(aggregate.getArgumentTypes()).containsExactly(DataType.cint());
+        assertThat(aggregate.getArgumentTypes()).containsExactly(cint());
         assertThat(aggregate.getFinalFunc()).isNull();
         assertThat(aggregate.getInitCond()).isNull();
-        assertThat(aggregate.getReturnType()).isEqualTo(DataType.cint());
+        assertThat(aggregate.getReturnType()).isEqualTo(cint());
         assertThat(aggregate.getStateFunc()).isEqualTo(stateFunc);
-        assertThat(aggregate.getStateType()).isEqualTo(DataType.cint());
-
-        assertThat(keyspace.getAggregate("sum", DataType.cint())).isEqualTo(aggregate);
-
-        assertThat(aggregate.toString()).isEqualTo("CREATE AGGREGATE ks.sum(int) SFUNC plus STYPE int;");
-
-        assertThat(aggregate.exportAsString()).isEqualTo("CREATE AGGREGATE ks.sum(int)\n"
-            + "SFUNC plus STYPE int;");
+        assertThat(aggregate.getStateType()).isEqualTo(cint());
+        assertThat(aggregate.toString()).isEqualTo(cqlAggregate);
+        assertThat(aggregate.exportAsString()).isEqualTo(String.format("CREATE AGGREGATE %s.sum(int)\n"
+            + "SFUNC plus2 STYPE int;", this.keyspace));
     }
 
-    private static final String INT = "org.apache.cassandra.db.marshal.Int32Type";
-    private static final String TEXT = "org.apache.cassandra.db.marshal.UTF8Type";
-
-    private static final Row SYSTEM_ROW_CAT_TOS = mockRow("cat_tos", ImmutableList.of("int"), ImmutableList.of(INT),
-        null, TypeCodec.VarcharCodec.instance.serialize("0", PROTOCOL_VERSION), TEXT, "cat", TEXT);
-
-    private static final Row SYSTEM_ROW_MYCOUNT = mockRow("mycount", Collections.<String>emptyList(), Collections.<String>emptyList(),
-        null, TypeCodec.IntCodec.instance.serialize(0, PROTOCOL_VERSION), INT, "inc", INT);
-
-    private static final Row SYSTEM_ROW_PRETTYSUM = mockRow("prettysum", ImmutableList.of("int"), ImmutableList.of(INT),
-        "announce", TypeCodec.IntCodec.instance.serialize(0, PROTOCOL_VERSION), TEXT, "plus", INT);
-
-    private static final Row SYSTEM_ROW_SUM = mockRow("sum", ImmutableList.of("int"), ImmutableList.of(INT),
-        null, null, INT, "plus", INT);
-
-    private static Row mockRow(String aggregateName, List<String> signature, List<String> argumentTypes, String finalFunc,
-                               ByteBuffer initCond, String returnType, String stateFunc, String stateType) {
-        Row row = mock(Row.class);
-
-        when(row.getString("aggregate_name")).thenReturn(aggregateName);
-        when(row.getList("signature", String.class)).thenReturn(signature);
-        when(row.getList("argument_types", String.class)).thenReturn(argumentTypes);
-        when(row.getString("final_func")).thenReturn(finalFunc);
-        when(row.getBytes("initcond")).thenReturn(initCond);
-        when(row.getString("return_type")).thenReturn(returnType);
-        when(row.getString("state_func")).thenReturn(stateFunc);
-        when(row.getString("state_type")).thenReturn(stateType);
-
-        return row;
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return Collections.emptyList();
     }
+
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeParserTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeParserTest.java
@@ -1,0 +1,94 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.Collection;
+
+import com.google.common.collect.Lists;
+import org.testng.annotations.Test;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+import static com.datastax.driver.core.DataType.*;
+import static com.datastax.driver.core.DataTypeParser.parse;
+public class DataTypeParserTest extends CCMBridge.PerClassSingleNodeCluster {
+
+    @Test(groups = "short")
+    public void should_parse_native_types() {
+        assertThat(parse("ascii", cluster.getMetadata())).isEqualTo(ascii());
+        assertThat(parse("bigint", cluster.getMetadata())).isEqualTo(bigint());
+        assertThat(parse("blob", cluster.getMetadata())).isEqualTo(blob());
+        assertThat(parse("boolean", cluster.getMetadata())).isEqualTo(cboolean());
+        assertThat(parse("counter", cluster.getMetadata())).isEqualTo(counter());
+        assertThat(parse("decimal", cluster.getMetadata())).isEqualTo(decimal());
+        assertThat(parse("double", cluster.getMetadata())).isEqualTo(cdouble());
+        assertThat(parse("float", cluster.getMetadata())).isEqualTo(cfloat());
+        assertThat(parse("inet", cluster.getMetadata())).isEqualTo(inet());
+        assertThat(parse("int", cluster.getMetadata())).isEqualTo(cint());
+        assertThat(parse("text", cluster.getMetadata())).isEqualTo(text());
+        assertThat(parse("varchar", cluster.getMetadata())).isEqualTo(varchar());
+        assertThat(parse("timestamp", cluster.getMetadata())).isEqualTo(timestamp());
+        assertThat(parse("date", cluster.getMetadata())).isEqualTo(date());
+        assertThat(parse("time", cluster.getMetadata())).isEqualTo(time());
+        assertThat(parse("uuid", cluster.getMetadata())).isEqualTo(uuid());
+        assertThat(parse("varint", cluster.getMetadata())).isEqualTo(varint());
+        assertThat(parse("timeuuid", cluster.getMetadata())).isEqualTo(timeuuid());
+        assertThat(parse("tinyint", cluster.getMetadata())).isEqualTo(tinyint());
+        assertThat(parse("smallint", cluster.getMetadata())).isEqualTo(smallint());
+    }
+
+    @Test(groups = "short")
+    public void should_ignore_whitespace() {
+        assertThat(parse("  int  ", cluster.getMetadata())).isEqualTo(cint());
+        assertThat(parse("  set < bigint > ", cluster.getMetadata())).isEqualTo(set(bigint()));
+        assertThat(parse("  map  <  date  ,  timeuuid  >  ", cluster.getMetadata())).isEqualTo(map(date(), timeuuid()));
+    }
+
+    @Test(groups = "short")
+    public void should_parse_collection_types() {
+        assertThat(parse("list<int>", cluster.getMetadata())).isEqualTo(list(cint()));
+        assertThat(parse("set<bigint>", cluster.getMetadata())).isEqualTo(set(bigint()));
+        assertThat(parse("map<date,timeuuid>", cluster.getMetadata())).isEqualTo(map(date(), timeuuid()));
+    }
+
+    @Test(groups = "short")
+    public void should_parse_frozen_collection_types() {
+        assertThat(parse("frozen<list<int>>", cluster.getMetadata())).isEqualTo(list(cint(), true));
+        assertThat(parse("frozen<set<bigint>>", cluster.getMetadata())).isEqualTo(set(bigint(), true));
+        assertThat(parse("frozen<map<date,timeuuid>>", cluster.getMetadata())).isEqualTo(map(date(), timeuuid(), true));
+    }
+
+    @Test(groups = "short")
+    public void should_parse_nested_collection_types() {
+        assertThat(parse("list<list<int>>", cluster.getMetadata())).isEqualTo(list(list(cint())));
+        assertThat(parse("set<list<frozen<map<bigint,varchar>>>>", cluster.getMetadata())).isEqualTo(set(list(map(bigint(), varchar(), true))));
+    }
+
+    @Test(groups = "short")
+    public void should_parse_tuple_types() {
+        assertThat(parse("tuple<int,list<text>>", cluster.getMetadata())).isEqualTo(cluster.getMetadata().newTupleType(cint(), list(text())));
+    }
+
+    @Test(groups = "short", enabled = false)
+    public void should_parse_user_defined_types() {
+        assertThat(parse(keyspace + ".udt1", cluster.getMetadata())).isEqualTo(cluster.getMetadata().getKeyspace(keyspace).getUserType("udt1"));
+    }
+
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return Lists.newArrayList(String.format("CREATE TYPE %s.udt1 (f1 int, f2 frozen<list<text>>)", keyspace));
+    }
+    
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
@@ -220,9 +220,7 @@ public class IndexMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
             wrap("{\"foo\" : \"bar\", \"class_name\" : \"dummy.DummyIndex\"}") // index options
         );
         Row row = ArrayBackedRow.fromData(defs, M3PToken.FACTORY, cluster.getConfiguration().getProtocolOptions().getProtocolVersion(), data);
-        Raw raw = Raw.fromRow(row, VersionNumber.parse("2.1"),
-            cluster.getConfiguration().getProtocolOptions().getProtocolVersion(),
-            cluster.getConfiguration().getCodecRegistry());
+        Raw raw = Raw.fromRow(row, VersionNumber.parse("2.1"), cluster);
         ColumnMetadata column = ColumnMetadata.fromRaw(table, raw);
         IndexMetadata index = IndexMetadata.fromLegacy(column, raw);
         assertThat(index).hasName("custom_index")
@@ -258,9 +256,7 @@ public class IndexMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
             wrap("null") // index options
         );
         Row row = ArrayBackedRow.fromData(defs, M3PToken.FACTORY, cluster.getConfiguration().getProtocolOptions().getProtocolVersion(), data);
-        Raw raw = Raw.fromRow(row, VersionNumber.parse("2.1"),
-            cluster.getConfiguration().getProtocolOptions().getProtocolVersion(),
-            cluster.getConfiguration().getCodecRegistry());
+        Raw raw = Raw.fromRow(row, VersionNumber.parse("2.1"), cluster);
         ColumnMetadata column = ColumnMetadata.fromRaw(table, raw);
         IndexMetadata index = IndexMetadata.fromLegacy(column, raw);
         assertThat(index).hasName("cfs_archive_parent_path")

--- a/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
@@ -18,7 +18,6 @@ package com.datastax.driver.core;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.entry;


### PR DESCRIPTION
This commit also incorporates the new "clustering_order" column in schema 'columns' table. 

Note that this is a work in progress. In particular UDTs do not work yet.
