### PR TITLE
JAVA-933: Consider allowing users to override default codecs.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/CodecFactory.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CodecFactory.java
@@ -1,0 +1,250 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.reflect.TypeToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.datastax.driver.core.TypeCodec.*;
+
+import static com.datastax.driver.core.DataType.Name.*;
+
+/**
+ * A factory for {@link TypeCodec} instances.
+ * Instances of this interface are used by the {@link CodecRegistry} to create
+ * codecs on-the-fly.
+ */
+public interface CodecFactory {
+
+    /**
+     * The default instance.
+     */
+    CodecFactory DEFAULT_INSTANCE = new DefaultCodecFactory();
+
+    /**
+     * Create a new codec for the given CQL type and Java type pair.
+     * This method should return {@code null} to indicate that a suitable codec cannot be created.
+     *
+     * @param cqlType The {@link DataType CQL type} the codec should accept; must not be {@code null}.
+     * @param javaType The {@link TypeToken Java type} the codec should accept; can be {@code null}.
+     * @param codecRegistry The {@link CodecRegistry} instance to use when creating composite codecs.
+     * @return A newly-created codec, or {@code null} if none could be created.
+     */
+    <T> TypeCodec<T> newCodec(DataType cqlType, TypeToken<T> javaType, CodecRegistry codecRegistry);
+
+    /**
+     * Create a new codec for the given CQL type and Java type pair.
+     * This method should return {@code null} to indicate that a suitable codec cannot be created.
+     *
+     * @param cqlType The {@link DataType CQL type} the codec should accept; can be {@code null}.
+     * @param value The value the codec should accept; must not be {@code null}.
+     * @param codecRegistry The {@link CodecRegistry} instance to use when creating composite codecs.
+     * @return A newly-created codec, or {@code null} if none could be created.
+     */
+    <T> TypeCodec<T> newCodec(DataType cqlType, T value, CodecRegistry codecRegistry);
+
+    /**
+     * The default {@link CodecFactory} used by the {@link CodecRegistry}.
+     * It is capable of creating the following codecs on-the-fly:
+     * <ul>
+     *     <li>Codecs for CQL collections ({@code list}, {@code set} and {@code map}) are created with {@link ListCodec},  {@link SetCodec} and  {@link MapCodec} respectively;</li>
+     *     <li>Codecs for User-defined types (UDTs) are created with {@link UDTCodec};</li>
+     *     <li>Codecs for Tuple types are created with {@link TupleCodec}.</li>
+     *     <li>Codecs for Java enums are created with {@link EnumStringCodec} or {@link EnumIntCodec}, depending on the CQL type;</li>
+     * </ul>
+     */
+    class DefaultCodecFactory implements CodecFactory {
+
+        @SuppressWarnings("ALL")
+        @Override
+        public <T> TypeCodec<T> newCodec(DataType cqlType, TypeToken<T> javaType, CodecRegistry codecRegistry) {
+
+            checkNotNull(cqlType, "Parameter cqlType cannot be null");
+
+            if (cqlType.getName() == LIST && (javaType == null || List.class.isAssignableFrom(javaType.getRawType()))) {
+                TypeToken<?> elementType = null;
+                if (javaType != null && javaType.getType() instanceof ParameterizedType) {
+                    Type[] typeArguments = ((ParameterizedType)javaType.getType()).getActualTypeArguments();
+                    elementType = TypeToken.of(typeArguments[0]);
+                }
+                TypeCodec<?> eltCodec = codecRegistry.codecFor(cqlType.getTypeArguments().get(0), elementType);
+                return (TypeCodec<T>)newListCodec(eltCodec);
+            }
+
+            if (cqlType.getName() == SET && (javaType == null || Set.class.isAssignableFrom(javaType.getRawType()))) {
+                TypeToken<?> elementType = null;
+                if (javaType != null && javaType.getType() instanceof ParameterizedType) {
+                    Type[] typeArguments = ((ParameterizedType)javaType.getType()).getActualTypeArguments();
+                    elementType = TypeToken.of(typeArguments[0]);
+                }
+                TypeCodec<?> eltCodec = codecRegistry.codecFor(cqlType.getTypeArguments().get(0), elementType);
+                return (TypeCodec<T>)newSetCodec(eltCodec);
+            }
+
+            if (cqlType.getName() == MAP && (javaType == null || Map.class.isAssignableFrom(javaType.getRawType()))) {
+                TypeToken<?> keyType = null;
+                TypeToken<?> valueType = null;
+                if (javaType != null && javaType.getType() instanceof ParameterizedType) {
+                    Type[] typeArguments = ((ParameterizedType)javaType.getType()).getActualTypeArguments();
+                    keyType = TypeToken.of(typeArguments[0]);
+                    valueType = TypeToken.of(typeArguments[1]);
+                }
+                TypeCodec<?> keyCodec = codecRegistry.codecFor(cqlType.getTypeArguments().get(0), keyType);
+                TypeCodec<?> valueCodec = codecRegistry.codecFor(cqlType.getTypeArguments().get(1), valueType);
+                return (TypeCodec<T>)newMapCodec(keyCodec, valueCodec);
+            }
+
+            if (cqlType instanceof TupleType && (javaType == null || TupleValue.class.isAssignableFrom(javaType.getRawType()))) {
+                return (TypeCodec<T>)new TupleCodec((TupleType)cqlType);
+            }
+
+            if (cqlType instanceof UserType && (javaType == null || UDTValue.class.isAssignableFrom(javaType.getRawType()))) {
+                return (TypeCodec<T>)new UDTCodec((UserType)cqlType);
+            }
+
+            if ((cqlType.getName() == VARCHAR || cqlType.getName() == TEXT) && javaType != null && Enum.class.isAssignableFrom(javaType.getRawType())) {
+                return new EnumStringCodec(javaType.getRawType());
+            }
+
+            if (cqlType != null && cqlType.getName() == INT && Enum.class.isAssignableFrom(javaType.getRawType())) {
+                return new EnumIntCodec(javaType.getRawType());
+            }
+
+            return null;
+
+        }
+
+        @SuppressWarnings("ALL")
+        @Override
+        public <T> TypeCodec<T> newCodec(DataType cqlType, T value, CodecRegistry codecRegistry) {
+
+            checkNotNull(value, "Parameter value cannot be null");
+
+            if ((cqlType == null || cqlType.getName() == LIST) && value instanceof List) {
+                List list = (List)value;
+                if (list.isEmpty()) {
+                    DataType elementType = (cqlType == null || cqlType.getTypeArguments().isEmpty())
+                        ? DataType.blob()
+                        : cqlType.getTypeArguments().get(0);
+                    return newListCodec(codecRegistry.codecFor(elementType, (TypeToken)null));
+                } else {
+                    DataType elementType = (cqlType == null || cqlType.getTypeArguments().isEmpty())
+                        ? null
+                        : cqlType.getTypeArguments().get(0);
+                    return (TypeCodec<T>)newListCodec(codecRegistry.codecFor(elementType, list.iterator().next()));
+                }
+            }
+
+            if ((cqlType == null || cqlType.getName() == SET) && value instanceof Set) {
+                Set set = (Set)value;
+                if (set.isEmpty()) {
+                    DataType elementType = (cqlType == null || cqlType.getTypeArguments().isEmpty())
+                        ? DataType.blob()
+                        : cqlType.getTypeArguments().get(0);
+                    return newSetCodec(codecRegistry.codecFor(elementType, (TypeToken)null));
+                } else {
+                    DataType elementType = (cqlType == null || cqlType.getTypeArguments().isEmpty())
+                        ? null
+                        : cqlType.getTypeArguments().get(0);
+                    return (TypeCodec<T>)newSetCodec(codecRegistry.codecFor(elementType, set.iterator().next()));
+                }
+            }
+
+            if ((cqlType == null || cqlType.getName() == MAP) && value instanceof Map) {
+                Map map = (Map)value;
+                if (map.isEmpty()) {
+                    DataType keyType = (cqlType == null || cqlType.getTypeArguments().size() < 1)
+                        ? DataType.blob()
+                        : cqlType.getTypeArguments().get(0);
+                    DataType valueType = (cqlType == null || cqlType.getTypeArguments().size() < 2)
+                        ? DataType.blob() :
+                        cqlType.getTypeArguments().get(1);
+                    return newMapCodec(
+                        codecRegistry.codecFor(keyType, (TypeToken)null),
+                        codecRegistry.codecFor(valueType, (TypeToken)null));
+                } else {
+                    DataType keyType = (cqlType == null || cqlType.getTypeArguments().size() < 1)
+                        ? null
+                        : cqlType.getTypeArguments().get(0);
+                    DataType valueType = (cqlType == null || cqlType.getTypeArguments().size() < 2)
+                        ? null
+                        : cqlType.getTypeArguments().get(1);
+                    Map.Entry entry = (Map.Entry)map.entrySet().iterator().next();
+                    return (TypeCodec<T>)newMapCodec(
+                        codecRegistry.codecFor(keyType, entry.getKey()),
+                        codecRegistry.codecFor(valueType, entry.getValue()));
+                }
+            }
+
+            if ((cqlType == null || cqlType.getName() == DataType.Name.TUPLE) && value instanceof TupleValue) {
+                return (TypeCodec<T>)new TupleCodec(cqlType == null ? ((TupleValue)value).getType() : (TupleType)cqlType);
+            }
+
+            if ((cqlType == null || cqlType.getName() == DataType.Name.UDT) && value instanceof UDTValue) {
+                return (TypeCodec<T>)new UDTCodec(cqlType == null ? ((UDTValue)value).getType() : (UserType)cqlType);
+            }
+
+            if ((cqlType == null || cqlType.getName() == VARCHAR || cqlType.getName() == TEXT) && value instanceof Enum) {
+                return new EnumStringCodec(value.getClass());
+            }
+
+            if (cqlType != null && cqlType.getName() == INT && value instanceof Enum) {
+                return new EnumIntCodec(value.getClass());
+            }
+
+            return null;
+
+        }
+
+        /**
+         * Hook for subclasses wishing to customize codecs for CQL {@code list} types.
+         * @param eltCodec The element codec.
+         * @return A suitable codec.
+         */
+        protected <T> TypeCodec<List<T>> newListCodec(TypeCodec<T> eltCodec) {
+            return new ListCodec<T>(eltCodec);
+        }
+
+        /**
+         * Hook for subclasses wishing to customize codecs for CQL {@code set} types.
+         * @param eltCodec The element codec.
+         * @return A suitable codec.
+         */
+        protected <T> TypeCodec<Set<T>> newSetCodec(TypeCodec<T> eltCodec) {
+            return new SetCodec<T>(eltCodec);
+        }
+
+        /**
+         * Hook for subclasses wishing to customize codecs for CQL {@code map} types.
+         * @param keyCodec The map key codec.
+         * @param valueCodec The map value codec.
+         * @return A suitable codec.
+         */
+        protected <K, V> TypeCodec<Map<K, V>> newMapCodec(TypeCodec<K> keyCodec, TypeCodec<V> valueCodec) {
+            return new MapCodec<K, V>(keyCodec, valueCodec);
+        }
+
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
@@ -15,9 +15,8 @@
  */
 package com.datastax.driver.core;
 
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 
@@ -34,26 +33,22 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.datastax.driver.core.TypeCodec.*;
 import com.datastax.driver.core.exceptions.CodecNotFoundException;
 
-import static com.datastax.driver.core.DataType.Name.*;
-
 /**
- * A registry for {@link TypeCodec}s. When the driver
+ * A registry for {@link TypeCodec codec}s. When the driver
  * needs to serialize or deserialize an object,
- * it will lookup in the {@link CodecRegistry} for
+ * it will lookup in the registry for
  * a suitable codec.
  *
  * <h3>Usage</h3>
  *
  * <p>
- * Most users won't need to manipulate {@link CodecRegistry} instances directly.
- * Only those willing to register user-defined codecs are required to do so.
- * By default, the driver uses {@link CodecRegistry#DEFAULT_INSTANCE}, a shareable
- * instance that initially contains all the built-in codecs required by the driver.
+ * By default, the driver uses the CodecRegistry's {@link CodecRegistry#DEFAULT_INSTANCE},
+ * a shareable instance that initially contains all the built-in codecs required by the driver.
  *
  * <p>
- * Users willing to customize their {@link CodecRegistry} can do so by {@code register registering}
- * new {@link TypeCodec}s either on {@link CodecRegistry#DEFAULT_INSTANCE},
- * or on a newly-crated one:
+ * For most users, the default instance is good enough and
+ * they won't need to manipulate {@link CodecRegistry} instances directly.
+ * Only those willing to {@link #register(TypeCodec) register} user-defined codecs are required to do so:
  *
  * <pre>
  * CodecRegistry myCodecRegistry;
@@ -61,18 +56,9 @@ import static com.datastax.driver.core.DataType.Name.*;
  * myCodecRegistry = CodecRegistry.DEFAULT_INSTANCE;
  * // or alternatively, create a new one
  * myCodecRegistry = new CodecRegistry();
- * // then
+ * // then register additional codecs
  * myCodecRegistry.register(myCodec1, myCodec2, myCodec3);
  * </pre>
- *
- * <p>
- * Note that the order in which codecs are registered matters;
- * if a codec is registered while another codec already handles the same
- * CQL-to-Java mapping, that codec will never be used (unless
- * the user forces its usage through e.g. {@link GettableByIndexData#get(int, TypeCodec)}).
- * In order words, it is not possible to replace an existing codec,
- * specially the built-in ones; it is only possible to enrich the initial
- * set of codecs with new ones.
  *
  * <p>
  * To be used by the driver, {@link CodecRegistry} instances must then
@@ -90,20 +76,21 @@ import static com.datastax.driver.core.DataType.Name.*;
  * CodecRegistry registry = cluster.getConfiguration().getCodecRegistry();
  * </pre>
  *
- * <p>
- * By default, {@link Cluster} instances will use {@link CodecRegistry#DEFAULT_INSTANCE}.
- *
  * <h3>Example</h3>
  *
  * <p>
- * E.g. let's suppose you want to have all your CQL timestamps
- * deserialized as {@code java.time.DateTime} instances:
+ * Suppose that one wants to have all CQL timestamps seamlessly
+ * converted to {@code java.time.DateTime} instances and vice versa; the following
+ * code contains the necessary steps to achieve this:
  *
  * <pre>
+ * // 1. Instantiate the custom codec
  * TypeCodec&lt;DateTime> timestampCodec = ...
- * CodecRegistry myCodecRegistry = new CodecRegistry().register(timestampCodec);
+ * // 2. Register the codec
+ * CodecRegistry.DEFAULT_INSTANCE.register(timestampCodec);
  * </pre>
  *
+ * <p>
  * Read the
  * <a href="http://datastax.github.io/java-driver/features/custom_codecs">online documentation</a>
  * for more examples.
@@ -111,35 +98,36 @@ import static com.datastax.driver.core.DataType.Name.*;
  * <h3>Notes</h3>
  *
  * <p>
- * When a {@link CodecRegistry} cannot find a suitable codec among all registered codecs,
- * it will attempt to create a suitable codec.
+ * <strong>Registration order</strong>: the order in which codecs are registered matters:
+ * when looking for a suitable codec, the registry will consider
+ * all registered codecs <em>in the order they were registered</em>, and
+ * will pick the first matching one. If a codec is registered while another codec <em>already handles the same
+ * CQL-to-Java mapping</em>, that codec will <em>override</em> the previously-registered one;
+ * the driver will log a warning in these situations. Overriding registered codecs,
+ * and specially the built-in ones, should rarely be justified.
+ *
  * <p>
- * If the creation succeeds, that codec is added to the list of known codecs and is returned;
- * otherwise, a {@link CodecNotFoundException} is thrown.
+ * <strong>On-the-fly codec instantiation</strong>: When a {@link CodecRegistry}
+ * cannot find a suitable codec among all registered codecs,
+ * it will attempt to create such a codec on-the-fly, using the {@link CodecFactory}
+ * provided at instantiation time. By default, the registry uses CodecFactory's {@link CodecFactory#DEFAULT_INSTANCE}.
+ * If the factory is unable to create the codec, or if the created codec is not suitable,
+ * then a {@link CodecNotFoundException} is thrown.
+ *
  * <p>
- * Note that {@link CodecRegistry} instances can only create codecs in very limited situations:
- * <ol>
- *     <li>Codecs for Enums are created on the fly using {@link EnumStringCodec};</li>
- *     <li>Codecs for {@link UserType user types} are created on the fly using  {@link UDTCodec};</li>
- *     <li>Codecs for {@link TupleType tuple types} are created on the fly using  {@link TupleCodec};</li>
- *     <li>Codecs for collections are created on the fly using {@link ListCodec}, {@link SetCodec} and
- *     {@link MapCodec}, if their element types can be handled by existing codecs (or codecs that can
- *     themselves be generated).</li>
- * </ol>
- * Other combinations of Java and CQL types cannot have their codecs created on the fly;
- * such codecs must be manually registered.
+ * <strong>Debugging the codec registry</strong>: it is possible to turn on log messages
+ * by setting the {@code com.datastax.driver.core.CodecRegistry} logger level to {@code TRACE}.
+ * Beware that the registry can be very verbose at this log level.
+ *
  * <p>
- * Note that the default set of codecs has no support for
- * <a href="https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/db/marshal/AbstractType.java">Cassandra custom types</a>;
+ * <strong>Custom CQL types</strong>: Note that the default set of codecs has no support for
+ * <a href="https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/db/marshal/AbstractType.java">custom CQL types</a>;
  * to be able to deserialize values of such types, you need to manually register an appropriate codec.
+ *
  * <p>
- * {@link CodecRegistry} instances are not meant to be shared between two or more {@link Cluster} instances; doing so
- * could yield unexpected results.
- * <p>
- * {@link CodecRegistry} instances are thread-safe.
+ * <strong>Thread-safety</strong>: {@link CodecRegistry} instances are thread-safe.
  *
  */
-@SuppressWarnings("all")
 public final class CodecRegistry {
 
     private static final Logger logger = LoggerFactory.getLogger(CodecRegistry.class);
@@ -174,13 +162,16 @@ public final class CodecRegistry {
      */
     public static final CodecRegistry DEFAULT_INSTANCE = new CodecRegistry();
 
-    private static final class CacheKey {
+    /**
+     * Cache key for the codecs cache.
+     */
+    private static final class TypeCodecCacheKey {
 
         private final DataType cqlType;
 
         private final TypeToken<?> javaType;
 
-        public CacheKey(DataType cqlType, TypeToken<?> javaType) {
+        public TypeCodecCacheKey(DataType cqlType, TypeToken<?> javaType) {
             this.javaType = javaType;
             this.cqlType = cqlType;
         }
@@ -191,18 +182,28 @@ public final class CodecRegistry {
                 return true;
             if (o == null || getClass() != o.getClass())
                 return false;
-            CacheKey cacheKey = (CacheKey)o;
+            TypeCodecCacheKey cacheKey = (TypeCodecCacheKey)o;
             return Objects.equal(cqlType, cacheKey.cqlType) && Objects.equal(javaType, cacheKey.javaType);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(javaType, cqlType);
+            return Objects.hashCode(cqlType, javaType);
+        }
+
+    }
+
+    /**
+     * Cache loader for the codecs cache.
+     */
+    private class TypeCodecCacheLoader extends CacheLoader<TypeCodecCacheKey, TypeCodec<?>> {
+        public TypeCodec<?> load(TypeCodecCacheKey cacheKey) {
+            return findCodec(cacheKey.cqlType, cacheKey.javaType);
         }
     }
 
     /**
-     * A complexity-based weigher.
+     * A complexity-based weigher for the codecs cache.
      * Weights are computed mainly according to the CQL type:
      * <ol>
      * <li>Manually-registered codecs always weigh 0;
@@ -214,10 +215,10 @@ public final class CodecRegistry {
      * A consequence of this algorithm is that codecs for primitive types and codecs for all "shallow" collections thereof
      * are never evicted.
      */
-    private class TypeCodecWeigher implements Weigher<CacheKey, TypeCodec<?>> {
+    private class TypeCodecWeigher implements Weigher<TypeCodecCacheKey, TypeCodec<?>> {
 
         @Override
-        public int weigh(CacheKey key, TypeCodec<?> value) {
+        public int weigh(TypeCodecCacheKey key, TypeCodec<?> value) {
             return codecs.contains(value) ? 0 : weigh(key.cqlType, 0);
         }
 
@@ -254,15 +255,19 @@ public final class CodecRegistry {
         }
     }
 
-    private class TypeCodecRemovalListener implements RemovalListener<CacheKey, TypeCodec<?>> {
+    /**
+     * Simple removal listener for the codec cache (can be used for debugging purposes
+     * by setting the {@code com.datastax.driver.core.CodecRegistry} logger level to {@code TRACE}.
+     */
+    private class TypeCodecRemovalListener implements RemovalListener<TypeCodecCacheKey, TypeCodec<?>> {
         @Override
-        public void onRemoval(RemovalNotification<CacheKey, TypeCodec<?>> notification) {
+        public void onRemoval(RemovalNotification<TypeCodecCacheKey, TypeCodec<?>> notification) {
             logger.trace("Evicting codec from cache: {} (cause: {})", notification.getValue(), notification.getCause());
         }
     }
 
     /**
-     * The list of all known codecs.
+     * The list of "initial" codecs.
      * This list is initialized with the built-in codecs;
      * User-defined codecs are appended to the list.
      */
@@ -272,29 +277,64 @@ public final class CodecRegistry {
      * A LoadingCache to serve requests for codecs whenever possible.
      * The cache can be used as long as at least the CQL type is known.
      */
-    private final LoadingCache<CacheKey, TypeCodec<?>> cache;
+    private final LoadingCache<TypeCodecCacheKey, TypeCodec<?>> cache;
 
     /**
-     * Creates a default CodecRegistry instance with default cache options.
+     * The factory to create codecs on-the-fly.
+     */
+    private final CodecFactory codecFactory;
+
+    /**
+     * Creates a default CodecRegistry instance with default cache options
+     * and the default codec factory.
      */
     public CodecRegistry() {
+        this(CodecFactory.DEFAULT_INSTANCE);
+    }
+
+    /**
+     * Creates a CodecRegistry instance with the provided cache builder
+     * and the default codec factory.
+     */
+    public CodecRegistry(CacheBuilder<TypeCodecCacheKey, TypeCodec<?>> cacheBuilder) {
+        this(cacheBuilder, CodecFactory.DEFAULT_INSTANCE);
+    }
+
+    /**
+     * Creates a default CodecRegistry instance with default cache options
+     * and the provided codec factory.
+     */
+    public CodecRegistry(CodecFactory codecFactory) {
         this.codecs = new CopyOnWriteArrayList<TypeCodec<?>>(PRIMITIVE_CODECS);
-        this.cache = CacheBuilder.newBuilder()
+        this.cache = defaultCacheBuilder().build(new TypeCodecCacheLoader());
+        this.codecFactory = codecFactory;
+    }
+
+    /**
+     * Creates a CodecRegistry instance with the provided cache builder and the provided
+     * codec factory.
+     *
+     * @param cacheBuilder The codec cache builder.
+     * @param codecFactory The codec factory.
+     */
+    public CodecRegistry(CacheBuilder<TypeCodecCacheKey, TypeCodec<?>> cacheBuilder, CodecFactory codecFactory) {
+        this.codecs = new CopyOnWriteArrayList<TypeCodec<?>>(PRIMITIVE_CODECS);
+        this.cache = cacheBuilder.build(new TypeCodecCacheLoader());
+        this.codecFactory = codecFactory;
+    }
+
+    private CacheBuilder<TypeCodecCacheKey, TypeCodec<?>> defaultCacheBuilder() {
+        CacheBuilder<TypeCodecCacheKey, TypeCodec<?>> builder = CacheBuilder.newBuilder()
             // 19 primitive codecs + collections thereof = 19*3 + 19*19 = 418 codecs,
             // so let's start with roughly 1/4 of that
             .initialCapacity(100)
             .weigher(new TypeCodecWeigher())
-            // a cache with all 418 "basic" codecs weighs 399 (19*2 + 19*19),
-            // so let's cap at roughly 2.5x this size
             .maximumWeight(1000)
-            .concurrencyLevel(Runtime.getRuntime().availableProcessors() * 4)
-            .removalListener(new TypeCodecRemovalListener())
-            .build(
-                new CacheLoader<CacheKey, TypeCodec<?>>() {
-                    public TypeCodec<?> load(CacheKey cacheKey) {
-                        return findCodec(cacheKey.cqlType, cacheKey.javaType);
-                    }
-                });
+            .concurrencyLevel(Runtime.getRuntime().availableProcessors() * 4);
+        if (logger.isTraceEnabled())
+            // do not bother adding a listener if it will be ineffective
+            builder = builder.removalListener(new TypeCodecRemovalListener());
+        return builder;
     }
 
     /**
@@ -325,7 +365,20 @@ public final class CodecRegistry {
      */
     public CodecRegistry register(Iterable<? extends TypeCodec<?>> codecs) {
         for (TypeCodec<?> codec : codecs) {
-            this.codecs.add(codec);
+            // protect against the check-then-act idiom;
+            // a synchronized block is enough since this method
+            // is not meant to be called very often,
+            // and this is the only place where the collection is updated
+            synchronized (this.codecs) {
+                int i = this.codecs.indexOf(codec);
+                if (i != -1) {
+                    // override existing codec
+                    TypeCodec<?> old = this.codecs.set(i, codec);
+                    logger.warn("{} is overriding {}", codec, old);
+                } else {
+                    this.codecs.add(codec);
+                }
+            }
         }
         return this;
     }
@@ -355,9 +408,7 @@ public final class CodecRegistry {
      * @throws CodecNotFoundException if a suitable codec cannot be found.
      */
     public <T> TypeCodec<T> codecFor(T value) {
-        checkNotNull(value, "Parameter value cannot be null");
-        TypeCodec<T> codec = findCodec(null, value);
-        return codec;
+        return findCodec(null, value);
     }
 
     /**
@@ -394,7 +445,7 @@ public final class CodecRegistry {
      * Codecs returned by this method are cached.
      *
      * @param cqlType The {@link DataType CQL type} the codec should accept; must not be {@code null}.
-     * @param javaType The Java type the codec should accept; must not be {@code null}.
+     * @param javaType The Java type the codec should accept; can be {@code null}.
      * @return A suitable codec.
      * @throws CodecNotFoundException if a suitable codec cannot be found.
      */
@@ -416,13 +467,11 @@ public final class CodecRegistry {
      * Codecs returned by this method are cached.
      *
      * @param cqlType The {@link DataType CQL type} the codec should accept; must not be {@code null}.
-     * @param javaType The {@link TypeToken Java type} the codec should accept; must not be {@code null}.
+     * @param javaType The {@link TypeToken Java type} the codec should accept; can be {@code null}.
      * @return A suitable codec.
      * @throws CodecNotFoundException if a suitable codec cannot be found.
      */
     public <T> TypeCodec<T> codecFor(DataType cqlType, TypeToken<T> javaType) throws CodecNotFoundException {
-        checkNotNull(cqlType, "Parameter cqlType cannot be null");
-        checkNotNull(javaType, "Parameter javaType cannot be null");
         return lookupCodec(cqlType, javaType);
     }
 
@@ -438,28 +487,27 @@ public final class CodecRegistry {
      * <p>
      * Codecs returned by this method are <em>NOT</em> cached.
      *
-     * @param cqlType The {@link DataType CQL type} the codec should accept; must not be {@code null}.
+     * @param cqlType The {@link DataType CQL type} the codec should accept; can be {@code null}.
      * @param value The value the codec should accept; must not be {@code null}.
      * @return A suitable codec.
      * @throws CodecNotFoundException if a suitable codec cannot be found.
      */
     public <T> TypeCodec<T> codecFor(DataType cqlType, T value) {
-        checkNotNull(cqlType, "Parameter cqlType cannot be null");
-        checkNotNull(value, "Parameter value cannot be null");
         return findCodec(cqlType, value);
     }
 
+    @SuppressWarnings("unchecked")
     private <T> TypeCodec<T> lookupCodec(DataType cqlType, TypeToken<T> javaType) {
         checkNotNull(cqlType, "Parameter cqlType cannot be null");
-        logger.trace("Querying cache for codec [{} <-> {}]", cqlType, javaType);
-        CacheKey cacheKey = new CacheKey(cqlType, javaType);
+        logger.trace("Querying cache for codec [{} <-> {}]", cqlType, javaType == null ? "ANY" : javaType);
+        TypeCodecCacheKey cacheKey = new TypeCodecCacheKey(cqlType, javaType);
         try {
             TypeCodec<?> codec = cache.get(cacheKey);
-            logger.trace("Returning cached codec [{} <-> {}]", cqlType, javaType);
+            logger.trace("Returning cached codec {}", codec);
             return (TypeCodec<T>)codec;
         } catch (UncheckedExecutionException e) {
-            if(e.getCause() instanceof CodecNotFoundException) {
-                throw (CodecNotFoundException) e.getCause();
+            if (e.getCause() instanceof CodecNotFoundException) {
+                throw (CodecNotFoundException)e.getCause();
             }
             throw new CodecNotFoundException(e.getCause(), cqlType, javaType);
         } catch (ExecutionException e) {
@@ -467,13 +515,12 @@ public final class CodecRegistry {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private <T> TypeCodec<T> findCodec(DataType cqlType, TypeToken<T> javaType) {
         checkNotNull(cqlType, "Parameter cqlType cannot be null");
-        logger.trace("Looking for codec [{} <-> {}]",
-            cqlType == null ? "ANY" : cqlType,
-            javaType == null ? "ANY" : javaType);
+        logger.trace("Looking for codec [{} <-> {}]", cqlType, javaType == null ? "ANY" : javaType);
         for (TypeCodec<?> codec : codecs) {
-            if ((cqlType == null || codec.accepts(cqlType)) && (javaType == null || codec.accepts(javaType))) {
+            if (codec.accepts(cqlType) && (javaType == null || codec.accepts(javaType))) {
                 logger.trace("Codec found: {}", codec);
                 return (TypeCodec<T>)codec;
             }
@@ -481,6 +528,7 @@ public final class CodecRegistry {
         return createCodec(cqlType, javaType);
     }
 
+    @SuppressWarnings("unchecked")
     private <T> TypeCodec<T> findCodec(DataType cqlType, T value) {
         checkNotNull(value, "Parameter value cannot be null");
         logger.trace("Looking for codec [{} <-> {}]", cqlType == null ? "ANY" : cqlType, value.getClass());
@@ -494,153 +542,28 @@ public final class CodecRegistry {
     }
 
     private <T> TypeCodec<T> createCodec(DataType cqlType, TypeToken<T> javaType) {
-        TypeCodec<T> codec = maybeCreateCodec(cqlType, javaType);
+        TypeCodec<T> codec = codecFactory.newCodec(cqlType, javaType, this);
         if (codec == null)
-            throw newException(cqlType, javaType);
+            throw notFound(cqlType, javaType);
         // double-check that the created codec satisfies the initial request
         if (!codec.accepts(cqlType) || (javaType != null && !codec.accepts(javaType)))
-            throw newException(cqlType, javaType);
+            throw notFound(cqlType, javaType);
         logger.trace("Codec created: {}", codec);
         return codec;
     }
 
     private <T> TypeCodec<T> createCodec(DataType cqlType, T value) {
-        TypeCodec<T> codec = maybeCreateCodec(cqlType, value);
-        if(codec == null)
-            throw newException(cqlType, TypeToken.of(value.getClass()));
+        TypeCodec<T> codec = codecFactory.newCodec(cqlType, value, this);
+        if (codec == null)
+            throw notFound(cqlType, TypeToken.of(value.getClass()));
         // double-check that the created codec satisfies the initial request
-        if((cqlType != null && !codec.accepts(cqlType)) || !codec.accepts(value))
-            throw newException(cqlType, TypeToken.of(value.getClass()));
+        if ((cqlType != null && !codec.accepts(cqlType)) || !codec.accepts(value))
+            throw notFound(cqlType, TypeToken.of(value.getClass()));
         logger.trace("Codec created: {}", codec);
         return codec;
     }
 
-    private <T> TypeCodec<T> maybeCreateCodec(DataType cqlType, TypeToken<T> javaType) {
-        checkNotNull(cqlType);
-
-        if ((cqlType.getName() == VARCHAR || cqlType.getName() == TEXT) && javaType != null && Enum.class.isAssignableFrom(javaType.getRawType())) {
-            return new EnumStringCodec(javaType.getRawType());
-        }
-
-        if (cqlType.getName() == LIST && (javaType == null || List.class.isAssignableFrom(javaType.getRawType()))) {
-            TypeToken<?> elementType = null;
-            if (javaType != null && javaType.getType() instanceof ParameterizedType) {
-                Type[] typeArguments = ((ParameterizedType)javaType.getType()).getActualTypeArguments();
-                elementType = TypeToken.of(typeArguments[0]);
-            }
-            TypeCodec<?> eltCodec = findCodec(cqlType.getTypeArguments().get(0), elementType);
-            return new ListCodec(eltCodec);
-        }
-
-        if (cqlType.getName() == SET && (javaType == null || Set.class.isAssignableFrom(javaType.getRawType()))) {
-            TypeToken<?> elementType = null;
-            if (javaType != null && javaType.getType() instanceof ParameterizedType) {
-                Type[] typeArguments = ((ParameterizedType)javaType.getType()).getActualTypeArguments();
-                elementType = TypeToken.of(typeArguments[0]);
-            }
-            TypeCodec<?> eltCodec = findCodec(cqlType.getTypeArguments().get(0), elementType);
-            return new SetCodec(eltCodec);
-        }
-
-        if (cqlType.getName() == MAP && (javaType == null || Map.class.isAssignableFrom(javaType.getRawType()))) {
-            TypeToken<?> keyType = null;
-            TypeToken<?> valueType = null;
-            if (javaType != null && javaType.getType() instanceof ParameterizedType) {
-                Type[] typeArguments = ((ParameterizedType)javaType.getType()).getActualTypeArguments();
-                keyType = TypeToken.of(typeArguments[0]);
-                valueType = TypeToken.of(typeArguments[1]);
-            }
-            TypeCodec<?> keyCodec = findCodec(cqlType.getTypeArguments().get(0), keyType);
-            TypeCodec<?> valueCodec = findCodec(cqlType.getTypeArguments().get(1), valueType);
-            return new MapCodec(keyCodec, valueCodec);
-        }
-
-        if (cqlType instanceof TupleType && (javaType == null || TupleValue.class.isAssignableFrom(javaType.getRawType()))) {
-            return (TypeCodec<T>)new TupleCodec((TupleType)cqlType);
-        }
-
-        if (cqlType instanceof UserType && (javaType == null || UDTValue.class.isAssignableFrom(javaType.getRawType()))) {
-            return (TypeCodec<T>)new UDTCodec((UserType)cqlType);
-        }
-
-        return null;
-    }
-
-    private <T> TypeCodec<T> maybeCreateCodec(DataType cqlType, T value) {
-        checkNotNull(value);
-
-        if ((cqlType == null || cqlType.getName() == VARCHAR || cqlType.getName() == TEXT) && value instanceof Enum) {
-            return new EnumStringCodec(value.getClass());
-        }
-
-        if ((cqlType == null || cqlType.getName() == LIST) && value instanceof List) {
-            List list = (List)value;
-            if (list.isEmpty()) {
-                DataType elementType = (cqlType == null || cqlType.getTypeArguments().isEmpty())
-                    ? DataType.blob()
-                    : cqlType.getTypeArguments().get(0);
-                return new ListCodec(findCodec(elementType, (TypeToken)null));
-            } else {
-                DataType elementType = (cqlType == null || cqlType.getTypeArguments().isEmpty())
-                    ? null
-                    : cqlType.getTypeArguments().get(0);
-                return new ListCodec(findCodec(elementType, list.iterator().next()));
-            }
-        }
-
-        if ((cqlType == null || cqlType.getName() == SET) && value instanceof Set) {
-            Set set = (Set)value;
-            if (set.isEmpty()) {
-                DataType elementType = (cqlType == null || cqlType.getTypeArguments().isEmpty())
-                    ? DataType.blob()
-                    : cqlType.getTypeArguments().get(0);
-                return new SetCodec(findCodec(elementType, (TypeToken)null));
-            } else {
-                DataType elementType = (cqlType == null || cqlType.getTypeArguments().isEmpty())
-                    ? null
-                    : cqlType.getTypeArguments().get(0);
-                return new SetCodec(findCodec(elementType, set.iterator().next()));
-            }
-        }
-
-        if ((cqlType == null || cqlType.getName() == MAP) && value instanceof Map) {
-            Map map = (Map)value;
-            if (map.isEmpty()) {
-                DataType keyType = (cqlType == null || cqlType.getTypeArguments().size() < 1)
-                    ? DataType.blob()
-                    : cqlType.getTypeArguments().get(0);
-                DataType valueType = (cqlType == null || cqlType.getTypeArguments().size() < 2)
-                    ? DataType.blob() :
-                    cqlType.getTypeArguments().get(1);
-                return new MapCodec(
-                    findCodec(keyType, (TypeToken)null),
-                    findCodec(valueType, (TypeToken)null));
-            } else {
-                DataType keyType = (cqlType == null || cqlType.getTypeArguments().size() < 1)
-                    ? null
-                    : cqlType.getTypeArguments().get(0);
-                DataType valueType = (cqlType == null || cqlType.getTypeArguments().size() < 2)
-                    ? null
-                    : cqlType.getTypeArguments().get(1);
-                Map.Entry entry = (Map.Entry)map.entrySet().iterator().next();
-                return new MapCodec(
-                    findCodec(keyType, entry.getKey()),
-                    findCodec(valueType, entry.getValue()));
-            }
-        }
-
-        if ((cqlType == null || cqlType.getName() == DataType.Name.TUPLE) && value instanceof TupleValue) {
-            return (TypeCodec<T>)new TupleCodec(cqlType == null ? ((TupleValue)value).getType() : (TupleType) cqlType);
-        }
-
-        if ((cqlType == null || cqlType.getName() == DataType.Name.UDT) && value instanceof UDTValue) {
-            return (TypeCodec<T>)new UDTCodec(cqlType == null ? ((UDTValue)value).getType() : (UserType) cqlType);
-        }
-
-        return null;
-    }
-
-    private static CodecNotFoundException newException(DataType cqlType, TypeToken<?> javaType) {
+    private CodecNotFoundException notFound(DataType cqlType, TypeToken<?> javaType) {
         String msg = String.format("Codec not found for requested operation: [%s <-> %s]",
             cqlType == null ? "ANY" : cqlType,
             javaType == null ? "ANY" : javaType);

--- a/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
@@ -19,6 +19,7 @@ import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.cache.*;
 import com.google.common.collect.ImmutableSet;
@@ -561,4 +562,9 @@ public final class CodecRegistry {
         return new CodecNotFoundException(msg, cqlType, javaType);
     }
 
+    @VisibleForTesting void reset() {
+        cache.invalidateAll();
+        codecs.clear();
+        codecs.addAll(PRIMITIVE_CODECS);
+    }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
@@ -293,33 +293,12 @@ public final class CodecRegistry {
     }
 
     /**
-     * Creates a CodecRegistry instance with the provided cache builder
-     * and the default codec factory.
-     */
-    public CodecRegistry(CacheBuilder<TypeCodecCacheKey, TypeCodec<?>> cacheBuilder) {
-        this(cacheBuilder, CodecFactory.DEFAULT_INSTANCE);
-    }
-
-    /**
      * Creates a default CodecRegistry instance with default cache options
      * and the provided codec factory.
      */
     public CodecRegistry(CodecFactory codecFactory) {
         this.codecs = new CopyOnWriteArrayList<TypeCodec<?>>(PRIMITIVE_CODECS);
         this.cache = defaultCacheBuilder().build(new TypeCodecCacheLoader());
-        this.codecFactory = codecFactory;
-    }
-
-    /**
-     * Creates a CodecRegistry instance with the provided cache builder and the provided
-     * codec factory.
-     *
-     * @param cacheBuilder The codec cache builder.
-     * @param codecFactory The codec factory.
-     */
-    public CodecRegistry(CacheBuilder<TypeCodecCacheKey, TypeCodec<?>> cacheBuilder, CodecFactory codecFactory) {
-        this.codecs = new CopyOnWriteArrayList<TypeCodec<?>>(PRIMITIVE_CODECS);
-        this.cache = cacheBuilder.build(new TypeCodecCacheLoader());
         this.codecFactory = codecFactory;
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
@@ -308,8 +308,7 @@ public final class CodecRegistry {
             // so let's start with roughly 1/4 of that
             .initialCapacity(100)
             .weigher(new TypeCodecWeigher())
-            .maximumWeight(1000)
-            .concurrencyLevel(Runtime.getRuntime().availableProcessors() * 4);
+            .maximumWeight(1000);
         if (logger.isTraceEnabled())
             // do not bother adding a listener if it will be ineffective
             builder = builder.removalListener(new TypeCodecRemovalListener());

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
@@ -29,7 +29,6 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
 
@@ -299,21 +298,6 @@ public abstract class TypeCodec<T> {
     public boolean accepts(Object value) {
         checkNotNull(value);
         return accepts(TypeToken.of(value.getClass()));
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (!(o instanceof TypeCodec))
-            return false;
-        TypeCodec<?> typeCodec = (TypeCodec<?>)o;
-        return Objects.equal(cqlType, typeCodec.cqlType) && Objects.equal(javaType, typeCodec.javaType);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(cqlType, javaType);
     }
 
     @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
@@ -308,12 +308,12 @@ public abstract class TypeCodec<T> {
         if (!(o instanceof TypeCodec))
             return false;
         TypeCodec<?> typeCodec = (TypeCodec<?>)o;
-        return Objects.equal(javaType, typeCodec.javaType) && Objects.equal(cqlType, typeCodec.cqlType);
+        return Objects.equal(cqlType, typeCodec.cqlType) && Objects.equal(javaType, typeCodec.javaType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(javaType, cqlType);
+        return Objects.hashCode(cqlType, javaType);
     }
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecOverridingIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecOverridingIntegrationTest.java
@@ -1,0 +1,179 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.List;
+
+import com.google.common.reflect.TypeToken;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import com.datastax.driver.core.CodecFactory.DefaultCodecFactory;
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+
+import static com.datastax.driver.core.DataType.cint;
+import static com.datastax.driver.core.DataType.list;
+
+public class TypeCodecOverridingIntegrationTest extends CCMBridge.PerClassSingleNodeCluster {
+
+    private static final String query = "INSERT INTO \"myTable\" (c_int, l_int) VALUES (?, ?)";
+
+    private CodecRegistry registry;
+
+    private MockIntCodec codec;
+
+    private DefaultCodecFactory factory;
+
+    private TypeCodec.ListCodec<Integer> listCodec;
+
+    private PreparedStatement ps;
+
+    private ProtocolVersion protocolVersion;
+
+    @Override
+    protected Collection<String> getTableDefinitions() {
+        return newArrayList(
+            "CREATE TABLE \"myTable\" ("
+                + "c_int int PRIMARY KEY, "
+                + "l_int list<int> "
+                + ")"
+        );
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Cluster.Builder configure(Cluster.Builder builder) {
+        codec = new MockIntCodec();
+        listCodec = spy(new TypeCodec.ListCodec<Integer>(codec));
+        factory = spy((DefaultCodecFactory)DefaultCodecFactory.DEFAULT_INSTANCE);
+        registry = new CodecRegistry(factory).register(codec);
+        return builder.withCodecRegistry(registry);
+    }
+
+    @BeforeClass(groups = "short")
+    public void recordProtocolVersion(){
+        protocolVersion = cluster.getConfiguration().getProtocolOptions().getProtocolVersion();
+    }
+
+    @BeforeMethod(groups = "short")
+    public void prepareStatements() {
+        ps = session.prepare(query);
+    }
+
+    @BeforeMethod(groups = "short")
+    public void prepareMocks() {
+        doReturn(listCodec).when(factory).newListCodec(codec);
+    }
+
+    @AfterMethod(groups = "short", alwaysRun = true)
+    @SuppressWarnings("unchecked")
+    public void resetMocks() {
+        codec.reset();
+        reset(factory);
+        reset(listCodec);
+    }
+
+    @Test(groups = "short")
+    public void should_use_overriding_codecs_with_simple_statements() {
+        session.execute(query,
+            42,
+            newArrayList(42)
+        );
+        assertMocksInvoked();
+    }
+
+    @Test(groups = "short")
+    public void should_use_overriding_codecs_with_prepared_statements_1() {
+        session.execute(
+            ps.bind()
+                .setInt(0, 42)
+                .setList(1, newArrayList(42))
+        );
+        assertMocksInvoked();
+    }
+
+    @Test(groups = "short")
+    public void should_use_overriding_codecs_with_prepared_statements_2() {
+        session.execute(
+            ps.bind()
+                .setObject(0, 42)
+                .setObject(1, newArrayList(42))
+        );
+        assertMocksInvoked();
+    }
+
+    private void assertMocksInvoked() {
+        assertThat(codec.actualValue).isEqualTo(42);
+        assertThat(registry.codecFor(cint(), TypeToken.of(Integer.class))).isSameAs(codec);
+        assertThat(registry.codecFor(list(cint()), new TypeToken<List<Integer>>(){})).isSameAs(listCodec);
+        verify(listCodec).serialize(newArrayList(42), protocolVersion);
+        verify(factory).newListCodec(codec);
+    }
+
+    // can't spy or mock this as we need the original equals() method to be invoked
+    private class MockIntCodec extends TypeCodec<Integer> implements TypeCodec.PrimitiveIntCodec {
+
+        private Integer actualValue = null;
+
+        private MockIntCodec() {
+            super(cint(), Integer.class);
+        }
+
+        private void reset() {
+            actualValue = null;
+        }
+
+        @Override
+        public ByteBuffer serializeNoBoxing(int v, ProtocolVersion protocolVersion) {
+            actualValue = v;
+            return IntCodec.instance.serializeNoBoxing(v, protocolVersion);
+        }
+
+        @Override
+        public int deserializeNoBoxing(ByteBuffer v, ProtocolVersion protocolVersion) {
+            return IntCodec.instance.deserializeNoBoxing(v, protocolVersion);
+        }
+
+        @Override
+        public ByteBuffer serialize(Integer value, ProtocolVersion protocolVersion) throws InvalidTypeException {
+            return serializeNoBoxing(value, protocolVersion);
+        }
+
+        @Override
+        public Integer deserialize(ByteBuffer bytes, ProtocolVersion protocolVersion) throws InvalidTypeException {
+            return deserializeNoBoxing(bytes, protocolVersion);
+        }
+
+        @Override
+        public Integer parse(String value) throws InvalidTypeException {
+            return IntCodec.instance.parse(value);
+        }
+
+        @Override
+        public String format(Integer value) throws InvalidTypeException {
+            return IntCodec.instance.format(value);
+        }
+    }
+
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
@@ -16,7 +16,6 @@
 package com.datastax.driver.core;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -190,7 +189,10 @@ public class TypeCodecTest {
         assertThat(codecRegistry.codecFor(cint(), A.class)).isNotNull().isSameAs(aCodec);
         // inheritance works: B is assignable to A
         assertThat(codecRegistry.codecFor(cint(), B.class)).isNotNull().isSameAs(aCodec);
-        assertThat(codecRegistry.codecFor(list(cint()), new TypeToken<List<A>>(){})).isNotNull().isEqualTo(new TypeCodec.ListCodec<A>(aCodec));
+        TypeCodec<List<A>> expected = new TypeCodec.ListCodec<A>(aCodec);
+        TypeCodec<List<A>> actual = codecRegistry.codecFor(list(cint()), new TypeToken<List<A>>(){});
+        assertThat(actual.getCqlType()).isEqualTo(expected.getCqlType());
+        assertThat(actual.getJavaType()).isEqualTo(expected.getJavaType());
         // cannot work: List<B> is not assignable to List<A>
         try {
             codecRegistry.codecFor(list(cint()), new TypeToken<List<B>>(){});
@@ -214,7 +216,11 @@ public class TypeCodecTest {
         } catch (CodecNotFoundException e) {
             // ok
         }
-        assertThat(codecRegistry.codecFor(list(cint()), new TypeToken<List<B>>(){})).isNotNull().isEqualTo(new TypeCodec.ListCodec<B>(bCodec));
+        TypeCodec<List<B>> expectedB = new TypeCodec.ListCodec<B>(bCodec);
+        TypeCodec<List<B>> actualB = codecRegistry.codecFor(list(cint()), new TypeToken<List<B>>() {
+        });
+        assertThat(actualB.getCqlType()).isEqualTo(expectedB.getCqlType());
+        assertThat(actualB.getJavaType()).isEqualTo(expectedB.getJavaType());
     }
 
 

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
@@ -16,14 +16,13 @@
 package com.datastax.driver.core;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
+import com.google.common.base.*;
 import com.google.common.base.Objects;
-import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 import org.testng.annotations.Test;
@@ -248,6 +247,16 @@ public class TypeCodecTest {
         assertThat(actual).isEqualTo(expected);
     }
 
+    @Test(groups = "unit")
+    public void should_override_codec() {
+        CodecRegistry codecRegistry = new CodecRegistry(); // use a custom instance
+        MyOwnPrivateVarcharCodec codec = new MyOwnPrivateVarcharCodec();
+        codecRegistry.register(codec);
+        assertThat(codecRegistry.codecFor("foo")).isSameAs(codec);
+        assertThat(codecRegistry.codecFor(varchar())).isSameAs(codec);
+        assertThat(codecRegistry.codecFor(varchar(), String.class)).isSameAs(codec);
+        assertThat(codecRegistry.codecFor(varchar(), TypeToken.of(String.class))).isSameAs(codec);
+    }
 
     private class ListVarcharToListListInteger extends TypeCodec<List<List<Integer>>> {
 
@@ -290,6 +299,13 @@ public class TypeCodecTest {
         @Override
         public String format(List<List<Integer>> value) {
             throw new UnsupportedOperationException();
+        }
+    }
+
+    private class MyOwnPrivateVarcharCodec extends TypeCodec.StringCodec {
+
+        public MyOwnPrivateVarcharCodec() {
+            super(varchar(), Charsets.UTF_8);
         }
     }
 

--- a/features/custom_codecs/README.md
+++ b/features/custom_codecs/README.md
@@ -129,8 +129,7 @@ Cluster cluster = new Cluster.builder().withCodecRegistry(myCodecRegistry).build
 ```
 
 Note: when you instantiate a new `CodecRegistry`, it automatically registers all the default codecs used by the driver.
-This ensures that the new registry will not lack of an essential codec. *You cannot deregister default codecs, only
-register new ones*.
+This ensures that the new registry will not lack of an essential codec.
 
 From now on, your custom codec is fully operational. It will be used every time the driver encounters
 a `MyPojo` instance when executing queries, or when you ask it to retrieve a `MyPojo` instance from a `ResultSet`.
@@ -313,6 +312,19 @@ That's also how the object mapper handles UDTs, and you can rely on the
 mapper to generate UDT codecs for you; see
 [this page](../object_mapper/custom_codecs/#implicit-udt-codecs) for more
 information.
+
+### Replacing (overriding) built-in codecs
+
+User-provided codecs should generally *enrich* the driver capabilities, e.g. by adding support
+for additional Java types; it is usually not recommended to register a codec that handles
+the exact same CQL-to-Java mapping as another already registered codec's. 
+
+Overriding a registered codec is however permitted, even if the driver will log a warning.
+
+The only cases that could justify overriding a codec are:
+ 
+ * The overriding codec returns a different implementation of a common Java interface;
+ * The overriding codec claims to perform better than the registered one.
 
 ### Limitations
 

--- a/features/logging/README.md
+++ b/features/logging/README.md
@@ -110,6 +110,10 @@ and provide hints about what's going wrong.
 * `com.datastax.driver.core.Message`
     * TRACE
         * Custom payloads
+* `com.datastax.driver.core.CodecRegistry`
+    * TRACE
+        * Codec registration
+        * Codec lookups
 
 ### Logging query latencies
 


### PR DESCRIPTION
Overview of changes:
- The overriding of a single codec takes place in `CodecRegistry.register()` : if the exact same CQL-Java mapping already exists, the existing codec is replaced by the new one (note the additional log warning).
- The _on the fly_  overriding of collection codecs is more complex: there is now a new `CodecFactory` class that can be subclassed for this purpose. 
- Behavior in case of _overlapping_ codecs didn't change: it is still possible to register more than one codec for the same CQL type.

Note: the CodecFactory class allow users to override the on-the-fly instantiation mechanism, but we could live without it. If the user knows which _exact_ list types he needs to handle, the following code:

``` java
CodecFactory factory = new DefaultCodecFactory() {
    protected <T> TypeCodec<List<T>> newListCodec(TypeCodec<T> eltCodec) {
        return new MyListCodec<T>(eltCodec);
    }
};
CodecRegistry registry = new CodecRegistry(factory);
```

Could easily be replaced with:

``` java
CodecRegistry registry = new CodecRegistry();
registry.register(new MyListCodec(IntCodec.instance));
registry.register(new MyListCodec(VarcharCodec.instance));
// etc. register all list types required by the application
```
