### PR TITLE
JAVA-739: Expose private listen_address of each Cassandra node.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Host.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Host.java
@@ -38,7 +38,19 @@ public class Host {
 
     static final Logger statesLogger = LoggerFactory.getLogger(Host.class.getName() + ".STATES");
 
+    // The rpc_address of this host
     private final InetSocketAddress address;
+
+    // The broadcast_address as known by Cassandra.
+    // We use that internally because
+    // that's the 'peer' in the 'System.peers' table and avoids querying the full peers table in
+    // ControlConnection.refreshNodeInfo.
+    private volatile InetAddress broadcastAddress;
+
+    // The listen_address as known by Cassandra.
+    // This is usually the same as broadcast_address unless
+    // specified otherwise in cassandra.yaml file.
+    private volatile InetAddress listenAddress;
 
     enum State {ADDED, DOWN, UP}
 
@@ -59,12 +71,6 @@ public class Host {
     private volatile String datacenter;
     private volatile String rack;
     private volatile VersionNumber cassandraVersion;
-
-    // The listen_address (really, the broadcast one) as know by Cassandra. We use that internally because
-    // that's the 'peer' in the 'System.peers' table and avoids querying the full peers table in
-    // ControlConnection.refreshNodeInfo. We don't want to expose however because we don't always have the info
-    // (partly because the 'System.local' doesn't have it for some weird reason for instance).
-    volatile InetAddress listenAddress;
 
     private volatile Set<Token> tokens;
 
@@ -87,37 +93,93 @@ public class Host {
         this.rack = rack;
     }
 
-    void setVersionAndListenAdress(String cassandraVersion, InetAddress listenAddress) {
-        if (listenAddress != null)
-            this.listenAddress = listenAddress;
-
-        if (cassandraVersion == null)
-            return;
+    void setVersion(String cassandraVersion) {
+        VersionNumber versionNumber = null;
         try {
-            this.cassandraVersion = VersionNumber.parse(cassandraVersion);
+            if (cassandraVersion != null) {
+                versionNumber = VersionNumber.parse(cassandraVersion);
+            }
         } catch (IllegalArgumentException e) {
             logger.warn("Error parsing Cassandra version {}. This shouldn't have happened", cassandraVersion);
         }
+        this.cassandraVersion = versionNumber;
+    }
+
+    void setBroadcastAddress(InetAddress broadcastAddress) {
+        this.broadcastAddress = broadcastAddress;
+    }
+
+    void setListenAddress(InetAddress listenAddress) {
+        this.listenAddress = listenAddress;
     }
 
     /**
-     * Returns the node address.
+     * Returns the node RPC address, i.e. the IP by which it should be contacted by clients.
+     * <p/>
+     * This is the address
+     * configured in cassandra.yaml file under the following settings:
+     * {@code rpc_address}, {@code rpc_interface} or {@code broadcast_rpc_address}.
      * <p/>
      * This is a shortcut for {@code getSocketAddress().getAddress()}.
      *
-     * @return the node {@link InetAddress}.
+     * @return the node RPC address.
+     * @see <a href="https://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configCassandra_yaml_r.html>The cassandra.yaml configuration file</a>
      */
     public InetAddress getAddress() {
         return address.getAddress();
     }
 
     /**
-     * Returns the node socket address.
+     * Returns the node RPC address and port, i.e. the IP and port by which it should be contacted by clients.
+     * <p/>
+     * This is inferred from the following
+     * cassandra.yaml file settings:
+     * <ol>
+     * <li>{@code rpc_address}, {@code rpc_interface} or {@code broadcast_rpc_address}</li>
+     * <li>{@code native_transport_port}</li>
+     * </ol>
      *
-     * @return the node {@link InetSocketAddress}.
+     * @return the node RPC address and port.
+     * @see <a href="https://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configCassandra_yaml_r.html>The cassandra.yaml configuration file</a>
      */
     public InetSocketAddress getSocketAddress() {
         return address;
+    }
+
+    /**
+     * Returns the node broadcast address, i.e. the IP by which it should be contacted by other peers in the cluster.
+     * <p/>
+     * This corresponds to the {@code broadcast_address} cassandra.yaml file setting and
+     * is by default the same as {@link #getListenAddress()}, unless specified
+     * otherwise in cassandra.yaml.
+     * <em>This is NOT the address clients should use to contact this node</em>.
+     * <p/>
+     * Note that, depending on the Cassandra version the node is currently in,
+     * it might not be possible to determine the node's broadcast address, in which
+     * case this method will return {@code null}.
+     *
+     * @return the node broadcast address.
+     * @see <a href="https://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configCassandra_yaml_r.html>The cassandra.yaml configuration file</a>
+     */
+    public InetAddress getBroadcastAddress() {
+        return broadcastAddress;
+    }
+
+    /**
+     * Returns the node listen address, i.e. the IP the node uses to contact other peers in the cluster.
+     * <p/>
+     * This corresponds to the {@code listen_address} cassandra.yaml file setting.
+     * <em>This is NOT the address clients should use to contact this node</em>.
+     * <p/>
+     * Note that, depending on the Cassandra version the node is currently in,
+     * it might not be possible to determine the node's listen address, in which
+     * case this method will return {@code null}.
+     *
+     * @return the node listen address.
+     * @see <a href="https://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configCassandra_yaml_r.html>The cassandra.yaml configuration file</a>
+     */
+    public InetAddress getListenAddress() {
+        return listenAddress;
     }
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
@@ -83,9 +83,9 @@ public abstract class TokenIntegrationTest {
                 .addContactPoints(CCMBridge.ipOfNode(1))
                 .withLoadBalancingPolicy(lbp)
                 .withQueryOptions(new QueryOptions()
-                                .setRefreshNodeIntervalMillis(0)
-                                .setRefreshNodeListIntervalMillis(0)
-                                .setRefreshSchemaIntervalMillis(0)
+                        .setRefreshNodeIntervalMillis(0)
+                        .setRefreshNodeListIntervalMillis(0)
+                        .setRefreshSchemaIntervalMillis(0)
                 )
                 .build();
         cluster.init();
@@ -315,9 +315,9 @@ public abstract class TokenIntegrationTest {
             // Check against the info in the system tables, which is a bit weak since it's exactly how the metadata is
             // constructed in the first place, but there's not much else we can do.
             // Note that this relies on all queries going to node 1, which is why we use a WhiteList LBP in setup().
-            Row row = (host.listenAddress == null)
+            Row row = (host.getBroadcastAddress() == null)
                     ? session.execute("select tokens from system.local").one()
-                    : session.execute("select tokens from system.peers where peer = '" + host.listenAddress.getHostAddress() + "'").one();
+                    : session.execute("select tokens from system.peers where peer = '" + host.getBroadcastAddress().getHostAddress() + "'").one();
             Set<String> tokenStrings = row.getSet("tokens", String.class);
             assertThat(tokenStrings).hasSize(numTokens);
             Iterable<Token> tokensFromSystemTable = Iterables.transform(tokenStrings, new Function<String, Token>() {
@@ -350,12 +350,12 @@ public abstract class TokenIntegrationTest {
         assertOnlyOneWrapped(ranges);
 
         Iterable<TokenRange> splitRanges = Iterables.concat(Iterables.transform(ranges,
-                        new Function<TokenRange, Iterable<TokenRange>>() {
-                            @Override
-                            public Iterable<TokenRange> apply(TokenRange input) {
-                                return input.splitEvenly(10);
-                            }
-                        })
+                new Function<TokenRange, Iterable<TokenRange>>() {
+                    @Override
+                    public Iterable<TokenRange> apply(TokenRange input) {
+                        return input.splitEvenly(10);
+                    }
+                })
         );
 
         assertOnlyOneWrapped(splitRanges);


### PR DESCRIPTION
This commit exposes both `broadcast_address` and `listen_address`.
However `listen_address` is not present in `system.peers`, so in my opinion the driver is still not able to provide the info required by the Spark connector team.
