### PR TITLE
JAVA-833: Improve message when a nested type can't be serialized.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -11,6 +11,7 @@
 - [improvement] JAVA-1030: Log token to replica map computation times.
 - [bug] JAVA-1039: Minor bugs in Event Debouncer.
 - [improvement] JAVA-843: Disable frozen checks in mapper.
+- [improvement] JAVA-833: Improve message when a nested type can't be serialized.
 
 Merged from 2.0 branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/DataType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataType.java
@@ -713,12 +713,11 @@ public abstract class DataType {
         if (value == null)
             return null;
 
-        DataType dt = TypeCodec.getDataTypeFor(value);
-        if (dt == null)
-            throw new IllegalArgumentException(String.format("Value of type %s does not correspond to any CQL3 type", value.getClass()));
-
         try {
+            DataType dt = TypeCodec.getDataTypeFor(value);
             return dt.serialize(value, protocolVersion);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(String.format("Could not serialize value of type %s", value.getClass()), e);
         } catch (InvalidTypeException e) {
             // In theory we couldn't get that if getDataTypeFor does his job correctly,
             // but there is no point in sending an exception that the user won't expect if we're

--- a/driver-core/src/main/java/com/datastax/driver/core/SimpleStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SimpleStatement.java
@@ -96,7 +96,7 @@ public class SimpleStatement extends RegularStatement {
                 serializedValues[i] = DataType.serializeValue(value, protocolVersion);
             } catch (IllegalArgumentException e) {
                 // Catch and rethrow to provide a more helpful error message (one that include which value is bad)
-                throw new IllegalArgumentException(String.format("Value %d of type %s does not correspond to any CQL3 type", i, value.getClass()));
+                throw new IllegalArgumentException(String.format("Could not serialize value %d of type %s", i, value.getClass()), e.getCause());
             }
         }
         return serializedValues;


### PR DESCRIPTION
Throw an exception instead of propagating null back. I also changed the base message to avoid repeating the same thing twice when the wrong type is the root type.

This does not need to be merged in 3.0.
