### PR TITLE
JAVA-917: Document SSL configuration.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -11,6 +11,7 @@
 - [bug] JAVA-960: Avoid race in control connection shutdown.
 - [bug] JAVA-656: Fix NPE in ControlConnection.updateLocationInfo.
 - [bug] JAVA-966: Count uninitialized connections in conviction policy.
+- [improvement] JAVA-917: Document SSL configuration.
 
 
 ### 2.0.11

--- a/driver-core/src/main/java/com/datastax/driver/core/SSLOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SSLOptions.java
@@ -24,8 +24,6 @@ import java.security.NoSuchAlgorithmException;
  */
 public class SSLOptions {
 
-    private static final String SSL_PROTOCOL = "TLS";
-
     /**
      * The default SSL cipher suites.
      */
@@ -63,12 +61,8 @@ public class SSLOptions {
 
     private static SSLContext makeDefaultContext() throws IllegalStateException {
         try {
-            SSLContext ctx = SSLContext.getInstance(SSL_PROTOCOL);
-            ctx.init(null, null, null); // use defaults
-            return ctx;
+            return SSLContext.getDefault();
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("This JVM doesn't support TLS, this shouldn't happen");
-        } catch (KeyManagementException e) {
             throw new IllegalStateException("Cannot initialize SSL Context", e);
         }
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -60,8 +60,12 @@ public class CCMBridge {
     public static final String DEFAULT_CLIENT_TRUSTSTORE_PASSWORD = "cassandra1sfun";
     public static final String DEFAULT_CLIENT_TRUSTSTORE_PATH = "/client.truststore";
 
+    public static final File DEFAULT_CLIENT_TRUSTSTORE_FILE = createTempStore(DEFAULT_CLIENT_TRUSTSTORE_PATH);
+
     public static final String DEFAULT_CLIENT_KEYSTORE_PASSWORD = "cassandra1sfun";
     public static final String DEFAULT_CLIENT_KEYSTORE_PATH = "/client.keystore";
+
+    public static final File DEFAULT_CLIENT_KEYSTORE_FILE = createTempStore(DEFAULT_CLIENT_KEYSTORE_PATH);
 
     public static final String DEFAULT_SERVER_TRUSTSTORE_PASSWORD = "cassandra1sfun";
     public static final String DEFAULT_SERVER_TRUSTSTORE_PATH = "/server.truststore";

--- a/driver-core/src/test/java/com/datastax/driver/core/SSLAuthenticatedEncryptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLAuthenticatedEncryptionTest.java
@@ -20,8 +20,7 @@ import org.testng.annotations.Test;
 
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 
-import static com.datastax.driver.core.CCMBridge.DEFAULT_CLIENT_KEYSTORE_PATH;
-import static com.datastax.driver.core.CCMBridge.DEFAULT_CLIENT_TRUSTSTORE_PATH;
+import static com.datastax.driver.core.CCMBridge.*;
 
 public class SSLAuthenticatedEncryptionTest extends SSLTestBase {
 
@@ -58,5 +57,27 @@ public class SSLAuthenticatedEncryptionTest extends SSLTestBase {
     @Test(groups="short", expectedExceptions={NoHostAvailableException.class})
     public void should_not_connect_without_client_auth_but_node_requires_auth() throws Exception {
         connectWithSSLOptions(getSSLOptions(Optional.<String>absent(), Optional.of(DEFAULT_CLIENT_TRUSTSTORE_PATH)));
+    }
+
+    /**
+     * <p>
+     * Validates that SSL connectivity can be configured via the standard javax.net.ssl System properties.
+     * </p>
+     *
+     * @test_category connection:ssl, authentication
+     * @expected_result Connection can be established.
+     */
+    @Test(groups="short")
+    public void should_use_system_properties_with_default_ssl_options() throws Exception {
+        try {
+            System.setProperty("javax.net.ssl.keyStore", DEFAULT_CLIENT_KEYSTORE_FILE.getAbsolutePath());
+            System.setProperty("javax.net.ssl.keyStorePassword", DEFAULT_CLIENT_KEYSTORE_PASSWORD);
+            System.setProperty("javax.net.ssl.trustStore", DEFAULT_CLIENT_TRUSTSTORE_FILE.getAbsolutePath());
+            System.setProperty("javax.net.ssl.trustStorePassword", DEFAULT_CLIENT_TRUSTSTORE_PASSWORD);
+
+            connectWithSSL();
+        } finally {
+            clearSystemProperties();
+        }
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/SSLEncryptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLEncryptionTest.java
@@ -23,8 +23,7 @@ import org.testng.annotations.Test;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 
 import static com.datastax.driver.core.Assertions.assertThat;
-import static com.datastax.driver.core.CCMBridge.DEFAULT_CLIENT_KEYSTORE_PATH;
-import static com.datastax.driver.core.CCMBridge.DEFAULT_CLIENT_TRUSTSTORE_PATH;
+import static com.datastax.driver.core.CCMBridge.*;
 
 public class SSLEncryptionTest extends SSLTestBase {
 
@@ -116,6 +115,26 @@ public class SSLEncryptionTest extends SSLTestBase {
         } finally {
             if (cluster != null)
                 cluster.close();
+        }
+    }
+
+    /**
+     * <p>
+     * Validates that SSL connectivity can be configured via the standard javax.net.ssl System properties.
+     * </p>
+     *
+     * @test_category connection:ssl
+     * @expected_result Connection can be established.
+     */
+    @Test(groups="short")
+    public void should_use_system_properties_with_default_ssl_options() throws Exception {
+        try {
+            System.setProperty("javax.net.ssl.trustStore", DEFAULT_CLIENT_TRUSTSTORE_FILE.getAbsolutePath());
+            System.setProperty("javax.net.ssl.trustStorePassword", DEFAULT_CLIENT_TRUSTSTORE_PASSWORD);
+
+            connectWithSSL();
+        } finally {
+            clearSystemProperties();
         }
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/SSLTestBase.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLTestBase.java
@@ -25,7 +25,9 @@ import javax.net.ssl.TrustManagerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
+import static com.datastax.driver.core.CCMBridge.DEFAULT_CLIENT_KEYSTORE_FILE;
 import static com.datastax.driver.core.CCMBridge.DEFAULT_CLIENT_KEYSTORE_PASSWORD;
+import static com.datastax.driver.core.CCMBridge.DEFAULT_CLIENT_TRUSTSTORE_FILE;
 import static com.datastax.driver.core.CCMBridge.DEFAULT_CLIENT_TRUSTSTORE_PASSWORD;
 public abstract class SSLTestBase {
 
@@ -72,6 +74,40 @@ public abstract class SSLTestBase {
             if (cluster != null)
                 cluster.close();
         }
+    }
+
+    /**
+     * <p>
+     * Attempts to connect to a cassandra cluster with using {@link Cluster.Builder#withSSL} with no
+     * provided {@link SSLOptions} and then closes the created {@link Cluster} instance.
+     * </p>
+     *
+     * @throws Exception A {@link com.datastax.driver.core.exceptions.NoHostAvailableException} will be
+     *  raised here if connection cannot be established.
+     */
+    protected void connectWithSSL() throws Exception {
+        Cluster cluster = null;
+        try {
+            cluster = Cluster.builder()
+                .addContactPoint(CCMBridge.IP_PREFIX + '1')
+                .withSSL()
+                .build();
+
+            cluster.connect();
+        } finally {
+            if (cluster != null)
+                cluster.close();
+        }
+    }
+
+    /**
+     * Clears all System properties associated with SSL key and trust stores.
+     */
+    protected void clearSystemProperties() {
+        System.clearProperty("javax.net.ssl.keyStore");
+        System.clearProperty("javax.net.ssl.keyStorePassword");
+        System.clearProperty("javax.net.ssl.trustStore");
+        System.clearProperty("javax.net.ssl.trustStorePassword");
     }
 
     /**

--- a/features/ssl/README.md
+++ b/features/ssl/README.md
@@ -1,0 +1,180 @@
+## SSL
+
+You can secure traffic between the driver and Cassandra with SSL. There
+are two aspects to that:
+
+* **client-to-node encryption**, where the traffic is encrypted, and the
+  client verifies the identity of the Cassandra nodes it connects to;
+* optionally, **client certificate authentication**, where Cassandra
+  nodes also verify the identity of the client.
+
+This section describes the driver-side configuration; it assumes that
+you've already configured SSL in Cassandra:
+
+* [the Cassandra documentation](http://docs.datastax.com/en/cassandra/2.0/cassandra/security/secureSSLClientToNode_t.html)
+  covers a basic approach with self-signed certificates, which is fine
+  for development and tests.
+* [this blog post](http://thelastpickle.com/blog/2015/09/30/hardening-cassandra-step-by-step-part-1-server-to-server.html)
+  details a more advanced solution based on a Certificate Authority
+  (CA).
+
+### Preparing the certificates
+
+#### Client truststore
+
+This is required for client-to-node encryption.
+
+If you're using self-signed certificates, you need to export the public
+part of each node's certificate from that node's keystore:
+
+```
+keytool -export -alias cassandra -file cassandranode0.cer -keystore .keystore
+```
+
+Then add all public certificates to the client truststore:
+
+```
+keytool -import -v -trustcacerts -alias <cassandra_node0> -file cassandranode0.cer -keystore client.truststore
+keytool -import -v -trustcacerts -alias <cassandra_node1> -file cassandranode1.cer -keystore client.truststore
+...
+```
+
+If you're using a Certificate Authority, the client truststore only
+needs to contain the CA's certificate:
+
+```
+keytool -import -v -trustcacerts -alias CARoot -file ca.cer -keystore client.truststore
+```
+
+#### Client keystore
+
+If you also intend to use client certificate authentication, generate
+the public and private key pair for the client:
+
+```
+keytool -genkey -keyalg RSA -alias client -keystore client.keystore
+```
+
+If you're using self-signed certificates, extract the public part of the
+client certificate, and import it in the truststore of each Cassandra
+node:
+
+```
+keytool -export -alias client -file client.cer -keystore client.keystore
+keytool -import -v -trustcacerts -alias client -file client.cer -keystore server.truststore
+```
+
+If you're using a CA, sign the client certificate with it (see the blog
+post linked at the top of this page). Then the nodes' truststores only
+need to contain the CA's certificate (which should already be the case
+if you've followed the steps for inter-node encryption).
+
+### Driver configuration
+
+#### Property-based
+
+`withSSL()` gives you a basic JSSE configuration:
+
+```java
+Cluster cluster = Cluster.builder()
+  .addContactPoint("127.0.0.1")
+  .withSSL()
+  .build();
+```
+
+You can then use
+[JSSE system properties](http://docs.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#Customization)
+for specific details, like keystore locations and passwords:
+
+```
+-Djavax.net.ssl.trustStore=/path/to/client.truststore
+-Djavax.net.ssl.trustStorePassword=password123
+# If you're using client authentication:
+-Djavax.net.ssl.keyStore=/path/to/client.keystore
+-Djavax.net.ssl.keyStorePassword=password123
+```
+
+#### Programmatic
+
+If you need more control than what system properties allow, you can
+configure SSL programmatically by creating an [SSLOptions] instance:
+
+```java
+SSLContext sslContext = ... // create and configure SSL context
+String[] cipherSuites = ...
+
+SSLOptions sslOptions = new SSLOptions(sslContext, cipherSuites);
+
+Cluster cluster = Cluster.builder()
+  .addContactPoint("127.0.0.1")
+  .withSSL(sslOptions)
+  .build();
+```
+
+A known limitation of the current API is that you can't customize the
+`SSLEngine`, which prevents advanced features like hostname
+verification. This will be fixed in 3.0 (see
+[JAVA-841](https://datastax-oss.atlassian.net/browse/JAVA-841)), in the
+meantime see below for a workaround.
+
+
+### Bypassing `SSLOptions`
+
+For advanced use cases, it's possible to bypass `SSLOptions` entirely:
+since the driver provides a hook into the Netty pipeline (by way of
+[NettyOptions]), you can add the SSL handler yourself:
+
+```java
+import io.netty.handler.ssl.SslHandler;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+
+// Base implementation: each time a connection is established, create an SSL handler
+// and add it to the pipeline:
+public abstract class SslNettyOptions extends NettyOptions {
+  @Override
+  public void afterChannelInitialized(SocketChannel channel) throws Exception {
+    channel.pipeline().addFirst("ssl", createSslHandler(channel));
+  }
+
+  protected abstract SslHandler createSslHandler(SocketChannel channel);
+}
+
+// Concrete implementation based on JSSE
+public class MyNettyOptions extends SslNettyOptions {
+
+  private final SSLContext sslContext = createContext();
+
+  protected SslHandler createSslHandler(SocketChannel channel) {
+    return new SslHandler(createEngine(sslContext, channel));
+  }
+
+  private static SSLContext createContext() {
+    ... // create and configure context
+  }
+
+  private static SSLEngine createEngine(SSLContext sslContext, SocketChannel channel) {
+    SSLEngine engine = sslContext.createSSLEngine();
+    engine.setUseClientMode(true);
+    ... // any extra configuration
+    return engine;
+  }
+}
+
+cluster = Cluster.builder()
+  .addContactPoint("127.0.0.1")
+  .withNettyOptions(new MyNettyOptions())
+  .build();
+```
+
+This could be used for the following use cases:
+
+* fine control over JSSE configuration, for example tuning the SSL
+  engine for hostname verification;
+* bypassing JSSE altogether in favor of another SSL implementation:
+  recent Netty versions support
+  [OpenSSL](http://netty.io/wiki/forked-tomcat-native.html)
+  for improved performance.
+
+[SSLOptions]: http://docs.datastax.com/en/drivers/java/2.0/com/datastax/driver/core/SSLOptions.html
+[NettyOptions]: http://docs.datastax.com/en/drivers/java/2.0/com/datastax/driver/core/NettyOptions.html


### PR DESCRIPTION
Planning this for 2.0.12 since it required little effort to backport to older branches.
I'll do the 3.0-specific documentation on #508.
