### PR TITLE
JAVA-1015: Support for codec lookups by Java type only in CodecRegistry

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,7 @@
 
 ### 3.0.0-rc1 (in progress)
 
+- [new feature]: JAVA-1015: Support for codec lookups by Java type only in CodecRegistry.
 
 ### 3.0.0-beta1
 

--- a/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
@@ -407,8 +407,14 @@ public final class CodecRegistry {
     /**
      * Returns a {@link TypeCodec codec} that accepts the given {@link DataType CQL type}.
      * <p/>
-     * This method returns the first matching codec, regardless of its accepted Java type.
-     * It should be reserved for situations where the Java type is not available or unknown.
+     * This method returns the first matching codec, regardless of its accepted Java type;
+     * moreover, if one of the driver's built-in codecs matches the given CQL type, 
+     * no user-registered codec would ever be returned for it by this method.
+     * If you want to force the registry to prefer a user-registered codec over
+     * a built-in one for the same CQL type, consider using the non-ambiguous method
+     * {@link #codecFor(DataType, TypeToken)} instead.
+     * <p/>
+     * Usage of this method should be reserved for situations where the Java type is not available or unknown.
      * In the Java driver, this happens mainly when deserializing a value using the
      * {@link GettableByIndexData#getObject(int) getObject} method.
      * <p/>
@@ -427,8 +433,15 @@ public final class CodecRegistry {
     /**
      * Returns a {@link TypeCodec codec} that accepts the given Java class.
      * <p/>
-     * This method returns the first matching codec, regardless of its accepted CQL type.
-     * It should be reserved for situations where the CQL type is not available or unknown.
+     * This method returns the first matching codec, regardless of its accepted CQL type;
+     * moreover, if one of the driver's built-in codecs matches the given Java class, 
+     * no user-registered codec would ever be returned for it by this method.
+     * If you want to force the registry to prefer a user-registered codec over
+     * a built-in one for the same Java class, consider using the non-ambiguous method
+     * {@link #codecFor(DataType, Class)} instead.
+     * <p/>
+     * Usage of this method should be reserved for situations where the CQL type is not available or unknown.
+     * Such situations do not happen inside the Java driver, but could occur in client code.
      * <p/>
      * Codecs returned by this method are cached (see the {@link CodecRegistry top-level documentation}
      * of this class for more explanations about caching).
@@ -444,8 +457,15 @@ public final class CodecRegistry {
     /**
      * Returns a {@link TypeCodec codec} that accepts the given Java type.
      * <p/>
-     * This method returns the first matching codec, regardless of its accepted CQL type.
-     * It should be reserved for situations where the CQL type is not available or unknown.
+     * This method returns the first matching codec, regardless of its accepted CQL type;
+     * moreover, if one of the driver's built-in codecs matches the given Java type, 
+     * no user-registered codec would ever be returned for it by this method.
+     * If you want to force the registry to prefer a user-registered codec over
+     * a built-in one for the same Java type, consider using the non-ambiguous method
+     * {@link #codecFor(DataType, TypeToken)} instead.
+     * <p/>
+     * Usage of this method should be reserved for situations where the CQL type is not available or unknown.
+     * Such situations do not happen inside the Java driver, but could occur in client code.
      * <p/>
      * Codecs returned by this method are cached (see the {@link CodecRegistry top-level documentation}
      * of this class for more explanations about caching).
@@ -462,6 +482,14 @@ public final class CodecRegistry {
     /**
      * Returns a {@link TypeCodec codec} that accepts the given {@link DataType CQL type}
      * and the given Java class.
+     * <p/>
+     * Both parameters cannot be {@code null} at the same time;
+     * if {@code cqlType} is {@code null}, this method picks the first codec
+     * that matches {@code javaType}, regardless of its accepted CQL type
+     * (thus behaving like {@link #codecFor(Class)});
+     * if {@code javaType} is {@code null}, this method picks the first codec
+     * that matches {@code cqlType}, regardless of its accepted Java class
+     * (thus behaving like {@link #codecFor(DataType)}).
      * <p/>
      * This method can only handle raw (non-parameterized) Java types.
      * For parameterized types, use {@link #codecFor(DataType, TypeToken)} instead.
@@ -481,6 +509,14 @@ public final class CodecRegistry {
     /**
      * Returns a {@link TypeCodec codec} that accepts the given {@link DataType CQL type}
      * and the given Java type.
+     * <p/>
+     * Both parameters cannot be {@code null} at the same time;
+     * if {@code cqlType} is {@code null}, this method picks the first codec
+     * that matches {@code javaType}, regardless of its accepted CQL type
+     * (thus behaving like {@link #codecFor(TypeToken)});
+     * if {@code javaType} is {@code null}, this method picks the first codec
+     * that matches {@code cqlType}, regardless of its accepted Java type
+     * (thus behaving like {@link #codecFor(DataType)}).
      * <p/>
      * This method handles parameterized types thanks to Guava's {@link TypeToken} API.
      * <p/>

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
@@ -551,6 +551,22 @@ public abstract class TypeCodec<T> {
     }
 
     /**
+     * Return {@code true} if this codec is capable of serializing
+     * the given {@code javaType}.
+     * <p/>
+     * This implementation simply calls {@link #accepts(TypeToken)}.
+     *
+     * @param javaType The Java type this codec should serialize from and deserialize to; cannot be {@code null}.
+     * @return {@code true} if the codec is capable of serializing
+     * the given {@code javaType}, and {@code false} otherwise.
+     * @throws NullPointerException if {@code javaType} is {@code null}.
+     */
+    public boolean accepts(Class<?> javaType) {
+        checkNotNull(javaType);
+        return accepts(TypeToken.of(javaType));
+    }
+
+    /**
      * Return {@code true} if this codec is capable of deserializing
      * the given {@code cqlType}.
      *

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
@@ -531,7 +531,7 @@ public abstract class TypeCodec<T> {
      * @throws NullPointerException if {@code javaType} is {@code null}.
      */
     public boolean accepts(TypeToken javaType) {
-        checkNotNull(javaType);
+        checkNotNull(javaType, "Parameter javaType cannot be null");
         return this.javaType.equals(javaType.wrap());
     }
 
@@ -547,7 +547,7 @@ public abstract class TypeCodec<T> {
      * @throws NullPointerException if {@code javaType} is {@code null}.
      */
     public boolean accepts(Class<?> javaType) {
-        checkNotNull(javaType);
+        checkNotNull(javaType, "Parameter javaType cannot be null");
         return accepts(TypeToken.of(javaType));
     }
 
@@ -561,7 +561,7 @@ public abstract class TypeCodec<T> {
      * @throws NullPointerException if {@code cqlType} is {@code null}.
      */
     public boolean accepts(DataType cqlType) {
-        checkNotNull(cqlType);
+        checkNotNull(cqlType, "Parameter cqlType cannot be null");
         return this.cqlType.equals(cqlType);
     }
 
@@ -597,7 +597,7 @@ public abstract class TypeCodec<T> {
      * @throws NullPointerException if {@code value} is {@code null}.
      */
     public boolean accepts(Object value) {
-        checkNotNull(value);
+        checkNotNull(value, "Parameter value cannot be null");
         return this.javaType.isAssignableFrom(TypeToken.of(value.getClass()));
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
@@ -17,7 +17,6 @@ package com.datastax.driver.core;
 
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 import com.datastax.driver.core.utils.Bytes;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
 
 import java.math.BigDecimal;
@@ -98,17 +97,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @param <T> The codec's Java type
  */
 public abstract class TypeCodec<T> {
-
-    private static final Map<TypeToken<?>, TypeToken<?>> primitiveToWrapperMap = ImmutableMap.<TypeToken<?>, TypeToken<?>>builder()
-            .put(TypeToken.of(Boolean.TYPE), TypeToken.of(Boolean.class))
-            .put(TypeToken.of(Byte.TYPE), TypeToken.of(Byte.class))
-            .put(TypeToken.of(Character.TYPE), TypeToken.of(Character.class))
-            .put(TypeToken.of(Short.TYPE), TypeToken.of(Short.class))
-            .put(TypeToken.of(Integer.TYPE), TypeToken.of(Integer.class))
-            .put(TypeToken.of(Long.TYPE), TypeToken.of(Long.class))
-            .put(TypeToken.of(Double.TYPE), TypeToken.of(Double.class))
-            .put(TypeToken.of(Float.TYPE), TypeToken.of(Float.class))
-            .build();
 
     /**
      * Return the default codec for the CQL type {@code boolean}.
@@ -531,7 +519,7 @@ public abstract class TypeCodec<T> {
      * The implementation is <em>invariant</em> with respect to the passed
      * argument (through the usage of {@link TypeToken#equals(Object)}
      * and <em>it's strongly recommended not to modify this behavior</em>.
-     * This means that a codec will only ever accept the
+     * This means that a codec will only ever return {@code true} for the
      * <em>exact</em> Java type that it has been created for.
      * <p/>
      * If the argument represents a Java primitive type, its wrapper type
@@ -544,10 +532,7 @@ public abstract class TypeCodec<T> {
      */
     public boolean accepts(TypeToken javaType) {
         checkNotNull(javaType);
-        if (javaType.isPrimitive()) {
-            javaType = primitiveToWrapperMap.get(javaType);
-        }
-        return this.javaType.equals(javaType);
+        return this.javaType.equals(javaType.wrap());
     }
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
@@ -76,8 +76,8 @@ public class Assertions extends org.assertj.core.api.Assertions {
         return new IndexMetadataAssert(index);
     }
 
-    public static TypeCodecAssert assertThat(TypeCodec codec) {
-        return new TypeCodecAssert(codec);
+    public static <T> TypeCodecAssert<T> assertThat(TypeCodec<T> codec) {
+        return new TypeCodecAssert<T>(codec);
     }
 
     public static MaterializedViewMetadataAssert assertThat(MaterializedViewMetadata view) {

--- a/driver-core/src/test/java/com/datastax/driver/core/CodecRegistryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CodecRegistryTest.java
@@ -15,19 +15,522 @@
  */
 package com.datastax.driver.core;
 
+import com.datastax.driver.core.exceptions.CodecNotFoundException;
 import com.google.common.reflect.TypeToken;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.List;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.util.*;
 
 import static com.datastax.driver.core.Assertions.assertThat;
+import static com.datastax.driver.core.DataType.*;
+import static com.datastax.driver.core.DataType.list;
+import static com.datastax.driver.core.ProtocolVersion.V4;
+import static com.datastax.driver.core.TypeTokens.*;
+import static com.google.common.reflect.TypeToken.of;
+import static java.util.Collections.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.fail;
 
 public class CodecRegistryTest {
-    TypeToken<List<Integer>> LIST_OF_INT_TOKEN = TypeTokens.listOf(Integer.class);
+
+    @DataProvider
+    public static Object[][] cql() {
+        return new Object[][]{
+                {DataType.blob(), TypeCodec.blob()},
+                {DataType.cboolean(), TypeCodec.cboolean()},
+                {DataType.smallint(), TypeCodec.smallInt()},
+                {DataType.tinyint(), TypeCodec.tinyInt()},
+                {DataType.cint(), TypeCodec.cint()},
+                {DataType.bigint(), TypeCodec.bigint()},
+                {DataType.counter(), TypeCodec.counter()},
+                {DataType.cdouble(), TypeCodec.cdouble()},
+                {DataType.cfloat(), TypeCodec.cfloat()},
+                {DataType.varint(), TypeCodec.varint()},
+                {DataType.decimal(), TypeCodec.decimal()},
+                {DataType.varchar(), TypeCodec.varchar()},
+                {DataType.ascii(), TypeCodec.ascii()},
+                {DataType.timestamp(), TypeCodec.timestamp()},
+                {DataType.date(), TypeCodec.date()},
+                {DataType.time(), TypeCodec.time()},
+                {DataType.uuid(), TypeCodec.uuid()},
+                {DataType.timeuuid(), TypeCodec.timeUUID()},
+                {DataType.inet(), TypeCodec.inet()}
+        };
+    }
+
+    @DataProvider
+    public static Object[][] java() {
+        return new Object[][]{
+                {ByteBuffer.class, TypeCodec.blob()},
+                {Boolean.class, TypeCodec.cboolean()},
+                {Short.class, TypeCodec.smallInt()},
+                {Byte.class, TypeCodec.tinyInt()},
+                {Integer.class, TypeCodec.cint()},
+                {Long.class, TypeCodec.bigint()},
+                {Double.class, TypeCodec.cdouble()},
+                {Float.class, TypeCodec.cfloat()},
+                {BigInteger.class, TypeCodec.varint()},
+                {BigDecimal.class, TypeCodec.decimal()},
+                {String.class, TypeCodec.varchar()},
+                {Date.class, TypeCodec.timestamp()},
+                {LocalDate.class, TypeCodec.date()},
+                {UUID.class, TypeCodec.uuid()},
+                {InetAddress.class, TypeCodec.inet()}
+        };
+    }
+
+    @DataProvider
+    public static Object[][] cqlAndJava() {
+        return new Object[][]{
+                {DataType.blob(), ByteBuffer.class, TypeCodec.blob()},
+                {DataType.cboolean(), Boolean.class, TypeCodec.cboolean()},
+                {DataType.smallint(), Short.class, TypeCodec.smallInt()},
+                {DataType.tinyint(), Byte.class, TypeCodec.tinyInt()},
+                {DataType.cint(), Integer.class, TypeCodec.cint()},
+                {DataType.bigint(), Long.class, TypeCodec.bigint()},
+                {DataType.counter(), Long.class, TypeCodec.counter()},
+                {DataType.cdouble(), Double.class, TypeCodec.cdouble()},
+                {DataType.cfloat(), Float.class, TypeCodec.cfloat()},
+                {DataType.varint(), BigInteger.class, TypeCodec.varint()},
+                {DataType.decimal(), BigDecimal.class, TypeCodec.decimal()},
+                {DataType.varchar(), String.class, TypeCodec.varchar()},
+                {DataType.ascii(), String.class, TypeCodec.ascii()},
+                {DataType.timestamp(), Date.class, TypeCodec.timestamp()},
+                {DataType.date(), LocalDate.class, TypeCodec.date()},
+                {DataType.time(), Long.class, TypeCodec.time()},
+                {DataType.uuid(), UUID.class, TypeCodec.uuid()},
+                {DataType.timeuuid(), UUID.class, TypeCodec.timeUUID()},
+                {DataType.inet(), InetAddress.class, TypeCodec.inet()}
+        };
+    }
+
+    @DataProvider
+    public static Object[][] value() {
+        return new Object[][]{
+                {ByteBuffer.allocate(0), TypeCodec.blob()},
+                {Boolean.TRUE, TypeCodec.cboolean()},
+                {(short) 42, TypeCodec.smallInt()},
+                {(byte) 42, TypeCodec.tinyInt()},
+                {42, TypeCodec.cint()},
+                {42L, TypeCodec.bigint()},
+                {42D, TypeCodec.cdouble()},
+                {42F, TypeCodec.cfloat()},
+                {new BigInteger("1234"), TypeCodec.varint()},
+                {new BigDecimal("123.45"), TypeCodec.decimal()},
+                {"foo", TypeCodec.varchar()},
+                {new Date(42), TypeCodec.timestamp()},
+                {LocalDate.fromDaysSinceEpoch(42), TypeCodec.date()},
+                {UUID.randomUUID(), TypeCodec.uuid()},
+                {mock(InetAddress.class), TypeCodec.inet()}
+        };
+    }
+
+    @DataProvider
+    public static Object[][] cqlAndValue() {
+        return new Object[][]{
+                {DataType.blob(), ByteBuffer.allocate(0), TypeCodec.blob()},
+                {DataType.cboolean(), true, TypeCodec.cboolean()},
+                {DataType.smallint(), (short) 42, TypeCodec.smallInt()},
+                {DataType.tinyint(), (byte) 42, TypeCodec.tinyInt()},
+                {DataType.cint(), 42, TypeCodec.cint()},
+                {DataType.bigint(), 42L, TypeCodec.bigint()},
+                {DataType.counter(), 42L, TypeCodec.counter()},
+                {DataType.cdouble(), 42D, TypeCodec.cdouble()},
+                {DataType.cfloat(), 42F, TypeCodec.cfloat()},
+                {DataType.varint(), new BigInteger("1234"), TypeCodec.varint()},
+                {DataType.decimal(), new BigDecimal("123.45"), TypeCodec.decimal()},
+                {DataType.varchar(), "foo", TypeCodec.varchar()},
+                {DataType.ascii(), "foo", TypeCodec.ascii()},
+                {DataType.timestamp(), new Date(42), TypeCodec.timestamp()},
+                {DataType.date(), LocalDate.fromDaysSinceEpoch(42), TypeCodec.date()},
+                {DataType.time(), 42L, TypeCodec.time()},
+                {DataType.uuid(), UUID.randomUUID(), TypeCodec.uuid()},
+                {DataType.timeuuid(), UUID.randomUUID(), TypeCodec.timeUUID()},
+                {DataType.inet(), mock(InetAddress.class), TypeCodec.inet()}
+        };
+    }
+
+    @Test(groups = "unit", dataProvider = "cql")
+    public void should_find_codec_by_cql_type(DataType cqlType, TypeCodec<?> expected) {
+        // given
+        CodecRegistry registry = new CodecRegistry();
+        // when
+        TypeCodec<?> actual = registry.codecFor(cqlType);
+        // then
+        assertThat(actual)
+                .isNotNull()
+                .accepts(cqlType)
+                .isSameAs(expected);
+    }
+
+    @Test(groups = "unit", dataProvider = "java")
+    public void should_find_codec_by_java_type(Class<?> javaType, TypeCodec<?> expected) {
+        // given
+        CodecRegistry registry = new CodecRegistry();
+        // when
+        TypeCodec<?> actual = registry.codecFor(javaType);
+        // then
+        assertThat(actual)
+                .isNotNull()
+                .accepts(javaType)
+                .isSameAs(expected);
+    }
+
+    @Test(groups = "unit", dataProvider = "cqlAndJava")
+    public void should_find_codec_by_cql_type_java_type(DataType cqlType, Class<?> javaType, TypeCodec<?> expected) {
+        // given
+        CodecRegistry registry = new CodecRegistry();
+        // when
+        TypeCodec<?> actual = registry.codecFor(cqlType, javaType);
+        // then
+        assertThat(actual)
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType)
+                .isSameAs(expected);
+    }
+
+    @Test(groups = "unit", dataProvider = "value")
+    public void should_find_codec_by_value(Object value, TypeCodec<?> expected) {
+        // given
+        CodecRegistry registry = new CodecRegistry();
+        // when
+        TypeCodec<?> actual = registry.codecFor(value);
+        // then
+        assertThat(actual)
+                .isNotNull()
+                .accepts(value)
+                .isSameAs(expected);
+    }
+
+    @Test(groups = "unit", dataProvider = "cqlAndValue")
+    public void should_find_codec_by_cql_type_and_value(DataType cqlType, Object value, TypeCodec<?> expected) {
+        // given
+        CodecRegistry registry = new CodecRegistry();
+        // when
+        TypeCodec<?> actual = registry.codecFor(cqlType, value);
+        // then
+        assertThat(actual)
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(value)
+                .isSameAs(expected);
+    }
+
+    @Test(groups = "unit")
+    public void should_find_newly_registered_codec_by_cql_type() {
+        // given
+        CodecRegistry registry = new CodecRegistry();
+        TypeCodec expected = mockCodec(list(text()), listOf(String.class));
+        registry.register(expected);
+        // when
+        TypeCodec<?> actual = registry.codecFor(list(text()));
+        // then
+        assertThat(actual)
+                .isNotNull()
+                .isSameAs(expected);
+    }
+
+    @Test(groups = "unit")
+    public void should_find_default_codec_if_cql_type_already_registered() {
+        // given
+        CodecRegistry registry = new CodecRegistry();
+        TypeCodec newCodec = mockCodec(text(), of(StringBuilder.class));
+        registry.register(newCodec);
+        // when
+        TypeCodec<?> actual = registry.codecFor(text());
+        // then
+        assertThat(actual)
+                .isNotNull()
+                .isNotSameAs(newCodec)
+                .accepts(text())
+                .accepts(String.class)
+                .doesNotAccept(StringBuilder.class);
+    }
+
+    @Test(groups = "unit")
+    public void should_find_newly_registered_codec_by_java_type() {
+        // given
+        CodecRegistry registry = new CodecRegistry();
+        TypeCodec expected = mockCodec(text(), of(StringBuilder.class));
+        registry.register(expected);
+        // when
+        TypeCodec<?> actual = registry.codecFor(StringBuilder.class);
+        // then
+        assertThat(actual)
+                .isNotNull()
+                .isSameAs(expected);
+    }
+
+    @Test(groups = "unit")
+    public void should_find_default_codec_if_java_type_already_registered() {
+        // given
+        CodecRegistry registry = new CodecRegistry();
+        TypeCodec newCodec = mockCodec(cint(), of(String.class));
+        registry.register(newCodec);
+        // when
+        TypeCodec<?> actual = registry.codecFor(String.class);
+        // then
+        assertThat(actual)
+                .isNotNull()
+                .isNotSameAs(newCodec)
+                .accepts(String.class)
+                .accepts(text())
+                .doesNotAccept(cint());
+    }
+
+    @Test(groups = "unit")
+    public void should_find_newly_registered_codec_by_cql_type_and_java_type() {
+        // given
+        CodecRegistry registry = new CodecRegistry();
+        TypeCodec expected = mockCodec(list(text()), listOf(String.class));
+        registry.register(expected);
+        // when
+        TypeCodec<?> actual = registry.codecFor(list(text()), listOf(String.class));
+        // then
+        assertThat(actual)
+                .isNotNull()
+                .isSameAs(expected);
+    }
+
+    @Test(groups = "unit")
+    public void should_create_list_codec() {
+        CollectionType cqlType = list(cint());
+        TypeToken<List<Integer>> javaType = listOf(Integer.class);
+        assertThat(new CodecRegistry().codecFor(cqlType))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+        assertThat(new CodecRegistry().codecFor(javaType))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+        assertThat(new CodecRegistry().codecFor(cqlType, javaType))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+        assertThat(new CodecRegistry().codecFor(singletonList(42)))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+        assertThat(new CodecRegistry().codecFor(cqlType, singletonList(42)))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+        assertThat(new CodecRegistry().codecFor(new ArrayList<Integer>()))
+                .isNotNull()
+                // empty collections are mapped to blob codec if no CQL type provided
+                .accepts(list(blob()))
+                .accepts(listOf(ByteBuffer.class));
+        assertThat(new CodecRegistry().codecFor(cqlType, new ArrayList<Integer>()))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+    }
+
+    @Test(groups = "unit")
+    public void should_create_set_codec() {
+        CollectionType cqlType = set(cint());
+        TypeToken<Set<Integer>> javaType = setOf(Integer.class);
+        assertThat(new CodecRegistry().codecFor(cqlType))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+        assertThat(new CodecRegistry().codecFor(javaType))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+        assertThat(new CodecRegistry().codecFor(cqlType, javaType))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+        assertThat(new CodecRegistry().codecFor(singleton(42)))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+        assertThat(new CodecRegistry().codecFor(cqlType, singleton(42)))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+        assertThat(new CodecRegistry().codecFor(new HashSet<Integer>()))
+                .isNotNull()
+                // empty collections are mapped to blob codec if no CQL type provided
+                .accepts(set(blob()))
+                .accepts(setOf(ByteBuffer.class));
+        assertThat(new CodecRegistry().codecFor(cqlType, new HashSet<Integer>()))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+    }
+
+    @Test(groups = "unit")
+    public void should_create_map_codec() {
+        CollectionType cqlType = map(cint(), list(varchar()));
+        TypeToken<Map<Integer, List<String>>> javaType = mapOf(of(Integer.class), listOf(String.class));
+        assertThat(new CodecRegistry().codecFor(cqlType))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+        assertThat(new CodecRegistry().codecFor(javaType))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+        assertThat(new CodecRegistry().codecFor(cqlType, javaType))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+        assertThat(new CodecRegistry().codecFor(singletonMap(42, singletonList("foo"))))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+        assertThat(new CodecRegistry().codecFor(cqlType, singletonMap(42, singletonList("foo"))))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+        assertThat(new CodecRegistry().codecFor(new HashMap<Integer, List<String>>()))
+                .isNotNull()
+                // empty collections are mapped to blob codec if no CQL type provided
+                .accepts(map(blob(), blob()))
+                .accepts(mapOf(ByteBuffer.class, ByteBuffer.class));
+        assertThat(new CodecRegistry().codecFor(cqlType, new HashMap<Integer, List<String>>()))
+                .isNotNull()
+                .accepts(cqlType)
+                .accepts(javaType);
+    }
+
+    @Test(groups = "unit")
+    public void should_create_tuple_codec() {
+        CodecRegistry registry = new CodecRegistry();
+        TupleType tupleType = TupleType.of(V4, registry, cint(), varchar());
+        assertThat(registry.codecFor(tupleType))
+                .isNotNull()
+                .accepts(tupleType)
+                .accepts(TupleValue.class);
+        registry = new CodecRegistry();
+        try {
+            registry.codecFor(TupleValue.class);
+            fail("Should not have found a codec for TupleValue without its CQL type");
+        } catch (CodecNotFoundException e) {
+            // expected
+        }
+        registry = new CodecRegistry();
+        tupleType = TupleType.of(V4, registry, cint(), varchar());
+        assertThat(registry.codecFor(tupleType, TupleValue.class))
+                .isNotNull()
+                .accepts(tupleType)
+                .accepts(TupleValue.class);
+        registry = new CodecRegistry();
+        tupleType = TupleType.of(V4, registry, cint(), varchar());
+        assertThat(registry.codecFor(new TupleValue(tupleType)))
+                .isNotNull()
+                .accepts(tupleType)
+                .accepts(TupleValue.class);
+        assertThat(registry.codecFor(tupleType, new TupleValue(tupleType)))
+                .isNotNull()
+                .accepts(tupleType)
+                .accepts(TupleValue.class);
+    }
+
+    @Test(groups = "unit")
+    public void should_create_udt_codec() {
+        CodecRegistry registry = new CodecRegistry();
+        UserType udt = new UserType("ks", "test", Collections.<UserType.Field>emptyList(), V4, registry);
+        assertThat(registry.codecFor(udt))
+                .isNotNull()
+                .accepts(udt)
+                .accepts(UDTValue.class);
+        registry = new CodecRegistry();
+        try {
+            registry.codecFor(UDTValue.class);
+            fail("Should not have found a codec for UDTValue without its CQL type");
+        } catch (CodecNotFoundException e) {
+            // expected
+        }
+        registry = new CodecRegistry();
+        udt = new UserType("ks", "test", Collections.<UserType.Field>emptyList(), V4, registry);
+        assertThat(registry.codecFor(udt, UDTValue.class))
+                .isNotNull()
+                .accepts(udt)
+                .accepts(UDTValue.class);
+        registry = new CodecRegistry();
+        udt = new UserType("ks", "test", Collections.<UserType.Field>emptyList(), V4, registry);
+        assertThat(registry.codecFor(new UDTValue(udt)))
+                .isNotNull()
+                .accepts(udt)
+                .accepts(UDTValue.class);
+        registry = new CodecRegistry();
+        udt = new UserType("ks", "test", Collections.<UserType.Field>emptyList(), V4, registry);
+        assertThat(registry.codecFor(udt, new UDTValue(udt)))
+                .isNotNull()
+                .accepts(udt)
+                .accepts(UDTValue.class);
+    }
+
+    @Test(groups = "unit")
+    public void should_create_codec_for_custom_cql_type() {
+        DataType custom = DataType.custom("foo");
+        assertThat(new CodecRegistry().codecFor(custom))
+                .isNotNull()
+                .accepts(custom)
+                .accepts(ByteBuffer.class);
+        assertThat(new CodecRegistry().codecFor(custom, ByteBuffer.class))
+                .isNotNull()
+                .accepts(custom)
+                .accepts(ByteBuffer.class);
+        assertThat(new CodecRegistry().codecFor(custom, ByteBuffer.allocate(0)))
+                .isNotNull()
+                .accepts(custom)
+                .accepts(ByteBuffer.class);
+    }
+
+    @Test(groups = "unit")
+    public void should_create_derived_codecs_for_java_type_handled_by_custom_codec() {
+        TypeCodec<?> newCodec = mockCodec(varchar(), of(StringBuilder.class));
+        CodecRegistry registry = new CodecRegistry().register(newCodec);
+        // lookup by CQL type only returns default codec
+        assertThat(registry.codecFor(list(varchar()))).doesNotAccept(listOf(StringBuilder.class));
+        assertThat(registry.codecFor(listOf(StringBuilder.class)))
+                .isNotNull()
+                .accepts(list(varchar()));
+        assertThat(registry.codecFor(list(varchar()), listOf(StringBuilder.class)))
+                .isNotNull();
+    }
+
+    @Test(groups = "unit")
+    public void should_not_find_codec_if_java_type_unknown() {
+        try {
+            new CodecRegistry().codecFor(StringBuilder.class);
+            fail("Should not have found a codec for ANY <-> StringBuilder");
+        } catch (CodecNotFoundException e) {
+            // expected
+        }
+        try {
+            new CodecRegistry().codecFor(varchar(), StringBuilder.class);
+            fail("Should not have found a codec for varchar <-> StringBuilder");
+        } catch (CodecNotFoundException e) {
+            // expected
+        }
+        try {
+            new CodecRegistry().codecFor(new StringBuilder());
+            fail("Should not have found a codec for ANY <-> StringBuilder");
+        } catch (CodecNotFoundException e) {
+            // expected
+        }
+        try {
+            new CodecRegistry().codecFor(varchar(), new StringBuilder());
+            fail("Should not have found a codec for varchar <-> StringBuilder");
+        } catch (CodecNotFoundException e) {
+            // expected
+        }
+    }
 
     @Test(groups = "unit")
     public void should_ignore_codec_colliding_with_already_registered_codec() {
@@ -35,16 +538,13 @@ public class CodecRegistryTest {
 
         CodecRegistry registry = new CodecRegistry();
 
-        TypeCodec newCodec = mock(TypeCodec.class);
-        when(newCodec.getCqlType()).thenReturn(DataType.cint());
-        when(newCodec.getJavaType()).thenReturn(TypeToken.of(Integer.class));
-        when(newCodec.toString()).thenReturn("newCodec");
+        TypeCodec newCodec = mockCodec(cint(), of(Integer.class));
 
         registry.register(newCodec);
 
-        assertThat(logs.getNext()).contains("Ignoring codec newCodec");
+        assertThat(logs.getNext()).contains("Ignoring codec MockCodec");
         assertThat(
-                registry.codecFor(DataType.cint(), Integer.class)
+                registry.codecFor(cint(), Integer.class)
         ).isNotSameAs(newCodec);
 
         stopCapturingLogs(logs);
@@ -57,18 +557,15 @@ public class CodecRegistryTest {
         CodecRegistry registry = new CodecRegistry();
 
         // Force generation of a list token from the default token
-        registry.codecFor(DataType.list(DataType.cint()), LIST_OF_INT_TOKEN);
+        registry.codecFor(list(cint()), listOf(Integer.class));
 
-        TypeCodec newCodec = mock(TypeCodec.class);
-        when(newCodec.getCqlType()).thenReturn(DataType.list(DataType.cint()));
-        when(newCodec.getJavaType()).thenReturn(LIST_OF_INT_TOKEN);
-        when(newCodec.toString()).thenReturn("newCodec");
+        TypeCodec newCodec = mockCodec(list(cint()), listOf(Integer.class));
 
         registry.register(newCodec);
 
-        assertThat(logs.getNext()).contains("Ignoring codec newCodec");
+        assertThat(logs.getNext()).contains("Ignoring codec MockCodec");
         assertThat(
-                registry.codecFor(DataType.list(DataType.cint()), LIST_OF_INT_TOKEN)
+                registry.codecFor(list(cint()), listOf(Integer.class))
         ).isNotSameAs(newCodec);
 
         stopCapturingLogs(logs);
@@ -87,4 +584,15 @@ public class CodecRegistryTest {
         registryLogger.setLevel(null);
         registryLogger.removeAppender(logs);
     }
+
+    private TypeCodec<?> mockCodec(DataType cqlType, TypeToken<?> javaType) {
+        TypeCodec newCodec = mock(TypeCodec.class);
+        when(newCodec.getCqlType()).thenReturn(cqlType);
+        when(newCodec.getJavaType()).thenReturn(javaType);
+        when(newCodec.accepts(cqlType)).thenReturn(true);
+        when(newCodec.accepts(javaType)).thenReturn(true);
+        when(newCodec.toString()).thenReturn(String.format("MockCodec [%s <-> %s]", cqlType, javaType));
+        return newCodec;
+    }
+
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecAssert.java
@@ -24,59 +24,65 @@ import static org.assertj.core.api.Fail.fail;
 /**
  */
 @SuppressWarnings("unused")
-public class TypeCodecAssert extends AbstractAssert<TypeCodecAssert, TypeCodec> {
+public class TypeCodecAssert<T> extends AbstractAssert<TypeCodecAssert<T>, TypeCodec<T>> {
 
     private ProtocolVersion version = TestUtils.getDesiredProtocolVersion();
 
-    protected TypeCodecAssert(TypeCodec<?> actual) {
+    protected TypeCodecAssert(TypeCodec<T> actual) {
         super(actual, TypeCodecAssert.class);
     }
 
-    public TypeCodecAssert accepts(Class<?> clazz) {
-        return accepts(TypeToken.of(clazz));
-    }
-
-    public TypeCodecAssert accepts(TypeToken<?> javaType) {
-        assertThat(actual.accepts(javaType)).isTrue();
+    public TypeCodecAssert<T> accepts(TypeToken<?> javaType) {
+        assertThat(actual.accepts(javaType)).as("Codec %s should accept %s but it does not", actual, javaType).isTrue();
         return this;
     }
 
-    public TypeCodecAssert doesNotAccept(TypeToken<?> javaType) {
-        assertThat(actual.accepts(javaType)).isFalse();
+    public TypeCodecAssert<T> doesNotAccept(TypeToken<?> javaType) {
+        assertThat(actual.accepts(javaType)).as("Codec %s should not accept %s but it does", actual, javaType).isFalse();
         return this;
     }
 
-    public TypeCodecAssert accepts(Object value) {
+    public TypeCodecAssert<T> accepts(Class<?> javaType) {
+        assertThat(actual.accepts(javaType)).as("Codec %s should accept %s but it does not", actual, javaType).isTrue();
+        return this;
+    }
+
+    public TypeCodecAssert<T> doesNotAccept(Class<?> javaType) {
+        assertThat(actual.accepts(javaType)).as("Codec %s should not accept %s but it does", actual, javaType).isFalse();
+        return this;
+    }
+
+    public TypeCodecAssert<T> accepts(Object value) {
         assertThat(actual.accepts(value)).as("Codec %s should accept %s but it does not", actual, value).isTrue();
         return this;
     }
 
-    public TypeCodecAssert doesNotAccept(Object value) {
-        assertThat(actual.accepts(value)).isFalse();
+    public TypeCodecAssert<T> doesNotAccept(Object value) {
+        assertThat(actual.accepts(value)).as("Codec %s should not accept %s but it does", actual, value).isFalse();
         return this;
     }
 
-    public TypeCodecAssert accepts(DataType cqlType) {
-        assertThat(actual.accepts(cqlType)).isTrue();
+    public TypeCodecAssert<T> accepts(DataType cqlType) {
+        assertThat(actual.accepts(cqlType)).as("Codec %s should accept %s but it does not", actual, cqlType).isTrue();
         return this;
     }
 
-    public TypeCodecAssert doesNotAccept(DataType cqlType) {
-        assertThat(actual.accepts(cqlType)).isFalse();
+    public TypeCodecAssert<T> doesNotAccept(DataType cqlType) {
+        assertThat(actual.accepts(cqlType)).as("Codec %s should not accept %s but it does", actual, cqlType).isFalse();
         return this;
     }
 
-    public TypeCodecAssert withProtocolVersion(ProtocolVersion version) {
+    public TypeCodecAssert<T> withProtocolVersion(ProtocolVersion version) {
         if (version == null) fail("ProtocolVersion cannot be null");
         this.version = version;
         return this;
     }
 
     @SuppressWarnings("unchecked")
-    public TypeCodecAssert canSerialize(Object value) {
+    public TypeCodecAssert<T> canSerialize(Object value) {
         if (version == null) fail("ProtocolVersion cannot be null");
         try {
-            assertThat(actual.deserialize(actual.serialize(value, version), version)).isEqualTo(value);
+            assertThat(actual.deserialize(actual.serialize((T) value, version), version)).isEqualTo(value);
         } catch (Exception e) {
             fail(String.format("Codec is supposed to serialize this value but it actually doesn't: %s", value), e);
         }
@@ -84,10 +90,10 @@ public class TypeCodecAssert extends AbstractAssert<TypeCodecAssert, TypeCodec> 
     }
 
     @SuppressWarnings("unchecked")
-    public TypeCodecAssert cannotSerialize(Object value) {
+    public TypeCodecAssert<T> cannotSerialize(Object value) {
         if (version == null) fail("ProtocolVersion cannot be null");
         try {
-            actual.serialize(value, version);
+            actual.serialize((T) value, version);
             fail("Should not have been able to serialize " + value + " with " + actual);
         } catch (Exception e) {
             //ok
@@ -96,9 +102,9 @@ public class TypeCodecAssert extends AbstractAssert<TypeCodecAssert, TypeCodec> 
     }
 
     @SuppressWarnings("unchecked")
-    public TypeCodecAssert cannotFormat(Object value) {
+    public TypeCodecAssert<T> cannotFormat(Object value) {
         try {
-            actual.format(value);
+            actual.format((T) value);
             fail("Should not have been able to format " + value + " with " + actual);
         } catch (Exception e) {
             // ok

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
@@ -31,6 +31,7 @@ import java.util.*;
 import static com.datastax.driver.core.Assertions.assertThat;
 import static com.datastax.driver.core.DataType.*;
 import static com.datastax.driver.core.ProtocolVersion.V3;
+import static com.datastax.driver.core.TypeTokens.listOf;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.testng.Assert.fail;
 
@@ -252,13 +253,39 @@ public class TypeCodecTest {
                 .cannotFormat(type4UUID);
     }
 
+    /**
+     * Ensures that primitive types are correctly handled and wrapped when necessary.
+     */
+    @Test(groups = "unit")
+    public void should_unwrap_primitive_types() {
+        assertThat(TypeCodec.cboolean())
+                .accepts(Boolean.class)
+                .accepts(Boolean.TYPE)
+                .accepts(true);
+        assertThat(TypeCodec.cint())
+                .accepts(Integer.class)
+                .accepts(Integer.TYPE)
+                .accepts(42);
+        assertThat(TypeCodec.bigint())
+                .accepts(Long.class)
+                .accepts(Long.TYPE)
+                .accepts(42L);
+        assertThat(TypeCodec.cfloat())
+                .accepts(Float.class)
+                .accepts(Float.TYPE)
+                .accepts(42.0F);
+        assertThat(TypeCodec.cdouble())
+                .accepts(Double.class)
+                .accepts(Double.TYPE)
+                .accepts(42.0D);
+    }
 
     private class ListVarcharToListListInteger extends TypeCodec<List<List<Integer>>> {
 
         private final TypeCodec<List<String>> codec = TypeCodec.list(TypeCodec.varchar());
 
         protected ListVarcharToListListInteger() {
-            super(DataType.list(DataType.varchar()), TypeTokens.listOf(TypeTokens.listOf(Integer.class)));
+            super(DataType.list(DataType.varchar()), listOf(listOf(Integer.class)));
         }
 
         @Override


### PR DESCRIPTION
This PR also introduces two improvements in `TypeCodec`:
- A new overloaded method `accepts(Class<?> javaType)`: the motivation behind it is that oftentimes caller code calls by mistake e.g. `accepts(Integer.class)` which will actually resolve to `accepts(Object value)` leading to unexpected results.
- Removal of field `primitiveToWrapperMap`, replaced with `TypeToken.wrap()`.

This PR also improves test coverage for `CodecRegistry`.
