### PR TITLE
Add support for using DataStax Enterprise with CCMBridge.

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -51,9 +51,11 @@ public class CCMBridge {
 
     public static final String IP_PREFIX;
 
-    static final String CASSANDRA_VERSION;
+    private static final String CASSANDRA_VERSION;
 
-    static final String CASSANDRA_INSTALL_ARGS;
+    private static final String CASSANDRA_INSTALL_ARGS;
+
+    private static final boolean IS_DSE;
 
     public static final String DEFAULT_CLIENT_TRUSTSTORE_PASSWORD = "cassandra1sfun";
     public static final String DEFAULT_CLIENT_TRUSTSTORE_PATH = "/client.truststore";
@@ -86,6 +88,49 @@ public class CCMBridge {
     private static final Map<String, String> ENVIRONMENT_MAP;
 
     /**
+     * A mapping of full DSE versions to their C* counterpart.  This is not meant to be comprehensive.  Used by
+     * {@link #getCassandraVersion()}.  If C* version cannot be derived, the method makes a 'best guess'.
+     */
+    private static final Map<String, String> dseToCassandraVersions = ImmutableMap.<String, String>builder()
+            .put("5.0", "3.0")
+            .put("4.8.3", "2.1.11")
+            .put("4.8.2", "2.1.11")
+            .put("4.8.1", "2.1.11")
+            .put("4.8", "2.1.9")
+            .put("4.7.6", "2.1.11")
+            .put("4.7.5", "2.1.11")
+            .put("4.7.4", "2.1.11")
+            .put("4.7.3", "2.1.8")
+            .put("4.7.2", "2.1.8")
+            .put("4.7.1", "2.1.5")
+            .put("4.6.11", "2.0.16")
+            .put("4.6.10", "2.0.16")
+            .put("4.6.9", "2.0.16")
+            .put("4.6.8", "2.0.16")
+            .put("4.6.7", "2.0.14")
+            .put("4.6.6", "2.0.14")
+            .put("4.6.5", "2.0.14")
+            .put("4.6.4", "2.0.14")
+            .put("4.6.3", "2.0.12")
+            .put("4.6.2", "2.0.12")
+            .put("4.6.1", "2.0.12")
+            .put("4.6", "2.0.11")
+            .put("4.5.9", "2.0.16")
+            .put("4.5.8", "2.0.14")
+            .put("4.5.7", "2.0.12")
+            .put("4.5.6", "2.0.12")
+            .put("4.5.5", "2.0.12")
+            .put("4.5.4", "2.0.11")
+            .put("4.5.3", "2.0.11")
+            .put("4.5.2", "2.0.10")
+            .put("4.5.1", "2.0.8")
+            .put("4.5", "2.0.8")
+            .put("4.0", "2.0")
+            .put("3.2", "1.2")
+            .put("3.1", "1.2")
+            .build();
+
+    /**
      * The command to use to launch CCM
      */
     private static final String CCM_COMMAND;
@@ -94,13 +139,29 @@ public class CCMBridge {
         CASSANDRA_VERSION = System.getProperty("cassandra.version");
         String installDirectory = System.getProperty("cassandra.directory");
         String branch = System.getProperty("cassandra.branch");
+
+        String dseProperty = System.getProperty("dse");
+        // If -Ddse, if the value is empty interpret it as enabled,
+        // otherwise if there is a value, parse as boolean.
+        IS_DSE = dseProperty != null && (dseProperty.isEmpty() || Boolean.parseBoolean(dseProperty));
+
+        StringBuilder installArgs = new StringBuilder();
         if (installDirectory != null && !installDirectory.trim().isEmpty()) {
-            CASSANDRA_INSTALL_ARGS = "--install-dir=" + new File(installDirectory).getAbsolutePath();
+            installArgs.append("--install-dir=");
+            installArgs.append(new File(installDirectory).getAbsolutePath());
         } else if (branch != null && !branch.trim().isEmpty()) {
-            CASSANDRA_INSTALL_ARGS = "-v git:" + branch;
+            installArgs.append("-v git:");
+            installArgs.append(branch.trim().replaceAll("\"", ""));
         } else {
-            CASSANDRA_INSTALL_ARGS = "-v " + CASSANDRA_VERSION;
+            installArgs.append("-v");
+            installArgs.append(CASSANDRA_VERSION);
         }
+
+        if (IS_DSE) {
+            installArgs.append(" --dse");
+        }
+
+        CASSANDRA_INSTALL_ARGS = installArgs.toString();
 
         String ip_prefix = System.getProperty("ipprefix");
         if (ip_prefix == null || ip_prefix.isEmpty()) {
@@ -132,6 +193,14 @@ public class CCMBridge {
             envMap.put("JAVA_HOME", ccmJavaHome);
         }
         ENVIRONMENT_MAP = ImmutableMap.copyOf(envMap);
+
+        if (CCMBridge.isDSE()) {
+            logger.info("Tests requiring CCM will use DSE version {} (C* {}, install arguments: {})",
+                    CCMBridge.getDSEVersion(), CCMBridge.getCassandraVersion(), CCMBridge.getInstallArguments());
+        } else {
+            logger.info("Tests requiring CCM will use Cassandra version {} (install arguments: {})",
+                    CCMBridge.getCassandraVersion(), CCMBridge.getInstallArguments());
+        }
     }
 
     /**
@@ -147,8 +216,68 @@ public class CCMBridge {
 
     private final File ccmDir;
 
-    private CCMBridge() {
+    private final boolean isDSE;
+
+    private CCMBridge(boolean isDSE) {
         this.ccmDir = Files.createTempDir();
+        this.isDSE = isDSE;
+    }
+
+    /**
+     * @return The configured cassandra version.  If -Ddse=true was used, this value is derived from the
+     * DSE version provided.  If the DSE version can't be derived the following logic is used:
+     * <ol>
+     * <li>If <= 3.X, use C* 1.2</li>
+     * <li>If 4.X, use 2.1 for >= 4.7, 2.0 otherwise.</li>
+     * <li>Otherwise 3.0</li>
+     * </ol>
+     */
+    public static String getCassandraVersion() {
+        if (isDSE()) {
+            String cassandraVersion = dseToCassandraVersions.get(CASSANDRA_VERSION);
+            if (cassandraVersion != null) {
+                return cassandraVersion;
+            } else if (CASSANDRA_VERSION.startsWith("3.") || CASSANDRA_VERSION.compareTo("3") <= 0) {
+                return "1.2";
+            } else if (CASSANDRA_VERSION.startsWith("4.")) {
+                if (CASSANDRA_VERSION.compareTo("4.7") >= 0) {
+                    return "2.1";
+                } else {
+                    return "2.0";
+                }
+            } else {
+                // Fallback on 3.0 by default.
+                return "3.0";
+            }
+
+        } else {
+            return CASSANDRA_VERSION;
+        }
+    }
+
+    /**
+     * @return The configured DSE version if '-Ddse=true' specified, otherwise null.
+     */
+    public static String getDSEVersion() {
+        if (isDSE()) {
+            return CASSANDRA_VERSION;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @return Whether or not DSE was configured via '-Ddse=true'.
+     */
+    public static boolean isDSE() {
+        return IS_DSE;
+    }
+
+    /**
+     * @return The install arguments to pass to CCM when creating the cluster.
+     */
+    public static String getInstallArguments() {
+        return CASSANDRA_INSTALL_ARGS;
     }
 
     /**
@@ -216,9 +345,14 @@ public class CCMBridge {
         execute(CCM_COMMAND + " node%d start --wait-other-notice --wait-for-binary-proto", n);
     }
 
-    public void start(int n, String jvmArg) {
-        logger.info("Starting: " + IP_PREFIX + n + " with " + jvmArg);
-        execute(CCM_COMMAND + " node%d start --wait-other-notice --wait-for-binary-proto --jvm_arg=%s", n, jvmArg);
+    public void start(int n, String... jvmArg) {
+        StringBuilder jvmArgs = new StringBuilder("");
+        for (int i = 0; i < jvmArg.length; i++) {
+            jvmArgs.append(" --jvm_arg=");
+            jvmArgs.append(jvmArg[i]);
+        }
+        logger.info("Starting: " + IP_PREFIX + n + " with " + jvmArgs);
+        execute(CCM_COMMAND + " node%d start --wait-other-notice --wait-for-binary-proto %s", n, jvmArgs.toString());
     }
 
     public void stop(int n) {
@@ -257,9 +391,9 @@ public class CCMBridge {
 
     public void bootstrapNode(int n, String dc) {
         if (dc == null)
-            execute(CCM_COMMAND + " add node%d -i %s%d -j %d -r %d -b -s", n, IP_PREFIX, n, 7000 + 100 * n, 8000 + 100 * n);
+            execute(CCM_COMMAND + " add node%d -i %s%d -j %d -r %d -b -s" + (isDSE ? " --dse" : ""), n, IP_PREFIX, n, 7000 + 100 * n, 8000 + 100 * n);
         else
-            execute(CCM_COMMAND + " add node%d -i %s%d -j %d -b -d %s -s", n, IP_PREFIX, n, 7000 + 100 * n, dc);
+            execute(CCM_COMMAND + " add node%d -i %s%d -j %d -b -d %s -s" + (isDSE ? " --dse" : ""), n, IP_PREFIX, n, 7000 + 100 * n, dc);
         execute(CCM_COMMAND + " node%d start --wait-other-notice --wait-for-binary-proto", n);
     }
 
@@ -268,7 +402,7 @@ public class CCMBridge {
         String storageItf = IP_PREFIX + n + ":" + storagePort;
         String binaryItf = IP_PREFIX + n + ":" + binaryPort;
         String remoteLogItf = IP_PREFIX + n + ":" + remoteDebugPort;
-        execute(CCM_COMMAND + " add node%d -i %s%d -b -t %s -l %s --binary-itf %s -j %d -r %s -s",
+        execute(CCM_COMMAND + " add node%d -i %s%d -b -t %s -l %s --binary-itf %s -j %d -r %s -s" + (isDSE ? " --dse" : ""),
                 n, IP_PREFIX, n, thriftItf, storageItf, binaryItf, jmxPort, remoteLogItf);
         execute(CCM_COMMAND + " node%d start --wait-other-notice --wait-for-binary-proto", n);
     }
@@ -283,6 +417,18 @@ public class CCMBridge {
             confStr.append(entry.getKey() + ":" + entry.getValue() + " ");
         }
         execute(CCM_COMMAND + " updateconf " + confStr);
+    }
+
+    public void updateDSEConfig(Map<String, String> configs) {
+        StringBuilder confStr = new StringBuilder();
+        for (Map.Entry<String, String> entry : configs.entrySet()) {
+            confStr.append(entry.getKey() + ":" + entry.getValue() + " ");
+        }
+        execute(CCM_COMMAND + " updatedseconf " + confStr);
+    }
+
+    public void setWorkload(int node, String workload) {
+        execute(CCM_COMMAND + " node%d setworkload %s", node, workload);
     }
 
     private void execute(String command, Object... args) {
@@ -618,9 +764,13 @@ public class CCMBridge {
         private final String clusterName;
         private Integer[] nodes = {1};
         private boolean start = true;
+        private boolean isDSE = IS_DSE;
         private String cassandraInstallArgs = CASSANDRA_INSTALL_ARGS;
         private String[] startOptions = new String[0];
+
         private Map<String, String> cassandraConfiguration = Maps.newHashMap();
+
+        private Map<String, String> dseConfiguration = Maps.newHashMap();
 
 
         Builder(String clusterName) {
@@ -665,6 +815,13 @@ public class CCMBridge {
          */
         public Builder withCassandraVersion(String cassandraVersion) {
             this.cassandraInstallArgs = "-v " + cassandraVersion;
+            this.isDSE = false;
+            return this;
+        }
+
+        public Builder withDSEVersion(String dseVersion) {
+            this.cassandraInstallArgs = "-v " + dseVersion + " --dse";
+            this.isDSE = true;
             return this;
         }
 
@@ -684,10 +841,18 @@ public class CCMBridge {
             return this;
         }
 
+        public Builder withDSEConfiguration(String key, String value) {
+            this.dseConfiguration.put(key, value);
+            return this;
+        }
+
         public CCMBridge build() {
-            CCMBridge ccm = new CCMBridge();
+            CCMBridge ccm = new CCMBridge(isDSE);
             ccm.execute(buildCreateCommand());
-            ccm.updateConfig(cassandraConfiguration);
+            if (!cassandraConfiguration.isEmpty())
+                ccm.updateConfig(cassandraConfiguration);
+            if (!dseConfiguration.isEmpty())
+                ccm.updateDSEConfig(dseConfiguration);
             if (start)
                 ccm.start();
             return ccm;

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -24,7 +24,6 @@ import org.scassandra.Scassandra;
 import org.scassandra.ScassandraFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.SkipException;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -392,16 +391,6 @@ public abstract class TestUtils {
         return testForDown ? !host.isUp() : host.isUp();
     }
 
-    public static void versionCheck(double majorCheck, int minorCheck, String skipString) {
-        String version = System.getProperty("cassandra.version");
-        String[] versionArray = version.split("\\.|-");
-        double major = Double.parseDouble(versionArray[0] + "." + versionArray[1]);
-        int minor = Integer.parseInt(versionArray[2]);
-
-        if (major < majorCheck || (major == majorCheck && minor < minorCheck)) {
-            throw new SkipException("Version >= " + majorCheck + "." + minorCheck + " required.  Description: " + skipString);
-        }
-    }
 
     public static Host findOrWaitForHost(Cluster cluster, int node, long duration, TimeUnit unit) {
         return findOrWaitForHost(cluster, CCMBridge.ipOfNode(node), duration, unit);

--- a/driver-core/src/test/java/com/datastax/driver/core/utils/DseVersion.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/utils/DseVersion.java
@@ -19,20 +19,20 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- * <p>Annotation for a Class or Method that defines a Cassandra Version requirement.  If the cassandra version in use
- * does not meet the version requirement, the test is skipped.</p>
+ * <p>Annotation for a Class or Method that defines a DataStax Enterprise Version requirement.
+ * If the version in use does not meet the version requirement or DSE is not used, the test is skipped.</p>
  *
  * @see {@link com.datastax.driver.core.TestListener#beforeInvocation(org.testng.IInvokedMethod, org.testng.ITestResult)} for usage.
  */
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CassandraVersion {
+public @interface DseVersion {
     /**
-     * @return The major version required to execute this test, i.e. "2.0"
+     * @return The major version required to execute this test, i.e. "4.8"
      */
-    double major();
+    double major() default 0.0;
 
     /**
-     * @return The minor version required to execute this test, i.e. "0"
+     * @return The minor version required to execute this test, i.e. "3"
      */
     int minor() default 0;
 


### PR DESCRIPTION
Adds support for running integration tests with DataStax Enterprise.

To run tests with DSE, set the system property 'dse.version' to the version of DSE you want to test with.  Note that you will still need to pass in a 'cassandra.version' property to indicate which major version of cassandra is associated with this DSE version (as this affects behavior of some tests).

Rather than adding system properties for DSE credentials, this relies on a [recent change](pcmanus/ccm#https://github.com/pcmanus/ccm/pull/426) in CCM to support providing credentials via $HOME/.ccm/.dse.ini.  The contents of this file needs to be formed in this way:

``` ini
[dse_credentials]
dse_username = myusername
dse_password = mypassword
```
