### PR TITLE
Code quality - Exception handlers should preserve the original exception

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractReconnectionHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractReconnectionHandler.java
@@ -102,7 +102,7 @@ abstract class AbstractReconnectionHandler implements Runnable {
             ready.countDown();
         } catch (RejectedExecutionException e) {
             // The executor has been shutdown, fair enough, just ignore
-            logger.debug("Aborting reconnection handling since the cluster is shutting down");
+            logger.debug("Aborting reconnection handling since the cluster is shutting down", e);
         }
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/CBUtil.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CBUtil.java
@@ -53,7 +53,7 @@ abstract class CBUtil { // TODO rename
             int length = cb.readUnsignedShort();
             return readString(cb, length);
         } catch (IndexOutOfBoundsException e) {
-            throw new DriverInternalError("Not enough bytes to read an UTF8 serialized string preceded by it's 2 bytes length");
+            throw new DriverInternalError("Not enough bytes to read an UTF8 serialized string preceded by it's 2 bytes length.", e);
         }
     }
 
@@ -87,7 +87,7 @@ abstract class CBUtil { // TODO rename
             int length = cb.readInt();
             return readString(cb, length);
         } catch (IndexOutOfBoundsException e) {
-            throw new DriverInternalError("Not enough bytes to read an UTF8 serialized string preceded by it's 4 bytes length");
+            throw new DriverInternalError("Not enough bytes to read an UTF8 serialized string preceded by it's 4 bytes length.", e);
         }
     }
 
@@ -108,7 +108,7 @@ abstract class CBUtil { // TODO rename
             cb.readBytes(bytes);
             return bytes;
         } catch (IndexOutOfBoundsException e) {
-            throw new DriverInternalError("Not enough bytes to read a byte array preceded by it's 2 bytes length");
+            throw new DriverInternalError("Not enough bytes to read a byte array preceded by it's 2 bytes length.", e);
         }
     }
 
@@ -138,7 +138,7 @@ abstract class CBUtil { // TODO rename
         try {
             return Enum.valueOf(enumType, value.toUpperCase());
         } catch (IllegalArgumentException e) {
-            throw new DriverInternalError(String.format("Invalid value '%s' for %s", value, enumType.getSimpleName()));
+            throw new DriverInternalError(String.format("Invalid value '%s' for %s", value, enumType.getSimpleName()), e);
         }
     }
 
@@ -311,7 +311,7 @@ abstract class CBUtil { // TODO rename
         try {
             return new InetSocketAddress(InetAddress.getByAddress(address), port);
         } catch (UnknownHostException e) {
-            throw new DriverInternalError(String.format("Invalid IP address (%d.%d.%d.%d) while deserializing inet address", address[0], address[1], address[2], address[3]));
+            throw new DriverInternalError(String.format("Invalid IP address (%d.%d.%d.%d) while deserializing inet address", address[0], address[1], address[2], address[3]), e);
         }
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -860,7 +860,7 @@ public class Cluster implements Closeable {
                 this.rawAddresses.add(InetAddress.getByName(address));
                 return this;
             } catch (UnknownHostException e) {
-                throw new IllegalArgumentException(e.getMessage());
+                throw new IllegalArgumentException(e.getMessage(), e);
             }
         }
 
@@ -913,7 +913,7 @@ public class Cluster implements Closeable {
             try {
                 addContactPoints(InetAddress.getAllByName(address));
             } catch (UnknownHostException e) {
-                throw new IllegalArgumentException(e.getMessage());
+                throw new IllegalArgumentException(e.getMessage(), e);
             }
             return this;
         }
