### PR TITLE
Code quality fix - Constructors should only call non-overridable methods

### DIFF
--- a/clirr-ignores.xml
+++ b/clirr-ignores.xml
@@ -11,6 +11,41 @@
 <differences>
 
   <difference>
+    <differenceType>7014</differenceType> <!-- method now final -->    
+    <className>com/datastax/driver/core/QueryLogger$DynamicThresholdQueryLogger</className>
+    <method>*setPerHostPercentileLatencyTracker(com.datastax.driver.core.PerHostPercentileTracker)</method>    
+    <justification>It is being called in constructor, so it should be final</justification>
+  </difference>
+  
+  <difference>
+    <differenceType>7014</differenceType> <!-- method now final -->    
+    <className>com/datastax/driver/core/QueryLogger$DynamicThresholdQueryLogger</className>
+    <method>*setSlowQueryLatencyThresholdPercentile(double)</method>    
+    <justification>It is being called in constructor, so it should be final</justification>
+  </difference>
+
+   <difference>
+    <differenceType>7014</differenceType> <!-- method now final -->    
+    <className>com/datastax/driver/core/QueryLogger$ConstantThresholdQueryLogger</className>
+    <method>*setSlowQueryLatencyThresholdMillis(long)</method>    
+    <justification>It is being called in constructor, so it should be final</justification>
+  </difference>
+  
+  <difference>
+    <differenceType>7014</differenceType> <!-- method now final -->    
+    <className>com/datastax/driver/core/querybuilder/Batch</className>
+    <method>*add(com.datastax.driver.core.RegularStatement)</method>    
+    <justification>It is being called in constructor, so it should be final</justification>
+  </difference>
+
+  <difference>
+    <differenceType>7014</differenceType> <!-- method now final -->    
+    <className>com/datastax/driver/core/querybuilder/BuiltStatement</className>
+    <method>*escapeId(java.lang.String)</method>    
+    <justification>It is being called in constructor, so it should be final</justification>
+  </difference>
+  
+  <difference>
     <differenceType>6006</differenceType> <!-- field now final -->
     <className>com/datastax/driver/core/ProtocolVersion</className>
     <field>NEWEST_SUPPORTED</field>

--- a/driver-core/src/main/java/com/datastax/driver/core/QueryLogger.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/QueryLogger.java
@@ -264,7 +264,7 @@ public abstract class QueryLogger implements LatencyTracker {
          *                                        It must be strictly positive.
          * @throws IllegalArgumentException if {@code slowQueryLatencyThresholdMillis <= 0}.
          */
-        public void setSlowQueryLatencyThresholdMillis(long slowQueryLatencyThresholdMillis) {
+        public final void setSlowQueryLatencyThresholdMillis(long slowQueryLatencyThresholdMillis) {
             if (slowQueryLatencyThresholdMillis <= 0)
                 throw new IllegalArgumentException("Invalid slowQueryLatencyThresholdMillis, should be > 0, got " + slowQueryLatencyThresholdMillis);
             this.slowQueryLatencyThresholdMillis = slowQueryLatencyThresholdMillis;
@@ -327,7 +327,7 @@ public abstract class QueryLogger implements LatencyTracker {
          * @param perHostPercentileLatencyTracker the {@link PerHostPercentileTracker} instance to use.
          * @throws IllegalArgumentException if {@code perHostPercentileLatencyTracker == null}.
          */
-        public void setPerHostPercentileLatencyTracker(PerHostPercentileTracker perHostPercentileLatencyTracker) {
+        public final void setPerHostPercentileLatencyTracker(PerHostPercentileTracker perHostPercentileLatencyTracker) {
             if (perHostPercentileLatencyTracker == null)
                 throw new IllegalArgumentException("perHostPercentileLatencyTracker cannot be null");
             this.perHostPercentileLatencyTracker = perHostPercentileLatencyTracker;
@@ -353,7 +353,7 @@ public abstract class QueryLogger implements LatencyTracker {
          *                                        It must be comprised between 0 inclusive and 100 exclusive.
          * @throws IllegalArgumentException if {@code slowQueryLatencyThresholdPercentile < 0 || slowQueryLatencyThresholdPercentile >= 100}.
          */
-        public void setSlowQueryLatencyThresholdPercentile(double slowQueryLatencyThresholdPercentile) {
+        public final void setSlowQueryLatencyThresholdPercentile(double slowQueryLatencyThresholdPercentile) {
             if (slowQueryLatencyThresholdPercentile < 0.0 || slowQueryLatencyThresholdPercentile >= 100.0)
                 throw new IllegalArgumentException("Invalid slowQueryLatencyThresholdPercentile, should be >= 0 and < 100, got " + slowQueryLatencyThresholdPercentile);
             this.slowQueryLatencyThresholdPercentile = slowQueryLatencyThresholdPercentile;

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Batch.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Batch.java
@@ -92,7 +92,7 @@ public class Batch extends BuiltStatement {
      * @throws IllegalArgumentException if counter and non-counter operations
      * are mixed.
      */
-    public Batch add(RegularStatement statement) {
+    public final Batch add(RegularStatement statement) {
         boolean isCounterOp = statement instanceof BuiltStatement && ((BuiltStatement) statement).isCounterOp();
 
         if (this.isCounterOp == null)

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
@@ -59,7 +59,7 @@ public abstract class BuiltStatement extends RegularStatement {
     }
 
     // Same as Metadata.escapeId, but we don't have access to it here.
-    protected String escapeId(String ident) {
+    protected final String escapeId(String ident) {
         // we don't need to escape if it's lowercase and match non-quoted CQL3 ids.
         return lowercaseId.matcher(ident).matches() ? ident : Metadata.quote(ident);
     }

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/Mapper.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/Mapper.java
@@ -99,7 +99,7 @@ public class Mapper<T> {
         this.defaultDeleteOptions = NO_OPTIONS;
     }
 
-    Session session() {
+    final Session session() {
         return manager.getSession();
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1699 - (Constructors should only call non-overridable methods) 
Calling an overridable method from a constructor could result in failures or strange behaviors when instantiating a subclass which overrides the method.

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1699

Please let me know if you have any questions.

Faisal
