### PR TITLE
JAVA-994: Don't call on(Up|Down|Add|Remove) if Cluster is closed.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 2.0.13 (in progress)
+
+- [bug] JAVA-994: Don't call on(Up|Down|Add|Remove) methods if Cluster is closed/closing.
+
 ### 2.0.12
 
 - [bug] JAVA-950: Fix Cluster.connect with a case-sensitive keyspace.

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1608,12 +1608,16 @@ public class Cluster implements Closeable {
         }
 
         public ListenableFuture<?> triggerOnUp(final Host host) {
-            return executor.submit(new ExceptionCatchingRunnable() {
-                @Override
-                public void runMayThrow() throws InterruptedException, ExecutionException {
-                    onUp(host, null);
-                }
-            });
+            if (!isClosed()) {
+                return executor.submit(new ExceptionCatchingRunnable() {
+                    @Override
+                    public void runMayThrow() throws InterruptedException, ExecutionException {
+                        onUp(host, null);
+                    }
+                });
+            } else {
+                return MoreFutures.VOID_SUCCESS;
+            }
         }
 
         // Use triggerOnUp unless you're sure you want to run this on the current thread.
@@ -1723,12 +1727,16 @@ public class Cluster implements Closeable {
         }
 
         public ListenableFuture<?> triggerOnDown(final Host host, final boolean isHostAddition, final boolean startReconnection) {
-            return executor.submit(new ExceptionCatchingRunnable() {
-                @Override
-                public void runMayThrow() throws InterruptedException, ExecutionException {
-                    onDown(host, isHostAddition, startReconnection);
-                }
-            });
+            if(!isClosed()) {
+                return executor.submit(new ExceptionCatchingRunnable() {
+                    @Override
+                    public void runMayThrow() throws InterruptedException, ExecutionException {
+                        onDown(host, isHostAddition, startReconnection);
+                    }
+                });
+            } else {
+                return MoreFutures.VOID_SUCCESS;
+            }
         }
 
         // Use triggerOnDown unless you're sure you want to run this on the current thread.
@@ -1883,12 +1891,16 @@ public class Cluster implements Closeable {
         }
 
         public ListenableFuture<?> triggerOnAdd(final Host host) {
-            return executor.submit(new ExceptionCatchingRunnable() {
-                @Override
-                public void runMayThrow() throws InterruptedException, ExecutionException {
-                    onAdd(host, null);
-                }
-            });
+            if (!isClosed()) {
+                return executor.submit(new ExceptionCatchingRunnable() {
+                    @Override
+                    public void runMayThrow() throws InterruptedException, ExecutionException {
+                        onAdd(host, null);
+                    }
+                });
+            } else {
+                return MoreFutures.VOID_SUCCESS;
+            }
         }
 
         // Use triggerOnAdd unless you're sure you want to run this on the current thread.
@@ -1988,12 +2000,16 @@ public class Cluster implements Closeable {
         }
 
         public ListenableFuture<?> triggerOnRemove(final Host host) {
-            return executor.submit(new ExceptionCatchingRunnable() {
-                @Override
-                public void runMayThrow() throws InterruptedException, ExecutionException {
-                    onRemove(host);
-                }
-            });
+            if (!isClosed()) {
+                return executor.submit(new ExceptionCatchingRunnable() {
+                    @Override
+                    public void runMayThrow() throws InterruptedException, ExecutionException {
+                        onRemove(host);
+                    }
+                });
+            } else {
+                return MoreFutures.VOID_SUCCESS;
+            }
         }
 
         // Use triggerOnRemove unless you're sure you want to run this on the current thread.


### PR DESCRIPTION
For [JAVA-994](https://datastax-oss.atlassian.net/browse/JAVA-994).

A simple change to only submit executor tasks in `trigger*` methods if `!Cluster#isClosed()`.  This should only be an issue in the `DOWN` case, but to be symmetric with the check in the `on*` methods it made sense to perform the check for all events.

I opened this up against 2.0 mostly since this affects tests, but can change this to 2.1 if it is more appropriate.
