### PR TITLE
JAVA-982: Add isSerial() to distinguish between query and serial CLs.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@
 - [improvement] Pass the authenticator name from the server to the auth provider (JAVA-885) 
 - [improvement] Raise an exception when an older version of guava (<16.01) is found (JAVA-961)
 - [bug] TypeCodec.parse() implementations should be case insensitive when checking for keyword NULL (JAVA-972)
+- [improvement] Add isSerial() to distinguish between query and serial CLs in ConsistencyLevel (JAVA-982)
 
 ### 3.0.0-alpha4
 

--- a/driver-core/src/main/java/com/datastax/driver/core/ConsistencyLevel.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ConsistencyLevel.java
@@ -64,4 +64,13 @@ public enum ConsistencyLevel {
     public boolean isDCLocal() {
         return this == LOCAL_ONE || this == LOCAL_QUORUM;
     }
+
+    /**
+     * Whether or not the consistency level is a serial consistency level.
+     *
+     * @return whether this consistency level is {@code LOCAL_SERIAL} or {@code SERIAL}.
+     */
+    public boolean isSerial() {
+        return this == LOCAL_SERIAL || this == SERIAL;
+    }
 }


### PR DESCRIPTION
For [JAVA-982](https://datastax-oss.atlassian.net/browse/JAVA-982).  This just adds a convenience method `isSerial` to `ConsistencyLevel`.   In the general case this isn't particularly useful except perhaps for programatic and library use.

Not an urgent request, doesn't need to be in upcoming release(s).
