### PR TITLE
JAVA-989: Include keyspace name when invalid replication found.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -7,6 +7,7 @@
 - [improvement] JAVA-863: Idempotence propagation in PreparedStatements.
 - [bug] JAVA-937: TypeCodec static initializers not always correctly executed.
 - [improvement] JAVA-989: Include keyspace name when invalid replication found when generating token map.
+- [improvement] JAVA-664: Reduce heap consumption for TokenMap.
 
 Merged from 2.0 branch:
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -6,6 +6,7 @@
 - [bug] JAVA-983: QueryBuilder cannot handle collections containing function calls.
 - [improvement] JAVA-863: Idempotence propagation in PreparedStatements.
 - [bug] JAVA-937: TypeCodec static initializers not always correctly executed.
+- [improvement] JAVA-989: Include keyspace name when invalid replication found when generating token map.
 
 Merged from 2.0 branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -751,7 +751,7 @@ public class Metadata {
                 ReplicationStrategy strategy = keyspace.replicationStrategy();
                 Map<Token, Set<Host>> ksTokens = (strategy == null)
                     ? makeNonReplicatedMap(tokenToPrimary)
-                    : strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+                    : strategy.computeTokenToReplicaMap(keyspace.getName(), tokenToPrimary, ring);
 
                 tokenToHosts.put(keyspace.getName(), ksTokens);
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -745,13 +745,18 @@ public class Metadata {
             Set<TokenRange> tokenRanges = makeTokenRanges(ring, factory);
 
             Map<String, Map<Token, Set<Host>>> tokenToHosts = new HashMap<String, Map<Token, Set<Host>>>();
+            Map<ReplicationStrategy, Map<Token, Set<Host>>> replStrategyToHosts = new HashMap<ReplicationStrategy, Map<Token, Set<Host>>>();
             Map<String, Map<Host, Set<TokenRange>>> hostsToRanges = new HashMap<String, Map<Host, Set<TokenRange>>>();
             for (KeyspaceMetadata keyspace : keyspaces)
             {
                 ReplicationStrategy strategy = keyspace.replicationStrategy();
-                Map<Token, Set<Host>> ksTokens = (strategy == null)
-                    ? makeNonReplicatedMap(tokenToPrimary)
-                    : strategy.computeTokenToReplicaMap(keyspace.getName(), tokenToPrimary, ring);
+                Map<Token, Set<Host>> ksTokens = replStrategyToHosts.get(strategy);
+                if (ksTokens == null) {
+                    ksTokens = (strategy == null)
+                        ? makeNonReplicatedMap(tokenToPrimary)
+                        : strategy.computeTokenToReplicaMap(keyspace.getName(), tokenToPrimary, ring);
+                    replStrategyToHosts.put(strategy, ksTokens);
+                }
 
                 tokenToHosts.put(keyspace.getName(), ksTokens);
 

--- a/driver-core/src/main/java/com/datastax/driver/core/ReplicationStategy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ReplicationStategy.java
@@ -60,7 +60,7 @@ abstract class ReplicationStrategy {
         }
     }
 
-    abstract Map<Token, Set<Host>> computeTokenToReplicaMap(Map<Token, Host> tokenToPrimary, List<Token> ring);
+    abstract Map<Token, Set<Host>> computeTokenToReplicaMap(String keyspaceName, Map<Token, Host> tokenToPrimary, List<Token> ring);
 
     private static Token getTokenWrapping(int i, List<Token> ring) {
         return ring.get(i % ring.size());
@@ -74,7 +74,7 @@ abstract class ReplicationStrategy {
             this.replicationFactor = replicationFactor;
         }
 
-        Map<Token, Set<Host>> computeTokenToReplicaMap(Map<Token, Host> tokenToPrimary, List<Token> ring) {
+        Map<Token, Set<Host>> computeTokenToReplicaMap(String keyspaceName, Map<Token, Host> tokenToPrimary, List<Token> ring) {
 
             int rf = Math.min(replicationFactor, ring.size());
 
@@ -117,7 +117,7 @@ abstract class ReplicationStrategy {
             this.replicationFactors = replicationFactors;
         }
 
-        Map<Token, Set<Host>> computeTokenToReplicaMap(Map<Token, Host> tokenToPrimary, List<Token> ring) {
+        Map<Token, Set<Host>> computeTokenToReplicaMap(String keyspaceName, Map<Token, Host> tokenToPrimary, List<Token> ring) {
 
              // This is essentially a copy of org.apache.cassandra.locator.NetworkTopologyStrategy
             Map<String, Set<String>> racks = getRacksInDcs(tokenToPrimary.values());
@@ -189,10 +189,10 @@ abstract class ReplicationStrategy {
                     int expectedFactor = replicationFactors.get(dcName);
                     int achievedFactor = entry.getValue().size();
                     if (achievedFactor < expectedFactor && !warnedDcs.contains(dcName)) {
-                        logger.warn("Error while computing token map for datacenter {}: "
+                        logger.warn("Error while computing token map for keyspace {} with datacenter {}: "
                                 + "could not achieve replication factor {} (found {} replicas only), "
                                 + "check your keyspace replication settings.",
-                            dcName, expectedFactor, achievedFactor);
+                            keyspaceName, dcName, expectedFactor, achievedFactor);
                         // only warn once per DC
                         warnedDcs.add(dcName);
                     }

--- a/driver-core/src/test/java/com/datastax/driver/core/NetworkTopologyStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/NetworkTopologyStrategyTest.java
@@ -109,6 +109,9 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
     private static final List<Token> largeRing = Lists.newArrayList();
     private static final Map<Token, Host> largeRingTokenToPrimary = Maps.newHashMap();
+
+    private static final String keyspace = "Excelsior";
+
     static {
         for (int i = 0; i < 100; i++) {
             InetSocketAddress address = socketAddress("127.0.0." + i);
@@ -186,7 +189,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
         ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 1), rf(DC2, 1));
 
-        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
         assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2);
         assertReplicaPlacement(replicaMap, TOKEN04, IP2, IP1);
@@ -220,7 +223,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
         ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 1), rf(DC2, 1));
 
-        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
         assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2);
         assertReplicaPlacement(replicaMap, TOKEN03, IP2, IP3);
@@ -254,7 +257,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
         ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 1), rf(DC2, 1), rf(DC3, 1));
 
-        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
         assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2, IP3);
         assertReplicaPlacement(replicaMap, TOKEN05, IP2, IP3, IP1);
@@ -294,7 +297,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
         ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 2), rf(DC2, 2));
 
