### PR TITLE
Update OSGi example guava versions. Refine bundle version detection.

### DIFF
--- a/driver-examples/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceIT.java
+++ b/driver-examples/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceIT.java
@@ -54,7 +54,7 @@ public class MailboxServiceIT {
     }
 
     private MavenArtifactProvisionOption guavaBundle() {
-        return mavenBundle("com.google.guava", "guava", "14.0.1");
+        return mavenBundle("com.google.guava", "guava", "16.0.1");
     }
 
     private CompositeOption nettyBundles() {
@@ -105,26 +105,6 @@ public class MailboxServiceIT {
             driverBundle(),
             guavaBundle(),
             nettyBundles(),
-            defaultOptions()
-        );
-    }
-
-    @Configuration
-    public Option[] guava15Config() {
-        return options(
-            driverBundle(),
-            nettyBundles(),
-            guavaBundle().version("15.0"),
-            defaultOptions()
-        );
-    }
-
-    @Configuration
-    public Option[] guava16Config() {
-        return options(
-            driverBundle(),
-            nettyBundles(),
-            guavaBundle().version("16.0.1"),
             defaultOptions()
         );
     }

--- a/driver-examples/osgi/src/test/java/com/datastax/driver/osgi/VersionProvider.java
+++ b/driver-examples/osgi/src/test/java/com/datastax/driver/osgi/VersionProvider.java
@@ -15,6 +15,9 @@
  */
 package com.datastax.driver.osgi;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import com.jcabi.manifests.Manifests;
 
 /**
@@ -25,11 +28,25 @@ import com.jcabi.manifests.Manifests;
  */
 public class VersionProvider {
 
-    private static String PROJECT_VERSION;
+    private static final Pattern versionPattern = Pattern.compile(("(\\d+.\\d+\\.\\d+)(.*)"));
+
+    private static final String PROJECT_VERSION;
     static {
         String bundleName = Manifests.read("Bundle-SymbolicName");
         if (bundleName.equals("com.datastax.driver.osgi")) {
-            PROJECT_VERSION = Manifests.read("Bundle-Version").replaceAll("\\.SNAPSHOT", "-SNAPSHOT");
+            String bundleVersion = Manifests.read("Bundle-Version");
+            Matcher matcher = versionPattern.matcher(bundleVersion);
+            if(matcher.matches()) {
+                String majorVersion = matcher.group(1);
+                // Replace all instances of '.' after the main version with '-' to properly
+                // resolve the correct version.
+                String rest = matcher.group(2).replaceAll("\\.", "-");
+                PROJECT_VERSION = majorVersion + rest;
+            } else {
+                // This should never happen, but if we are using a non X.Y.Z version number
+                // we'll just back off to the bundle version.
+                PROJECT_VERSION = bundleVersion;
+            }
         } else {
             throw new RuntimeException("Couldn't resolve bundle manifest (try building with mvn compile)");
         }


### PR DESCRIPTION
Since Guava 16.0.1 is now required for the driver, updated the OSGi example configurations to reflect this. Also refined the bundle version detection as it was not working with rc/alpha/beta versions (wasn't replacing .rcX with -rcX for example).

Original PR: #489 
