### PR TITLE
Switch to container-based infrastructure for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ jdk:
   - openjdk6
   - oraclejdk7
   - oraclejdk8
+sudo: false
+cache:
+  directories:
+    - $HOME/.m2


### PR DESCRIPTION
See: http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

Also sets up caching for the $HOME/.m2 directory, which should speed up build times by not downloading dependencies on every build.
