### PR TITLE
JAVA-1007: Make SimpleStatement and QueryBuilder "detached" again.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -11,6 +11,7 @@
 - [improvement] JAVA-863: Idempotence propagation in prepared statements.
 - [improvement] JAVA-996: Make CodecRegistry available to ProtocolDecoder.
 - [bug] JAVA-819: Driver shouldn't retry on client timeout if statement is not idempotent.
+- [improvement] JAVA-1007: Make SimpleStatement and QueryBuilder "detached" again.
 
 Merged from 2.1 branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractSession.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractSession.java
@@ -36,7 +36,7 @@ public abstract class AbstractSession implements Session {
      */
     @Override
     public ResultSet execute(String query) {
-        return execute(newSimpleStatement(query));
+        return execute(new SimpleStatement(query));
     }
 
     /**
@@ -44,7 +44,7 @@ public abstract class AbstractSession implements Session {
      */
     @Override
     public ResultSet execute(String query, Object... values) {
-        return execute(newSimpleStatement(query, values));
+        return execute(new SimpleStatement(query, values));
     }
 
     /**
@@ -60,7 +60,7 @@ public abstract class AbstractSession implements Session {
      */
     @Override
     public ResultSetFuture executeAsync(String query) {
-        return executeAsync(newSimpleStatement(query));
+        return executeAsync(new SimpleStatement(query));
     }
 
     /**
@@ -68,23 +68,7 @@ public abstract class AbstractSession implements Session {
      */
     @Override
     public ResultSetFuture executeAsync(String query, Object... values) {
-        return executeAsync(newSimpleStatement(query, values));
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SimpleStatement newSimpleStatement(String query) {
-        return new SimpleStatement(query, this.getCluster());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SimpleStatement newSimpleStatement(String query, Object... values) {
-        return new SimpleStatement(query, this.getCluster(), values);
+        return executeAsync(new SimpleStatement(query, values));
     }
 
     /**
@@ -132,7 +116,9 @@ public abstract class AbstractSession implements Session {
         return Futures.transform(prepared, new Function<PreparedStatement, PreparedStatement>() {
             @Override
             public PreparedStatement apply(PreparedStatement prepared) {
-                ByteBuffer routingKey = statement.getRoutingKey();
+                ProtocolVersion protocolVersion = getCluster().getConfiguration().getProtocolOptions().getProtocolVersion();
+                CodecRegistry codecRegistry = getCluster().getConfiguration().getCodecRegistry();
+                ByteBuffer routingKey = statement.getRoutingKey(protocolVersion, codecRegistry);
                 if (routingKey != null)
                     prepared.setRoutingKey(routingKey);
                 prepared.setConsistencyLevel(statement.getConsistencyLevel());

--- a/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
@@ -81,14 +81,14 @@ public class BatchStatement extends Statement {
         this.batchType = batchType;
     }
 
-    IdAndValues getIdAndValues() {
+    IdAndValues getIdAndValues(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
         IdAndValues idAndVals = new IdAndValues(statements.size());
         for (Statement statement : statements) {
             if(statement instanceof StatementWrapper)
                 statement = ((StatementWrapper) statement).getWrappedStatement();
             if (statement instanceof RegularStatement) {
                 RegularStatement st = (RegularStatement)statement;
-                ByteBuffer[] vals = st.getValues();
+                ByteBuffer[] vals = st.getValues(protocolVersion, codecRegistry);
                 String query = st.getQueryString();
                 idAndVals.ids.add(query);
                 idAndVals.values.add(vals == null ? Collections.<ByteBuffer>emptyList() : Arrays.asList(vals));
@@ -213,11 +213,11 @@ public class BatchStatement extends Statement {
     }
 
     @Override
-    public ByteBuffer getRoutingKey() {
+    public ByteBuffer getRoutingKey(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
         for (Statement statement : statements) {
             if(statement instanceof StatementWrapper)
                 statement = ((StatementWrapper) statement).getWrappedStatement();
-            ByteBuffer rk = statement.getRoutingKey();
+            ByteBuffer rk = statement.getRoutingKey(protocolVersion, codecRegistry);
             if (rk != null)
                 return rk;
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -222,9 +222,13 @@ public class BoundStatement extends Statement implements SettableData<BoundState
      * precedence. If the routing key has been set through {@link PreparedStatement#setRoutingKey} then that is used
      * next. If neither of those are set then it is computed.
      *
+     * @param protocolVersion unused by this implementation (no internal serialization is required to compute the key).
+     * @param codecRegistry unused by this implementation (no internal serialization is required to compute the key).
+     *
      * @return the routing key for this statement or {@code null}.
      */
-    public ByteBuffer getRoutingKey() {
+    @Override
+    public ByteBuffer getRoutingKey(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
         if (this.routingKey != null) {
             return this.routingKey;
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
@@ -88,8 +88,8 @@ import static com.datastax.driver.core.DataType.Name.SET;
  *     <li>all driver types that implement {@link GettableByIndexData}, {@link GettableByNameData},
  *     {@link SettableByIndexData} and/or {@link SettableByNameData}. Namely: {@link Row},
  *     {@link BoundStatement}, {@link UDTValue} and {@link TupleValue};</li>
- *     <li>{@link Session#newSimpleStatement(String, Object...) simple statements};</li>
- *     <li>statements created with the {@link com.datastax.driver.core.querybuilder.QueryBuilder#QueryBuilder(Cluster) Query builder}.</li>
+ *     <li>{@link SimpleStatement(String, Object...) simple statements};</li>
+ *     <li>statements created with the {@link com.datastax.driver.core.querybuilder.QueryBuilder Query builder}.</li>
  * </ul>
  *
  * Example:
@@ -393,7 +393,7 @@ public final class CodecRegistry {
      * Furthermore, this method returns the first matching codec, regardless of its accepted CQL type.
      * It should be reserved for situations where the target CQL type is not available or unknown.
      * In the Java driver, this happens mainly when serializing a value in a
-     * {@link Session#newSimpleStatement(String, Object...) SimpleStatement} or in the
+     * {@link SimpleStatement(String, Object...) SimpleStatement} or in the
      * {@link com.datastax.driver.core.querybuilder.QueryBuilder}, where no CQL type information is available.
      * <p>
      * Codecs returned by this method are <em>NOT</em> cached (see the {@link CodecRegistry top-level documentation}

--- a/driver-core/src/main/java/com/datastax/driver/core/ExecutionInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ExecutionInfo.java
@@ -34,17 +34,19 @@ public class ExecutionInfo {
     private final QueryTrace trace;
     private final ByteBuffer pagingState;
     private final ProtocolVersion protocolVersion;
+    private final CodecRegistry codecRegistry;
     private final Statement statement;
     private volatile boolean schemaInAgreement;
     private final List<String> warnings;
     private final Map<String, ByteBuffer> incomingPayload;
 
-    private ExecutionInfo(List<Host> triedHosts, ConsistencyLevel achievedConsistency, QueryTrace trace, ByteBuffer pagingState, ProtocolVersion protocolVersion, Statement statement, boolean schemaAgreement, List<String> warnings, Map<String, ByteBuffer> incomingPayload) {
+    private ExecutionInfo(List<Host> triedHosts, ConsistencyLevel achievedConsistency, QueryTrace trace, ByteBuffer pagingState, ProtocolVersion protocolVersion, CodecRegistry codecRegistry, Statement statement, boolean schemaAgreement, List<String> warnings, Map<String, ByteBuffer> incomingPayload) {
         this.triedHosts = triedHosts;
         this.achievedConsistency = achievedConsistency;
         this.trace = trace;
         this.pagingState = pagingState;
         this.protocolVersion = protocolVersion;
+        this.codecRegistry = codecRegistry;
         this.statement = statement;
         this.schemaInAgreement = schemaAgreement;
         this.warnings = warnings;
@@ -52,27 +54,27 @@ public class ExecutionInfo {
     }
 
     ExecutionInfo(List<Host> triedHosts) {
-        this(triedHosts, null, null, null, null, null, true, Collections.<String>emptyList(), null);
+        this(triedHosts, null, null, null, null, null, null, true, Collections.<String>emptyList(), null);
     }
 
     ExecutionInfo withTraceAndWarnings(QueryTrace newTrace, List<String> warnings) {
-        return new ExecutionInfo(triedHosts, achievedConsistency, newTrace, pagingState, protocolVersion, statement, schemaInAgreement, warnings, incomingPayload);
+        return new ExecutionInfo(triedHosts, achievedConsistency, newTrace, pagingState, protocolVersion, codecRegistry, statement, schemaInAgreement, warnings, incomingPayload);
     }
 
     ExecutionInfo withAchievedConsistency(ConsistencyLevel newConsistency) {
-        return new ExecutionInfo(triedHosts, newConsistency, trace, pagingState, protocolVersion, statement, schemaInAgreement, warnings, incomingPayload);
+        return new ExecutionInfo(triedHosts, newConsistency, trace, pagingState, protocolVersion, codecRegistry, statement, schemaInAgreement, warnings, incomingPayload);
     }
 
-    ExecutionInfo withPagingState(ByteBuffer pagingState, ProtocolVersion protocolVersion) {
-        return new ExecutionInfo(triedHosts, achievedConsistency, trace, pagingState, protocolVersion, statement, schemaInAgreement, warnings, incomingPayload);
+    ExecutionInfo withPagingState(ByteBuffer pagingState, ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
+        return new ExecutionInfo(triedHosts, achievedConsistency, trace, pagingState, protocolVersion, codecRegistry, statement, schemaInAgreement, warnings, incomingPayload);
     }
 
     ExecutionInfo withStatement(Statement statement) {
-        return new ExecutionInfo(triedHosts, achievedConsistency, trace, pagingState, protocolVersion, statement, schemaInAgreement, warnings, incomingPayload);
+        return new ExecutionInfo(triedHosts, achievedConsistency, trace, pagingState, protocolVersion, codecRegistry, statement, schemaInAgreement, warnings, incomingPayload);
     }
 
     ExecutionInfo withIncomingPayload(Map<String, ByteBuffer> incomingPayload) {
-        return new ExecutionInfo(triedHosts, achievedConsistency, trace, pagingState, protocolVersion, statement, schemaInAgreement, warnings, incomingPayload);
+        return new ExecutionInfo(triedHosts, achievedConsistency, trace, pagingState, protocolVersion, codecRegistry, statement, schemaInAgreement, warnings, incomingPayload);
     }
 
     /**
@@ -175,7 +177,7 @@ public class ExecutionInfo {
     public PagingState getPagingState() {
         if (this.pagingState == null)
             return null;
-        return new PagingState(this.pagingState, this.statement, this.protocolVersion);
+        return new PagingState(this.pagingState, this.statement, this.protocolVersion, this.codecRegistry);
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/Session.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Session.java
@@ -119,7 +119,7 @@ public interface Session extends Closeable {
      *
      * @param query the CQL query to execute.
      * @param values values required for the execution of {@code query}. See
-     * {@link #newSimpleStatement(String, Object...)} for more detail.
+     * {@link SimpleStatement(String, Object...)} for more detail.
      * @return the result of the query. That result will never be null but can
      * be empty (and will be for any non SELECT query).
      *
@@ -181,7 +181,7 @@ public interface Session extends Closeable {
      *
      * @param query the CQL query to execute.
      * @param values values required for the execution of {@code query}. See
-     * {@link #newSimpleStatement(String, Object...)} for more detail.
+     * {@link SimpleStatement(String, Object...)} for more detail.
      * @return a future on the result of the query.
      *
      * @throws UnsupportedFeatureException if version 1 of the protocol
@@ -189,68 +189,6 @@ public interface Session extends Closeable {
      * or you use Cassandra 1.2).
      */
     ResultSetFuture executeAsync(String query, Object... values);
-
-    /**
-     * Builds, but does not execute, a simple statement containing the provided query.
-     *
-     * Use this method when you want to customize certain aspects of the statement before
-     * executing it (fetch size, tracing...); you can then pass the statement to
-     * {@link #execute(Statement)}.
-     *
-     * @param query the CQL query to execute.
-     * @return the simple statement.
-     */
-    SimpleStatement newSimpleStatement(String query);
-
-    /**
-     * Builds, but does not execute, a simple statement containing the provided query with
-     * the provided parameters.
-     *
-     * Use this method when you want to customize certain aspects of the statement before
-     * executing it (fetch size, tracing...); you can then pass the statement to
-     * {@link #execute(Statement)}.
-     * <p>
-     * Parameterized simple statements are useful when you want to execute a
-     * query only once (and thus do not want to resort to prepared statements), but
-     * do not want to convert all column values to string (typically, if you have blob
-     * values, encoding them to a hexadecimal string is not very efficient). In
-     * that case, you can provide a query string with bind marker to this method,
-     * along with the values for those bind variables. When executed, the server will
-     * prepare the provided query, bind the provided values to that prepare statement and
-     * execute the resulting statement. Thus,
-     * <pre>
-     *   session.execute(session.newSimpleStatement(query, value1, value2, value3));
-     * </pre>
-     * is functionally equivalent to
-     * <pre>
-     *   PreparedStatement ps = session.prepare(query);
-     *   session.execute(ps.bind(value1, value2, value3));
-     * </pre>
-     * except that the former version:
-     * <ul>
-     *   <li>Requires only one round-trip to a Cassandra node.</li>
-     *   <li>Does not leave any prepared statement stored in memory (neither client or
-     *   server side) once it has been executed.</li>
-     * </ul>
-     * <p>
-     * Note that the type of the {@code values} provided to this method will
-     * not be validated by the driver as is done by {@link BoundStatement#bind} since
-     * {@code query} is not parsed (and hence the driver cannot know what those value
-     * should be). The codec to serialize each value will be chosen in the codec registry
-     * associated with this session's cluster, based on the value's Java type
-     * (this is the equivalent to calling {@link CodecRegistry#codecFor(Object)}).
-     * If too many or too few values are provided, or if a value is not a valid one for
-     * the variable it is bound to, an
-     * {@link com.datastax.driver.core.exceptions.InvalidQueryException} will be thrown
-     * by Cassandra at execution time. A {@code CodecNotFoundException} may be
-     * thrown by this constructor however, if the codec registry does not know how to
-     * handle one of the values.
-     *
-     * @param query the CQL query to execute.
-     * @param values values required for the execution of {@code query}.
-     * @return the simple statement.
-     */
-    SimpleStatement newSimpleStatement(String query, Object... values);
 
     /**
      * Executes the provided query asynchronously.

--- a/driver-core/src/main/java/com/datastax/driver/core/StatementWrapper.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/StatementWrapper.java
@@ -111,8 +111,8 @@ public abstract class StatementWrapper extends Statement {
     }
 
     @Override
-    public ByteBuffer getRoutingKey() {
-        return wrapped.getRoutingKey();
+    public ByteBuffer getRoutingKey(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
+        return wrapped.getRoutingKey(protocolVersion, codecRegistry);
     }
 
     @Override
@@ -126,8 +126,8 @@ public abstract class StatementWrapper extends Statement {
     }
 
     @Override
-    public Statement setPagingState(PagingState pagingState) {
-        return wrapped.setPagingState(pagingState);
+    public Statement setPagingState(PagingState pagingState, CodecRegistry codecRegistry) {
+        return wrapped.setPagingState(pagingState, codecRegistry);
     }
 
     @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
@@ -22,10 +22,57 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import com.datastax.driver.core.*;
+import com.datastax.driver.core.exceptions.CodecNotFoundException;
 import com.datastax.driver.core.policies.RetryPolicy;
 
 /**
- * Common ancestor to the query builder built statements.
+ * Common ancestor to statements generated with the {@link QueryBuilder}.
+ * <p>
+ * The actual query string will be generated and cached the first time it is requested,
+ * which is either when the driver tries to execute the query, or when you call certain
+ * public methods (for example {@link RegularStatement#getQueryString(CodecRegistry)},
+ * {@link #getObject(int, CodecRegistry)}).
+ * <p>
+ * Whenever possible (and unless you call {@link #setForceNoValues(boolean)}, the builder
+ * will try to handle values passed to its methods as standalone values bound to the query
+ * string with placeholders. For instance:
+ * <pre>
+ *     select().all().from("foo").where(eq("k", "the key"));
+ *     // Is equivalent to:
+ *     new SimpleStatement("SELECT * FROM foo WHERE k=?", "the key");
+ * </pre>
+ * There are a few exceptions to this rule:
+ * <ul>
+ *     <li>for fixed-size number types, the builder can't guess what the actual CQL type
+ *     is. Standalone values are sent to Cassandra in their serialized form, and number
+ *     types aren't all serialized in the same way, so picking the wrong type could
+ *     lead to a query error;</li>
+ *     <li>if the value is a "special" element like a function call, it can't be serialized.
+ *     This also applies to collections mixing special elements and regular objects.</li>
+ * </ul>
+ * In these cases, the builder will inline the value in the query string:
+ * <pre>
+ *     select().all().from("foo").where(eq("k", 1));
+ *     // Is equivalent to:
+ *     new SimpleStatement("SELECT * FROM foo WHERE k=1");
+ * </pre>
+ * One final thing to consider is {@link CodecRegistry custom codecs}. If you've registered
+ * codecs to handle your own Java types against the cluster, then you can pass instances of
+ * those types to query builder methods. But should the builder have to inline those values,
+ * it needs your codecs to {@link TypeCodec#format(Object) convert them to string form}.
+ * That is why some of the public methods of this class take a {@code CodecRegistry} as a
+ * parameter:
+ * <pre>
+ *     BuiltStatement s = select().all().from("foo").where(eq("k", myCustomObject));
+ *     // if we do this codecs will definitely be needed:
+ *     s.forceNoValues(true);
+ *     s.getQueryString(myCodecRegistry);
+ * </pre>
+ * For convenience, there are no-arg versions of those methods that use
+ * {@link CodecRegistry#DEFAULT_INSTANCE}. But you should only use them if you are sure that
+ * no custom values will need to be inlined while building the statement, or if you have
+ * registered your custom codecs with the default registry instance. Otherwise, you will get
+ * a {@link CodecNotFoundException}.
  */
 public abstract class BuiltStatement extends RegularStatement {
 
@@ -34,8 +81,6 @@ public abstract class BuiltStatement extends RegularStatement {
     private final List<ColumnMetadata> partitionKey;
     private final List<Object> routingKeyValues;
     final String keyspace;
-    private final ProtocolVersion protocolVersion;
-    private final CodecRegistry codecRegistry;
 
     private boolean dirty;
     private String cache;
@@ -48,20 +93,16 @@ public abstract class BuiltStatement extends RegularStatement {
     boolean hasBindMarkers;
     private boolean forceNoValues;
 
-    BuiltStatement(String keyspace, ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
+    BuiltStatement(String keyspace) {
         this.partitionKey = null;
         this.routingKeyValues = null;
         this.keyspace = keyspace;
-        this.protocolVersion = protocolVersion;
-        this.codecRegistry = codecRegistry;
     }
 
-    BuiltStatement(TableMetadata tableMetadata, ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
+    BuiltStatement(TableMetadata tableMetadata) {
         this.partitionKey = tableMetadata.getPartitionKey();
         this.routingKeyValues = Arrays.asList(new Object[tableMetadata.getPartitionKey().size()]);
         this.keyspace = escapeId(tableMetadata.getKeyspace().getName());
-        this.protocolVersion = protocolVersion;
-        this.codecRegistry = codecRegistry;
     }
 
     // Same as Metadata.escapeId, but we don't have access to it here.
@@ -71,13 +112,42 @@ public abstract class BuiltStatement extends RegularStatement {
     }
 
     @Override
-    public String getQueryString() {
-        maybeRebuildCache();
+    public String getQueryString(CodecRegistry codecRegistry) {
+        maybeRebuildCache(codecRegistry);
         return cache;
     }
 
     /**
      * Returns the {@code i}th value as the Java type matching its CQL type.
+     *
+     * @param i the index to retrieve.
+     * @param codecRegistry the codec registry that will be used if the statement must be
+     *                      rebuilt in order to determine if it has values, and Java objects
+     *                      must be inlined in the process (see {@link BuiltStatement} for
+     *                      more explanations on why this is so).
+     * @return the value of the {@code i}th value of this statement.
+     *
+     * @throws IllegalStateException if this statement does not have values.
+     * @throws IndexOutOfBoundsException if {@code i} is not a valid index for this object.
+     *
+     * @see #getObject(int)
+     */
+    public Object getObject(int i, CodecRegistry codecRegistry) {
+        maybeRebuildCache(codecRegistry);
+        if (values == null || values.isEmpty())
+            throw new IllegalStateException("This statement does not have values");
+        if (i < 0 || i >= values.size())
+            throw new ArrayIndexOutOfBoundsException(i);
+        return values.get(i);
+    }
+    /**
+     * Returns the {@code i}th value as the Java type matching its CQL type.
+     * <p>
+     * This method calls {@link #getObject(int, CodecRegistry)} with
+     * {@link CodecRegistry#DEFAULT_INSTANCE}.
+     * It's safe to use if you don't use any custom codecs, or if your custom codecs are in
+     * the default registry; otherwise, use the other method and provide the registry that
+     * contains your codecs.
      *
      * @param i the index to retrieve.
      * @return the value of the {@code i}th value of this statement.
@@ -86,15 +156,10 @@ public abstract class BuiltStatement extends RegularStatement {
      * @throws IndexOutOfBoundsException if {@code i} is not a valid index for this object.
      */
     public Object getObject(int i) {
-        maybeRebuildCache();
-        if (values == null || values.isEmpty())
-            throw new IllegalStateException("This statement does not have values");
-        if (i < 0 || i >= values.size())
-            throw new ArrayIndexOutOfBoundsException(i);
-        return values.get(i);
+        return getObject(i, CodecRegistry.DEFAULT_INSTANCE);
     }
 
-    private void maybeRebuildCache() {
+    private void maybeRebuildCache(CodecRegistry codecRegistry) {
         if (!dirty && cache != null)
             return;
 
@@ -102,10 +167,10 @@ public abstract class BuiltStatement extends RegularStatement {
         values = null;
 
         if (hasBindMarkers || forceNoValues) {
-            sb = buildQueryString(null);
+            sb = buildQueryString(null, codecRegistry);
         } else {
             values = new ArrayList<Object>();
-            sb = buildQueryString(values);
+            sb = buildQueryString(values, codecRegistry);
 
             if (values.size() > 65535)
                 throw new IllegalArgumentException("Too many values for built statement, the maximum allowed is 65535");
@@ -134,7 +199,7 @@ public abstract class BuiltStatement extends RegularStatement {
         return sb;
     }
 
-    abstract StringBuilder buildQueryString(List<Object> variables);
+    abstract StringBuilder buildQueryString(List<Object> variables, CodecRegistry codecRegistry);
 
     boolean isCounterOp() {
         return isCounterOp == null ? false : isCounterOp;
@@ -177,26 +242,17 @@ public abstract class BuiltStatement extends RegularStatement {
         }
     }
 
-    CodecRegistry getCodecRegistry(){
-        return codecRegistry;
-    }
-
-    ProtocolVersion getProtocolVersion() {
-        return protocolVersion;
-    }
-
     @Override
-    public ByteBuffer getRoutingKey() {
+    public ByteBuffer getRoutingKey(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
         if (routingKeyValues == null)
             return null;
         ByteBuffer[] routingKeyParts = new ByteBuffer[partitionKey.size()];
-        CodecRegistry codecRegistry = getCodecRegistry();
         for (int i = 0; i < partitionKey.size(); i++) {
             Object value = routingKeyValues.get(i);
             if(value == null)
                 return null;
             TypeCodec<Object> codec = codecRegistry.codecFor(partitionKey.get(i).getType(), value);
-            routingKeyParts[i] = codec.serialize(value, getProtocolVersion());
+            routingKeyParts[i] = codec.serialize(value, protocolVersion);
         }
         return routingKeyParts.length == 1
             ? routingKeyParts[0]
@@ -208,20 +264,15 @@ public abstract class BuiltStatement extends RegularStatement {
         return keyspace;
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Note: Calling this method may trigger the underlying {@link Cluster} initialization.
-     */
     @Override
-    public ByteBuffer[] getValues() {
-        maybeRebuildCache();
-        return values == null ? null : Utils.convert(values.toArray(), getProtocolVersion(), getCodecRegistry());
+    public ByteBuffer[] getValues(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
+        maybeRebuildCache(codecRegistry);
+        return values == null ? null : Utils.convert(values.toArray(), protocolVersion, codecRegistry);
     }
 
     @Override
-    public boolean hasValues() {
-        maybeRebuildCache();
+    public boolean hasValues(CodecRegistry codecRegistry) {
+        maybeRebuildCache(codecRegistry);
         return values != null;
     }
 
@@ -235,17 +286,18 @@ public abstract class BuiltStatement extends RegularStatement {
         return !hasNonIdempotentOps();
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Note: Calling this method may trigger the underlying {@link Cluster} initialization.
-     */
     @Override
     public String toString() {
-        if (forceNoValues) {
-            return getQueryString();
+        try {
+            if (forceNoValues) {
+                return getQueryString();
+            }
+            StringBuilder queryString = buildQueryString(null, CodecRegistry.DEFAULT_INSTANCE);
+            return maybeAddSemicolon(queryString).toString();
+        } catch (CodecNotFoundException e) {
+            // Ugly but we have absolutely no context to get the registry from
+            return String.format("built query (could not generate with default codec registry: %s)", e.getMessage());
         }
-        return maybeAddSemicolon(buildQueryString(null)).toString();
     }
 
     /**
@@ -253,16 +305,16 @@ public abstract class BuiltStatement extends RegularStatement {
      * <p>
      * By default (and unless the protocol version 1 is in use, see below) and
      * for performance reasons, the query builder will not serialize all values
-     * provided to strings. This means that the {@link #getQueryString} may
-     * return a query string with bind markers (where and when is at the
+     * provided to strings. This means that {@link #getQueryString(CodecRegistry)}
+     * may return a query string with bind markers (where and when is at the
      * discretion of the builder) and {@link #getValues} will return the binary
      * values for those markers. This method allows to force the builder to not
-     * generate binary values but rather to serialize them all in the query
+     * generate binary values but rather to inline them all in the query
      * string. In practice, this means that if you call {@code
      * setForceNoValues(true)}, you are guaranteed that {@code getValues()} will
      * return {@code null} and that the string returned by {@code
-     * getQueryString()} will contain no other bind markers than the one
-     * inputted by the user.
+     * getQueryString()} will contain no other bind markers than the ones
+     * specified by the user.
      * <p>
      * If the native protocol version 1 is in use, the driver will default
      * to not generating values since those are not supported by that version of
@@ -290,23 +342,23 @@ public abstract class BuiltStatement extends RegularStatement {
         T statement;
 
         ForwardingStatement(T statement) {
-            super((String)null, statement.getProtocolVersion(), statement.getCodecRegistry());
+            super((String)null);
             this.statement = statement;
         }
 
         @Override
-        public String getQueryString() {
-            return statement.getQueryString();
+        public String getQueryString(CodecRegistry codecRegistry) {
+            return statement.getQueryString(codecRegistry);
         }
 
         @Override
-        StringBuilder buildQueryString(List<Object> values) {
-            return statement.buildQueryString(values);
+        StringBuilder buildQueryString(List<Object> values, CodecRegistry codecRegistry) {
+            return statement.buildQueryString(values, codecRegistry);
         }
 
         @Override
-        public ByteBuffer getRoutingKey() {
-            return statement.getRoutingKey();
+        public ByteBuffer getRoutingKey(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
+            return statement.getRoutingKey(protocolVersion, codecRegistry);
         }
 
         @Override
@@ -370,8 +422,8 @@ public abstract class BuiltStatement extends RegularStatement {
         }
 
         @Override
-        public ByteBuffer[] getValues() {
-            return statement.getValues();
+        public ByteBuffer[] getValues(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
+            return statement.getValues(protocolVersion, codecRegistry);
         }
 
         @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
@@ -19,9 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.CodecRegistry;
-import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.TableMetadata;
 
 /**
@@ -35,23 +33,22 @@ public class Insert extends BuiltStatement {
     private final Options usings;
     private boolean ifNotExists;
 
-    Insert(ProtocolVersion protocolVersion, CodecRegistry codecRegistry, String keyspace, String table) {
-        super(keyspace, protocolVersion, codecRegistry);
+    Insert(String keyspace, String table) {
+        super(keyspace);
         this.table = table;
         this.usings = new Options(this);
     }
 
-    Insert(ProtocolVersion protocolVersion, CodecRegistry codecRegistry, TableMetadata table) {
-        super(table, protocolVersion, codecRegistry);
+    Insert(TableMetadata table) {
+        super(table);
         this.table = escapeId(table.getName());
         this.usings = new Options(this);
     }
 
     @Override
-    StringBuilder buildQueryString(List<Object> variables) {
+    StringBuilder buildQueryString(List<Object> variables, CodecRegistry codecRegistry) {
         StringBuilder builder = new StringBuilder();
 
-        CodecRegistry codecRegistry = getCodecRegistry();
         builder.append("INSERT INTO ");
         if (keyspace != null)
             Utils.appendName(keyspace, builder).append('.');

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
@@ -38,41 +38,7 @@ import com.datastax.driver.core.exceptions.InvalidQueryException;
  */
 public final class QueryBuilder {
 
-    private final ProtocolVersion protocolVersion;
-    private final CodecRegistry codecRegistry;
-
-    /**
-     * Create a new QueryBuilder instance and associate it with the given {@link Cluster}.
-     * Note: if the {@link Cluster} is not yet initialized, this method
-     * will trigger its initialization.
-     *
-     * @param cluster The {@link Cluster} instance this object should be attached to.
-     */
-    public QueryBuilder(Cluster cluster) {
-        this(getProtocolVersion(cluster), cluster.getConfiguration().getCodecRegistry());
-    }
-
-    private static ProtocolVersion getProtocolVersion(Cluster cluster) {
-        cluster.init();
-        return cluster.getConfiguration().getProtocolOptions().getProtocolVersion();
-    }
-
-    /**
-     * Create a "disconnected" QueryBuilder instance (<b>you should prefer
-     * {@link #QueryBuilder(Cluster)} whenever possible</b>).
-     * <p>
-     * This constructor is only exposed for situations where you don't have a {@code Cluster}
-     * instance available. If you use this constructor, and use statements built from it
-     * with a {@code Cluster} later, you won't be able to rely on custom codecs registered
-     * against the cluster, or you might get errors if the protocol versions don't match.
-     *
-     * @param protocolVersion the protocol version.
-     * @param codecRegistry the codec registry.
-     */
-    public QueryBuilder(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
-        this.protocolVersion = protocolVersion;
-        this.codecRegistry = codecRegistry;
-    }
+    private QueryBuilder() {}
 
     /**
      * Start building a new SELECT query that selects the provided names.
@@ -83,8 +49,8 @@ public final class QueryBuilder {
      * @return an in-construction SELECT query (you will need to provide at
      * least a FROM clause to complete the query).
      */
-    public Select.Builder select(String... columns) {
-        return new Select.Builder(protocolVersion, codecRegistry, Arrays.asList((Object[])columns));
+    public static Select.Builder select(String... columns) {
+        return new Select.Builder(Arrays.asList((Object[])columns));
     }
 
     /**
@@ -93,9 +59,9 @@ public final class QueryBuilder {
      * @return an in-construction SELECT query (you will need to provide a
      * column selection and at least a FROM clause to complete the query).
      */
-    public Select.Selection select() {
+    public static Select.Selection select() {
         // Note: the fact we return Select.Selection as return type is on purpose.
-        return new Select.SelectionOrAlias(protocolVersion, codecRegistry);
+        return new Select.SelectionOrAlias();
     }
 
     /**
@@ -104,8 +70,8 @@ public final class QueryBuilder {
      * @param table the name of the table in which to insert.
      * @return an in-construction INSERT query.
      */
-    public Insert insertInto(String table) {
-        return new Insert(protocolVersion, codecRegistry, null, table);
+    public static Insert insertInto(String table) {
+        return new Insert(null, table);
     }
 
     /**
@@ -115,8 +81,8 @@ public final class QueryBuilder {
      * @param table the name of the table to insert into.
      * @return an in-construction INSERT query.
      */
-    public Insert insertInto(String keyspace, String table) {
-        return new Insert(protocolVersion, codecRegistry, keyspace, table);
+    public static Insert insertInto(String keyspace, String table) {
+        return new Insert(keyspace, table);
     }
 
     /**
@@ -125,8 +91,8 @@ public final class QueryBuilder {
      * @param table the name of the table to insert into.
      * @return an in-construction INSERT query.
      */
-    public Insert insertInto(TableMetadata table) {
-        return new Insert(protocolVersion, codecRegistry, table);
+    public static Insert insertInto(TableMetadata table) {
+        return new Insert(table);
     }
 
     /**
@@ -136,8 +102,8 @@ public final class QueryBuilder {
      * @return an in-construction UPDATE query (at least a SET and a WHERE
      * clause needs to be provided to complete the query).
      */
-    public Update update(String table) {
-        return new Update(protocolVersion, codecRegistry, null, table);
+    public static Update update(String table) {
+        return new Update(null, table);
     }
 
     /**
@@ -148,8 +114,8 @@ public final class QueryBuilder {
      * @return an in-construction UPDATE query (at least a SET and a WHERE
      * clause needs to be provided to complete the query).
      */
-    public Update update(String keyspace, String table) {
-        return new Update(protocolVersion, codecRegistry, keyspace, table);
+    public static Update update(String keyspace, String table) {
+        return new Update(keyspace, table);
     }
 
     /**
@@ -159,8 +125,8 @@ public final class QueryBuilder {
      * @return an in-construction UPDATE query (at least a SET and a WHERE
      * clause needs to be provided to complete the query).
      */
-    public Update update(TableMetadata table) {
-        return new Update(protocolVersion, codecRegistry, table);
+    public static Update update(TableMetadata table) {
+        return new Update(table);
     }
 
     /**
@@ -170,8 +136,8 @@ public final class QueryBuilder {
      * @return an in-construction DELETE query (At least a FROM and a WHERE
      * clause needs to be provided to complete the query).
      */
-    public Delete.Builder delete(String... columns) {
-        return new Delete.Builder(protocolVersion, codecRegistry, columns);
+    public static Delete.Builder delete(String... columns) {
+        return new Delete.Builder(columns);
     }
 
     /**
@@ -181,8 +147,8 @@ public final class QueryBuilder {
      * column selection and at least a FROM and a WHERE clause to complete the
      * query).
      */
-    public Delete.Selection delete() {
-        return new Delete.Selection(protocolVersion, codecRegistry);
+    public static Delete.Selection delete() {
+        return new Delete.Selection();
     }
 
     /**
@@ -198,8 +164,8 @@ public final class QueryBuilder {
      * @param statements the statements to batch.
      * @return a new {@code RegularStatement} that batch {@code statements}.
      */
-    public Batch batch(RegularStatement... statements) {
-        return new Batch(protocolVersion, codecRegistry, statements, true);
+    public static Batch batch(RegularStatement... statements) {
+        return new Batch(statements, true);
     }
 
     /**
@@ -219,8 +185,8 @@ public final class QueryBuilder {
      * @return a new {@code RegularStatement} that batch {@code statements} without
      * using the batch log.
      */
-    public Batch unloggedBatch(RegularStatement... statements) {
-        return new Batch(protocolVersion, codecRegistry, statements, false);
+    public static Batch unloggedBatch(RegularStatement... statements) {
+        return new Batch(statements, false);
     }
 
     /**
@@ -229,8 +195,8 @@ public final class QueryBuilder {
      * @param table the name of the table to truncate.
      * @return the truncation query.
      */
-    public Truncate truncate(String table) {
-        return new Truncate(protocolVersion, codecRegistry, null, table);
+    public static Truncate truncate(String table) {
+        return new Truncate(null, table);
     }
 
     /**
@@ -240,8 +206,8 @@ public final class QueryBuilder {
      * @param table the name of the table to truncate.
      * @return the truncation query.
      */
-    public Truncate truncate(String keyspace, String table) {
-        return new Truncate(protocolVersion, codecRegistry, keyspace, table);
+    public static Truncate truncate(String keyspace, String table) {
+        return new Truncate(keyspace, table);
     }
 
     /**
@@ -250,8 +216,8 @@ public final class QueryBuilder {
      * @param table the table to truncate.
      * @return the truncation query.
      */
-    public Truncate truncate(TableMetadata table) {
-        return new Truncate(protocolVersion, codecRegistry, table);
+    public static Truncate truncate(TableMetadata table) {
+        return new Truncate(table);
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Truncate.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Truncate.java
@@ -17,9 +17,7 @@ package com.datastax.driver.core.querybuilder;
 
 import java.util.List;
 
-import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.CodecRegistry;
-import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.TableMetadata;
 
 /**
@@ -29,18 +27,18 @@ public class Truncate extends BuiltStatement {
 
     private final String table;
 
-    Truncate(ProtocolVersion protocolVersion, CodecRegistry codecRegistry, String keyspace, String table) {
-        super(keyspace, protocolVersion, codecRegistry);
+    Truncate(String keyspace, String table) {
+        super(keyspace);
         this.table = table;
     }
 
-    Truncate(ProtocolVersion protocolVersion, CodecRegistry codecRegistry, TableMetadata table) {
-        super(table, protocolVersion, codecRegistry);
+    Truncate(TableMetadata table) {
+        super(table);
         this.table = escapeId(table.getName());
     }
 
     @Override
-    protected StringBuilder buildQueryString(List<Object> variables) {
+    protected StringBuilder buildQueryString(List<Object> variables, CodecRegistry codecRegistry) {
         StringBuilder builder = new StringBuilder();
 
         builder.append("TRUNCATE ");

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
@@ -18,9 +18,7 @@ package com.datastax.driver.core.querybuilder;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.CodecRegistry;
-import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.TableMetadata;
 import com.datastax.driver.core.querybuilder.Assignment.CounterAssignment;
 
@@ -36,8 +34,8 @@ public class Update extends BuiltStatement {
     private final Conditions conditions;
     private boolean ifExists;
 
-    Update(ProtocolVersion protocolVersion, CodecRegistry codecRegistry, String keyspace, String table) {
-        super(keyspace, protocolVersion, codecRegistry);
+    Update(String keyspace, String table) {
+        super(keyspace);
         this.table = table;
         this.assignments = new Assignments(this);
         this.where = new Where(this);
@@ -46,8 +44,8 @@ public class Update extends BuiltStatement {
         this.ifExists = false;
     }
 
-    Update(ProtocolVersion protocolVersion, CodecRegistry codecRegistry, TableMetadata table) {
-        super(table, protocolVersion, codecRegistry);
+    Update(TableMetadata table) {
+        super(table);
         this.table = escapeId(table.getName());
         this.assignments = new Assignments(this);
         this.where = new Where(this);
@@ -57,7 +55,7 @@ public class Update extends BuiltStatement {
     }
 
     @Override
-    StringBuilder buildQueryString(List<Object> variables) {
+    StringBuilder buildQueryString(List<Object> variables, CodecRegistry codecRegistry) {
         StringBuilder builder = new StringBuilder();
 
         builder.append("UPDATE ");
@@ -65,7 +63,6 @@ public class Update extends BuiltStatement {
             Utils.appendName(keyspace, builder).append('.');
         Utils.appendName(table, builder);
 
-        CodecRegistry codecRegistry = getCodecRegistry();
         if (!usings.usings.isEmpty()) {
             builder.append(" USING ");
             Utils.joinAndAppend(builder, codecRegistry, " AND ", usings.usings, variables);

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/SchemaStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/SchemaStatement.java
@@ -21,6 +21,8 @@ import java.util.List;
 
 import com.google.common.base.Strings;
 
+import com.datastax.driver.core.CodecRegistry;
+import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.RegularStatement;
 
 /**
@@ -42,7 +44,7 @@ public abstract class SchemaStatement extends RegularStatement {
     abstract String buildInternal();
 
     @Override
-    public String getQueryString() {
+    public String getQueryString(CodecRegistry codecRegistry) {
         if (cache == null) {
             cache = buildInternal();
         }
@@ -50,13 +52,13 @@ public abstract class SchemaStatement extends RegularStatement {
     }
 
     @Override
-    public ByteBuffer[] getValues() {
+    public ByteBuffer[] getValues(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
         // DDL statements never have values
         return new ByteBuffer[0];
     }
 
     @Override
-    public boolean hasValues() {
+    public boolean hasValues(CodecRegistry codecRegistry) {
         return false;
     }
 
@@ -67,8 +69,14 @@ public abstract class SchemaStatement extends RegularStatement {
         return null;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @param protocolVersion unused by this implementation (the key is always null for schema statements).
+     * @param codecRegistry unused by this implementation (the key is always null for schema statements).
+     */
     @Override
-    public ByteBuffer getRoutingKey() {
+    public ByteBuffer getRoutingKey(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
         return null; // there is no token awareness for DDL statements
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/AbstractPoliciesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AbstractPoliciesTest.java
@@ -24,12 +24,12 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-import com.datastax.driver.core.querybuilder.QueryBuilder;
-
 import static com.datastax.driver.core.TestUtils.CREATE_KEYSPACE_GENERIC_FORMAT;
 import static com.datastax.driver.core.TestUtils.CREATE_KEYSPACE_SIMPLE_FORMAT;
 import static com.datastax.driver.core.TestUtils.SIMPLE_KEYSPACE;
 import static com.datastax.driver.core.TestUtils.SIMPLE_TABLE;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.batch;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
 
 public abstract class AbstractPoliciesTest {
     private static final boolean DEBUG = false;
@@ -184,11 +184,11 @@ public abstract class AbstractPoliciesTest {
         for (int i = 0; i < n; ++i)
             if (batch)
                 // BUG: WriteType == SIMPLE
-                c.session.execute(new QueryBuilder(c.cluster).batch()
-                        .add(new QueryBuilder(c.cluster).insertInto(SIMPLE_TABLE).values(new String[]{ "k", "i"}, new Object[]{ 0, 0 }))
+                c.session.execute(batch()
+                        .add(insertInto(SIMPLE_TABLE).values(new String[]{ "k", "i"}, new Object[]{ 0, 0 }))
                         .setConsistencyLevel(cl));
             else
-                c.session.execute(c.session.newSimpleStatement(String.format("INSERT INTO %s(k, i) VALUES (0, 0)", SIMPLE_TABLE)).setConsistencyLevel(cl));
+                c.session.execute(new SimpleStatement(String.format("INSERT INTO %s(k, i) VALUES (0, 0)", SIMPLE_TABLE)).setConsistencyLevel(cl));
     }
 
 
@@ -216,7 +216,7 @@ public abstract class AbstractPoliciesTest {
             ByteBuffer routingKey = ByteBuffer.allocate(4);
             routingKey.putInt(0, 0);
             for (int i = 0; i < n; ++i)
-                addCoordinator(c.session.execute(c.session.newSimpleStatement(String.format("SELECT * FROM %s WHERE k = 0", SIMPLE_TABLE)).setRoutingKey(routingKey).setConsistencyLevel(cl)));
+                addCoordinator(c.session.execute(new SimpleStatement(String.format("SELECT * FROM %s WHERE k = 0", SIMPLE_TABLE)).setRoutingKey(routingKey).setConsistencyLevel(cl)));
         }
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncResultSetTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncResultSetTest.java
@@ -57,7 +57,7 @@ public class AsyncResultSetTest extends CCMBridge.PerClassSingleNodeCluster {
         for (int i = 0; i < totalCount; i++)
             session.execute(String.format("insert into ints (i) values (%d)", i));
 
-        Statement statement = session.newSimpleStatement("select * from ints").setFetchSize(fetchSize);
+        Statement statement = new SimpleStatement("select * from ints").setFetchSize(fetchSize);
         ResultsAccumulator results = new ResultsAccumulator();
 
         ListenableFuture<ResultSet> future = Futures.transform(

--- a/driver-core/src/test/java/com/datastax/driver/core/BatchStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/BatchStatementTest.java
@@ -40,7 +40,7 @@ public class BatchStatementTest extends CCMBridge.PerClassSingleNodeCluster {
 
             BatchStatement batch = new BatchStatement();
 
-            batch.add(session.newSimpleStatement("INSERT INTO test (k, v) VALUES (?, ?)", "key1", 0));
+            batch.add(new SimpleStatement("INSERT INTO test (k, v) VALUES (?, ?)", "key1", 0));
             batch.add(st.bind("key1", 1));
             batch.add(st.bind("key2", 0));
 
@@ -87,7 +87,7 @@ public class BatchStatementTest extends CCMBridge.PerClassSingleNodeCluster {
 
             BatchStatement batch = new BatchStatement();
 
-            batch.add(session.newSimpleStatement("INSERT INTO test (k, v) VALUES (?, ?)", "key1", 0));
+            batch.add(new SimpleStatement("INSERT INTO test (k, v) VALUES (?, ?)", "key1", 0));
             batch.add(st.bind("key1", 1));
             batch.add(st.bind("key1", 2));
 

--- a/driver-core/src/test/java/com/datastax/driver/core/ConditionalUpdateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ConditionalUpdateTest.java
@@ -78,7 +78,7 @@ public class ConditionalUpdateTest extends CCMBridge.PerClassSingleNodeCluster {
 
         // This is really contrived, we just want to cover the code path in ArrayBackedResultSet#MultiPage.
         // Currently CAS update results are never multipage, so it's hard to come up with a meaningful example.
-        ResultSet rs = session.execute(session.newSimpleStatement("SELECT * FROM test WHERE k1 = 1").setFetchSize(1));
+        ResultSet rs = session.execute(new SimpleStatement("SELECT * FROM test WHERE k1 = 1").setFetchSize(1));
 
         assertTrue(rs.wasApplied());
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
@@ -106,7 +106,7 @@ public class DataTypeIntegrationTest extends CCMBridge.PerClassSingleNodeCluster
                     session.execute(query);
                     break;
                 case SIMPLE_WITH_PARAM:
-                    SimpleStatement statement = session.newSimpleStatement(table.insertStatement, table.sampleValue);
+                    SimpleStatement statement = new SimpleStatement(table.insertStatement, table.sampleValue);
                     checkGetValuesReturnsSerializedValue(protocolVersion, statement, table);
                     session.execute(statement);
                     break;
@@ -157,7 +157,7 @@ public class DataTypeIntegrationTest extends CCMBridge.PerClassSingleNodeCluster
 
     public void checkGetValuesReturnsSerializedValue(ProtocolVersion protocolVersion, SimpleStatement statement, TestTable table) {
         CodecRegistry codecRegistry = cluster.getConfiguration().getCodecRegistry();
-        ByteBuffer[] values = statement.getValues();
+        ByteBuffer[] values = statement.getValues(protocolVersion, codecRegistry);
         assertThat(values.length).isEqualTo(1);
         assertThat(values[0])
             .as("Value not serialized as expected for " + table.sampleValue)

--- a/driver-core/src/test/java/com/datastax/driver/core/FetchingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/FetchingTest.java
@@ -43,7 +43,7 @@ public class FetchingTest extends CCMBridge.PerClassSingleNodeCluster {
             for (int i = 0; i < 100; i++)
                 session.execute(String.format("INSERT INTO test (k, v) VALUES ('%s', %d)", key, i));
 
-            SimpleStatement st = session.newSimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", key));
+            SimpleStatement st = new SimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", key));
             st.setFetchSize(5); // Ridiculously small fetch size for testing purpose. Don't do at home.
             ResultSet rs = session.execute(st);
 

--- a/driver-core/src/test/java/com/datastax/driver/core/MetricsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MetricsTest.java
@@ -82,7 +82,7 @@ public class MetricsTest extends CCMBridge.PerClassSingleNodeCluster {
         retryDecision = RetryDecision.retry(ConsistencyLevel.ONE);
 
         // We only have one node, this will throw an unavailable exception
-        Statement statement = session.newSimpleStatement("SELECT v FROM test WHERE k = 1").setConsistencyLevel(ConsistencyLevel.TWO);
+        Statement statement = new SimpleStatement("SELECT v FROM test WHERE k = 1").setConsistencyLevel(ConsistencyLevel.TWO);
         session.execute(statement);
 
         Errors errors = cluster.getMetrics().getErrorMetrics();

--- a/driver-core/src/test/java/com/datastax/driver/core/PagingStateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PagingStateTest.java
@@ -55,12 +55,12 @@ public class PagingStateTest extends CCMBridge.PerClassSingleNodeCluster {
      */
     @Test(groups = "short")
     public void should_complete_when_using_paging_state() {
-        SimpleStatement st = session.newSimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
+        SimpleStatement st = new SimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
         ResultSet result = session.execute(st.setFetchSize(20));
         int pageSize = result.getAvailableWithoutFetching();
         String savedPagingStateString = result.getExecutionInfo().getPagingState().toString();
 
-        st = session.newSimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
+        st = new SimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
         result = session.execute(st.setFetchSize(20).setPagingState(PagingState.fromString(savedPagingStateString)));
 
         //We have the result starting from the next page we stopped
@@ -85,7 +85,7 @@ public class PagingStateTest extends CCMBridge.PerClassSingleNodeCluster {
         boolean setWithFalseContent = false;
         boolean setWithWrongStatement = false;
 
-        SimpleStatement st = session.newSimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
+        SimpleStatement st = new SimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
         ResultSet result = session.execute(st.setFetchSize(20));
 
         PagingState savedPagingState = result.getExecutionInfo().getPagingState();
@@ -106,7 +106,7 @@ public class PagingStateTest extends CCMBridge.PerClassSingleNodeCluster {
         }
 
         // Changing the statement
-        st = session.newSimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", "paging"));
+        st = new SimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", "paging"));
         try {
             st.setFetchSize(20).setPagingState(PagingState.fromString(savedPagingStateString));
         } catch (PagingStateException e) {
@@ -170,7 +170,7 @@ public class PagingStateTest extends CCMBridge.PerClassSingleNodeCluster {
      */
     @Test(groups = "short")
     public void should_return_no_rows_when_paged_to_end() {
-        SimpleStatement st = session.newSimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
+        SimpleStatement st = new SimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
         ResultSet result = session.execute(st.setFetchSize(20));
 
         // Consume enough of the iterator to cause all the results to be paged in.
@@ -181,7 +181,7 @@ public class PagingStateTest extends CCMBridge.PerClassSingleNodeCluster {
 
         String savedPagingStateString = result.getExecutionInfo().getPagingState().toString();
 
-        st = session.newSimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
+        st = new SimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
         result = session.execute(st.setFetchSize(20).setPagingState(PagingState.fromString(savedPagingStateString)));
 
         assertThat(result.one()).isNull();
@@ -218,12 +218,12 @@ public class PagingStateTest extends CCMBridge.PerClassSingleNodeCluster {
      */
     @Test(groups = "short")
     public void should_complete_when_using_unsafe_paging_state() {
-        SimpleStatement st = session.newSimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
+        SimpleStatement st = new SimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
         ResultSet result = session.execute(st.setFetchSize(20));
         int pageSize = result.getAvailableWithoutFetching();
         byte[] savedPagingState = result.getExecutionInfo().getPagingStateUnsafe();
 
-        st = session.newSimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
+        st = new SimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
         result = session.execute(st.setFetchSize(20).setPagingStateUnsafe(savedPagingState));
 
         //We have the result starting from the next page we stopped

--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
@@ -341,7 +341,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
     @Test(groups = "short")
     public void prepareStatementInheritPropertiesTest() {
 
-        RegularStatement toPrepare = session.newSimpleStatement("SELECT * FROM test WHERE k=?");
+        RegularStatement toPrepare = new SimpleStatement("SELECT * FROM test WHERE k=?");
         toPrepare.setConsistencyLevel(ConsistencyLevel.QUORUM);
         toPrepare.enableTracing();
 
@@ -373,7 +373,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
             BatchStatement bs = new BatchStatement();
             bs.add(ps1.bind("one", "foo"));
             bs.add(ps2.bind("two"));
-            bs.add(session.newSimpleStatement("INSERT INTO " + SIMPLE_TABLE2 + " (k, v) VALUES ('three', 'foobar')"));
+            bs.add(new SimpleStatement("INSERT INTO " + SIMPLE_TABLE2 + " (k, v) VALUES ('three', 'foobar')"));
 
             session.execute(bs);
 
@@ -400,7 +400,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
 
         PreparedStatement ps = session.prepare(String.format("INSERT INTO %s.foo (i) VALUES (?)", keyspace));
         BoundStatement bs = ps.bind(1);
-        assertThat(bs.getRoutingKey()).isNotNull();
+        assertThat(bs.getRoutingKey(ProtocolVersion.NEWEST_SUPPORTED, CodecRegistry.DEFAULT_INSTANCE)).isNotNull();
     }
 
     @Test(groups = "short")
@@ -413,7 +413,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
 
         PreparedStatement ps = session.prepare("INSERT INTO \"Test\".\"Foo\" (i) VALUES (?)");
         BoundStatement bs = ps.bind(1);
-        assertThat(bs.getRoutingKey()).isNotNull();
+        assertThat(bs.getRoutingKey(ProtocolVersion.NEWEST_SUPPORTED, CodecRegistry.DEFAULT_INSTANCE)).isNotNull();
     }
 
     @Test(groups = "short", expectedExceptions = InvalidQueryException.class)
@@ -517,7 +517,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
         st2.setString(0, "foo");
         // i is UNSET
         session.execute(st2);
-        Statement st3 = session.newSimpleStatement("SELECT i from " + SIMPLE_TABLE + " where k = 'foo'");
+        Statement st3 = new SimpleStatement("SELECT i from " + SIMPLE_TABLE + " where k = 'foo'");
         st3.enableTracing();
         ResultSet rows = session.execute(st3);
         assertThat(rows.one().getInt("i")).isEqualTo(1234);
@@ -546,7 +546,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
         session.execute(bound);
 
         ResultSet rows = session.execute(
-            session.newSimpleStatement("SELECT i from " + SIMPLE_TABLE + " where k = 'foo'")
+            new SimpleStatement("SELECT i from " + SIMPLE_TABLE + " where k = 'foo'")
                 .enableTracing());
 
         assertThat(rows.one().isNull("i"));
@@ -575,7 +575,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
         session.execute(bound);
 
         ResultSet rows = session.execute(
-            session.newSimpleStatement("SELECT i from " + SIMPLE_TABLE + " where k = 'foo'")
+            new SimpleStatement("SELECT i from " + SIMPLE_TABLE + " where k = 'foo'")
                 .enableTracing());
 
         assertThat(rows.one().isNull("i"));
@@ -604,7 +604,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
         st2.setString(0, "foo");
         // i is UNSET
         session.execute(new BatchStatement().add(st2));
-        Statement st3 = session.newSimpleStatement("SELECT i from " + SIMPLE_TABLE + " where k = 'foo'");
+        Statement st3 = new SimpleStatement("SELECT i from " + SIMPLE_TABLE + " where k = 'foo'");
         st3.enableTracing();
         ResultSet rows = session.execute(st3);
         assertThat(rows.one().getInt("i")).isEqualTo(1234);
@@ -626,7 +626,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
         st1.setString(0, "foo");
         st1.setToNull(1);
         session.execute(st1);
-        Statement st2 = session.newSimpleStatement("SELECT i from " + SIMPLE_TABLE + " where k = 'foo'");
+        Statement st2 = new SimpleStatement("SELECT i from " + SIMPLE_TABLE + " where k = 'foo'");
         st2.enableTracing();
         ResultSet rows = session.execute(st2);
         assertThat(rows.one().isNull(0)).isTrue();
@@ -649,7 +649,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
         st1.setString(0, "foo");
         st1.setToNull(1);
         session.execute(new BatchStatement().add(st1));
-        Statement st2 = session.newSimpleStatement("SELECT i from " + SIMPLE_TABLE + " where k = 'foo'");
+        Statement st2 = new SimpleStatement("SELECT i from " + SIMPLE_TABLE + " where k = 'foo'");
         st2.enableTracing();
         ResultSet rows = session.execute(st2);
         assertThat(rows.one().isNull(0)).isTrue();
@@ -673,7 +673,7 @@ public class PreparedStatementTest extends CCMBridge.PerClassSingleNodeCluster {
         PreparedStatement prepared;
         BoundStatement bound;
 
-        statement = session.newSimpleStatement(String.format("SELECT * FROM %s.idempotencetest WHERE i = ?", keyspace));
+        statement = new SimpleStatement(String.format("SELECT * FROM %s.idempotencetest WHERE i = ?", keyspace));
 
         prepared = session.prepare(statement);
         bound = prepared.bind(1);

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
@@ -274,7 +274,7 @@ public class QueryLoggerTest extends CCMBridge.PerClassSingleNodeCluster {
         normal.setLevel(DEBUG);
         Statement unknownStatement = new Statement() {
             @Override
-            public ByteBuffer getRoutingKey() {
+            public ByteBuffer getRoutingKey(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
                 return null;
             }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryTimestampTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryTimestampTest.java
@@ -62,7 +62,7 @@ public class QueryTimestampTest extends CCMBridge.PerClassSingleNodeCluster {
     public void should_use_CQL_timestamp_over_anything_else() {
         timestampFromGenerator = 10;
         String query = "INSERT INTO foo (k, v) VALUES (1, 1) USING TIMESTAMP 20";
-        session.execute(session.newSimpleStatement(query).setDefaultTimestamp(30));
+        session.execute(new SimpleStatement(query).setDefaultTimestamp(30));
 
         long writeTime = session.execute("SELECT writeTime(v) FROM foo WHERE k = 1").one().getLong(0);
         assertEquals(writeTime, 20);
@@ -72,7 +72,7 @@ public class QueryTimestampTest extends CCMBridge.PerClassSingleNodeCluster {
     public void should_use_statement_timestamp_over_generator() {
         timestampFromGenerator = 10;
         String query = "INSERT INTO foo (k, v) VALUES (1, 1)";
-        session.execute(session.newSimpleStatement(query).setDefaultTimestamp(30));
+        session.execute(new SimpleStatement(query).setDefaultTimestamp(30));
 
         long writeTime = session.execute("SELECT writeTime(v) FROM foo WHERE k = 1").one().getLong(0);
         assertEquals(writeTime, 30);
@@ -102,8 +102,8 @@ public class QueryTimestampTest extends CCMBridge.PerClassSingleNodeCluster {
     @Test(groups = "short")
     public void should_apply_statement_timestamp_only_to_batched_queries_without_timestamp() {
         BatchStatement batch = new BatchStatement();
-        batch.add(session.newSimpleStatement("INSERT INTO foo (k, v) VALUES (1, 1)"));
-        batch.add(session.newSimpleStatement("INSERT INTO foo (k, v) VALUES (2, 1) USING TIMESTAMP 20"));
+        batch.add(new SimpleStatement("INSERT INTO foo (k, v) VALUES (1, 1)"));
+        batch.add(new SimpleStatement("INSERT INTO foo (k, v) VALUES (2, 1) USING TIMESTAMP 20"));
         batch.setDefaultTimestamp(10);
         session.execute(batch);
 
@@ -117,8 +117,8 @@ public class QueryTimestampTest extends CCMBridge.PerClassSingleNodeCluster {
     public void should_apply_generator_timestamp_only_to_batched_queries_without_timestamp() {
         timestampFromGenerator = 10;
         BatchStatement batch = new BatchStatement();
-        batch.add(session.newSimpleStatement("INSERT INTO foo (k, v) VALUES (1, 1)"));
-        batch.add(session.newSimpleStatement("INSERT INTO foo (k, v) VALUES (2, 1) USING TIMESTAMP 20"));
+        batch.add(new SimpleStatement("INSERT INTO foo (k, v) VALUES (1, 1)"));
+        batch.add(new SimpleStatement("INSERT INTO foo (k, v) VALUES (2, 1) USING TIMESTAMP 20"));
         session.execute(batch);
 
         long writeTime1 = session.execute("SELECT writeTime(v) FROM foo WHERE k = 1").one().getLong(0);
@@ -132,8 +132,8 @@ public class QueryTimestampTest extends CCMBridge.PerClassSingleNodeCluster {
         timestampFromGenerator = Long.MIN_VALUE;
         long clientTime = System.currentTimeMillis() * 1000;
         BatchStatement batch = new BatchStatement();
-        batch.add(session.newSimpleStatement("INSERT INTO foo (k, v) VALUES (1, 1)"));
-        batch.add(session.newSimpleStatement("INSERT INTO foo (k, v) VALUES (2, 1) USING TIMESTAMP 20"));
+        batch.add(new SimpleStatement("INSERT INTO foo (k, v) VALUES (1, 1)"));
+        batch.add(new SimpleStatement("INSERT INTO foo (k, v) VALUES (2, 1) USING TIMESTAMP 20"));
         session.execute(batch);
 
         long writeTime1 = session.execute("SELECT writeTime(v) FROM foo WHERE k = 1").one().getLong(0);
@@ -144,7 +144,7 @@ public class QueryTimestampTest extends CCMBridge.PerClassSingleNodeCluster {
 
     @Test(groups = "short")
     public void should_preserve_timestamp_when_retrying() {
-        SimpleStatement statement = session.newSimpleStatement("INSERT INTO foo (k, v) VALUES (1, 1)");
+        SimpleStatement statement = new SimpleStatement("INSERT INTO foo (k, v) VALUES (1, 1)");
         statement.setDefaultTimestamp(10);
         // This will fail since we test against a single-host cluster. The DowngradingConsistencyRetryPolicy
         // will retry it at ONE.

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryTracker.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryTracker.java
@@ -48,7 +48,7 @@ public class QueryTracker {
     }
 
     public void query(Session session, int times, ConsistencyLevel cl, Class<? extends Exception> expectedException) {
-        Statement statement = session.newSimpleStatement(QUERY);
+        Statement statement = new SimpleStatement(QUERY);
         if(cl != null) {
             statement.setConsistencyLevel(cl);
         }

--- a/driver-core/src/test/java/com/datastax/driver/core/SessionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionTest.java
@@ -62,11 +62,11 @@ public class SessionTest extends CCMBridge.PerClassSingleNodeCluster {
 
         // execute
         checkExecuteResultSet(session.execute(String.format(TestUtils.SELECT_ALL_FORMAT, TABLE1)), key);
-        checkExecuteResultSet(session.execute(session.newSimpleStatement(String.format(TestUtils.SELECT_ALL_FORMAT, TABLE1)).setConsistencyLevel(ConsistencyLevel.ONE)), key);
+        checkExecuteResultSet(session.execute(new SimpleStatement(String.format(TestUtils.SELECT_ALL_FORMAT, TABLE1)).setConsistencyLevel(ConsistencyLevel.ONE)), key);
 
         // executeAsync
         checkExecuteResultSet(session.executeAsync(String.format(TestUtils.SELECT_ALL_FORMAT, TABLE1)).getUninterruptibly(), key);
-        checkExecuteResultSet(session.executeAsync(session.newSimpleStatement(String.format(TestUtils.SELECT_ALL_FORMAT, TABLE1)).setConsistencyLevel(ConsistencyLevel.ONE)).getUninterruptibly(), key);
+        checkExecuteResultSet(session.executeAsync(new SimpleStatement(String.format(TestUtils.SELECT_ALL_FORMAT, TABLE1)).setConsistencyLevel(ConsistencyLevel.ONE)).getUninterruptibly(), key);
     }
 
     @Test(groups = "short")
@@ -151,11 +151,11 @@ public class SessionTest extends CCMBridge.PerClassSingleNodeCluster {
 
             // execute
             checkExecuteResultSet(compressedSession.execute(SELECT_ALL), key);
-            checkExecuteResultSet(compressedSession.execute(session.newSimpleStatement(SELECT_ALL).setConsistencyLevel(ConsistencyLevel.ONE)), key);
+            checkExecuteResultSet(compressedSession.execute(new SimpleStatement(SELECT_ALL).setConsistencyLevel(ConsistencyLevel.ONE)), key);
 
             // executeAsync
             checkExecuteResultSet(compressedSession.executeAsync(SELECT_ALL).getUninterruptibly(), key);
-            checkExecuteResultSet(compressedSession.executeAsync(session.newSimpleStatement(SELECT_ALL).setConsistencyLevel(ConsistencyLevel.ONE)).getUninterruptibly(), key);
+            checkExecuteResultSet(compressedSession.executeAsync(new SimpleStatement(SELECT_ALL).setConsistencyLevel(ConsistencyLevel.ONE)).getUninterruptibly(), key);
 
         } finally {
             cluster.getConfiguration().getProtocolOptions().setCompression(ProtocolOptions.Compression.NONE);

--- a/driver-core/src/test/java/com/datastax/driver/core/SimpleStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SimpleStatementTest.java
@@ -18,58 +18,42 @@ package com.datastax.driver.core;
 import java.util.Collections;
 import java.util.List;
 
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 public class SimpleStatementTest {
-
-    Cluster cluster;
-    CodecRegistry codecRegistry = new CodecRegistry();
-
-    @BeforeClass(groups = "unit")
-    public void setup() {
-        cluster = mock(Cluster.class);
-        Configuration configuration = mock(Configuration.class);
-        when(cluster.getConfiguration()).thenReturn(configuration);
-        ProtocolOptions protocolOptions = mock(ProtocolOptions.class);
-        when(configuration.getProtocolOptions()).thenReturn(protocolOptions);
-    }
 
     @Test(groups = "unit", expectedExceptions = { IllegalArgumentException.class })
     public void should_fail_if_too_many_variables() {
         List<Object> args = Collections.nCopies(1 << 16, (Object)1);
-        new SimpleStatement("mock query", cluster, args.toArray());
+        new SimpleStatement("mock query", args.toArray());
     }
 
     @Test(groups = "unit", expectedExceptions = { IllegalStateException.class })
     public void should_throw_ISE_if_getObject_called_on_statement_without_values() {
-        new SimpleStatement("doesn't matter", cluster).getObject(0);
+        new SimpleStatement("doesn't matter").getObject(0);
     }
 
     @Test(groups = "unit", expectedExceptions = { IndexOutOfBoundsException.class })
     public void should_throw_IOOBE_if_getObject_called_with_wrong_index() {
-        new SimpleStatement("doesn't matter", cluster, new Object()).getObject(1);
+        new SimpleStatement("doesn't matter", new Object()).getObject(1);
     }
 
     @Test(groups = "unit")
     public void should_return_object_at_ith_index() {
         Object expected = new Object();
-        Object actual = new SimpleStatement("doesn't matter", cluster, expected).getObject(0);
+        Object actual = new SimpleStatement("doesn't matter", expected).getObject(0);
         assertThat(actual).isSameAs(expected);
     }
 
     @Test(groups = "unit")
     public void should_return_number_of_values() {
         assertThat(
-            new SimpleStatement("doesn't matter", cluster).valuesCount()
+            new SimpleStatement("doesn't matter").valuesCount()
         ).isEqualTo(0);
         assertThat(
-            new SimpleStatement("doesn't matter", cluster, 1, 2).valuesCount()
+            new SimpleStatement("doesn't matter", 1, 2).valuesCount()
         ).isEqualTo(2);
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/SpeculativeExecutionIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SpeculativeExecutionIntegrationTest.java
@@ -67,7 +67,7 @@ public class SpeculativeExecutionIntegrationTest extends CCMBridge.PerClassSingl
 
         BatchStatement batch = new BatchStatement();
         for (int k = 0; k < 1000; k++) {
-            batch.add(session.newSimpleStatement("insert into foo(k,v) values (?,1)", k));
+            batch.add(new SimpleStatement("insert into foo(k,v) values (?,1)", k));
         }
         session.execute(batch);
 

--- a/driver-core/src/test/java/com/datastax/driver/core/SpeculativeExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SpeculativeExecutionTest.java
@@ -119,7 +119,7 @@ public class SpeculativeExecutionTest {
         long execStartCount = errors.getSpeculativeExecutions().getCount();
         long retriesStartCount = errors.getRetriesOnUnavailable().getCount();
 
-        SimpleStatement statement = session.newSimpleStatement("mock query");
+        SimpleStatement statement = new SimpleStatement("mock query");
         statement.setConsistencyLevel(ConsistencyLevel.TWO);
         ResultSet rs = session.execute(statement);
         Row row = rs.one();

--- a/driver-core/src/test/java/com/datastax/driver/core/StatementIdempotenceTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StatementIdempotenceTest.java
@@ -27,15 +27,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.datastax.driver.core.querybuilder.BuiltStatement;
-import com.datastax.driver.core.querybuilder.QueryBuilder;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 
 public class StatementIdempotenceTest {
 
     private Cluster cluster;
-
-    private QueryBuilder builder;
 
     @BeforeMethod(groups = "unit")
     public void setUpQueryBuilder() throws Exception {
@@ -47,7 +44,6 @@ public class StatementIdempotenceTest {
         when(configuration.getCodecRegistry()).thenReturn(codecRegistry);
         when(configuration.getProtocolOptions()).thenReturn(protocolOptions);
         when(protocolOptions.getProtocolVersion()).thenReturn(TestUtils.getDesiredProtocolVersion());
-        builder = new QueryBuilder(cluster);
     }
 
     @Test(groups = "unit")
@@ -112,66 +108,66 @@ public class StatementIdempotenceTest {
 
     private ImmutableList<BuiltStatement> idempotentBuiltStatements() {
         return ImmutableList.<BuiltStatement>of(
-            builder.update("foo").with(set("v", 1)).where(eq("k", 1)), // set simple value
-            builder.update("foo").with(add("s", 1)).where(eq("k", 1)), // add to set
-            builder.update("foo").with(put("m", "a", 1)).where(eq("k", 1)), // put in map
+            update("foo").with(set("v", 1)).where(eq("k", 1)), // set simple value
+            update("foo").with(add("s", 1)).where(eq("k", 1)), // add to set
+            update("foo").with(put("m", "a", 1)).where(eq("k", 1)), // put in map
 
             // select statements should be idempotent even with function calls
-            builder.select().countAll()         .from("foo").where(eq("k", 1)),
-            builder.select().ttl("v")           .from("foo").where(eq("k", 1)),
-            builder.select().writeTime("v")     .from("foo").where(eq("k", 1)),
-            builder.select().fcall("token", "k").from("foo").where(eq("k", 1))
+            select().countAll()         .from("foo").where(eq("k", 1)),
+            select().ttl("v")           .from("foo").where(eq("k", 1)),
+            select().writeTime("v")     .from("foo").where(eq("k", 1)),
+            select().fcall("token", "k").from("foo").where(eq("k", 1))
 
         );
     }
 
     private ImmutableList<BuiltStatement> nonIdempotentBuiltStatements() {
         return ImmutableList.of(
-            builder.update("foo").with(append("l", 1)).where(eq("k", 1)), // append to list
-            builder.update("foo").with(set("v", 1)).and(prepend("l", 1)).where(eq("k", 1)), // prepend to list
-            builder.update("foo").with(incr("c")).where(eq("k", 1)), // counter update
+            update("foo").with(append("l", 1)).where(eq("k", 1)), // append to list
+            update("foo").with(set("v", 1)).and(prepend("l", 1)).where(eq("k", 1)), // prepend to list
+            update("foo").with(incr("c")).where(eq("k", 1)), // counter update
 
             // function calls
 
-            builder.insertInto("foo").value("k", 1).value("v", fcall("token", "k")),
-            builder.insertInto("foo").value("k", 1).value("v", now()),
-            builder.insertInto("foo").value("k", 1).value("v", uuid()),
+            insertInto("foo").value("k", 1).value("v", fcall("token", "k")),
+            insertInto("foo").value("k", 1).value("v", now()),
+            insertInto("foo").value("k", 1).value("v", uuid()),
 
-            builder.insertInto("foo").value("k", 1).value("v", Sets.newHashSet(fcall("token", "k"))),
-            builder.insertInto("foo").value("k", 1).value("v", Sets.newHashSet(now())),
-            builder.insertInto("foo").value("k", 1).value("v", Sets.newHashSet(uuid())),
+            insertInto("foo").value("k", 1).value("v", Sets.newHashSet(fcall("token", "k"))),
+            insertInto("foo").value("k", 1).value("v", Sets.newHashSet(now())),
+            insertInto("foo").value("k", 1).value("v", Sets.newHashSet(uuid())),
 
-            builder.insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, fcall("token", "k")}),
-            builder.insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, now()}),
-            builder.insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, uuid()}),
+            insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, fcall("token", "k")}),
+            insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, now()}),
+            insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, uuid()}),
 
-            builder.insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, ImmutableMap.of("foo", fcall("token", "k"))}),
-            builder.insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, ImmutableMap.of("foo", now())}),
-            builder.insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, ImmutableMap.of("foo", uuid())}),
+            insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, ImmutableMap.of("foo", fcall("token", "k"))}),
+            insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, ImmutableMap.of("foo", now())}),
+            insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, ImmutableMap.of("foo", uuid())}),
 
-            builder.insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, ImmutableMap.of(fcall("token", "k"), "foo")}),
-            builder.insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, ImmutableMap.of(now()              , "foo")}),
-            builder.insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, ImmutableMap.of(uuid()             , "foo")}),
+            insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, ImmutableMap.of(fcall("token", "k"), "foo")}),
+            insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, ImmutableMap.of(now()              , "foo")}),
+            insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, ImmutableMap.of(uuid()             , "foo")}),
 
-            builder.update("foo").with(set("v", fcall("token", "k")))                    .where(eq("k", 1)),
-            builder.update("foo").with(set("v", now()))                                  .where(eq("k", 1)),
-            builder.update("foo").with(set("v", uuid()))                                 .where(eq("k", 1)),
+            update("foo").with(set("v", fcall("token", "k")))                    .where(eq("k", 1)),
+            update("foo").with(set("v", now()))                                  .where(eq("k", 1)),
+            update("foo").with(set("v", uuid()))                                 .where(eq("k", 1)),
 
-            builder.update("foo").with(set("v", Lists.newArrayList(fcall("token", "k")))).where(eq("k", 1)),
-            builder.update("foo").with(set("v", Lists.newArrayList(now())))              .where(eq("k", 1)),
-            builder.update("foo").with(set("v", Lists.newArrayList(uuid())))             .where(eq("k", 1)),
+            update("foo").with(set("v", Lists.newArrayList(fcall("token", "k")))).where(eq("k", 1)),
+            update("foo").with(set("v", Lists.newArrayList(now())))              .where(eq("k", 1)),
+            update("foo").with(set("v", Lists.newArrayList(uuid())))             .where(eq("k", 1)),
 
             // raw() calls
 
-            builder.insertInto("foo").value("k", 1).value("v", raw("foo()")),
-            builder.insertInto("foo").value("k", 1).value("v", Sets.newHashSet(raw("foo()"))),
+            insertInto("foo").value("k", 1).value("v", raw("foo()")),
+            insertInto("foo").value("k", 1).value("v", Sets.newHashSet(raw("foo()"))),
 
-            builder.insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, raw("foo()")}),
-            builder.insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, ImmutableMap.of("foo", raw("foo()"))}),
-            builder.insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, ImmutableMap.of(raw("foo()"), "foo")}),
+            insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, raw("foo()")}),
+            insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, ImmutableMap.of("foo", raw("foo()"))}),
+            insertInto("foo").values(new String[]{"k", "v"}, new Object[]{1, ImmutableMap.of(raw("foo()"), "foo")}),
 
-            builder.update("foo").with(set("v", raw("foo()")))                    .where(eq("k", 1)),
-            builder.update("foo").with(set("v", Lists.newArrayList(raw("foo()")))).where(eq("k", 1))
+            update("foo").with(set("v", raw("foo()")))                    .where(eq("k", 1)),
+            update("foo").with(set("v", Lists.newArrayList(raw("foo()")))).where(eq("k", 1))
 
         );
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/StatementWrapperTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StatementWrapperTest.java
@@ -49,7 +49,7 @@ public class StatementWrapperTest extends CCMBridge.PerClassSingleNodeCluster {
     public void should_pass_wrapped_statement_to_load_balancing_policy() {
         loadBalancingPolicy.customStatementsHandled.set(0);
 
-        SimpleStatement s = session.newSimpleStatement("select * from system.local");
+        SimpleStatement s = new SimpleStatement("select * from system.local");
         session.execute(s);
         assertThat(loadBalancingPolicy.customStatementsHandled.get()).isEqualTo(0);
 
@@ -61,7 +61,7 @@ public class StatementWrapperTest extends CCMBridge.PerClassSingleNodeCluster {
     public void should_pass_wrapped_statement_to_speculative_execution_policy() {
         speculativeExecutionPolicy.customStatementsHandled.set(0);
 
-        SimpleStatement s = session.newSimpleStatement("select * from system.local");
+        SimpleStatement s = new SimpleStatement("select * from system.local");
         session.execute(s);
         assertThat(speculativeExecutionPolicy.customStatementsHandled.get()).isEqualTo(0);
 
@@ -75,7 +75,7 @@ public class StatementWrapperTest extends CCMBridge.PerClassSingleNodeCluster {
 
         // Set CL TWO with only one node, so the statement will always cause UNAVAILABLE,
         // which our custom policy ignores.
-        Statement s = session.newSimpleStatement("select * from system.local")
+        Statement s = new SimpleStatement("select * from system.local")
             .setConsistencyLevel(ConsistencyLevel.TWO);
 
         session.execute(s);

--- a/driver-core/src/test/java/com/datastax/driver/core/TracingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TracingTest.java
@@ -58,7 +58,7 @@ public class TracingTest extends CCMBridge.PerClassSingleNodeCluster {
      */
     @Test(groups = "short")
     public void should_have_a_different_tracingId_for_each_page() {
-        SimpleStatement st = session.newSimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
+        SimpleStatement st = new SimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
         ResultSet result = session.execute(st.setFetchSize(40).enableTracing());
         result.all();
 
@@ -87,7 +87,7 @@ public class TracingTest extends CCMBridge.PerClassSingleNodeCluster {
      */
     @Test(groups = "short")
     public void should_preserve_tracing_status_across_retries() {
-        SimpleStatement st = session.newSimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
+        SimpleStatement st = new SimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
         st.setConsistencyLevel(ConsistencyLevel.THREE).enableTracing();
 
         ResultSet result = session.execute(st);

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecCollectionsIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecCollectionsIntegrationTest.java
@@ -22,8 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.datastax.driver.core.querybuilder.QueryBuilder;
-import com.datastax.driver.core.utils.CassandraVersion;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
 import org.testng.annotations.BeforeMethod;
@@ -34,12 +32,12 @@ import static com.google.common.collect.Sets.newHashSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.driver.core.querybuilder.BuiltStatement;
+import com.datastax.driver.core.utils.CassandraVersion;
 
-import static com.datastax.driver.core.TypeTokens.listOf;
-import static com.datastax.driver.core.TypeTokens.mapOf;
-import static com.datastax.driver.core.TypeTokens.setOf;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 
 @CassandraVersion(major=2.0)
 public class TypeCodecCollectionsIntegrationTest extends CCMBridge.PerClassSingleNodeCluster {
@@ -75,7 +73,7 @@ public class TypeCodecCollectionsIntegrationTest extends CCMBridge.PerClassSingl
 
     @BeforeMethod(groups = "short")
     public void createBuiltStatements() throws Exception {
-        insertStmt = new QueryBuilder(cluster).insertInto("\"myTable2\"")
+        insertStmt = insertInto("\"myTable2\"")
             .value("c_int", bindMarker())
             .value("l_int", bindMarker())
             .value("l_bigint", bindMarker())
@@ -83,7 +81,7 @@ public class TypeCodecCollectionsIntegrationTest extends CCMBridge.PerClassSingl
             .value("s_double", bindMarker())
             .value("m_varint", bindMarker())
             .value("m_decimal", bindMarker());
-        selectStmt = new QueryBuilder(cluster).select("c_int", "l_int", "l_bigint", "s_float", "s_double", "m_varint", "m_decimal")
+        selectStmt = select("c_int", "l_int", "l_bigint", "s_float", "s_double", "m_varint", "m_decimal")
             .from("\"myTable2\"")
             .where(eq("c_int", bindMarker()));
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecEncapsulationIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecEncapsulationIntegrationTest.java
@@ -31,11 +31,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 import com.datastax.driver.core.querybuilder.BuiltStatement;
-import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.utils.CassandraVersion;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 
 public class TypeCodecEncapsulationIntegrationTest extends CCMBridge.PerClassSingleNodeCluster {
 
@@ -85,14 +86,14 @@ public class TypeCodecEncapsulationIntegrationTest extends CCMBridge.PerClassSin
 
     @BeforeMethod(groups = "short")
     public void createBuiltStatements() throws Exception {
-        insertStmt = new QueryBuilder(cluster).insertInto("\"myTable\"")
+        insertStmt = insertInto("\"myTable\"")
             .value("c_int", bindMarker())
             .value("c_bigint", bindMarker())
             .value("c_float", bindMarker())
             .value("c_double", bindMarker())
             .value("c_varint", bindMarker())
             .value("c_decimal", bindMarker());
-        selectStmt = new QueryBuilder(cluster).select("c_int", "c_bigint", "c_float", "c_double", "c_varint", "c_decimal")
+        selectStmt = select("c_int", "c_bigint", "c_float", "c_double", "c_varint", "c_decimal")
             .from("\"myTable\"")
             .where(eq("c_int", bindMarker()))
             .and(eq("c_bigint", bindMarker()));

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNestedCollectionsIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNestedCollectionsIntegrationTest.java
@@ -30,11 +30,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 import com.datastax.driver.core.querybuilder.BuiltStatement;
-import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.utils.CassandraVersion;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 
 /**
  * Validates that nested collections are properly encoded,
@@ -84,10 +85,10 @@ public class TypeCodecNestedCollectionsIntegrationTest extends CCMBridge.PerClas
 
     @BeforeMethod(groups = "short")
     public void createBuiltStatements() throws Exception {
-        insertStmt = new QueryBuilder(cluster).insertInto("\"myTable\"")
+        insertStmt = insertInto("\"myTable\"")
             .value("pk", bindMarker())
             .value("v", bindMarker());
-        selectStmt = new QueryBuilder(cluster).select("pk", "v")
+        selectStmt = select("pk", "v")
             .from("\"myTable\"")
             .where(eq("pk", bindMarker()));
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicyIntegrationTest.java
@@ -90,7 +90,7 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest {
         RetryPolicy retryPolicy = session.getCluster().getConfiguration().getPolicies().getRetryPolicy();
         Mockito.reset(retryPolicy);
 
-        Statement s = session.newSimpleStatement("SELECT * FROM test.foo WHERE k = 0")
+        Statement s = new SimpleStatement("SELECT * FROM test.foo WHERE k = 0")
             .setConsistencyLevel(requested);
 
         ResultSet rs = session.execute(s);

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/IdempotenceAwareRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/IdempotenceAwareRetryPolicyIntegrationTest.java
@@ -63,7 +63,7 @@ public class IdempotenceAwareRetryPolicyIntegrationTest extends AbstractRetryPol
     @Test(groups = "short")
     public void should_retry_on_write_timeout_if_statement_idempotent() {
         simulateError(1, write_request_timeout);
-        session.execute(session.newSimpleStatement("mock query").setIdempotent(true));
+        session.execute(new SimpleStatement("mock query").setIdempotent(true));
         assertOnWriteTimeoutWasCalled(1);
         assertThat(errors.getWriteTimeouts().getCount()).isEqualTo(1);
         assertThat(errors.getRetries().getCount()).isEqualTo(1);
@@ -111,7 +111,7 @@ public class IdempotenceAwareRetryPolicyIntegrationTest extends AbstractRetryPol
                     .withQuery("mock query")
                     .withThen(then().withFixedDelay(1000L).withRows(row("result", "result1")))
                     .build());
-            session.execute(session.newSimpleStatement("mock query").setIdempotent(true));
+            session.execute(new SimpleStatement("mock query").setIdempotent(true));
             assertOnRequestErrorWasCalled(1, OperationTimedOutException.class);
             assertThat(errors.getClientTimeouts().getCount()).isEqualTo(1);
             assertThat(errors.getRetries().getCount()).isEqualTo(1);
@@ -157,7 +157,7 @@ public class IdempotenceAwareRetryPolicyIntegrationTest extends AbstractRetryPol
         simulateError(2, error);
         simulateError(3, error);
         try {
-            session.execute(session.newSimpleStatement("mock query").setIdempotent(true));
+            session.execute(new SimpleStatement("mock query").setIdempotent(true));
             fail("expected a NoHostAvailableException");
         } catch (NoHostAvailableException e) {
             assertThat(e.getErrors().keySet()).hasSize(3).containsOnly(

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
@@ -97,7 +97,7 @@ public class TokenAwarePolicyTest {
 
             // then: generating a query plan on a statement using that routing key should properly prioritize node 6 and its replicas.
             // Actual query does not matter, only the keyspace and routing key will be used
-            SimpleStatement statement = session.newSimpleStatement("select * from table where k=5");
+            SimpleStatement statement = new SimpleStatement("select * from table where k=5");
             statement.setRoutingKey(routingKey);
             statement.setKeyspace("keyspace");
 
@@ -154,7 +154,7 @@ public class TokenAwarePolicyTest {
 
             // Encodes into murmur hash '4557949199137838892' which should belong be owned by node 3.
             ByteBuffer routingKey = TypeCodec.varchar().serialize("should_choose_proper_host_based_on_routing_key", ProtocolVersion.NEWEST_SUPPORTED);
-            SimpleStatement statement = session.newSimpleStatement("select * from table where k=5")
+            SimpleStatement statement = new SimpleStatement("select * from table where k=5")
                 .setRoutingKey(routingKey)
                 .setKeyspace("keyspace");
 
@@ -200,7 +200,7 @@ public class TokenAwarePolicyTest {
 
             // Encodes into murmur hash '-8124212968526248339' which should belong to 1:1 in DC1 and 2:1 in DC2.
             ByteBuffer routingKey = TypeCodec.varchar().serialize("should_choose_host_in_local_dc_when_using_network_topology_strategy_and_dc_aware", ProtocolVersion.NEWEST_SUPPORTED);
-            SimpleStatement statement = session.newSimpleStatement("select * from table where k=5")
+            SimpleStatement statement = new SimpleStatement("select * from table where k=5")
                 .setRoutingKey(routingKey)
                 .setKeyspace("keyspace");
 
@@ -243,7 +243,7 @@ public class TokenAwarePolicyTest {
             // when: A query is made with a routing key and both hosts having that key's token are down.
             // Encodes into murmur hash '6444339665561646341' which should belong to node 4.
             ByteBuffer routingKey = TypeCodec.varchar().serialize("should_use_other_nodes_when_replicas_having_token_are_down", ProtocolVersion.NEWEST_SUPPORTED);
-            SimpleStatement statement = session.newSimpleStatement("select * from table where k=5")
+            SimpleStatement statement = new SimpleStatement("select * from table where k=5")
                 .setRoutingKey(routingKey)
             .setKeyspace("keyspace");
 

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilder21ExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilder21ExecutionTest.java
@@ -15,25 +15,25 @@
  */
 package com.datastax.driver.core.querybuilder;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.testng.annotations.Test;
+
 import com.datastax.driver.core.CCMBridge;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.utils.CassandraVersion;
 
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import static com.datastax.driver.core.Assertions.assertThat;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.contains;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.containsKey;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 
 @CassandraVersion(major=2.1)
 public class QueryBuilder21ExecutionTest extends CCMBridge.PerClassSingleNodeCluster {
-
-    private QueryBuilder builder;
 
     @Override
     protected Collection<String> getTableDefinitions() {
@@ -53,14 +53,9 @@ public class QueryBuilder21ExecutionTest extends CCMBridge.PerClassSingleNodeClu
         );
     }
 
-    @BeforeMethod(groups = "short")
-    public void setUpQueryBuilder() throws Exception {
-        builder = new QueryBuilder(cluster);
-    }
-
     @Test(groups="short")
     public void should_handle_contains_on_set_with_index() {
-        PreparedStatement byCategory = session.prepare(builder.select("id", "description", "categories")
+        PreparedStatement byCategory = session.prepare(select("id", "description", "categories")
                 .from("products")
                 .where(contains("categories", bindMarker("category"))));
 
@@ -74,7 +69,7 @@ public class QueryBuilder21ExecutionTest extends CCMBridge.PerClassSingleNodeClu
 
     @Test(groups="short")
     public void should_handle_contains_on_list_with_index() {
-        PreparedStatement byBuyer = session.prepare(builder.select("id", "description", "buyers")
+        PreparedStatement byBuyer = session.prepare(select("id", "description", "buyers")
                 .from("products")
                 .where(contains("buyers", bindMarker("buyer"))));
 
@@ -88,7 +83,7 @@ public class QueryBuilder21ExecutionTest extends CCMBridge.PerClassSingleNodeClu
 
     @Test(groups="short")
     public void should_handle_contains_on_map_with_index() {
-        PreparedStatement byFeatures = session.prepare(builder.select("id", "description", "features_values")
+        PreparedStatement byFeatures = session.prepare(select("id", "description", "features_values")
                 .from("products")
                 .where(contains("features_values", bindMarker("feature"))));
 
@@ -103,7 +98,7 @@ public class QueryBuilder21ExecutionTest extends CCMBridge.PerClassSingleNodeClu
 
     @Test(groups="short")
     public void should_handle_contains_key_on_map_with_index() {
-        PreparedStatement byFeatures = session.prepare(builder.select("id", "description", "features_keys")
+        PreparedStatement byFeatures = session.prepare(select("id", "description", "features_keys")
                 .from("products")
                 .where(containsKey("features_keys", bindMarker("feature"))));
 

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -41,8 +41,6 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 
 public class QueryBuilderTest {
 
-    private QueryBuilder builder = new QueryBuilder(TestUtils.getDesiredProtocolVersion(), CodecRegistry.DEFAULT_INSTANCE);
-
     @Test(groups = "unit")
     public void selectTest() throws Exception {
 
@@ -50,15 +48,15 @@ public class QueryBuilderTest {
         Statement select;
 
         query = "SELECT * FROM foo WHERE k=4 AND c>'a' AND c<='z';";
-        select = builder.select().all().from("foo").where(eq("k", 4)).and(gt("c", "a")).and(lte("c", "z"));
+        select = select().all().from("foo").where(eq("k", 4)).and(gt("c", "a")).and(lte("c", "z"));
         assertEquals(select.toString(), query);
 
         // Ensure where() and where(...) are equal
-        select = builder.select().all().from("foo").where().and(eq("k", 4)).and(gt("c", "a")).and(lte("c", "z"));
+        select = select().all().from("foo").where().and(eq("k", 4)).and(gt("c", "a")).and(lte("c", "z"));
         assertEquals(select.toString(), query);
 
         query = "SELECT a,b,\"C\" FROM foo WHERE a IN ('127.0.0.1','127.0.0.3') AND \"C\"='foo' ORDER BY a ASC,b DESC LIMIT 42;";
-        select = builder.select("a", "b", quote("C")).from("foo")
+        select = select("a", "b", quote("C")).from("foo")
             .where(in("a", InetAddress.getByName("127.0.0.1"), InetAddress.getByName("127.0.0.3")))
             .and(eq(quote("C"), "foo"))
             .orderBy(asc("a"), desc("b"))
@@ -66,113 +64,113 @@ public class QueryBuilderTest {
         assertEquals(select.toString(), query);
 
         query = "SELECT writetime(a),ttl(a) FROM foo ALLOW FILTERING;";
-        select = builder.select().writeTime("a").ttl("a").from("foo").allowFiltering();
+        select = select().writeTime("a").ttl("a").from("foo").allowFiltering();
         assertEquals(select.toString(), query);
 
         query = "SELECT DISTINCT longName AS a,ttl(longName) AS ttla FROM foo LIMIT :limit;";
-        select = builder.select().distinct().column("longName").as("a").ttl("longName").as("ttla").from("foo").limit(bindMarker("limit"));
+        select = select().distinct().column("longName").as("a").ttl("longName").as("ttla").from("foo").limit(bindMarker("limit"));
         assertEquals(select.toString(), query);
 
         query = "SELECT DISTINCT longName AS a,ttl(longName) AS ttla FROM foo WHERE k IN () LIMIT :limit;";
-        select = builder.select().distinct().column("longName").as("a").ttl("longName").as("ttla").from("foo").where(in("k")).limit(bindMarker("limit"));
+        select = select().distinct().column("longName").as("a").ttl("longName").as("ttla").from("foo").where(in("k")).limit(bindMarker("limit"));
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM foo WHERE bar=:barmark AND baz=:bazmark LIMIT :limit;";
-        select = builder.select().all().from("foo").where().and(eq("bar", bindMarker("barmark"))).and(eq("baz", bindMarker("bazmark"))).limit(bindMarker("limit"));
+        select = select().all().from("foo").where().and(eq("bar", bindMarker("barmark"))).and(eq("baz", bindMarker("bazmark"))).limit(bindMarker("limit"));
         assertEquals(select.toString(), query);
 
         query = "SELECT a FROM foo WHERE k IN ();";
-        select = builder.select("a").from("foo").where(in("k"));
+        select = select("a").from("foo").where(in("k"));
         assertEquals(select.toString(), query);
 
         query = "SELECT a FROM foo WHERE k IN ?;";
-        select = builder.select("a").from("foo").where(in("k", bindMarker()));
+        select = select("a").from("foo").where(in("k", bindMarker()));
         assertEquals(select.toString(), query);
 
         query = "SELECT DISTINCT a FROM foo WHERE k=1;";
-        select = builder.select("a").distinct().from("foo").where(eq("k", 1));
+        select = select("a").distinct().from("foo").where(eq("k", 1));
         assertEquals(select.toString(), query);
 
         query = "SELECT DISTINCT a,b FROM foo WHERE k=1;";
-        select = builder.select("a", "b").distinct().from("foo").where(eq("k", 1));
+        select = select("a", "b").distinct().from("foo").where(eq("k", 1));
         assertEquals(select.toString(), query);
 
         query = "SELECT count(*) FROM foo;";
-        select = builder.select().countAll().from("foo");
+        select = select().countAll().from("foo");
         assertEquals(select.toString(), query);
 
         query = "SELECT intToBlob(b) FROM foo;";
-        select = builder.select().fcall("intToBlob", column("b")).from("foo");
+        select = select().fcall("intToBlob", column("b")).from("foo");
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM foo WHERE k>42 LIMIT 42;";
-        select = builder.select().all().from("foo").where(gt("k", 42)).limit(42);
+        select = select().all().from("foo").where(gt("k", 42)).limit(42);
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM foo WHERE token(k)>token(42);";
-        select = builder.select().all().from("foo").where(gt(token("k"), fcall("token", 42)));
+        select = select().all().from("foo").where(gt(token("k"), fcall("token", 42)));
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM foo2 WHERE token(a,b)>token(42,101);";
-        select = builder.select().all().from("foo2").where(gt(token("a", "b"), fcall("token", 42, 101)));
+        select = select().all().from("foo2").where(gt(token("a", "b"), fcall("token", 42, 101)));
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM words WHERE w='):,ydL ;O,D';";
-        select = builder.select().all().from("words").where(eq("w", "):,ydL ;O,D"));
+        select = select().all().from("words").where(eq("w", "):,ydL ;O,D"));
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM words WHERE w='WA(!:gS)r(UfW';";
-        select = builder.select().all().from("words").where(eq("w", "WA(!:gS)r(UfW"));
+        select = select().all().from("words").where(eq("w", "WA(!:gS)r(UfW"));
         assertEquals(select.toString(), query);
 
         Date date = new Date();
         date.setTime(1234325);
         query = "SELECT * FROM foo WHERE d=1234325;";
-        select = builder.select().all().from("foo").where(eq("d", date));
+        select = select().all().from("foo").where(eq("d", date));
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM foo WHERE b=0xcafebabe;";
-        select = builder.select().all().from("foo").where(eq("b", Bytes.fromHexString("0xCAFEBABE")));
+        select = select().all().from("foo").where(eq("b", Bytes.fromHexString("0xCAFEBABE")));
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM foo WHERE e CONTAINS 'text';";
-        select = builder.select().from("foo").where(contains("e", "text"));
+        select = select().from("foo").where(contains("e", "text"));
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM foo WHERE e CONTAINS KEY 'key1';";
-        select = builder.select().from("foo").where(containsKey("e", "key1"));
+        select = select().from("foo").where(containsKey("e", "key1"));
         assertEquals(select.toString(), query);
 
         try {
-            builder.select().countAll().from("foo").orderBy(asc("a"), desc("b")).orderBy(asc("a"), desc("b"));
+            select().countAll().from("foo").orderBy(asc("a"), desc("b")).orderBy(asc("a"), desc("b"));
             fail();
         } catch (IllegalStateException e) {
             assertEquals(e.getMessage(), "An ORDER BY clause has already been provided");
         }
 
         try {
-            builder.select().column("a").all().from("foo");
+            select().column("a").all().from("foo");
             fail();
         } catch (IllegalStateException e) {
             assertEquals(e.getMessage(), "Some columns ([a]) have already been selected.");
         }
 
         try {
-            builder.select().column("a").countAll().from("foo");
+            select().column("a").countAll().from("foo");
             fail();
         } catch (IllegalStateException e) {
             assertEquals(e.getMessage(), "Some columns ([a]) have already been selected.");
         }
 
         try {
-            builder.select().all().from("foo").limit(-42);
+            select().all().from("foo").limit(-42);
             fail();
         } catch (IllegalArgumentException e) {
             assertEquals(e.getMessage(), "Invalid LIMIT value, must be strictly positive");
         }
 
         try {
-            builder.select().all().from("foo").limit(42).limit(42);
+            select().all().from("foo").limit(42).limit(42);
             fail();
         } catch (IllegalStateException e) {
             assertEquals(e.getMessage(), "A LIMIT value has already been provided");
@@ -187,7 +185,7 @@ public class QueryBuilderTest {
         Statement insert;
 
         query = "INSERT INTO foo (a,b,\"C\",d) VALUES (123,'127.0.0.1','foo''bar',{'x':3,'y':2}) USING TIMESTAMP 42 AND TTL 24;";
-        insert = builder.insertInto("foo")
+        insert = insertInto("foo")
             .value("a", 123)
             .value("b", InetAddress.getByName("127.0.0.1"))
             .value(quote("C"), "foo'bar")
@@ -199,13 +197,13 @@ public class QueryBuilderTest {
         assertEquals(insert.toString(), query);
 
         query = "INSERT INTO foo (a,b) VALUES (2,null);";
-        insert = builder.insertInto("foo")
+        insert = insertInto("foo")
             .value("a", 2)
             .value("b", null);
         assertEquals(insert.toString(), query);
 
         query = "INSERT INTO foo (a,b) VALUES ({2,3,4},3.4) USING TTL 24 AND TIMESTAMP 42;";
-        insert = builder.insertInto("foo").values(new String[]{ "a", "b" }, new Object[]{ new TreeSet<Integer>() {{
+        insert = insertInto("foo").values(new String[]{ "a", "b" }, new Object[]{ new TreeSet<Integer>() {{
             add(2);
             add(3);
             add(4);
@@ -213,7 +211,7 @@ public class QueryBuilderTest {
         assertEquals(insert.toString(), query);
 
         query = "INSERT INTO foo.bar (a,b) VALUES ({2,3,4},3.4) USING TTL ? AND TIMESTAMP ?;";
-        insert = builder.insertInto("foo", "bar")
+        insert = insertInto("foo", "bar")
             .values(new String[]{ "a", "b" }, new Object[]{ new TreeSet<Integer>() {{
                 add(2);
                 add(3);
@@ -225,7 +223,7 @@ public class QueryBuilderTest {
 
         // commutative result of TIMESTAMP
         query = "INSERT INTO foo.bar (a,b,c) VALUES ({2,3,4},3.4,123) USING TIMESTAMP 42;";
-        insert = builder.insertInto("foo", "bar")
+        insert = insertInto("foo", "bar")
             .using(timestamp(42))
             .values(new String[]{ "a", "b" }, new Object[]{ new TreeSet<Integer>() {{
                 add(2);
@@ -237,7 +235,7 @@ public class QueryBuilderTest {
 
         // commutative result of value() and values()
         query = "INSERT INTO foo (c,a,b) VALUES (123,{2,3,4},3.4) USING TIMESTAMP 42;";
-        insert = builder.insertInto("foo")
+        insert = insertInto("foo")
             .using(timestamp(42))
             .value("c", 123)
             .values(new String[]{ "a", "b" }, new Object[]{ new TreeSet<Integer>() {{
@@ -248,7 +246,7 @@ public class QueryBuilderTest {
         assertEquals(insert.toString(), query);
 
         try {
-            builder.insertInto("foo").values(new String[]{ "a", "b"}, new Object[]{ 1, 2, 3 });
+            insertInto("foo").values(new String[]{ "a", "b"}, new Object[]{ 1, 2, 3 });
             fail();
         } catch (IllegalArgumentException e) {
             assertEquals(e.getMessage(), "Got 2 names but 3 values");
@@ -256,7 +254,7 @@ public class QueryBuilderTest {
 
         // CAS test
         query = "INSERT INTO foo (k,x) VALUES (0,1) IF NOT EXISTS;";
-        insert = builder.insertInto("foo").value("k", 0).value("x", 1).ifNotExists();
+        insert = insertInto("foo").value("k", 0).value("x", 1).ifNotExists();
         assertEquals(insert.toString(), query);
 
         // Tuples: see QueryBuilderTupleExecutionTest
@@ -271,23 +269,23 @@ public class QueryBuilderTest {
         Statement update;
 
         query = "UPDATE foo.bar USING TIMESTAMP 42 SET a=12,b=[3,2,1],c=c+3 WHERE k=2;";
-        update = builder.update("foo", "bar").using(timestamp(42)).with(set("a", 12)).and(set("b", Arrays.asList(3, 2, 1))).and(incr("c", 3)).where(eq("k", 2));
+        update = update("foo", "bar").using(timestamp(42)).with(set("a", 12)).and(set("b", Arrays.asList(3, 2, 1))).and(incr("c", 3)).where(eq("k", 2));
         assertEquals(update.toString(), query);
 
         query = "UPDATE foo SET b=null WHERE k=2;";
-        update = builder.update("foo").where().and(eq("k", 2)).with(set("b", null));
+        update = update("foo").where().and(eq("k", 2)).with(set("b", null));
         assertEquals(update.toString(), query);
 
         query = "UPDATE foo SET a[2]='foo',b=[3,2,1]+b,c=c-{'a'} WHERE k=2 AND l='foo' AND m<4 AND n>=1;";
-        update = builder.update("foo").with(setIdx("a", 2, "foo")).and(prependAll("b", Arrays.asList(3, 2, 1))).and(remove("c", "a")).where(eq("k", 2)).and(eq("l", "foo")).and(lt("m", 4)).and(gte("n", 1));
+        update = update("foo").with(setIdx("a", 2, "foo")).and(prependAll("b", Arrays.asList(3, 2, 1))).and(remove("c", "a")).where(eq("k", 2)).and(eq("l", "foo")).and(lt("m", 4)).and(gte("n", 1));
         assertEquals(update.toString(), query);
 
         query = "UPDATE foo SET b=[3]+b,c=c+['a'],d=d+[1,2,3],e=e-[1];";
-        update = builder.update("foo").with().and(prepend("b", 3)).and(append("c", "a")).and(appendAll("d", Arrays.asList(1, 2, 3))).and(discard("e", 1));
+        update = update("foo").with().and(prepend("b", 3)).and(append("c", "a")).and(appendAll("d", Arrays.asList(1, 2, 3))).and(discard("e", 1));
         assertEquals(update.toString(), query);
 
         query = "UPDATE foo SET b=b-[1,2,3],c=c+{1},d=d+{2,3,4};";
-        update = builder.update("foo").with(discardAll("b", Arrays.asList(1, 2, 3))).and(add("c", 1)).and(addAll("d", new TreeSet<Integer>() {{
+        update = update("foo").with(discardAll("b", Arrays.asList(1, 2, 3))).and(add("c", 1)).and(addAll("d", new TreeSet<Integer>() {{
             add(2);
             add(3);
             add(4);
@@ -295,7 +293,7 @@ public class QueryBuilderTest {
         assertEquals(update.toString(), query);
 
         query = "UPDATE foo SET b=b-{2,3,4},c['k']='v',d=d+{'x':3,'y':2};";
-        update = builder.update("foo").with(removeAll("b", new TreeSet<Integer>() {{
+        update = update("foo").with(removeAll("b", new TreeSet<Integer>() {{
             add(2);
             add(3);
             add(4);
@@ -308,27 +306,27 @@ public class QueryBuilderTest {
         assertEquals(update.toString(), query);
 
         query = "UPDATE foo USING TTL 400;";
-        update = builder.update("foo").using(ttl(400));
+        update = update("foo").using(ttl(400));
         assertEquals(update.toString(), query);
 
         query = "UPDATE foo SET a=" + new BigDecimal(3.2) + ",b=42 WHERE k=2;";
-        update = builder.update("foo").with(set("a", new BigDecimal(3.2))).and(set("b", new BigInteger("42"))).where(eq("k", 2));
+        update = update("foo").with(set("a", new BigDecimal(3.2))).and(set("b", new BigInteger("42"))).where(eq("k", 2));
         assertEquals(update.toString(), query);
 
         query = "UPDATE foo USING TIMESTAMP 42 SET b=[3,2,1]+b WHERE k=2 AND l='foo';";
-        update = builder.update("foo").where().and(eq("k", 2)).and(eq("l", "foo")).with(prependAll("b", Arrays.asList(3, 2, 1))).using(timestamp(42));
+        update = update("foo").where().and(eq("k", 2)).and(eq("l", "foo")).with(prependAll("b", Arrays.asList(3, 2, 1))).using(timestamp(42));
         assertEquals(update.toString(), query);
 
         // Test commutative USING
-        update = builder.update("foo").where().and(eq("k", 2)).and(eq("l", "foo")).using(timestamp(42)).with(prependAll("b", Arrays.asList(3, 2, 1)));
+        update = update("foo").where().and(eq("k", 2)).and(eq("l", "foo")).using(timestamp(42)).with(prependAll("b", Arrays.asList(3, 2, 1)));
         assertEquals(update.toString(), query);
 
         // Test commutative USING
-        update = builder.update("foo").using(timestamp(42)).where(eq("k", 2)).and(eq("l", "foo")).with(prependAll("b", Arrays.asList(3, 2, 1)));
+        update = update("foo").using(timestamp(42)).where(eq("k", 2)).and(eq("l", "foo")).with(prependAll("b", Arrays.asList(3, 2, 1)));
         assertEquals(update.toString(), query);
 
         try {
-            builder.update("foo").using(ttl(-400));
+            update("foo").using(ttl(-400));
             fail();
         } catch (IllegalArgumentException e) {
             assertEquals(e.getMessage(), "Invalid ttl, must be positive");
@@ -336,11 +334,11 @@ public class QueryBuilderTest {
 
         // CAS test
         query = "UPDATE foo SET x=4 WHERE k=0 IF x=1;";
-        update = builder.update("foo").with(set("x", 4)).where(eq("k", 0)).onlyIf(eq("x", 1));
+        update = update("foo").with(set("x", 4)).where(eq("k", 0)).onlyIf(eq("x", 1));
         assertEquals(update.toString(), query);
 
         // IF EXISTS CAS test
-        update = builder.update("foo").with(set("x", 3)).where(eq("k", 2)).ifExists();
+        update = update("foo").with(set("x", 3)).where(eq("k", 2)).ifExists();
         assertThat(update.toString()).isEqualTo("UPDATE foo SET x=3 WHERE k=2 IF EXISTS;");
     }
     
@@ -351,60 +349,60 @@ public class QueryBuilderTest {
         Statement delete;
 
         query = "DELETE a,b,c FROM foo USING TIMESTAMP 0 WHERE k=1;";
-        delete = builder.delete("a", "b", "c").from("foo").using(timestamp(0)).where(eq("k", 1));
+        delete = delete("a", "b", "c").from("foo").using(timestamp(0)).where(eq("k", 1));
         assertEquals(delete.toString(), query);
 
         query = "DELETE a[3],b['foo'],c FROM foo WHERE k=1;";
-        delete = builder.delete().listElt("a", 3).mapElt("b", "foo").column("c").from("foo").where(eq("k", 1));
+        delete = delete().listElt("a", 3).mapElt("b", "foo").column("c").from("foo").where(eq("k", 1));
         assertEquals(delete.toString(), query);
 
         query = "DELETE a[?],b[?],c FROM foo WHERE k=1;";
-        delete = builder.delete().listElt("a", bindMarker()).mapElt("b", bindMarker()).column("c").from("foo").where(eq("k", 1));
+        delete = delete().listElt("a", bindMarker()).mapElt("b", bindMarker()).column("c").from("foo").where(eq("k", 1));
         assertEquals(delete.toString(), query);
 
         // Invalid CQL, testing edge case
         query = "DELETE a,b,c FROM foo;";
-        delete = builder.delete("a", "b", "c").from("foo");
+        delete = delete("a", "b", "c").from("foo");
         assertEquals(delete.toString(), query);
 
         query = "DELETE FROM foo USING TIMESTAMP 1240003134 WHERE k='value';";
-        delete = builder.delete().all().from("foo").using(timestamp(1240003134L)).where(eq("k", "value"));
+        delete = delete().all().from("foo").using(timestamp(1240003134L)).where(eq("k", "value"));
         assertEquals(delete.toString(), query);
-        delete = builder.delete().from("foo").using(timestamp(1240003134L)).where(eq("k", "value"));
+        delete = delete().from("foo").using(timestamp(1240003134L)).where(eq("k", "value"));
         assertEquals(delete.toString(), query);
 
         query = "DELETE a,b,c FROM foo.bar USING TIMESTAMP 1240003134 WHERE k=1;";
-        delete = builder.delete("a", "b", "c").from("foo", "bar").where().and(eq("k", 1)).using(timestamp(1240003134L));
+        delete = delete("a", "b", "c").from("foo", "bar").where().and(eq("k", 1)).using(timestamp(1240003134L));
         assertEquals(delete.toString(), query);
 
         query = "DELETE FROM foo.bar WHERE k1='foo' AND k2=1;";
-        delete = builder.delete().from("foo", "bar").where(eq("k1", "foo")).and(eq("k2", 1));
+        delete = delete().from("foo", "bar").where(eq("k1", "foo")).and(eq("k2", 1));
         assertEquals(delete.toString(), query);
 
         try {
-            builder.delete().column("a").all().from("foo");
+            delete().column("a").all().from("foo");
             fail();
         } catch (IllegalStateException e) {
             assertEquals(e.getMessage(), "Some columns ([a]) have already been selected.");
         }
 
         try {
-            builder.delete().from("foo").using(timestamp(-1240003134L));
+            delete().from("foo").using(timestamp(-1240003134L));
             fail();
         } catch (IllegalArgumentException e) {
             assertEquals(e.getMessage(), "Invalid timestamp, must be positive");
         }
 
         query = "DELETE FROM foo.bar WHERE k1='foo' IF EXISTS;";
-        delete = builder.delete().from("foo", "bar").where(eq("k1", "foo")).ifExists();
+        delete = delete().from("foo", "bar").where(eq("k1", "foo")).ifExists();
         assertEquals(delete.toString(), query);
 
         query = "DELETE FROM foo.bar WHERE k1='foo' IF a=1 AND b=2;";
-        delete = builder.delete().from("foo", "bar").where(eq("k1", "foo")).onlyIf(eq("a", 1)).and(eq("b", 2));
+        delete = delete().from("foo", "bar").where(eq("k1", "foo")).onlyIf(eq("a", 1)).and(eq("b", 2));
         assertEquals(delete.toString(), query);
 
         query = "DELETE FROM foo WHERE k=:key;";
-        delete = builder.delete().from("foo").where(eq("k", bindMarker("key")));
+        delete = delete().from("foo").where(eq("k", bindMarker("key")));
         assertEquals(delete.toString(), query);
     }
 
@@ -419,14 +417,14 @@ public class QueryBuilderTest {
         query += "UPDATE foo SET a[2]='foo',b=[3,2,1]+b,c=c-{'a'} WHERE k=2;";
         query += "DELETE a[3],b['foo'],c FROM foo WHERE k=1;";
         query += "APPLY BATCH;";
-        batch = builder.batch()
-            .add(builder.insertInto("foo").values(new String[]{ "a", "b" }, new Object[]{ new TreeSet<Integer>() {{
+        batch = batch()
+            .add(insertInto("foo").values(new String[]{ "a", "b" }, new Object[]{ new TreeSet<Integer>() {{
                 add(2);
                 add(3);
                 add(4);
             }}, 3.4 }))
-            .add(builder.update("foo").with(setIdx("a", 2, "foo")).and(prependAll("b", Arrays.asList(3, 2, 1))).and(remove("c", "a")).where(eq("k", 2)))
-            .add(builder.delete().listElt("a", 3).mapElt("b", "foo").column("c").from("foo").where(eq("k", 1)))
+            .add(update("foo").with(setIdx("a", 2, "foo")).and(prependAll("b", Arrays.asList(3, 2, 1))).and(remove("c", "a")).where(eq("k", 2)))
+            .add(delete().listElt("a", 3).mapElt("b", "foo").column("c").from("foo").where(eq("k", 1)))
             .using(timestamp(42));
         assertEquals(batch.toString(), query);
 
@@ -434,10 +432,10 @@ public class QueryBuilderTest {
         query = "BEGIN BATCH ";
         query += "DELETE a[3] FROM foo WHERE k=1;";
         query += "APPLY BATCH;";
-        batch = builder.batch(builder.delete().listElt("a", 3).from("foo").where(eq("k", 1)));
+        batch = batch(delete().listElt("a", 3).from("foo").where(eq("k", 1)));
         assertEquals(batch.toString(), query);
 
-        assertEquals(builder.batch().toString(), "BEGIN BATCH APPLY BATCH;");
+        assertEquals(batch().toString(), "BEGIN BATCH APPLY BATCH;");
     }
 
     @Test(groups = "unit")
@@ -451,10 +449,10 @@ public class QueryBuilderTest {
         query += "UPDATE foo SET b=b+2;";
         query += "UPDATE foo SET c=c+3;";
         query += "APPLY BATCH;";
-        batch = builder.batch()
-            .add(builder.update("foo").with(incr("a", 1)))
-            .add(builder.update("foo").with(incr("b", 2)))
-            .add(builder.update("foo").with(incr("c", 3)))
+        batch = batch()
+            .add(update("foo").with(incr("a", 1)))
+            .add(update("foo").with(incr("b", 2)))
+            .add(update("foo").with(incr("c", 3)))
             .using(timestamp(42));
         assertEquals(batch.toString(), query);
 
@@ -464,10 +462,10 @@ public class QueryBuilderTest {
         query += "UPDATE foo SET b=b+1;";
         query += "UPDATE foo SET c=c+1;";
         query += "APPLY BATCH;";
-        batch = builder.batch()
-            .add(builder.update("foo").with(incr("a")))
-            .add(builder.update("foo").with(incr("b")))
-            .add(builder.update("foo").with(incr("c")))
+        batch = batch()
+            .add(update("foo").with(incr("a")))
+            .add(update("foo").with(incr("b")))
+            .add(update("foo").with(incr("c")))
             .using(timestamp(42));
         assertEquals(batch.toString(), query);
 
@@ -477,10 +475,10 @@ public class QueryBuilderTest {
         query += "UPDATE foo SET b=b-2;";
         query += "UPDATE foo SET c=c-3;";
         query += "APPLY BATCH;";
-        batch = builder.batch()
-            .add(builder.update("foo").with(decr("a", 1)))
-            .add(builder.update("foo").with(decr("b", 2)))
-            .add(builder.update("foo").with(decr("c", 3)))
+        batch = batch()
+            .add(update("foo").with(decr("a", 1)))
+            .add(update("foo").with(decr("b", 2)))
+            .add(update("foo").with(decr("c", 3)))
             .using(timestamp(42));
         assertEquals(batch.toString(), query);
 
@@ -490,10 +488,10 @@ public class QueryBuilderTest {
         query += "UPDATE foo SET b=b-1;";
         query += "UPDATE foo SET c=c-1;";
         query += "APPLY BATCH;";
-        batch = builder.batch()
-            .add(builder.update("foo").with(decr("a")))
-            .add(builder.update("foo").with(decr("b")))
-            .add(builder.update("foo").with(decr("c")))
+        batch = batch()
+            .add(update("foo").with(decr("a")))
+            .add(update("foo").with(decr("b")))
+            .add(update("foo").with(decr("c")))
             .using(timestamp(42));
         assertEquals(batch.toString(), query);
 
@@ -503,20 +501,20 @@ public class QueryBuilderTest {
         query += "UPDATE foo SET b=b+-2;";
         query += "UPDATE foo SET c=c-3;";
         query += "APPLY BATCH;";
-        batch = builder.batch()
-            .add(builder.update("foo").with(decr("a", -1)))
-            .add(builder.update("foo").with(incr("b", -2)))
-            .add(builder.update("foo").with(decr("c", 3)))
+        batch = batch()
+            .add(update("foo").with(decr("a", -1)))
+            .add(update("foo").with(incr("b", -2)))
+            .add(update("foo").with(decr("c", 3)))
             .using(timestamp(42));
         assertEquals(batch.toString(), query);
     }
 
     @Test(groups = "unit", expectedExceptions = { IllegalArgumentException.class })
     public void batchMixedCounterTest() throws Exception {
-        builder.batch()
-            .add(builder.update("foo").with(incr("a", 1)))
-            .add(builder.update("foo").with(set("b", 2)))
-            .add(builder.update("foo").with(incr("c", 3)))
+        batch()
+            .add(update("foo").with(incr("a", 1)))
+            .add(update("foo").with(set("b", 2)))
+            .add(update("foo").with(incr("c", 3)))
             .using(timestamp(42));
     }
 
@@ -526,7 +524,7 @@ public class QueryBuilderTest {
         Statement insert;
 
         query = "INSERT INTO test (k,c) VALUES (0,?);";
-        insert = builder.insertInto("test")
+        insert = insertInto("test")
             .value("k", 0)
             .value("c", bindMarker());
         assertEquals(insert.toString(), query);
@@ -539,19 +537,19 @@ public class QueryBuilderTest {
         Statement select;
 
         query = "SELECT * FROM t WHERE c='C''est la vie!';";
-        select = builder.select().from("t").where(eq("c", "C'est la vie!"));
+        select = select().from("t").where(eq("c", "C'est la vie!"));
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM t WHERE c=C'est la vie!;";
-        select = builder.select().from("t").where(eq("c", raw("C'est la vie!")));
+        select = select().from("t").where(eq("c", raw("C'est la vie!")));
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM t WHERE c=now();";
-        select = builder.select().from("t").where(eq("c", fcall("now")));
+        select = select().from("t").where(eq("c", fcall("now")));
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM t WHERE c='now()';";
-        select = builder.select().from("t").where(eq("c", raw("'now()'")));
+        select = select().from("t").where(eq("c", raw("'now()'")));
         assertEquals(select.toString(), query);
     }
 
@@ -562,52 +560,52 @@ public class QueryBuilderTest {
         Statement select;
 
         query = "SELECT * FROM \"foo WHERE k=4\";";
-        select = builder.select().all().from("foo WHERE k=4");
+        select = select().all().from("foo WHERE k=4");
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM foo WHERE k='4 AND c=5';";
-        select = builder.select().all().from("foo").where(eq("k", "4 AND c=5"));
+        select = select().all().from("foo").where(eq("k", "4 AND c=5"));
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM foo WHERE k='4'' AND c=''5';";
-        select = builder.select().all().from("foo").where(eq("k", "4' AND c='5"));
+        select = select().all().from("foo").where(eq("k", "4' AND c='5"));
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM foo WHERE k='4'' OR ''1''=''1';";
-        select = builder.select().all().from("foo").where(eq("k", "4' OR '1'='1"));
+        select = select().all().from("foo").where(eq("k", "4' OR '1'='1"));
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM foo WHERE k='4; --test comment;';";
-        select = builder.select().all().from("foo").where(eq("k", "4; --test comment;"));
+        select = select().all().from("foo").where(eq("k", "4; --test comment;"));
         assertEquals(select.toString(), query);
 
         query = "SELECT \"*\" FROM foo;";
-        select = builder.select("*").from("foo");
+        select = select("*").from("foo");
         assertEquals(select.toString(), query);
 
         query = "SELECT a,b FROM foo WHERE a IN ('b','c''); --comment');";
-        select = builder.select("a", "b").from("foo").where(in("a", "b", "c'); --comment"));
+        select = select("a", "b").from("foo").where(in("a", "b", "c'); --comment"));
         assertEquals(select.toString(), query);
 
         // User Injection?
         query = "SELECT * FROM bar; --(b) FROM foo;";
-        select = builder.select().fcall("* FROM bar; --", column("b")).from("foo");
+        select = select().fcall("* FROM bar; --", column("b")).from("foo");
         assertEquals(select.toString(), query);
 
         query = "SELECT writetime(\"a) FROM bar; --\"),ttl(a) FROM foo ALLOW FILTERING;";
-        select = builder.select().writeTime("a) FROM bar; --").ttl("a").from("foo").allowFiltering();
+        select = select().writeTime("a) FROM bar; --").ttl("a").from("foo").allowFiltering();
         assertEquals(select.toString(), query);
 
         query = "SELECT writetime(a),ttl(\"a) FROM bar; --\") FROM foo ALLOW FILTERING;";
-        select = builder.select().writeTime("a").ttl("a) FROM bar; --").from("foo").allowFiltering();
+        select = select().writeTime("a").ttl("a) FROM bar; --").from("foo").allowFiltering();
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM foo WHERE \"k=1 OR k\">42 LIMIT 42;";
-        select = builder.select().all().from("foo").where(gt("k=1 OR k", 42)).limit(42);
+        select = select().all().from("foo").where(gt("k=1 OR k", 42)).limit(42);
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM foo WHERE token(\"k)>0 OR token(k\")>token(42);";
-        select = builder.select().all().from("foo").where(gt(token("k)>0 OR token(k"), fcall("token", 42)));
+        select = select().all().from("foo").where(gt(token("k)>0 OR token(k"), fcall("token", 42)));
         assertEquals(select.toString(), query);
     }
 
@@ -619,15 +617,15 @@ public class QueryBuilderTest {
         Statement insert;
 
         query = "INSERT INTO foo (a) VALUES ('123); --comment');";
-        insert = builder.insertInto("foo").value("a", "123); --comment");
+        insert = insertInto("foo").value("a", "123); --comment");
         assertEquals(insert.toString(), query);
 
         query = "INSERT INTO foo (\"a,b\") VALUES (123);";
-        insert = builder.insertInto("foo").value("a,b", 123);
+        insert = insertInto("foo").value("a,b", 123);
         assertEquals(insert.toString(), query);
 
         query = "INSERT INTO foo (a,b) VALUES ({'2''} space','3','4'},3.4) USING TTL 24 AND TIMESTAMP 42;";
-        insert = builder.insertInto("foo").values(new String[]{ "a", "b" }, new Object[]{ new TreeSet<String>() {{
+        insert = insertInto("foo").values(new String[]{ "a", "b" }, new Object[]{ new TreeSet<String>() {{
             add("2'} space");
             add("3");
             add("4");
@@ -642,15 +640,15 @@ public class QueryBuilderTest {
         Statement update;
 
         query = "UPDATE foo.bar USING TIMESTAMP 42 SET a=12 WHERE k='2 OR 1=1';";
-        update = builder.update("foo", "bar").using(timestamp(42)).with(set("a", 12)).where(eq("k", "2 OR 1=1"));
+        update = update("foo", "bar").using(timestamp(42)).with(set("a", 12)).where(eq("k", "2 OR 1=1"));
         assertEquals(update.toString(), query);
 
         query = "UPDATE foo SET b='null WHERE k=1; --comment' WHERE k=2;";
-        update = builder.update("foo").where().and(eq("k", 2)).with(set("b", "null WHERE k=1; --comment"));
+        update = update("foo").where().and(eq("k", 2)).with(set("b", "null WHERE k=1; --comment"));
         assertEquals(update.toString(), query);
 
         query = "UPDATE foo USING TIMESTAMP 42 SET \"b WHERE k=1; --comment\"=[3,2,1]+\"b WHERE k=1; --comment\" WHERE k=2;";
-        update = builder.update("foo").where().and(eq("k", 2)).with(prependAll("b WHERE k=1; --comment", Arrays.asList(3, 2, 1))).using(timestamp(42));
+        update = update("foo").where().and(eq("k", 2)).with(prependAll("b WHERE k=1; --comment", Arrays.asList(3, 2, 1))).using(timestamp(42));
         assertEquals(update.toString(), query);
     }
 
@@ -661,47 +659,47 @@ public class QueryBuilderTest {
         Statement delete;
 
         query = "DELETE FROM \"foo WHERE k=4\";";
-        delete = builder.delete().from("foo WHERE k=4");
+        delete = delete().from("foo WHERE k=4");
         assertEquals(delete.toString(), query);
 
         query = "DELETE FROM foo WHERE k='4 AND c=5';";
-        delete = builder.delete().from("foo").where(eq("k", "4 AND c=5"));
+        delete = delete().from("foo").where(eq("k", "4 AND c=5"));
         assertEquals(delete.toString(), query);
 
         query = "DELETE FROM foo WHERE k='4'' AND c=''5';";
-        delete = builder.delete().from("foo").where(eq("k", "4' AND c='5"));
+        delete = delete().from("foo").where(eq("k", "4' AND c='5"));
         assertEquals(delete.toString(), query);
 
         query = "DELETE FROM foo WHERE k='4'' OR ''1''=''1';";
-        delete = builder.delete().from("foo").where(eq("k", "4' OR '1'='1"));
+        delete = delete().from("foo").where(eq("k", "4' OR '1'='1"));
         assertEquals(delete.toString(), query);
 
         query = "DELETE FROM foo WHERE k='4; --test comment;';";
-        delete = builder.delete().from("foo").where(eq("k", "4; --test comment;"));
+        delete = delete().from("foo").where(eq("k", "4; --test comment;"));
         assertEquals(delete.toString(), query);
 
         query = "DELETE \"*\" FROM foo;";
-        delete = builder.delete("*").from("foo");
+        delete = delete("*").from("foo");
         assertEquals(delete.toString(), query);
 
         query = "DELETE a,b FROM foo WHERE a IN ('b','c''); --comment');";
-        delete = builder.delete("a", "b").from("foo")
+        delete = delete("a", "b").from("foo")
             .where(in("a", "b", "c'); --comment"));
         assertEquals(delete.toString(), query);
 
         query = "DELETE FROM foo WHERE \"k=1 OR k\">42;";
-        delete = builder.delete().from("foo").where(gt("k=1 OR k", 42));
+        delete = delete().from("foo").where(gt("k=1 OR k", 42));
         assertEquals(delete.toString(), query);
 
         query = "DELETE FROM foo WHERE token(\"k)>0 OR token(k\")>token(42);";
-        delete = builder.delete().from("foo").where(gt(token("k)>0 OR token(k"), fcall("token", 42)));
+        delete = delete().from("foo").where(gt(token("k)>0 OR token(k"), fcall("token", 42)));
         assertEquals(delete.toString(), query);
     }
 
     @Test(groups = "unit")
     public void statementForwardingTest() throws Exception {
 
-        Update upd = builder.update("foo");
+        Update upd = update("foo");
         upd.setConsistencyLevel(ConsistencyLevel.QUORUM);
         upd.enableTracing();
 
@@ -714,9 +712,10 @@ public class QueryBuilderTest {
     @Test(groups = "unit")
     public void rejectUnknownValueTest() throws Exception {
         try {
-            //noinspection ResultOfMethodCallIgnored
-            builder.update("foo").with(set("a", new byte[13])).where(eq("k", 2)).toString();
-            fail("Byte arrays should not be valid, ByteBuffer should be used instead");
+            RegularStatement s = update("foo").with(set("a", new byte[13])).where(eq("k", 2))
+                .setForceNoValues(true);
+            s.getQueryString();
+            fail("should have failed to inline a byte[]");
         } catch (CodecNotFoundException e) {
             // Ok, that's what we expect
         }
@@ -724,28 +723,28 @@ public class QueryBuilderTest {
 
     @Test(groups = "unit")
     public void truncateTest() throws Exception {
-        assertEquals(builder.truncate("foo").toString(), "TRUNCATE foo;");
-        assertEquals(builder.truncate("foo", quote("Bar")).toString(), "TRUNCATE foo.\"Bar\";");
+        assertEquals(truncate("foo").toString(), "TRUNCATE foo;");
+        assertEquals(truncate("foo", quote("Bar")).toString(), "TRUNCATE foo.\"Bar\";");
     }
 
     @Test(groups = "unit")
     public void quotingTest() {
-        assertEquals(builder.select().from("Metrics", "epochs").toString(),
+        assertEquals(select().from("Metrics", "epochs").toString(),
             "SELECT * FROM Metrics.epochs;");
-        assertEquals(builder.select().from("Metrics", quote("epochs")).toString(),
+        assertEquals(select().from("Metrics", quote("epochs")).toString(),
             "SELECT * FROM Metrics.\"epochs\";");
-        assertEquals(builder.select().from(quote("Metrics"), "epochs").toString(),
+        assertEquals(select().from(quote("Metrics"), "epochs").toString(),
             "SELECT * FROM \"Metrics\".epochs;");
-        assertEquals(builder.select().from(quote("Metrics"), quote("epochs")).toString(),
+        assertEquals(select().from(quote("Metrics"), quote("epochs")).toString(),
             "SELECT * FROM \"Metrics\".\"epochs\";");
 
-        assertEquals(builder.insertInto("Metrics", "epochs").toString(),
+        assertEquals(insertInto("Metrics", "epochs").toString(),
             "INSERT INTO Metrics.epochs () VALUES ();");
-        assertEquals(builder.insertInto("Metrics", quote("epochs")).toString(),
+        assertEquals(insertInto("Metrics", quote("epochs")).toString(),
             "INSERT INTO Metrics.\"epochs\" () VALUES ();");
-        assertEquals(builder.insertInto(quote("Metrics"), "epochs").toString(),
+        assertEquals(insertInto(quote("Metrics"), "epochs").toString(),
             "INSERT INTO \"Metrics\".epochs () VALUES ();");
-        assertEquals(builder.insertInto(quote("Metrics"), quote("epochs")).toString(),
+        assertEquals(insertInto(quote("Metrics"), quote("epochs")).toString(),
             "INSERT INTO \"Metrics\".\"epochs\" () VALUES ();");
     }
 
@@ -755,23 +754,23 @@ public class QueryBuilderTest {
         Statement select;
 
         query = "SELECT * FROM foo WHERE k=4 AND (c1,c2)>('a',2);";
-        select = builder.select().all().from("foo").where(eq("k", 4)).and(gt(Arrays.asList("c1", "c2"), Arrays.<Object>asList("a", 2)));
+        select = select().all().from("foo").where(eq("k", 4)).and(gt(Arrays.asList("c1", "c2"), Arrays.<Object>asList("a", 2)));
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM foo WHERE k=4 AND (c1,c2)>=('a',2) AND (c1,c2)<('b',0);";
-        select = builder.select().all().from("foo").where(eq("k", 4)).and(gte(Arrays.asList("c1", "c2"), Arrays.<Object>asList("a", 2)))
+        select = select().all().from("foo").where(eq("k", 4)).and(gte(Arrays.asList("c1", "c2"), Arrays.<Object>asList("a", 2)))
             .and(lt(Arrays.asList("c1", "c2"), Arrays.<Object>asList("b", 0)));
         assertEquals(select.toString(), query);
 
         query = "SELECT * FROM foo WHERE k=4 AND (c1,c2)<=('a',2);";
-        select = builder.select().all().from("foo").where(eq("k", 4)).and(lte(Arrays.asList("c1", "c2"), Arrays.<Object>asList("a", 2)));
+        select = select().all().from("foo").where(eq("k", 4)).and(lte(Arrays.asList("c1", "c2"), Arrays.<Object>asList("a", 2)));
         assertEquals(select.toString(), query);
     }
 
     @Test(groups = "unit", expectedExceptions = IllegalArgumentException.class)
     public void should_fail_if_in_clause_has_too_many_values() {
         List<Object> values = Collections.<Object>nCopies(65536, "a");
-        builder.select().all().from("foo").where(in("bar", values.toArray()));
+        select().all().from("foo").where(in("bar", values.toArray()));
     }
 
     @Test(groups = "unit", expectedExceptions = IllegalArgumentException.class)
@@ -779,13 +778,13 @@ public class QueryBuilderTest {
         List<Object> values = Collections.<Object>nCopies(65535, "a");
 
         // If the excessive count results from successive DSL calls, we don't check it on the fly so this statement works:
-        BuiltStatement statement = builder.select().all().from("foo")
+        BuiltStatement statement = select().all().from("foo")
             .where(eq("bar", "a"))
             .and(in("baz", values.toArray()));
 
         // But we still want to check it client-side, to fail fast instead of sending a bad query to Cassandra.
         // getValues() is called on any RegularStatement before we send it (see SessionManager.makeRequestMessage).
-        statement.getValues();
+        statement.getValues(ProtocolVersion.NEWEST_SUPPORTED, CodecRegistry.DEFAULT_INSTANCE);
     }
 
     @Test(groups = "unit")
@@ -796,57 +795,57 @@ public class QueryBuilderTest {
 
         query = "UPDATE foo SET l=[[1],[2]] WHERE k=1;";
         ImmutableList<ImmutableList<Integer>> list = ImmutableList.of(ImmutableList.of(1), ImmutableList.of(2));
-        statement = builder.update("foo").with(set("l", list)).where(eq("k", 1));
+        statement = update("foo").with(set("l", list)).where(eq("k", 1));
         assertThat(statement.toString()).isEqualTo(query);
 
         query = "UPDATE foo SET m={1:[[1],[2]],2:[[1],[2]]} WHERE k=1;";
-        statement = builder.update("foo").with(set("m", ImmutableMap.of(1, list, 2, list))).where(eq("k", 1));
+        statement = update("foo").with(set("m", ImmutableMap.of(1, list, 2, list))).where(eq("k", 1));
         assertThat(statement.toString()).isEqualTo(query);
 
         query = "UPDATE foo SET m=m+{1:[[1],[2]],2:[[1],[2]]} WHERE k=1;";
-        statement = builder.update("foo").with(putAll("m", ImmutableMap.of(1, list, 2, list))).where(eq("k", 1));
+        statement = update("foo").with(putAll("m", ImmutableMap.of(1, list, 2, list))).where(eq("k", 1));
         assertThat(statement.toString()).isEqualTo(query);
 
         query = "UPDATE foo SET l=[[1]]+l WHERE k=1;";
-        statement = builder.update("foo").with(prepend("l", ImmutableList.of(1))).where(eq("k", 1));
+        statement = update("foo").with(prepend("l", ImmutableList.of(1))).where(eq("k", 1));
         assertThat(statement.toString()).isEqualTo(query);
 
         query = "UPDATE foo SET l=[[1],[2]]+l WHERE k=1;";
-        statement = builder.update("foo").with(prependAll("l", list)).where(eq("k", 1));
+        statement = update("foo").with(prependAll("l", list)).where(eq("k", 1));
         assertThat(statement.toString()).isEqualTo(query);
     }
 
     @Test(groups = "unit", expectedExceptions = InvalidQueryException.class)
     public void should_not_allow_bind_marker_for_add() {
         // This generates the query "UPDATE foo SET s = s + {?} WHERE k = 1", which is invalid in Cassandra
-        builder.update("foo").with(add("s", bindMarker())).where(eq("k", 1));
+        update("foo").with(add("s", bindMarker())).where(eq("k", 1));
     }
 
     @Test(groups = "unit", expectedExceptions = InvalidQueryException.class)
     public void should_now_allow_bind_marker_for_prepend() {
-        builder.update("foo").with(prepend("l", bindMarker())).where(eq("k", 1));
+        update("foo").with(prepend("l", bindMarker())).where(eq("k", 1));
     }
 
     @Test(groups = "unit", expectedExceptions = InvalidQueryException.class)
     public void should_not_allow_bind_marker_for_append() {
-        builder.update("foo").with(append("l", bindMarker())).where(eq("k", 1));
+        update("foo").with(append("l", bindMarker())).where(eq("k", 1));
     }
 
     @Test(groups = "unit", expectedExceptions = InvalidQueryException.class)
     public void should_not_allow_bind_marker_for_remove() {
-        builder.update("foo").with(remove("s", bindMarker())).where(eq("k", 1));
+        update("foo").with(remove("s", bindMarker())).where(eq("k", 1));
     }
 
     @Test(groups = "unit", expectedExceptions = InvalidQueryException.class)
     public void should_not_allow_bind_marker_for_discard() {
-        builder.update("foo").with(discard("l", bindMarker())).where(eq("k", 1));
+        update("foo").with(discard("l", bindMarker())).where(eq("k", 1));
     }
 
     @Test(groups = "unit")
     public void should_quote_complex_column_names() {
         // A column name can be anything as long as it's quoted, so "foo.bar" is a valid name
         String query = "SELECT * FROM foo WHERE \"foo.bar\"=1;";
-        Statement statement = builder.select().from("foo").where(eq(quote("foo.bar"), 1));
+        Statement statement = select().from("foo").where(eq(quote("foo.bar"), 1));
 
         assertThat(statement.toString()).isEqualTo(query);
     }
@@ -855,32 +854,32 @@ public class QueryBuilderTest {
     public void should_quote_column_names_with_escaped_quotes() {
         // A column name can include quotes as long as it is escaped with another set of quotes, so "foo""bar" is a valid name.
         String query = "SELECT * FROM foo WHERE \"foo \"\" bar\"=1;";
-        Statement statement = builder.select().from("foo").where(eq(quote("foo \"\" bar"), 1));
+        Statement statement = select().from("foo").where(eq(quote("foo \"\" bar"), 1));
 
         assertThat(statement.toString()).isEqualTo(query);
     }
 
     @Test(groups = "unit")
     public void should_not_serialize_raw_query_values() {
-        RegularStatement select = builder.select().from("test").where(gt("i", raw("1")));
+        RegularStatement select = select().from("test").where(gt("i", raw("1")));
         assertThat(select.getQueryString()).doesNotContain("?");
-        assertThat(select.getValues()).isNull();
+        assertThat(select.getValues(ProtocolVersion.NEWEST_SUPPORTED, CodecRegistry.DEFAULT_INSTANCE)).isNull();
     }
 
     @Test(groups = "unit", expectedExceptions = { IllegalStateException.class })
     public void should_throw_ISE_if_getObject_called_on_statement_without_values() {
-        builder.select().from("test").where(eq("foo", 42)).getObject(0); // integers are appended to the CQL string
+        select().from("test").where(eq("foo", 42)).getObject(0); // integers are appended to the CQL string
     }
 
     @Test(groups = "unit", expectedExceptions = { IndexOutOfBoundsException.class })
     public void should_throw_IOOBE_if_getObject_called_with_wrong_index() {
-        builder.select().from("test").where(eq("foo", new Object())).getObject(1);
+        select().from("test").where(eq("foo", new Object())).getObject(1);
     }
 
     @Test(groups = "unit")
     public void should_return_object_at_ith_index() {
         Object expected = new Object();
-        Object actual = builder.select().from("test").where(eq("foo", expected)).getObject(0);
+        Object actual = select().from("test").where(eq("foo", expected)).getObject(0);
         assertThat(actual).isSameAs(expected);
     }
 
@@ -890,13 +889,13 @@ public class QueryBuilderTest {
         Set<UUID> set = Sets.newHashSet(UUID.randomUUID());
         List<Date> list = Lists.newArrayList(new Date());
         Map<BigInteger, String> map = ImmutableMap.of(new BigInteger("1"), "foo");
-        BuiltStatement query = builder.insertInto("foo").value("v", set);
+        BuiltStatement query = insertInto("foo").value("v", set);
         assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES (?);");
         assertThat(query.getObject(0)).isEqualTo(set);
-        query = builder.insertInto("foo").value("v", list);
+        query = insertInto("foo").value("v", list);
         assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES (?);");
         assertThat(query.getObject(0)).isEqualTo(list);
-        query = builder.insertInto("foo").value("v", map);
+        query = insertInto("foo").value("v", map);
         assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES (?);");
         assertThat(query.getObject(0)).isEqualTo(map);
     }
@@ -904,17 +903,17 @@ public class QueryBuilderTest {
     @Test(groups = "unit")
     @CassandraVersion(major = 2.1)
     public void should_not_attempt_to_serialize_function_calls_in_collections() {
-        BuiltStatement query = builder.insertInto("foo").value("v", Sets.newHashSet(fcall("func", 1)));
+        BuiltStatement query = insertInto("foo").value("v", Sets.newHashSet(fcall("func", 1)));
         assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES ({func(1)});");
-        assertThat(query.getValues()).isNullOrEmpty();
+        assertThat(query.getValues(ProtocolVersion.NEWEST_SUPPORTED, CodecRegistry.DEFAULT_INSTANCE)).isNullOrEmpty();
     }
 
     @Test(groups = "unit")
     @CassandraVersion(major = 2.1)
     public void should_not_attempt_to_serialize_raw_values_in_collections() {
-        BuiltStatement query = builder.insertInto("foo").value("v", ImmutableMap.of(1, raw("x")));
+        BuiltStatement query = insertInto("foo").value("v", ImmutableMap.of(1, raw("x")));
         assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES ({1:x});");
-        assertThat(query.getValues()).isNullOrEmpty();
+        assertThat(query.getValues(ProtocolVersion.NEWEST_SUPPORTED, CodecRegistry.DEFAULT_INSTANCE)).isNullOrEmpty();
     }
 
     @Test(groups = "unit")
@@ -923,17 +922,17 @@ public class QueryBuilderTest {
         BuiltStatement query;
         // lists
         List<Integer> list = Lists.newArrayList(1, 2, 3);
-        query = builder.insertInto("foo").value("v", list);
+        query = insertInto("foo").value("v", list);
         assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES ([1,2,3]);");
         assertThat(query.hasValues()).isFalse();
         // sets
         Set<Integer> set = Sets.newHashSet(1, 2, 3);
-        query = builder.insertInto("foo").value("v", set);
+        query = insertInto("foo").value("v", set);
         assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES ({1,2,3});");
         assertThat(query.hasValues()).isFalse();
         // maps
         Map<Integer, Float> map = ImmutableMap.of(1, 12.34f);
-        query = builder.insertInto("foo").value("v", map);
+        query = insertInto("foo").value("v", map);
         assertThat(query.getQueryString()).isEqualTo("INSERT INTO foo (v) VALUES ({1:12.34});");
         assertThat(query.hasValues()).isFalse();
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTupleExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTupleExecutionTest.java
@@ -32,7 +32,9 @@ import com.datastax.driver.core.utils.CassandraVersion;
 
 import static com.datastax.driver.core.DataType.cint;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.update;
 
 @CassandraVersion(major=2.1, minor=3)
 public class QueryBuilderTupleExecutionTest extends CCMBridge.PerClassSingleNodeCluster {
@@ -46,7 +48,7 @@ public class QueryBuilderTupleExecutionTest extends CCMBridge.PerClassSingleNode
     public void should_handle_tuple() throws Exception {
         String query = "INSERT INTO foo (k,x) VALUES (0,(1));";
         TupleType tupleType = cluster.getMetadata().newTupleType(cint());
-        BuiltStatement insert = new QueryBuilder(cluster).insertInto("foo").value("k", 0).value("x", tupleType.newValue(1));
+        BuiltStatement insert = insertInto("foo").value("k", 0).value("x", tupleType.newValue(1));
         assertEquals(insert.toString(), query);
     }
 
@@ -58,7 +60,7 @@ public class QueryBuilderTupleExecutionTest extends CCMBridge.PerClassSingleNode
         query = "UPDATE foo SET l=[(1,2)] WHERE k=1;";
         TupleType tupleType = cluster.getMetadata().newTupleType(cint(), cint());
         List<TupleValue> list = ImmutableList.of(tupleType.newValue(1, 2));
-        statement = new QueryBuilder(cluster).update("foo").with(set("l", list)).where(eq("k", 1));
+        statement = update("foo").with(set("l", list)).where(eq("k", 1));
         assertThat(statement.toString()).isEqualTo(query);
     }
 

--- a/driver-examples/osgi/src/main/java/com/datastax/driver/osgi/impl/MailboxImpl.java
+++ b/driver-examples/osgi/src/main/java/com/datastax/driver/osgi/impl/MailboxImpl.java
@@ -22,14 +22,12 @@ import java.util.UUID;
 
 import com.datastax.driver.core.*;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
-import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.utils.UUIDs;
 import com.datastax.driver.osgi.api.MailboxException;
 import com.datastax.driver.osgi.api.MailboxMessage;
 import com.datastax.driver.osgi.api.MailboxService;
 
-import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 
 public class MailboxImpl implements MailboxService {
 
@@ -71,18 +69,17 @@ public class MailboxImpl implements MailboxService {
                 "PRIMARY KEY (recipient, time))");
         }
 
-        QueryBuilder builder = new QueryBuilder(session.getCluster());
-        retrieveStatement = session.prepare(builder.select()
+        retrieveStatement = session.prepare(select()
             .from(keyspace, TABLE)
             .where(eq("recipient", bindMarker())));
 
-        insertStatement = session.prepare(builder.insertInto(keyspace, TABLE)
+        insertStatement = session.prepare(insertInto(keyspace, TABLE)
             .value("recipient", bindMarker())
             .value("time", bindMarker())
             .value("sender", bindMarker())
             .value("body", bindMarker()));
 
-        deleteStatement = session.prepare(builder.delete().from(keyspace, TABLE)
+        deleteStatement = session.prepare(delete().from(keyspace, TABLE)
             .where(eq("recipient", bindMarker())));
 
         initialized = true;

--- a/driver-examples/stress/src/main/java/com/datastax/driver/stress/Generators.java
+++ b/driver-examples/stress/src/main/java/com/datastax/driver/stress/Generators.java
@@ -124,7 +124,7 @@ public class Generators {
                     }
                     sb.append(" WHERE key = ").append(prefix | iteration);
                     ++iteration;
-                    return new QueryGenerator.Request.SimpleQuery(session.newSimpleStatement(sb.toString()));
+                    return new QueryGenerator.Request.SimpleQuery(new SimpleStatement(sb.toString()));
                 }
             };
         }
@@ -196,7 +196,7 @@ public class Generators {
                     StringBuilder sb = new StringBuilder();
                     sb.append("SELECT * FROM standard1 WHERE key = ").append(prefix | iteration);
                     ++iteration;
-                    return new QueryGenerator.Request.SimpleQuery(session.newSimpleStatement(sb.toString()));
+                    return new QueryGenerator.Request.SimpleQuery(new SimpleStatement(sb.toString()));
                 }
             };
         }

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/guava/OptionalCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/guava/OptionalCodecTest.java
@@ -30,7 +30,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.datastax.driver.core.*;
 import com.datastax.driver.core.CCMBridge.PerClassSingleNodeCluster;
 import com.datastax.driver.core.querybuilder.BuiltStatement;
-import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.utils.CassandraVersion;
 
 import static com.datastax.driver.core.TypeCodec.bigint;
@@ -39,6 +38,8 @@ import static com.datastax.driver.core.TypeCodec.list;
 import static com.datastax.driver.core.TypeCodec.varchar;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 
 public class OptionalCodecTest extends PerClassSingleNodeCluster {
 
@@ -62,8 +63,8 @@ public class OptionalCodecTest extends PerClassSingleNodeCluster {
 
     @BeforeMethod(groups = "short")
     public void createBuiltStatements() throws Exception {
-        insertStmt = new QueryBuilder(cluster).insertInto("foo").value("c1", bindMarker()).value("c2", bindMarker()).value("c3", bindMarker());
-        selectStmt = new QueryBuilder(cluster).select("c2", "c3").from("foo").where(eq("c1", bindMarker()));
+        insertStmt = insertInto("foo").value("c1", bindMarker()).value("c2", bindMarker()).value("c3", bindMarker());
+        selectStmt = select("c2", "c3").from("foo").where(eq("c1", bindMarker()));
     }
 
     /**

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/jdk8/OptionalCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/jdk8/OptionalCodecTest.java
@@ -30,7 +30,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.datastax.driver.core.*;
 import com.datastax.driver.core.CCMBridge.PerClassSingleNodeCluster;
 import com.datastax.driver.core.querybuilder.BuiltStatement;
-import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.utils.CassandraVersion;
 
 import static com.datastax.driver.core.TypeCodec.bigint;
@@ -39,6 +38,8 @@ import static com.datastax.driver.core.TypeCodec.list;
 import static com.datastax.driver.core.TypeCodec.varchar;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 
 public class OptionalCodecTest extends PerClassSingleNodeCluster {
 
@@ -62,8 +63,8 @@ public class OptionalCodecTest extends PerClassSingleNodeCluster {
 
     @BeforeMethod(groups = "short")
     public void createBuiltStatements() throws Exception {
-        insertStmt = new QueryBuilder(cluster).insertInto("foo").value("c1", bindMarker()).value("c2", bindMarker()).value("c3", bindMarker());
-        selectStmt = new QueryBuilder(cluster).select("c2", "c3").from("foo").where(eq("c1", bindMarker()));
+        insertStmt = insertInto("foo").value("c1", bindMarker()).value("c2", bindMarker()).value("c3", bindMarker());
+        selectStmt = select("c2", "c3").from("foo").where(eq("c1", bindMarker()));
     }
 
     /**

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/JacksonJsonCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/JacksonJsonCodecTest.java
@@ -28,12 +28,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.driver.core.*;
 import com.datastax.driver.core.querybuilder.BuiltStatement;
-import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.utils.CassandraVersion;
-import com.datastax.driver.extras.codecs.json.JacksonJsonCodec;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 
 public class JacksonJsonCodecTest extends CCMBridge.PerClassSingleNodeCluster {
 
@@ -97,11 +97,11 @@ public class JacksonJsonCodecTest extends CCMBridge.PerClassSingleNodeCluster {
 
     @Test(groups = "short")
     public void should_use_custom_codec_with_built_statements_1() {
-        BuiltStatement insertStmt = new QueryBuilder(cluster).insertInto("t1")
+        BuiltStatement insertStmt = insertInto("t1")
             .value("c1", bindMarker())
             .value("c2", bindMarker())
             .value("c3", bindMarker());
-        BuiltStatement selectStmt = new QueryBuilder(cluster).select("c1", "c2", "c3")
+        BuiltStatement selectStmt = select("c1", "c2", "c3")
             .from("t1")
             .where(eq("c1", bindMarker()))
             .and(eq("c2", bindMarker()));
@@ -113,12 +113,12 @@ public class JacksonJsonCodecTest extends CCMBridge.PerClassSingleNodeCluster {
 
     @Test(groups = "short")
     public void should_use_custom_codec_with_built_statements_2() {
-        BuiltStatement insertStmt = new QueryBuilder(cluster).insertInto("t1")
+        BuiltStatement insertStmt = insertInto("t1")
             .value("c1", notAJsonString)
             .value("c2", alice)
             .value("c3", bobAndCharlie);
         BuiltStatement selectStmt =
-            new QueryBuilder(cluster).select("c1", "c2", "c3")
+            select("c1", "c2", "c3")
                 .from("t1")
                 .where(eq("c1", notAJsonString))
                 .and(eq("c2", alice));

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/Jsr353JsonCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/Jsr353JsonCodecTest.java
@@ -28,12 +28,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.driver.core.*;
 import com.datastax.driver.core.querybuilder.BuiltStatement;
-import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.utils.CassandraVersion;
-import com.datastax.driver.extras.codecs.json.Jsr353JsonCodec;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 
 public class Jsr353JsonCodecTest extends CCMBridge.PerClassSingleNodeCluster {
 
@@ -99,10 +99,10 @@ public class Jsr353JsonCodecTest extends CCMBridge.PerClassSingleNodeCluster {
 
     @Test(groups = "short", dataProvider = "Jsr353JsonCodecTest")
     public void should_use_custom_codec_with_built_statements_1(JsonStructure object) throws IOException {
-        BuiltStatement insertStmt = new QueryBuilder(cluster).insertInto("t1")
+        BuiltStatement insertStmt = insertInto("t1")
             .value("c1", bindMarker())
             .value("c2", bindMarker());
-        BuiltStatement selectStmt = new QueryBuilder(cluster).select("c1", "c2")
+        BuiltStatement selectStmt = select("c1", "c2")
             .from("t1")
             .where(eq("c1", bindMarker()))
             .and(eq("c2", bindMarker()));
@@ -114,11 +114,11 @@ public class Jsr353JsonCodecTest extends CCMBridge.PerClassSingleNodeCluster {
 
     @Test(groups = "short", dataProvider = "Jsr353JsonCodecTest")
     public void should_use_custom_codec_with_built_statements_2(JsonStructure object) throws IOException {
-        BuiltStatement insertStmt = new QueryBuilder(cluster).insertInto("t1")
+        BuiltStatement insertStmt = insertInto("t1")
             .value("c1", notAJsonString)
             .value("c2", object);
         BuiltStatement selectStmt =
-            new QueryBuilder(cluster).select("c1", "c2")
+            select("c1", "c2")
                 .from("t1")
                 .where(eq("c1", notAJsonString))
                 .and(eq("c2", object));

--- a/features/custom_codecs/README.md
+++ b/features/custom_codecs/README.md
@@ -171,9 +171,9 @@ Cluster cluster = ...
 Session session = ...
 MyPojo myPojo = ...
 // Using SimpleStatement
-Statement stmt = session.newSimpleStatement("INSERT INTO t (id, json) VALUES (?, ?)", 42, myPojo));
+Statement stmt = new SimpleStatement("INSERT INTO t (id, json) VALUES (?, ?)", 42, myPojo));
 // Using the Query Builder
-BuiltStatement insertStmt = new QueryBuilder(cluster).insertInto("t")
+BuiltStatement insertStmt = QueryBuilder.insertInto("t")
     .value("id", 42)
     .value("json", myPojo);
 // Using BoundStatements

--- a/features/custom_payloads/README.md
+++ b/features/custom_payloads/README.md
@@ -71,7 +71,7 @@ Once the payload is set, you can either prepare the statement or execute it;
 in both cases, the payload will be sent along with the `PREPARE` or `QUERY` request respectively:
 
 ```java
-Statement statement = session.newSimpleStatement("SELECT foo FROM bar WHERE qix = 1");
+Statement statement = new SimpleStatement("SELECT foo FROM bar WHERE qix = 1");
 statement.setOutgoingPayload(myCustomPayload);
 session.execute(statement); // myCustomPayload will be sent with QUERY request
 session.prepare(statement); // myCustomPayload will be sent with PREPARE request
@@ -88,7 +88,7 @@ When sending payloads with batches, please note that payloads must be attached t
 `BatchStatement` itself, *not* to internal statements:
 
 ```java
-Statement statement = session.newSimpleStatement("INSERT INTO t1 (c1, c2) values ('foo', 'bar')")
+Statement statement = new SimpleStatement("INSERT INTO t1 (c1, c2) values ('foo', 'bar')")
 // correct
 Statement batch = new BatchStatement().add(statement);
 batch.setOutgoingPayload(myCustomPayload);
@@ -104,7 +104,7 @@ any outgoing payload set on the executed statement *will be transparently
 sent over and over for every new page request*.
 
 ```java
-Statement statement = session.newSimpleStatement("...");
+Statement statement = new SimpleStatement("...");
 statement.setOutgoingPayload(myCustomPayload);
 ResultSet rows = session.execute(...); // myCustomPayload will be sent with first QUERY request
 for (Row row : rows) {
@@ -148,7 +148,7 @@ Custom payloads sent back by the server can be retrieved in the following ways:
 1) From a `ResultSet`: use the `ExecutionInfo` class to retrieve the payload sent by the server.
 
 ```java
-Statement statement = session.newSimpleStatement("...");
+Statement statement = new SimpleStatement("...");
 ResultSet rows = session.execute(...);
 // last payload sent by the server
 Map<String,ByteBuffer> serverPayload = rows.getExecutionInfo().getIncomingPayload();
@@ -160,7 +160,7 @@ with its last `RESULT` response. If you need to retrieve all the
 payloads for all `RESULT` responses, use the following method instead:
 
 ```java
-Statement statement = session.newSimpleStatement("...");
+Statement statement = new SimpleStatement("...");
 ResultSet rows = session.execute(...);
 //all payloads sent by the server
 for (ExecutionInfo info : rows.getAllExecutionInfo()) {
@@ -183,7 +183,7 @@ to prepare a statement, as with all other properties in the given statement, its
 payload, if any, will become the default outgoing payload for the prepared statement.
 
 ```java
-Statement statement = session.newSimpleStatement("...");
+Statement statement = new SimpleStatement("...");
 statement.setOutgoingPayload(myCustomPayload)
 PreparedStatement ps = session.prepare(...); // myCustomPayload will be sent with PREPARE request 
                                              // AND become the default outgoing payload
@@ -194,7 +194,7 @@ The code below is roughly equivalent to the one above - except that the payload 
 with the `PREPARE` request:
 
 ```java
-Statement statement = session.newSimpleStatement("...");
+Statement statement = new SimpleStatement("...");
 PreparedStatement ps = session.prepare(...); // no payload sent with PREPARE request
 ps.setOutgoingPayload(myCustomPayload) // default outgoing payload is now myCustomPayload
 ```
@@ -218,7 +218,7 @@ the following rules apply:
    like in the example below:
    
 ```java
-Statement statement = session.newSimpleStatement("...");
+Statement statement = new SimpleStatement("...");
 PreparedStatement ps = session.prepare(...); // no payload sent with PREPARE request
 BoundStatement bs = ps.bind(1); // no outgoing payload by default
 bs.setOutgoingPayload(myCustomPayload); // outgoing payload for this specific statement

--- a/features/paging/README.md
+++ b/features/paging/README.md
@@ -25,7 +25,7 @@ cluster.getConfiguration().getQueryOptions().setFetchSize(2000);
 The fetch size can also be set on a statement:
 
 ```java
-Statement statement = session.newSimpleStatement("your query");
+Statement statement = new SimpleStatement("your query");
 statement.setFetchSize(2000);
 ```
 
@@ -130,7 +130,7 @@ retrieved later, we can deserialize it and reinject it in a statement:
 
 ```java
 PagingState pagingState = PagingState.fromString(string);
-Statement st = session.newSimpleStatement("your query");
+Statement st = new SimpleStatement("your query");
 st.setPagingState(pagingState);
 ResultSet rs = session.execute(st);
 ```
@@ -147,7 +147,7 @@ implementation for our web service:
 ```java
 final int RESULTS_PER_PAGE = 100;
 
-Statement st = session.newSimpleStatement("your query");
+Statement st = new SimpleStatement("your query");
 st.setFetchSize(RESULTS_PER_PAGE);
 
 String requestedPage = extractPagingStateStringFromURL();

--- a/features/query_timestamps/README.md
+++ b/features/query_timestamps/README.md
@@ -36,7 +36,7 @@ In addition, you can also override the default timestamp on a
 per-statement basis:
 
 ```java
-Statement statement = session.newSimpleStatement(
+Statement statement = new SimpleStatement(
     "UPDATE users SET email = 'x@y.com' where id = 1");
 statement.setDefaultTimestamp(1234567890);
 session.execute(statement);

--- a/features/speculative_execution/README.md
+++ b/features/speculative_execution/README.md
@@ -92,7 +92,7 @@ about what the query actually does. Therefore:
 You can override the value on each statement:
 
 ```java
-Statement s = session.newSimpleStatement("SELECT * FROM users WHERE id = 1");
+Statement s = new SimpleStatement("SELECT * FROM users WHERE id = 1");
 s.setIdempotent(true);
 ```
 

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -42,19 +42,12 @@ We've also seized the opportunity to remove code that was deprecated in 2.1.
         * `<V> T set(String name, V v, Class<V> targetClass)`
         * `<V> T set(String name, V v, TypeToken<V> targetType)`
         * `<V> T set(String name, V v, TypeCodec<V> codec)`
-    * `Session`. The following methods were added:
-        * `newSimpleStatement(String query)`
-        * `newSimpleStatement(String query, Object... values)`
+    * `Statement`. The following public methods were modified:
+        * `getRoutingKey(ProtocolVersion, CodecRegistry)`: both parameters added.
     * `RegularStatement`. The following public methods were modified:
-        * `getValues()`
-        * `hasValues()`
-    * `SimpleStatement`. Public constructors were removed; users are required to call either:
-        * `Session.newSimpleStatement(String query)` or
-        * `Session.newSimpleStatement(String query, Object... values)`
-    * `QueryBuilder`. This class now has a single, public constructor: `QueryBuilder(Cluster cluster)`.
-        Its fluent API has also changed; instead of e.g.: `QueryBuilder.select(...)`,
-        users should now use the following idiom: `new QueryBuilder(cluster).select(...)`
-        All methods that start a query are now instance methods instead of static ones.
+        * `getValues(ProtocolVersion, CodecRegistry)`: second parameter added.
+        * `getQueryString(CodecRegistry)` and `hasValues(CodecRegistry)`: parameter added. No-arg versions are still present
+           and use the default codec registry; refer to the Javadocs for guidance on which version to use.
     * `PreparedStatement`. The following public method was added:
         * `CodecRegistry getCodecRegistry()`.
     * `TupleType`. The following public method was deleted:


### PR DESCRIPTION
Signature changes in statement classes:
- `Statement#getRoutingKey(ProtocolVersion, CodecRegistry)`
- `RegularStatement#getValues(ProtocolVersion, CodecRegistry)`
- `RegularStatement#getQueryString(CodecRegistry)`, with a no-arg overload that uses the default instance.
- `RegularStatement#hasValues(CodecRegistry)`, with a no-arg overload that uses the default instance.

See javadocs for when to use each method. I added a paragraph in `BuiltStatement` javadoc to explain why it needs the codec registry.
