### PR TITLE
JAVA-965 Improve error handling of non-type 1 UUID used for timeuuid.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,8 +2,9 @@
 
 ### 3.0.0-beta1 (in progress)
 
- - [improvement] JAVA-958: Make TableOrView.Order visible.
- - [improvement] JAVA-968: Update metrics to the latest version.
+- [improvement] Make TableOrView.Order visible (JAVA-958)
+- [improvement] Update metrics to the latest version (JAVA-968)
+- [improvement] Improve error handling for when a non-type 1 UUID is given to bind() on a timeuuid column (JAVA-965)
 
 ### 3.0.0-alpha4
 

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
@@ -860,10 +860,20 @@ public abstract class TypeCodec<T> {
         }
 
         @Override
-        public boolean accepts(Object value) {
-            return value instanceof String && ASCII_PATTERN.matcher((String)value).matches();
+        public ByteBuffer serialize(String value, ProtocolVersion protocolVersion) {
+            if (value != null && !ASCII_PATTERN.matcher(value).matches()) {
+                throw new InvalidTypeException(String.format("%s is not a valid ASCII String", value));
+            }
+            return super.serialize(value, protocolVersion);
         }
 
+        @Override
+        public String format(String value) {
+            if (value != null && !ASCII_PATTERN.matcher(value).matches()) {
+                throw new InvalidTypeException(String.format("%s is not a valid ASCII String", value));
+            }
+            return super.format(value);
+        }
     }
 
     /**
@@ -1766,12 +1776,6 @@ public abstract class TypeCodec<T> {
 
         private TimeUUIDCodec() {
             super(timeuuid());
-        }
-
-        @Override
-        public boolean accepts(Object value) {
-            // only accept time-based uuids
-            return super.accepts(value) && ((UUID)value).version() == 1;
         }
 
         @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecAssert.java
@@ -83,11 +83,21 @@ public class TypeCodecAssert extends AbstractAssert<TypeCodecAssert, TypeCodec> 
     public TypeCodecAssert cannotSerialize(Object value) {
         if(version == null) fail("ProtocolVersion cannot be null");
         try {
-            assertThat(actual.deserialize(actual.serialize(value, version), version))
-                .describedAs(String.format("Codec is not supposed to serialize this value but it actually does: %s", value))
-                .isNotEqualTo(value);
+            actual.serialize(value, version);
+            fail("Should not have been able to serialize " + value + " with " + actual);
         } catch (Exception e) {
             //ok
+        }
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public TypeCodecAssert cannotFormat(Object value) {
+        try {
+            actual.format(value);
+            fail("Should not have been able to format " + value + " with " + actual);
+        } catch (Exception e) {
+            // ok
         }
         return this;
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
@@ -123,7 +123,6 @@ public class TypeCodecTest {
             .doesNotAccept(varchar())
             .doesNotAccept(text())
             .accepts(ascii)
-            .doesNotAccept(utf8)
             .canSerialize(ascii)
             .cannotSerialize(utf8);
         assertThat(utf8Codec)
@@ -249,6 +248,24 @@ public class TypeCodecTest {
         UDTValue actual = codecRegistry.codecFor(udt, UDTValue.class).deserialize(ByteBuffer.allocate(0), ProtocolVersion.NEWEST_SUPPORTED);
         assertThat(actual).isNotNull();
         assertThat(actual).isEqualTo(expected);
+    }
+
+    /**
+     * Ensures that {@link TypeCodec#timeUUID()} is resolved for all UUIDs and throws an
+     * {@link InvalidTypeException} when attempting to serialize or format a non-type 1
+     * UUID.
+     *
+     * @jira_ticket JAVA-965
+     */
+    @Test(groups = "unit")
+    public void should_resolve_timeuuid_codec_for_all_uuids_and_fail_to_serialize_non_type1_uuid() {
+        UUID type4UUID = UUID.randomUUID();
+        TypeCodec<UUID> codec = codecRegistry.codecFor(DataType.timeuuid(), type4UUID);
+        // Should resolve the TimeUUIDCodec, but not serialize/format a type4 uuid with it.
+        assertThat(codec).isSameAs(TypeCodec.timeUUID())
+            .accepts(UUID.class)
+            .cannotSerialize(type4UUID)
+            .cannotFormat(type4UUID);
     }
 
 


### PR DESCRIPTION
[JAVA-965](https://datastax-oss.atlassian.net/browse/JAVA-965)
