### PR TITLE
JAVA-978: Remove double quote - return NULL when entityMapper.getTableMetaSpace()

### DIFF
--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/Mapper.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/Mapper.java
@@ -75,7 +75,7 @@ public class Mapper<T> {
         this.mapper = mapper;
 
         KeyspaceMetadata keyspace = session().getCluster().getMetadata().getKeyspace(mapper.getKeyspace());
-        this.tableMetadata = keyspace == null ? null : keyspace.getTable(Metadata.quote(mapper.getTable()));
+        this.tableMetadata = keyspace == null ? null : keyspace.getTable(mapper.getTable());
 
         this.protocolVersion = manager.getSession().getCluster().getConfiguration().getProtocolOptions().getProtocolVersionEnum();
         this.mapOneFunction = new Function<ResultSet, T>() {

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperTest.java
@@ -419,6 +419,18 @@ public class MapperTest extends CCMBridge.PerClassSingleNodeCluster {
         session.execute("delete from posts where user_id = " + u1.getUserId());
     }
 
+
+    @Test(groups="short")
+    public void should_tableMetaData_not_null() throws Exception {
+        MappingManager manager = new MappingManager(session);
+
+        Mapper<Post> m = manager.mapper(Post.class);
+
+        assertThat(m.getTableMetadata()).isNotNull();
+        assertThat(m.getTableMetadata().getName()).isEqualTo("posts");
+        assertThat(m.getTableMetadata().getPartitionKey()).hasSize(1);
+    }
+
     @Test(groups="short")
     public void should_not_initialize_session_when_protocol_version_provided() {
         Session newSession = cluster.newSession();


### PR DESCRIPTION
```
MappingManager manager = new MappingManager(session);
Mapper<Post> m = manager.mapper(Post.class);

m.getTableMetadata() // is returning NULL
```

We are double quoting the name of the table, and we are not able to find in the table map of the Keyspace, which is a bug
