### PR TITLE
Add create alter drop keyspace statement builders

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/AlterKeyspace.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/AlterKeyspace.java
@@ -1,0 +1,41 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.schemabuilder;
+
+/**
+ * A built ALTER KEYSPACE statement.
+ */
+public class AlterKeyspace {
+
+    static final String COMMAND = "ALTER KEYSPACE";
+
+    private final String keyspaceName;
+
+    public AlterKeyspace(String keyspaceName) {
+        this.keyspaceName = keyspaceName;
+    }
+
+    /**
+     * Add options for this ALTER KEYSPACE statement.
+     *
+     * @return the options of this ALTER KEYSPACE statement.
+     */
+    public KeyspaceOptions with() {
+        return new KeyspaceOptions(COMMAND, keyspaceName);
+    }
+
+}
+

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/CreateKeyspace.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/CreateKeyspace.java
@@ -1,0 +1,56 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.schemabuilder;
+
+/**
+ * A built CREATE KEYSPACE statement.
+ */
+public class CreateKeyspace {
+
+    static final String command = "CREATE KEYSPACE";
+
+    private final String keyspaceName;
+    private boolean ifNotExists;
+
+    public CreateKeyspace(String keyspaceName) {
+        this.keyspaceName = keyspaceName;
+        this.ifNotExists = false;
+    }
+
+    public CreateKeyspace ifNotExists() {
+        this.ifNotExists = true;
+        return this;
+    }
+
+    /**
+     * Add options for this CREATE KEYSPACE statement.
+     *
+     * @return the options of this CREATE KEYSPACE statement.
+     */
+    public KeyspaceOptions with() {
+        return new KeyspaceOptions(buildCommand(), keyspaceName);
+    }
+
+    String buildCommand() {
+        StringBuilder createStatement = new StringBuilder();
+        createStatement.append(command);
+        if (ifNotExists) {
+            createStatement.append(" IF NOT EXISTS");
+        }
+        return createStatement.toString();
+    }
+
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/DropKeyspace.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/DropKeyspace.java
@@ -1,0 +1,54 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.schemabuilder;
+
+/**
+ * A built DROP KEYSPACE statement.
+ */
+public class DropKeyspace extends SchemaStatement {
+
+    private final String keyspaceName;
+    private boolean ifExists;
+
+    public DropKeyspace(String keyspaceName) {
+        this.keyspaceName = keyspaceName;
+        this.ifExists = false;
+        validateNotEmpty(keyspaceName, "Keyspace name");
+        validateNotKeyWord(keyspaceName,
+                String.format("The keyspace name '%s' is not allowed because it is a reserved keyword", keyspaceName));
+    }
+
+    /**
+     * Add the 'IF EXISTS' condition to this DROP statement.
+     *
+     * @return this statement.
+     */
+    public DropKeyspace ifExists() {
+        this.ifExists = true;
+        return this;
+    }
+
+    @Override
+    public String buildInternal() {
+        StringBuilder dropStatement = new StringBuilder("DROP KEYSPACE ");
+        if (ifExists) {
+            dropStatement.append("IF EXISTS ");
+        }
+        dropStatement.append(keyspaceName);
+        return dropStatement.toString();
+    }
+
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/KeyspaceOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/KeyspaceOptions.java
@@ -1,0 +1,126 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.schemabuilder;
+
+import com.google.common.base.Optional;
+
+import java.util.Map;
+
+/**
+ * The keyspace options used in CREATE KEYSPACE or ALTER KEYSPACE statements.
+ */
+public class KeyspaceOptions extends SchemaStatement {
+
+    private Optional<Map<String, Object>> replication = Optional.absent();
+    private Optional<Boolean> durableWrites = Optional.absent();
+
+    private final String command;
+    private final String keysapceName;
+
+    public KeyspaceOptions(String command, String keyspaceName) {
+        validateNotEmpty(keyspaceName, "Keyspace name");
+        validateNotKeyWord(keyspaceName,
+                String.format("The keyspace name '%s' is not allowed because it is a reserved keyword", keyspaceName));
+
+        this.command = command;
+        this.keysapceName = keyspaceName;
+    }
+
+    /**
+     * Define the replication options for the statement.
+     *
+     * @param replication replication properties map
+     * @return this {@code KeyspaceOptions} object
+     */
+    public KeyspaceOptions replication(Map<String, Object> replication) {
+        validateReplicationOptions(replication);
+        this.replication = Optional.fromNullable(replication);
+        return this;
+    }
+
+    /**
+     * Define the durable writes option for the statement. If set to false,
+     * data written to the keyspace will bypass the commit log.
+     *
+     * @param durableWrites durable write option
+     * @return this {@code KeyspaceOptions} object
+     */
+    public KeyspaceOptions durableWrites(Boolean durableWrites) {
+        this.durableWrites = Optional.fromNullable(durableWrites);
+        return this;
+    }
+
+    @Override
+    String buildInternal() {
+        StringBuilder builtStatement = new StringBuilder(STATEMENT_START);
+        builtStatement.append(command);
+        builtStatement.append(" ");
+        builtStatement.append(keysapceName);
+        builtStatement.append("\n\tWITH\n\t\t");
+
+        boolean putSeparator = false;
+        if (replication.isPresent()) {
+
+            builtStatement.append("REPLICATION = {");
+
+            int l = replication.get().entrySet().size();
+            for (Map.Entry<String, Object> e : replication.get().entrySet()) {
+                builtStatement.append("'")
+                        .append(e.getKey())
+                        .append("'")
+                        .append(": ");
+
+                if (e.getValue() instanceof String) {
+                    builtStatement.append("'")
+                            .append(e.getValue())
+                            .append("'");
+                } else {
+                    builtStatement.append(e.getValue());
+                }
+
+                if (--l > 0) {
+                    builtStatement.append(", ");
+                }
+            }
+
+            builtStatement.append('}');
+            builtStatement.append("\n\t\t");
+            putSeparator = true;
+        }
+
+
+        if (durableWrites.isPresent()) {
+            if (putSeparator) {
+                builtStatement.append("AND ");
+            }
+
+            builtStatement.append("DURABLE_WRITES = " + durableWrites.get().toString());
+        }
+
+
+        return builtStatement.toString();
+    }
+
+    static void validateReplicationOptions(Map<String, Object> replicationOptions) {
+        if (replicationOptions != null && !replicationOptions.containsKey("class")) {
+            throw new IllegalArgumentException("Replication Strategy 'class' should be provided");
+        }
+
+        if (replicationOptions != null && !(replicationOptions.get("class") instanceof String)) {
+            throw new IllegalArgumentException("Replication Strategy should be of type String");
+        }
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/SchemaBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/SchemaBuilder.java
@@ -32,6 +32,16 @@ public final class SchemaBuilder {
     }
 
     /**
+     * Start building a new CREATE KEYSPACE statement.
+     *
+     * @param keyspaceName the name of the keyspace to create.
+     * @return an in-construction CREATE KEYSPACE statement.
+     */
+    public static CreateKeyspace createKeyspace(String keyspaceName) {
+        return new CreateKeyspace(keyspaceName);
+    }
+
+    /**
      * Start building a new CREATE TABLE statement.
      *
      * @param tableName the name of the table to create.

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/SchemaBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/SchemaBuilder.java
@@ -63,6 +63,16 @@ public final class SchemaBuilder {
     }
 
     /**
+     * Start building a new ALTER KEYSPACE statement.
+     *
+     * @param keyspaceName the name of the keyspace to be altered.
+     * @return an in-construction ALTER KEYSPACE statement.
+     */
+    public static AlterKeyspace alterKeyspace(String keyspaceName) {
+        return new AlterKeyspace(keyspaceName);
+    }
+
+    /**
      * Start building a new ALTER TABLE statement.
      *
      * @param tableName the name of the table to be altered.

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/SchemaBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/SchemaBuilder.java
@@ -104,6 +104,16 @@ public final class SchemaBuilder {
     }
 
     /**
+     * Start building a new DROP KEYSPACE statement.
+     *
+     * @param keyspaceName the name of the keyspace to be dropped.
+     * @return an in-construction DROP KEYSPACE statement.
+     */
+    public static DropKeyspace dropKeyspace(String keyspaceName) {
+        return new DropKeyspace(keyspaceName);
+    }
+
+    /**
      * Start building a new DROP TABLE statement.
      *
      * @param keyspaceName the name of the keyspace to be used.

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/AlterKeyspaceTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/AlterKeyspaceTest.java
@@ -1,0 +1,56 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.schemabuilder;
+
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.datastax.driver.core.schemabuilder.SchemaBuilder.alterKeyspace;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AlterKeyspaceTest {
+
+    @Test(groups = "unit")
+    public void should_alter_keyspace_with_options() throws Exception {
+        Map<String, Object> replicationOptions = new HashMap<String, Object>();
+        replicationOptions.put("class", "SimpleStrategy");
+        replicationOptions.put("replication_factor", 1);
+
+        //When
+        SchemaStatement statement = alterKeyspace("test").with()
+                .durableWrites(true)
+                .replication(replicationOptions);
+
+        //Then
+        assertThat(statement.getQueryString())
+                .isEqualTo("\n\tALTER KEYSPACE test" +
+                           "\n\tWITH\n\t\t" +
+                           "REPLICATION = {'replication_factor': 1, 'class': 'SimpleStrategy'}\n\t\t" +
+                           "AND DURABLE_WRITES = true");
+    }
+
+    @Test(groups = "unit", expectedExceptions = IllegalArgumentException.class)
+    public void incorrect_replication_options() throws Exception {
+        Map<String, Object> replicationOptions = new HashMap<String, Object>();
+        replicationOptions.put("class", 5);
+
+        //When
+        alterKeyspace("test").with()
+                .replication(replicationOptions);
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/CreateKeyspaceTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/CreateKeyspaceTest.java
@@ -1,0 +1,56 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.schemabuilder;
+
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.datastax.driver.core.schemabuilder.SchemaBuilder.createKeyspace;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CreateKeyspaceTest {
+
+    @Test(groups = "unit")
+    public void should_create_keyspace_with_options() throws Exception {
+        Map<String, Object> replicationOptions = new HashMap<String, Object>();
+        replicationOptions.put("class", "SimpleStrategy");
+        replicationOptions.put("replication_factor", 1);
+
+        //When
+        SchemaStatement statement = createKeyspace("test").with()
+                .durableWrites(true)
+                .replication(replicationOptions);
+
+        //Then
+        assertThat(statement.getQueryString())
+                .isEqualTo("\n\tCREATE KEYSPACE test" +
+                           "\n\tWITH\n\t\t" +
+                           "REPLICATION = {'replication_factor': 1, 'class': 'SimpleStrategy'}\n\t\t" +
+                           "AND DURABLE_WRITES = true");
+    }
+
+    @Test(groups = "unit", expectedExceptions = IllegalArgumentException.class)
+    public void incorrect_replication_options() throws Exception {
+        Map<String, Object> replicationOptions = new HashMap<String, Object>();
+        replicationOptions.put("class", 5);
+
+        //When
+        createKeyspace("test").with()
+                .replication(replicationOptions);
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/DropKeyspaceTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/DropKeyspaceTest.java
@@ -1,0 +1,42 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.schemabuilder;
+
+import org.testng.annotations.Test;
+
+import static com.datastax.driver.core.schemabuilder.SchemaBuilder.dropKeyspace;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DropKeyspaceTest {
+
+    @Test(groups = "unit")
+    public void should_drop_keyspace() throws Exception {
+        //When
+        SchemaStatement statement = dropKeyspace("test");
+
+        //Then
+        assertThat(statement.getQueryString()).isEqualTo("DROP KEYSPACE test");
+    }
+
+    @Test(groups = "unit")
+    public void should_drop_keyspace_if_exists() throws Exception {
+        //When
+        SchemaStatement statement = dropKeyspace("test").ifExists();
+
+        //Then
+        assertThat(statement.getQueryString()).isEqualTo("DROP KEYSPACE IF EXISTS test");
+    }
+}


### PR DESCRIPTION
As discussed offline with @adutra, backporting the `CREATE`, `DROP` and `ALTER` statement builders from Cassaforte, Clojure driver for Cassandra: https://github.com/clojurewerkz/cassaforte/tree/master/src/java/com/datastax/driver/core/schemabuilder 

I've tried to keep the code style, indentations used within statements as close to their `TABLE` counterparts.
