### PR TITLE
JAVA-970 Don't complete Future in maybeAddPool until onDown completed.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -354,20 +354,31 @@ class SessionManager extends AbstractSession {
 
                     @Override
                     public void onFailure(Throwable t) {
+                        ListenableFuture<?> downFuture = null;
                         if (t instanceof UnsupportedProtocolVersionException) {
                             cluster.manager.logUnsupportedVersionProtocol(host);
-                            cluster.manager.triggerOnDown(host, false);
+                            downFuture = cluster.manager.triggerOnDown(host, false);
                         } else if (t instanceof ClusterNameMismatchException) {
                             ClusterNameMismatchException e = (ClusterNameMismatchException)t;
                             cluster.manager.logClusterNameMismatch(host, e.expectedClusterName, e.actualClusterName);
-                            cluster.manager.triggerOnDown(host, false);
+                            downFuture = cluster.manager.triggerOnDown(host, false);
                         } else if ((t instanceof SetKeyspaceException) && failOnKeyspaceError) {
                             future.setException(t.getCause());
                             return;
                         } else {
                             logger.error("Error creating pool to " + host, t);
                         }
-                        future.set(false);
+                        if (downFuture != null) {
+                            // Don't mark the future as complete until onDown completes.
+                            downFuture.addListener(new Runnable() {
+                                @Override
+                                public void run() {
+                                    future.set(false);
+                                }
+                            }, MoreExecutors.sameThreadExecutor());
+                        } else {
+                            future.set(false);
+                        }
                     }
                 });
                 return future;


### PR DESCRIPTION
For [JAVA-970](https://datastax-oss.atlassian.net/browse/JAVA-970)

Avoids a race in `updateCreatedPools` by not completing `Future` returned in `maybeAddPool` on failure until the `Future` returned from `triggerOnDown` completes.

Note: Did not add a changelog for this yet as wasn't sure if this would be a candidate for 2.0.11.1/2.0.12.
