### PR TITLE
DataType.serializeValue shouldn't swallow exception

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/DataType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataType.java
@@ -726,10 +726,7 @@ public abstract class DataType {
         try {
             return dt.serialize(value, protocolVersion);
         } catch (InvalidTypeException e) {
-            // In theory we couldn't get that if getDataTypeFor does his job correctly,
-            // but there is no point in sending an exception that the user won't expect if we're
-            // wrong on that.
-            throw new IllegalArgumentException(e.getMessage());
+            throw new IllegalArgumentException(e);
         }
     }
 


### PR DESCRIPTION
It's really important for users to see the original exception.
For example, without fix I see this:

```
java.lang.IllegalArgumentException: Value 3 of type class java.util.ArrayList does not correspond to any CQL3 type
        at com.datastax.driver.core.querybuilder.Utils.convert(Utils.java:83) ~[cassandra-driver-core-2.1.3.jar:na]
        at com.datastax.driver.core.querybuilder.BuiltStatement.getValues(BuiltStatement.java:172) ~[cassandra-driver-core-2.1.3.jar:na]
        at com.datastax.driver.core.querybuilder.BuiltStatement$ForwardingStatement.getValues(BuiltStatement.java:341) ~[cassandra-driver-core-2.1.3.jar:na]
        at com.datastax.driver.core.querybuilder.Update$Where.getValues(Update.java:217) ~[cassandra-driver-core-2.1.3.jar:na]
        at com.datastax.driver.core.SessionManager.makeRequestMessage(SessionManager.java:483) ~[cassandra-driver-core-2.1.3.jar:na]
        at com.datastax.driver.core.SessionManager.makeRequestMessage(SessionManager.java:452) ~[cassandra-driver-core-2.1.3.jar:na]
        at com.datastax.driver.core.SessionManager.executeAsync(SessionManager.java:118) ~[cassandra-driver-core-2.1.3.jar:na]
        at com.datastax.driver.core.AbstractSession.execute(AbstractSession.java:52) ~[cassandra-driver-core-2.1.3.jar:na]
...
```

and with fix I also see

```
...
Caused by: java.lang.IllegalArgumentException: Native protocol version 2 supports only elements with size up to 65535 bytes - but element size is 881707 bytes
        at com.datastax.driver.core.TypeCodec.sizeOfValue(TypeCodec.java:341) ~[cassandra-driver-core-2.1.3.jar:na]
        at com.datastax.driver.core.TypeCodec.pack(TypeCodec.java:235) ~[cassandra-driver-core-2.1.3.jar:na]
        at com.datastax.driver.core.TypeCodec.access$300(TypeCodec.java:31) ~[cassandra-driver-core-2.1.3.jar:na]
        at com.datastax.driver.core.TypeCodec$ListCodec.serialize(TypeCodec.java:981) ~[cassandra-driver-core-2.1.3.jar:na]
        at com.datastax.driver.core.TypeCodec$ListCodec.serialize(TypeCodec.java:918) ~[cassandra-driver-core-2.1.3.jar:na]
        at com.datastax.driver.core.DataType.serialize(DataType.java:561) ~[cassandra-driver-core-2.1.3.jar:na]
        at com.datastax.driver.core.DataType.serializeValue(DataType.java:666) ~[cassandra-driver-core-2.1.3.jar:na]
        at com.datastax.driver.core.querybuilder.Utils.convert(Utils.java:80) ~[cassandra-driver-core-2.1.3.jar:na]
        ... 18 common frames omitted
```
