### PR TITLE
JAVA-983: [2.1] QueryBuilder cannot handle collections containing function calls.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,7 @@
 ### 2.1.10 (in progress)
 
 - [bug] JAVA-988: Metadata.handleId should handle escaped double quotes.
+- [bug] JAVA-983: QueryBuilder cannot handle collections containing function calls.
 
 
 ### 2.1.9

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
@@ -160,11 +160,11 @@ public abstract class BuiltStatement extends RegularStatement {
 
     // TODO: Correctly document the InvalidTypeException
     void maybeAddRoutingKey(String name, Object value) {
-        if (routingKey == null || name == null || value == null || value instanceof BindMarker)
+        if (routingKey == null || name == null || value == null || Utils.containsSpecialValue(value))
             return;
 
         for (int i = 0; i < partitionKey.size(); i++) {
-            if (name.equals(partitionKey.get(i).getName()) && Utils.isRawValue(value)) {
+            if (name.equals(partitionKey.get(i).getName())) {
                 DataType dt = partitionKey.get(i).getType();
                 // We don't really care which protocol version we use, since the only place it matters if for
                 // collections (not inside UDT), and those are not allowed in a partition key anyway, hence the hardcoding.

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
@@ -52,7 +52,7 @@ public class Insert extends BuiltStatement {
         if (keyspace != null)
             Utils.appendName(keyspace, builder).append('.');
         Utils.appendName(table, builder);
-        builder.append('(');
+        builder.append(" (");
         Utils.joinAndAppendNames(builder, ",", names);
         builder.append(") VALUES (");
         Utils.joinAndAppendValues(builder, ",", values, variables);

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
@@ -82,11 +82,11 @@ public class QueryBuilderExecutionTest extends CCMBridge.PerClassSingleNodeClust
     public void prepareTest() throws Exception {
 
         // Just check we correctly avoid values when there is a bind marker
-        String query = "INSERT INTO foo(a,b,c,d) VALUES ('foo','bar',?,0);";
-        RegularStatement stmt = insertInto("foo").value("a", "foo").value("b", "bar").value("c", bindMarker()).value("d", 0);
+        String query = "INSERT INTO foo (a,b,c,d) VALUES ('foo','bar',?,0);";
+        BuiltStatement stmt = insertInto("foo").value("a", "foo").value("b", "bar").value("c", bindMarker()).value("d", 0);
         assertEquals(stmt.getQueryString(), query);
 
-        query = "INSERT INTO foo(a,b,c,d) VALUES ('foo','bar',:c,0);";
+        query = "INSERT INTO foo (a,b,c,d) VALUES ('foo','bar',:c,0);";
         stmt = insertInto("foo").value("a", "foo").value("b", "bar").value("c", bindMarker("c")).value("d", 0);
         assertEquals(stmt.getQueryString(), query);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
@@ -136,17 +136,17 @@ public class QueryBuilderITest extends CCMBridge.PerClassSingleNodeCluster {
         String query;
         Statement insert;
 
-        query = "INSERT INTO foo(a) VALUES ('123); --comment');";
+        query = "INSERT INTO foo (a) VALUES ('123); --comment');";
         insert = insertInto("foo")
                 .value("a", "123); --comment");
         assertEquals(insert.toString(), query);
 
-        query = "INSERT INTO foo(\"a,b\") VALUES (123);";
+        query = "INSERT INTO foo (\"a,b\") VALUES (123);";
         insert = insertInto("foo")
                 .value("a,b", 123);
         assertEquals(insert.toString(), query);
 
-        query = "INSERT INTO foo(a,b) VALUES ({'2''} space','3','4'},3.4) USING TTL 24 AND TIMESTAMP 42;";
+        query = "INSERT INTO foo (a,b) VALUES ({'2''} space','3','4'},3.4) USING TTL 24 AND TIMESTAMP 42;";
         insert = insertInto("foo").values(new String[]{ "a", "b"}, new Object[]{ new TreeSet<String>(){{ add("2'} space"); add("3"); add("4"); }}, 3.4 }).using(ttl(24)).and(timestamp(42));
         assertEquals(insert.toString(), query);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderRoutingKeyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderRoutingKeyTest.java
@@ -106,7 +106,7 @@ public class QueryBuilderRoutingKeyTest extends CCMBridge.PerClassSingleNodeClus
         query = select().from(table).where(eq("k", 42));
 
         batch_query = "BEGIN BATCH ";
-        batch_query += String.format("INSERT INTO %s.test_int(k,a) VALUES (42,1);", keyspace);
+        batch_query += String.format("INSERT INTO %s.test_int (k,a) VALUES (42,1);", keyspace);
         batch_query += String.format("UPDATE %s.test_int USING TTL 400;", keyspace);
         batch_query += "APPLY BATCH;";
         batch = batch()
@@ -133,7 +133,7 @@ public class QueryBuilderRoutingKeyTest extends CCMBridge.PerClassSingleNodeClus
         // TODO: rs = session.execute(batch); // Not guaranteed to be valid CQL
 
         batch_query = "BEGIN BATCH USING TIMESTAMP 42 ";
-        batch_query += "INSERT INTO foo.bar(a) VALUES (123);";
+        batch_query += "INSERT INTO foo.bar (a) VALUES (123);";
         batch_query += "APPLY BATCH;";
         batch = batch().using(timestamp(42)).add(insertInto("foo", "bar").value("a", 123));
         assertEquals(batch.getRoutingKey(), null);

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -22,6 +22,8 @@ import java.util.*;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -183,7 +185,7 @@ public class QueryBuilderTest {
         String query;
         Statement insert;
 
-        query = "INSERT INTO foo(a,b,\"C\",d) VALUES (123,'127.0.0.1','foo''bar',{'x':3,'y':2}) USING TIMESTAMP 42 AND TTL 24;";
+        query = "INSERT INTO foo (a,b,\"C\",d) VALUES (123,'127.0.0.1','foo''bar',{'x':3,'y':2}) USING TIMESTAMP 42 AND TTL 24;";
         insert = insertInto("foo")
             .value("a", 123)
             .value("b", InetAddress.getByName("127.0.0.1"))
@@ -195,13 +197,13 @@ public class QueryBuilderTest {
             .using(timestamp(42)).and(ttl(24));
         assertEquals(insert.toString(), query);
 
-        query = "INSERT INTO foo(a,b) VALUES (2,null);";
+        query = "INSERT INTO foo (a,b) VALUES (2,null);";
         insert = insertInto("foo")
             .value("a", 2)
             .value("b", null);
         assertEquals(insert.toString(), query);
 
-        query = "INSERT INTO foo(a,b) VALUES ({2,3,4},3.4) USING TTL 24 AND TIMESTAMP 42;";
+        query = "INSERT INTO foo (a,b) VALUES ({2,3,4},3.4) USING TTL 24 AND TIMESTAMP 42;";
         insert = insertInto("foo").values(new String[]{ "a", "b" }, new Object[]{ new TreeSet<Integer>() {{
             add(2);
             add(3);
@@ -209,7 +211,7 @@ public class QueryBuilderTest {
         }}, 3.4 }).using(ttl(24)).and(timestamp(42));
         assertEquals(insert.toString(), query);
 
-        query = "INSERT INTO foo.bar(a,b) VALUES ({2,3,4},3.4) USING TTL ? AND TIMESTAMP ?;";
+        query = "INSERT INTO foo.bar (a,b) VALUES ({2,3,4},3.4) USING TTL ? AND TIMESTAMP ?;";
         insert = insertInto("foo", "bar")
             .values(new String[]{ "a", "b" }, new Object[]{ new TreeSet<Integer>() {{
                 add(2);
@@ -221,7 +223,7 @@ public class QueryBuilderTest {
         assertEquals(insert.toString(), query);
 
         // commutative result of TIMESTAMP
-        query = "INSERT INTO foo.bar(a,b,c) VALUES ({2,3,4},3.4,123) USING TIMESTAMP 42;";
+        query = "INSERT INTO foo.bar (a,b,c) VALUES ({2,3,4},3.4,123) USING TIMESTAMP 42;";
         insert = insertInto("foo", "bar")
             .using(timestamp(42))
             .values(new String[]{ "a", "b" }, new Object[]{ new TreeSet<Integer>() {{
@@ -233,7 +235,7 @@ public class QueryBuilderTest {
         assertEquals(insert.toString(), query);
 
         // commutative result of value() and values()
-        query = "INSERT INTO foo(c,a,b) VALUES (123,{2,3,4},3.4) USING TIMESTAMP 42;";
+        query = "INSERT INTO foo (c,a,b) VALUES (123,{2,3,4},3.4) USING TIMESTAMP 42;";
         insert = insertInto("foo")
             .using(timestamp(42))
             .value("c", 123)
@@ -252,11 +254,11 @@ public class QueryBuilderTest {
         }
 
         // CAS test
-        query = "INSERT INTO foo(k,x) VALUES (0,1) IF NOT EXISTS;";
+        query = "INSERT INTO foo (k,x) VALUES (0,1) IF NOT EXISTS;";
         insert = insertInto("foo").value("k", 0).value("x", 1).ifNotExists();
         assertEquals(insert.toString(), query);
 
-        query = "INSERT INTO foo(k,x) VALUES (0,(1));";
+        query = "INSERT INTO foo (k,x) VALUES (0,(1));";
         insert = insertInto("foo").value("k", 0).value("x", TupleType.of(cint()).newValue(1));
         assertEquals(insert.toString(), query);
 
@@ -415,7 +417,7 @@ public class QueryBuilderTest {
         Statement batch;
 
         query = "BEGIN BATCH USING TIMESTAMP 42 ";
-        query += "INSERT INTO foo(a,b) VALUES ({2,3,4},3.4);";
+        query += "INSERT INTO foo (a,b) VALUES ({2,3,4},3.4);";
         query += "UPDATE foo SET a[2]='foo',b=[3,2,1]+b,c=c-{'a'} WHERE k=2;";
         query += "DELETE a[3],b['foo'],c FROM foo WHERE k=1;";
         query += "APPLY BATCH;";
@@ -525,7 +527,7 @@ public class QueryBuilderTest {
         String query;
         Statement insert;
 
-        query = "INSERT INTO test(k,c) VALUES (0,?);";
+        query = "INSERT INTO test (k,c) VALUES (0,?);";
         insert = insertInto("test")
             .value("k", 0)
             .value("c", bindMarker());
@@ -618,15 +620,15 @@ public class QueryBuilderTest {
         String query;
         Statement insert;
 
-        query = "INSERT INTO foo(a) VALUES ('123); --comment');";
+        query = "INSERT INTO foo (a) VALUES ('123); --comment');";
         insert = insertInto("foo").value("a", "123); --comment");
         assertEquals(insert.toString(), query);
 
-        query = "INSERT INTO foo(\"a,b\") VALUES (123);";
+        query = "INSERT INTO foo (\"a,b\") VALUES (123);";
         insert = insertInto("foo").value("a,b", 123);
         assertEquals(insert.toString(), query);
 
-        query = "INSERT INTO foo(a,b) VALUES ({'2''} space','3','4'},3.4) USING TTL 24 AND TIMESTAMP 42;";
+        query = "INSERT INTO foo (a,b) VALUES ({'2''} space','3','4'},3.4) USING TTL 24 AND TIMESTAMP 42;";
         insert = insertInto("foo").values(new String[]{ "a", "b" }, new Object[]{ new TreeSet<String>() {{
             add("2'} space");
             add("3");
@@ -731,23 +733,23 @@ public class QueryBuilderTest {
 
     @Test(groups = "unit")
     public void quotingTest() {
-        assertEquals(QueryBuilder.select().from("Metrics", "epochs").getQueryString(),
+        assertEquals(select().from("Metrics", "epochs").getQueryString(),
             "SELECT * FROM Metrics.epochs;");
-        assertEquals(QueryBuilder.select().from("Metrics", quote("epochs")).getQueryString(),
+        assertEquals(select().from("Metrics", quote("epochs")).getQueryString(),
             "SELECT * FROM Metrics.\"epochs\";");
-        assertEquals(QueryBuilder.select().from(quote("Metrics"), "epochs").getQueryString(),
+        assertEquals(select().from(quote("Metrics"), "epochs").getQueryString(),
             "SELECT * FROM \"Metrics\".epochs;");
-        assertEquals(QueryBuilder.select().from(quote("Metrics"), quote("epochs")).getQueryString(),
+        assertEquals(select().from(quote("Metrics"), quote("epochs")).getQueryString(),
             "SELECT * FROM \"Metrics\".\"epochs\";");
 
-        assertEquals(QueryBuilder.insertInto("Metrics", "epochs").getQueryString(),
-            "INSERT INTO Metrics.epochs() VALUES ();");
-        assertEquals(QueryBuilder.insertInto("Metrics", quote("epochs")).getQueryString(),
-            "INSERT INTO Metrics.\"epochs\"() VALUES ();");
-        assertEquals(QueryBuilder.insertInto(quote("Metrics"), "epochs").getQueryString(),
-            "INSERT INTO \"Metrics\".epochs() VALUES ();");
-        assertEquals(QueryBuilder.insertInto(quote("Metrics"), quote("epochs")).getQueryString(),
-            "INSERT INTO \"Metrics\".\"epochs\"() VALUES ();");
+        assertEquals(insertInto("Metrics", "epochs").toString(),
+            "INSERT INTO Metrics.epochs () VALUES ();");
+        assertEquals(insertInto("Metrics", quote("epochs")).toString(),
+            "INSERT INTO Metrics.\"epochs\" () VALUES ();");
+        assertEquals(insertInto(quote("Metrics"), "epochs").toString(),
+            "INSERT INTO \"Metrics\".epochs () VALUES ();");
+        assertEquals(insertInto(quote("Metrics"), quote("epochs")).toString(),
+            "INSERT INTO \"Metrics\".\"epochs\" () VALUES ();");
     }
 
     @Test(groups = "unit")
@@ -894,6 +896,68 @@ public class QueryBuilderTest {
         Object expected = new Object();
         Object actual = select().from("test").where(eq("foo", expected)).getObject(0);
         assertThat(actual).isSameAs(expected);
+    }
+
+    @Test(groups = "unit")
+    @CassandraVersion(major = 2.1)
+    public void should_serialize_collections_of_serializable_elements() {
+        Set<UUID> set = Sets.newHashSet(UUID.randomUUID());
+        List<Date> list = Lists.newArrayList(new Date());
+        Map<BigInteger, String> map = ImmutableMap.of(new BigInteger("1"), "foo");
+        BuiltStatement query = insertInto("foo").value("v", set);
+        assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES (?);");
+        assertThat(query.getObject(0)).isEqualTo(set);
+        query = insertInto("foo").value("v", list);
+        assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES (?);");
+        assertThat(query.getObject(0)).isEqualTo(list);
+        query = insertInto("foo").value("v", map);
+        assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES (?);");
+        assertThat(query.getObject(0)).isEqualTo(map);
+    }
+
+    @Test(groups = "unit")
+    @CassandraVersion(major = 2.1)
+    public void should_not_attempt_to_serialize_function_calls_in_collections() {
+        BuiltStatement query = insertInto("foo").value("v", Sets.newHashSet(fcall("func", 1)));
+        assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES ({func(1)});");
+        assertThat(query.getValues(ProtocolVersion.V3)).isNullOrEmpty();
+    }
+
+    @Test(groups = "unit")
+    @CassandraVersion(major = 2.1)
+    public void should_not_attempt_to_serialize_bind_markers_in_collections() {
+        BuiltStatement query = insertInto("foo").value("v", Lists.newArrayList(1, 2, bindMarker()));
+        assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES ([1,2,?]);");
+        assertThat(query.getValues(ProtocolVersion.V3)).isNullOrEmpty();
+    }
+
+    @Test(groups = "unit")
+    @CassandraVersion(major = 2.1)
+    public void should_not_attempt_to_serialize_raw_values_in_collections() {
+        BuiltStatement query = insertInto("foo").value("v", ImmutableMap.of(1, raw("x")));
+        assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES ({1:x});");
+        assertThat(query.getValues(ProtocolVersion.V3)).isNullOrEmpty();
+    }
+
+    @Test(groups = "unit")
+    @CassandraVersion(major = 2.1)
+    public void should_not_attempt_to_serialize_collections_containing_numbers() {
+        BuiltStatement query;
+        // lists
+        List<Integer> list = Lists.newArrayList(1, 2, 3);
+        query = insertInto("foo").value("v", list);
+        assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES ([1,2,3]);");
+        assertThat(query.hasValues()).isFalse();
+        // sets
+        Set<Integer> set = Sets.newHashSet(1, 2, 3);
+        query = insertInto("foo").value("v", set);
+        assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES ({1,2,3});");
+        assertThat(query.hasValues()).isFalse();
+        // maps
+        Map<Integer, Float> map = ImmutableMap.of(1, 12.34f);
+        query = insertInto("foo").value("v", map);
+        assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES ({1:12.34});");
+        assertThat(query.hasValues()).isFalse();
     }
 
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTupleExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTupleExecutionTest.java
@@ -1,0 +1,67 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.querybuilder;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
+
+import com.datastax.driver.core.CCMBridge;
+import com.datastax.driver.core.TupleType;
+import com.datastax.driver.core.TupleValue;
+import com.datastax.driver.core.utils.CassandraVersion;
+
+import static com.datastax.driver.core.DataType.cint;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.update;
+
+@CassandraVersion(major=2.1, minor=3)
+public class QueryBuilderTupleExecutionTest extends CCMBridge.PerClassSingleNodeCluster {
+
+    @Override
+    protected Collection<String> getTableDefinitions() {
+            return Collections.emptyList();
+    }
+
+    @Test(groups = "short")
+    public void should_handle_tuple() throws Exception {
+        String query = "INSERT INTO foo (k,x) VALUES (0,(1));";
+        TupleType tupleType = TupleType.of(cint());
+        BuiltStatement insert = insertInto("foo").value("k", 0).value("x", tupleType.newValue(1));
+        assertEquals(insert.toString(), query);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test(groups = "short")
+    public void should_handle_collections_of_tuples() {
+        String query;
+        BuiltStatement statement;
+        query = "UPDATE foo SET l=[(1, 2)] WHERE k=1;";
+        TupleType tupleType = TupleType.of(cint(), cint());
+        List<TupleValue> list = ImmutableList.of(tupleType.newValue(1, 2));
+        statement = update("foo").with(set("l", list)).where(eq("k", 1));
+        assertThat(statement.toString()).isEqualTo(query);
+    }
+
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderUDTExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderUDTExecutionTest.java
@@ -52,7 +52,7 @@ public class QueryBuilderUDTExecutionTest extends CCMBridge.PerClassSingleNodeCl
         UDTValue udtValue = udtType.newValue().setInt("i", 2).setInet("a", InetAddress.getByName("localhost"));
 
         Statement insert = insertInto("udtTest").value("k", 1).value("t", udtValue);
-        assertEquals(insert.toString(), "INSERT INTO udtTest(k,t) VALUES (1,{i:2, a:'127.0.0.1'});");
+        assertEquals(insert.toString(), "INSERT INTO udtTest (k,t) VALUES (1,{i:2, a:'127.0.0.1'});");
 
         session.execute(insert);
 
@@ -71,7 +71,7 @@ public class QueryBuilderUDTExecutionTest extends CCMBridge.PerClassSingleNodeCl
         UDTValue udtValue2 = udtType.newValue().setInt("i", 3).setInet("a", InetAddress.getByName("localhost"));
 
         Statement insert = insertInto("udtTest").value("k", 1).value("l", ImmutableList.of(udtValue));
-        assertThat(insert.toString()).isEqualTo("INSERT INTO udtTest(k,l) VALUES (1,[{i:2, a:'127.0.0.1'}]);");
+        assertThat(insert.toString()).isEqualTo("INSERT INTO udtTest (k,l) VALUES (1,[{i:2, a:'127.0.0.1'}]);");
 
         session.execute(insert);
 


### PR DESCRIPTION
This is the same PR as #517 but targeting branch 2.1.

This commit also incidentally formats INSERT statements with a whitestpace between table name and column list, so that they do not look like a function call.