@@ -1428,13 +1428,13 @@ public class Cluster implements Closeable {
                 try {
                     controlConnection.connect();
                 } catch (UnsupportedProtocolVersionException e) {
-                    logger.debug("Cannot connect with protocol {}, trying {}", e.unsupportedVersion, e.serverVersion);
+                    logger.debug("Cannot connect with protocol {}, trying {}", e.unsupportedVersion, e.serverVersion, e);
 
                     connectionFactory.protocolVersion = e.serverVersion;
                     try {
                         controlConnection.connect();
                     } catch (UnsupportedProtocolVersionException e1) {
-                        throw new DriverInternalError("Cannot connect to node with its own version, this makes no sense", e);
+                        throw new DriverInternalError("Cannot connect to node with its own version, this makes no sense", e1);
                     }
                 }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -440,14 +440,14 @@ class Connection {
         } catch (BusyConnectionException e) {
             logger.warn("Tried to set the keyspace on busy {}. "
                 + "This should not happen but is not critical (it will be retried)", this);
-            throw new ConnectionException(address, "Tried to set the keyspace on busy connection");
+            throw new ConnectionException(address, "Tried to set the keyspace on busy connection", e);
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
             if (cause instanceof OperationTimedOutException) {
                 // Rethrow so that the caller doesn't try to use the connection, but do not defunct as we don't want to mark down
                 logger.warn("Timeout while setting keyspace on {}. "
                     + "This should not happen but is not critical (it will be retried)", this);
-                throw new ConnectionException(address, "Timeout while setting keyspace on connection");
+                throw new ConnectionException(address, "Timeout while setting keyspace on connection", e);
             } else {
                 throw defunct(new ConnectionException(address, "Error while setting keyspace", cause));
             }

--- a/driver-core/src/main/java/com/datastax/driver/core/DataType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataType.java
@@ -622,7 +622,7 @@ public abstract class DataType {
             return codec(protocolVersion).serialize(value);
         } catch (ClassCastException e) {
             // With collections, the element type has not been checked, so it can throw
-            throw new InvalidTypeException("Invalid type for collection element: " + e.getMessage());
+            throw new InvalidTypeException("Invalid type for collection element: " + e.getMessage(), e);
         }
     }
 
@@ -729,7 +729,7 @@ public abstract class DataType {
             // In theory we couldn't get that if getDataTypeFor does his job correctly,
             // but there is no point in sending an exception that the user won't expect if we're
             // wrong on that.
-            throw new IllegalArgumentException(e.getMessage());
+            throw new IllegalArgumentException(e.getMessage(), e);
         }
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Frame.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Frame.java
@@ -198,9 +198,9 @@ class Frame {
                     // it there).
                     return Frame.create(frame);
                 } catch (CorruptedFrameException e) {
-                    throw new DriverInternalError(e.getMessage());
+                    throw new DriverInternalError(e.getMessage(), e);
                 } catch (TooLongFrameException e) {
-                    throw new DriverInternalError(e.getMessage());
+                    throw new DriverInternalError(e.getMessage(), e);
                 }
             }
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/FrameCompressor.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/FrameCompressor.java
@@ -41,10 +41,10 @@ abstract class FrameCompressor {
                 i = new SnappyCompressor();
             } catch (NoClassDefFoundError e) {
                 i = null;
-                logger.warn("Cannot find Snappy class, you should make sure the Snappy library is in the classpath if you intend to use it. Snappy compression will not be available for the protocol.");
+                logger.warn("Cannot find Snappy class, you should make sure the Snappy library is in the classpath if you intend to use it. Snappy compression will not be available for the protocol.", e);
             } catch (Throwable e) {
                 i = null;
-                logger.warn("Error loading Snappy library ({}). Snappy compression will not be available for the protocol.", e.toString());
+                logger.warn("Error loading Snappy library ({}). Snappy compression will not be available for the protocol.", e.toString(), e);
             }
             instance = i;
         }
