### PR TITLE
JAVA-936: Adapt schema metadata parsing logic to new storage format of CQL types in C* 3.0

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -5,7 +5,7 @@
 - [improvement] JAVA-958: Make TableOrView.Order visible.
 - [improvement] JAVA-968: Update metrics to the latest version.
 - [improvement] JAVA-965: Improve error handling for when a non-type 1 UUID is given to bind() on a timeuuid column.
-- [improvement] JAVA-885: Pass the authenticator name from the server to the auth provider. 
+- [improvement] JAVA-885: Pass the authenticator name from the server to the auth provider.
 - [improvement] JAVA-961: Raise an exception when an older version of guava (<16.01) is found.
 - [bug] JAVA-972: TypeCodec.parse() implementations should be case insensitive when checking for keyword NULL.
 - [bug] JAVA-971: Make type codecs invariant.
@@ -13,6 +13,7 @@
 - [improvement] JAVA-841: Refactor SSLOptions API.
 - [improvement] JAVA-948: Don't limit cipher suites by default.
 - [improvement] JAVA-917: Document SSL configuration.
+- [improvement] JAVA-936: Adapt schema metadata parsing logic to new storage format of CQL types in C* 3.0.
 
 Merged from 2.1 branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
@@ -499,6 +499,8 @@ public final class CodecRegistry {
                 throw (CodecNotFoundException) e.getCause();
             }
             throw new CodecNotFoundException(e.getCause(), cqlType, javaType);
