### PR TITLE
Update tests to only use netty openssl on JDK 1.7+ and add note to docs.

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/SSLAuthenticatedEncryptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLAuthenticatedEncryptionTest.java
@@ -15,20 +15,11 @@
  */
 package com.datastax.driver.core;
 
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 
-import static com.datastax.driver.core.SSLTestBase.SslImplementation.JDK;
-import static com.datastax.driver.core.SSLTestBase.SslImplementation.NETTY_OPENSSL;
-
 public class SSLAuthenticatedEncryptionTest extends SSLTestBase {
-
-    @DataProvider(name="sslImplementation")
-    public static Object[][] sslImplementation() {
-        return new Object[][]{ { JDK }, { NETTY_OPENSSL } };
-    }
 
     public SSLAuthenticatedEncryptionTest() {
         super(true);
@@ -44,7 +35,7 @@ public class SSLAuthenticatedEncryptionTest extends SSLTestBase {
      * @test_category connection:ssl, authentication
      * @expected_result Connection can be established to a cassandra node using SSL that requires client auth.
      */
-    @Test(groups="short", dataProvider = "sslImplementation")
+    @Test(groups="short", dataProvider = "sslImplementation", dataProviderClass = SSLTestBase.class)
     public void should_connect_with_ssl_with_client_auth_and_node_requires_auth(SslImplementation sslImplementation) throws Exception {
         connectWithSSLOptions(getSSLOptions(sslImplementation, true, true));
     }
@@ -59,7 +50,7 @@ public class SSLAuthenticatedEncryptionTest extends SSLTestBase {
      * @test_category connection:ssl, authentication
      * @expected_result Connection is not established.
      */
-    @Test(groups="short", dataProvider = "sslImplementation", expectedExceptions={NoHostAvailableException.class})
+    @Test(groups="short", dataProvider = "sslImplementation", dataProviderClass = SSLTestBase.class, expectedExceptions={NoHostAvailableException.class})
     public void should_not_connect_without_client_auth_but_node_requires_auth(SslImplementation sslImplementation) throws Exception {
         connectWithSSLOptions(getSSLOptions(sslImplementation, false, true));
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/SSLEncryptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLEncryptionTest.java
@@ -17,21 +17,13 @@ package com.datastax.driver.core;
 
 import java.util.concurrent.TimeUnit;
 
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 
 import static com.datastax.driver.core.Assertions.assertThat;
-import static com.datastax.driver.core.SSLTestBase.SslImplementation.JDK;
-import static com.datastax.driver.core.SSLTestBase.SslImplementation.NETTY_OPENSSL;
 
 public class SSLEncryptionTest extends SSLTestBase {
-
-    @DataProvider(name="sslImplementation")
-    public static Object[][] sslImplementation() {
-        return new Object[][]{ { JDK }, { NETTY_OPENSSL } };
-    }
 
     public SSLEncryptionTest() {
         super(false);
@@ -46,7 +38,7 @@ public class SSLEncryptionTest extends SSLTestBase {
      * @test_category connection:ssl
      * @expected_result Connection can be established to a cassandra node using SSL.
      */
-    @Test(groups="short", dataProvider = "sslImplementation")
+    @Test(groups="short", dataProvider = "sslImplementation", dataProviderClass = SSLTestBase.class)
     public void should_connect_with_ssl_without_client_auth_and_node_doesnt_require_auth(SslImplementation sslImplementation) throws Exception {
         connectWithSSLOptions(getSSLOptions(sslImplementation, false, true));
     }
@@ -60,7 +52,7 @@ public class SSLEncryptionTest extends SSLTestBase {
      * @test_category connection:ssl
      * @expected_result Connection can not be established to a cassandra node using SSL with an untrusted cert.
      */
-    @Test(groups="short", dataProvider = "sslImplementation", expectedExceptions={NoHostAvailableException.class})
+    @Test(groups="short", dataProvider = "sslImplementation", dataProviderClass = SSLTestBase.class, expectedExceptions={NoHostAvailableException.class})
     public void should_not_connect_with_ssl_without_trusting_server_cert(SslImplementation sslImplementation) throws Exception {
         connectWithSSLOptions(getSSLOptions(sslImplementation, false, false));
     }
@@ -103,7 +95,7 @@ public class SSLEncryptionTest extends SSLTestBase {
      * @test_category connection:ssl
      * @expected_result Connection is re-established within a sufficient amount of time after a node comes back online.
      */
-    @Test(groups="long", dataProvider = "sslImplementation")
+    @Test(groups="long", dataProvider = "sslImplementation", dataProviderClass = SSLTestBase.class)
     public void should_reconnect_with_ssl_on_node_up(SslImplementation sslImplementation) throws Exception {
         Cluster cluster = null;
         try {

--- a/driver-core/src/test/java/com/datastax/driver/core/SSLTestBase.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLTestBase.java
@@ -24,10 +24,13 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 
 import static io.netty.handler.ssl.SslProvider.OPENSSL;
 import static org.assertj.core.api.Assertions.fail;
 
+import static com.datastax.driver.core.SSLTestBase.SslImplementation.JDK;
+import static com.datastax.driver.core.SSLTestBase.SslImplementation.NETTY_OPENSSL;
 
 public abstract class SSLTestBase {
 
@@ -37,6 +40,17 @@ public abstract class SSLTestBase {
 
     public SSLTestBase(boolean requireClientAuth) {
         this.requireClientAuth = requireClientAuth;
+    }
+
+    @DataProvider(name="sslImplementation")
+    public static Object[][] sslImplementation() {
+        // Bypass Netty SSL if on JDK 1.6 since it only works on 1.7+.
+        String javaVersion = System.getProperty("java.version");
+        if(javaVersion.startsWith("1.6")) {
+            return new Object[][]{ { JDK } };
+        } else {
+            return new Object[][]{ { JDK }, { NETTY_OPENSSL } };
+        }
     }
 
     @BeforeClass(groups={"isolated", "short", "long"})

--- a/features/ssl/README.md
+++ b/features/ssl/README.md
@@ -149,6 +149,8 @@ Netty-tcnative provides the native integration with OpenSSL. Follow
 [these instructions](http://netty.io/wiki/forked-tomcat-native.html) to
 add it to your dependencies.
 
+Note that using netty-tcnative requires JDK 1.7 or above.
+
 ##### Configuring the context
 
 Use the following Java code to configure OpenSSL with your certificates:


### PR DESCRIPTION
For [JAVA-841](https://datastax-oss.atlassian.net/browse/JAVA-841), I noticed that netty-tcnative requires JDK 1.7.  Updated the tests to only run with Netty OpenSSL if the JDK version is not 1.6.  Also added a note in the docs that using netty-tcnative requires 1.7 or above.
