### PR TITLE
Prevent reverse DNS lookup in HostMock.toString()

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/AbstractReplicationStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AbstractReplicationStrategyTest.java
@@ -56,7 +56,7 @@ public class AbstractReplicationStrategyTest {
 
         @Override
         public String toString() {
-            return address.getHostName();
+            return address.toString();
         }
 
         public InetSocketAddress getMockAddress() {


### PR DESCRIPTION
`InetSocketAddress.getHostName()` does a reverse DNS lookup, this is costly and unreliable.   Noticed some of the TopologyStrategyTests taking an unreasonable amount of time in a Windows Openstack environment.  Using `InetSocketAddress.toString()` like `Host` does fixes this.