-        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
         assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2, IP3, IP4);
         assertReplicaPlacement(replicaMap, TOKEN03, IP1, IP2, IP3, IP4);
@@ -350,7 +353,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
         ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 2), rf(DC2, 2));
 
-        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
         assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2, IP3, IP4);
         assertReplicaPlacement(replicaMap, TOKEN02, IP2, IP3, IP4, IP5);
@@ -414,7 +417,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
         ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 3), rf(DC2, 3));
 
-        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
         assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2, IP5, IP3, IP6, IP4);
         assertReplicaPlacement(replicaMap, TOKEN02, IP2, IP3, IP5, IP6, IP4, IP7);
@@ -477,7 +480,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
         ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 3), rf(DC2, 3));
 
-        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
         assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP5, IP3, IP2, IP6, IP4);
         assertReplicaPlacement(replicaMap, TOKEN02, IP1, IP5, IP3, IP2, IP6, IP4);
@@ -541,7 +544,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
         //all nodes will contain all data, question is the replica order
         ReplicationStrategy strategy = networkTopologyStrategy(rf(DC1, 4), rf(DC2, 4));
 
-        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
         assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP5, IP3, IP7, IP2, IP6, IP4, IP8);
         assertReplicaPlacement(replicaMap, TOKEN02, IP1, IP5, IP3, IP7, IP2, IP6, IP4, IP8);
@@ -563,7 +566,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
     @Test(groups = "unit")
     public void networkTopologyStrategyExampleTopologyTest() {
-        Map<Token, Set<Host>> replicaMap = exampleStrategy.computeTokenToReplicaMap(exampleTokenToPrimary, exampleRing);
+        Map<Token, Set<Host>> replicaMap = exampleStrategy.computeTokenToReplicaMap(keyspace, exampleTokenToPrimary, exampleRing);
 
         //105 and 106 will appear as replica for all as they're in separate racks
         assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP5, IP2, IP6);