@@ -87,7 +87,7 @@ abstract class FrameCompressor {
                 logger.warn("Cannot find LZ4 class, you should make sure the LZ4 library is in the classpath if you intend to use it. LZ4 compression will not be available for the protocol.");
             } catch (Throwable e) {
                 i = null;
-                logger.warn("Error loading LZ4 library ({}). LZ4 compression will not be available for the protocol.", e.toString());
+                logger.warn("Error loading LZ4 library ({}). LZ4 compression will not be available for the protocol.", e.toString(), e);
             }
             instance = i;
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/Host.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Host.java
@@ -93,7 +93,7 @@ public class Host {
         try {
             this.cassandraVersion = VersionNumber.parse(cassandraVersion);
         } catch (IllegalArgumentException e) {
-            logger.warn("Error parsing Cassandra version {}. This shouldn't have happened", cassandraVersion);
+            logger.warn("Error parsing Cassandra version {}. This shouldn't have happened", cassandraVersion, e);
         }
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -472,21 +472,21 @@ class HostConnectionPool implements Connection.Owner {
             return false;
         } catch (ConnectionException e) {
             open.decrementAndGet();
-            logger.debug("Connection error to {} while creating additional connection", host);
+            logger.debug("Connection error to {} while creating additional connection ", host, e);
             return false;
         } catch (AuthenticationException e) {
             // This shouldn't really happen in theory
             open.decrementAndGet();
-            logger.error("Authentication error while creating additional connection (error is: {})", e.getMessage());
+            logger.error("Authentication error while creating additional connection (error is: {}) ", e.getMessage(), e);
             return false;
         } catch (UnsupportedProtocolVersionException e) {
             // This shouldn't happen since we shouldn't have been able to connect in the first place
             open.decrementAndGet();
-            logger.error("UnsupportedProtocolVersionException error while creating additional connection (error is: {})", e.getMessage());
+            logger.error("UnsupportedProtocolVersionException error while creating additional connection (error is: {}) ", e.getMessage(), e);
             return false;
         } catch (ClusterNameMismatchException e) {
             open.decrementAndGet();
-            logger.error("ClusterNameMismatchException error while creating additional connection (error is: {})", e.getMessage());
+            logger.error("ClusterNameMismatchException error while creating additional connection (error is: {}) ", e.getMessage(), e);
             return false;
         }
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -737,6 +737,7 @@ public class Metadata {
                         hostTokens.add(t);
                     } catch (IllegalArgumentException e) {
                         // If we failed parsing that token, skip it
+                        logger.trace("Skipping the token - unable to parse.", e);
                     }
                 }
             }

--- a/driver-core/src/main/java/com/datastax/driver/core/SimpleStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SimpleStatement.java
@@ -96,7 +96,7 @@ public class SimpleStatement extends RegularStatement {
                 serializedValues[i] = DataType.serializeValue(value, protocolVersion);
             } catch (IllegalArgumentException e) {
                 // Catch and rethrow to provide a more helpful error message (one that include which value is bad)
-                throw new IllegalArgumentException(String.format("Value %d of type %s does not correspond to any CQL3 type", i, value.getClass()));
+                throw new IllegalArgumentException(String.format("Value %d of type %s does not correspond to any CQL3 type", i, value.getClass()), e);
             }
         }
         return serializedValues;

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
@@ -696,7 +696,7 @@ abstract class TypeCodec<T> {
             try {
                 return InetAddress.getByAddress(Bytes.getArray(bytes));
             } catch (UnknownHostException e) {
-                throw new InvalidTypeException("Invalid bytes for inet value, got " + bytes.remaining() + " bytes");
+                throw new InvalidTypeException("Invalid bytes for inet value, got " + bytes.remaining() + " bytes", e);
             }
         }
     }
@@ -838,7 +838,7 @@ abstract class TypeCodec<T> {
             try {
                 return UUID.fromString(value);
             } catch (IllegalArgumentException e) {
-                throw new InvalidTypeException(String.format("Cannot parse UUID value from \"%s\"", value));
+                throw new InvalidTypeException(String.format("Cannot parse UUID value from \"%s\"", value), e);
             }
         }
 
