### PR TITLE
JAVA-971: Make type codecs invariant.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@
 - [improvement] JAVA-885: Pass the authenticator name from the server to the auth provider. 
 - [improvement] JAVA-961: Raise an exception when an older version of guava (<16.01) is found.
 - [bug] JAVA-972: TypeCodec.parse() implementations should be case insensitive when checking for keyword NULL.
+- [bug] JAVA-971: Make type codecs invariant.
 
 Merged from 2.1 branch:
 
@@ -24,6 +25,7 @@ Merged from 2.1 branch:
 - [improvement] JAVA-917: Document SSL configuration.
 - [improvement] JAVA-652: Add DCAwareRoundRobinPolicy builder.
 - [improvement] JAVA-808: Add generic filtering policy that can be used to exclude specific DCs.
+
 
 ### 3.0.0-alpha4
 

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
@@ -508,6 +508,15 @@ public abstract class TypeCodec<T> {
     /**
      * Return {@code true} if this codec is capable of serializing
      * the given {@code javaType}.
+     * <p>
+     * The implementation is <em>invariant</em> with respect to the passed
+     * argument (through the usage of {@link TypeToken#equals(Object)}
+     * and <em>it's strongly recommended not to modify this behavior</em>.
+     * This means that a codec will only ever accept the
+     * <em>exact</em> Java type that it has been created for.
+     * <p>
+     * If the argument represents a Java primitive type, its wrapper type
+     * is considered instead.
      *
      * @param javaType The Java type this codec should serialize from and deserialize to; cannot be {@code null}.
      * @return {@code true} if the codec is capable of serializing
@@ -519,7 +528,7 @@ public abstract class TypeCodec<T> {
         if (javaType.isPrimitive()) {
             javaType = primitiveToWrapperMap.get(javaType);
         }
-        return this.javaType.isAssignableFrom(javaType);
+        return this.javaType.equals(javaType);
     }
 
     /**
@@ -548,13 +557,17 @@ public abstract class TypeCodec<T> {
      * <p>
      * Implementation notes:
      * <ol>
+     * <li>The default implementation is <em>covariant</em> with respect to the passed
+     * argument (through the usage of {@link TypeToken#isAssignableFrom(TypeToken)}
+     * and <em>it's strongly recommended not to modify this behavior</em>.
+     * This means that, by default, a codec will accept
+     * <em>any subtype</em> of the Java type that it has been created for.</li>
      * <li>The base implementation provided here can only handle non-parameterized types;
      * codecs handling parameterized types, such as collection types, must override
      * this method and perform some sort of "manual"
      * inspection of the actual type parameters.</li>
-     * <li>Similarly, codecs that only accept a partial subset of all possible values,
-     * such as {@link TimeUUIDCodec} or {@link AsciiCodec}, must override
-     * this method and manually inspect the object to check if it
+     * <li>Similarly, codecs that only accept a partial subset of all possible values
+     * must override this method and manually inspect the object to check if it
      * complies or not with the codec's limitations.</li>
      * </ol>
      *
@@ -565,7 +578,7 @@ public abstract class TypeCodec<T> {
      */
     public boolean accepts(Object value) {
         checkNotNull(value);
-        return accepts(TypeToken.of(value.getClass()));
+        return this.javaType.isAssignableFrom(TypeToken.of(value.getClass()));
     }
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
@@ -184,8 +184,13 @@ public class TypeCodecTest {
         ACodec aCodec = new ACodec();
         codecRegistry.register(aCodec);
         assertThat(codecRegistry.codecFor(cint(), A.class)).isNotNull().isSameAs(aCodec);
-        // inheritance works: B is assignable to A
-        assertThat(codecRegistry.codecFor(cint(), B.class)).isNotNull().isSameAs(aCodec);
+        try {
+            // covariance not accepted: no codec handles B exactly
+            codecRegistry.codecFor(cint(), B.class);
+            fail();
+        } catch (CodecNotFoundException e) {
+            //ok
+        }
         TypeCodec<List<A>> expected = TypeCodec.list(aCodec);
         TypeCodec<List<A>> actual = codecRegistry.codecFor(list(cint()), new TypeToken<List<A>>(){});
         assertThat(actual.getCqlType()).isEqualTo(expected.getCqlType());
@@ -214,8 +219,7 @@ public class TypeCodecTest {
             // ok
         }
         TypeCodec<List<B>> expectedB = TypeCodec.list(bCodec);
-        TypeCodec<List<B>> actualB = codecRegistry.codecFor(list(cint()), new TypeToken<List<B>>() {
-        });
+        TypeCodec<List<B>> actualB = codecRegistry.codecFor(list(cint()), new TypeToken<List<B>>(){});
         assertThat(actualB.getCqlType()).isEqualTo(expectedB.getCqlType());
         assertThat(actualB.getJavaType()).isEqualTo(expectedB.getJavaType());
     }

--- a/features/README.md
+++ b/features/README.md
@@ -6,12 +6,12 @@ specific topics.
 If you're reading this from the [generated HTML documentation on
 github.io](http://datastax.github.io/java-driver/), use the "Read More"
 menu on the right hand side. If you're [browsing the source files on
-github.com](https://github.com/datastax/java-driver/tree/2.2/features),
+github.com](https://github.com/datastax/java-driver/tree/3.0/features),
 simply navigate to each sub-directory.
 
 This is a work in progress: new sections will be added to cover existing
 features or document new ones.
 
 You can also find more help in the legacy
-[user documentation](http://docs.datastax.com/en/developer/java-driver/2.2/java-driver/whatsNew2.html)
+[user documentation](http://docs.datastax.com/en/developer/java-driver/2.1/java-driver/whatsNew2.html)
 on the DataStax website.

--- a/features/address_resolution/README.md
+++ b/features/address_resolution/README.md
@@ -31,7 +31,7 @@ Cluster cluster = Cluster.builder()
 Note: the contact points provided while creating the `Cluster` are not translated, only
 addresses retrieved from or sent by Cassandra nodes are.
 
-[at]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/policies/AddressTranslator.html
+[at]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/policies/AddressTranslator.html
 
 ### EC2 multi-region
 
@@ -56,4 +56,4 @@ This class performs a reverse DNS lookup of the origin address, to find the doma
 target instance. Then it performs a forward DNS lookup of the domain name; the EC2 DNS does the
 private/public switch automatically based on location.
 
-[ec2]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/policies/EC2MultiRegionAddressTranslator.html
+[ec2]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/policies/EC2MultiRegionAddressTranslator.html

--- a/features/custom_payloads/README.md
+++ b/features/custom_payloads/README.md
@@ -241,8 +241,8 @@ The log message contains a pretty-printed version of the payload itself, and its
 [CASSANDRA-8553]: https://issues.apache.org/jira/browse/CASSANDRA-8553
 [v4spec]: https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec
 [qh]: https://issues.apache.org/jira/browse/CASSANDRA-6659
-[nhae]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/exceptions/NoHostAvailableException.html
+[nhae]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/exceptions/NoHostAvailableException.html
 [chm]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html
 [immutablemap]: http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/collect/ImmutableMap.html
-[ufe]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/exceptions/UnsupportedFeatureException.html
+[ufe]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/exceptions/UnsupportedFeatureException.html
 

--- a/features/logging/README.md
+++ b/features/logging/README.md
@@ -303,4 +303,4 @@ It also turns on slow query tracing as described above.
 </log4j:configuration>
 ```
 
-[query_logger]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/QueryLogger.html
+[query_logger]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/QueryLogger.html

--- a/features/metadata/README.md
+++ b/features/metadata/README.md
@@ -4,7 +4,7 @@ The driver maintains global information about the Cassandra cluster it
 is connected to. It is available via
 [Cluster#getMetadata()][getMetadata].
 
-[getMetadata]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Cluster.html#getMetadata()
+[getMetadata]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Cluster.html#getMetadata()
 
 ### Schema metadata
 
@@ -12,8 +12,8 @@ Use [getKeyspace(String)][getKeyspace] or [getKeyspaces()][getKeyspaces]
 to get keyspace-level metadata. From there you can access the keyspace's
 objects (tables, and UDTs and UDFs if relevant).
 
-[getKeyspace]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Metadata.html#getKeyspace(java.lang.String)
-[getKeyspaces]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Metadata.html#getKeyspaces()
+[getKeyspace]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Metadata.html#getKeyspace(java.lang.String)
+[getKeyspaces]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Metadata.html#getKeyspaces()
 
 #### Refreshes
 
@@ -135,9 +135,9 @@ custom executor).
 
 Check out the API docs for the features in this section:
 
-* [withMaxSchemaAgreementWaitSeconds(int)](http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Cluster.Builder.html#withMaxSchemaAgreementWaitSeconds(int))
-* [isSchemaInAgreement()](http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/ExecutionInfo.html#isSchemaInAgreement())
-* [checkSchemaAgreement()](http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Metadata.html#checkSchemaAgreement())
+* [withMaxSchemaAgreementWaitSeconds(int)](http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Cluster.Builder.html#withMaxSchemaAgreementWaitSeconds(int))
+* [isSchemaInAgreement()](http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/ExecutionInfo.html#isSchemaInAgreement())
+* [checkSchemaAgreement()](http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Metadata.html#checkSchemaAgreement())
 
 
 ### Token metadata
@@ -181,14 +181,14 @@ Starting with Cassandra 2.1.5, this information is available in a system
 table (see
 [CASSANDRA-7688](https://issues.apache.org/jira/browse/CASSANDRA-7688)).
 
-[metadata]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Metadata.html
-[getTokenRanges]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Metadata.html#getTokenRanges()
-[getTokenRanges2]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Metadata.html#getTokenRanges(java.lang.String,%20com.datastax.driver.core.Host)
-[getReplicas]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Metadata.html#getReplicas(java.lang.String,%20com.datastax.driver.core.TokenRange)
-[newToken]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Metadata.html#newToken(java.lang.String)
-[newTokenRange]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Metadata.html#newTokenRange(com.datastax.driver.core.Token,%20com.datastax.driver.core.Token)
-[TokenRange]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/TokenRange.html
-[getTokens]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Host.html#getTokens()
-[setToken]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/BoundStatement.html#setToken(int,%20com.datastax.driver.core.Token)
-[getToken]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Row.html#getToken(int)
-[getPKToken]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Row.html#getPartitionKeyToken()
+[metadata]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Metadata.html
+[getTokenRanges]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Metadata.html#getTokenRanges()
+[getTokenRanges2]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Metadata.html#getTokenRanges(java.lang.String,%20com.datastax.driver.core.Host)
+[getReplicas]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Metadata.html#getReplicas(java.lang.String,%20com.datastax.driver.core.TokenRange)
+[newToken]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Metadata.html#newToken(java.lang.String)
+[newTokenRange]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Metadata.html#newTokenRange(com.datastax.driver.core.Token,%20com.datastax.driver.core.Token)
+[TokenRange]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/TokenRange.html
+[getTokens]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Host.html#getTokens()
+[setToken]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/BoundStatement.html#setToken(int,%20com.datastax.driver.core.Token)
+[getToken]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Row.html#getToken(int)
+[getPKToken]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Row.html#getPartitionKeyToken()

--- a/features/native_protocol/README.md
+++ b/features/native_protocol/README.md
@@ -59,7 +59,7 @@ All host(s) tried for query failed
   [/127.0.0.1:9042] Host /127.0.0.1:9042 does not support protocol version V3 but V2))
 ```
 
-[gpv]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/ProtocolOptions.html#getProtocolVersion()
+[gpv]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/ProtocolOptions.html#getProtocolVersion()
 
 #### Protocol version with mixed clusters
 
@@ -90,19 +90,19 @@ To avoid this issue, you can use one the following workarounds:
 #### v1 to v2
 
 * bound variables in simple statements
-  ([Session#execute(String, Object...)](http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Session.html#execute(java.lang.String,%20java.lang.Object...)))
-* [batch statements](http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/BatchStatement.html)
+  ([Session#execute(String, Object...)](http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Session.html#execute(java.lang.String,%20java.lang.Object...)))
+* [batch statements](http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/BatchStatement.html)
 * [query paging](../paging/)
 
 #### v2 to v3
 
 * the number of stream ids per connection goes from 128 to 32768 (see
   [Connection pooling](../pooling/))
-* [serial consistency on batch statements](http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/BatchStatement.html#setSerialConsistencyLevel(com.datastax.driver.core.ConsistencyLevel))
+* [serial consistency on batch statements](http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/BatchStatement.html#setSerialConsistencyLevel(com.datastax.driver.core.ConsistencyLevel))
 * [client-side timestamps](../query_timestamps/)
 
 #### v3 to v4
 
-* [query warnings](http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/ExecutionInfo.html#getWarnings())
+* [query warnings](http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/ExecutionInfo.html#getWarnings())
 * allowed unset values in bound statements
 * [Custom payloads](../custom_payloads/)

--- a/features/object_mapper/creating/README.md
+++ b/features/object_mapper/creating/README.md
@@ -43,9 +43,9 @@ The class must provide a default constructor, and all fields (except the
 ones annotated `@Transient`) must have corresponding setters and
 getters.
 
-[table]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/Table.html
+[table]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/Table.html
 [case-sensitive]:http://docs.datastax.com/en/cql/3.3/cql/cql_reference/ucase-lcase_r.html
-[consistency level]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/ConsistencyLevel.html
+[consistency level]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/ConsistencyLevel.html
 
 #### Column names
 
@@ -54,7 +54,7 @@ case insensitive column of the same name. If you want to use a different
 name, or [case-sensitive] names, use the [@Column][column] annotation on
 the field.
 
-[column]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/Column.html
+[column]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/Column.html
 
 #### Primary key fields
 
@@ -78,8 +78,8 @@ private String areaCode;
 The order of the indices must match that of the columns in the table
 declaration.
 
-[pk]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/PartitionKey.html
-[cc]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/ClusteringColumn.html
+[pk]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/PartitionKey.html
+[cc]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/ClusteringColumn.html
 [pks]:http://thelastpickle.com/blog/2013/01/11/primary-keys-in-cql.html
 
 #### Enumerations
@@ -105,7 +105,7 @@ CREATE TABLE person (id uuid PRIMARY KEY, name text, gender int);
 private Gender gender;
 ```
 
-[enum]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/Enumerated.html
+[enum]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/Enumerated.html
 
 #### Computed fields
 
@@ -140,13 +140,13 @@ version (see
 [JAVA-832](https://datastax-oss.atlassian.net/browse/JAVA-832)).
 
 [User Defined Functions]:http://www.planetcassandra.org/blog/user-defined-functions-in-cassandra-3-0/
-[computed]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/Computed.html
+[computed]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/Computed.html
 
 #### Transient fields
 
 [@Transient][transient] can be used to prevent a field from being mapped.
 
-[transient]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/Transient.html
+[transient]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/Transient.html
 
 ### Mapping User Types
 
@@ -207,8 +207,8 @@ public static class Company {
 arbitrary level of nesting)
 
 [User Defined Types]:http://docs.datastax.com/en/developer/java-driver/2.1/java-driver/reference/userDefinedTypes.html
-[udt]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/UDT.html
-[field]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/Field.html
+[udt]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/UDT.html
+[field]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/Field.html
 
 ### Mapping collections
 
@@ -244,6 +244,6 @@ private Map<Address, List<String>> frozenKeyValueMap;
 private Map<String, List<Address>> frozenValueMap;
 ```
 
-[frozen]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/Frozen.html
-[frozenkey]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/FrozenKey.html
-[frozenvalue]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/FrozenValue.html
+[frozen]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/Frozen.html
+[frozenkey]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/FrozenKey.html
+[frozenvalue]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/FrozenValue.html

--- a/features/object_mapper/custom_codecs/README.md
+++ b/features/object_mapper/custom_codecs/README.md
@@ -98,9 +98,9 @@ instance (one per column) and cache it for future use.
 
 This also works with [@Field][field] and [@Param][param] annotations.
 
-[column]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/Column.html
-[field]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/Field.html
-[param]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/Param.html
+[column]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/Column.html
+[field]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/Field.html
+[param]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/Param.html
 
 
 ## Implicit UDT codecs

--- a/features/object_mapper/using/README.md
+++ b/features/object_mapper/using/README.md
@@ -28,9 +28,9 @@ Mapper<User> mapper = manager.mapper(User.class);
 calling `manager#mapper` more than once for the same class will return
 the previously generated mapper.
 
-[Mapper]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/Mapper.html
-[MappingManager]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/MappingManager.html
-[Session]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Session.html
+[Mapper]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/Mapper.html
+[MappingManager]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/MappingManager.html
+[Session]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Session.html
 
 #### Basic CRUD operations
 
@@ -174,7 +174,7 @@ It provides methods `one()`, `all()`, `iterator()`, `getExecutionInfo()`
 and `isExhausted()`. Note that iterating the `Result` will consume the
 `ResultSet`, and vice-versa.
 
-[Result]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/Result.html
+[Result]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/Result.html
 
 ### Accessors
 
@@ -224,7 +224,7 @@ corresponds to which marker:
 ResultSet insert(@Param("u") UUID userId, @Param("n") String name);
 ```
 
-[param]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/Param.html
+[param]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/Param.html
 
 If a method argument is a Java enumeration, it must be annotated with
 `@Enumerated` to indicate how to convert it to a CQL type (the rules are
@@ -292,4 +292,4 @@ query with the annotation [@QueryParameters]. Then, options like
 public ListenableFuture<Result<User>> getAllAsync();
 ```
 
-[@QueryParameters]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/mapping/annotations/QueryParameters.html
+[@QueryParameters]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/QueryParameters.html

--- a/features/paging/README.md
+++ b/features/paging/README.md
@@ -171,8 +171,8 @@ if (nextPage != null) {
 }
 ```
 
-[result_set]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/ResultSet.html
-[paging_state]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/PagingState.html
+[result_set]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/ResultSet.html
+[paging_state]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/PagingState.html
 
 
 Due to internal implementation details, `PagingState` instances are not
@@ -214,8 +214,8 @@ There are two situations where you might want to use the unsafe API:
   implementing your own validation logic (for example, signing the raw
   state with a private key).
 
-[gpsu]: http://www.datastax.com/drivers/java/2.2/com/datastax/driver/core/ExecutionInfo.html#getPagingStateUnsafe()
-[spsu]: http://www.datastax.com/drivers/java/2.2/com/datastax/driver/core/Statement.html#setPagingStateUnsafe(byte[])
+[gpsu]: http://www.datastax.com/drivers/java/3.0/com/datastax/driver/core/ExecutionInfo.html#getPagingStateUnsafe()
+[spsu]: http://www.datastax.com/drivers/java/3.0/com/datastax/driver/core/Statement.html#setPagingStateUnsafe(byte[])
 
 ### Offset queries
 

--- a/features/pooling/README.md
+++ b/features/pooling/README.md
@@ -277,14 +277,14 @@ either:
   [newConnectionThreshold][nct] so that enough connections are added by
   the time you reach the bottleneck.
 
-[result_set_future]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/ResultSetFuture.html
-[pooling_options]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/PoolingOptions.html
-[lbp]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/policies/LoadBalancingPolicy.html
-[nct]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/PoolingOptions.html#setNewConnectionThreshold(com.datastax.driver.core.HostDistance,%20int)
-[mrpc]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/PoolingOptions.html#setMaxRequestsPerConnection(com.datastax.driver.core.HostDistance,%20int)
-[sits]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/PoolingOptions.html#setIdleTimeoutSeconds(int)
-[rtm]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/SocketOptions.html#getReadTimeoutMillis()
-[exec_async]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Session.html#executeAsync(com.datastax.driver.core.Statement)
-[ptm]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/PoolingOptions.html#setPoolTimeoutMillis(int)
-[nhae]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/exceptions/NoHostAvailableException.html
-[get_state]:http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Session.html#getState()
+[result_set_future]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/ResultSetFuture.html
+[pooling_options]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/PoolingOptions.html
+[lbp]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/policies/LoadBalancingPolicy.html
+[nct]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/PoolingOptions.html#setNewConnectionThreshold(com.datastax.driver.core.HostDistance,%20int)
+[mrpc]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/PoolingOptions.html#setMaxRequestsPerConnection(com.datastax.driver.core.HostDistance,%20int)
+[sits]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/PoolingOptions.html#setIdleTimeoutSeconds(int)
+[rtm]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/SocketOptions.html#getReadTimeoutMillis()
+[exec_async]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Session.html#executeAsync(com.datastax.driver.core.Statement)
+[ptm]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/PoolingOptions.html#setPoolTimeoutMillis(int)
+[nhae]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/exceptions/NoHostAvailableException.html
+[get_state]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Session.html#getState()

--- a/features/query_timestamps/README.md
+++ b/features/query_timestamps/README.md
@@ -16,7 +16,7 @@ session.execute("INSERT INTO my_table(c1, c2) values (1, 1) " +
 
 ### Client-side generation
 
-This is enabled by default if you're using the driver 2.2 and a version
+This is enabled by default if you're using the driver 3.0 and a version
 of Cassandra that supports [native protocol](../native_protocol) v3 or
 above.
 
@@ -42,8 +42,8 @@ statement.setDefaultTimestamp(1234567890);
 session.execute(statement);
 ```
 
-[tsg]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/TimestampGenerator.html
-[amtsg]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/AtomicMonotonicTimestampGenerator.html
+[tsg]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/TimestampGenerator.html
+[amtsg]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/AtomicMonotonicTimestampGenerator.html
 
 
 ### Server-side generation

--- a/features/speculative_execution/README.md
+++ b/features/speculative_execution/README.md
@@ -108,8 +108,8 @@ default cluster-wide:
 cluster.getConfiguration().getQueryOptions().setDefaultIdempotence(true);
 ```
 
-[isIdempotent]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Statement.html#isIdempotent()
-[QueryBuilder]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/querybuilder/QueryBuilder.html
+[isIdempotent]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Statement.html#isIdempotent()
+[QueryBuilder]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/querybuilder/QueryBuilder.html
 
 ### Enabling speculative executions
 
@@ -118,7 +118,7 @@ Speculative executions are controlled by an instance of
 `Cluster`.  This policy defines the threshold after which a new
 speculative execution will be triggered.
 
-[sep]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/policies/SpeculativeExecutionPolicy.html
+[sep]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/policies/SpeculativeExecutionPolicy.html
 
 Two implementations are provided with the driver:
 
@@ -146,7 +146,7 @@ way:
 * if no response has been received at t0 + 1000 milliseconds, start
   another speculative execution on a third node.
 
-[csep]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/policies/ConstantSpeculativeExecutionPolicy.html
+[csep]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/policies/ConstantSpeculativeExecutionPolicy.html
 
 #### [PercentileSpeculativeExecutionPolicy][psep]
 
@@ -207,9 +207,9 @@ Note that `PerHostPercentileTracker` may also be used with a slow query
 logger (see the [Logging](../logging/) section). In that case, you would
 create a single tracker object and share it with both components.
 
-[psep]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/policies/PercentileSpeculativeExecutionPolicy.html
+[psep]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/policies/PercentileSpeculativeExecutionPolicy.html
 [hdr]: http://hdrhistogram.github.io/HdrHistogram/
-[phpt]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/PerHostPercentileTracker.html
+[phpt]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/PerHostPercentileTracker.html
 
 #### Using your own
 
@@ -263,7 +263,7 @@ client           driver          exec1  exec2
 The only impact is that all executions of the same query always share
 the same query plan, so each host will be used by at most one execution.
 
-[retry_policy]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/policies/RetryPolicy.html
+[retry_policy]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/policies/RetryPolicy.html
 
 ### Tuning and practical details
 
@@ -278,8 +278,8 @@ You can monitor how many speculative executions were triggered with the
 It should only be a few percents of the total number of requests
 ([cluster.getMetrics().getRequestsTimer().getCount()][request_metric]).
 
-[se_metric]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Metrics.Errors.html#getSpeculativeExecutions()
-[request_metric]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Metrics.html#getRequestsTimer()
+[se_metric]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Metrics.Errors.html#getSpeculativeExecutions()
+[request_metric]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Metrics.html#getRequestsTimer()
 
 #### Stream id exhaustion
 
@@ -308,8 +308,8 @@ sustained. If you're unsure of which native protocol version you're
 using, you can check with
 [cluster.getConfiguration().getProtocolOptions().getProtocolVersion()][protocol_version].
 
-[session_state]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/Session.State.html
-[protocol_version]: http://docs.datastax.com/en/drivers/java/2.2/com/datastax/driver/core/ProtocolOptions.html#getProtocolVersion()
+[session_state]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/Session.State.html
+[protocol_version]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/ProtocolOptions.html#getProtocolVersion()
 
 #### Request ordering and client timestamps
 


### PR DESCRIPTION
This commit makes TypeCodec.accepts(TypeToken) invariant with respect to the Java type passed as argument.
TypeCodec.accepts(Object) remains covariant with respect to the runtime type of the passed object.
This commit also updates the documentation on custom codecs.
