### PR TITLE
Update metrics to the latest version

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
       <version>${metrics.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <slf4j-log4j12.version>1.7.6</slf4j-log4j12.version>
     <guava.version>16.0.1</guava.version>
     <netty.version>4.0.27.Final</netty.version>
-    <metrics.version>3.0.2</metrics.version>
+    <metrics.version>3.1.2</metrics.version>
     <snappy.version>1.0.5</snappy.version>
     <lz4.version>1.2.0</lz4.version>
     <hdr.version>2.1.4</hdr.version>


### PR DESCRIPTION
Latest version changed groupId to io.dropwizard.metrics from com.codahale.metrics.

This is moved from #333 
