### PR TITLE
Add isolated test group and profile for tests requiring their own JVM.

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -10,12 +10,24 @@ cassandra:
 build:
   - type: maven
     version: 3.2.5
-    goals: clean compile test --fail-never -Plong
+    goals: verify --fail-never -Plong
     properties: |
       com.datastax.driver.TEST_BASE_NODE_WAIT=120
       com.datastax.driver.NEW_NODE_DELAY_SECONDS=100
       cassandra.version=$CCM_CASSANDRA_VERSION
       ccm.java.home=$CCM_JAVA_HOME
+      failIfNoTests=false
+      maven.test.failure.ignore=true
+  - type: maven
+    version: 3.2.5
+    goals: verify --fail-never -Pisolated
+    properties: |
+      com.datastax.driver.TEST_BASE_NODE_WAIT=120
+      com.datastax.driver.NEW_NODE_DELAY_SECONDS=100
+      cassandra.version=$CCM_CASSANDRA_VERSION
+      ccm.java.home=$CCM_JAVA_HOME
+      failIfNoTests=false
+      maven.test.failure.ignore=true
   - xunit:
     - "**/target/surefire-reports/TEST-*.xml"
     - "**/target/failsafe-reports/TEST-*.xml" 

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -340,6 +340,41 @@
     </profile>
 
     <profile>
+      <id>isolated</id>
+      <properties>
+        <env>default</env>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.16</version>
+            <configuration>
+              <forkCount>1</forkCount>
+              <reuseForks>false</reuseForks>
+              <groups>isolated</groups>
+              <!-- Files containing tests to be included must be added here.
+                   this prevents a fork being created for each test class. -->
+              <includes>
+                <include>**/SSL*Test.java</include>
+              </includes>
+              <reportNameSuffix>isolated</reportNameSuffix>
+              <useFile>false</useFile>
+              <systemPropertyVariables>
+                <cassandra.version>${cassandra.version}</cassandra.version>
+                <ipprefix>${ipprefix}</ipprefix>
+              </systemPropertyVariables>
+              <classpathDependencyExcludes>
+                <classpathDependencyExcludes>io.netty:netty-transport-native-epoll</classpathDependencyExcludes>
+              </classpathDependencyExcludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>long</id>
       <properties>
         <env>default</env>

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -429,13 +429,13 @@ public class CCMBridge {
             erroredOut = true;
         }
 
-        @BeforeClass(groups = { "short", "long" })
+        @BeforeClass(groups = { "isolated", "short", "long" })
         public void beforeClass() {
             maybeInitCluster();
             initKeyspace();
         }
 
-        @AfterClass(groups = { "short", "long" })
+        @AfterClass(groups = { "isolated", "short", "long" })
         public void afterClass() {
             try {
                 clearSimpleKeyspace();

--- a/driver-core/src/test/java/com/datastax/driver/core/SSLAuthenticatedEncryptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLAuthenticatedEncryptionTest.java
@@ -67,17 +67,13 @@ public class SSLAuthenticatedEncryptionTest extends SSLTestBase {
      * @test_category connection:ssl, authentication
      * @expected_result Connection can be established.
      */
-    @Test(groups="short")
+    @Test(groups="isolated")
     public void should_use_system_properties_with_default_ssl_options() throws Exception {
-        try {
-            System.setProperty("javax.net.ssl.keyStore", DEFAULT_CLIENT_KEYSTORE_FILE.getAbsolutePath());
-            System.setProperty("javax.net.ssl.keyStorePassword", DEFAULT_CLIENT_KEYSTORE_PASSWORD);
-            System.setProperty("javax.net.ssl.trustStore", DEFAULT_CLIENT_TRUSTSTORE_FILE.getAbsolutePath());
-            System.setProperty("javax.net.ssl.trustStorePassword", DEFAULT_CLIENT_TRUSTSTORE_PASSWORD);
+        System.setProperty("javax.net.ssl.keyStore", DEFAULT_CLIENT_KEYSTORE_FILE.getAbsolutePath());
+        System.setProperty("javax.net.ssl.keyStorePassword", DEFAULT_CLIENT_KEYSTORE_PASSWORD);
+        System.setProperty("javax.net.ssl.trustStore", DEFAULT_CLIENT_TRUSTSTORE_FILE.getAbsolutePath());
+        System.setProperty("javax.net.ssl.trustStorePassword", DEFAULT_CLIENT_TRUSTSTORE_PASSWORD);
 
-            connectWithSSL();
-        } finally {
-            clearSystemProperties();
-        }
+        connectWithSSL();
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/SSLEncryptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLEncryptionTest.java
@@ -126,15 +126,11 @@ public class SSLEncryptionTest extends SSLTestBase {
      * @test_category connection:ssl
      * @expected_result Connection can be established.
      */
-    @Test(groups="short")
+    @Test(groups="isolated")
     public void should_use_system_properties_with_default_ssl_options() throws Exception {
-        try {
-            System.setProperty("javax.net.ssl.trustStore", DEFAULT_CLIENT_TRUSTSTORE_FILE.getAbsolutePath());
-            System.setProperty("javax.net.ssl.trustStorePassword", DEFAULT_CLIENT_TRUSTSTORE_PASSWORD);
+        System.setProperty("javax.net.ssl.trustStore", DEFAULT_CLIENT_TRUSTSTORE_FILE.getAbsolutePath());
+        System.setProperty("javax.net.ssl.trustStorePassword", DEFAULT_CLIENT_TRUSTSTORE_PASSWORD);
 
-            connectWithSSL();
-        } finally {
-            clearSystemProperties();
-        }
+        connectWithSSL();
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/SSLTestBase.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLTestBase.java
@@ -39,14 +39,14 @@ public abstract class SSLTestBase {
         this.requireClientAuth = requireClientAuth;
     }
 
-    @BeforeClass(groups={"short", "long"})
+    @BeforeClass(groups={"isolated", "short", "long"})
     public void beforeClass() {
         ccm = CCMBridge.builder("test")
             .withSSL(requireClientAuth)
             .build();
     }
 
-    @AfterClass(groups={"short", "long"})
+    @AfterClass(groups={"isolated", "short", "long"})
     public void afterClass() {
         ccm.remove();
     }
@@ -98,16 +98,6 @@ public abstract class SSLTestBase {
             if (cluster != null)
                 cluster.close();
         }
-    }
-
-    /**
-     * Clears all System properties associated with SSL key and trust stores.
-     */
-    protected void clearSystemProperties() {
-        System.clearProperty("javax.net.ssl.keyStore");
-        System.clearProperty("javax.net.ssl.keyStorePassword");
-        System.clearProperty("javax.net.ssl.trustStore");
-        System.clearProperty("javax.net.ssl.trustStorePassword");
     }
 
     /**


### PR DESCRIPTION
This is useful for tests that touch static members or require a 'clean' environment.

Applied to currently failing SSL tests that rely on SSLContext.getDefault which depends on System properties and is only ever loaded once.

Also configure failure parameters such that OSGi integration tests may run despite any test failures.
