### PR TITLE
JAVA-1005: DowngradingConsistencyRetryPolicy does not work with EACH_QUORUM when 1 DC is down.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -40,6 +40,7 @@
 - [bug] JAVA-1094: Backport TypeCodec parse and format fixes from 3.0.
 - [improvement] JAVA-852: Ignore peers with null entries during discovery.
 - [bug] JAVA-1132: Executing bound statement with no variables results in exception with protocol v1.
+- [bug] JAVA-1005: DowngradingConsistencyRetryPolicy does not work with EACH_QUORUM when 1 DC is down.
 
 Merged from 2.0 branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/DCAwareRoundRobinPolicy.java
@@ -381,7 +381,7 @@ public class DCAwareRoundRobinPolicy implements LoadBalancingPolicy, CloseableLo
          * When used in conjunction with {@link #withUsedHostsPerRemoteDc(int) usedHostsPerRemoteDc} > 0, this overrides the policy of
          * never using remote datacenter nodes for {@code LOCAL_ONE} and {@code LOCAL_QUORUM} queries. It is however inadvisable to do
          * so in almost all cases, as this would potentially break consistency guarantees and if you are fine with that, it's probably
-         * better to use a weaker consitency like {@code ONE}, {@code TWO} or {@code THREE}. As such, this method should generally be
+         * better to use a weaker consistency like {@code ONE}, {@code TWO} or {@code THREE}. As such, this method should generally be
          * avoided; use it only if you know and understand what you do.
          *
          * @return this builder.

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicy.java
@@ -20,39 +20,47 @@ import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.WriteType;
 
 /**
- * A retry policy that sometimes retry with a lower consistency level than
+ * A retry policy that sometimes retries with a lower consistency level than
  * the one initially requested.
  * <p/>
- * <b>BEWARE</b>: This policy may retry queries using a lower consistency
+ * <b>BEWARE</b>: this policy may retry queries using a lower consistency
  * level than the one initially requested. By doing so, it may break
  * consistency guarantees. In other words, if you use this retry policy,
- * there is cases (documented below) where a read at {@code QUORUM}
+ * there are cases (documented below) where a read at {@code QUORUM}
  * <b>may not</b> see a preceding write at {@code QUORUM}. Do not use this
  * policy unless you have understood the cases where this can happen and
  * are ok with that. It is also highly recommended to always wrap this
  * policy into {@link LoggingRetryPolicy} to log the occurrences of
- * such consistency break.
+ * such consistency breaks.
  * <p/>
  * This policy implements the same retries than the {@link DefaultRetryPolicy}
  * policy. But on top of that, it also retries in the following cases:
  * <ul>
- * <li>On a read timeout: if the number of replica that responded is
- * greater than one but lower than is required by the requested
+ * <li>On a read timeout: if the number of replicas that responded is
+ * greater than one, but lower than is required by the requested
  * consistency level, the operation is retried at a lower consistency
  * level.</li>
- * <li>On a write timeout: if the operation is an {@code
+ * <li>On a write timeout: if the operation is a {@code
  * WriteType.UNLOGGED_BATCH} and at least one replica acknowledged the
  * write, the operation is retried at a lower consistency level.
- * Furthermore, for other operation, if at least one replica acknowledged
+ * Furthermore, for other operations, if at least one replica acknowledged
  * the write, the timeout is ignored.</li>
  * <li>On an unavailable exception: if at least one replica is alive, the
  * operation is retried at a lower consistency level.</li>
  * </ul>
+ * The lower consistency level to use for retries is determined by the following rules:
+ * <ul>
+ * <li>if more than 3 replicas responded, use {@code THREE}.</li>
+ * <li>if 1, 2 or 3 replicas responded, use the corresponding level {@code ONE}, {@code TWO} or {@code THREE}.</li>
+ * </ul>
+ * Note that if the initial consistency level was {@code EACH_QUORUM}, Cassandra returns the number of live replicas
+ * <em>in the datacenter that failed to reach consistency</em>, not the overall number in the cluster. Therefore if this
+ * number is 0, we still retry at {@code ONE}, on the assumption that a host may still be up in another datacenter.
  * <p/>
  * The reasoning being this retry policy is the following one. If, based
  * on the information the Cassandra coordinator node returns, retrying the
- * operation with the initially requested consistency has a change to
- * succeed, do it. Otherwise, if based on these information we know <b>the
+ * operation with the initially requested consistency has a chance to
+ * succeed, do it. Otherwise, if based on this information we know <b>the
  * initially requested consistency level cannot be achieve currently</b>, then:
  * <ul>
  * <li>For writes, ignore the exception (thus silently failing the
@@ -73,15 +81,20 @@ public class DowngradingConsistencyRetryPolicy implements ExtendedRetryPolicy {
     private DowngradingConsistencyRetryPolicy() {
     }
 
-    private RetryDecision maxLikelyToWorkCL(int knownOk) {
+    private RetryDecision maxLikelyToWorkCL(int knownOk, ConsistencyLevel currentCL) {
         if (knownOk >= 3)
             return RetryDecision.retry(ConsistencyLevel.THREE);
-        else if (knownOk == 2)
+
+        if (knownOk == 2)
             return RetryDecision.retry(ConsistencyLevel.TWO);
-        else if (knownOk == 1)
+
+        // JAVA-1005: EACH_QUORUM does not report a global number of alive replicas
+        // so even if we get 0 alive replicas, there might be
+        // a node up in some other datacenter
+        if (knownOk == 1 || currentCL == ConsistencyLevel.EACH_QUORUM)
             return RetryDecision.retry(ConsistencyLevel.ONE);
-        else
-            return RetryDecision.rethrow();
+        
+        return RetryDecision.rethrow();
     }
 
     /**
@@ -108,7 +121,7 @@ public class DowngradingConsistencyRetryPolicy implements ExtendedRetryPolicy {
 
         if (receivedResponses < requiredResponses) {
             // Tries the biggest CL that is expected to work
-            return maxLikelyToWorkCL(receivedResponses);
+            return maxLikelyToWorkCL(receivedResponses, cl);
         }
 
         return !dataRetrieved ? RetryDecision.retry(cl) : RetryDecision.rethrow();
@@ -140,7 +153,7 @@ public class DowngradingConsistencyRetryPolicy implements ExtendedRetryPolicy {
             case UNLOGGED_BATCH:
                 // Since only part of the batch could have been persisted,
                 // retry with whatever consistency should allow to persist all
-                return maxLikelyToWorkCL(receivedAcks);
+                return maxLikelyToWorkCL(receivedAcks, cl);
             case BATCH_LOG:
                 return RetryDecision.retry(cl);
         }
@@ -166,7 +179,7 @@ public class DowngradingConsistencyRetryPolicy implements ExtendedRetryPolicy {
             return RetryDecision.tryNextHost(null);
 
         // Tries the biggest CL that is expected to work
-        return maxLikelyToWorkCL(aliveReplica);
+        return maxLikelyToWorkCL(aliveReplica, cl);
     }
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/AbstractRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/AbstractRetryPolicyIntegrationTest.java
@@ -135,6 +135,11 @@ public class AbstractRetryPolicyIntegrationTest {
         return query(session);
     }
 
+    protected ResultSet queryWithCL(ConsistencyLevel cl) {
+        Statement statement = new SimpleStatement("mock query").setConsistencyLevel(cl);
+        return session.execute(statement);
+    }
+
     protected ResultSet query(Session session) {
         return session.execute("mock query");
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicyIntegrationTest.java
@@ -81,6 +81,32 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         };
     }
 
+    /**
+     * Ensures that when handling a read timeout with {@link DowngradingConsistencyRetryPolicy} that a retry is
+     * reattempted with {@link ConsistencyLevel#ONE} if the consistency level on the statement executed is
+     * {@link ConsistencyLevel#EACH_QUORUM}, even if the number of known alive replicas was 0.
+     *
+     * @jira_ticket JAVA-1005
+     * @test_category retry_policy
+     */
+    @Test(groups = "short")
+    public void should_retry_once_on_same_host_from_each_quorum_to_one() {
+        simulateError(1, read_request_timeout, new ReadTimeoutConfig(0, 3, false));
+
+        try {
+            queryWithCL(ConsistencyLevel.EACH_QUORUM);
+        } catch (ReadTimeoutException e) {
+            assertThat(e.getConsistencyLevel()).isEqualTo(ConsistencyLevel.ONE);
+        }
+
+        assertOnReadTimeoutWasCalled(2);
+        assertThat(errors.getRetries().getCount()).isEqualTo(1);
+        assertThat(errors.getReadTimeouts().getCount()).isEqualTo(2);
+        assertThat(errors.getRetriesOnReadTimeout().getCount()).isEqualTo(1);
+        assertQueried(1, 2);
+        assertQueried(2, 0);
+        assertQueried(3, 0);
+    }
 
     /**
      * Ensures that when handling a read timeout with {@link DowngradingConsistencyRetryPolicy} that a retry is


### PR DESCRIPTION
I'm proposing to downgrade to `ONE` if `aliveReplicas == 0`. This is a bit like picking a number blindly, but with `EACH_QUORUM` the number of alive replicas cannot be trusted.
