### PR TITLE
JAVA-1097: AccessorMapper<T>.prepare() loses exception details

### DIFF
--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/AccessorMapper.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/AccessorMapper.java
@@ -45,7 +45,7 @@ abstract class AccessorMapper<T> {
             for (int i = 0; i < methods.size(); i++)
                 methods.get(i).prepare(manager, preparedStatements.get(i));
         } catch (Exception e) {
-            throw new RuntimeException("Error preparing queries for accessor " + daoClass.getSimpleName(), e);
+            throw new RuntimeException("Error preparing queries for accessor " + daoClass.getSimpleName() + " : " + e.toString(), e);
         }
     }
 


### PR DESCRIPTION
`AccessorMapper<T>.prepare()` catches/rethrows exceptions but
loses the details of the original exception.  Instead, the
meaningful content of the exception is reduced to:

> Error preparing queries for accessor

This patch appends the original exception text to the
message to produce a meaningful exception such as:

> Error preparing queries for accessor Dao :
> java.lang.RuntimeException: Cannot map return of method
> public abstract java.util.Iterator ... to unsupported type
> java.util.Iterator<...>
