### PR TITLE
JAVA-958: Make TableOrView.Order visible.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 3.0.0-beta1 (in progress)
+
+ - [improvement] JAVA-958: Make TableOrView.Order visible.
+ - [improvement] JAVA-968: Update metrics to the latest version.
+
 ### 3.0.0-alpha4
 
 - [improvement] Change default consistency level to LOCAL_QUORUM (JAVA-926)

--- a/driver-core/src/main/java/com/datastax/driver/core/ClusteringOrder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ClusteringOrder.java
@@ -1,0 +1,28 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+/**
+ * Clustering orders.
+ * <p>
+ * This is used by metadata classes to indicate the clustering
+ * order of a clustering column in a table or materialized view.
+ */
+public enum ClusteringOrder {
+
+    ASC, DESC;
+
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/MaterializedViewMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/MaterializedViewMetadata.java
@@ -48,7 +48,7 @@ public class MaterializedViewMetadata extends TableOrView {
         boolean includeAllColumns,
         String whereClause,
         TableOptionsMetadata options,
-        List<Order> clusteringOrder,
+        List<ClusteringOrder> clusteringOrder,
         VersionNumber cassandraVersion) {
         super(keyspace, name, id, partitionKey, clusteringColumns, columns, options, clusteringOrder, cassandraVersion);
         this.baseTable = baseTable;
@@ -77,7 +77,7 @@ public class MaterializedViewMetadata extends TableOrView {
 
         List<ColumnMetadata> partitionKey = new ArrayList<ColumnMetadata>(Collections.<ColumnMetadata>nCopies(partitionKeySize, null));
         List<ColumnMetadata> clusteringColumns = new ArrayList<ColumnMetadata>(Collections.<ColumnMetadata>nCopies(clusteringSize, null));
-        List<Order> clusteringOrder = new ArrayList<Order>(Collections.<Order>nCopies(clusteringSize, null));
+        List<ClusteringOrder> clusteringOrder = new ArrayList<ClusteringOrder>(Collections.<ClusteringOrder>nCopies(clusteringSize, null));
 
         // We use a linked hashmap because we will keep this in the order of a 'SELECT * FROM ...'.
         LinkedHashMap<String, ColumnMetadata> columns = new LinkedHashMap<String, ColumnMetadata>();
@@ -108,7 +108,7 @@ public class MaterializedViewMetadata extends TableOrView {
                     break;
                 case CLUSTERING_COLUMN:
                     clusteringColumns.set(rawCol.position, col);
-                    clusteringOrder.set(rawCol.position, rawCol.isReversed ? Order.DESC : Order.ASC);
+                    clusteringOrder.set(rawCol.position, rawCol.isReversed ? ClusteringOrder.DESC : ClusteringOrder.ASC);
                     break;
                 default:
                     otherColumns.add(col);

--- a/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
@@ -62,7 +62,7 @@ public class TableMetadata extends TableOrView {
                           Map<String, ColumnMetadata> columns,
                           Map<String, IndexMetadata> indexes,
                           TableOptionsMetadata options,
-                          List<Order> clusteringOrder,
+                          List<ClusteringOrder> clusteringOrder,
                           VersionNumber cassandraVersion) {
         super(keyspace, name, id, partitionKey, clusteringColumns, columns, options, clusteringOrder, cassandraVersion);
         this.indexes = indexes;
@@ -123,7 +123,7 @@ public class TableMetadata extends TableOrView {
 
         List<ColumnMetadata> partitionKey = new ArrayList<ColumnMetadata>(Collections.<ColumnMetadata>nCopies(partitionKeySize, null));
         List<ColumnMetadata> clusteringColumns = new ArrayList<ColumnMetadata>(Collections.<ColumnMetadata>nCopies(clusteringSize, null));
-        List<Order> clusteringOrder = new ArrayList<Order>(Collections.<Order>nCopies(clusteringSize, null));
+        List<ClusteringOrder> clusteringOrder = new ArrayList<ClusteringOrder>(Collections.<ClusteringOrder>nCopies(clusteringSize, null));
 
         // We use a linked hashmap because we will keep this in the order of a 'SELECT * FROM ...'.
         LinkedHashMap<String, ColumnMetadata> columns = new LinkedHashMap<String, ColumnMetadata>();
@@ -165,7 +165,7 @@ public class TableMetadata extends TableOrView {
             for (int i = 0; i < clusteringSize; i++) {
                 String alias = columnAliases.size() > i ? columnAliases.get(i) : DEFAULT_COLUMN_ALIAS + (i + 1);
                 clusteringColumns.set(i, ColumnMetadata.forAlias(tm, alias, comparator.types.get(i)));
-                clusteringOrder.set(i, comparator.reversed.get(i) ? Order.DESC : Order.ASC);
+                clusteringOrder.set(i, comparator.reversed.get(i) ? ClusteringOrder.DESC : ClusteringOrder.ASC);
             }
 
             // if we're dense, chances are that we have a single regular "value" column with an alias
@@ -187,7 +187,7 @@ public class TableMetadata extends TableOrView {
                     break;
                 case CLUSTERING_COLUMN:
                     clusteringColumns.set(rawCol.position, col);
-                    clusteringOrder.set(rawCol.position, rawCol.isReversed ? Order.DESC : Order.ASC);
+                    clusteringOrder.set(rawCol.position, rawCol.isReversed ? ClusteringOrder.DESC : ClusteringOrder.ASC);
                     break;
                 default:
                     otherColumns.add(col);

--- a/driver-core/src/main/java/com/datastax/driver/core/TableOrView.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableOrView.java
@@ -32,6 +32,12 @@ abstract class TableOrView {
         }
     };
 
+    static final Predicate<ClusteringOrder> isAscending = new Predicate<ClusteringOrder>() {
+        public boolean apply(ClusteringOrder o) {
+            return o == ClusteringOrder.ASC;
+        }
+    };
+
     protected final KeyspaceMetadata keyspace;
     protected final String name;
     protected final UUID id;
@@ -39,24 +45,8 @@ abstract class TableOrView {
     protected final List<ColumnMetadata> clusteringColumns;
     protected final Map<String, ColumnMetadata> columns;
     protected final TableOptionsMetadata options;
-    protected final List<Order> clusteringOrder;
+    protected final List<ClusteringOrder> clusteringOrder;
     protected final VersionNumber cassandraVersion;
-
-    /**
-     * Clustering orders.
-     * <p>
-     * This is used by {@link #getClusteringOrder} to indicate the clustering
-     * order of a table.
-     */
-    public enum Order {
-        ASC, DESC;
-
-        static final Predicate<Order> isAscending = new Predicate<Order>() {
-            public boolean apply(Order o) {
-                return o == ASC;
-            }
-        };
-    }
 
     TableOrView(KeyspaceMetadata keyspace,
                         String name,
@@ -65,7 +55,7 @@ abstract class TableOrView {
                         List<ColumnMetadata> clusteringColumns,
                         Map<String, ColumnMetadata> columns,
                         TableOptionsMetadata options,
-                        List<Order> clusteringOrder,
+                        List<ClusteringOrder> clusteringOrder,
                         VersionNumber cassandraVersion) {
         this.keyspace = keyspace;
         this.name = name;
@@ -182,11 +172,11 @@ abstract class TableOrView {
      * descending) of the {@code i}th clustering column (see
      * {@link #getClusteringColumns}). Note that a table defined without any
      * particular clustering order is equivalent to one for which all the
-     * clustering key are in ascending order.
+     * clustering keys are in ascending order.
      *
      * @return a list with the clustering order for each clustering column.
      */
-    public List<Order> getClusteringOrder() {
+    public List<ClusteringOrder> getClusteringOrder() {
         return clusteringOrder;
     }
 
@@ -248,7 +238,7 @@ abstract class TableOrView {
         sb.append(" WITH ");
         if (options.isCompactStorage())
             and(sb.append("COMPACT STORAGE"), formatted);
-        if (!Iterables.all(clusteringOrder, Order.isAscending))
+        if (!Iterables.all(clusteringOrder, isAscending))
             and(appendClusteringOrder(sb), formatted);
         sb.append("read_repair_chance = ").append(options.getReadRepairChance());
         and(sb, formatted).append("dclocal_read_repair_chance = ").append(options.getLocalReadRepairChance());

--- a/driver-core/src/test/java/com/datastax/driver/core/ColumnMetadataAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ColumnMetadataAssert.java
@@ -55,8 +55,8 @@ public class ColumnMetadataAssert extends AbstractAssert<ColumnMetadataAssert, C
         return this;
     }
 
-    public ColumnMetadataAssert hasClusteringOrder(TableOrView.Order order) {
-        assertThat(actual.getParent().getClusteringOrder().get(actual.getParent().getClusteringColumns().indexOf(actual))).isEqualTo(order);
+    public ColumnMetadataAssert hasClusteringOrder(ClusteringOrder clusteringOrder) {
+        assertThat(actual.getParent().getClusteringOrder().get(actual.getParent().getClusteringColumns().indexOf(actual))).isEqualTo(clusteringOrder);
         return this;
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/MaterializedViewMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MaterializedViewMetadataTest.java
@@ -24,7 +24,7 @@ import com.datastax.driver.core.utils.CassandraVersion;
 
 import static com.datastax.driver.core.Assertions.assertThat;
 import static com.datastax.driver.core.DataType.*;
-import static com.datastax.driver.core.TableOrView.Order.DESC;
+import static com.datastax.driver.core.ClusteringOrder.DESC;
 
 @CassandraVersion(major = 3)
 public class MaterializedViewMetadataTest extends CCMBridge.PerClassSingleNodeCluster {

--- a/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
@@ -28,8 +28,8 @@ import com.datastax.driver.core.utils.CassandraVersion;
 
 import static com.datastax.driver.core.Assertions.assertThat;
 import static com.datastax.driver.core.DataType.*;
-import static com.datastax.driver.core.TableOrView.Order.ASC;
-import static com.datastax.driver.core.TableOrView.Order.DESC;
+import static com.datastax.driver.core.ClusteringOrder.ASC;
+import static com.datastax.driver.core.ClusteringOrder.DESC;
 
 public class TableMetadataTest extends CCMBridge.PerClassSingleNodeCluster {
     @Override


### PR DESCRIPTION
This commit promotes the enum Order to a public top level class and renames it to ClusteringOrder.