+        } catch (RuntimeException e) {
+            throw new CodecNotFoundException(e.getCause(), cqlType, javaType);
         } catch (ExecutionException e) {
             throw new CodecNotFoundException(e.getCause(), cqlType, javaType);
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/CodecUtils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CodecUtils.java
@@ -80,7 +80,7 @@ public final class CodecUtils {
         if(cqlType instanceof UserType) {
             UserType userType = (UserType)cqlType;
             userType.setCodecRegistry(codecRegistry);
-            for (UserType.Field field : userType.byIdx) {
+            for (UserType.Field field : userType.getFields()) {
                 setCodecRegistry(field.getType(), codecRegistry);
             }
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -340,7 +340,7 @@ class ControlConnection implements Connection.Owner {
         }
 
         SchemaParser.forVersion(cassandraVersion)
-            .refresh(cluster.metadata,
+            .refresh(cluster.getCluster(),
                 targetType, targetKeyspace, targetName, targetSignature,
                 connection, cassandraVersion);
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/DataType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataType.java
@@ -162,8 +162,8 @@ public abstract class DataType {
         switch (name) {
             case CUSTOM:
                 String className = CBUtil.readString(buffer);
-                return CassandraTypeParser.isUserType(className) || CassandraTypeParser.isTupleType(className)
-                     ? CassandraTypeParser.parseOne(className, protocolVersion, codecRegistry)
+                return DataTypeClassNameParser.isUserType(className) || DataTypeClassNameParser.isTupleType(className)
+                     ? DataTypeClassNameParser.parseOne(className, protocolVersion, codecRegistry)
                      : custom(className);
             case LIST:
                 return list(decode(buffer, protocolVersion, codecRegistry));

--- a/driver-core/src/main/java/com/datastax/driver/core/DataTypeClassNameParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataTypeClassNameParser.java
@@ -25,8 +25,9 @@ import com.datastax.driver.core.exceptions.DriverInternalError;
 import com.datastax.driver.core.utils.Bytes;
 
 /*
- * Helps transforming Cassandra types (as read in the schema tables) to
- * DataType.
+ * Parse data types from schema tables, for Cassandra 3.0 and above.
+ * In these versions, data types appear as class names, like "org.apache.cassandra.db.marshal.AsciiType"
+ * or "org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.Int32Type)".
  *
  * This is modified (and simplified) from Cassandra's TypeParser class to suit
  * our needs. In particular it's not very efficient, but it doesn't really matter
@@ -36,8 +37,8 @@ import com.datastax.driver.core.utils.Bytes;
  * problem because in theory we'll only parse class names coming from Cassandra and
  * so there shouldn't be anything wrong with them.
  */
-class CassandraTypeParser {
-    private static final Logger logger = LoggerFactory.getLogger(CassandraTypeParser.class);
+class DataTypeClassNameParser {
+    private static final Logger logger = LoggerFactory.getLogger(DataTypeClassNameParser.class);
 
     private static final String REVERSED_TYPE = "org.apache.cassandra.db.marshal.ReversedType";
     private static final String FROZEN_TYPE = "org.apache.cassandra.db.marshal.FrozenType";

--- a/driver-core/src/main/java/com/datastax/driver/core/DataTypeCqlNameParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataTypeCqlNameParser.java
@@ -1,0 +1,295 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.datastax.driver.core.exceptions.DriverInternalError;
+import com.datastax.driver.core.exceptions.UnresolvedUserTypeException;
+
+import static com.datastax.driver.core.DataType.*;
+import static com.datastax.driver.core.ParseUtils.isBlank;
+import static com.datastax.driver.core.ParseUtils.isIdentifierChar;
+import static com.datastax.driver.core.ParseUtils.skipSpaces;
+
+/*
+ * Parse data types from schema tables, for Cassandra 3.0 and above.
+ * In these versions, data types appear as string literals, like "ascii" or "tuple<int,int>".
+ *
+ * Note that these methods all throw DriverInternalError when there is a parsing
+ * problem because in theory we'll only parse class names coming from Cassandra and
+ * so there shouldn't be anything wrong with them.
+ */
+class DataTypeCqlNameParser {
+
+    private static final String FROZEN = "frozen";
+    private static final String LIST   = "list";
+    private static final String SET    = "set";
+    private static final String MAP    = "map";
+    private static final String TUPLE  = "tuple";
+    private static final String EMPTY  = "empty";
+
+    private static final ImmutableMap<String, DataType> NATIVE_TYPES_MAP =
+        new ImmutableMap.Builder<String, DataType>()
+            .put("ascii",     ascii())
+            .put("bigint",    bigint())
+            .put("blob",      blob())
+            .put("boolean",   cboolean())
+            .put("counter",   counter())
+            .put("decimal",   decimal())
+            .put("double",    cdouble())
+            .put("float",     cfloat())
+            .put("inet",      inet())
+            .put("int",       cint())
+            .put("text",      text())
+            .put("varchar",   varchar())
+            .put("timestamp", timestamp())
+            .put("date",      date())
+            .put("time",      time())
+            .put("uuid",      uuid())
+            .put("varint",    varint())
+            .put("timeuuid",  timeuuid())
+            .put("tinyint",   tinyint())
+            .put("smallint",  smallint())
+            .build();
+
+    /**
+     * @param currentUserTypes if this method gets called as part of a refresh that spans multiple user types, this contains the ones
+     *                         that have already been refreshed. If the type we are parsing references a user type, we want to pick its
+     *                         definition from this map in priority.
+     * @param oldUserTypes this contains all the keyspace's user types as they were before the refresh started. If we can't find a
+     *                     definition in {@code currentUserTypes}, we'll check this map as a fallback.
+     */
+    static DataType parse(String toParse, Cluster cluster, String currentKeyspaceName, Map<String, UserType> currentUserTypes, Map<String, UserType> oldUserTypes, boolean frozen, boolean shallowUserTypes) {
+
+        Parser parser = new Parser(toParse, 0);
+        String type = parser.parseTypeName();
+
+        DataType nativeType = NATIVE_TYPES_MAP.get(type.toLowerCase());
+        if (nativeType != null)
+            return nativeType;
+
+        if (type.equalsIgnoreCase(LIST)) {
+            List<String> parameters = parser.parseTypeParameters();
+            if (parameters.size() != 1)
+                throw new DriverInternalError(String.format("Excepting single parameter for list, got %s", parameters));
+            DataType elementType = parse(parameters.get(0), cluster, currentKeyspaceName, currentUserTypes, oldUserTypes, false, shallowUserTypes);
+            return list(elementType, frozen);
+        }
+
+        if (type.equalsIgnoreCase(SET)) {
+            List<String> parameters = parser.parseTypeParameters();
+            if (parameters.size() != 1)
+                throw new DriverInternalError(String.format("Excepting single parameter for set, got %s", parameters));
+            DataType elementType = parse(parameters.get(0), cluster, currentKeyspaceName, currentUserTypes, oldUserTypes, false, shallowUserTypes);
+            return set(elementType, frozen);
+        }
+
+        if (type.equalsIgnoreCase(MAP)) {
+            List<String> parameters = parser.parseTypeParameters();
+            if (parameters.size() != 2)
+                throw new DriverInternalError(String.format("Excepting two parameters for map, got %s", parameters));
+            DataType keyType = parse(parameters.get(0), cluster, currentKeyspaceName, currentUserTypes, oldUserTypes, false, shallowUserTypes);
+            DataType valueType = parse(parameters.get(1), cluster, currentKeyspaceName, currentUserTypes, oldUserTypes, false, shallowUserTypes);
+            return map(keyType, valueType, frozen);
+        }
+
+        if (type.equalsIgnoreCase(FROZEN)) {
+            List<String> parameters = parser.parseTypeParameters();
+            if (parameters.size() != 1)
+                throw new DriverInternalError(String.format("Excepting single parameter for frozen keyword, got %s", parameters));
+            return parse(parameters.get(0), cluster, currentKeyspaceName, currentUserTypes, oldUserTypes, true, shallowUserTypes);
+        }
+
+        if (type.equalsIgnoreCase(TUPLE)) {
+            List<String> rawTypes = parser.parseTypeParameters();
+            List<DataType> types = new ArrayList<DataType>(rawTypes.size());
+            for (String rawType : rawTypes) {
+                types.add(parse(rawType, cluster, currentKeyspaceName, currentUserTypes, oldUserTypes, false, shallowUserTypes));
+            }
+            return cluster.getMetadata().newTupleType(types);
+        }
+
+        // return a custom type for the special empty type
+        // so that it gets detected later on, see TableMetadata
+        if(type.equalsIgnoreCase(EMPTY))
+            return custom(type);
+
+        // We need to remove escaped double quotes within the type name as it is stored unescaped.
+        // Otherwise it's a UDT. If we only want a shallow definition build it, otherwise search known definitions.
+        if (shallowUserTypes)
+            return new UserType.Shallow(currentKeyspaceName, Metadata.handleId(type));
+
+        UserType userType = null;
+        if (currentUserTypes != null)
+            userType = currentUserTypes.get(Metadata.handleId(type));
+        if (userType == null && oldUserTypes != null)
+            userType = oldUserTypes.get(Metadata.handleId(type));
+
+        if (userType == null)
+            throw new UnresolvedUserTypeException(currentKeyspaceName, type);
+        else
+            return userType;
+    }
+
+    private static class Parser {
+
+        private final String str;
+
+        private int idx;
+
+        Parser(String str, int idx) {
+            this.str = str;
+            this.idx = idx;
+        }
+
+        String parseTypeName() {
+            idx = skipSpaces(str, idx);
+            return readNextIdentifier();
+        }
+
+        List<String> parseTypeParameters() {
+            List<String> list = new ArrayList<String>();
+
+            if (isEOS())
+                return list;
+
+            skipBlankAndComma();
+
+            if (str.charAt(idx) != '<')
+                throw new IllegalStateException();
+
+            ++idx; // skipping '<'
+
+            while (skipBlankAndComma()) {
+                if (str.charAt(idx) == '>') {
+                    ++idx;
+                    return list;
+                }
+
+                try {
+                    String name = parseTypeName();
+                    String args = readRawTypeParameters();
+                    list.add(name + args);
+                } catch (DriverInternalError e) {
+                    DriverInternalError ex = new DriverInternalError(String.format("Exception while parsing '%s' around char %d", str, idx));
+                    ex.initCause(e);
+                    throw ex;
+                }
+            }
+            throw new DriverInternalError(String.format("Syntax error parsing '%s' at char %d: unexpected end of string", str, idx));
+        }
+
+        // left idx positioned on the character stopping the read
+        private String readNextIdentifier() {
+            int startIdx = idx;
+            // if first character is a quote, this is a quoted identifier.
+            if(str.charAt(startIdx) == '"') {
+                ++idx;
+                // read until closing quote.
+                while(!isEOS()) {
+                    boolean atQuote = str.charAt(idx) == '"';
+                    ++idx;
+                    if (atQuote) {
+                        // if the next character is also a quote, this is an escaped
+                        // quote, continue reading, otherwise stop.
+                        if(!isEOS() && str.charAt(idx) == '"')
+                            ++idx;
+                        else
+                            break;
+                    }
+                }
+            } else {
+                while (!isEOS() && (isIdentifierChar(str.charAt(idx)) || str.charAt(idx) == '"'))
+                    ++idx;
+            }
+            return str.substring(startIdx, idx);
+        }
+
+        // Assumes we have just read a type name and read it's potential arguments
+        // blindly. I.e. it assume that either parsing is done or that we're on a '<'
+        // and this reads everything up until the corresponding closing '>'. It
+        // returns everything read, including the enclosing brackets.
+        private String readRawTypeParameters() {
+            idx = skipSpaces(str, idx);
+
+            if (isEOS() || str.charAt(idx) == '>' || str.charAt(idx) == ',')
+                return "";
+
+            if (str.charAt(idx) != '<')
+                throw new IllegalStateException(String.format("Expecting char %d of %s to be '<' but '%c' found", idx, str, str.charAt(idx)));
+
+            int i = idx;
+            int open = 1;
+            boolean inQuotes = false;
+            while (open > 0) {
+                ++idx;
+
+                if (isEOS())
+                    throw new IllegalStateException("Non closed angle brackets");
+
+                // Only parse for '<' and '>' characters if not within a quoted identifier.
+                // Note we don't need to handle escaped quotes ("") in type names here, because they just cause inQuotes to flip
+                // to false and immediately back to true
+                if(!inQuotes) {
+                    if (str.charAt(idx) == '"') {
+                        inQuotes = true;
+                    } else if (str.charAt(idx) == '<') {
+                        open++;
+                    } else if (str.charAt(idx) == '>') {
+                        open--;
+                    }
+                } else if(str.charAt(idx) == '"') {
+                    inQuotes = false;
+                }
+            }
+            // we've stopped at the last closing ')' so move past that
+            ++idx;
+            return str.substring(i, idx);
+        }
+
+        // skip all blank and at best one comma, return true if there not EOS
+        private boolean skipBlankAndComma() {
+            boolean commaFound = false;
+            while (!isEOS()) {
+                int c = str.charAt(idx);
+                if (c == ',') {
+                    if (commaFound)
+                        return true;
+                    else
+                        commaFound = true;
+                } else if (!isBlank(c)) {
+                    return true;
+                }
+                ++idx;
+            }
+            return false;
+        }
+
+        private boolean isEOS() {
+            return idx >= str.length();
+        }
+
+        @Override
+        public String toString() {
+            return str.substring(0, idx) + "[" + (idx == str.length() ? "" : str.charAt(idx)) + "]" + str.substring(idx+1);
+        }
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/DirectedGraph.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DirectedGraph.java
@@ -1,0 +1,92 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.*;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+
+import com.datastax.driver.core.exceptions.DriverInternalError;
+
+/**
+ * A basic directed graph implementation to perform topological sorts.
+ */
+class DirectedGraph<V> {
+
+    // We need to keep track of the predecessor count. For simplicity, use a map to store it alongside the vertices.
+    final Map<V, Integer> vertices;
+    final Multimap<V, V> adjacencyList;
+    boolean wasSorted;
+
+    DirectedGraph(List<V> vertices) {
+        this.vertices = Maps.newHashMapWithExpectedSize(vertices.size());
+        this.adjacencyList = HashMultimap.create();
+
+        for (V vertex : vertices) {
+            this.vertices.put(vertex, 0);
+        }
+    }
+
+    DirectedGraph(V... vertices) {
+        this(Arrays.asList(vertices));
+    }
+
+    /** this assumes that {@code from} and {@code to} were part of the vertices passed to the constructor */
+    void addEdge(V from, V to) {
+        Preconditions.checkArgument(vertices.containsKey(from) && vertices.containsKey(to));
+        adjacencyList.put(from, to);
+        vertices.put(to, vertices.get(to) + 1);
+    }
+
+    /** one-time use only, calling this multiple times on the same graph won't work */
+    List<V> topologicalSort() {
+        Preconditions.checkState(!wasSorted);
+        wasSorted = true;
+
+        Queue<V> queue = new LinkedList<V>();
+
+        for (Map.Entry<V, Integer> entry : vertices.entrySet()) {
+            if (entry.getValue() == 0)
+                queue.add(entry.getKey());
+        }
+
+        List<V> result = Lists.newArrayList();
+        while (!queue.isEmpty()) {
+            V vertex = queue.remove();
+            result.add(vertex);
+            for (V successor : adjacencyList.get(vertex)) {
+                if (decrementAndGetCount(successor) == 0)
+                    queue.add(successor);
+            }
+        }
+
+        if (result.size() != vertices.size())
+            throw new DriverInternalError("failed to perform topological sort, graph has a cycle");
+
+        return result;
+    }
+
+    private int decrementAndGetCount(V vertex) {
+        Integer count = vertices.get(vertex);
+        count = count - 1;
+        vertices.put(vertex, count);
+        return count;
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -364,7 +364,17 @@ public class Metadata {
      * @return the newly created tuple type.
      */
     public TupleType newTupleType(DataType... types) {
-        return new TupleType(Arrays.asList(types), cluster.protocolVersion(), cluster.configuration.getCodecRegistry());
+        return newTupleType(Arrays.asList(types));
+    }
+
+    /**
+     * Creates a tuple type given a list of types.
+     *
+     * @param types the types for the tuple type.
+     * @return the newly created tuple type.
+     */
+    public TupleType newTupleType(List<DataType> types) {
+        return new TupleType(types, cluster.protocolVersion(), cluster.configuration.getCodecRegistry());
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/UDTValue.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/UDTValue.java
@@ -30,11 +30,11 @@ public class UDTValue extends AbstractData<UDTValue> {
     }
 
     protected DataType getType(int i) {
-        return definition.byIdx[i].getType();
+        return definition.getFields()[i].getType();
     }
 
     protected String getName(int i) {
-        return definition.byIdx[i].getName();
+        return definition.getFields()[i].getName();
     }
 
     @Override
@@ -43,7 +43,7 @@ public class UDTValue extends AbstractData<UDTValue> {
     }
 
     protected int[] getAllIndexesOf(String name) {
-        int[] indexes = definition.byName.get(Metadata.handleId(name));
+        int[] indexes = definition.getFieldIndicesByName().get(Metadata.handleId(name));
         if (indexes == null)
             throw new IllegalArgumentException(name + " is not a field defined in this UDT");
         return indexes;

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnresolvedUserTypeException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnresolvedUserTypeException.java
@@ -1,0 +1,52 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.exceptions;
+
+/**
+ * Thrown when a user type cannot be resolved.
+ */
+public class UnresolvedUserTypeException extends InvalidTypeException {
+
+    private final String keyspaceName;
+
+    private final String name;
+
+    public UnresolvedUserTypeException(String keyspaceName, String name) {
+        super(String.format("Cannot resolve user type %s.%s", keyspaceName, name));
+        this.keyspaceName = keyspaceName;
+        this.name = name;
+    }
+
+    private UnresolvedUserTypeException(String keyspaceName, String name, Throwable cause) {
+        super(String.format("Cannot resolve user type %s.%s", keyspaceName, name), cause);
+        this.keyspaceName = keyspaceName;
+        this.name = name;
+    }
+
+    public String getKeyspaceName() {
+        return keyspaceName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public DriverException copy() {
+        return new UnresolvedUserTypeException(keyspaceName, name, this);
+    }
+
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
@@ -35,6 +35,15 @@ public class Assertions extends org.assertj.core.api.Assertions {
         return new DataTypeAssert(type);
     }
 
+    /**
+     * This method is here only to disambiguate
+     * calls to assertThat with a UserType instance,
+     * because UserType also implements Iterable.
+     */
+    public static DataTypeAssert assertThat(UserType type) {
+        return new DataTypeAssert(type);
+    }
+
     public static LocalDateAssert assertThat(LocalDate localDate) {
         return new LocalDateAssert(localDate);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -103,7 +103,7 @@ public class CCMBridge {
         if (installDirectory != null && !installDirectory.trim().isEmpty()) {
             CASSANDRA_INSTALL_ARGS = "--install-dir=" + new File(installDirectory).getAbsolutePath();
         } else if(branch != null && !branch.trim().isEmpty()) {
-            CASSANDRA_INSTALL_ARGS = "-v git:" + branch;
+            CASSANDRA_INSTALL_ARGS = "-v " + branch.replaceAll("\"", "");
         } else {
             CASSANDRA_INSTALL_ARGS = "-v " + CASSANDRA_VERSION;
         }

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeAssert.java
@@ -37,6 +37,14 @@ public class DataTypeAssert extends AbstractAssert<DataTypeAssert, DataType> {
         return this;
     }
 
+    public DataTypeAssert isShallowUserType(String keyspaceName, String userTypeName) {
+        assertThat(actual).isInstanceOf(UserType.Shallow.class);
+        UserType.Shallow shallow = (UserType.Shallow)actual;
+        assertThat(shallow.keyspaceName).isEqualTo(keyspaceName);
+        assertThat(shallow.typeName).isEqualTo(userTypeName);
+        return this;
+    }
+
     public DataTypeAssert isFrozen() {
         assertThat(actual.isFrozen()).isTrue();
         return this;
@@ -56,4 +64,12 @@ public class DataTypeAssert extends AbstractAssert<DataTypeAssert, DataType> {
         assertThat(actual.getTypeArguments()).containsExactly(expected);
         return this;
     }
+
+    public DataTypeAssert hasField(String name, DataType expected) {
+        assertThat(actual).isInstanceOf(UserType.class);
+        UserType userType = (UserType)this.actual;
+        assertThat(userType.getFieldType(name)).isEqualTo(expected);
+        return this;
+    }
+
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeClassNameParserTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeClassNameParserTest.java
@@ -27,7 +27,7 @@ import static org.testng.Assert.assertTrue;
 
 import static com.datastax.driver.core.Assertions.assertThat;
 
-public class CassandraTypeParserTest {
+public class DataTypeClassNameParserTest {
 
     private ProtocolVersion protocolVersion = TestUtils.getDesiredProtocolVersion();
     private CodecRegistry codecRegistry = new CodecRegistry();
@@ -35,21 +35,21 @@ public class CassandraTypeParserTest {
     @Test(groups = "unit")
     public void parseOneTest() {
 
-        assertEquals(CassandraTypeParser.parseOne("org.apache.cassandra.db.marshal.ByteType", protocolVersion, codecRegistry), DataType.tinyint());
-        assertEquals(CassandraTypeParser.parseOne("org.apache.cassandra.db.marshal.ShortType", protocolVersion, codecRegistry), DataType.smallint());
-        assertEquals(CassandraTypeParser.parseOne("org.apache.cassandra.db.marshal.SimpleDateType", protocolVersion, codecRegistry), DataType.date());
-        assertEquals(CassandraTypeParser.parseOne("org.apache.cassandra.db.marshal.TimeType", protocolVersion, codecRegistry), DataType.time());
-        assertEquals(CassandraTypeParser.parseOne("org.apache.cassandra.db.marshal.InetAddressType", protocolVersion, codecRegistry), DataType.inet());
-        assertEquals(CassandraTypeParser.parseOne("org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.UTF8Type)", protocolVersion, codecRegistry), DataType.list(DataType.text()));
-        assertEquals(CassandraTypeParser.parseOne("org.apache.cassandra.db.marshal.ReversedType(org.apache.cassandra.db.marshal.UTF8Type)", protocolVersion, codecRegistry), DataType.text());
+        assertEquals(DataTypeClassNameParser.parseOne("org.apache.cassandra.db.marshal.ByteType", protocolVersion, codecRegistry), DataType.tinyint());
+        assertEquals(DataTypeClassNameParser.parseOne("org.apache.cassandra.db.marshal.ShortType", protocolVersion, codecRegistry), DataType.smallint());
+        assertEquals(DataTypeClassNameParser.parseOne("org.apache.cassandra.db.marshal.SimpleDateType", protocolVersion, codecRegistry), DataType.date());
+        assertEquals(DataTypeClassNameParser.parseOne("org.apache.cassandra.db.marshal.TimeType", protocolVersion, codecRegistry), DataType.time());
+        assertEquals(DataTypeClassNameParser.parseOne("org.apache.cassandra.db.marshal.InetAddressType", protocolVersion, codecRegistry), DataType.inet());
+        assertEquals(DataTypeClassNameParser.parseOne("org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.UTF8Type)", protocolVersion, codecRegistry), DataType.list(DataType.text()));
+        assertEquals(DataTypeClassNameParser.parseOne("org.apache.cassandra.db.marshal.ReversedType(org.apache.cassandra.db.marshal.UTF8Type)", protocolVersion, codecRegistry), DataType.text());
 
         String s;
 
         s = "org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type, org.apache.cassandra.db.marshal.Int32Type)";
-        assertEquals(CassandraTypeParser.parseOne(s, protocolVersion, codecRegistry), DataType.custom(s));
+        assertEquals(DataTypeClassNameParser.parseOne(s, protocolVersion, codecRegistry), DataType.custom(s));
 
         s = "org.apache.cassandra.db.marshal.ReversedType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type))";
-        assertEquals(CassandraTypeParser.parseOne(s, protocolVersion, codecRegistry), DataType.list(DataType.cint()));
+        assertEquals(DataTypeClassNameParser.parseOne(s, protocolVersion, codecRegistry), DataType.list(DataType.cint()));
     }
 
     @Test(groups = "unit")
@@ -57,13 +57,13 @@ public class CassandraTypeParserTest {
 
         String s = "org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.Int32Type, org.apache.cassandra.db.marshal.UTF8Type,";
         s += "org.apache.cassandra.db.marshal.ColumnToCollectionType(6162:org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)))";
-        CassandraTypeParser.ParseResult r1 = CassandraTypeParser.parseWithComposite(s, protocolVersion, codecRegistry);
+        DataTypeClassNameParser.ParseResult r1 = DataTypeClassNameParser.parseWithComposite(s, protocolVersion, codecRegistry);
         assertTrue(r1.isComposite);
         assertEquals(r1.types, Arrays.asList(DataType.cint(), DataType.text()));
         assertEquals(r1.collections.size(), 1);
         assertEquals(r1.collections.get("ab"), DataType.list(DataType.cint()));
 
-        CassandraTypeParser.ParseResult r2 = CassandraTypeParser.parseWithComposite("org.apache.cassandra.db.marshal.TimestampType", protocolVersion, codecRegistry);
+        DataTypeClassNameParser.ParseResult r2 = DataTypeClassNameParser.parseWithComposite("org.apache.cassandra.db.marshal.TimestampType", protocolVersion, codecRegistry);
         assertFalse(r2.isComposite);
         assertEquals(r2.types, Arrays.asList(DataType.timestamp()));
         assertEquals(r2.collections.size(), 0);
@@ -73,7 +73,7 @@ public class CassandraTypeParserTest {
     public void parseUserTypes() {
 
         String s = "org.apache.cassandra.db.marshal.UserType(foo,61646472657373,737472656574:org.apache.cassandra.db.marshal.UTF8Type,7a6970636f6465:org.apache.cassandra.db.marshal.Int32Type,70686f6e6573:org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UserType(foo,70686f6e65,6e616d65:org.apache.cassandra.db.marshal.UTF8Type,6e756d626572:org.apache.cassandra.db.marshal.UTF8Type)))";
-        UserType def = (UserType)CassandraTypeParser.parseOne(s, protocolVersion, codecRegistry);
+        UserType def = (UserType)DataTypeClassNameParser.parseOne(s, protocolVersion, codecRegistry);
 
         assertEquals(def.getKeyspace(), "foo");
         assertEquals(def.getTypeName(), "address");
@@ -112,7 +112,7 @@ public class CassandraTypeParserTest {
     @Test(groups = "unit")
     public void parseTupleTest() {
         String s = "org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.FloatType)";
-        TupleType type = (TupleType)CassandraTypeParser.parseOne(s, protocolVersion, codecRegistry);
+        TupleType type = (TupleType)DataTypeClassNameParser.parseOne(s, protocolVersion, codecRegistry);
         assertNotNull(type);
         assertEquals(type.getComponentTypes().get(0), DataType.cint());
         assertEquals(type.getComponentTypes().get(1), DataType.text());
@@ -124,7 +124,7 @@ public class CassandraTypeParserTest {
         // map<text, frozen<map<int,int>>>
         String s = "org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.Int32Type)))";
 
-        DataType parentMap = CassandraTypeParser.parseOne(s, protocolVersion, codecRegistry);
+        DataType parentMap = DataTypeClassNameParser.parseOne(s, protocolVersion, codecRegistry);
         assertThat(parentMap)
             .hasName(DataType.Name.MAP)
             .isNotFrozen()

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeCqlNameParserTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeCqlNameParserTest.java
@@ -1,0 +1,129 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.Collection;
+
+import com.google.common.collect.Lists;
+import org.testng.annotations.Test;
+
+import com.datastax.driver.core.utils.CassandraVersion;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+import static com.datastax.driver.core.DataType.*;
+import static com.datastax.driver.core.DataTypeCqlNameParser.parse;
+
+@CassandraVersion(major = 3.0)
+public class DataTypeCqlNameParserTest extends CCMBridge.PerClassSingleNodeCluster {
+
+    @Test(groups = "short")
+    public void should_parse_native_types() {
+        assertThat(parse("ascii", cluster, null, null, null, false, false)).isEqualTo(ascii());
+        assertThat(parse("bigint", cluster, null, null, null, false, false)).isEqualTo(bigint());
+        assertThat(parse("blob", cluster, null, null, null, false, false)).isEqualTo(blob());
+        assertThat(parse("boolean", cluster, null, null, null, false, false)).isEqualTo(cboolean());
+        assertThat(parse("counter", cluster, null, null, null, false, false)).isEqualTo(counter());
+        assertThat(parse("decimal", cluster, null, null, null, false, false)).isEqualTo(decimal());
+        assertThat(parse("double", cluster, null, null, null, false, false)).isEqualTo(cdouble());
+        assertThat(parse("float", cluster, null, null, null, false, false)).isEqualTo(cfloat());
+        assertThat(parse("inet", cluster, null, null, null, false, false)).isEqualTo(inet());
+        assertThat(parse("int", cluster, null, null, null, false, false)).isEqualTo(cint());
+        assertThat(parse("text", cluster, null, null, null, false, false)).isEqualTo(text());
+        assertThat(parse("varchar", cluster, null, null, null, false, false)).isEqualTo(varchar());
+        assertThat(parse("timestamp", cluster, null, null, null, false, false)).isEqualTo(timestamp());
+        assertThat(parse("date", cluster, null, null, null, false, false)).isEqualTo(date());
+        assertThat(parse("time", cluster, null, null, null, false, false)).isEqualTo(time());
+        assertThat(parse("uuid", cluster, null, null, null, false, false)).isEqualTo(uuid());
+        assertThat(parse("varint", cluster, null, null, null, false, false)).isEqualTo(varint());
+        assertThat(parse("timeuuid", cluster, null, null, null, false, false)).isEqualTo(timeuuid());
+        assertThat(parse("tinyint", cluster, null, null, null, false, false)).isEqualTo(tinyint());
+        assertThat(parse("smallint", cluster, null, null, null, false, false)).isEqualTo(smallint());
+    }
+
+    @Test(groups = "short")
+    public void should_ignore_whitespace() {
+        assertThat(parse("  int  ", cluster, null, null, null, false, false)).isEqualTo(cint());
+        assertThat(parse("  set < bigint > ", cluster, null, null, null, false, false)).isEqualTo(set(bigint()));
+        assertThat(parse("  map  <  date  ,  timeuuid  >  ", cluster, null, null, null, false, false)).isEqualTo(map(date(), timeuuid()));
+    }
+
+    @Test(groups = "short")
+    public void should_ignore_case() {
+        assertThat(parse("INT", cluster, null, null, null, false, false)).isEqualTo(cint());
+        assertThat(parse("SET<BIGint>", cluster, null, null, null, false, false)).isEqualTo(set(bigint()));
+        assertThat(parse("FROZEN<mAp<Date,Tuple<timeUUID>>>", cluster, null, null, null, false, false)).isEqualTo(map(date(), cluster.getMetadata().newTupleType(timeuuid()), true));
+    }
+
+    @Test(groups = "short")
+    public void should_parse_collection_types() {
+        assertThat(parse("list<int>", cluster, null, null, null, false, false)).isEqualTo(list(cint()));
+        assertThat(parse("set<bigint>", cluster, null, null, null, false, false)).isEqualTo(set(bigint()));
+        assertThat(parse("map<date,timeuuid>", cluster, null, null, null, false, false)).isEqualTo(map(date(), timeuuid()));
+    }
+
+    @Test(groups = "short")
+    public void should_parse_frozen_collection_types() {
+        assertThat(parse("frozen<list<int>>", cluster, null, null, null, false, false)).isEqualTo(list(cint(), true));
+        assertThat(parse("frozen<set<bigint>>", cluster, null, null, null, false, false)).isEqualTo(set(bigint(), true));
+        assertThat(parse("frozen<map<date,timeuuid>>", cluster, null, null, null, false, false)).isEqualTo(map(date(), timeuuid(), true));
+    }
+
+    @Test(groups = "short")
+    public void should_parse_nested_collection_types() {
+        Metadata metadata = cluster.getMetadata();
+        KeyspaceMetadata keyspaceMetadata = metadata.getKeyspace(this.keyspace);
+        assertThat(parse("list<list<int>>", cluster, null, null, null, false, false)).isEqualTo(list(list(cint())));
+        assertThat(parse("set<list<frozen<map<bigint,varchar>>>>", cluster, null, null, null, false, false)).isEqualTo(set(list(map(bigint(), varchar(), true))));
+
+        UserType keyType = keyspaceMetadata.getUserType("Incr,edibly\" EvilTy<>><<><p\"e");
+        UserType valueType = keyspaceMetadata.getUserType("\"A\"");
+        assertThat(parse("map<frozen<\"Incr,edibly\"\" EvilTy<>><<><p\"\"e\">,frozen<\"A\">>", cluster, keyspace, keyspaceMetadata.userTypes, null, false, false))
+            .isEqualTo(map(keyType, valueType, false));
+    }
+
+    @Test(groups = "short")
+    public void should_parse_tuple_types() {
+        assertThat(parse("tuple<int,list<text>>", cluster, null, null, null, false, false)).isEqualTo(cluster.getMetadata().newTupleType(cint(), list(text())));
+    }
+
+    @Test(groups = "short")
+    public void should_parse_user_defined_type_when_definition_in_current_user_types() {
+        Metadata metadata = cluster.getMetadata();
+        KeyspaceMetadata keyspaceMetadata = metadata.getKeyspace(this.keyspace);
+        assertThat(parse("frozen<\"A\">", cluster, keyspace, keyspaceMetadata.userTypes, null, false, false)).isUserType(keyspace, "A");
+    }
+
+    @Test(groups = "short")
+    public void should_parse_user_defined_type_when_definition_in_old_user_types() {
+        Metadata metadata = cluster.getMetadata();
+        KeyspaceMetadata keyspaceMetadata = metadata.getKeyspace(this.keyspace);
+        assertThat(parse("\"A\"", cluster, keyspace, null, keyspaceMetadata.userTypes, false, false)).isUserType(keyspace, "A");
+    }
+
+    @Test(groups = "short")
+    public void should_parse_user_defined_type_to_shallow_type_if_requested() {
+        assertThat(parse("\"A\"", cluster, keyspace, null, null, false, true)).isShallowUserType(keyspace, "A");
+    }
+
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return Lists.newArrayList(
+            String.format("CREATE TYPE %s.\"A\" (f1 int)", keyspace),
+            String.format("CREATE TYPE %s.\"Incr,edibly\"\" EvilTy<>><<><p\"\"e\" (a frozen<\"A\">)", keyspace)
+        );
+    }
+
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/DirectedGraphTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DirectedGraphTest.java
@@ -1,0 +1,96 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.driver.core.exceptions.DriverInternalError;
+
+public class DirectedGraphTest {
+    @Test(groups = "unit")
+    public void should_sort_empty_graph() {
+        DirectedGraph<String> g = new DirectedGraph<String>();
+        assertThat(g.topologicalSort()).isEmpty();
+    }
+
+    @Test(groups = "unit")
+    public void should_sort_graph_with_one_node() {
+        DirectedGraph<String> g = new DirectedGraph<String>("A");
+        assertThat(g.topologicalSort())
+            .containsExactly("A");
+    }
+
+    @Test(groups = "unit")
+    public void should_sort_complex_graph() {
+        //         H   G
+        //        / \ /\
+        //       F   |  E
+        //        \ /  /
+        //         D  /
+        //        / \/
+        //        B  C
+        //        |
+        //        A
+        DirectedGraph<String> g = new DirectedGraph<String>("A", "B", "C", "D", "E", "F", "G", "H");
+        g.addEdge("H", "F");
+        g.addEdge("G", "E");
+        g.addEdge("H", "D");
+        g.addEdge("F", "D");
+        g.addEdge("G", "D");
+        g.addEdge("D", "C");
+        g.addEdge("E", "C");
+        g.addEdge("D", "B");
+        g.addEdge("B", "A");
+
+        // Topological sort order should be : GH,FE,D,CB,A
+        // There's no guarantee on the order within the same level, so we use sublists:
+        List<String> sorted = g.topologicalSort();
+        assertThat(sorted.subList(0, 2))
+            .contains("G", "H");
+        assertThat(sorted.subList(2, 4))
+            .contains("F", "E");
+        assertThat(sorted.subList(4, 5))
+            .contains("D");
+        assertThat(sorted.subList(5, 7))
+            .contains("C", "B" );
+        assertThat(sorted.subList(7, 8))
+            .contains("A");
+    }
+
+    @Test(groups = "unit", expectedExceptions = DriverInternalError.class)
+    public void should_fail_to_sort_if_graph_has_a_cycle() {
+        DirectedGraph<String> g = new DirectedGraph<String>("A", "B", "C");
+        g.addEdge("A", "B");
+        g.addEdge("B", "C");
+        g.addEdge("C", "B");
+
+        g.topologicalSort();
+    }
+
+    @Test(groups = "unit", expectedExceptions = DriverInternalError.class)
+    public void should_fail_to_sort_if_graph_is_a_cycle() {
+        DirectedGraph<String> g = new DirectedGraph<String>("A", "B", "C");
+        g.addEdge("A", "B");
+        g.addEdge("B", "C");
+        g.addEdge("C", "A");
+
+        g.topologicalSort();
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/FunctionMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/FunctionMetadataTest.java
@@ -15,63 +15,60 @@
  */
 package com.datastax.driver.core;
 
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 
-import com.google.common.collect.ImmutableList;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import com.datastax.driver.core.utils.CassandraVersion;
 
 import static com.datastax.driver.core.Assertions.assertThat;
+import static com.datastax.driver.core.DataType.cint;
 
-public class FunctionMetadataTest {
-    KeyspaceMetadata keyspace;
-    private ProtocolVersion protocolVersion = TestUtils.getDesiredProtocolVersion();
-    private CodecRegistry codecRegistry = new CodecRegistry();
+@CassandraVersion(major = 2.2)
+public class FunctionMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
 
-    @BeforeMethod(groups = "unit")
-    public void setup() {
-        keyspace = new KeyspaceMetadata("ks", false, Collections.<String, String>emptyMap());
-    }
-
-    @Test(groups = "unit")
+    @Test(groups = "short")
     public void should_parse_and_format_simple_function() {
-        FunctionMetadata function = FunctionMetadata.build(keyspace, SYSTEM_ROW_PLUS, protocolVersion, codecRegistry);
-
+        // given
+        String cql = String.format("CREATE FUNCTION %s.plus(s int,v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return s+v;';", keyspace);
+        // when
+        session.execute(cql);
+        // then
+        KeyspaceMetadata keyspace = cluster.getMetadata().getKeyspace(this.keyspace);
+        FunctionMetadata function = keyspace.getFunction("plus", cint(), cint());
         assertThat(function).isNotNull();
         assertThat(function.getKeyspace()).isEqualTo(keyspace);
         assertThat(function.getFullName()).isEqualTo("plus(int,int)");
         assertThat(function.getSimpleName()).isEqualTo("plus");
-        assertThat(function.getReturnType()).isEqualTo(DataType.cint());
+        assertThat(function.getReturnType()).isEqualTo(cint());
         assertThat(function.getArguments())
-            .containsEntry("s", DataType.cint())
-            .containsEntry("v", DataType.cint());
+            .containsEntry("s", cint())
+            .containsEntry("v", cint());
         assertThat(function.getLanguage()).isEqualTo("java");
         assertThat(function.getBody()).isEqualTo("return s+v;");
         assertThat(function.isCalledOnNullInput()).isFalse();
-
-        assertThat(keyspace.getFunction("plus", DataType.cint(), DataType.cint())).isEqualTo(function);
-
         assertThat(function.toString())
-            .isEqualTo("CREATE FUNCTION ks.plus(s int,v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return s+v;';");
-
+            .isEqualTo(cql);
         assertThat(function.exportAsString())
-            .isEqualTo("CREATE FUNCTION ks.plus(\n"
+            .isEqualTo(String.format("CREATE FUNCTION %s.plus(\n"
                 + "    s int,\n"
                 + "    v int)\n"
                 + "RETURNS NULL ON NULL INPUT\n"
                 + "RETURNS int\n"
                 + "LANGUAGE java\n"
-                + "AS 'return s+v;';");
+                + "AS 'return s+v;';", this.keyspace));
     }
 
-    @Test(groups = "unit")
+    @Test(groups = "short")
     public void should_parse_and_format_function_with_no_arguments() {
-        FunctionMetadata function = FunctionMetadata.build(keyspace, SYSTEM_ROW_PI, protocolVersion, codecRegistry);
-
+        // given
+        String cql = String.format("CREATE FUNCTION %s.pi() CALLED ON NULL INPUT RETURNS double LANGUAGE java AS 'return Math.PI;';", keyspace);
+        // when
+        session.execute(cql);
+        // then
+        KeyspaceMetadata keyspace = cluster.getMetadata().getKeyspace(this.keyspace);
+        FunctionMetadata function = keyspace.getFunction("pi");
         assertThat(function).isNotNull();
         assertThat(function.getKeyspace()).isEqualTo(keyspace);
         assertThat(function.getFullName()).isEqualTo("pi()");
@@ -81,45 +78,20 @@ public class FunctionMetadataTest {
         assertThat(function.getLanguage()).isEqualTo("java");
         assertThat(function.getBody()).isEqualTo("return Math.PI;");
         assertThat(function.isCalledOnNullInput()).isTrue();
-
         assertThat(keyspace.getFunction("pi")).isEqualTo(function);
-
         assertThat(function.toString())
-            .isEqualTo("CREATE FUNCTION ks.pi() CALLED ON NULL INPUT RETURNS double LANGUAGE java AS 'return Math.PI;';");
-
+            .isEqualTo(cql);
         assertThat(function.exportAsString())
-            .isEqualTo("CREATE FUNCTION ks.pi()\n"
+            .isEqualTo(String.format("CREATE FUNCTION %s.pi()\n"
                 + "CALLED ON NULL INPUT\n"
                 + "RETURNS double\n"
                 + "LANGUAGE java\n"
-                + "AS 'return Math.PI;';");
+                + "AS 'return Math.PI;';", this.keyspace));
     }
 
-    private static final String INT = "org.apache.cassandra.db.marshal.Int32Type";
-    private static final String DOUBLE = "org.apache.cassandra.db.marshal.DoubleType";
-
-    private static final Row SYSTEM_ROW_PLUS = mockRow("plus",
-        ImmutableList.of("int", "int"), ImmutableList.of("s", "v"), ImmutableList.of(INT, INT),
-        "return s+v;", false, "java", INT
-    );
-
-    private static final Row SYSTEM_ROW_PI = mockRow("pi",
-        Collections.<String>emptyList(), Collections.<String>emptyList(), Collections.<String>emptyList(),
-        "return Math.PI;", true, "java", DOUBLE);
-
-    private static Row mockRow(String functionName, List<String> signature, List<String> argumentNames, List<String> argumentTypes,
-                               String body, boolean calledOnNullInput, String language, String returnType) {
-        Row row = mock(Row.class);
-
-        when(row.getString("function_name")).thenReturn(functionName);
-        when(row.getList("signature", String.class)).thenReturn(signature);
-        when(row.getList("argument_names", String.class)).thenReturn(argumentNames);
-        when(row.getList("argument_types", String.class)).thenReturn(argumentTypes);
-        when(row.getString("body")).thenReturn(body);
-        when(row.getBool("called_on_null_input")).thenReturn(calledOnNullInput);
-        when(row.getString("language")).thenReturn(language);
-        when(row.getString("return_type")).thenReturn(returnType);
-
-        return row;
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return Collections.emptyList();
     }
+
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
@@ -61,18 +61,19 @@ public class IndexMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
         definition(IndexMetadata.KIND, text()),
         definition(IndexMetadata.OPTIONS, map(text(), text()))
     });
-    public static final TypeCodec<Map<String, String>> MAP_CODEC = TypeCodec.map(TypeCodec.varchar(), TypeCodec.varchar());
+    
+    private static final TypeCodec<Map<String, String>> MAP_CODEC = TypeCodec.map(TypeCodec.varchar(), TypeCodec.varchar());
+    
+    private ProtocolVersion protocolVersion;
 
-    private static ProtocolVersion protocolVersion;
-    private static CodecRegistry codecRegistry;
-
+    @Override
     @BeforeClass(groups = { "short", "long" })
     public void beforeClass() {
         super.beforeClass();
-        protocolVersion = cluster.getConfiguration().getProtocolOptions().getProtocolVersion();
-        codecRegistry = cluster.getConfiguration().getCodecRegistry();
+        CodecRegistry codecRegistry = cluster.getConfiguration().getCodecRegistry();
         legacyColumnDefs.setCodecRegistry(codecRegistry);
         indexColumnDefs.setCodecRegistry(codecRegistry);
+        protocolVersion = cluster.getConfiguration().getProtocolOptions().getProtocolVersion();
     }
 
     @Override
@@ -285,8 +286,8 @@ public class IndexMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
             wrap("{\"foo\" : \"bar\", \"class_name\" : \"dummy.DummyIndex\"}") // index options
         );
         Row columnRow = ArrayBackedRow.fromData(legacyColumnDefs, M3PToken.FACTORY, protocolVersion, columnData);
-        Raw columnRaw = Raw.fromRow(columnRow, VersionNumber.parse("2.1"), protocolVersion, codecRegistry);
-        ColumnMetadata column = ColumnMetadata.fromRaw(table, columnRaw);
+        Raw columnRaw = Raw.fromRow(columnRow, VersionNumber.parse("2.1"));
+        ColumnMetadata column = ColumnMetadata.fromRaw(table, columnRaw, DataType.varchar());
         IndexMetadata index = IndexMetadata.fromLegacy(column, columnRaw);
         assertThat(index)
             .isNotNull()
@@ -348,10 +349,8 @@ public class IndexMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
             wrap("null") // index options
         );
         Row row = ArrayBackedRow.fromData(legacyColumnDefs, M3PToken.FACTORY, cluster.getConfiguration().getProtocolOptions().getProtocolVersion(), data);
-        Raw raw = Raw.fromRow(row, VersionNumber.parse("2.1"),
-            cluster.getConfiguration().getProtocolOptions().getProtocolVersion(),
-            cluster.getConfiguration().getCodecRegistry());
-        ColumnMetadata column = ColumnMetadata.fromRaw(table, raw);
+        Raw raw = Raw.fromRow(row, VersionNumber.parse("2.1"));
+        ColumnMetadata column = ColumnMetadata.fromRaw(table, raw, DataType.blob());
         IndexMetadata index = IndexMetadata.fromLegacy(column, raw);
         assertThat(index)
             .isNotNull()

--- a/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
@@ -1,0 +1,106 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+
+import com.google.common.collect.Lists;
+import org.testng.annotations.Test;
+
+import com.datastax.driver.core.utils.CassandraVersion;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+import static com.datastax.driver.core.DataType.cint;
+import static com.datastax.driver.core.DataType.list;
+import static com.datastax.driver.core.DataType.map;
+import static com.datastax.driver.core.DataType.set;
+
+@CassandraVersion(major = 3.0)
+public class UnresolvedUserTypeTest extends CCMBridge.PerClassSingleNodeCluster {
+
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return Lists.newArrayList(
+            /*
+            Creates the following acyclic graph (edges directed upwards
+            meaning "depends on"):
+
+                H   G
+               / \ /\
+              F   |  E
+               \ /  /
+                D  /
+               / \/
+              B  C
+                 |
+                 A
+
+             Topological sort order should be : GH,FE,D,CB,A
+             */
+            String.format("CREATE TYPE %s.h (f1 int)", keyspace),
+            String.format("CREATE TYPE %s.g (f1 int)", keyspace),
+            String.format("CREATE TYPE %s.\"F\" (f1 frozen<h>)", keyspace),
+            String.format("CREATE TYPE %s.\"E\" (f1 frozen<list<g>>)", keyspace),
+            String.format("CREATE TYPE %s.\"D\" (f1 frozen<tuple<\"F\",g,h>>)", keyspace),
+            String.format("CREATE TYPE %s.\"C\" (f1 frozen<map<\"E\",\"D\">>)", keyspace),
+            String.format("CREATE TYPE %s.\"B\" (f1 frozen<set<\"D\">>)", keyspace),
+            String.format("CREATE TYPE %s.\"A\" (f1 frozen<\"C\">)", keyspace)
+        );
+    }
+
+    @Test(groups = "short")
+    public void should_resolve_nested_user_types() throws ExecutionException, InterruptedException {
+
+        // Each CREATE TYPE statement in getTableDefinitions() has triggered a partial schema refresh that
+        // should have used previous UDT definitions for dependencies.
+        checkUserTypes(cluster.getMetadata());
+
+        // Create a different Cluster instance to force a full refresh where all UDTs are loaded at once.
+        // The parsing logic should sort them to make sure they are loaded in the right order.
+        Cluster newCluster = null;
+        try {
+            newCluster = Cluster.builder().addContactPointsWithPorts(Collections.singletonList(hostAddress)).build();
+            checkUserTypes(newCluster.getMetadata());
+        } finally {
+            if (newCluster != null)
+                newCluster.close();
+        }
+    }
+
+    private void checkUserTypes(Metadata metadata) {
+        KeyspaceMetadata keyspaceMetadata = metadata.getKeyspace(keyspace);
+
+        UserType a = keyspaceMetadata.getUserType("\"A\"");
+        UserType b = keyspaceMetadata.getUserType("\"B\"");
+        UserType c = keyspaceMetadata.getUserType("\"C\"");
+        UserType d = keyspaceMetadata.getUserType("\"D\"");
+        UserType e = keyspaceMetadata.getUserType("\"E\"");
+        UserType f = keyspaceMetadata.getUserType("\"F\"");
+        UserType g = keyspaceMetadata.getUserType("g");
+        UserType h = keyspaceMetadata.getUserType("h");
+
+        assertThat(a).hasField("f1", c);
+        assertThat(b).hasField("f1", set(d));
+        assertThat(c).hasField("f1", map(e, d));
+        assertThat(d).hasField("f1", metadata.newTupleType(f, g, h));
+        assertThat(e).hasField("f1", list(g));
+        assertThat(f).hasField("f1", h);
+        assertThat(g).hasField("f1", cint());
+        assertThat(h).hasField("f1", cint());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cassandra.version>3.0.0-rc1</cassandra.version>
+    <cassandra.version>3.0.0</cassandra.version>
     <java.version>1.6</java.version>
     <log4j.version>1.2.17</log4j.version>
     <slf4j-log4j12.version>1.7.6</slf4j-log4j12.version>


### PR DESCRIPTION
NOTE: can now be tested against the newly-released C\* 3.0.0.

Majors changes:

Several columns in the schema metadata tables used to contain internal cassandra types. They now contain a CQL representation of the type, instead of internal Cassandra names. `DataTypeParser` is now used to parse them (instead of `CassandraTypeParser`).

This poses a problem for UDTs: they are now simply represented by their names (whereas before the column would contain enough information to build the UserType from scratch). The problem is even worse for nested UDTs.

From now on, this problem is solved by two techniques:
- Topological sort of UDTs: when the entire schema (or keyspace) is rebuilt, we have enough information to be able to build the dependency graph for UDTs. This allows us to process them in topological sort order, and all UDTs are resolved (note that nested udts now reference the same instance, whereas before we would construct a different, but equivalent instance).
- during a partial refresh, if a UDT definition references a nested UDT u2, and u2 is not part of the refresh, we look for the definition of u2 in the "old" metadata as it was before the start of the refresh. Thanks to the topological sort, we're sure that we won't reference a stale definition that would be updated later in the refresh.

The only case were UDT resolution should fail is if Cassandra sends us notifications out of order. In this case we abort the whole refresh and log a warning that the metadata will be out of date.

The other noticeable difference is initconds. They used to be stored as blobs; now they are stored as CQL literals.

See CASSANDRA-10365 and CASSANDRA-10650 for details.
