### PR TITLE
JAVA-961: Raise an exception when an older version of guava (< 16.0.1) is found.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -6,6 +6,8 @@
 - [improvement] Update metrics to the latest version (JAVA-968)
 - [improvement] Improve error handling for when a non-type 1 UUID is given to bind() on a timeuuid column (JAVA-965)
 - [improvement] Pass the authenticator name from the server to the auth provider (JAVA-885) 
+- [improvement] Raise an exception when an older version of guava (<16.01) is found (JAVA-961)
+
 
 ### 3.0.0-alpha4
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -66,6 +66,11 @@ public class Cluster implements Closeable {
 
     private static final Logger logger = LoggerFactory.getLogger(Cluster.class);
 
+    static {
+        // Perform sanity checks to inform user of possible environment misconfiguration.
+        SanityChecks.check();
+    }
+
     @VisibleForTesting
     static final int NEW_NODE_DELAY_SECONDS = SystemProperties.getInt("com.datastax.driver.NEW_NODE_DELAY_SECONDS", 1);
     private static final int NON_BLOCKING_EXECUTOR_SIZE = SystemProperties.getInt("com.datastax.driver.NON_BLOCKING_EXECUTOR_SIZE",

--- a/driver-core/src/main/java/com/datastax/driver/core/SanityChecks.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SanityChecks.java
@@ -1,0 +1,69 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+import com.google.common.reflect.TypeToken;
+
+class SanityChecks {
+
+    /**
+     * Performs a series of runtime checks to ensure the environment does not have any
+     * incompatible libraries or configurations.  Depending on the severity of an
+     * incompatibility an {@link IllegalStateException} may be thrown or an ERROR or
+     * WARNING is logged.
+     *
+     * @throws IllegalStateException If an environment incompatibility is detected.
+     * @see #checkGuava
+     */
+    static void check() {
+        checkGuava();
+    }
+
+    /**
+     * Detects if a version of guava older than 16.01 is present by attempting to create
+     * a {@link TypeToken} instance for <code>Map&lt;String,String&gt;</code> and ensures that the
+     * value type argument is of instance {@link String}.  If using an older version of guava
+     * this will resolve to {@link Object} instead.  In this case an {@link IllegalStateException}
+     * is thrown.
+     *
+     * @throws IllegalStateException if version of guava less than 16.01 is detected.
+     */
+    static void checkGuava() {
+        boolean resolved = false;
+        TypeToken<Map<String,String>> mapOfString = CodecUtils.mapOf(String.class, String.class);
+        Type type = mapOfString.getType();
+        if(type instanceof ParameterizedType) {
+            ParameterizedType pType = (ParameterizedType)type;
+            Type[] types = pType.getActualTypeArguments();
+            if(types.length == 2) {
+                TypeToken valueType = TypeToken.of(types[1]);
+                resolved = valueType.getRawType().equals(String.class);
+            }
+        }
+
+        if(!resolved) {
+            throw new IllegalStateException(
+                "Detected Guava issue #1635 which indicates that a version of Guava less than 16.01 is in use.  "
+                    + "This introduces codec resolution issues and potentially other incompatibility issues in the driver.  "
+                    + "Please upgrade to Guava 16.01 or later.");
+        }
+    }
+
+}

--- a/driver-examples/osgi/pom.xml
+++ b/driver-examples/osgi/pom.xml
@@ -31,6 +31,7 @@
   <properties>
     <felix.version>4.6.0</felix.version>
     <pax-exam.version>3.6.0</pax-exam.version>
+    <logback.version>1.1.3</logback.version>
     <main.basedir>${project.parent.parent.basedir}</main.basedir>
   </properties>
 
@@ -91,20 +92,6 @@
     </dependency>
 
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>${log4j.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>${slf4j-log4j12.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-manifests</artifactId>
       <version>1.1</version>
@@ -130,6 +117,18 @@
       <artifactId>commons-exec</artifactId>
       <version>1.3</version>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <version>${logback.version}</version>
     </dependency>
   </dependencies>
 

--- a/driver-examples/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
+++ b/driver-examples/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
@@ -1,0 +1,86 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.osgi;
+
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.options.CompositeOption;
+import org.ops4j.pax.exam.options.MavenArtifactProvisionOption;
+import org.ops4j.pax.exam.options.UrlProvisionOption;
+import org.ops4j.pax.exam.util.PathUtils;
+
+import static org.ops4j.pax.exam.CoreOptions.bundle;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+import static org.ops4j.pax.exam.CoreOptions.systemPackages;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+
+import com.datastax.driver.core.CCMBridge;
+
+import static com.datastax.driver.osgi.VersionProvider.projectVersion;
+
+public class BundleOptions {
+
+    public static UrlProvisionOption driverBundle() {
+        return driverBundle(false);
+    }
+
+    public static UrlProvisionOption driverBundle(boolean useShaded) {
+        String classifier = useShaded ? "-shaded" : "";
+        return bundle("reference:file:" + PathUtils.getBaseDir()  + "/../../driver-core/target/cassandra-driver-core-" + projectVersion() + classifier + ".jar");
+    }
+
+    public static MavenArtifactProvisionOption guavaBundle() {
+        return mavenBundle("com.google.guava", "guava", "16.0.1");
+    }
+
+    public static CompositeOption nettyBundles() {
+        final String nettyVersion = "4.0.27.Final";
+        return new CompositeOption() {
+
+            @Override public Option[] getOptions() {
+                return options(
+                    mavenBundle("io.netty", "netty-buffer", nettyVersion),
+                    mavenBundle("io.netty", "netty-codec", nettyVersion),
+                    mavenBundle("io.netty", "netty-common", nettyVersion),
+                    mavenBundle("io.netty", "netty-handler", nettyVersion),
+                    mavenBundle("io.netty", "netty-transport", nettyVersion)
+                );
+            }
+        };
+    }
+
+    public static UrlProvisionOption mailboxBundle() {
+        return bundle("reference:file:" + PathUtils.getBaseDir() + "/target/classes");
+    }
+
+    public static CompositeOption defaultOptions() {
+        return new CompositeOption() {
+
+            @Override public Option[] getOptions() {
+                return options(
+                    systemProperty("cassandra.contactpoints").value(CCMBridge.IP_PREFIX + 1),
+                    systemProperty("logback.configurationFile").value("file:" + PathUtils.getBaseDir() + "/src/test/resources/logback.xml"),
+                    mavenBundle("org.slf4j", "slf4j-api", "1.7.5"),
+                    mavenBundle("ch.qos.logback", "logback-classic", "1.1.3"),
+                    mavenBundle("ch.qos.logback", "logback-core", "1.1.3"),
+                    mavenBundle("io.dropwizard.metrics", "metrics-core", "3.1.2"),
+                    systemPackages("org.testng", "org.junit", "org.junit.runner", "org.junit.runner.manipulation",
+                        "org.junit.runner.notification", "com.jcabi.manifests")
+                );
+            }
+        };
+    }
+}

--- a/driver-examples/osgi/src/test/java/com/datastax/driver/osgi/GuavaSanityCheckNegativeIT.java
+++ b/driver-examples/osgi/src/test/java/com/datastax/driver/osgi/GuavaSanityCheckNegativeIT.java
@@ -1,0 +1,102 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.osgi;
+
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.testng.listener.PaxExam;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static org.ops4j.pax.exam.CoreOptions.options;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import com.datastax.driver.core.Cluster;
+
+import static com.datastax.driver.osgi.BundleOptions.defaultOptions;
+import static com.datastax.driver.osgi.BundleOptions.driverBundle;
+import static com.datastax.driver.osgi.BundleOptions.guavaBundle;
+import static com.datastax.driver.osgi.BundleOptions.nettyBundles;
+
+@Listeners({PaxExam.class})
+@Test(groups="short")
+public class GuavaSanityCheckNegativeIT {
+
+    @Configuration
+    public Option[] guava14_0_1Config() {
+        return options(
+            driverBundle(),
+            nettyBundles(),
+            guavaBundle().version("14.0.1"),
+            defaultOptions()
+        );
+    }
+
+    @Configuration
+    public Option[] guava15Config() {
+        return options(
+            driverBundle(),
+            nettyBundles(),
+            guavaBundle().version("15.0"),
+            defaultOptions()
+        );
+    }
+
+    @Configuration
+    public Option[] guava16Config() {
+        return options(
+            driverBundle(),
+            nettyBundles(),
+            guavaBundle().version("16.0"),
+            defaultOptions()
+        );
+    }
+
+    /**
+     * <p>
+     * Validates that the driver is able to detect that the guava library in the classpath is
+     * less than version 16.01 and throws an {@link IllegalStateException} in this case and
+     * is raised as the cause of an {@link ExceptionInInitializerError} since the failure
+     * occurs at static initialization.
+     * </p>
+     *
+     * The following configurations are tried (defined via methods with the @Configuration annotation):
+     * <ol>
+     *   <li>With Guava 14.0.1</li>
+     *   <li>With Guava 15.0</li>
+     *   <li>With Guava 16.0</li>
+     * </ol>
+     *
+     * @test_category packaging
+     * @expected_result An {@link IllegalStateException} is thrown.
+     * @jira_ticket JAVA-961
+     * @since 3.0.0-beta1
+     */
+    public void should_raise_guava_version_error_if_lt_16_0_1() throws Throwable {
+        try {
+            Cluster.builder();
+            fail("Expected an IllegalStateException for Guava version incompatibility");
+        }
+        catch(ExceptionInInitializerError e) {
+            try {
+                throw e.getCause();
+            } catch(IllegalStateException ise) {
+                assertTrue(ise.getMessage().contains("Detected Guava issue #1635"));
+            }
+        }
+    }
+}

--- a/driver-examples/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceIT.java
+++ b/driver-examples/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceIT.java
@@ -22,78 +22,29 @@ import java.util.GregorianCalendar;
 import javax.inject.Inject;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.options.CompositeOption;
-import org.ops4j.pax.exam.options.MavenArtifactProvisionOption;
-import org.ops4j.pax.exam.options.UrlProvisionOption;
 import org.ops4j.pax.exam.testng.listener.PaxExam;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
-import static org.ops4j.pax.exam.CoreOptions.*;
+import static org.ops4j.pax.exam.CoreOptions.options;
 import static org.testng.Assert.assertEquals;
 
-import com.datastax.driver.core.CCMBridge;
 import com.datastax.driver.osgi.api.MailboxException;
 import com.datastax.driver.osgi.api.MailboxMessage;
 import com.datastax.driver.osgi.api.MailboxService;
 
-import static com.datastax.driver.osgi.VersionProvider.projectVersion;
+import static com.datastax.driver.osgi.BundleOptions.*;
 
 @Listeners({CCMBridgeListener.class, PaxExam.class})
 @Test(groups="short")
 public class MailboxServiceIT {
     @Inject MailboxService service;
 
-    private UrlProvisionOption driverBundle() {
-        return driverBundle(false);
-    }
-
-    private UrlProvisionOption driverBundle(boolean useShaded) {
-        String classifier = useShaded ? "-shaded" : "";
-        return bundle("reference:file:../../driver-core/target/cassandra-driver-core-" + projectVersion() + classifier + ".jar");
-    }
-
-    private MavenArtifactProvisionOption guavaBundle() {
-        return mavenBundle("com.google.guava", "guava", "16.0.1");
-    }
-
-    private CompositeOption nettyBundles() {
-        final String nettyVersion = "4.0.27.Final";
-        return new CompositeOption() {
-
-            @Override public Option[] getOptions() {
-                return options(
-                    mavenBundle("io.netty", "netty-buffer", nettyVersion),
-                    mavenBundle("io.netty", "netty-codec", nettyVersion),
-                    mavenBundle("io.netty", "netty-common", nettyVersion),
-                    mavenBundle("io.netty", "netty-handler", nettyVersion),
-                    mavenBundle("io.netty", "netty-transport", nettyVersion)
-                );
-            }
-        };
-    }
-
-    private CompositeOption defaultOptions() {
-        return new CompositeOption() {
-
-            @Override public Option[] getOptions() {
-                return options(
-                    systemProperty("cassandra.contactpoints").value(CCMBridge.IP_PREFIX + 1),
-                    bundle("reference:file:target/classes"),
-                    mavenBundle("com.codahale.metrics", "metrics-core", "3.0.2"),
-                    mavenBundle("org.slf4j", "slf4j-api", "1.7.5"),
-                    mavenBundle("org.slf4j", "slf4j-simple", "1.7.5").noStart(),
-                    systemPackages("org.testng", "org.junit", "org.junit.runner", "org.junit.runner.manipulation",
-                        "org.junit.runner.notification", "com.jcabi.manifests")
-                );
-            }
-        };
-    }
-
     @Configuration
     public Option[] shadedConfig() {
         return options(
             driverBundle(true),
+            mailboxBundle(),
             guavaBundle(),
             defaultOptions()
         );
@@ -103,6 +54,7 @@ public class MailboxServiceIT {
     public Option[] defaultConfig() {
         return options(
             driverBundle(),
+            mailboxBundle(),
             guavaBundle(),
             nettyBundles(),
             defaultOptions()
@@ -113,6 +65,7 @@ public class MailboxServiceIT {
     public Option[] guava17Config() {
         return options(
             driverBundle(),
+            mailboxBundle(),
             nettyBundles(),
             guavaBundle().version("17.0"),
             defaultOptions()
@@ -123,6 +76,7 @@ public class MailboxServiceIT {
     public Option[] guava18Config() {
         return options(
             driverBundle(),
+            mailboxBundle(),
             nettyBundles(),
             guavaBundle().version("18.0"),
             defaultOptions()
@@ -139,8 +93,7 @@ public class MailboxServiceIT {
      * <ol>
      *   <li>Default bundle (Driver with all of it's dependencies)</li>
      *   <li>Shaded bundle (Driver with netty shaded)</li>
-     *   <li>With Guava 15</li>
-     *   <li>With Guava 16</li>
+     *   <li>With Guava 16.0.1</li>
      *   <li>With Guava 17</li>
      *   <li>With Guava 18</li>
      * </ol>

--- a/driver-examples/osgi/src/test/resources/exam.properties
+++ b/driver-examples/osgi/src/test/resources/exam.properties
@@ -14,15 +14,5 @@
 #   limitations under the License.
 #
 
-# Set root logger level to DEBUG and its only appender to A1.
-log4j.rootLogger=INFO, A1
-
-# Scassandra's info log is a bit verbose
-log4j.logger.org.scassandra=WARN
-
-# A1 is set to be a ConsoleAppender.
-log4j.appender.A1=org.apache.log4j.ConsoleAppender
-
-# A1 uses PatternLayout.
-log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=\    %-6r [%t] %-5p %c %x - %m%n
+pax.exam.system=test
+pax.exam.logging=none

--- a/driver-examples/osgi/src/test/resources/logback.xml
+++ b/driver-examples/osgi/src/test/resources/logback.xml
@@ -1,0 +1,27 @@
+<!--
+
+         Copyright (C) 2012-2015 DataStax Inc.
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+-->
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
+    </layout>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
For [JAVA-961](https://datastax-oss.atlassian.net/browse/JAVA-961).

Introduces a check on reference of `CodecRegistry` where is creating a `TypeToken<Map<String,String>>` improperly sets the type information for the value type (`Object`/`V` instead of `String`) a warning is logged.

I'm unsure if this is the best way of determining this, but it seems pretty reliable.

When running with Guava 15.0 to 16.01, the following will happen when attempting to resolve a codec with more than one parameterized type argument:

```
WARN  [2015-10-22 18:57:20,308] [main] - Detected Guava Issue #1635 which indicates that a version of Guava less than 16.01 is in use.  This may introduce codec resolution issues in the driver, please upgrade to Guava 16.01 or later.
INFO  [2015-10-22 18:57:20,406] [main] - Did not find Netty's native epoll transport in the classpath, defaulting to NIO.
INFO  [2015-10-22 18:57:20,912] [main] - Using data-center name 'datacenter1' for DCAwareRoundRobinPolicy (if this is incorrect, please provide the correct datacenter name with DCAwareRoundRobinPolicy constructor)
INFO  [2015-10-22 18:57:20,912] [main] - New Cassandra host /127.0.0.1:9042 added
INFO  [2015-10-22 18:57:20,913] [main] - New Cassandra host /127.0.0.2:9042 added
INFO  [2015-10-22 18:57:20,913] [main] - New Cassandra host /127.0.0.3:9042 added
Exception in thread "main" com.datastax.driver.core.exceptions.CodecNotFoundException: Codec not found for requested operation: [varchar <-> V]
    at com.datastax.driver.core.CodecRegistry.notFound(CodecRegistry.java:711)
    at com.datastax.driver.core.CodecRegistry.createCodec(CodecRegistry.java:558)
    at com.datastax.driver.core.CodecRegistry.findCodec(CodecRegistry.java:539)
    at com.datastax.driver.core.CodecRegistry.maybeCreateCodec(CodecRegistry.java:613)
    at com.datastax.driver.core.CodecRegistry.createCodec(CodecRegistry.java:556)
    at com.datastax.driver.core.CodecRegistry.findCodec(CodecRegistry.java:539)
    at com.datastax.driver.core.CodecRegistry.access$200(CodecRegistry.java:153)
    at com.datastax.driver.core.CodecRegistry$TypeCodecCacheLoader.load(CodecRegistry.java:246)
    at com.datastax.driver.core.CodecRegistry$TypeCodecCacheLoader.load(CodecRegistry.java:243)
    at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3522)
    at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2315)
    at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2278)
    at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2193)
    at com.google.common.cache.LocalCache.get(LocalCache.java:3932)
    at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3936)
    at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4806)
    at com.datastax.driver.core.CodecRegistry.lookupCodec(CodecRegistry.java:516)
    at com.datastax.driver.core.CodecRegistry.codecFor(CodecRegistry.java:485)
    at com.datastax.driver.core.AbstractGettableByIndexData.codecFor(AbstractGettableByIndexData.java:81)
    at com.datastax.driver.core.AbstractGettableByIndexData.getMap(AbstractGettableByIndexData.java:346)
    at com.datastax.driver.core.AbstractGettableData.getMap(AbstractGettableData.java:26)
    at com.datastax.driver.core.AbstractGettableByIndexData.getMap(AbstractGettableByIndexData.java:335)
    at com.datastax.driver.core.AbstractGettableData.getMap(AbstractGettableData.java:26)
    at com.datastax.driver.core.AbstractGettableData.getMap(AbstractGettableData.java:233)
```

In this case the pre-emptive warning should give the user enough information to know that they need to upgrade guava.

In the case of using older versions of guava (<= 14.01) a `NoSuchMethodError` is raised while registering default codecs because `TypeToken.isPrimitive` is missing:

```
WARN  [2015-10-22 19:02:54,807] [main] - Detected Guava Issue #1635 which indicates that a version of Guava less than 16.01 is in use.  This may introduce codec resolution issues in the driver, please upgrade to Guava 16.01 or later.
Exception in thread "main" java.lang.NoSuchMethodError: com.google.common.reflect.TypeToken.isPrimitive()Z
    at com.datastax.driver.core.TypeCodec.<init>(TypeCodec.java:406)
    at com.datastax.driver.core.TypeCodec.<init>(TypeCodec.java:400)
    at com.datastax.driver.core.TypeCodec$BlobCodec.<init>(TypeCodec.java:947)
    at com.datastax.driver.core.TypeCodec$BlobCodec.<clinit>(TypeCodec.java:944)
    at com.datastax.driver.core.TypeCodec.blob(TypeCodec.java:248)
    at com.datastax.driver.core.CodecRegistry.<clinit>(CodecRegistry.java:180)
    at com.datastax.driver.core.Configuration$Builder.build(Configuration.java:267)
    at com.datastax.driver.core.Cluster$Builder.getConfiguration(Cluster.java:1228)
    at com.datastax.driver.core.Cluster.<init>(Cluster.java:113)
    at com.datastax.driver.core.Cluster.buildFrom(Cluster.java:182)
    at com.datastax.driver.core.Cluster$Builder.build(Cluster.java:1249)
```

In this case I consider the warning adequate information to know that the user needs to upgrade as well.

Thoughts on this strategy/idea?   Is the error descriptive enough? I can add tests (can add an integration test to osgi-examples) if this sounds ok.