@@ -895,7 +895,7 @@ abstract class TypeCodec<T> {
             try {
                 return new BigInteger(value);
             } catch (NumberFormatException e) {
-                throw new InvalidTypeException(String.format("Cannot parse varint value from \"%s\"", value));
+                throw new InvalidTypeException(String.format("Cannot parse varint value from \"%s\"", value), e);
             }
         }
 
@@ -993,7 +993,7 @@ abstract class TypeCodec<T> {
                 }
                 return l;
             } catch (BufferUnderflowException e) {
-                throw new InvalidTypeException("Not enough bytes to deserialize list");
+                throw new InvalidTypeException("Not enough bytes to deserialize list.", e);
             }
         }
     }
@@ -1077,7 +1077,7 @@ abstract class TypeCodec<T> {
                 }
                 return l;
             } catch (BufferUnderflowException e) {
-                throw new InvalidTypeException("Not enough bytes to deserialize a set");
+                throw new InvalidTypeException("Not enough bytes to deserialize a set.", e);
             }
         }
     }
@@ -1184,7 +1184,7 @@ abstract class TypeCodec<T> {
                 }
                 return m;
             } catch (BufferUnderflowException e) {
-                throw new InvalidTypeException("Not enough bytes to deserialize a map");
+                throw new InvalidTypeException("Not enough bytes to deserialize a map.", e);
             }
         }
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
@@ -68,7 +68,7 @@ abstract class Utils {
                 serializedValues[i] = DataType.serializeValue(values.get(i), protocolVersion);
             } catch (IllegalArgumentException e) {
                 // Catch and rethrow to provide a more helpful error message (one that include which value is bad)
-                throw new IllegalArgumentException(String.format("Value %d of type %s does not correspond to any CQL3 type", i, values.get(i).getClass()));
+                throw new IllegalArgumentException(String.format("Value %d of type %s does not correspond to any CQL3 type", i, values.get(i).getClass()), e);
             }
         }
         return serializedValues;

