### PR TITLE
JAVA-995: Defunct connection even if initializing.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,8 @@
 ### 2.0.13 (in progress)
 
 - [bug] JAVA-994: Don't call on(Up|Down|Add|Remove) methods if Cluster is closed/closing.
+- [bug] JAVA-995: Defunct connection even if initializing.
+
 
 ### 2.0.12
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -1049,7 +1049,7 @@ class Connection {
         public void operationComplete(ChannelFuture future) throws Exception {
             // If we've closed the channel client side then we don't really want to defunct the connection, but
             // if there is remaining thread waiting on us, we still want to wake them up
-            if (!isInitialized || isClosed()) {
+            if (isClosed()) {
                 dispatcher.errorOutAllHandler(new TransportException(address, "Channel has been closed"));
                 // we still want to force so that the future completes
                 Connection.this.closeAsync().force();


### PR DESCRIPTION
For [JAVA-995](https://datastax-oss.atlassian.net/browse/JAVA-995).  I think to fix this particular problem all that is needed is to make sure the connection is defuncted in ChannelCloseListener, even if initializing.  If already closed, there is no need to defunct as that process has likely already been initiated (since the closeFuture is initialized in the first place).

Can change to 2.1 branch target if that is more appropriate.
