### PR TITLE
Verify on empty list signature in should_debounce_and_coalesce_multiple_alter_events_on_same_table_into_refresh_table

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaRefreshDebouncerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaRefreshDebouncerTest.java
@@ -16,6 +16,7 @@
 package com.datastax.driver.core;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.mockito.ArgumentCaptor;
 import org.testng.SkipException;
@@ -248,7 +249,7 @@ public class SchemaRefreshDebouncerTest extends CCMBridge.PerClassSingleNodeClus
             .doesNotHaveComment(comment);
 
         // Verify a refresh of the table was executed, but only once.
-        verify(controlConnection, times(1)).refreshSchema(TABLE, keyspace, table, null);
+        verify(controlConnection, times(1)).refreshSchema(TABLE, keyspace, table, Collections.<String>emptyList());
 
         KeyspaceMetadata ksm = cluster2.getMetadata().getKeyspace(keyspace);
         assertThat(ksm).isNotNull();


### PR DESCRIPTION
Just a trivial test change so that the signature expected in refreshSchema is an empty list instead of null, as in coalesce the original 'create keyspace' SchemaRefreshRequest is used which has an empty signature.
