### PR TITLE
JAVA-1043: Use protected fields in RoundRobinPolicy to enable subclassing

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,7 @@
 
 ### 3.0.0 (in progress)
 
+- [improvement] JAVA-1043: Use protected fields in RoundRobinPolicy to enable subclassing.
 - [bug] JAVA-1034: fix metadata parser for collections of custom types.
 - [improvement] JAVA-1035: Expose host broadcast_address and listen_address if available.
 

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/RoundRobinPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/RoundRobinPolicy.java
@@ -43,11 +43,11 @@ public class RoundRobinPolicy implements LoadBalancingPolicy {
 
     private static final Logger logger = LoggerFactory.getLogger(RoundRobinPolicy.class);
 
-    private final CopyOnWriteArrayList<Host> liveHosts = new CopyOnWriteArrayList<Host>();
-    private final AtomicInteger index = new AtomicInteger();
+    protected final CopyOnWriteArrayList<Host> liveHosts = new CopyOnWriteArrayList<Host>();
+    protected final AtomicInteger index = new AtomicInteger();
 
-    private volatile Configuration configuration;
-    private volatile boolean hasLoggedLocalCLUse;
+    protected volatile Configuration configuration;
+    protected volatile boolean hasLoggedLocalCLUse;
 
     /**
      * Creates a load balancing policy that picks host to query in a round robin


### PR DESCRIPTION
This PR applies the patch by @djatnieks .
