### PR TITLE
JAVA-819: Driver shouldn't retry on client timeout if statement is not idempotent.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@
 - [improvement] Pass the authenticator name from the server to the auth provider (JAVA-885) 
 - [improvement] Raise an exception when an older version of guava (<16.01) is found (JAVA-961)
 - [bug] TypeCodec.parse() implementations should be case insensitive when checking for keyword NULL (JAVA-972)
+- [bug] JAVA-819: Driver shouldn't retry on client timeout if statement is not idempotent.
 
 Merged from 2.1 branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -733,7 +733,11 @@ class RequestHandler {
                 connection.release();
 
                 logError(connection.address, timeoutException);
-                retry(false, null);
+                // JAVA-819: DO not retry query if statement is not idempotent
+                if (statement.isIdempotentWithDefault(manager.cluster.manager.configuration.getQueryOptions()))
+                    retry(false, null);
+                else
+                    reportNoMoreHosts(this);
             } catch (Exception e) {
                 // This shouldn't happen, but if it does, we want to signal the callback, not let it hang indefinitely
                 setFinalException(null, new DriverInternalError("An unexpected error happened while handling timeout", e));

--- a/driver-core/src/main/java/com/datastax/driver/core/SocketOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SocketOptions.java
@@ -87,7 +87,7 @@ public class SocketOptions {
      * <p>
      * Please note that this is not the maximum time a call to {@link Session#execute} may block;
      * this is the maximum time that call will wait for one particular
-     * Cassandra host, but other hosts will be tried if one of them times out. In
+     * Cassandra host, but other hosts could be tried if one of them times out. In
      * other words, a {@link Session#execute} call may theoretically wait up to
      * {@code getReadTimeoutMillis() * <number_of_cassandra_hosts>} (though the
      * total number of hosts tried for a given query also depends on the

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -208,6 +208,13 @@ We've also seized the opportunity to remove code that was deprecated in 2.1.
 20. `TableMetadata.Options` has been made a top-level class and renamed to
     `TableOptionsMetadata`. It is now also used by `MaterializedViewMetadata`.
 
+21. The driver will not retry anymore a query that failed due to a client
+    timeout (see `SocketOptions.getReadTimeoutMillis()`), *unless
+    the statement is explicitly marked idempotent* (see `Statement.isIdempotent()`).
+    Since statement are considered non idempotent by default,
+    this is a significant behavioral change in the driver. It was introduced
+    by [JAVA-819](https://datastax-oss.atlassian.net/browse/JAVA-819).
+
 
 ### 2.1.8
 


### PR DESCRIPTION
This commit prevents a retry from happening in the event of a client timeout if the statement is not idempotent.