--- a/driver-core/src/main/java/com/datastax/driver/core/utils/Bytes.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/utils/Bytes.java
@@ -19,11 +19,16 @@ import java.lang.reflect.Constructor;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Simple utility methods to make working with bytes (blob) easier.
  */
 public final class Bytes {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(Bytes.class);
+    
     private Bytes() {}
 
     private static final byte[] charToByte = new byte[256];
@@ -57,6 +62,7 @@ public final class Bytes {
             c = String.class.getDeclaredConstructor(int.class, int.class, char[].class);
             c.setAccessible(true);
         } catch (Exception e) {
+            LOGGER.warn("Unable to get String constructor (int, int, char[]).", e);
             c = null;
         }
         stringConstructor = c;

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -367,7 +367,7 @@ public class CCMBridge {
             connectionSuccessful = true;
             logger.debug("Successfully connected");
         } catch (IOException e) {
-            logger.debug("Connection failed");
+            logger.debug("Connection failed", e);
         } finally {
             if (socket != null)
                 try {

--- a/driver-examples/osgi/src/main/java/com/datastax/driver/osgi/impl/MailboxImpl.java
+++ b/driver-examples/osgi/src/main/java/com/datastax/driver/osgi/impl/MailboxImpl.java
@@ -20,6 +20,9 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.UUID;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.datastax.driver.core.*;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.datastax.driver.core.utils.UUIDs;
@@ -35,6 +38,8 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 
 public class MailboxImpl implements MailboxService {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(MailboxImpl.class);
+    
     private static final String TABLE = "mailbox";
 
     private final Session session;
@@ -62,6 +67,8 @@ public class MailboxImpl implements MailboxService {
         try {
             session.execute("USE " + keyspace);
         } catch (InvalidQueryException e) {
+            LOGGER.warn("Error executing query : USE " + keyspace, e);
+            
             session.execute("CREATE KEYSPACE " + keyspace +
                 " with replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}");
 

--- a/driver-examples/stress/src/main/java/com/datastax/driver/stress/BlockingConsumer.java
+++ b/driver-examples/stress/src/main/java/com/datastax/driver/stress/BlockingConsumer.java
@@ -17,13 +17,17 @@ package com.datastax.driver.stress;
 
 import java.util.Iterator;
 
-import com.google.common.util.concurrent.Uninterruptibles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.exceptions.DriverException;
 
 public class BlockingConsumer implements Consumer {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(BlockingConsumer.class);
+    
     private final Runner runner = new Runner();
 
     private final Session session;
@@ -60,7 +64,7 @@ public class BlockingConsumer implements Consumer {
                 while (requests.hasNext())
                     handle(requests.next());
             } catch (DriverException e) {
-                System.err.println("Error during query: " + e.getMessage());
+                LOGGER.warn("Error during query: " + e.getMessage(), e);
             }
         }
 

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/AccessorReflectionMapper.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/AccessorReflectionMapper.java
@@ -42,7 +42,7 @@ class AccessorReflectionMapper<T> extends AccessorMapper<T> {
         try {
             return (T) Proxy.newProxyInstance(daoClass.getClassLoader(), proxyClasses, handler);
         } catch (Exception e) {
-            throw new RuntimeException("Cannot create instance for Accessor interface " + daoClass.getName());
+            throw new RuntimeException("Cannot create instance for Accessor interface " + daoClass.getName(), e);
         }
     }
 

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationChecks.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationChecks.java
@@ -72,7 +72,7 @@ class AnnotationChecks {
             } catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException(String.format("Error while checking frozen types on field %s of %s %s: %s",
                                                                  field.getName(), classDescription,
-                                                                 field.getDeclaringClass().getName(), e.getMessage()));
+                                                                 field.getDeclaringClass().getName(), e.getMessage()), e);
             }
         }
         checkValidComputed(field);

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/ReflectionMapper.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/ReflectionMapper.java
@@ -50,7 +50,7 @@ class ReflectionMapper<T> extends EntityMapper<T> {
         try {
             return entityClass.newInstance();
         } catch (Exception e) {
-            throw new RuntimeException("Can't create an instance of " + entityClass.getName());
+            throw new RuntimeException("Can't create an instance of " + entityClass.getName(), e);
         }
     }
 
@@ -74,7 +74,7 @@ class ReflectionMapper<T> extends EntityMapper<T> {
             try {
                 return readMethod.invoke(entity);
             } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Could not get field '" + fieldName + "'");
+                throw new IllegalArgumentException("Could not get field '" + fieldName + "'", e);
             } catch (Exception e) {
                 throw new IllegalStateException("Unable to access getter for '" + fieldName + "' in " + entity.getClass().getName(), e);
             }
@@ -85,7 +85,7 @@ class ReflectionMapper<T> extends EntityMapper<T> {
             try {
                 writeMethod.invoke(entity, value);
             } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Could not set field '" + fieldName + "' to value '" + value + "'");
+                throw new IllegalArgumentException("Could not set field '" + fieldName + "' to value '" + value + "'", e);
             } catch (Exception e) {
                 throw new IllegalStateException("Unable to access setter for '" + fieldName + "' in " + entity.getClass().getName(), e);
             }
@@ -231,7 +231,7 @@ class ReflectionMapper<T> extends EntityMapper<T> {
                 return new LiteralMapper<T>(field, position, pd, columnCounter);
 
             } catch (IntrospectionException e) {
-                throw new IllegalArgumentException("Cannot find matching getter and setter for field '" + fieldName + "'");
+                throw new IllegalArgumentException("Cannot find matching getter and setter for field '" + fieldName + "'", e);
             }
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1166 - (Exception handlers should preserve the original exception) 
When handling a caught exception, the original exception's message and stack trace should be logged or passed forward

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1166

Please let me know if you have any questions.

Faisal
