### PR TITLE
JAVA-952 Tests for validating equals/hashCode implementations and include MaterializedViewMetadata#whereClause in equals/hashCode

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -139,6 +139,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <version>1.7.5</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/driver-core/src/main/java/com/datastax/driver/core/AggregateMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AggregateMetadata.java
@@ -292,30 +292,36 @@ public class AggregateMetadata {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public final boolean equals(Object other) {
         if (other == this)
             return true;
         
         if (other instanceof AggregateMetadata) {
             AggregateMetadata that = (AggregateMetadata)other;
-            return this.keyspace.getName().equals(that.keyspace.getName()) &&
-                this.fullName.equals(that.fullName) &&
-                this.argumentTypes.equals(that.argumentTypes) &&
+
+            boolean keyspaceCmp = this.keyspace == that.keyspace;
+            if(!keyspaceCmp && this.keyspace != null && that.keyspace != null) {
+                keyspaceCmp = Objects.equal(this.keyspace.getName(), that.keyspace.getName());
+            }
+
+            return keyspaceCmp &&
+                Objects.equal(this.fullName, that.fullName) &&
+                Objects.equal(this.argumentTypes, that.argumentTypes) &&
                 Objects.equal(this.finalFuncFullName, that.finalFuncFullName) &&
                 // Note: this might be a problem if a custom codec has been registered for the initCond's type, with a target Java type that
                 // does not properly implement equals. We don't have any control over this, at worst this would lead to spurious change
                 // notifications.
                 Objects.equal(this.initCond, that.initCond) &&
-                this.returnType.equals(that.returnType) &&
-                this.stateFuncFullName.equals(that.stateFuncFullName) &&
-                this.stateType.equals(that.stateType);
+                Objects.equal(this.returnType, that.returnType) &&
+                Objects.equal(this.stateFuncFullName, that.stateFuncFullName) &&
+                Objects.equal(this.stateType, that.stateType);
         }
         return false;
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(this.keyspace.getName(), this.fullName, this.argumentTypes,
+    public final int hashCode() {
+        return Objects.hashCode(this.keyspace == null ? null : this.keyspace.getName(), this.fullName, this.argumentTypes,
             this.finalFuncFullName, this.initCond, this.returnType, this.stateFuncFullName, this.stateType);
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/ColumnDefinitions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ColumnDefinitions.java
@@ -15,7 +15,15 @@
  */
 package com.datastax.driver.core;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Objects;
+
+
 
 /**
  * Metadata describing the columns returned in a {@link ResultSet} or a
@@ -355,10 +363,10 @@ public class ColumnDefinitions implements Iterable<ColumnDefinitions.Definition>
                 return false;
 
             Definition other = (Definition)o;
-            return keyspace.equals(other.keyspace)
-                && table.equals(other.table)
-                && name.equals(other.name)
-                && type.equals(other.type);
+            return Objects.equal(keyspace, other.keyspace)
+                && Objects.equal(table, other.table)
+                && Objects.equal(name, other.name)
+                && Objects.equal(type, other.type);
         }
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
@@ -102,20 +102,20 @@ public class ColumnMetadata {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public final boolean equals(Object other) {
         if (other == this)
             return true;
         if (!(other instanceof ColumnMetadata))
             return false;
 
         ColumnMetadata that = (ColumnMetadata)other;
-        return this.name.equals(that.name) &&
-            this.isStatic == that.isStatic &&
-            this.type.equals(that.type);
+        return Objects.equal(name, that.name) &&
+            Objects.equal(type, that.type) &&
+            isStatic == that.isStatic;
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         return Objects.hashCode(name, isStatic, type);
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/FunctionMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/FunctionMetadata.java
@@ -271,25 +271,31 @@ public class FunctionMetadata {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public final boolean equals(Object other) {
         if (other == this)
             return true;
 
         if (other instanceof FunctionMetadata) {
             FunctionMetadata that = (FunctionMetadata)other;
-            return this.keyspace.getName().equals(that.keyspace.getName()) &&
-                this.fullName.equals(that.fullName) &&
-                this.arguments.equals(that.arguments) &&
-                this.body.equals(that.body) &&
-                this.calledOnNullInput == that.calledOnNullInput &&
-                this.language.equals(that.language) &&
-                this.returnType.equals(that.returnType);
+
+            boolean keyspaceCmp = this.keyspace == that.keyspace;
+            if(!keyspaceCmp && this.keyspace != null && that.keyspace != null) {
+                keyspaceCmp = Objects.equal(this.keyspace.getName(), that.keyspace.getName());
+            }
+
+            return keyspaceCmp &&
+                Objects.equal(fullName, that.fullName) &&
+                Objects.equal(arguments, that.arguments) &&
+                Objects.equal(body, that.body) &&
+                Objects.equal(calledOnNullInput, that.calledOnNullInput) &&
+                Objects.equal(language, that.language) &&
+                Objects.equal(returnType, that.returnType);
         }
         return false;
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(keyspace.getName(), fullName, arguments, body, calledOnNullInput, language, returnType);
+    public final int hashCode() {
+        return Objects.hashCode(keyspace == null ? null : keyspace.getName(), fullName, arguments, body, calledOnNullInput, language, returnType);
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/IndexMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/IndexMetadata.java
@@ -239,11 +239,11 @@ public class IndexMetadata {
         return builder.toString();
     }
 
-    public int hashCode() {
+    public final int hashCode() {
         return Objects.hashCode(name, kind, target, options);
     }
 
-    public boolean equals(Object obj) {
+    public final boolean equals(Object obj) {
         if (obj == this)
             return true;
 

--- a/driver-core/src/main/java/com/datastax/driver/core/KeyspaceMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/KeyspaceMetadata.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 
 /**
@@ -314,34 +315,24 @@ public class KeyspaceMetadata {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public final boolean equals(Object o) {
         if (this == o)
             return true;
-        if (o == null || getClass() != o.getClass())
+        if (!(o instanceof KeyspaceMetadata))
             return false;
 
         KeyspaceMetadata that = (KeyspaceMetadata)o;
 
-        if (durableWrites != that.durableWrites)
-            return false;
-        if (!name.equals(that.name))
-            return false;
-        if (strategy != null ? !strategy.equals(that.strategy) : that.strategy != null)
-            return false;
-        if (!replication.equals(that.replication))
-            return false;
-        return tables.equals(that.tables);
-
+        return durableWrites == that.durableWrites &&
+            Objects.equal(name, that.name) &&
+            Objects.equal(strategy, that.strategy) &&
+            Objects.equal(replication, that.replication) &&
+            Objects.equal(tables, that.tables);
     }
 
     @Override
-    public int hashCode() {
-        int result = name.hashCode();
-        result = 31 * result + (durableWrites ? 1 : 0);
-        result = 31 * result + (strategy != null ? strategy.hashCode() : 0);
-        result = 31 * result + replication.hashCode();
-        result = 31 * result + tables.hashCode();
-        return result;
+    public final int hashCode() {
+        return Objects.hashCode(name, durableWrites, strategy, replication, tables);
     }
 
     void add(TableMetadata tm) {

--- a/driver-core/src/main/java/com/datastax/driver/core/MaterializedViewMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/MaterializedViewMetadata.java
@@ -206,13 +206,19 @@ public class MaterializedViewMetadata extends TableOrView {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public final boolean equals(Object other) {
         if (other == this)
             return true;
         if (!(other instanceof MaterializedViewMetadata))
             return false;
 
         MaterializedViewMetadata that = (MaterializedViewMetadata)other;
+
+        boolean tableCmp = this.baseTable == that.baseTable;
+        if(!tableCmp && this.baseTable != null && that.baseTable != null) {
+            tableCmp = Objects.equal(this.baseTable.getName(), that.baseTable.getName());
+        }
+
         return Objects.equal(this.name, that.name) &&
             Objects.equal(this.id, that.id) &&
             Objects.equal(this.partitionKey, that.partitionKey) &&
@@ -220,13 +226,14 @@ public class MaterializedViewMetadata extends TableOrView {
             Objects.equal(this.columns, that.columns) &&
             Objects.equal(this.options, that.options) &&
             Objects.equal(this.clusteringOrder, that.clusteringOrder) &&
-            Objects.equal(this.baseTable.getName(), that.baseTable.getName()) &&
+            tableCmp &&
+            Objects.equal(this.whereClause, that.whereClause) &&
             this.includeAllColumns == that.includeAllColumns;
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(name, id, partitionKey, clusteringColumns, columns, options, clusteringOrder,
-            baseTable.getName(), includeAllColumns);
+    public final int hashCode() {
+        return Objects.hashCode(name, id, partitionKey, clusteringColumns, columns, options, clusteringOrder, whereClause,
+            baseTable == null ? null : baseTable.getName(), includeAllColumns);
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
@@ -420,7 +420,7 @@ public class TableMetadata extends TableOrView {
     }
 
     @Override
-    public boolean equals(Object other) {
+    public final boolean equals(Object other) {
         if (other == this)
             return true;
         if (!(other instanceof TableMetadata))
@@ -440,7 +440,7 @@ public class TableMetadata extends TableOrView {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         return Objects.hashCode(name, id, partitionKey, clusteringColumns, columns, options, clusteringOrder, indexes, views);
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/UserType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/UserType.java
@@ -17,6 +17,7 @@ package com.datastax.driver.core;
 
 import java.util.*;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
 
@@ -170,10 +171,8 @@ public class UserType extends DataType implements Iterable<UserType.Field>{
     }
 
     @Override
-    public int hashCode() {
-        int result = name.hashCode();
-        result = 31 * result + keyspace.hashCode();
-        result = 31 * result + typeName.hashCode();
+    public final int hashCode() {
+        int result = Objects.hashCode(name, keyspace, typeName);
         result = 31 * result + Arrays.hashCode(byIdx);
         return result;
     }
@@ -187,9 +186,9 @@ public class UserType extends DataType implements Iterable<UserType.Field>{
 
         // Note: we don't test byName because it's redundant with byIdx in practice,
         // but also because the map holds 'int[]' which don't have proper equal.
-        return name.equals(other.name)
-            && keyspace.equals(other.keyspace)
-            && typeName.equals(other.typeName)
+        return Objects.equal(name, other.name)
+            && Objects.equal(keyspace, other.keyspace)
+            && Objects.equal(typeName, other.typeName)
             && Arrays.equals(byIdx, other.byIdx);
     }
 
@@ -305,8 +304,8 @@ public class UserType extends DataType implements Iterable<UserType.Field>{
                 return false;
 
             Field other = (Field)o;
-            return name.equals(other.name)
-                && type.equals(other.type);
+            return Objects.equal(name, other.name)
+                && Objects.equal(type, other.type);
         }
 
         @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/AggregateMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AggregateMetadataTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -40,6 +41,13 @@ public class AggregateMetadataTest {
     @BeforeMethod(groups = "unit")
     public void setup() {
         keyspace = new KeyspaceMetadata("ks", false, Collections.<String, String>emptyMap());
+    }
+
+    @Test(groups = "unit")
+    public void should_use_all_fields_in_equals_and_hashCode() {
+        EqualsVerifier.forClass(AggregateMetadata.class)
+            .allFieldsShouldBeUsedExcept("simpleName", "finalFuncSimpleName", "stateFuncSimpleName", "stateTypeCodec")
+            .verify();
     }
 
     @Test(groups = "unit")

--- a/driver-core/src/test/java/com/datastax/driver/core/ColumnDefinitionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ColumnDefinitionsTest.java
@@ -15,10 +15,16 @@
  */
 package com.datastax.driver.core;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertTrue;
 
 public class ColumnDefinitionsTest {
+
+    @Test(groups = "unit")
+    public void should_use_all_fields_in_equals_and_hashCode() {
+        EqualsVerifier.forClass(ColumnDefinitions.Definition.class).allFieldsShouldBeUsed().verify();
+    }
 
     @Test(groups = "unit")
     public void caseTest() {

--- a/driver-core/src/test/java/com/datastax/driver/core/ColumnMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ColumnMetadataTest.java
@@ -1,0 +1,29 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.testng.annotations.Test;
+
+public class ColumnMetadataTest {
+
+    @Test(groups = "unit")
+    public void should_use_all_fields_in_equals_and_hashCode() {
+        EqualsVerifier.forClass(ColumnMetadata.class)
+            .allFieldsShouldBeUsedExcept("parent")
+            .verify();
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/FunctionMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/FunctionMetadataTest.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -35,6 +36,13 @@ public class FunctionMetadataTest {
     @BeforeMethod(groups = "unit")
     public void setup() {
         keyspace = new KeyspaceMetadata("ks", false, Collections.<String, String>emptyMap());
+    }
+
+    @Test(groups = "unit")
+    public void should_use_all_fields_in_equals_and_hashCode() {
+        EqualsVerifier.forClass(FunctionMetadata.class)
+            .allFieldsShouldBeUsedExcept("simpleName")
+            .verify();
     }
 
     @Test(groups = "unit")

--- a/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -100,6 +101,13 @@ public class IndexMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
         );
 
         return builder.build();
+    }
+
+    @Test(groups = "unit")
+    public void should_use_all_fields_in_equals_and_hashCode() {
+        EqualsVerifier.forClass(IndexMetadata.class)
+            .allFieldsShouldBeUsedExcept("table")
+            .verify();
     }
 
     @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/KeyspaceMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/KeyspaceMetadataTest.java
@@ -1,0 +1,29 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.testng.annotations.Test;
+
+public class KeyspaceMetadataTest {
+
+    @Test(groups = "unit")
+    public void should_use_all_fields_in_equals_and_hashCode() {
+        EqualsVerifier.forClass(KeyspaceMetadata.class)
+            .allFieldsShouldBeUsedExcept("views", "userTypes", "functions", "aggregates")
+            .verify();
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/MaterializedViewMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MaterializedViewMetadataTest.java
@@ -18,6 +18,7 @@ package com.datastax.driver.core;
 import java.util.Collection;
 import java.util.Collections;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.testng.annotations.Test;
 
 import com.datastax.driver.core.utils.CassandraVersion;
@@ -28,6 +29,13 @@ import static com.datastax.driver.core.TableOrView.Order.DESC;
 
 @CassandraVersion(major = 3)
 public class MaterializedViewMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
+
+    @Test(groups = "unit")
+    public void should_use_all_fields_in_equals_and_hashCode() {
+        EqualsVerifier.forClass(MaterializedViewMetadata.class)
+            .allFieldsShouldBeUsedExcept("cassandraVersion", "keyspace")
+            .verify();
+    }
 
     /**
      * Validates that a materialized view is properly retrieved and parsed.

--- a/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import com.google.common.collect.ImmutableMap;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.entry;
@@ -65,6 +66,13 @@ public class TableMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
             .setRefreshNodeListIntervalMillis(0)
             .setRefreshSchemaIntervalMillis(0)
         );
+    }
+
+    @Test(groups = "unit")
+    public void should_use_all_fields_in_equals_and_hashCode() {
+        EqualsVerifier.forClass(TableMetadata.class)
+            .allFieldsShouldBeUsedExcept("cassandraVersion", "keyspace")
+            .verify();
     }
 
     @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/UserTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/UserTypeTest.java
@@ -1,0 +1,28 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.testng.annotations.Test;
+
+public class UserTypeTest {
+    @Test(groups = "unit")
+    public void should_use_all_fields_in_equals_and_hashCode() {
+        EqualsVerifier.forClass(UserType.class)
+            .allFieldsShouldBeUsedExcept("protocolVersion", "codecRegistry", "byName")
+            .verify();
+    }
+}


### PR DESCRIPTION
There have been a few occasions now where we've added fields to classes and missed updating equals/hashCode implementations.  I thought it would be good to use [equalsverifier](http://www.jqno.nl/equalsverifier/) to validate that equals and hashCode implementations are correct where applicable.  Having tests for classes that depend on equals/hashCode will 'future-proof' any changes to these classes by detecting missing field use in these methods.

I didn't implement this comprehensively for all classes overriding equals/hashCode in the driver, just the ones that were related to schema.

I chose to make this change on 3.0 since it adds some API restrictions (marking methods final that previously weren't).  We could make this worker on older branches but not sure if it's worth it since schema changes seem less likely.

I found a variety of issues which were since fixed.  The only remaining issue I've identifier that should probably be definitively fixed is:
- MaterializedViewMetadata was not including whereClause in equals/hashcode.

There are a few cases where its debatable where certain fields need to be included in equals/hashCode as they may not factor in what we use these methods for (i.e. keyspace/table parentage of the type).  I've added comments in the test classes where this is applicable.

Source-Level Changes:
- Add test level dependency for equalsverifier to device-core/pom.xml
- In General
  - Use Objects.equal in favor of .equals() for non-primitives not already using it.
  - Null-checking (Maybe we should use Nonnull annotation instead?)
  - Made equals and hashCode final.  Did this instead of making whole class final (as can't mock classes that are final).