@@ -590,7 +593,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
     public void networkTopologyStrategyNoNodesInDCTest() {
         long t1 = System.currentTimeMillis();
         Map<Token, Set<Host>> replicaMap =  networkTopologyStrategy(rf(DC1, 2), rf(DC2, 2))
-                .computeTokenToReplicaMap(largeRingTokenToPrimary, largeRing);
+                .computeTokenToReplicaMap(keyspace, largeRingTokenToPrimary, largeRing);
         assertThat(System.currentTimeMillis() - t1).isLessThan(10000);
 
         InetSocketAddress currNode = null;
@@ -612,7 +615,7 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
     @Test(groups = "unit")
     public void networkTopologyStrategyExampleTopologyTooManyReplicasTest() {
-        Map<Token, Set<Host>> replicaMap = exampleStrategyTooManyReplicas.computeTokenToReplicaMap(exampleTokenToPrimary, exampleRing);
+        Map<Token, Set<Host>> replicaMap = exampleStrategyTooManyReplicas.computeTokenToReplicaMap(keyspace, exampleTokenToPrimary, exampleRing);
 
         assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP5, IP3, IP2, IP6, IP4);
         assertReplicaPlacement(replicaMap, TOKEN02, IP1, IP5, IP3, IP2, IP6, IP4);
@@ -657,15 +660,15 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
 
         // Wrong configuration: impossible replication factor for DC2
         networkTopologyStrategy(rf(DC1, 2), rf(DC2, 3))
-            .computeTokenToReplicaMap(tokenToPrimary, ring);
+            .computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
         assertThat(logs.getNext())
-            .contains("Error while computing token map for datacenter DC2");
+            .contains(String.format("Error while computing token map for keyspace %s with datacenter %s", keyspace, DC2));
 
         // Wrong configuration: non-existing datacenter
         networkTopologyStrategy(rf(DC1, 2), rf("does_not_exist", 2))
-            .computeTokenToReplicaMap(tokenToPrimary, ring);
+            .computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
         assertThat(logs.getNext())
-            .contains("Error while computing token map for datacenter does_not_exist");
+            .contains(String.format("Error while computing token map for keyspace %s with datacenter %s", keyspace, "does_not_exist"));
 
         logger.setLevel(null);
         logger.removeAppender(logs);

--- a/driver-core/src/test/java/com/datastax/driver/core/SimpleStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SimpleStrategyTest.java
@@ -114,6 +114,8 @@ public class SimpleStrategyTest extends AbstractReplicationStrategyTest {
                                                                   .put(TOKEN18, host(IP6))
                                                                   .build();
 
+    private static final String keyspace = "excalibur";
+
     /*
      * --------------
      *     Tests
@@ -138,7 +140,7 @@ public class SimpleStrategyTest extends AbstractReplicationStrategyTest {
 
         ReplicationStrategy strategy = simpleStrategy(2);
 
-        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
         assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2);
         assertReplicaPlacement(replicaMap, TOKEN06, IP2, IP1);
@@ -164,7 +166,7 @@ public class SimpleStrategyTest extends AbstractReplicationStrategyTest {
 
         ReplicationStrategy strategy = simpleStrategy(2);
 
-        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
         assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2);
         assertReplicaPlacement(replicaMap, TOKEN06, IP1, IP2);
@@ -190,7 +192,7 @@ public class SimpleStrategyTest extends AbstractReplicationStrategyTest {
 
         ReplicationStrategy strategy = simpleStrategy(2);
 
-        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(tokenToPrimary, ring);
+        Map<Token, Set<Host>> replicaMap = strategy.computeTokenToReplicaMap(keyspace, tokenToPrimary, ring);
 
         assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP2);
         assertReplicaPlacement(replicaMap, TOKEN06, IP1, IP2);
@@ -200,7 +202,7 @@ public class SimpleStrategyTest extends AbstractReplicationStrategyTest {
 
     @Test(groups = "unit")
     public void simpleStrategyExampleTopologyMapTest() {
-        Map<Token, Set<Host>> replicaMap = exampleStrategy.computeTokenToReplicaMap(exampleTokenToPrimary, exampleRing);
+        Map<Token, Set<Host>> replicaMap = exampleStrategy.computeTokenToReplicaMap(keyspace, exampleTokenToPrimary, exampleRing);
 
         assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP5, IP3);
         assertReplicaPlacement(replicaMap, TOKEN02, IP1, IP5, IP3);
@@ -224,7 +226,7 @@ public class SimpleStrategyTest extends AbstractReplicationStrategyTest {
 
     @Test(groups = "unit")
     public void simpleStrategyExampleTopologyTooManyReplicasTest() {
-        Map<Token, Set<Host>> replicaMap = exampleStrategyTooManyReplicas.computeTokenToReplicaMap(exampleTokenToPrimary, exampleRing);
+        Map<Token, Set<Host>> replicaMap = exampleStrategyTooManyReplicas.computeTokenToReplicaMap(keyspace, exampleTokenToPrimary, exampleRing);
 
         assertReplicaPlacement(replicaMap, TOKEN01, IP1, IP5, IP3, IP2, IP6, IP4);
         assertReplicaPlacement(replicaMap, TOKEN02, IP1, IP5, IP3, IP2, IP6, IP4);


### PR DESCRIPTION
For [JAVA-989](https://datastax-oss.atlassian.net/browse/JAVA-989).  Now logs the following when invalid replication is found on a keyspace:

> Error while computing token map for keyspace X with datacenter Y: could not achieve replication factor 3 (found 2 replicas only), check your keyspace replication settings.

The one thing i'm not so sure of here is passing the keyspace name into `computeTokenToReplicaMap`.  It is only used for logging, so seems somewhat extraneous, but since this is an internal API maybe this is not too much of a problem.
