### PR TITLE
Integration Test Grooming

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractReconnectionHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractReconnectionHandler.java
@@ -18,6 +18,7 @@ package com.datastax.driver.core;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.AbstractFuture;
 import org.slf4j.Logger;
@@ -183,7 +184,8 @@ abstract class AbstractReconnectionHandler implements Runnable {
     }
 
     // The future that the handler exposes to its clients via currentAttempt
-    private static class HandlerFuture extends AbstractFuture<Void> {
+    @VisibleForTesting
+    static class HandlerFuture extends AbstractFuture<Void> {
         // A future representing completion of the next task submitted to the executor
         volatile ScheduledFuture<?> nextTry;
 

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
@@ -170,7 +170,9 @@ public class ClusterInitTest {
         try {
             cluster.init();
         } finally {
-            assertThat(reconnectionPolicy.count.get()).isEqualTo(0);
+            // We expect a nextDelay invocation from the ConvictionPolicy for each host, but that will
+            // not trigger a reconnection.
+            assertThat(reconnectionPolicy.count.get()).isEqualTo(2);
             for (FakeHost fakeHost : hosts) {
                 fakeHost.stop();
             }

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
@@ -47,6 +47,7 @@ import static com.datastax.driver.core.Assertions.fail;
 import static com.datastax.driver.core.FakeHost.Behavior.THROWING_CONNECT_TIMEOUTS;
 import static com.datastax.driver.core.HostDistance.LOCAL;
 import static com.datastax.driver.core.TestUtils.nonDebouncingQueryOptions;
+import static com.datastax.driver.core.TestUtils.nonQuietClusterCloseOptions;
 
 public class ClusterInitTest {
     private static final Logger logger = LoggerFactory.getLogger(ClusterInitTest.class);
@@ -189,6 +190,7 @@ public class ClusterInitTest {
     public void should_be_able_to_close_cluster_that_never_successfully_connected() throws Exception {
         Cluster cluster = Cluster.builder()
             .addContactPointsWithPorts(Collections.singleton(new InetSocketAddress("127.0.0.1", 65534)))
+            .withNettyOptions(nonQuietClusterCloseOptions)
             .build();
         try {
             cluster.connect();

--- a/driver-core/src/test/java/com/datastax/driver/core/HostAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostAssert.java
@@ -120,26 +120,4 @@ public class HostAssert extends AbstractAssert<HostAssert, Host> {
         fail(actual + " did not go down within " + duration + " " + unit);
         return this;
     }
-
-    public static class StateListenerBase implements StateListener {
-        @Override
-        public void onAdd(Host host) {
-        }
-
-        @Override
-        public void onUp(Host host) {
-        }
-
-        @Override
-        public void onSuspected(Host host) {
-        }
-
-        @Override
-        public void onDown(Host host) {
-        }
-
-        @Override
-        public void onRemove(Host host) {
-        }
-    }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryOptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryOptionsTest.java
@@ -66,7 +66,8 @@ public class QueryOptionsTest {
     public void validatePrepared(boolean expectAll) {
         // Prepare the statement
         String query = "select sansa_stark from the_known_world";
-        session.prepare(query);
+        PreparedStatement statement = session.prepare(query);
+        assertThat(cluster.manager.preparedQueries).containsValue(statement);
 
         // Ensure prepared properly based on expectation.
         List<PreparedStatementPreparation> preparationOne = scassandra.retrievePreparedStatementPreparations(1);

--- a/driver-core/src/test/java/com/datastax/driver/core/RefreshConnectedHostTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RefreshConnectedHostTest.java
@@ -78,6 +78,8 @@ public class RefreshConnectedHostTest {
             assertThat(cluster).host(2)
                                .hasState(State.UP)
                                .isAtDistance(HostDistance.LOCAL);
+
+            // Ensure that the host is added to the Cluster.
             assertThat(cluster).host(3)
                                .comesUpWithin(Cluster.NEW_NODE_DELAY_SECONDS+1, SECONDS)
                                .isAtDistance(HostDistance.IGNORED);

--- a/driver-core/src/test/java/com/datastax/driver/core/SessionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionTest.java
@@ -290,7 +290,7 @@ public class SessionTest extends CCMBridge.PerClassSingleNodeCluster {
             startLatch.countDown();
 
             executor.shutdown();
-            boolean normalShutdown = executor.awaitTermination(1, TimeUnit.SECONDS);
+            boolean normalShutdown = executor.awaitTermination(5, TimeUnit.SECONDS);
             assertTrue(normalShutdown);
 
             // The deadlock occurred here before JAVA-418

--- a/driver-core/src/test/java/com/datastax/driver/core/StateListenerBase.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StateListenerBase.java
@@ -1,0 +1,40 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+public class StateListenerBase implements Host.StateListener {
+    @Override
+    public void onAdd(Host host) {
+    }
+
+    @Override
+    public void onUp(Host host) {
+    }
+
+    @Override
+    public void onSuspected(Host host) {
+
+    }
+
+    @Override
+    public void onDown(Host host) {
+    }
+
+    @Override
+    public void onRemove(Host host) {
+    }
+
+}


### PR DESCRIPTION
Addresses some inconsistently passing tests on the 2.0 branch.   There are a few more than need addressing (primary in RecommissionedNodeTest).
