### PR TITLE
Fixes for tests using enable_user_defined_functions 

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
@@ -18,10 +18,12 @@ package com.datastax.driver.core;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.datastax.driver.core.exceptions.UnsupportedFeatureException;
 import com.datastax.driver.core.utils.CassandraVersion;
+import com.google.common.util.concurrent.Uninterruptibles;
 import org.testng.annotations.Test;
 
 import java.net.InetAddress;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import static com.datastax.driver.core.TestUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -609,7 +611,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
      * @jira_ticket JAVA-777
      * @since 2.2.0
      */
-    @Test(groups = "short")
+    @Test(groups = "long")
     public void should_create_tombstone_when_null_value_on_bound_statement() {
         PreparedStatement prepared = session.prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (?, ?)");
         BoundStatement st1 = prepared.bind();
@@ -620,6 +622,8 @@ public class PreparedStatementTest extends CCMTestsSupport {
         st2.enableTracing();
         ResultSet rows = session.execute(st2);
         assertThat(rows.one().isNull(0)).isTrue();
+        // sleep 1 minute to make sure the trace will be complete
+        Uninterruptibles.sleepUninterruptibly(1, TimeUnit.MINUTES);
         QueryTrace queryTrace = rows.getExecutionInfo().getQueryTrace();
         assertEventsContain(queryTrace, "1 tombstone");
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/exceptions/FunctionExecutionExceptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/exceptions/FunctionExecutionExceptionTest.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.driver.core.exceptions;
 
+import com.datastax.driver.core.CCMConfig;
 import com.datastax.driver.core.CCMTestsSupport;
 import com.datastax.driver.core.utils.CassandraVersion;
 import com.google.common.collect.Lists;
@@ -23,6 +24,7 @@ import org.testng.annotations.Test;
 import java.util.Collection;
 
 @CassandraVersion(major = 2.2)
+@CCMConfig(config = "enable_user_defined_functions:true")
 public class FunctionExecutionExceptionTest extends CCMTestsSupport {
 
     @Override


### PR DESCRIPTION
Some quick fixes after 2.1 -> 3.0 merge around the 'enable_user_defined_functions' configuration.

Tests that use this config option are failing with < 2.2 cassandra versions since C\* doesn't allow unknown configs in cassandra.yaml.  Added a `configVersionRequirements` map to CCMTestsSupport that contains a listing of configurations and their version requirements.  If a config is found that requires a certain version and the version requirement can't be met, it is not used.  Not sure if this is the best approach, but does the job.

Also updated FunctionExecutionExceptionTest to use enable_user_defined_functions.

There may be more issues with the merge.  I noticed that the 3.0 C\* version builds didn't run well, but 2 of the 3 failed because of what appeared to be CI issues, so there might not actually be a problem there.
