### PR TITLE
[wip] JAVA-939 Add crcCheckChance to Options#equals/hashCode.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -10,6 +10,7 @@
 - [new feature] Prepare API for async query trace (JAVA-902)
 - [new feature] Add BoundStatement#unset (JAVA-930)
 - [bug] Make table metadata options class visible (JAVA-946)
+- [bug] Add crcCheckChance to TableOptionsMetadata#equals/hashCode (JAVA-939)
 
 
 ### 3.0.0-alpha3

--- a/driver-core/src/main/java/com/datastax/driver/core/TableOptionsMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableOptionsMetadata.java
@@ -391,6 +391,7 @@ public class TableOptionsMetadata {
             Objects.equal(this.maxIndexInterval, that.maxIndexInterval) &&
             Objects.equal(this.compaction, that.compaction) &&
             Objects.equal(this.compression, that.compression) &&
+            Objects.equal(this.crcCheckChance, that.crcCheckChance) &&
             Objects.equal(this.extensions, that.extensions);
     }
 
@@ -398,6 +399,6 @@ public class TableOptionsMetadata {
     public int hashCode() {
         return Objects.hashCode(isCompactStorage, comment, readRepair, localReadRepair, replicateOnWrite, gcGrace,
             bfFpChance, caching, populateCacheOnFlush, memtableFlushPeriodMs, defaultTTL, speculativeRetry,
-            indexInterval, minIndexInterval, maxIndexInterval, compaction, compression, extensions);
+            indexInterval, minIndexInterval, maxIndexInterval, compaction, compression, crcCheckChance, extensions);
     }
 }


### PR DESCRIPTION
[JAVA-939](https://datastax-oss.atlassian.net/browse/JAVA-939)

Just a small change to include crcCheckChance in equals and hashCode implementation of TableOrView#equals and hashCode
