### PR TITLE
JAVA-986: Update documentation links to reference 3.0.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -9,6 +9,7 @@
 - [improvement] JAVA-961: Raise an exception when an older version of guava (<16.01) is found.
 - [bug] JAVA-972: TypeCodec.parse() implementations should be case insensitive when checking for keyword NULL.
 - [bug] JAVA-971: Make type codecs invariant.
+- [bug] JAVA-986: Update documentation links to reference 3.0.
 
 Merged from 2.1 branch:
 

--- a/features/logging/README.md
+++ b/features/logging/README.md
@@ -181,9 +181,8 @@ Currently the `QueryLogger` can be configured to track slow queries using either
 a constant threshold in milliseconds (which is the default behavior), or 
 a dynamic threshold based on per-host latency percentiles, as computed by `PerHostPercentileTracker`.
 
-**Dynamic thresholds are still a beta feature as of version 2.2.0-rc3: they
-haven't been extensively tested yet, and the API is still subject to
-change.**
+**Dynamic thresholds are still a beta feature: they haven't been extensively 
+tested yet, and the API is still subject to change.**
 
 Refer to the `QueryLogger` [API docs][query_logger] for an example of usage.
 

--- a/features/native_protocol/README.md
+++ b/features/native_protocol/README.md
@@ -16,11 +16,11 @@ Cassandra when the first connection is established. Both sides are
 backward-compatible with older versions:
 
 <table border="1" style="text-align:center; width:100%;margin-bottom:1em;">
-<tr><td>&nbsp;</td><td>Cassandra: 1.2.x<br/>(DSE 3.2)</td><td>2.0.x<br/>(DSE 4.0 to 4.6)</td><td>2.1.x<br/>(DSE 4.7)</td><td>2.2.x</td></tr>
-<tr><td>Driver: 1.0.x</td> <td>v1</td> <td>v1</td>  <td>v1</td> <td>v1</td> </tr>
-<tr><td>2.0.x to 2.1.1</td> <td>v1</td> <td>v2</td>  <td>v2</td> <td>v2</td> </tr>
-<tr><td>2.1.2 to 2.2.0</td> <td>v1</td> <td>v2</td>  <td>v3</td> <td>v3</td> </tr>
-<tr><td>2.2.0 or more</td> <td>v1</td> <td>v2</td>  <td>v3</td> <td>v4</td> </tr>
+<tr><td>&nbsp;</td><td>Cassandra: 1.2.x<br/>(DSE 3.2)</td><td>2.0.x<br/>(DSE 4.0 to 4.6)</td><td>2.1.x<br/>(DSE 4.7)</td><td>2.2.x</td><td>3.0.x</td></tr>
+<tr><td>Driver: 1.0.x</td> <td>v1</td> <td>v1</td>  <td>v1</td> <td>v1</td>  <td>Unsupported</td> </tr>
+<tr><td>2.0.x to 2.1.1</td> <td>v1</td> <td>v2</td>  <td>v2</td> <td>v2</td> <td>Unsupported</td> </tr>
+<tr><td>2.1.2 to 2.2.0</td> <td>v1</td> <td>v2</td>  <td>v3</td> <td>v3</td> <td>v3</td> </tr>
+<tr><td>2.2.0 or more</td> <td>v1</td> <td>v2</td>  <td>v3</td> <td>v4</td> <td>v4</td> </tr>
 </table>
 
 For example, if you use version 2.1.5 of the driver to connect to


### PR DESCRIPTION
For [JAVA-986](https://datastax-oss.atlassian.net/browse/JAVA-986).  Updates feature documentation to reference 3.0 instead of 2.2 where applicable.  Validated with doc tool that there are no broken links.
