### PR TITLE
More CCM test fixes

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/AbstractPoliciesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AbstractPoliciesTest.java
@@ -15,6 +15,10 @@
  */
 package com.datastax.driver.core;
 
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
 import java.net.InetAddress;
@@ -23,45 +27,53 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import static com.datastax.driver.core.TestUtils.*;
+import static com.datastax.driver.core.ConditionChecker.check;
+import static com.datastax.driver.core.TestUtils.CREATE_KEYSPACE_GENERIC_FORMAT;
+import static com.datastax.driver.core.TestUtils.CREATE_KEYSPACE_SIMPLE_FORMAT;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.batch;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
-import static org.testng.Assert.*;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.testng.Assert.assertEquals;
 
 public abstract class AbstractPoliciesTest extends CCMTestsSupport {
 
-    private static final boolean DEBUG = false;
+    private static final Logger logger = LoggerFactory.getLogger(AbstractPoliciesTest.class);
+    private String tableName;
+
+    private static class SchemaInAgreement implements Callable<Boolean> {
+
+        private final Cluster cluster;
+
+        private SchemaInAgreement(Cluster cluster) {
+            this.cluster = cluster;
+        }
+
+        @Override
+        public Boolean call() throws Exception {
+            return cluster.getMetadata().checkSchemaAgreement();
+        }
+    }
 
     protected Map<InetAddress, Integer> coordinators = new HashMap<InetAddress, Integer>();
 
     protected PreparedStatement prepared;
 
     protected void createSchema(int replicationFactor) {
-        final String ks = TestUtils.getAvailableKeyspaceName();
-        session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, ks, replicationFactor));
-        // tests fail randomly here with InvalidQueryException: Keyspace 'xxx' does not exist
-        ConditionChecker.awaitUntil(new Callable<Boolean>() {
-            @Override
-            public Boolean call() {
-                return cluster.getMetadata().getKeyspace(ks) != null;
-            }
-        }, 60000);
-        session.execute("USE " + ks);
-        session.execute(String.format("CREATE TABLE %s (k int PRIMARY KEY, i int)", SIMPLE_TABLE));
+        final String ks = TestUtils.generateIdentifier("ks_");
+        tableName = TestUtils.generateIdentifier("table_");
+        session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, ks, replicationFactor));
+        useKeyspace(ks);
+        session().execute(String.format("CREATE TABLE %s (k int PRIMARY KEY, i int)", tableName));
+        check().before(5, MINUTES).that(new SchemaInAgreement(cluster())).becomesTrue();
     }
 
     protected void createMultiDCSchema(int dc1RF, int dc2RF) {
-        final String ks = TestUtils.getAvailableKeyspaceName();
-        session.execute(String.format(CREATE_KEYSPACE_GENERIC_FORMAT, ks, "NetworkTopologyStrategy", String.format("'dc1' : %d, 'dc2' : %d", dc1RF, dc2RF)));
-        // tests fail randomly here with InvalidQueryException: Keyspace 'xxx' does not exist
-        ConditionChecker.awaitUntil(new Callable<Boolean>() {
-            @Override
-            public Boolean call() {
-                return cluster.getMetadata().getKeyspace(ks) != null;
-            }
-        }, 60000);
-        session.execute("USE " + ks);
-        session.execute(String.format("CREATE TABLE %s (k int PRIMARY KEY, i int)", SIMPLE_TABLE));
+        final String ks = TestUtils.generateIdentifier("ks_");
+        tableName = TestUtils.generateIdentifier("table_");
+        session().execute(String.format(CREATE_KEYSPACE_GENERIC_FORMAT, ks, "NetworkTopologyStrategy", String.format("'dc1' : %d, 'dc2' : %d", dc1RF, dc2RF)));
+        useKeyspace(ks);
+        session().execute(String.format("CREATE TABLE %s (k int PRIMARY KEY, i int)", tableName));
+        check().before(5, MINUTES).that(new SchemaInAgreement(cluster())).becomesTrue();
     }
 
     /**
@@ -78,6 +90,12 @@ public abstract class AbstractPoliciesTest extends CCMTestsSupport {
         coordinators = new HashMap<InetAddress, Integer>();
     }
 
+    @AfterMethod(groups = "long")
+    protected void pause() {
+        // pause before engaging in another expensive CCM cluster creation
+        Uninterruptibles.sleepUninterruptibly(1, MINUTES);
+    }
+
     private String queriedMapString() {
         StringBuilder sb = new StringBuilder();
         sb.append("{");
@@ -92,66 +110,14 @@ public abstract class AbstractPoliciesTest extends CCMTestsSupport {
     protected void assertQueried(String host, int n) {
         try {
             Integer queried = coordinators.get(InetAddress.getByName(host));
-            if (DEBUG)
-                System.out.println(String.format("Expected: %s\tReceived: %s", n, queried));
-            else {
-                assertEquals(queried == null ? 0 : queried, n, queriedMapString());
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    protected void assertQueriedAtLeast(String host, int n) {
-        try {
-            Integer queried = coordinators.get(InetAddress.getByName(host));
-            queried = queried == null ? 0 : queried;
-            if (DEBUG)
-                System.out.println(String.format("Expected > %s\tReceived: %s", n, queried));
+            if (logger.isDebugEnabled())
+                logger.debug(String.format("Expected: %s\tReceived: %s", n, queried));
             else
-                assertTrue(queried >= n, "For " + host);
+                assertEquals(queried == null ? 0 : queried, n, queriedMapString());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
-
-    /**
-     * Assert that one of the nodes in the list was queried with n, no matter which one
-     */
-    protected void assertOneNodeQueried(int n, String... hosts) {
-        try {
-            boolean found = false;
-            for (String host : hosts) {
-                InetAddress addr = InetAddress.getByName(host);
-                int queried = coordinators.containsKey(addr) ? coordinators.get(addr) : 0;
-                if (DEBUG)
-                    System.out.println(String.format("Expected: %s\tReceived: %s", n, queried));
-                else {
-
-                    if (n == queried) {
-                        if (found)
-                            throw new AssertionError(String.format("Found 2 nodes with %s queries in %s", n, queriedMapString()));
-                        found = true;
-                    } else {
-                        if (queried != 0)
-                            throw new AssertionError(String.format("Host %s should have be queried: %s", addr, queriedMapString()));
-                    }
-                }
-            }
-            if (!found)
-                throw new AssertionError("Found no host queried exactly " + n + " times in " + queriedMapString());
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    protected void failDebug(String message) {
-        if (DEBUG)
-            System.out.println(message);
-        else
-            fail(message);
-    }
-
 
     /**
      * Init methods that handle writes using batch and consistency options.
@@ -170,7 +136,7 @@ public abstract class AbstractPoliciesTest extends CCMTestsSupport {
 
     protected void init(int n, boolean batch, ConsistencyLevel cl) {
         write(n, batch, cl);
-        prepared = session.prepare("SELECT * FROM " + SIMPLE_TABLE + " WHERE k = ?").setConsistencyLevel(cl);
+        prepared = session().prepare("SELECT * FROM " + tableName + " WHERE k = ?").setConsistencyLevel(cl);
     }
 
     protected void write(int n) {
@@ -191,11 +157,11 @@ public abstract class AbstractPoliciesTest extends CCMTestsSupport {
         for (int i = 0; i < n; ++i)
             if (batch)
                 // BUG: WriteType == SIMPLE
-                session.execute(batch()
-                        .add(insertInto(SIMPLE_TABLE).values(new String[]{"k", "i"}, new Object[]{0, 0}))
+                session().execute(batch()
+                        .add(insertInto(tableName).values(new String[]{"k", "i"}, new Object[]{0, 0}))
                         .setConsistencyLevel(cl));
             else
-                session.execute(new SimpleStatement(String.format("INSERT INTO %s(k, i) VALUES (0, 0)", SIMPLE_TABLE)).setConsistencyLevel(cl));
+                session().execute(new SimpleStatement(String.format("INSERT INTO %s(k, i) VALUES (0, 0)", tableName)).setConsistencyLevel(cl));
     }
 
 
@@ -218,12 +184,13 @@ public abstract class AbstractPoliciesTest extends CCMTestsSupport {
         if (usePrepared) {
             BoundStatement bs = prepared.bind(0);
             for (int i = 0; i < n; ++i)
-                addCoordinator(session.execute(bs));
+                addCoordinator(session().execute(bs));
         } else {
             ByteBuffer routingKey = ByteBuffer.allocate(4);
             routingKey.putInt(0, 0);
             for (int i = 0; i < n; ++i)
-                addCoordinator(session.execute(new SimpleStatement(String.format("SELECT * FROM %s WHERE k = 0", SIMPLE_TABLE)).setRoutingKey(routingKey).setConsistencyLevel(cl)));
+                addCoordinator(session().execute(new SimpleStatement(String.format("SELECT * FROM %s WHERE k = 0", tableName)).setRoutingKey(routingKey).setConsistencyLevel(cl)));
         }
     }
+
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/AbstractReconnectionHandlerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AbstractReconnectionHandlerTest.java
@@ -31,6 +31,7 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.datastax.driver.core.ConditionChecker.check;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.fail;
@@ -41,8 +42,14 @@ public class AbstractReconnectionHandlerTest {
     ScheduledExecutorService executor;
     MockReconnectionSchedule schedule;
     MockReconnectionWork work;
-    final AtomicReference<ListenableFuture<?>> future = new AtomicReference<ListenableFuture<?>>();
+    AtomicReference<ListenableFuture<?>> future = new AtomicReference<ListenableFuture<?>>();
     AbstractReconnectionHandler handler;
+    Callable<Boolean> nextTryAssigned = new Callable<Boolean>() {
+        @Override
+        public Boolean call() throws Exception {
+            return handler.handlerFuture.nextTry != null;
+        }
+    };
 
     @BeforeMethod(groups = {"unit", "short"})
     public void setup() {
@@ -58,7 +65,7 @@ public class AbstractReconnectionHandlerTest {
 
             @Override
             protected void onReconnection(Connection connection) {
-                work.onReconnection(connection);
+                work.onReconnection();
             }
         };
     }
@@ -149,12 +156,7 @@ public class AbstractReconnectionHandlerTest {
         verify(executor, timeout(10000)).schedule(handler, schedule.delay, TimeUnit.MILLISECONDS);
 
         // Wait until nextTry is assigned after schedule completes.
-        ConditionChecker.awaitUntil(new Callable<Boolean>() {
-            @Override
-            public Boolean call() throws Exception {
-                return handler.handlerFuture.nextTry != null;
-            }
-        }, 10000);
+        check().before(10000).that(nextTryAssigned).becomesTrue();
 
         future.get().cancel(false);
 
@@ -341,7 +343,7 @@ public class AbstractReconnectionHandlerTest {
             tries += 1;
             logger.debug("in reconnection work, wait for tick from main thread");
             try {
-                barrier.await(10, TimeUnit.SECONDS);
+                barrier.await(60, TimeUnit.SECONDS);
                 logger.debug("in reconnection work, got tick from main thread, proceeding");
             } catch (Exception e) {
                 fail("Error while waiting for tick", e);
@@ -362,14 +364,14 @@ public class AbstractReconnectionHandlerTest {
         public void tick() {
             logger.debug("send tick to reconnection work");
             try {
-                barrier.await(10, TimeUnit.SECONDS);
+                barrier.await(60, TimeUnit.SECONDS);
             } catch (Exception e) {
                 fail("Error while sending tick, no thread was waiting", e);
             }
             barrier.reset();
         }
 
-        protected void onReconnection(Connection connection) {
+        protected void onReconnection() {
             success = true;
         }
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/AuthenticationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AuthenticationTest.java
@@ -39,7 +39,7 @@ public class AuthenticationTest extends CCMTestsSupport {
     public void sleepIf12() {
         // For C* 1.2, sleep before attempting to connect as there is a small delay between
         // user being created.
-        if (ccm.getVersion().getMajor() < 2) {
+        if (ccm().getVersion().getMajor() < 2) {
             Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
         }
     }
@@ -47,7 +47,8 @@ public class AuthenticationTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void should_connect_with_credentials() throws InterruptedException {
         Cluster cluster = register(Cluster.builder()
-                .addContactPointsWithPorts(getInitialContactPoints())
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
                 .withCredentials("cassandra", "cassandra")
                 .build());
         cluster.connect();
@@ -56,7 +57,8 @@ public class AuthenticationTest extends CCMTestsSupport {
     @Test(groups = "short", expectedExceptions = AuthenticationException.class)
     public void should_fail_to_connect_with_wrong_credentials() throws InterruptedException {
         Cluster cluster = register(Cluster.builder()
-                .addContactPointsWithPorts(getInitialContactPoints())
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
                 .withCredentials("bogus", "bogus")
                 .build());
         cluster.connect();
@@ -65,7 +67,8 @@ public class AuthenticationTest extends CCMTestsSupport {
     @Test(groups = "short", expectedExceptions = AuthenticationException.class)
     public void should_fail_to_connect_without_credentials() throws InterruptedException {
         Cluster cluster = register(Cluster.builder()
-                .addContactPointsWithPorts(getInitialContactPoints())
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
                 .build());
         cluster.connect();
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/BoundStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/BoundStatementTest.java
@@ -20,8 +20,6 @@ import com.google.common.collect.Lists;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.util.Collection;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -30,13 +28,13 @@ public class BoundStatementTest extends CCMTestsSupport {
     PreparedStatement prepared;
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Lists.newArrayList("CREATE TABLE foo (k int primary key, v1 text, v2 list<int>)");
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE foo (k int primary key, v1 text, v2 list<int>)");
     }
 
     @BeforeClass(groups = "short")
     public void setup() {
-        prepared = session.prepare("INSERT INTO foo (k, v1, v2) VALUES (?, ?, ?)");
+        prepared = session().prepare("INSERT INTO foo (k, v1, v2) VALUES (?, ?, ?)");
     }
 
     @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMAccess.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMAccess.java
@@ -22,6 +22,8 @@ import java.util.Map;
 
 public interface CCMAccess extends Closeable {
 
+    enum Workload {cassandra, solr, hadoop, spark, cfs, graph}
+
     // Inspection methods
 
     /**
@@ -130,6 +132,10 @@ public interface CCMAccess extends Closeable {
      */
     void updateDSEConfig(Map<String, Object> configs);
 
+    /**
+     * Checks for errors in the logs of all nodes in the cluster.
+     */
+    String checkForErrors();
 
     // Methods altering nodes
 
@@ -201,7 +207,7 @@ public interface CCMAccess extends Closeable {
      *
      * @param n the node number (starting from 1).
      */
-    void setWorkload(int n, String workload);
+    void setWorkload(int n, Workload workload);
 
 
     // Methods blocking until nodes are up or down

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -31,7 +31,6 @@ import java.io.*;
 import java.net.InetSocketAddress;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.datastax.driver.core.TestUtils.executeNoFail;
 import static com.datastax.driver.core.TestUtils.findAvailablePort;
@@ -380,7 +379,17 @@ public class CCMBridge implements CCMAccess {
             return;
         if (logger.isDebugEnabled())
             logger.debug("Starting: {} - free memory: {} MB", this, TestUtils.getFreeMemoryMB());
-        execute(CCM_COMMAND + " start --wait-other-notice --wait-for-binary-proto" + jvmArgs);
+        try {
+            execute(CCM_COMMAND + " start --wait-other-notice --wait-for-binary-proto" + jvmArgs);
+        } catch (CCMException e) {
+            logger.error("Could not start " + this, e);
+            logger.error("CCM output:\n{}", e.getOut());
+            setKeepLogs(true);
+            String errors = checkForErrors();
+            if (errors != null)
+                logger.error("CCM check errors:\n{}", errors);
+            throw e;
+        }
         if (logger.isDebugEnabled())
             logger.debug("Started: {} - Free memory: {} MB", this, TestUtils.getFreeMemoryMB());
         started = true;
@@ -392,7 +401,6 @@ public class CCMBridge implements CCMAccess {
             return;
         if (logger.isDebugEnabled())
             logger.debug("Stopping: {} - free memory: {} MB", this, TestUtils.getFreeMemoryMB());
-        execute(CCM_COMMAND + " stop");
         if (logger.isDebugEnabled())
             logger.debug("Stopped: {} - free memory: {} MB", this, TestUtils.getFreeMemoryMB());
         closed = true;
@@ -408,9 +416,37 @@ public class CCMBridge implements CCMAccess {
     }
 
     @Override
+    public synchronized void remove() {
+        stop();
+        logger.debug("Removing: {}", this);
+        execute(CCM_COMMAND + " remove");
+    }
+
+    @Override
+    public String checkForErrors() {
+        logger.debug("Checking for errors in: {}", this);
+        try {
+            return execute(CCM_COMMAND + " checklogerror");
+        } catch (CCMException e) {
+            logger.warn("Check for errors failed");
+            return null;
+        }
+    }
+
+    @Override
     public void start(int n) {
         logger.debug(String.format("Starting: node %s (%s%s:%s) in %s", n, TestUtils.IP_PREFIX, n, binaryPort, this));
-        execute(CCM_COMMAND + " node%d start --wait-other-notice --wait-for-binary-proto" + jvmArgs, n);
+        try {
+            execute(CCM_COMMAND + " node%d start --wait-other-notice --wait-for-binary-proto" + jvmArgs, n);
+        } catch (CCMException e) {
+            logger.error(String.format("Could not start node %s in %s", n, this), e);
+            logger.error("CCM output:\n{}", e.getOut());
+            setKeepLogs(true);
+            String errors = checkForErrors();
+            if (errors != null)
+                logger.error("CCM check errors:\n{}", errors);
+            throw e;
+        }
     }
 
     @Override
@@ -423,13 +459,6 @@ public class CCMBridge implements CCMAccess {
     public void forceStop(int n) {
         logger.debug(String.format("Force stopping: node %s (%s%s:%s) in %s", n, TestUtils.IP_PREFIX, n, binaryPort, this));
         execute(CCM_COMMAND + " node%d stop --not-gently", n);
-    }
-
-    @Override
-    public synchronized void remove() {
-        stop();
-        logger.debug("Removing: {}", this);
-        execute(CCM_COMMAND + " remove");
     }
 
     @Override
@@ -505,31 +534,36 @@ public class CCMBridge implements CCMAccess {
     }
 
     @Override
-    public void setWorkload(int node, String workload) {
+    public void setWorkload(int node, Workload workload) {
         execute(CCM_COMMAND + " node%d setworkload %s", node, workload);
     }
 
-    private void execute(String command, Object... args) {
-
+    private String execute(String command, Object... args) {
         String fullCommand = String.format(command, args) + " --config-dir=" + ccmDir;
         Closer closer = Closer.create();
         // 10 minutes timeout
         ExecuteWatchdog watchDog = new ExecuteWatchdog(TimeUnit.MINUTES.toMillis(10));
+        StringWriter sw = new StringWriter();
+        final PrintWriter pw = new PrintWriter(sw);
+        closer.register(pw);
         try {
             logger.trace("Executing: " + fullCommand);
             CommandLine cli = CommandLine.parse(fullCommand);
             Executor executor = new DefaultExecutor();
-
             LogOutputStream outStream = new LogOutputStream() {
                 @Override
                 protected void processLine(String line, int logLevel) {
-                    logger.debug("ccmout> " + line);
+                    String out = "ccmout> " + line;
+                    logger.debug(out);
+                    pw.println(out);
                 }
             };
             LogOutputStream errStream = new LogOutputStream() {
                 @Override
                 protected void processLine(String line, int logLevel) {
-                    logger.error("ccmerr> " + line);
+                    String err = "ccmerr> " + line;
+                    logger.error(err);
+                    pw.println(err);
                 }
             };
             closer.register(outStream);
@@ -537,16 +571,17 @@ public class CCMBridge implements CCMAccess {
             ExecuteStreamHandler streamHandler = new PumpStreamHandler(outStream, errStream);
             executor.setStreamHandler(streamHandler);
             executor.setWatchdog(watchDog);
-
             int retValue = executor.execute(cli, ENVIRONMENT_MAP);
             if (retValue != 0) {
                 logger.error("Non-zero exit code ({}) returned from executing ccm command: {}", retValue, fullCommand);
-                throw new RuntimeException();
+                pw.flush();
+                throw new CCMException(String.format("Non-zero exit code (%s) returned from executing ccm command: %s", retValue, fullCommand), sw.toString());
             }
         } catch (IOException e) {
             if (watchDog.killedProcess())
-                logger.error("The command {} was killed after 5 minutes", fullCommand);
-            throw new RuntimeException(String.format("The command %s failed to execute", fullCommand), e);
+                logger.error("The command {} was killed after 10 minutes", fullCommand);
+            pw.flush();
+            throw new CCMException(String.format("The command %s failed to execute", fullCommand), sw.toString(), e);
         } finally {
             try {
                 closer.close();
@@ -554,6 +589,7 @@ public class CCMBridge implements CCMAccess {
                 Throwables.propagate(e);
             }
         }
+        return sw.toString();
     }
 
     /**
@@ -622,8 +658,7 @@ public class CCMBridge implements CCMAccess {
      * use {@link #builder()} to get an instance
      */
     public static class Builder {
-        private static final AtomicInteger COUNTER = new AtomicInteger(0);
-        private final String clusterName = "test_" + COUNTER.incrementAndGet();
+        private final String clusterName = TestUtils.generateIdentifier("cluster_");
         int[] nodes = {1};
         private boolean start = true;
         private boolean isDSE = isDSE();
@@ -636,6 +671,7 @@ public class CCMBridge implements CCMAccess {
         private int thriftPort = -1;
         private int binaryPort = -1;
         private int storagePort = -1;
+        private Map<Integer, Workload> workloads = new HashMap<Integer, Workload>();
 
         private Builder() {
         }
@@ -710,7 +746,7 @@ public class CCMBridge implements CCMAccess {
 
         /**
          * Free-form options that will be added at the end of the {@code ccm create} command
-         *  (defaults to {@link #getInstallArguments()} if this is never called).
+         * (defaults to {@link #getInstallArguments()} if this is never called).
          */
         public Builder withCreateOptions(String... createOptions) {
             Collections.addAll(this.createOptions, createOptions);
@@ -758,6 +794,18 @@ public class CCMBridge implements CCMAccess {
             return this;
         }
 
+        /**
+         * Sets the DSE workload for a given node.
+         *
+         * @param node     The node to set the workload for (starting with 1).
+         * @param workload The workload (e.g. solr, spark, hadoop)
+         * @return This builder
+         */
+        public Builder withWorkload(int node, Workload workload) {
+            this.workloads.put(node, workload);
+            return this;
+        }
+
         public CCMBridge build() {
             // be careful NOT to alter internal state (hashCode/equals) during build!
             int storagePort = this.storagePort == -1 ? findAvailablePort() : this.storagePort;
@@ -781,6 +829,9 @@ public class CCMBridge implements CCMAccess {
             ccm.updateConfig(config);
             if (!dseConfiguration.isEmpty())
                 ccm.updateDSEConfig(dseConfiguration);
+            for (Map.Entry<Integer, Workload> entry : workloads.entrySet()) {
+                ccm.setWorkload(entry.getKey(), entry.getValue());
+            }
             if (start)
                 ccm.start();
             return ccm;
@@ -886,8 +937,9 @@ public class CCMBridge implements CCMAccess {
             if (!Arrays.equals(nodes, builder.nodes)) return false;
             if (!createOptions.equals(builder.createOptions)) return false;
             if (!jvmArgs.equals(builder.jvmArgs)) return false;
-            if (!dseConfiguration.equals(builder.dseConfiguration)) return false;
             if (!cassandraConfiguration.equals(builder.cassandraConfiguration)) return false;
+            if (!dseConfiguration.equals(builder.dseConfiguration)) return false;
+            if (!workloads.equals(builder.workloads)) return false;
             return version.equals(builder.version);
         }
 
@@ -901,6 +953,7 @@ public class CCMBridge implements CCMAccess {
             result = 31 * result + jvmArgs.hashCode();
             result = 31 * result + cassandraConfiguration.hashCode();
             result = 31 * result + dseConfiguration.hashCode();
+            result = 31 * result + workloads.hashCode();
             result = 31 * result + thriftPort;
             result = 31 * result + binaryPort;
             result = 31 * result + storagePort;

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMCache.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMCache.java
@@ -140,6 +140,11 @@ public class CCMCache {
         }
 
         @Override
+        public String checkForErrors() {
+            return ccm.checkForErrors();
+        }
+
+        @Override
         public void start(int n) {
             ccm.start(n);
         }
@@ -185,7 +190,7 @@ public class CCMCache {
         }
 
         @Override
-        public void setWorkload(int n, String workload) {
+        public void setWorkload(int n, Workload workload) {
             ccm.setWorkload(n, workload);
         }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMException.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMException.java
@@ -1,0 +1,36 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+public class CCMException extends RuntimeException {
+
+    private final String out;
+
+    public CCMException(String message, String out) {
+        super(message);
+        this.out = out;
+    }
+
+    public CCMException(String message, String out, Throwable cause) {
+        super(message, cause);
+        this.out = out;
+    }
+
+    public String getOut() {
+        return out;
+    }
+
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
@@ -15,11 +15,14 @@
  */
 package com.datastax.driver.core;
 
+import com.datastax.driver.core.CCMAccess.Workload;
 import com.datastax.driver.core.CreateCCM.TestMode;
+import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
+import com.google.common.util.concurrent.Uninterruptibles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.ITestResult;
@@ -32,10 +35,12 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.lang.reflect.ParameterizedType;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.*;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.datastax.driver.core.CreateCCM.TestMode.PER_CLASS;
@@ -59,12 +64,11 @@ public class CCMTestsSupport {
             .put("enable_user_defined_functions", VersionNumber.parse("2.2.0"))
             .build();
 
-
-    private static class ReadOnlyCCMBridge implements CCMAccess {
+    private static class ReadOnlyCCMAccess implements CCMAccess {
 
         private final CCMAccess delegate;
 
-        private ReadOnlyCCMBridge(CCMAccess delegate) {
+        private ReadOnlyCCMAccess(CCMAccess delegate) {
             this.delegate = delegate;
         }
 
@@ -121,6 +125,11 @@ public class CCMTestsSupport {
         @Override
         public void setKeepLogs(boolean keepLogs) {
             delegate.setKeepLogs(keepLogs);
+        }
+
+        @Override
+        public String checkForErrors() {
+            return delegate.checkForErrors();
         }
 
         @Override
@@ -204,7 +213,7 @@ public class CCMTestsSupport {
         }
 
         @Override
-        public void setWorkload(int node, String workload) {
+        public void setWorkload(int node, Workload workload) {
             throw new UnsupportedOperationException("This CCM cluster is read-only");
         }
 
@@ -281,7 +290,7 @@ public class CCMTestsSupport {
         @SuppressWarnings("SimplifiableIfStatement")
         private Map<String, Object> config() {
             Map<String, Object> config = new HashMap<String, Object>();
-            for (int i = annotations.size() - 1; i == 0; i--) {
+            for (int i = annotations.size() - 1; i >= 0; i--) {
                 CCMConfig ann = annotations.get(i);
                 addConfigOptions(ann.config(), config);
             }
@@ -342,6 +351,22 @@ public class CCMTestsSupport {
             return args;
         }
 
+        private List<Workload> workloads() {
+            int total = 0;
+            for (int perDc : numberOfNodes())
+                total += perDc;
+            List<Workload> workloads = new ArrayList<Workload>(Collections.<Workload>nCopies(total, null));
+            for (int i = annotations.size() - 1; i >= 0; i--) {
+                CCMConfig ann = annotations.get(i);
+                Workload[] annWorkloads = ann.workloads();
+                for (int j = 0; j < annWorkloads.length; j++) {
+                    Workload workload = annWorkloads[j];
+                    workloads.set(j, workload);
+                }
+            }
+            return workloads;
+        }
+
         @SuppressWarnings("SimplifiableIfStatement")
         private boolean createCcm() {
             for (CCMConfig ann : annotations) {
@@ -387,34 +412,69 @@ public class CCMTestsSupport {
             return false;
         }
 
-        private CCMBridge.Builder ccmBuilder() {
+        private CCMBridge.Builder ccmBuilder(Object testInstance) throws Exception {
             if (ccmBuilder == null) {
-                ccmBuilder = CCMBridge.builder().withNodes(numberOfNodes()).notStarted();
-                if (version() != null)
-                    ccmBuilder.withVersion(version());
-                if (dse())
-                    ccmBuilder.withDSE();
-                if (ssl())
-                    ccmBuilder.withSSL();
-                if (auth())
-                    ccmBuilder.withAuth();
-                for (Map.Entry<String, Object> entry : config().entrySet()) {
-                    ccmBuilder.withCassandraConfiguration(entry.getKey(), entry.getValue());
-                }
-                for (Map.Entry<String, Object> entry : dseConfig().entrySet()) {
-                    ccmBuilder.withDSEConfiguration(entry.getKey(), entry.getValue());
-                }
-                for (String option : startOptions()) {
-                    ccmBuilder.withCreateOptions(option);
-                }
-                for (String arg : jvmArgs()) {
-                    ccmBuilder.withJvmArgs(arg);
+                ccmBuilder = ccmProvider(testInstance);
+                if (ccmBuilder == null) {
+                    ccmBuilder = CCMBridge.builder().withNodes(numberOfNodes()).notStarted();
+                    if (version() != null)
+                        ccmBuilder.withVersion(version());
+                    if (dse())
+                        ccmBuilder.withDSE();
+                    if (ssl())
+                        ccmBuilder.withSSL();
+                    if (auth())
+                        ccmBuilder.withAuth();
+                    for (Map.Entry<String, Object> entry : config().entrySet()) {
+                        ccmBuilder.withCassandraConfiguration(entry.getKey(), entry.getValue());
+                    }
+                    for (Map.Entry<String, Object> entry : dseConfig().entrySet()) {
+                        ccmBuilder.withDSEConfiguration(entry.getKey(), entry.getValue());
+                    }
+                    for (String option : startOptions()) {
+                        ccmBuilder.withCreateOptions(option);
+                    }
+                    for (String arg : jvmArgs()) {
+                        ccmBuilder.withJvmArgs(arg);
+                    }
+                    List<Workload> workloads = workloads();
+                    for (int i = 0; i < workloads.size(); i++) {
+                        Workload workload = workloads.get(i);
+                        if (workload != null)
+                            ccmBuilder.withWorkload(i + 1, workload);
+                    }
                 }
             }
             return ccmBuilder;
         }
 
-        private Cluster.Builder clusterBuilder(Object testInstance) throws Exception {
+        private CCMBridge.Builder ccmProvider(Object testInstance) throws Exception {
+            String methodName = null;
+            Class<?> clazz = null;
+            for (int i = annotations.size() - 1; i >= 0; i--) {
+                CCMConfig ann = annotations.get(i);
+                if (!ann.ccmProvider().isEmpty()) {
+                    methodName = ann.ccmProvider();
+                }
+                if (!ann.ccmProviderClass().equals(CCMConfig.Undefined.class)) {
+                    clazz = ann.ccmProviderClass();
+                }
+            }
+            if (methodName == null)
+                return null;
+            if (clazz == null)
+                clazz = testInstance.getClass();
+            Method method = locateMethod(methodName, clazz);
+            assert CCMBridge.Builder.class.isAssignableFrom(method.getReturnType());
+            if (Modifier.isStatic(method.getModifiers())) {
+                return (CCMBridge.Builder) method.invoke(null);
+            } else {
+                Object receiver = testInstance.getClass().equals(clazz) ? testInstance : instantiate(clazz);
+                return (CCMBridge.Builder) method.invoke(receiver);
+            }
+        }
+
+        private Cluster.Builder clusterProvider(Object testInstance) throws Exception {
             String methodName = null;
             Class<?> clazz = null;
             for (int i = annotations.size() - 1; i >= 0; i--) {
@@ -441,31 +501,28 @@ public class CCMTestsSupport {
         }
 
         @SuppressWarnings("unchecked")
-        private Collection<String> fixtures(Object testInstance) throws Exception {
+        private void invokeInitTest(Object testInstance) throws Exception {
             String methodName = null;
             Class<?> clazz = null;
             for (int i = annotations.size() - 1; i >= 0; i--) {
                 CCMConfig ann = annotations.get(i);
-                if (!ann.fixturesProvider().isEmpty()) {
-                    methodName = ann.fixturesProvider();
+                if (!ann.testInitializer().isEmpty()) {
+                    methodName = ann.testInitializer();
                 }
-                if (!ann.fixturesProviderClass().equals(CCMConfig.Undefined.class)) {
-                    clazz = ann.fixturesProviderClass();
+                if (!ann.testInitializerClass().equals(CCMConfig.Undefined.class)) {
+                    clazz = ann.testInitializerClass();
                 }
             }
             if (methodName == null)
-                methodName = "createTestFixtures";
+                methodName = "onTestContextInitialized";
             if (clazz == null)
                 clazz = testInstance.getClass();
             Method method = locateMethod(methodName, clazz);
-            assert Collection.class.isAssignableFrom(method.getReturnType());
-            assert method.getGenericReturnType() instanceof ParameterizedType;
-            assert String.class.equals(((ParameterizedType) method.getGenericReturnType()).getActualTypeArguments()[0]);
             if (Modifier.isStatic(method.getModifiers())) {
-                return (Collection<String>) method.invoke(null);
+                method.invoke(null);
             } else {
                 Object receiver = testInstance.getClass().equals(clazz) ? testInstance : instantiate(clazz);
-                return (Collection<String>) method.invoke(receiver);
+                method.invoke(receiver);
             }
         }
 
@@ -473,13 +530,15 @@ public class CCMTestsSupport {
 
     private TestMode testMode;
 
-    private CCMTestConfig ccmTestConfig;
+    protected CCMTestConfig ccmTestConfig;
 
-    protected CCMAccess ccm;
+    private CCMAccess ccm;
 
-    protected Cluster cluster;
+    private CCMBridge.Builder ccmBuilder;
 
-    protected Session session;
+    private Cluster cluster;
+
+    private Session session;
 
     protected String keyspace;
 
@@ -508,11 +567,18 @@ public class CCMTestsSupport {
         testMode = determineTestMode(testInstance.getClass());
         if (testMode == PER_CLASS) {
             closer = Closer.create();
-            initTestContext(testInstance, null);
-            initTestCluster(testInstance);
-            initTestSession();
-            initTestKeyspace();
-            initTestFixtures(testInstance);
+            try {
+                initTestContext(testInstance, null);
+                initTestCluster(testInstance);
+                initTestSession();
+                initTestKeyspace();
+                initTest(testInstance);
+            } catch (Exception e) {
+                LOGGER.error(e.getMessage(), e);
+                errorOut();
+                fail(e.getMessage());
+
+            }
         }
     }
 
@@ -538,11 +604,17 @@ public class CCMTestsSupport {
             if (closer == null)
                 closer = Closer.create();
             if (testMode == PER_METHOD || erroredOut) {
-                initTestContext(testInstance, testMethod);
-                initTestCluster(testInstance);
-                initTestSession();
-                initTestKeyspace();
-                initTestFixtures(testInstance);
+                try {
+                    initTestContext(testInstance, testMethod);
+                    initTestCluster(testInstance);
+                    initTestSession();
+                    initTestKeyspace();
+                    initTest(testInstance);
+                } catch (Exception e) {
+                    LOGGER.error(e.getMessage(), e);
+                    errorOut();
+                    fail(e.getMessage());
+                }
             }
             assert ccmTestConfig != null;
             assert !ccmTestConfig.createCcm() || ccm != null;
@@ -553,7 +625,7 @@ public class CCMTestsSupport {
      * Hook executed after each test method.
      */
     @AfterMethod(groups = {"isolated", "short", "long", "stress", "duration"}, alwaysRun = true)
-    public void afterTestMethod(ITestResult tr) {
+    public void afterTestMethod(ITestResult tr) throws Exception {
         if (isCcmEnabled(tr.getMethod().getConstructorOrMethod().getMethod())) {
             if (tr.getStatus() == ITestResult.FAILURE) {
                 errorOut();
@@ -571,7 +643,7 @@ public class CCMTestsSupport {
      * Hook executed after each test class.
      */
     @AfterClass(groups = {"isolated", "short", "long", "stress", "duration"}, alwaysRun = true)
-    public void afterTestClass() {
+    public void afterTestClass() throws Exception {
         if (testMode == PER_CLASS) {
             closeCloseables();
             closeTestCluster();
@@ -607,20 +679,85 @@ public class CCMTestsSupport {
     }
 
     /**
-     * The CQL statements to execute before the tests in this class.
-     * Useful to create tables or other objects inside the test keyspace,
-     * or to insert test data.
+     * Hook invoked when the test context is ready, but before the test itself.
+     * Useful to create fixtures or to insert test data.
      * <p/>
-     * Statements do not need to be qualified with keyspace name.
+     * This method is invoked once per class is the {@link TestMode} is {@link TestMode#PER_CLASS}
+     * or before each test method, if the  {@link TestMode} is {@link TestMode#PER_METHOD}.
      * <p/>
-     * The default implementation returns an empty list (no fixtures required).
-     *
-     * @return The DDL statements to execute before the tests.
+     * When this method is called, the cluster and the session are ready
+     * to be used (unless the configuration specifies that such objects
+     * should not be created).
+     * <p/>
+     * Statements executed inside this method do not need to be qualified with a keyspace name,
+     * in which case they are executed with the default keyspace for the test
+     * (unless the configuration specifies that no keyspace should be creaed for the test).
+     * <p/>
+     * The default implementation does nothing (no fixtures required).
      */
-    public Collection<String> createTestFixtures() {
-        return Collections.emptyList();
+    public void onTestContextInitialized() {
+        // nothing to do by default
     }
 
+    /**
+     * @return The {@link CCMAccess} instance to use with this test.
+     */
+    public CCMAccess ccm() {
+        return ccm;
+    }
+
+    /**
+     * @return The {@link Cluster} instance to use with this test.
+     * Can be null if CCM configuration specifies {@code createCluster = false}.
+     */
+    public Cluster cluster() {
+        return cluster;
+    }
+
+    /**
+     * @return The {@link Session} instance to use with this test.
+     * Can be null if CCM configuration specifies {@code createSession = false}.
+     */
+    public Session session() {
+        return session;
+    }
+
+    /**
+     * Executes the given statements with the test's session object.
+     * <p/>
+     * Useful to create test fixtures and/or load data before tests.
+     * <p/>
+     * This method should not be called if a session object hasn't been created
+     * (if CCM configuration specifies {@code createSession = false})
+     *
+     * @param statements The statements to execute.
+     */
+    public void execute(String... statements) {
+        execute(Arrays.asList(statements));
+    }
+
+    /**
+     * Executes the given statements with the test's session object.
+     * <p/>
+     * Useful to create test fixtures and/or load data before tests.
+     * <p/>
+     * This method should not be called if a session object hasn't been created
+     * (if CCM configuration specifies {@code createSession = false})
+     *
+     * @param statements The statements to execute.
+     */
+    public void execute(Collection<String> statements) {
+        assert session != null;
+        for (String stmt : statements) {
+            try {
+                session.execute(stmt);
+            } catch (Exception e) {
+                errorOut();
+                LOGGER.error("Could not execute statement: " + stmt, e);
+                Throwables.propagate(e);
+            }
+        }
+    }
     /**
      * Signals that the test has encountered an unexpected error.
      * <p/>
@@ -635,8 +772,9 @@ public class CCMTestsSupport {
      */
     public void errorOut() {
         erroredOut = true;
-        if (ccm != null)
+        if (ccm != null) {
             ccm.setKeepLogs(true);
+        }
     }
 
     /**
@@ -651,7 +789,38 @@ public class CCMTestsSupport {
      *
      * @return the contact points to use to contact the CCM cluster.
      */
-    public List<InetSocketAddress> getInitialContactPoints() {
+    public List<InetAddress> getContactPoints() {
+        assert ccmTestConfig != null;
+        List<InetAddress> contactPoints = new ArrayList<InetAddress>();
+        int n = 1;
+        int[] numberOfNodes = ccmTestConfig.numberOfNodes();
+        for (int dc = 1; dc <= numberOfNodes.length; dc++) {
+            int nodesInDc = numberOfNodes[dc - 1];
+            for (int i = 0; i < nodesInDc; i++) {
+                try {
+                    contactPoints.add(InetAddress.getByName(ipOfNode(n)));
+                } catch (UnknownHostException e) {
+                    Throwables.propagate(e);
+                }
+                n++;
+            }
+        }
+        return contactPoints;
+    }
+
+    /**
+     * Returns the contact points to use to contact the CCM cluster.
+     * <p/>
+     * This method returns as many contact points as the number of nodes initially present in the CCM cluster,
+     * according to {@link CCMConfig} annotations.
+     * <p/>
+     * On a multi-DC setup, this will include nodes in all data centers.
+     * <p/>
+     * This method should not be called before the test has started, nor after the test is finished.
+     *
+     * @return the contact points to use to contact the CCM cluster.
+     */
+    public List<InetSocketAddress> getContactPointsWithPorts() {
         assert ccmTestConfig != null;
         List<InetSocketAddress> contactPoints = new ArrayList<InetSocketAddress>();
         int n = 1;
@@ -679,52 +848,73 @@ public class CCMTestsSupport {
         return closeable;
     }
 
-    private void initTestContext(Object testInstance, Method testMethod) throws Exception {
+    /**
+     * Tests fail randomly with InvalidQueryException: Keyspace 'xxx' does not exist;
+     * this method tries at most 3 times to issue a successful USE statement.
+     *
+     * @param ks The keyspace to use
+     */
+    public void useKeyspace(String ks) {
+        final int maxTries = 3;
+        for (int i = 1; i <= maxTries; i++) {
+            try {
+                session.execute("USE " + ks);
+            } catch (InvalidQueryException e) {
+                if (i == maxTries)
+                    throw e;
+                LOGGER.error("Could not USE keyspace, retrying");
+                Uninterruptibles.sleepUninterruptibly(1, TimeUnit.MINUTES);
+            }
+        }
+    }
+
+    protected void initTestContext(Object testInstance, Method testMethod) throws Exception {
         erroredOut = false;
         ccmTestConfig = createCCMTestConfig(testInstance, testMethod);
         assert ccmTestConfig != null;
         if (ccmTestConfig.createCcm()) {
-            CCMAccess ccm = CCMCache.get(ccmTestConfig.ccmBuilder());
+            ccmBuilder = ccmTestConfig.ccmBuilder(testInstance);
+            CCMAccess ccm = CCMCache.get(ccmBuilder);
             assert ccm != null;
             if (ccmTestConfig.dirtiesContext()) {
                 this.ccm = ccm;
             } else {
-                this.ccm = new ReadOnlyCCMBridge(ccm);
+                this.ccm = new ReadOnlyCCMAccess(ccm);
             }
             try {
                 ccm.start();
-            } catch (RuntimeException e) {
-                LOGGER.error("Could not start " + ccm, e);
+            } catch (CCMException e) {
+                errorOut();
                 fail(e.getMessage());
             }
             LOGGER.debug("Using {}", ccm);
         }
     }
 
-    private void initTestCluster(Object testInstance) throws Exception {
+    protected void initTestCluster(Object testInstance) throws Exception {
         if (ccmTestConfig.createCcm() && ccmTestConfig.createCluster()) {
-            Cluster.Builder builder = ccmTestConfig.clusterBuilder(testInstance);
+            Cluster.Builder builder = ccmTestConfig.clusterProvider(testInstance);
             // add contact points only if the provided builder didn't do so
             if (builder.getContactPoints().isEmpty())
-                builder.addContactPointsWithPorts(getInitialContactPoints());
+                builder.addContactPoints(getContactPoints());
             builder.withPort(ccm.getBinaryPort());
             cluster = register(builder.build());
             cluster.init();
         }
     }
 
-    private void initTestSession() throws Exception {
+    protected void initTestSession() throws Exception {
         if (ccmTestConfig.createCcm() && ccmTestConfig.createCluster() && ccmTestConfig.createSession())
             session = register(cluster.connect());
     }
 
-    private void initTestKeyspace() {
+    protected void initTestKeyspace() {
         if (ccmTestConfig.createCcm() && ccmTestConfig.createCluster() && ccmTestConfig.createSession() && ccmTestConfig.createKeyspace()) {
             try {
-                keyspace = TestUtils.getAvailableKeyspaceName();
+                keyspace = TestUtils.generateIdentifier("ks_");
                 LOGGER.debug("Using keyspace " + keyspace);
                 session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, keyspace, 1));
-                session.execute("USE " + keyspace);
+                useKeyspace(keyspace);
             } catch (Exception e) {
                 errorOut();
                 LOGGER.error("Could not create test keyspace", e);
@@ -733,35 +923,25 @@ public class CCMTestsSupport {
         }
     }
 
-    private void initTestFixtures(Object testInstance) throws Exception {
-        if (ccmTestConfig.createCcm() && ccmTestConfig.createCluster() && ccmTestConfig.createSession()) {
-            for (String stmt : ccmTestConfig.fixtures(testInstance)) {
-                try {
-                    session.execute(stmt);
-                } catch (Exception e) {
-                    errorOut();
-                    LOGGER.error("Could not execute statement: " + stmt, e);
-                    Throwables.propagate(e);
-                }
-            }
-        }
+    protected void initTest(Object testInstance) throws Exception {
+        ccmTestConfig.invokeInitTest(testInstance);
     }
 
-    private void closeTestContext() {
-        if (ccmTestConfig != null && ccm != null) {
-            CCMBridge.Builder key = ccmTestConfig.ccmBuilder();
+    protected void closeTestContext() throws Exception {
+        if (ccmTestConfig != null && ccmBuilder != null && ccm != null) {
             if (ccmTestConfig.dirtiesContext()) {
-                CCMCache.remove(key);
+                CCMCache.remove(ccmBuilder);
                 ccm.close();
             } else {
-                ((ReadOnlyCCMBridge) ccm).delegate.close();
+                ((ReadOnlyCCMAccess) ccm).delegate.close();
             }
         }
         ccmTestConfig = null;
+        ccmBuilder = null;
         ccm = null;
     }
 
-    private void closeTestCluster() {
+    protected void closeTestCluster() {
         if (cluster != null && !cluster.isClosed())
             executeNoFail(new Runnable() {
                 @Override
@@ -774,7 +954,7 @@ public class CCMTestsSupport {
         keyspace = null;
     }
 
-    private void closeCloseables() {
+    protected void closeCloseables() {
         if (closer != null)
             executeNoFail(new Callable<Void>() {
                 @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/CaseSensitivityTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CaseSensitivityTest.java
@@ -26,7 +26,7 @@ public class CaseSensitivityTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void testCaseInsensitiveKeyspace() throws Throwable {
         String ksName = "MyKeyspace1";
-        session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, ksName, 1));
+        session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, ksName, 1));
         assertExists(ksName, "mykeyspace1");
         assertExists("mykeyspace1", "mykeyspace1");
         assertExists("MYKEYSPACE1", "mykeyspace1");
@@ -35,7 +35,7 @@ public class CaseSensitivityTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void testCaseSensitiveKeyspace() throws Throwable {
         String ksName = "\"MyKeyspace2\"";
-        session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, ksName, 1));
+        session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, ksName, 1));
         assertExists(ksName, "MyKeyspace2");
         assertExists(Metadata.quote("MyKeyspace2"), "MyKeyspace2");
         assertNotExists("mykeyspace2");
@@ -44,13 +44,13 @@ public class CaseSensitivityTest extends CCMTestsSupport {
     }
 
     private void assertExists(String fetchName, String realName) {
-        KeyspaceMetadata km = cluster.getMetadata().getKeyspace(fetchName);
+        KeyspaceMetadata km = cluster().getMetadata().getKeyspace(fetchName);
         assertNotNull(km);
         assertEquals(realName, km.getName());
     }
 
     private void assertNotExists(String name) {
-        assertNull(cluster.getMetadata().getKeyspace(name));
+        assertNull(cluster().getMetadata().getKeyspace(name));
     }
 
 

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterDelegateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterDelegateTest.java
@@ -23,7 +23,7 @@ public class ClusterDelegateTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_allow_subclass_to_delegate_to_other_instance() {
-        SimpleDelegatingCluster delegatingCluster = new SimpleDelegatingCluster(cluster);
+        SimpleDelegatingCluster delegatingCluster = new SimpleDelegatingCluster(cluster());
 
         ResultSet rs = delegatingCluster.connect().execute("select * from system.local");
 

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
@@ -172,7 +172,9 @@ public class ClusterStressTest extends CCMTestsSupport {
 
         CreateClusterAndCheckConnections(CountDownLatch startSignal) {
             this.startSignal = startSignal;
-            this.cluster = Cluster.builder().addContactPointsWithPorts(getInitialContactPoints())
+            this.cluster = Cluster.builder()
+                    .addContactPoints(getContactPoints())
+                    .withPort(ccm().getBinaryPort())
                     .withPoolingOptions(new PoolingOptions().setCoreConnectionsPerHost(HostDistance.LOCAL, 1))
                     .withNettyOptions(channelMonitor.nettyOptions()).build();
         }
@@ -186,19 +188,19 @@ public class ClusterStressTest extends CCMTestsSupport {
                 cluster.init();
                 assertEquals(cluster.manager.sessions.size(), 0);
                 assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
-                assertEquals(channelMonitor.openChannels(getInitialContactPoints()).size(), 1);
+                assertEquals(channelMonitor.openChannels(getContactPointsWithPorts()).size(), 1);
 
                 // The first session initializes the cluster and its control connection
                 Session session = cluster.connect();
                 assertEquals(cluster.manager.sessions.size(), 1);
                 assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1 + TestUtils.numberOfLocalCoreConnections(cluster));
-                assertEquals(channelMonitor.openChannels(getInitialContactPoints()).size(), 1 + TestUtils.numberOfLocalCoreConnections(cluster));
+                assertEquals(channelMonitor.openChannels(getContactPointsWithPorts()).size(), 1 + TestUtils.numberOfLocalCoreConnections(cluster));
 
                 // Closing the session keeps the control connection opened
                 session.close();
                 assertEquals(cluster.manager.sessions.size(), 0);
                 assertEquals((int) cluster.getMetrics().getOpenConnections().getValue(), 1);
-                assertEquals(channelMonitor.openChannels(getInitialContactPoints()).size(), 1);
+                assertEquals(channelMonitor.openChannels(getContactPointsWithPorts()).size(), 1);
 
                 return this;
             } catch (AssertionError e) {
@@ -230,7 +232,7 @@ public class ClusterStressTest extends CCMTestsSupport {
             try {
                 cluster.close();
                 assertEquals(cluster.manager.sessions.size(), 0);
-                assertEquals(channelMonitor.openChannels(getInitialContactPoints()).size(), 0);
+                assertEquals(channelMonitor.openChannels(getContactPointsWithPorts()).size(), 0);
             } finally {
                 channelMonitor.stop();
                 cluster = null;

--- a/driver-core/src/test/java/com/datastax/driver/core/ConditionChecker.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ConditionChecker.java
@@ -23,83 +23,106 @@ import org.slf4j.LoggerFactory;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static com.google.common.base.Preconditions.checkState;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Fail.fail;
 
 public class ConditionChecker {
 
-    private static final Logger logger = LoggerFactory.getLogger(ConditionChecker.class);
-
     private static final int DEFAULT_PERIOD_MILLIS = 500;
 
-    public static <T> void awaitUntil(T input, Predicate<? super T> predicate, long timeoutMillis) {
-        new ConditionChecker(input, predicate).await(timeoutMillis);
+    private static final int DEFAULT_TIMEOUT_MILLIS = 60000;
+
+    public static class ConditionCheckerBuilder {
+
+        private long timeout = DEFAULT_TIMEOUT_MILLIS;
+
+        private TimeUnit timeoutUnit = TimeUnit.MILLISECONDS;
+
+        private long period = DEFAULT_PERIOD_MILLIS;
+
+        private TimeUnit periodUnit = TimeUnit.MILLISECONDS;
+
+        private Object input;
+
+        private Predicate<?> predicate;
+
+        public ConditionCheckerBuilder every(long period, TimeUnit unit) {
+            this.period = period;
+            periodUnit = unit;
+            return this;
+        }
+
+        public ConditionCheckerBuilder every(long periodMillis) {
+            period = periodMillis;
+            periodUnit = TimeUnit.MILLISECONDS;
+            return this;
+        }
+
+        public ConditionCheckerBuilder before(long timeout, TimeUnit unit) {
+            this.timeout = timeout;
+            timeoutUnit = unit;
+            return this;
+        }
+
+        public ConditionCheckerBuilder before(long timeoutMillis) {
+            timeout = timeoutMillis;
+            timeoutUnit = TimeUnit.MILLISECONDS;
+            return this;
+        }
+
+        public <T> ConditionCheckerBuilder that(T input, Predicate<? super T> predicate) {
+            this.input = input;
+            this.predicate = predicate;
+            return this;
+        }
+
+        public ConditionCheckerBuilder that(final Callable<Boolean> condition) {
+            this.input = null;
+            this.predicate = new Predicate<Void>() {
+                @Override
+                public boolean apply(Void input) {
+                    try {
+                        return condition.call();
+                    } catch (Exception e) {
+                        logger.error("Evaluation of condition threw exception", e);
+                        return false;
+                    }
+                }
+            };
+            return this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public void becomesTrue() {
+            new ConditionChecker(input, (Predicate<Object>) predicate, period, periodUnit).await(timeout, timeoutUnit);
+        }
+
+        @SuppressWarnings("unchecked")
+        public void becomesFalse() {
+            this.predicate = Predicates.not(predicate);
+            new ConditionChecker(input, (Predicate<Object>) predicate, period, periodUnit).await(timeout, timeoutUnit);
+        }
+
     }
 
-    public static void awaitUntil(final Callable<Boolean> condition, long timeoutMillis) {
-        new ConditionChecker(condition).await(timeoutMillis);
-    }
+    private static final Logger logger = LoggerFactory.getLogger(ConditionChecker.class);
 
-    public static <T> void awaitWhile(T input, Predicate<? super T> predicate, long timeoutMillis) {
-        new ConditionChecker(input, Predicates.not(predicate)).await(timeoutMillis);
-    }
-
-    public static void awaitWhile(final Callable<Boolean> condition, long timeoutMillis) {
-        new ConditionChecker(new Callable<Boolean>() {
-            @Override
-            public Boolean call() throws Exception {
-                return !condition.call();
-            }
-        }).await(timeoutMillis);
+    public static ConditionCheckerBuilder check() {
+        return new ConditionCheckerBuilder();
     }
 
     private final Object input;
-
     private final Predicate<Object> predicate;
-
     private final Lock lock;
-
     private final Condition condition;
-
     private final Timer timer;
 
-    /**
-     * When using this constructor, one must override {@link #evalCondition()}.
-     */
-    public ConditionChecker() {
-        this(null, null);
-        checkState(!this.getClass().equals(ConditionChecker.class), "This constructor requires subclassing ConditionChecker");
-    }
-
-    public ConditionChecker(Callable<Boolean> condition) {
-        this(condition, DEFAULT_PERIOD_MILLIS);
-    }
-
-    public ConditionChecker(final Callable<Boolean> condition, int periodMillis) {
-        this(null, new Predicate<Void>() {
-            @Override
-            public boolean apply(Void input) {
-                try {
-                    return condition.call();
-                } catch (Exception e) {
-                    logger.error("Evaluation of condition threw exception", e);
-                    return false;
-                }
-            }
-        }, periodMillis);
-    }
-
-    public <T> ConditionChecker(T input, Predicate<? super T> predicate) {
-        this(input, predicate, DEFAULT_PERIOD_MILLIS);
-    }
-
     @SuppressWarnings("unchecked")
-    public <T> ConditionChecker(T input, Predicate<? super T> predicate, int periodMillis) {
+    public <T> ConditionChecker(T input, Predicate<? super T> predicate, long period, TimeUnit periodUnit) {
         this.input = input;
         this.predicate = (Predicate<Object>) predicate;
         lock = new ReentrantLock();
@@ -110,23 +133,21 @@ public class ConditionChecker {
             public void run() {
                 checkCondition();
             }
-        }, 0, periodMillis);
+        }, 0, periodUnit.toMillis(period));
     }
 
     /**
      * Waits until the predicate becomes true,
      * or a timeout occurs, whichever happens first.
-     *
-     * @param timeoutMillis timeout in milliseconds
      */
-    public void await(long timeoutMillis) {
+    public void await(long timeout, TimeUnit unit) {
         boolean interrupted = false;
-        long nanos = MILLISECONDS.toNanos(timeoutMillis);
+        long nanos = unit.toNanos(timeout);
         lock.lock();
         try {
             while (!evalCondition()) {
                 if (nanos <= 0L)
-                    fail(String.format("Timeout after %s milliseconds while waiting for condition", timeoutMillis));
+                    fail(String.format("Timeout after %s %s while waiting for condition", timeout, unit.toString().toLowerCase()));
                 try {
                     nanos = condition.awaitNanos(nanos);
                 } catch (InterruptedException e) {
@@ -151,7 +172,7 @@ public class ConditionChecker {
         }
     }
 
-    protected boolean evalCondition() {
+    private boolean evalCondition() {
         return predicate.apply(input);
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/ConditionalUpdateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ConditionalUpdateTest.java
@@ -18,9 +18,6 @@ package com.datastax.driver.core;
 import com.datastax.driver.core.utils.CassandraVersion;
 import org.testng.annotations.Test;
 
-import java.util.Collection;
-import java.util.Collections;
-
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -31,55 +28,55 @@ import static org.testng.Assert.assertTrue;
 public class ConditionalUpdateTest extends CCMTestsSupport {
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Collections.singletonList("CREATE TABLE test(k1 int, k2 int, v int, PRIMARY KEY (k1, k2))");
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE test(k1 int, k2 int, v int, PRIMARY KEY (k1, k2))");
     }
 
     @Test(groups = "short")
     public void singleUpdateTest() {
-        session.execute("TRUNCATE test");
-        session.execute("INSERT INTO test (k1, k2, v) VALUES (1, 1, 1)");
+        session().execute("TRUNCATE test");
+        session().execute("INSERT INTO test (k1, k2, v) VALUES (1, 1, 1)");
 
-        ResultSet rs = session.execute("UPDATE test SET v = 3 WHERE k1 = 1 AND k2 = 1 IF v = 2");
+        ResultSet rs = session().execute("UPDATE test SET v = 3 WHERE k1 = 1 AND k2 = 1 IF v = 2");
         assertFalse(rs.wasApplied());
         // Ensure that reading the status does not consume a row:
         assertFalse(rs.isExhausted());
 
-        rs = session.execute("UPDATE test SET v = 3 WHERE k1 = 1 AND k2 = 1 IF v = 1");
+        rs = session().execute("UPDATE test SET v = 3 WHERE k1 = 1 AND k2 = 1 IF v = 1");
         assertTrue(rs.wasApplied());
         assertFalse(rs.isExhausted());
 
         // Non-conditional statement
-        rs = session.execute("UPDATE test SET v = 4 WHERE k1 = 1 AND k2 = 1");
+        rs = session().execute("UPDATE test SET v = 4 WHERE k1 = 1 AND k2 = 1");
         assertTrue(rs.wasApplied());
     }
 
     @Test(groups = "short")
     public void batchUpdateTest() {
-        session.execute("TRUNCATE test");
-        session.execute("INSERT INTO test (k1, k2, v) VALUES (1, 1, 1)");
-        session.execute("INSERT INTO test (k1, k2, v) VALUES (1, 2, 1)");
+        session().execute("TRUNCATE test");
+        session().execute("INSERT INTO test (k1, k2, v) VALUES (1, 1, 1)");
+        session().execute("INSERT INTO test (k1, k2, v) VALUES (1, 2, 1)");
 
-        PreparedStatement ps = session.prepare("UPDATE test SET v = :new WHERE k1 = :k1 AND k2 = :k2 IF v = :old");
+        PreparedStatement ps = session().prepare("UPDATE test SET v = :new WHERE k1 = :k1 AND k2 = :k2 IF v = :old");
         BatchStatement batch = new BatchStatement();
         batch.add(ps.bind().setInt("k1", 1).setInt("k2", 1).setInt("old", 2).setInt("new", 3)); // will fail
         batch.add(ps.bind().setInt("k1", 1).setInt("k2", 2).setInt("old", 1).setInt("new", 3));
 
 
-        ResultSet rs = session.execute(batch);
+        ResultSet rs = session().execute(batch);
         assertFalse(rs.wasApplied());
     }
 
 
     @Test(groups = "short")
     public void multipageResultSetTest() {
-        session.execute("TRUNCATE test");
-        session.execute("INSERT INTO test (k1, k2, v) VALUES (1, 1, 1)");
-        session.execute("INSERT INTO test (k1, k2, v) VALUES (1, 2, 1)");
+        session().execute("TRUNCATE test");
+        session().execute("INSERT INTO test (k1, k2, v) VALUES (1, 1, 1)");
+        session().execute("INSERT INTO test (k1, k2, v) VALUES (1, 2, 1)");
 
         // This is really contrived, we just want to cover the code path in ArrayBackedResultSet#MultiPage.
         // Currently CAS update results are never multipage, so it's hard to come up with a meaningful example.
-        ResultSet rs = session.execute(new SimpleStatement("SELECT * FROM test WHERE k1 = 1").setFetchSize(1));
+        ResultSet rs = session().execute(new SimpleStatement("SELECT * FROM test WHERE k1 = 1").setFetchSize(1));
 
         assertTrue(rs.wasApplied());
     }
@@ -95,13 +92,13 @@ public class ConditionalUpdateTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void insert_if_not_exist_should_support_wasApplied_boolean() {
         // First, make sure the test table and the row exist
-        session.execute("CREATE TABLE IF NOT EXISTS Java358 (key int primary key, value int)");
+        session().execute("CREATE TABLE IF NOT EXISTS Java358 (key int primary key, value int)");
         ResultSet rs;
-        rs = session.execute("INSERT INTO Java358(key, value) VALUES (42, 42) IF NOT EXISTS");
+        rs = session().execute("INSERT INTO Java358(key, value) VALUES (42, 42) IF NOT EXISTS");
         assertTrue(rs.wasApplied());
 
         // Then, make sure the flag reports correctly that we did not create a new row
-        rs = session.execute("INSERT INTO Java358(key, value) VALUES (42, 42) IF NOT EXISTS");
+        rs = session().execute("INSERT INTO Java358(key, value) VALUES (42, 42) IF NOT EXISTS");
         assertFalse(rs.wasApplied());
     }
 
@@ -116,16 +113,16 @@ public class ConditionalUpdateTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void delete_if_not_exist_should_support_wasApplied_boolean() {
         // First, make sure the test table and the row exist
-        session.execute("CREATE TABLE IF NOT EXISTS Java358 (key int primary key, value int)");
-        session.execute("INSERT INTO Java358(key, value) VALUES (42, 42)");
+        session().execute("CREATE TABLE IF NOT EXISTS Java358 (key int primary key, value int)");
+        session().execute("INSERT INTO Java358(key, value) VALUES (42, 42)");
 
         // Then, make sure the flag reports correctly that we did delete the row
         ResultSet rs;
-        rs = session.execute("DELETE FROM Java358 WHERE KEY=42 IF EXISTS");
+        rs = session().execute("DELETE FROM Java358 WHERE KEY=42 IF EXISTS");
         assertTrue(rs.wasApplied());
 
         // Finally, make sure the flag reports correctly that we did did not delete an non-existing row
-        rs = session.execute("DELETE FROM Java358 WHERE KEY=42 IF EXISTS");
+        rs = session().execute("DELETE FROM Java358 WHERE KEY=42 IF EXISTS");
         assertFalse(rs.wasApplied());
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/ConsistencyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ConsistencyTest.java
@@ -48,10 +48,12 @@ import static org.testng.Assert.fail;
         dirtiesContext = true,
         createKeyspace = false,
         config = {
+                // tests fail often with write or read timeouts
                 "hinted_handoff_enabled:true",
-                "phi_convict_threshold:1",
+                "phi_convict_threshold:5",
                 "read_request_timeout_in_ms:100000",
-                "write_request_timeout_in_ms:100000"}
+                "write_request_timeout_in_ms:100000"
+        }
 )
 public class ConsistencyTest extends AbstractPoliciesTest {
 
@@ -719,9 +721,9 @@ public class ConsistencyTest extends AbstractPoliciesTest {
 
     private void stopAndWait(int node) {
         logger.debug("Stopping node " + node);
-        ccm.stop(node);
-        ccm.waitForDown(node);// this uses port ping
-        TestUtils.waitForDown(ipOfNode(node), cluster, 10); // this uses UP/DOWN events
+        ccm().stop(node);
+        ccm().waitForDown(node);// this uses port ping
+        TestUtils.waitForDown(ipOfNode(node), cluster()); // this uses UP/DOWN events
         logger.debug("Node " + node + " stopped, sleeping one extra minute to allow nodes to gossip");
         Uninterruptibles.sleepUninterruptibly(1, TimeUnit.MINUTES);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
@@ -74,19 +74,19 @@ public class ControlConnectionTest extends CCMTestsSupport {
 
         // We pass only the first host as contact point, so we know the control connection will be on this host
         cluster = register(Cluster.builder()
-                .addContactPoints(ccm.addressOfNode(1).getAddress())
-                .withPort(ccm.getBinaryPort())
+                .addContactPoints(getContactPoints().get(0))
+                .withPort(ccm().getBinaryPort())
                 .withReconnectionPolicy(reconnectionPolicy)
                 .withLoadBalancingPolicy(loadBalancingPolicy)
                 .build());
         cluster.init();
 
         // Kill the control connection host, there should be exactly one reconnection attempt
-        ccm.stop(1);
+        ccm().stop(1);
         TimeUnit.SECONDS.sleep(1); // Sleep for a while to make sure our final count is not the result of lucky timing
         assertThat(reconnectionAttempts.get()).isEqualTo(1);
 
-        ccm.stop(2);
+        ccm().stop(2);
         TimeUnit.SECONDS.sleep(1);
         assertThat(reconnectionAttempts.get()).isEqualTo(2);
     }
@@ -101,11 +101,11 @@ public class ControlConnectionTest extends CCMTestsSupport {
     @CassandraVersion(major = 2.1)
     public void should_parse_UDT_definitions_when_using_default_protocol_version() {
         Cluster cluster;
-        InetSocketAddress firstHost = ccm.addressOfNode(1);
+        InetSocketAddress firstHost = ccm().addressOfNode(1);
         // First driver instance: create UDT
         cluster = register(Cluster.builder()
                 .addContactPointsWithPorts(firstHost)
-                .withPort(ccm.getBinaryPort())
+                .withPort(ccm().getBinaryPort())
                 .build());
         Session session = cluster.connect();
         session.execute("create keyspace ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
@@ -131,10 +131,10 @@ public class ControlConnectionTest extends CCMTestsSupport {
     @Test(groups = "long")
     @CCMConfig(numberOfNodes = 3)
     public void should_reestablish_if_control_node_decommissioned() throws InterruptedException {
-        InetSocketAddress firstHost = ccm.addressOfNode(1);
+        InetSocketAddress firstHost = ccm().addressOfNode(1);
         Cluster cluster = register(Cluster.builder()
                 .addContactPointsWithPorts(firstHost)
-                .withPort(ccm.getBinaryPort())
+                .withPort(ccm().getBinaryPort())
                 .withQueryOptions(nonDebouncingQueryOptions())
                 .build());
         cluster.init();
@@ -144,7 +144,7 @@ public class ControlConnectionTest extends CCMTestsSupport {
         assertThat(controlHost).isEqualTo(firstHost.getAddress());
 
         // Decommission the node.
-        ccm.decommission(1);
+        ccm().decommission(1);
 
         // Ensure that the new control connection is not null and it's host is not equal to the decommissioned node.
         Host newHost = cluster.manager.controlConnection.connectedHost();

--- a/driver-core/src/test/java/com/datastax/driver/core/CustomTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CustomTypeTest.java
@@ -19,8 +19,6 @@ import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import static org.testng.Assert.assertEquals;
@@ -31,8 +29,8 @@ import static org.testng.Assert.assertEquals;
 public class CustomTypeTest extends CCMTestsSupport {
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Collections.singleton(
+    public void onTestContextInitialized() {
+        execute(
                 "CREATE TABLE test ("
                         + "    k int,"
                         + "    c 'DynamicCompositeType(s => UTF8Type, i => Int32Type)',"
@@ -79,11 +77,11 @@ public class CustomTypeTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void DynamicCompositeTypeTest() {
 
-        session.execute("INSERT INTO test(k, c, v) VALUES (0, 's@foo:i@32', 1)");
-        session.execute("INSERT INTO test(k, c, v) VALUES (0, 'i@42', 2)");
-        session.execute("INSERT INTO test(k, c, v) VALUES (0, 'i@12:i@3', 3)");
+        session().execute("INSERT INTO test(k, c, v) VALUES (0, 's@foo:i@32', 1)");
+        session().execute("INSERT INTO test(k, c, v) VALUES (0, 'i@42', 2)");
+        session().execute("INSERT INTO test(k, c, v) VALUES (0, 'i@12:i@3', 3)");
 
-        ResultSet rs = session.execute("SELECT * FROM test");
+        ResultSet rs = session().execute("SELECT * FROM test");
 
         Row r = rs.one();
         assertEquals(r.getInt("k"), 0);

--- a/driver-core/src/test/java/com/datastax/driver/core/DseCCMClusterTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DseCCMClusterTest.java
@@ -59,6 +59,13 @@ import org.testng.annotations.Test;
  * dse_username = myusername
  * dse_password = mypassword
  * </pre>
+ * <p/>
+ * <h3>Other requirements</h3>
+ * <p/>
+ * DSE requires your {@code PATH} variable to provide access
+ * to super-user executables in {@code /usr/sbin}.
+ * <p/>
+ * A correct example is as follows: {@code /usr/bin:/usr/local/bin:/bin:/usr/sbin:$JAVA_HOME/bin:$PATH}.
  */
 @Test(enabled = false)
 @CCMConfig(dse = true, version = "4.8.3")

--- a/driver-core/src/test/java/com/datastax/driver/core/EventDebouncerIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/EventDebouncerIntegrationTest.java
@@ -44,8 +44,8 @@ public class EventDebouncerIntegrationTest extends CCMTestsSupport {
     public void should_wait_until_load_balancing_policy_is_fully_initialized() throws InterruptedException {
         TestLoadBalancingPolicy policy = new TestLoadBalancingPolicy();
         final Cluster cluster = register(createClusterBuilderNoDebouncing()
-                .addContactPoints(ccm.addressOfNode(1).getAddress())
-                .withPort(ccm.getBinaryPort())
+                .addContactPoints(getContactPoints().get(0))
+                .withPort(ccm().getBinaryPort())
                 .withLoadBalancingPolicy(policy).build());
         new Thread() {
             @Override
@@ -59,8 +59,8 @@ public class EventDebouncerIntegrationTest extends CCMTestsSupport {
         // because the debouncers are not started
         // note: a graceful stop notify other nodes which send a topology change event to the driver right away
         // while forceStop kills the node so other nodes take much more time to detect node failure
-        ccm.stop(3);
-        ccm.waitForDown(3);
+        ccm().stop(3);
+        ccm().waitForDown(3);
         // finish cluster initialization and deliver the DOWN event
         policy.proceed();
         assertThat(policy.onDownCalledBeforeInit).isFalse();

--- a/driver-core/src/test/java/com/datastax/driver/core/FetchingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/FetchingTest.java
@@ -18,9 +18,6 @@ package com.datastax.driver.core;
 import com.datastax.driver.core.exceptions.UnsupportedFeatureException;
 import org.testng.annotations.Test;
 
-import java.util.Collection;
-import java.util.Collections;
-
 import static org.testng.Assert.*;
 
 /**
@@ -29,8 +26,8 @@ import static org.testng.Assert.*;
 public class FetchingTest extends CCMTestsSupport {
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Collections.singletonList("CREATE TABLE test (k text, v int, PRIMARY KEY (k, v))");
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE test (k text, v int, PRIMARY KEY (k, v))");
     }
 
     @Test(groups = "short")
@@ -39,11 +36,11 @@ public class FetchingTest extends CCMTestsSupport {
             // Insert data
             String key = "paging_test";
             for (int i = 0; i < 100; i++)
-                session.execute(String.format("INSERT INTO test (k, v) VALUES ('%s', %d)", key, i));
+                session().execute(String.format("INSERT INTO test (k, v) VALUES ('%s', %d)", key, i));
 
             SimpleStatement st = new SimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", key));
             st.setFetchSize(5); // Ridiculously small fetch size for testing purpose. Don't do at home.
-            ResultSet rs = session.execute(st);
+            ResultSet rs = session().execute(st);
 
             assertFalse(rs.isFullyFetched());
 
@@ -59,7 +56,7 @@ public class FetchingTest extends CCMTestsSupport {
 
         } catch (UnsupportedFeatureException e) {
             // This is expected when testing the protocol v1
-            assertEquals(cluster.getConfiguration().getProtocolOptions().getProtocolVersionEnum(), ProtocolVersion.V1);
+            assertEquals(cluster().getConfiguration().getProtocolOptions().getProtocolVersionEnum(), ProtocolVersion.V1);
         }
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/HeartbeatTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HeartbeatTest.java
@@ -57,8 +57,8 @@ public class HeartbeatTest extends CCMTestsSupport {
     @Test(groups = "long")
     public void should_send_heartbeat_when_connection_is_inactive() throws InterruptedException {
         Cluster cluster = register(Cluster.builder()
-                .addContactPoints(ccm.addressOfNode(1).getAddress())
-                .withPort(ccm.getBinaryPort())
+                .addContactPoints(getContactPoints().get(0))
+                .withPort(ccm().getBinaryPort())
                 .withPoolingOptions(new PoolingOptions()
                         .setHeartbeatIntervalSeconds(3))
                 .build());
@@ -113,8 +113,8 @@ public class HeartbeatTest extends CCMTestsSupport {
     @Test(groups = "long")
     public void should_not_send_heartbeat_when_disabled() throws InterruptedException {
         Cluster cluster = register(Cluster.builder()
-                .addContactPoints(ccm.addressOfNode(1).getAddress())
-                .withPort(ccm.getBinaryPort())
+                .addContactPoints(getContactPoints().get(0))
+                .withPort(ccm().getBinaryPort())
                 .withPoolingOptions(new PoolingOptions()
                         .setHeartbeatIntervalSeconds(0))
                 .build());

--- a/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
@@ -432,7 +432,6 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
             // On returning of the connection, should detect that there are no available streams and trash it.
             assertThat(pool.trash).hasSize(0);
             pool.returnConnection(extra1);
-            assertThat(pool.connections).hasSize(1);
             assertThat(pool.trash).hasSize(1);
         } finally {
             completeRequests(requests);

--- a/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
@@ -23,7 +23,6 @@ import com.google.common.primitives.Ints;
 import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
-import java.util.Collection;
 import java.util.List;
 
 import static com.datastax.driver.core.Assertions.assertThat;
@@ -49,7 +48,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     });
 
     @Override
-    public Collection<String> createTestFixtures() {
+    public void onTestContextInitialized() {
         String createTable = "CREATE TABLE indexing ("
                 + "id int primary key,"
                 + "map_values map<text, int>,"
@@ -58,21 +57,21 @@ public class IndexMetadataTest extends CCMTestsSupport {
                 + "text_column text"
                 +
                 // Frozen collections was introduced only in C* 2.1.3
-                (ccm.getVersion().compareTo(VersionNumber.parse("2.1.3")) >= 0
+                (ccm().getVersion().compareTo(VersionNumber.parse("2.1.3")) >= 0
                         ?
                         ", map_full frozen<map<text, int>>,"
                                 + "set_full frozen<set<text>>,"
                                 + "list_full frozen<list<text>>);"
                         :
                         ")");
-        return ImmutableList.of(createTable);
+        execute(createTable);
     }
 
     @Test(
             groups = "short")
     public void should_not_flag_text_column_index_type() {
         String createValuesIndex = String.format("CREATE INDEX text_column_index ON %s.indexing (text_column);", keyspace);
-        session.execute(createValuesIndex);
+        session().execute(createValuesIndex);
         IndexMetadata index = getIndexForColumn("text_column");
         assertThat(index).hasName("text_column_index")
                 .isNotKeys()
@@ -88,7 +87,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
             major = 2.1)
     public void should_not_flag_map_index_type() {
         String createValuesIndex = String.format("CREATE INDEX map_values_index ON %s.indexing (map_values);", keyspace);
-        session.execute(createValuesIndex);
+        session().execute(createValuesIndex);
         IndexMetadata index = getIndexForColumn("map_values");
         assertThat(index).hasName("map_values_index")
                 .isNotKeys()
@@ -104,7 +103,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
             major = 2.1)
     public void should_flag_map_index_type_as_keys() {
         String createKeysIndex = String.format("CREATE INDEX map_keys_index ON %s.indexing (KEYS(map_keys));", keyspace);
-        session.execute(createKeysIndex);
+        session().execute(createKeysIndex);
         IndexMetadata index = getIndexForColumn("map_keys");
         assertThat(index).hasName("map_keys_index")
                 .isKeys()
@@ -121,7 +120,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
             minor = 3)
     public void should_flag_map_index_type_as_full() {
         String createFullIndex = String.format("CREATE INDEX map_full_index ON %s.indexing (FULL(map_full));", keyspace);
-        session.execute(createFullIndex);
+        session().execute(createFullIndex);
         IndexMetadata index = getIndexForColumn("map_full");
         assertThat(index).hasName("map_full_index")
                 .isNotKeys()
@@ -138,7 +137,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
             minor = 3)
     public void should_flag_set_index_type_as_full() {
         String createFullIndex = String.format("CREATE INDEX set_full_index ON %s.indexing (FULL(set_full));", keyspace);
-        session.execute(createFullIndex);
+        session().execute(createFullIndex);
         IndexMetadata index = getIndexForColumn("set_full");
         assertThat(index).hasName("set_full_index")
                 .isNotKeys()
@@ -155,7 +154,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
             minor = 3)
     public void should_flag_list_index_type_as_full() {
         String createFullIndex = String.format("CREATE INDEX list_full_index ON %s.indexing (FULL(list_full));", keyspace);
-        session.execute(createFullIndex);
+        session().execute(createFullIndex);
         IndexMetadata index = getIndexForColumn("list_full");
         assertThat(index).hasName("list_full_index")
                 .isNotKeys()
@@ -171,7 +170,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
             major = 3.0)
     public void should_flag_map_index_type_as_entries() {
         String createEntriesIndex = String.format("CREATE INDEX map_entries_index ON %s.indexing (ENTRIES(map_entries));", keyspace);
-        session.execute(createEntriesIndex);
+        session().execute(createEntriesIndex);
         IndexMetadata index = getIndexForColumn("map_entries");
         assertThat(index).hasName("map_entries_index")
                 .isNotKeys()
@@ -265,7 +264,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     private TableMetadata getTable(String name) {
-        return cluster.getMetadata().getKeyspace(keyspace).getTable(name);
+        return cluster().getMetadata().getKeyspace(keyspace).getTable(name);
     }
 
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/LargeDataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LargeDataTest.java
@@ -43,11 +43,11 @@ public class LargeDataTest extends CCMTestsSupport {
     private void testWideRows(int key) throws Throwable {
         // Write data
         for (int i = 0; i < 1000000; ++i) {
-            session.execute(insertInto("wide_rows").value("k", key).value("i", i).setConsistencyLevel(ConsistencyLevel.QUORUM));
+            session().execute(insertInto("wide_rows").value("k", key).value("i", i).setConsistencyLevel(ConsistencyLevel.QUORUM));
         }
 
         // Read data
-        ResultSet rs = session.execute(select("i").from("wide_rows").where(eq("k", key)));
+        ResultSet rs = session().execute(select("i").from("wide_rows").where(eq("k", key)));
 
         // Verify data
         int i = 0;
@@ -68,10 +68,10 @@ public class LargeDataTest extends CCMTestsSupport {
         for (int i = 0; i < 10000; ++i) {
             q = q.add(insertInto("wide_batch_rows").value("k", key).value("i", i));
         }
-        session.execute(q.setConsistencyLevel(ConsistencyLevel.QUORUM));
+        session().execute(q.setConsistencyLevel(ConsistencyLevel.QUORUM));
 
         // Read data
-        ResultSet rs = session.execute(select("i").from("wide_batch_rows").where(eq("k", key)));
+        ResultSet rs = session().execute(select("i").from("wide_batch_rows").where(eq("k", key)));
 
         // Verify data
         int i = 0;
@@ -94,11 +94,11 @@ public class LargeDataTest extends CCMTestsSupport {
 
         // Write data
         for (int i = 0; i < 1000000; ++i) {
-            session.execute(insertInto("wide_byte_rows").value("k", key).value("i", bb).setConsistencyLevel(ConsistencyLevel.QUORUM));
+            session().execute(insertInto("wide_byte_rows").value("k", key).value("i", bb).setConsistencyLevel(ConsistencyLevel.QUORUM));
         }
 
         // Read data
-        ResultSet rs = session.execute(select("i").from("wide_byte_rows").where(eq("k", key)));
+        ResultSet rs = session().execute(select("i").from("wide_byte_rows").where(eq("k", key)));
 
         // Verify data
         for (Row row : rs) {
@@ -119,10 +119,10 @@ public class LargeDataTest extends CCMTestsSupport {
             // Create ultra-long text
             b.append(i);
         }
-        session.execute(insertInto("large_text").value("k", key).value("txt", b.toString()).setConsistencyLevel(ConsistencyLevel.QUORUM));
+        session().execute(insertInto("large_text").value("k", key).value("txt", b.toString()).setConsistencyLevel(ConsistencyLevel.QUORUM));
 
         // Read data
-        Row row = session.execute(select().all().from("large_text").where(eq("k", key))).one();
+        Row row = session().execute(select().all().from("large_text").where(eq("k", key))).one();
 
         // Verify data
         assertTrue(b.toString().equals(row.getString("txt")));
@@ -166,10 +166,10 @@ public class LargeDataTest extends CCMTestsSupport {
         for (int i = 0; i < 330; ++i) {
             insertStatement = insertStatement.value(createColumnName(i), i);
         }
-        session.execute(insertStatement.setConsistencyLevel(ConsistencyLevel.QUORUM));
+        session().execute(insertStatement.setConsistencyLevel(ConsistencyLevel.QUORUM));
 
         // Read data
-        Row row = session.execute(select().all().from("wide_table").where(eq("k", key))).one();
+        Row row = session().execute(select().all().from("wide_table").where(eq("k", key))).one();
 
         // Verify data
         for (int i = 0; i < 330; ++i) {
@@ -186,9 +186,9 @@ public class LargeDataTest extends CCMTestsSupport {
     @Test(groups = "stress")
     @CassandraVersion(major = 2.0, minor = 0, description = "< 2.0 is skipped as 1.2 does not handle reading wide rows well.")
     public void wideRows() throws Throwable {
-        session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "large_data", 1));
-        session.execute("USE large_data");
-        session.execute(String.format("CREATE TABLE %s (k INT, i INT, PRIMARY KEY(k, i))", "wide_rows"));
+        session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "large_data", 1));
+        session().execute("USE large_data");
+        session().execute(String.format("CREATE TABLE %s (k INT, i INT, PRIMARY KEY(k, i))", "wide_rows"));
         testWideRows(0);
     }
 
@@ -200,9 +200,9 @@ public class LargeDataTest extends CCMTestsSupport {
     @Test(groups = "stress")
     @CassandraVersion(major = 2.0, minor = 0, description = "< 2.0 is skipped as 1.2 does not handle large batches well.")
     public void wideBatchRows() throws Throwable {
-        session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "large_data", 1));
-        session.execute("USE large_data");
-        session.execute(String.format("CREATE TABLE %s (k INT, i INT, PRIMARY KEY(k, i))", "wide_batch_rows"));
+        session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "large_data", 1));
+        session().execute("USE large_data");
+        session().execute(String.format("CREATE TABLE %s (k INT, i INT, PRIMARY KEY(k, i))", "wide_batch_rows"));
         testWideBatchRows(0);
     }
 
@@ -213,9 +213,9 @@ public class LargeDataTest extends CCMTestsSupport {
      */
     @Test(groups = "stress")
     public void wideByteRows() throws Throwable {
-        session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "large_data", 1));
-        session.execute("USE large_data");
-        session.execute(String.format("CREATE TABLE %s (k INT, i BLOB, PRIMARY KEY(k, i))", "wide_byte_rows"));
+        session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "large_data", 1));
+        session().execute("USE large_data");
+        session().execute(String.format("CREATE TABLE %s (k INT, i BLOB, PRIMARY KEY(k, i))", "wide_byte_rows"));
         testByteRows(0);
     }
 
@@ -226,9 +226,9 @@ public class LargeDataTest extends CCMTestsSupport {
      */
     @Test(groups = "stress")
     public void largeText() throws Throwable {
-        session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "large_data", 1));
-        session.execute("USE large_data");
-        session.execute(String.format("CREATE TABLE %s (k int PRIMARY KEY, txt text)", "large_text"));
+        session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "large_data", 1));
+        session().execute("USE large_data");
+        session().execute(String.format("CREATE TABLE %s (k int PRIMARY KEY, txt text)", "large_text"));
         testLargeText(0);
     }
 
@@ -239,8 +239,8 @@ public class LargeDataTest extends CCMTestsSupport {
      */
     @Test(groups = "stress")
     public void wideTable() throws Throwable {
-        session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "large_data", 1));
-        session.execute("USE large_data");
+        session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "large_data", 1));
+        session().execute("USE large_data");
         // Create the extra wide table definition
         StringBuilder tableDeclaration = new StringBuilder();
         tableDeclaration.append("CREATE TABLE wide_table (");
@@ -249,7 +249,7 @@ public class LargeDataTest extends CCMTestsSupport {
             tableDeclaration.append(String.format(", %s INT", createColumnName(i)));
         }
         tableDeclaration.append(')');
-        session.execute(tableDeclaration.toString());
+        session().execute(tableDeclaration.toString());
         testWideTable(0);
     }
 
@@ -261,12 +261,12 @@ public class LargeDataTest extends CCMTestsSupport {
     @Test(groups = "duration")
     @CCMConfig(numberOfNodes = 3)
     public void mixedDurationTest() throws Throwable {
-        session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "large_data", 3));
-        session.execute("USE large_data");
-        session.execute(String.format("CREATE TABLE %s (k INT, i INT, PRIMARY KEY(k, i))", "wide_rows"));
-        session.execute(String.format("CREATE TABLE %s (k INT, i INT, PRIMARY KEY(k, i))", "wide_batch_rows"));
-        session.execute(String.format("CREATE TABLE %s (k INT, i BLOB, PRIMARY KEY(k, i))", "wide_byte_rows"));
-        session.execute(String.format("CREATE TABLE %s (k int PRIMARY KEY, txt text)", "large_text"));
+        session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "large_data", 3));
+        session().execute("USE large_data");
+        session().execute(String.format("CREATE TABLE %s (k INT, i INT, PRIMARY KEY(k, i))", "wide_rows"));
+        session().execute(String.format("CREATE TABLE %s (k INT, i INT, PRIMARY KEY(k, i))", "wide_batch_rows"));
+        session().execute(String.format("CREATE TABLE %s (k INT, i BLOB, PRIMARY KEY(k, i))", "wide_byte_rows"));
+        session().execute(String.format("CREATE TABLE %s (k int PRIMARY KEY, txt text)", "large_text"));
         // Create the extra wide table definition
         StringBuilder tableDeclaration = new StringBuilder();
         tableDeclaration.append("CREATE TABLE wide_table (");
@@ -275,7 +275,7 @@ public class LargeDataTest extends CCMTestsSupport {
             tableDeclaration.append(String.format(", %s INT", createColumnName(i)));
         }
         tableDeclaration.append(')');
-        session.execute(tableDeclaration.toString());
+        session().execute(tableDeclaration.toString());
         for (int i = 0; i < 10; ++i) {
             switch ((int) (Math.random() * 5)) {
                 case 0:

--- a/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyBootstrapTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyBootstrapTest.java
@@ -48,8 +48,8 @@ public class LoadBalancingPolicyBootstrapTest extends CCMTestsSupport {
         HistoryPolicy policy = new HistoryPolicy(new RoundRobinPolicy());
 
         Cluster cluster = register(Cluster.builder()
-                .addContactPointsWithPorts(getInitialContactPoints())
-                .withPort(ccm.getBinaryPort())
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
                 .withLoadBalancingPolicy(policy)
                 .build());
 
@@ -85,13 +85,13 @@ public class LoadBalancingPolicyBootstrapTest extends CCMTestsSupport {
             nodeToStop = (nodeToStop == 1) ? 2 : 1; // switch nodes at each try
             int activeNode = nodeToStop == 2 ? 1 : 2;
 
-            ccm.stop(nodeToStop);
-            ccm.waitForDown(nodeToStop);
+            ccm().stop(nodeToStop);
+            ccm().waitForDown(nodeToStop);
 
             HistoryPolicy policy = new HistoryPolicy(new RoundRobinPolicy());
             Cluster cluster = register(Cluster.builder()
-                    .addContactPointsWithPorts(getInitialContactPoints())
-                    .withPort(ccm.getBinaryPort())
+                    .addContactPoints(getContactPoints())
+                    .withPort(ccm().getBinaryPort())
                     .withLoadBalancingPolicy(policy)
                     .build());
 
@@ -114,8 +114,8 @@ public class LoadBalancingPolicyBootstrapTest extends CCMTestsSupport {
 
                 cluster.close();
 
-                ccm.start(nodeToStop);
-                ccm.waitForUp(nodeToStop);
+                ccm().start(nodeToStop);
+                ccm().waitForUp(nodeToStop);
             }
         }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyRefreshTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyRefreshTest.java
@@ -82,20 +82,20 @@ public class LoadBalancingPolicyRefreshTest extends CCMTestsSupport {
     public void refreshTest() throws Throwable {
         // Ugly
         Host[] hosts = new Host[2];
-        for (Host h : cluster.getMetadata().getAllHosts()) {
+        for (Host h : cluster().getMetadata().getAllHosts()) {
             if (h.getAddress().equals(InetAddress.getByName(TestUtils.IP_PREFIX + '1')))
                 hosts[0] = h;
             else
                 hosts[1] = h;
         }
 
-        assertTrue(session.getState().getConnectedHosts().contains(hosts[0]), "Connected hosts: " + session.getState().getConnectedHosts());
-        assertTrue(!session.getState().getConnectedHosts().contains(hosts[1]), "Connected hosts: " + session.getState().getConnectedHosts());
+        assertTrue(session().getState().getConnectedHosts().contains(hosts[0]), "Connected hosts: " + session().getState().getConnectedHosts());
+        assertTrue(!session().getState().getConnectedHosts().contains(hosts[1]), "Connected hosts: " + session().getState().getConnectedHosts());
 
         policy.changeTheHost(hosts[1]);
 
-        assertTrue(!session.getState().getConnectedHosts().contains(hosts[0]), "Connected hosts: " + session.getState().getConnectedHosts());
-        assertTrue(session.getState().getConnectedHosts().contains(hosts[1]), "Connected hosts: " + session.getState().getConnectedHosts());
+        assertTrue(!session().getState().getConnectedHosts().contains(hosts[0]), "Connected hosts: " + session().getState().getConnectedHosts());
+        assertTrue(session().getState().getConnectedHosts().contains(hosts[1]), "Connected hosts: " + session().getState().getConnectedHosts());
     }
 
     @SuppressWarnings("unused")

--- a/driver-core/src/test/java/com/datastax/driver/core/MetricsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MetricsTest.java
@@ -18,10 +18,7 @@ package com.datastax.driver.core;
 import com.datastax.driver.core.Metrics.Errors;
 import com.datastax.driver.core.policies.RetryPolicy;
 import com.datastax.driver.core.policies.RetryPolicy.RetryDecision;
-import com.google.common.collect.Lists;
 import org.testng.annotations.Test;
-
-import java.util.Collection;
 
 import static org.testng.Assert.assertEquals;
 
@@ -49,8 +46,8 @@ public class MetricsTest extends CCMTestsSupport {
     }
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Lists.newArrayList("CREATE TABLE test (k int primary key, v int)",
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE test (k int primary key, v int)",
                 "INSERT INTO test (k, v) VALUES (1, 1)");
     }
 
@@ -60,15 +57,15 @@ public class MetricsTest extends CCMTestsSupport {
 
         // We only have one node, this will throw an unavailable exception
         Statement statement = new SimpleStatement("SELECT v FROM test WHERE k = 1").setConsistencyLevel(ConsistencyLevel.TWO);
-        session.execute(statement);
+        session().execute(statement);
 
-        Errors errors = cluster.getMetrics().getErrorMetrics();
+        Errors errors = cluster().getMetrics().getErrorMetrics();
         assertEquals(errors.getUnavailables().getCount(), 1);
         assertEquals(errors.getRetries().getCount(), 1);
         assertEquals(errors.getRetriesOnUnavailable().getCount(), 1);
 
         retryDecision = RetryDecision.ignore();
-        session.execute(statement);
+        session().execute(statement);
 
         assertEquals(errors.getUnavailables().getCount(), 2);
         assertEquals(errors.getIgnores().getCount(), 1);

--- a/driver-core/src/test/java/com/datastax/driver/core/MissingRpcAddressTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MissingRpcAddressTest.java
@@ -42,22 +42,22 @@ public class MissingRpcAddressTest extends CCMTestsSupport {
         deleteNode2RpcAddressFromNode1();
         // Use only one contact point to make sure that the control connection is on node1
         Cluster cluster = register(Cluster.builder()
-                .addContactPoints(ccm.addressOfNode(1).getAddress())
-                .withPort(ccm.getBinaryPort())
+                .addContactPoints(getContactPoints().get(0))
+                .withPort(ccm().getBinaryPort())
                 .build());
         cluster.connect();
 
         // Since node2's RPC address is unknown on our control host, it should have been ignored
         assertEquals(cluster.getMetrics().getConnectedToHosts().getValue().intValue(), 1);
-        assertNull(cluster.getMetadata().getHost(getInitialContactPoints().get(1)));
+        assertNull(cluster.getMetadata().getHost(getContactPointsWithPorts().get(1)));
     }
 
     // Artificially modify the system tables to simulate the missing rpc_address.
     private void deleteNode2RpcAddressFromNode1() throws Exception {
-        InetSocketAddress firstHost = ccm.addressOfNode(1);
+        InetSocketAddress firstHost = ccm().addressOfNode(1);
         Cluster cluster = register(Cluster.builder()
                 .addContactPointsWithPorts(singleton(firstHost))
-                .withPort(ccm.getBinaryPort())
+                .withPort(ccm().getBinaryPort())
                 // ensure we will only connect to node1
                 .withLoadBalancingPolicy(new WhiteListPolicy(Policies.defaultLoadBalancingPolicy(),
                         Lists.newArrayList(firstHost)))

--- a/driver-core/src/test/java/com/datastax/driver/core/NettyOptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/NettyOptionsTest.java
@@ -65,8 +65,8 @@ public class NettyOptionsTest extends CCMTestsSupport {
             }
         }).when(nettyOptions).afterChannelInitialized(any(SocketChannel.class));
         Cluster cluster = register(Cluster.builder()
-                .addContactPointsWithPorts(ccm.addressOfNode(1))
-                .withPort(ccm.getBinaryPort())
+                .addContactPoints(getContactPoints().get(0))
+                .withPort(ccm().getBinaryPort())
                 .withPoolingOptions(new PoolingOptions()
                         .setConnectionsPerHost(HostDistance.LOCAL, coreConnections, coreConnections)
                 )

--- a/driver-core/src/test/java/com/datastax/driver/core/NodeRefreshDebouncerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/NodeRefreshDebouncerTest.java
@@ -43,17 +43,17 @@ public class NodeRefreshDebouncerTest extends CCMTestsSupport {
         int refreshNodeInterval = 30000;
         QueryOptions queryOptions = new QueryOptions().setRefreshNodeIntervalMillis(refreshNodeInterval);
         Cluster cluster = register(Cluster.builder()
-                .addContactPoints(ccm.addressOfNode(1).getAddress())
-                .withPort(ccm.getBinaryPort())
+                .addContactPoints(getContactPoints().get(0))
+                .withPort(ccm().getBinaryPort())
                 .withQueryOptions(queryOptions)
                 .build());
         cluster.connect();
         Host.StateListener listener = mock(Host.StateListener.class);
         cluster.register(listener);
-        ccm.add(2);
-        ccm.start(2);
-        ccm.stop(2);
-        ccm.start(2);
+        ccm().add(2);
+        ccm().start(2);
+        ccm().stop(2);
+        ccm().start(2);
 
         ArgumentCaptor<Host> captor = forClass(Host.class);
 

--- a/driver-core/src/test/java/com/datastax/driver/core/PoolingOptionsIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PoolingOptionsIntegrationTest.java
@@ -58,21 +58,21 @@ public class PoolingOptionsIntegrationTest extends CCMTestsSupport {
      */
     @Test(groups = "short")
     public void should_be_able_to_use_custom_initialization_executor() {
-        cluster.init();
+        cluster().init();
         // Ensure executor used.
         verify(executor, atLeastOnce()).execute(any(Runnable.class));
 
         // Reset invocation count.
         reset();
 
-        Session session = cluster.connect();
+        Session session = cluster().connect();
 
         // Ensure executor used again to establish core connections.
         verify(executor, atLeastOnce()).execute(any(Runnable.class));
 
         // Expect core connections + control connection.
-        assertThat(cluster.getMetrics().getOpenConnections().getValue()).isEqualTo(
-                TestUtils.numberOfLocalCoreConnections(cluster) + 1);
+        assertThat(cluster().getMetrics().getOpenConnections().getValue()).isEqualTo(
+                TestUtils.numberOfLocalCoreConnections(cluster()) + 1);
 
         reset();
 
@@ -82,6 +82,6 @@ public class PoolingOptionsIntegrationTest extends CCMTestsSupport {
         verify(executor, atLeastOnce()).execute(any(Runnable.class));
 
         // Only the control connection should remain.
-        assertThat(cluster.getMetrics().getOpenConnections().getValue()).isEqualTo(1);
+        assertThat(cluster().getMetrics().getOpenConnections().getValue()).isEqualTo(1);
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
@@ -21,7 +21,10 @@ import com.datastax.driver.core.utils.CassandraVersion;
 import org.testng.annotations.Test;
 
 import java.net.InetAddress;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.datastax.driver.core.TestUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,8 +50,11 @@ public class PreparedStatementTest extends CCMTestsSupport {
     }
 
     @Override
-    public Collection<String> createTestFixtures() {
+    public void onTestContextInitialized() {
+        execute(createTestFixtures());
+    }
 
+    private List<String> createTestFixtures() {
         List<String> defs = new ArrayList<String>(4);
 
         StringBuilder sb = new StringBuilder();
@@ -101,7 +107,6 @@ public class PreparedStatementTest extends CCMTestsSupport {
 
         defs.add(String.format("CREATE TABLE %s (k text PRIMARY KEY, i int)", SIMPLE_TABLE));
         defs.add(String.format("CREATE TABLE %s (k text PRIMARY KEY, v text)", SIMPLE_TABLE2));
-
         return defs;
     }
 
@@ -114,11 +119,11 @@ public class PreparedStatementTest extends CCMTestsSupport {
                 continue;
 
             String name = "c_" + type;
-            PreparedStatement ps = session.prepare(String.format("INSERT INTO %s(k, %s) VALUES ('prepared_native', ?)", ALL_NATIVE_TABLE, name));
+            PreparedStatement ps = session().prepare(String.format("INSERT INTO %s(k, %s) VALUES ('prepared_native', ?)", ALL_NATIVE_TABLE, name));
             BoundStatement bs = ps.bind();
-            session.execute(setBoundValue(bs, name, type, getFixedValue(type)));
+            session().execute(setBoundValue(bs, name, type, getFixedValue(type)));
 
-            Row row = session.execute(String.format("SELECT %s FROM %s WHERE k='prepared_native'", name, ALL_NATIVE_TABLE)).one();
+            Row row = session().execute(String.format("SELECT %s FROM %s WHERE k='prepared_native'", name, ALL_NATIVE_TABLE)).one();
             assertEquals(getValue(row, name, type), getFixedValue(type), "For type " + type);
         }
     }
@@ -135,11 +140,11 @@ public class PreparedStatementTest extends CCMTestsSupport {
                 continue;
 
             String name = "c_" + type;
-            PreparedStatement ps = session.prepare(String.format("INSERT INTO %s(k, %s) VALUES ('prepared_native', ?)", ALL_NATIVE_TABLE, name));
+            PreparedStatement ps = session().prepare(String.format("INSERT INTO %s(k, %s) VALUES ('prepared_native', ?)", ALL_NATIVE_TABLE, name));
             BoundStatement bs = ps.bind();
-            session.execute(setBoundValue(bs, name, type, getFixedValue2(type)));
+            session().execute(setBoundValue(bs, name, type, getFixedValue2(type)));
 
-            Row row = session.execute(String.format("SELECT %s FROM %s WHERE k='prepared_native'", name, ALL_NATIVE_TABLE)).one();
+            Row row = session().execute(String.format("SELECT %s FROM %s WHERE k='prepared_native'", name, ALL_NATIVE_TABLE)).one();
             assertEquals(getValue(row, name, type), getFixedValue2(type), "For type " + type);
         }
     }
@@ -156,12 +161,12 @@ public class PreparedStatementTest extends CCMTestsSupport {
             String name = "c_list_" + rawType;
             DataType type = DataType.list(rawType);
             List<Object> value = (List<Object>) getFixedValue(type);
-            ;
-            PreparedStatement ps = session.prepare(String.format("INSERT INTO %s(k, %s) VALUES ('prepared_list', ?)", ALL_LIST_TABLE, name));
-            BoundStatement bs = ps.bind();
-            session.execute(setBoundValue(bs, name, type, value));
 
-            Row row = session.execute(String.format("SELECT %s FROM %s WHERE k='prepared_list'", name, ALL_LIST_TABLE)).one();
+            PreparedStatement ps = session().prepare(String.format("INSERT INTO %s(k, %s) VALUES ('prepared_list', ?)", ALL_LIST_TABLE, name));
+            BoundStatement bs = ps.bind();
+            session().execute(setBoundValue(bs, name, type, value));
+
+            Row row = session().execute(String.format("SELECT %s FROM %s WHERE k='prepared_list'", name, ALL_LIST_TABLE)).one();
             assertEquals(getValue(row, name, type), value, "For type " + type);
         }
     }
@@ -181,12 +186,12 @@ public class PreparedStatementTest extends CCMTestsSupport {
             String name = "c_list_" + rawType;
             DataType type = DataType.list(rawType);
             List<Object> value = (List<Object>) getFixedValue2(type);
-            ;
-            PreparedStatement ps = session.prepare(String.format("INSERT INTO %s(k, %s) VALUES ('prepared_list', ?)", ALL_LIST_TABLE, name));
-            BoundStatement bs = ps.bind();
-            session.execute(setBoundValue(bs, name, type, value));
 
-            Row row = session.execute(String.format("SELECT %s FROM %s WHERE k='prepared_list'", name, ALL_LIST_TABLE)).one();
+            PreparedStatement ps = session().prepare(String.format("INSERT INTO %s(k, %s) VALUES ('prepared_list', ?)", ALL_LIST_TABLE, name));
+            BoundStatement bs = ps.bind();
+            session().execute(setBoundValue(bs, name, type, value));
+
+            Row row = session().execute(String.format("SELECT %s FROM %s WHERE k='prepared_list'", name, ALL_LIST_TABLE)).one();
             assertEquals(getValue(row, name, type), value, "For type " + type);
         }
     }
@@ -203,12 +208,12 @@ public class PreparedStatementTest extends CCMTestsSupport {
             String name = "c_set_" + rawType;
             DataType type = DataType.set(rawType);
             Set<Object> value = (Set<Object>) getFixedValue(type);
-            ;
-            PreparedStatement ps = session.prepare(String.format("INSERT INTO %s(k, %s) VALUES ('prepared_set', ?)", ALL_SET_TABLE, name));
-            BoundStatement bs = ps.bind();
-            session.execute(setBoundValue(bs, name, type, value));
 
-            Row row = session.execute(String.format("SELECT %s FROM %s WHERE k='prepared_set'", name, ALL_SET_TABLE)).one();
+            PreparedStatement ps = session().prepare(String.format("INSERT INTO %s(k, %s) VALUES ('prepared_set', ?)", ALL_SET_TABLE, name));
+            BoundStatement bs = ps.bind();
+            session().execute(setBoundValue(bs, name, type, value));
+
+            Row row = session().execute(String.format("SELECT %s FROM %s WHERE k='prepared_set'", name, ALL_SET_TABLE)).one();
             assertEquals(getValue(row, name, type), value, "For type " + type);
         }
     }
@@ -228,12 +233,12 @@ public class PreparedStatementTest extends CCMTestsSupport {
             String name = "c_set_" + rawType;
             DataType type = DataType.set(rawType);
             Set<Object> value = (Set<Object>) getFixedValue2(type);
-            ;
-            PreparedStatement ps = session.prepare(String.format("INSERT INTO %s(k, %s) VALUES ('prepared_set', ?)", ALL_SET_TABLE, name));
-            BoundStatement bs = ps.bind();
-            session.execute(setBoundValue(bs, name, type, value));
 
-            Row row = session.execute(String.format("SELECT %s FROM %s WHERE k='prepared_set'", name, ALL_SET_TABLE)).one();
+            PreparedStatement ps = session().prepare(String.format("INSERT INTO %s(k, %s) VALUES ('prepared_set', ?)", ALL_SET_TABLE, name));
+            BoundStatement bs = ps.bind();
+            session().execute(setBoundValue(bs, name, type, value));
+
+            Row row = session().execute(String.format("SELECT %s FROM %s WHERE k='prepared_set'", name, ALL_SET_TABLE)).one();
             assertEquals(getValue(row, name, type), value, "For type " + type);
         }
     }
@@ -255,12 +260,12 @@ public class PreparedStatementTest extends CCMTestsSupport {
                 String name = "c_map_" + rawKeyType + '_' + rawValueType;
                 DataType type = DataType.map(rawKeyType, rawValueType);
                 Map<Object, Object> value = (Map<Object, Object>) getFixedValue(type);
-                ;
-                PreparedStatement ps = session.prepare(String.format("INSERT INTO %s(k, %s) VALUES ('prepared_map', ?)", ALL_MAP_TABLE, name));
-                BoundStatement bs = ps.bind();
-                session.execute(setBoundValue(bs, name, type, value));
 
-                Row row = session.execute(String.format("SELECT %s FROM %s WHERE k='prepared_map'", name, ALL_MAP_TABLE)).one();
+                PreparedStatement ps = session().prepare(String.format("INSERT INTO %s(k, %s) VALUES ('prepared_map', ?)", ALL_MAP_TABLE, name));
+                BoundStatement bs = ps.bind();
+                session().execute(setBoundValue(bs, name, type, value));
+
+                Row row = session().execute(String.format("SELECT %s FROM %s WHERE k='prepared_map'", name, ALL_MAP_TABLE)).one();
                 assertEquals(getValue(row, name, type), value, "For type " + type);
             }
         }
@@ -286,12 +291,12 @@ public class PreparedStatementTest extends CCMTestsSupport {
                 String name = "c_map_" + rawKeyType + '_' + rawValueType;
                 DataType type = DataType.map(rawKeyType, rawValueType);
                 Map<Object, Object> value = (Map<Object, Object>) getFixedValue2(type);
-                ;
-                PreparedStatement ps = session.prepare(String.format("INSERT INTO %s(k, %s) VALUES ('prepared_map', ?)", ALL_MAP_TABLE, name));
-                BoundStatement bs = ps.bind();
-                session.execute(setBoundValue(bs, name, type, value));
 
-                Row row = session.execute(String.format("SELECT %s FROM %s WHERE k='prepared_map'", name, ALL_MAP_TABLE)).one();
+                PreparedStatement ps = session().prepare(String.format("INSERT INTO %s(k, %s) VALUES ('prepared_map', ?)", ALL_MAP_TABLE, name));
+                BoundStatement bs = ps.bind();
+                session().execute(setBoundValue(bs, name, type, value));
+
+                Row row = session().execute(String.format("SELECT %s FROM %s WHERE k='prepared_map'", name, ALL_MAP_TABLE)).one();
                 assertEquals(getValue(row, name, type), value, "For type " + type);
             }
         }
@@ -300,16 +305,16 @@ public class PreparedStatementTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void prepareWithNullValuesTest() throws Exception {
 
-        PreparedStatement ps = session.prepare("INSERT INTO " + SIMPLE_TABLE2 + "(k, v) VALUES (?, ?)");
+        PreparedStatement ps = session().prepare("INSERT INTO " + SIMPLE_TABLE2 + "(k, v) VALUES (?, ?)");
 
-        session.execute(ps.bind("prepWithNull1", null));
+        session().execute(ps.bind("prepWithNull1", null));
 
         BoundStatement bs = ps.bind();
         bs.setString("k", "prepWithNull2");
         bs.setString("v", null);
-        session.execute(bs);
+        session().execute(bs);
 
-        ResultSet rs = session.execute("SELECT * FROM " + SIMPLE_TABLE2 + " WHERE k IN ('prepWithNull1', 'prepWithNull2')");
+        ResultSet rs = session().execute("SELECT * FROM " + SIMPLE_TABLE2 + " WHERE k IN ('prepWithNull1', 'prepWithNull2')");
         Row r1 = rs.one();
         Row r2 = rs.one();
         assertTrue(rs.isExhausted());
@@ -328,7 +333,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
         toPrepare.setConsistencyLevel(ConsistencyLevel.QUORUM);
         toPrepare.enableTracing();
 
-        PreparedStatement prepared = session.prepare(toPrepare);
+        PreparedStatement prepared = session().prepare(toPrepare);
         BoundStatement bs = prepared.bind("someValue");
 
         assertEquals(ConsistencyLevel.QUORUM, bs.getConsistencyLevel());
@@ -350,17 +355,17 @@ public class PreparedStatementTest extends CCMTestsSupport {
     public void batchTest() throws Exception {
 
         try {
-            PreparedStatement ps1 = session.prepare("INSERT INTO " + SIMPLE_TABLE2 + "(k, v) VALUES (?, ?)");
-            PreparedStatement ps2 = session.prepare("INSERT INTO " + SIMPLE_TABLE2 + "(k, v) VALUES (?, 'bar')");
+            PreparedStatement ps1 = session().prepare("INSERT INTO " + SIMPLE_TABLE2 + "(k, v) VALUES (?, ?)");
+            PreparedStatement ps2 = session().prepare("INSERT INTO " + SIMPLE_TABLE2 + "(k, v) VALUES (?, 'bar')");
 
             BatchStatement bs = new BatchStatement();
             bs.add(ps1.bind("one", "foo"));
             bs.add(ps2.bind("two"));
             bs.add(new SimpleStatement("INSERT INTO " + SIMPLE_TABLE2 + " (k, v) VALUES ('three', 'foobar')"));
 
-            session.execute(bs);
+            session().execute(bs);
 
-            List<Row> all = session.execute("SELECT * FROM " + SIMPLE_TABLE2).all();
+            List<Row> all = session().execute("SELECT * FROM " + SIMPLE_TABLE2).all();
 
             assertEquals("three", all.get(0).getString("k"));
             assertEquals("foobar", all.get(0).getString("v"));
@@ -372,46 +377,46 @@ public class PreparedStatementTest extends CCMTestsSupport {
             assertEquals("bar", all.get(2).getString("v"));
         } catch (UnsupportedFeatureException e) {
             // This is expected when testing the protocol v1
-            if (cluster.getConfiguration().getProtocolOptions().getProtocolVersionEnum() != ProtocolVersion.V1)
+            if (cluster().getConfiguration().getProtocolOptions().getProtocolVersionEnum() != ProtocolVersion.V1)
                 throw e;
         }
     }
 
     @Test(groups = "short", expectedExceptions = {IllegalStateException.class})
     public void unboundVariableInBoundStatementTest() {
-        PreparedStatement ps = session.prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (?, ?)");
+        PreparedStatement ps = session().prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (?, ?)");
         BoundStatement bs = ps.bind("k");
         assertFalse(bs.isSet("i"));
-        session.execute(bs);
+        session().execute(bs);
     }
 
     @Test(groups = "short", expectedExceptions = {IllegalStateException.class})
     @CassandraVersion(major = 2.0)
     public void unboundVariableInBatchStatementTest() {
-        PreparedStatement ps = session.prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (?, ?)");
+        PreparedStatement ps = session().prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (?, ?)");
         BatchStatement batch = new BatchStatement();
         batch.add(ps.bind("k"));
-        session.execute(batch);
+        session().execute(batch);
     }
 
     @Test(groups = "short")
     public void should_set_routing_key_on_case_insensitive_keyspace_and_table() {
-        session.execute(String.format("CREATE TABLE %s.foo (i int PRIMARY KEY)", keyspace));
+        session().execute(String.format("CREATE TABLE %s.foo (i int PRIMARY KEY)", keyspace));
 
-        PreparedStatement ps = session.prepare(String.format("INSERT INTO %s.foo (i) VALUES (?)", keyspace));
+        PreparedStatement ps = session().prepare(String.format("INSERT INTO %s.foo (i) VALUES (?)", keyspace));
         BoundStatement bs = ps.bind(1);
         assertThat(bs.getRoutingKey()).isNotNull();
     }
 
     @Test(groups = "short")
     public void should_set_routing_key_on_case_sensitive_keyspace_and_table() {
-        session.execute("CREATE KEYSPACE \"Test\" WITH replication = { "
+        session().execute("CREATE KEYSPACE \"Test\" WITH replication = { "
                 + "  'class': 'SimpleStrategy',"
                 + "  'replication_factor': '1'"
                 + "}");
-        session.execute("CREATE TABLE \"Test\".\"Foo\" (i int PRIMARY KEY)");
+        session().execute("CREATE TABLE \"Test\".\"Foo\" (i int PRIMARY KEY)");
 
-        PreparedStatement ps = session.prepare("INSERT INTO \"Test\".\"Foo\" (i) VALUES (?)");
+        PreparedStatement ps = session().prepare("INSERT INTO \"Test\".\"Foo\" (i) VALUES (?)");
         BoundStatement bs = ps.bind(1);
         assertThat(bs.getRoutingKey()).isNotNull();
     }
@@ -419,14 +424,15 @@ public class PreparedStatementTest extends CCMTestsSupport {
     @Test(groups = "short", expectedExceptions = InvalidQueryException.class)
     public void should_fail_when_prepared_on_another_cluster() throws Exception {
         Cluster otherCluster = Cluster.builder()
-                .addContactPointsWithPorts(getInitialContactPoints())
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
                 .build();
         try {
             PreparedStatement pst = otherCluster.connect().prepare("select * from system.peers where inet = ?");
             BoundStatement bs = pst.bind().setInet(0, InetAddress.getByName("localhost"));
 
             // We expect that the error gets detected without a roundtrip to the server, so use executeAsync
-            session.executeAsync(bs);
+            session().executeAsync(bs);
         } finally {
             otherCluster.close();
         }
@@ -434,7 +440,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_propagate_idempotence_in_statements() {
-        session.execute(String.format("CREATE TABLE %s.idempotencetest (i int PRIMARY KEY)", keyspace));
+        session().execute(String.format("CREATE TABLE %s.idempotencetest (i int PRIMARY KEY)", keyspace));
 
         SimpleStatement statement;
         IdempotenceAwarePreparedStatement prepared;
@@ -442,21 +448,21 @@ public class PreparedStatementTest extends CCMTestsSupport {
 
         statement = new SimpleStatement(String.format("SELECT * FROM %s.idempotencetest WHERE i = ?", keyspace));
 
-        prepared = (IdempotenceAwarePreparedStatement) session.prepare(statement);
+        prepared = (IdempotenceAwarePreparedStatement) session().prepare(statement);
         bound = prepared.bind(1);
 
         assertThat(prepared.isIdempotent()).isNull();
         assertThat(bound.isIdempotent()).isNull();
 
         statement.setIdempotent(true);
-        prepared = (IdempotenceAwarePreparedStatement) session.prepare(statement);
+        prepared = (IdempotenceAwarePreparedStatement) session().prepare(statement);
         bound = prepared.bind(1);
 
         assertThat(prepared.isIdempotent()).isTrue();
         assertThat(bound.isIdempotent()).isTrue();
 
         statement.setIdempotent(false);
-        prepared = (IdempotenceAwarePreparedStatement) session.prepare(statement);
+        prepared = (IdempotenceAwarePreparedStatement) session().prepare(statement);
         bound = prepared.bind(1);
 
         assertThat(prepared.isIdempotent()).isFalse();

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
@@ -122,8 +122,8 @@ public class QueryLoggerTest extends CCMTestsSupport {
 
     @AfterMethod(groups = {"short", "unit"}, alwaysRun = true)
     public void unregisterQueryLogger() {
-        if (cluster != null && queryLogger != null) {
-            cluster.unregister(queryLogger);
+        if (cluster() != null && queryLogger != null) {
+            cluster().unregister(queryLogger);
         }
     }
 
@@ -133,12 +133,12 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_log_regular_statements() throws Exception {
         // given
         normal.setLevel(DEBUG);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withConstantThreshold(Long.MAX_VALUE)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         String query = "SELECT c_text FROM test WHERE pk = 42";
-        session.execute(query);
+        session().execute(query);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -152,14 +152,14 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_log_bound_statements() throws Exception {
         // given
         normal.setLevel(DEBUG);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withConstantThreshold(Long.MAX_VALUE)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         String query = "SELECT * FROM test where pk = ?";
-        PreparedStatement ps = session.prepare(query);
+        PreparedStatement ps = session().prepare(query);
         BoundStatement bs = ps.bind(42);
-        session.execute(bs);
+        session().execute(bs);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -174,20 +174,20 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_log_batch_statements() throws Exception {
         // given
         normal.setLevel(DEBUG);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withConstantThreshold(Long.MAX_VALUE)
                 .withMaxQueryStringLength(Integer.MAX_VALUE)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         // when
         String query1 = "INSERT INTO test (pk) VALUES (?)";
         String query2 = "UPDATE test SET c_int = ? WHERE pk = 42";
-        PreparedStatement ps1 = session.prepare(query1);
-        PreparedStatement ps2 = session.prepare(query2);
+        PreparedStatement ps1 = session().prepare(query1);
+        PreparedStatement ps2 = session().prepare(query2);
         BatchStatement batch = new BatchStatement();
         batch.add(ps1.bind(42));
         batch.add(ps2.bind(1234));
-        session.execute(batch);
+        session().execute(batch);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -205,20 +205,20 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_log_unlogged_batch_statements() throws Exception {
         // given
         normal.setLevel(DEBUG);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withConstantThreshold(Long.MAX_VALUE)
                 .withMaxQueryStringLength(Integer.MAX_VALUE)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         // when
         String query1 = "INSERT INTO test (pk) VALUES (?)";
         String query2 = "UPDATE test SET c_int = ? WHERE pk = 42";
-        PreparedStatement ps1 = session.prepare(query1);
-        PreparedStatement ps2 = session.prepare(query2);
+        PreparedStatement ps1 = session().prepare(query1);
+        PreparedStatement ps2 = session().prepare(query2);
         BatchStatement batch = new BatchStatement(UNLOGGED);
         batch.add(ps1.bind(42));
         batch.add(ps2.bind(1234));
-        session.execute(batch);
+        session().execute(batch);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -235,25 +235,25 @@ public class QueryLoggerTest extends CCMTestsSupport {
     @CassandraVersion(major = 2.0)
     public void should_log_counter_batch_statements() throws Exception {
         // Create a special table for testing with counters.
-        session.execute(
+        session().execute(
                 "CREATE TABLE IF NOT EXISTS counter_test (pk int PRIMARY KEY, c_count COUNTER, c_count2 COUNTER)");
 
         // given
         normal.setLevel(DEBUG);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withConstantThreshold(Long.MAX_VALUE)
                 .withMaxQueryStringLength(Integer.MAX_VALUE)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         // when
         String query1 = "UPDATE counter_test SET c_count = c_count + ? WHERE pk = 42";
         String query2 = "UPDATE counter_test SET c_count2 = c_count2 + ? WHERE pk = 42";
-        PreparedStatement ps1 = session.prepare(query1);
-        PreparedStatement ps2 = session.prepare(query2);
+        PreparedStatement ps1 = session().prepare(query1);
+        PreparedStatement ps2 = session().prepare(query2);
         BatchStatement batch = new BatchStatement(COUNTER);
         batch.add(ps1.bind(1234L));
         batch.add(ps2.bind(5678L));
-        session.execute(batch);
+        session().execute(batch);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -347,16 +347,16 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_log_normal_queries() throws Exception {
         // given
         normal.setLevel(DEBUG);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withConstantThreshold(Long.MAX_VALUE)
                 .withMaxQueryStringLength(Integer.MAX_VALUE)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         // when
         String query = "SELECT * FROM test where pk = ?";
-        PreparedStatement ps = session.prepare(query);
+        PreparedStatement ps = session().prepare(query);
         BoundStatement bs = ps.bind(42);
-        session.execute(bs);
+        session().execute(bs);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -375,18 +375,18 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_log_non_null_named_parameter() throws Exception {
         // given
         normal.setLevel(TRACE);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withConstantThreshold(Long.MAX_VALUE)
                 .withMaxQueryStringLength(Integer.MAX_VALUE)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         // when
         String query = "UPDATE test SET c_text = :param1 WHERE pk = :param2";
-        PreparedStatement ps = session.prepare(query);
+        PreparedStatement ps = session().prepare(query);
         BoundStatement bs = ps.bind();
         bs.setString("param1", "foo");
         bs.setInt("param2", 42);
-        session.execute(bs);
+        session().execute(bs);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -401,15 +401,15 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_log_non_null_positional_parameter() throws Exception {
         // given
         normal.setLevel(TRACE);
-        queryLogger = QueryLogger.builder(cluster).build();
-        cluster.register(queryLogger);
+        queryLogger = QueryLogger.builder(cluster()).build();
+        cluster().register(queryLogger);
         // when
         String query = "UPDATE test SET c_text = ? WHERE pk = ?";
-        PreparedStatement ps = session.prepare(query);
+        PreparedStatement ps = session().prepare(query);
         BoundStatement bs = ps.bind();
         bs.setString("c_text", "foo");
         bs.setInt("pk", 42);
-        session.execute(bs);
+        session().execute(bs);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -424,15 +424,15 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_log_null_parameter() throws Exception {
         // given
         normal.setLevel(TRACE);
-        queryLogger = QueryLogger.builder(cluster).build();
-        cluster.register(queryLogger);
+        queryLogger = QueryLogger.builder(cluster()).build();
+        cluster().register(queryLogger);
         // when
         String query = "UPDATE test SET c_text = ? WHERE pk = ?";
-        PreparedStatement ps = session.prepare(query);
+        PreparedStatement ps = session().prepare(query);
         BoundStatement bs = ps.bind();
         bs.setString("c_text", null);
         bs.setInt("pk", 42);
-        session.execute(bs);
+        session().execute(bs);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -448,15 +448,15 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_log_bound_statement_parameters_inside_batch_statement() throws Exception {
         // given
         normal.setLevel(TRACE);
-        queryLogger = QueryLogger.builder(cluster).build();
-        cluster.register(queryLogger);
+        queryLogger = QueryLogger.builder(cluster()).build();
+        cluster().register(queryLogger);
         // when
         String query1 = "UPDATE test SET c_text = ? WHERE pk = ?";
         String query2 = "UPDATE test SET c_int = ? WHERE pk = ?";
         BatchStatement batch = new BatchStatement();
-        batch.add(session.prepare(query1).bind("foo", 42));
-        batch.add(session.prepare(query2).bind(12345, 43));
-        session.execute(batch);
+        batch.add(session().prepare(query1).bind("foo", 42));
+        batch.add(session().prepare(query2).bind(12345, 43));
+        session().execute(batch);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -475,15 +475,15 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_log_all_parameter_types() throws Exception {
         // given
         normal.setLevel(TRACE);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withMaxParameterValueLength(Integer.MAX_VALUE)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         // when
         String query = "UPDATE test SET " + assignments + " WHERE pk = 42";
-        PreparedStatement ps = session.prepare(query);
+        PreparedStatement ps = session().prepare(query);
         BoundStatement bs = ps.bind(values.toArray());
-        session.execute(bs);
+        session().execute(bs);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -501,13 +501,13 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_truncate_query_when_max_length_exceeded() throws Exception {
         // given
         normal.setLevel(DEBUG);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withMaxQueryStringLength(5)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         // when
         String query = "SELECT * FROM test WHERE pk = 42";
-        session.execute(query);
+        session().execute(query);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -522,17 +522,17 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_show_total_statements_for_batches_even_if_query_truncated() throws Exception {
         // given
         normal.setLevel(DEBUG);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withMaxQueryStringLength(5)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         // when
         String query1 = "UPDATE test SET c_text = ? WHERE pk = ?";
         String query2 = "UPDATE test SET c_int = ? WHERE pk = ?";
         BatchStatement batch = new BatchStatement();
-        batch.add(session.prepare(query1).bind("foo", 42));
-        batch.add(session.prepare(query2).bind(12345, 43));
-        session.execute(batch);
+        batch.add(session().prepare(query1).bind("foo", 42));
+        batch.add(session().prepare(query2).bind(12345, 43));
+        session().execute(batch);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -548,13 +548,13 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_not_truncate_query_when_max_length_unlimited() throws Exception {
         // given
         normal.setLevel(DEBUG);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withMaxQueryStringLength(-1)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         // when
         String query = "SELECT * FROM test WHERE pk = 42";
-        session.execute(query);
+        session().execute(query);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -569,17 +569,17 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_truncate_parameter_when_max_length_exceeded() throws Exception {
         // given
         normal.setLevel(TRACE);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withMaxParameterValueLength(5)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         // when
         String query = "UPDATE test SET c_int = ? WHERE pk = ?";
-        PreparedStatement ps = session.prepare(query);
+        PreparedStatement ps = session().prepare(query);
         BoundStatement bs = ps.bind();
         bs.setInt("c_int", 123456);
         bs.setInt("pk", 42);
-        session.execute(bs);
+        session().execute(bs);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -593,17 +593,17 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_truncate_blob_parameter_when_max_length_exceeded() throws Exception {
         // given
         normal.setLevel(TRACE);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withMaxParameterValueLength(6)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         // when
         String query = "UPDATE test SET c_blob = ? WHERE pk = ?";
-        PreparedStatement ps = session.prepare(query);
+        PreparedStatement ps = session().prepare(query);
         BoundStatement bs = ps.bind();
         bs.setBytes("c_blob", ByteBuffer.wrap(Bytes.toArray(Lists.newArrayList(1, 2, 3))));
         bs.setInt("pk", 42);
-        session.execute(bs);
+        session().execute(bs);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -617,17 +617,17 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_not_truncate_parameter_when_max_length_unlimited() throws Exception {
         // given
         normal.setLevel(TRACE);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withMaxParameterValueLength(-1)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         // when
         String query = "UPDATE test SET c_int = ? WHERE pk = ?";
-        PreparedStatement ps = session.prepare(query);
+        PreparedStatement ps = session().prepare(query);
         BoundStatement bs = ps.bind();
         bs.setInt("c_int", 123456);
         bs.setInt("pk", 42);
-        session.execute(bs);
+        session().execute(bs);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -641,17 +641,17 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_not_log_exceeding_number_of_parameters() throws Exception {
         // given
         normal.setLevel(TRACE);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withMaxLoggedParameters(1)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         // when
         String query = "UPDATE test SET c_int = ? WHERE pk = ?";
-        PreparedStatement ps = session.prepare(query);
+        PreparedStatement ps = session().prepare(query);
         BoundStatement bs = ps.bind();
         bs.setInt("c_int", 123456);
         bs.setInt("pk", 42);
-        session.execute(bs);
+        session().execute(bs);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -667,17 +667,17 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_not_log_exceeding_number_of_parameters_in_batch_statement() throws Exception {
         // given
         normal.setLevel(TRACE);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withMaxLoggedParameters(1)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         // when
         String query1 = "UPDATE test SET c_text = ? WHERE pk = ?";
         String query2 = "UPDATE test SET c_int = ? WHERE pk = ?";
         BatchStatement batch = new BatchStatement();
-        batch.add(session.prepare(query1).bind("foo", 42));
-        batch.add(session.prepare(query2).bind(12345, 43));
-        session.execute(batch);
+        batch.add(session().prepare(query1).bind("foo", 42));
+        batch.add(session().prepare(query2).bind(12345, 43));
+        session().execute(batch);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -696,17 +696,17 @@ public class QueryLoggerTest extends CCMTestsSupport {
     public void should_log_all_parameters_when_max_unlimited() throws Exception {
         // given
         normal.setLevel(TRACE);
-        queryLogger = QueryLogger.builder(cluster)
+        queryLogger = QueryLogger.builder(cluster())
                 .withMaxLoggedParameters(-1)
                 .build();
-        cluster.register(queryLogger);
+        cluster().register(queryLogger);
         // when
         String query = "UPDATE test SET c_int = ? WHERE pk = ?";
-        PreparedStatement ps = session.prepare(query);
+        PreparedStatement ps = session().prepare(query);
         BoundStatement bs = ps.bind();
         bs.setInt("c_int", 123456);
         bs.setInt("pk", 42);
-        session.execute(bs);
+        session().execute(bs);
         // then
         String line = normalAppender.waitAndGet(10000);
         assertThat(line)
@@ -717,8 +717,8 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Override
-    public List<String> createTestFixtures() {
-        return Lists.newArrayList("CREATE TABLE test (pk int PRIMARY KEY, " + definitions + ")");
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE test (pk int PRIMARY KEY, " + definitions + ")");
     }
 
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
@@ -45,9 +45,8 @@ public class RecommissionedNodeTest {
 
     @Test(groups = "long")
     public void should_ignore_recommissioned_node_on_reconnection_attempt() throws Exception {
-        mainCcmBuilder = CCMBridge.builder().withNodes(3).notStarted();
+        mainCcmBuilder = CCMBridge.builder().withNodes(3);
         mainCcm = CCMCache.get(mainCcmBuilder);
-        mainCcm.start();
 
         // node1 will be our "recommissioned" node, for now we just stop it so that it stays in the peers table.
         mainCcm.stop(1);
@@ -67,9 +66,8 @@ public class RecommissionedNodeTest {
                 .withStoragePort(mainCcm.getStoragePort())
                 .withThriftPort(mainCcm.getThriftPort())
                 .withBinaryPort(mainCcm.getBinaryPort())
-                .withNodes(1).notStarted();
+                .withNodes(1);
         otherCcm = CCMCache.get(otherCcmBuilder);
-        otherCcm.start();
         otherCcm.waitForUp(1);
 
         // Give the driver the time to notice the node is back up and try to connect to it.
@@ -80,9 +78,8 @@ public class RecommissionedNodeTest {
 
     @Test(groups = "long")
     public void should_ignore_recommissioned_node_on_control_connection_reconnect() throws Exception {
-        mainCcmBuilder = CCMBridge.builder().withNodes(2).notStarted();
+        mainCcmBuilder = CCMBridge.builder().withNodes(2);
         mainCcm = CCMCache.get(mainCcmBuilder);
-        mainCcm.start();
         mainCcm.stop(1);
         mainCcm.waitForDown(1);
 
@@ -99,9 +96,8 @@ public class RecommissionedNodeTest {
                 .withStoragePort(mainCcm.getStoragePort())
                 .withThriftPort(mainCcm.getThriftPort())
                 .withBinaryPort(mainCcm.getBinaryPort())
-                .withNodes(1).notStarted();
+                .withNodes(1);
         otherCcm = CCMCache.get(otherCcmBuilder);
-        otherCcm.start();
         otherCcm.waitForUp(1);
 
         // Stop node2, the control connection gets defunct
@@ -115,9 +111,8 @@ public class RecommissionedNodeTest {
     @Test(groups = "long")
     public void should_ignore_recommissioned_node_on_session_init() throws Exception {
         // Simulate the bug before starting the cluster
-        mainCcmBuilder = CCMBridge.builder().withNodes(2).notStarted();
+        mainCcmBuilder = CCMBridge.builder().withNodes(2);
         mainCcm = CCMCache.get(mainCcmBuilder);
-        mainCcm.start();
         mainCcm.stop(1);
         mainCcm.waitForDown(1);
 
@@ -125,9 +120,8 @@ public class RecommissionedNodeTest {
                 .withStoragePort(mainCcm.getStoragePort())
                 .withThriftPort(mainCcm.getThriftPort())
                 .withBinaryPort(mainCcm.getBinaryPort())
-                .withNodes(1).notStarted();
+                .withNodes(1);
         otherCcm = CCMCache.get(otherCcmBuilder);
-        otherCcm.start();
         otherCcm.waitForUp(1);
 
         // Start the driver, it should only connect to node 2
@@ -154,9 +148,8 @@ public class RecommissionedNodeTest {
     @CassandraVersion(major = 2.0)
     public void should_ignore_node_that_does_not_support_protocol_version_on_session_init() throws Exception {
         // Simulate the bug before starting the cluster
-        mainCcmBuilder = CCMBridge.builder().withNodes(2).notStarted();
+        mainCcmBuilder = CCMBridge.builder().withNodes(2);
         mainCcm = CCMCache.get(mainCcmBuilder);
-        mainCcm.start();
         mainCcm.stop(1);
         mainCcm.waitForDown(1);
 
@@ -164,9 +157,8 @@ public class RecommissionedNodeTest {
                 .withStoragePort(mainCcm.getStoragePort())
                 .withThriftPort(mainCcm.getThriftPort())
                 .withBinaryPort(mainCcm.getBinaryPort())
-                .withVersion("1.2.19").notStarted();
+                .withVersion("1.2.19");
         otherCcm = CCMCache.get(otherCcmBuilder);
-        otherCcm.start();
         otherCcm.waitForUp(1);
 
         // Start the driver, it should only connect to node 2

--- a/driver-core/src/test/java/com/datastax/driver/core/ReconnectionPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReconnectionPolicyTest.java
@@ -46,12 +46,12 @@ public class ReconnectionPolicyTest extends AbstractPoliciesTest {
     public void exponentialReconnectionPolicyTest() throws Throwable {
 
         // Ensure that ExponentialReconnectionPolicy is what we should be testing
-        if (!(cluster.getConfiguration().getPolicies().getReconnectionPolicy() instanceof ExponentialReconnectionPolicy)) {
+        if (!(cluster().getConfiguration().getPolicies().getReconnectionPolicy() instanceof ExponentialReconnectionPolicy)) {
             fail("Set policy does not match retrieved policy.");
         }
 
         // Test basic getters
-        ExponentialReconnectionPolicy reconnectionPolicy = (ExponentialReconnectionPolicy) cluster.getConfiguration().getPolicies().getReconnectionPolicy();
+        ExponentialReconnectionPolicy reconnectionPolicy = (ExponentialReconnectionPolicy) cluster().getConfiguration().getPolicies().getReconnectionPolicy();
         assertTrue(reconnectionPolicy.getBaseDelayMs() == 2 * 1000);
         assertTrue(reconnectionPolicy.getMaxDelayMs() == 5 * 60 * 1000);
 
@@ -112,12 +112,12 @@ public class ReconnectionPolicyTest extends AbstractPoliciesTest {
     public void constantReconnectionPolicyTest() throws Throwable {
 
         // Ensure that ConstantReconnectionPolicy is what we should be testing
-        if (!(cluster.getConfiguration().getPolicies().getReconnectionPolicy() instanceof ConstantReconnectionPolicy)) {
+        if (!(cluster().getConfiguration().getPolicies().getReconnectionPolicy() instanceof ConstantReconnectionPolicy)) {
             fail("Set policy does not match retrieved policy.");
         }
 
         // Test basic getters
-        ConstantReconnectionPolicy reconnectionPolicy = (ConstantReconnectionPolicy) cluster.getConfiguration().getPolicies().getReconnectionPolicy();
+        ConstantReconnectionPolicy reconnectionPolicy = (ConstantReconnectionPolicy) cluster().getConfiguration().getPolicies().getReconnectionPolicy();
         assertTrue(reconnectionPolicy.getConstantDelayMs() == 10 * 1000);
 
         // Test erroneous instantiations
@@ -153,7 +153,7 @@ public class ReconnectionPolicyTest extends AbstractPoliciesTest {
         // Ensure a basic test works
         assertQueried(TestUtils.IP_PREFIX + '1', 12);
         resetCoordinators();
-        ccm.forceStop(1);
+        ccm().forceStop(1);
 
         // Start timing and ensure that the node is down
         long startTime = 0;
@@ -172,7 +172,7 @@ public class ReconnectionPolicyTest extends AbstractPoliciesTest {
 
             // Restart node at restartTime
             if (!restarted && thisTime - startTime > restartTime) {
-                ccm.start(1);
+                ccm().start(1);
                 restarted = true;
             }
 
@@ -197,7 +197,7 @@ public class ReconnectionPolicyTest extends AbstractPoliciesTest {
             resetCoordinators();
 
             // Ensure the reconnection times reset
-            ccm.forceStop(1);
+            ccm().forceStop(1);
 
             // Start timing and ensure that the node is down
             startTime = 0;
@@ -215,7 +215,7 @@ public class ReconnectionPolicyTest extends AbstractPoliciesTest {
 
                 // Restart node at restartTime
                 if (!restarted && thisTime - startTime > restartTime) {
-                    ccm.start(1);
+                    ccm().start(1);
                     restarted = true;
                 }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/RefreshConnectedHostTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RefreshConnectedHostTest.java
@@ -41,9 +41,9 @@ public class RefreshConnectedHostTest extends CCMTestsSupport {
         LimitingLoadBalancingPolicy loadBalancingPolicy = new LimitingLoadBalancingPolicy(new RoundRobinPolicy(), 2, 1);
 
         PoolingOptions poolingOptions = Mockito.spy(new PoolingOptions());
-        cluster = register(Cluster.builder()
-                .addContactPointsWithPorts(ccm.addressOfNode(1))
-                .withPort(ccm.getBinaryPort())
+        Cluster cluster = register(Cluster.builder()
+                .addContactPoints(getContactPoints().get(0))
+                .withPort(ccm().getBinaryPort())
                 .withPoolingOptions(poolingOptions)
                 .withLoadBalancingPolicy(loadBalancingPolicy)
                 .withReconnectionPolicy(new ConstantReconnectionPolicy(1000))
@@ -63,9 +63,9 @@ public class RefreshConnectedHostTest extends CCMTestsSupport {
                 .isAtDistance(HostDistance.LOCAL);
 
         // Add and bring host 3 up, its presence should be acknowledged but it should be ignored
-        ccm.add(3);
-        ccm.start(3);
-        ccm.waitForUp(3);
+        ccm().add(3);
+        ccm().start(3);
+        ccm().waitForUp(3);
 
         assertThat(cluster).host(1)
                 .hasState(State.UP)
@@ -81,8 +81,8 @@ public class RefreshConnectedHostTest extends CCMTestsSupport {
         assertThat(session).hasNoPoolFor(3);
 
         // Kill host 2, host 3 should take its place
-        ccm.stop(2);
-        TestUtils.waitFor(TestUtils.ipOfNode(3), cluster);
+        ccm().stop(2);
+        TestUtils.waitForUp(TestUtils.ipOfNode(3), cluster);
 
         assertThat(cluster).host(1)
                 .hasState(State.UP)

--- a/driver-core/src/test/java/com/datastax/driver/core/SSLEncryptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLEncryptionTest.java
@@ -74,8 +74,8 @@ public class SSLEncryptionTest extends SSLTestBase {
     @Test(groups = "short", expectedExceptions = {NoHostAvailableException.class})
     public void should_not_connect_without_ssl_but_node_uses_ssl() throws Exception {
         Cluster cluster = register(Cluster.builder()
-                .addContactPointsWithPorts(this.getInitialContactPoints())
-                .withPort(ccm.getBinaryPort())
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
                 .build());
         cluster.connect();
     }
@@ -93,15 +93,15 @@ public class SSLEncryptionTest extends SSLTestBase {
     @Test(groups = "long")
     public void should_reconnect_with_ssl_on_node_up() throws Exception {
         Cluster cluster = register(Cluster.builder()
-                .addContactPointsWithPorts(this.getInitialContactPoints())
-                .withPort(ccm.getBinaryPort())
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
                 .withSSL(getSSLOptions(Optional.of(DEFAULT_CLIENT_KEYSTORE_PATH), Optional.of(DEFAULT_CLIENT_TRUSTSTORE_PATH)))
                 .build());
 
         cluster.connect();
 
-        ccm.stop(1);
-        ccm.start(1);
+        ccm().stop(1);
+        ccm().start(1);
 
         assertThat(cluster).host(1).comesUpWithin(TestUtils.TEST_BASE_NODE_WAIT, TimeUnit.SECONDS);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/SSLTestBase.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLTestBase.java
@@ -41,8 +41,8 @@ public abstract class SSLTestBase extends CCMTestsSupport {
      */
     protected void connectWithSSLOptions(SSLOptions sslOptions) throws Exception {
         Cluster cluster = register(Cluster.builder()
-                .addContactPointsWithPorts(this.getInitialContactPoints())
-                .withPort(ccm.getBinaryPort())
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
                 .withSSL(sslOptions)
                 .build());
         cluster.connect();
@@ -59,8 +59,8 @@ public abstract class SSLTestBase extends CCMTestsSupport {
      */
     protected void connectWithSSL() throws Exception {
         Cluster cluster = register(Cluster.builder()
-                .addContactPointsWithPorts(this.getInitialContactPoints())
-                .withPort(ccm.getBinaryPort())
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
                 .withSSL()
                 .build());
         cluster.connect();

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaAgreementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaAgreementTest.java
@@ -34,32 +34,32 @@ public class SchemaAgreementTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_set_flag_on_successful_agreement() {
-        ProtocolOptions protocolOptions = cluster.getConfiguration().getProtocolOptions();
+        ProtocolOptions protocolOptions = cluster().getConfiguration().getProtocolOptions();
         protocolOptions.maxSchemaAgreementWaitSeconds = 10;
-        ResultSet rs = session.execute(String.format(CREATE_TABLE, COUNTER.getAndIncrement()));
+        ResultSet rs = session().execute(String.format(CREATE_TABLE, COUNTER.getAndIncrement()));
         assertThat(rs.getExecutionInfo().isSchemaInAgreement()).isTrue();
     }
 
     @Test(groups = "short")
     public void should_set_flag_on_non_schema_altering_statement() {
-        ProtocolOptions protocolOptions = cluster.getConfiguration().getProtocolOptions();
+        ProtocolOptions protocolOptions = cluster().getConfiguration().getProtocolOptions();
         protocolOptions.maxSchemaAgreementWaitSeconds = 10;
-        ResultSet rs = session.execute("select release_version from system.local");
+        ResultSet rs = session().execute("select release_version from system.local");
         assertThat(rs.getExecutionInfo().isSchemaInAgreement()).isTrue();
     }
 
     @Test(groups = "short")
     public void should_unset_flag_on_failed_agreement() {
         // Setting to 0 results in no query being set, so agreement fails
-        ProtocolOptions protocolOptions = cluster.getConfiguration().getProtocolOptions();
+        ProtocolOptions protocolOptions = cluster().getConfiguration().getProtocolOptions();
         protocolOptions.maxSchemaAgreementWaitSeconds = 0;
-        ResultSet rs = session.execute(String.format(CREATE_TABLE, COUNTER.getAndIncrement()));
+        ResultSet rs = session().execute(String.format(CREATE_TABLE, COUNTER.getAndIncrement()));
         assertThat(rs.getExecutionInfo().isSchemaInAgreement()).isFalse();
     }
 
     @Test(groups = "short")
     public void should_check_agreement_through_cluster_metadata() {
-        Cluster controlCluster = register(TestUtils.buildControlCluster(cluster, ccm));
+        Cluster controlCluster = register(TestUtils.buildControlCluster(cluster(), ccm()));
         Session controlSession = controlCluster.connect();
 
         Row localRow = controlSession.execute("SELECT schema_version FROM system.local").one();
@@ -71,11 +71,11 @@ public class SchemaAgreementTest extends CCMTestsSupport {
         assertThat(localVersion).isEqualTo(peerVersion);
 
         // Now check the method under test:
-        assertThat(cluster.getMetadata().checkSchemaAgreement()).isTrue();
+        assertThat(cluster().getMetadata().checkSchemaAgreement()).isTrue();
 
         // Insert a fake version to simulate a disagreement:
         forceSchemaVersion(controlSession, peerAddress, UUIDs.random());
-        assertThat(cluster.getMetadata().checkSchemaAgreement()).isFalse();
+        assertThat(cluster().getMetadata().checkSchemaAgreement()).isFalse();
 
         forceSchemaVersion(controlSession, peerAddress, peerVersion);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesCCTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesCCTest.java
@@ -56,15 +56,15 @@ public class SchemaChangesCCTest extends CCMTestsSupport {
         Cluster cluster = register(
                 Cluster.builder()
                         .withLoadBalancingPolicy(lbPolicy)
-                        .addContactPointsWithPorts(ccm.addressOfNode(1))
-                        .withPort(ccm.getBinaryPort())
+                        .addContactPointsWithPorts(ccm().addressOfNode(1))
+                        .withPort(ccm().getBinaryPort())
                         .build());
         // Put cluster2 control connection on node 2 so it doesn't go down (to prevent noise for debugging).
         Cluster cluster2 = register(
                 Cluster.builder()
                         .withLoadBalancingPolicy(lbPolicy)
-                        .addContactPointsWithPorts(ccm.addressOfNode(2))
-                        .withPort(ccm.getBinaryPort())
+                        .addContactPointsWithPorts(ccm().addressOfNode(2))
+                        .withPort(ccm().getBinaryPort())
                         .build());
         SchemaChangeListener listener = mock(SchemaChangeListener.class);
 
@@ -93,7 +93,7 @@ public class SchemaChangesCCTest extends CCMTestsSupport {
         lbPolicy.returnEmptyQueryPlan = true;
 
         // Stop node 1, which hosts the control connection.
-        ccm.stop(1);
+        ccm().stop(1);
         assertThat(cluster).host(1).goesDownWithin(20, TimeUnit.SECONDS);
 
         // Ensure control connection is down.

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
@@ -24,6 +24,7 @@ import org.mockito.ArgumentCaptor;
 import org.testng.annotations.*;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static com.datastax.driver.core.Assertions.assertThat;
 import static com.datastax.driver.core.Metadata.handleId;
@@ -45,7 +46,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     /**
      * The maximum time that the test will wait to check that listeners have been notified
      */
-    private static final int NOTIF_TIMEOUT_MS = 120000;
+    private static final long NOTIF_TIMEOUT_MS = TimeUnit.MINUTES.toMillis(1);
 
     Cluster cluster1;
     Cluster cluster2; // a second cluster to check that other clients also get notified
@@ -66,12 +67,14 @@ public class SchemaChangesTest extends CCMTestsSupport {
     @BeforeClass(groups = "short")
     public void setup() throws InterruptedException {
         Cluster.Builder builder = Cluster.builder()
-                .addContactPointsWithPorts(getInitialContactPoints())
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
                 .withQueryOptions(nonDebouncingQueryOptions());
         cluster1 = builder.build();
         cluster2 = builder.build();
         schemaDisabledCluster = spy(Cluster.builder()
-                .addContactPointsWithPorts(getInitialContactPoints())
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
                 .withClusterName("schema-disabled")
                 .withQueryOptions(nonDebouncingQueryOptions()
                                 .setMetadataEnabled(false)
@@ -343,7 +346,8 @@ public class SchemaChangesTest extends CCMTestsSupport {
     @Test(groups = "short", expectedExceptions = IllegalStateException.class)
     public void should_throw_illegal_state_exception_on_newToken_with_metadata_disabled() {
         Cluster cluster = Cluster.builder()
-                .addContactPointsWithPorts(getInitialContactPoints())
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
                 .withQueryOptions(nonDebouncingQueryOptions()
                                 .setMetadataEnabled(false)
                 ).build();
@@ -367,7 +371,8 @@ public class SchemaChangesTest extends CCMTestsSupport {
     @Test(groups = "short", expectedExceptions = IllegalStateException.class)
     public void should_throw_illegal_state_exception_on_newTokenRange_with_metadata_disabled() {
         Cluster cluster = Cluster.builder()
-                .addContactPointsWithPorts(getInitialContactPoints())
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
                 .withQueryOptions(nonDebouncingQueryOptions()
                                 .setMetadataEnabled(false)
                 ).build();

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaRefreshDebouncerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaRefreshDebouncerTest.java
@@ -16,7 +16,6 @@
 package com.datastax.driver.core;
 
 import org.mockito.ArgumentCaptor;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -52,10 +51,11 @@ public class SchemaRefreshDebouncerTest extends CCMTestsSupport {
         queryOptions.setRefreshSchemaIntervalMillis(DEBOUNCE_TIME);
         queryOptions.setMaxPendingRefreshSchemaRequests(5);
         // Create a separate cluster that will receive the schema events on its control connection.
-        cluster2 = Cluster.builder()
-                .addContactPointsWithPorts(getInitialContactPoints())
+        cluster2 = register(Cluster.builder()
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
                 .withQueryOptions(queryOptions)
-                .build();
+                .build());
         session2 = cluster2.connect();
 
         // Create a spy of the Cluster's control connection and replace it with the spy.
@@ -70,11 +70,6 @@ public class SchemaRefreshDebouncerTest extends CCMTestsSupport {
         reset(controlConnection);
     }
 
-    @AfterMethod(groups = "short")
-    public void beforeMethod() {
-        cluster2.close();
-    }
-
     /**
      * Ensures that when a CREATED and UPDATED schema_change events are received on a control
      * connection for the same keyspace within {@link QueryOptions#getRefreshSchemaIntervalMillis()}
@@ -86,9 +81,9 @@ public class SchemaRefreshDebouncerTest extends CCMTestsSupport {
      */
     @Test(groups = "short")
     public void should_debounce_and_coalesce_create_and_alter_keyspace_into_refresh_keyspace() throws Exception {
-        String keyspace = "sdaccaak";
-        session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, keyspace, 1));
-        session.execute(String.format("ALTER KEYSPACE %s WITH DURABLE_WRITES=false", keyspace));
+        String keyspace = TestUtils.generateIdentifier("ks_");
+        session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, keyspace, 1));
+        session().execute(String.format("ALTER KEYSPACE %s WITH DURABLE_WRITES=false", keyspace));
 
         ArgumentCaptor<KeyspaceMetadata> captor = forClass(KeyspaceMetadata.class);
         verify(listener, timeout(DEBOUNCE_TIME * 2).only()).onKeyspaceAdded(captor.capture());
@@ -117,17 +112,17 @@ public class SchemaRefreshDebouncerTest extends CCMTestsSupport {
      */
     @Test(groups = "short")
     public void should_debounce_and_coalesce_create_keyspace_and_table_into_refresh_keyspace() throws Exception {
-        String keyspace = "sdacckt";
+        String keyspace = TestUtils.generateIdentifier("ks_");
         String table = "tbl1";
-        session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, keyspace, 1));
-        session.execute(String.format(CREATE_TABLE_SIMPLE_FORMAT, keyspace + "." + table));
+        session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, keyspace, 1));
+        session().execute(String.format(CREATE_TABLE_SIMPLE_FORMAT, keyspace + "." + table));
 
         ArgumentCaptor<KeyspaceMetadata> keyspaceCaptor = forClass(KeyspaceMetadata.class);
         verify(listener, timeout(DEBOUNCE_TIME * 2).times(1)).onKeyspaceAdded(keyspaceCaptor.capture());
         assertThat(keyspaceCaptor.getValue()).hasName(keyspace);
 
         ArgumentCaptor<TableMetadata> tableCaptor = forClass(TableMetadata.class);
-        verify(listener, times(1)).onTableAdded(tableCaptor.capture());
+        verify(listener, timeout(DEBOUNCE_TIME * 2).times(1)).onTableAdded(tableCaptor.capture());
         assertThat(tableCaptor.getValue()).hasName(table);
 
         // Verify the schema refresh was debounced and coalesced when a keyspace event and table event
@@ -152,7 +147,7 @@ public class SchemaRefreshDebouncerTest extends CCMTestsSupport {
      */
     @Test(groups = "short")
     public void should_debounce_and_coalesce_tables_in_same_keyspace_into_refresh_keyspace() throws Exception {
-        String keyspace = "sdactisk";
+        String keyspace = TestUtils.generateIdentifier("ks_");
         session2.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, keyspace, 1));
         // Reset invocations as creating keyspace causes a keyspace refresh.
         reset(controlConnection);
@@ -160,7 +155,7 @@ public class SchemaRefreshDebouncerTest extends CCMTestsSupport {
 
         int tableCount = 3;
         for (int i = 0; i < tableCount; i++) {
-            session.execute(String.format(CREATE_TABLE_SIMPLE_FORMAT, keyspace + "." + "tbl" + i));
+            session().execute(String.format(CREATE_TABLE_SIMPLE_FORMAT, keyspace + "." + "tbl" + i));
         }
 
         verify(listener, timeout(DEBOUNCE_TIME * 3).times(3)).onTableAdded(any(TableMetadata.class));
@@ -192,7 +187,7 @@ public class SchemaRefreshDebouncerTest extends CCMTestsSupport {
      */
     @Test(groups = "short")
     public void should_debounce_and_coalesce_multiple_alter_events_on_same_table_into_refresh_table() throws Exception {
-        String keyspace = "sdacmaeost";
+        String keyspace = TestUtils.generateIdentifier("ks_");
         String table = "tbl1";
         String comment = "I am changing this table.";
         String columnName = "added_column";
@@ -202,8 +197,8 @@ public class SchemaRefreshDebouncerTest extends CCMTestsSupport {
         reset(controlConnection);
         reset(listener);
 
-        session.execute(String.format("ALTER TABLE %s.%s WITH comment = '%s'", keyspace, table, comment));
-        session.execute(String.format("ALTER TABLE %s.%s ADD %s int", keyspace, table, columnName));
+        session().execute(String.format("ALTER TABLE %s.%s WITH comment = '%s'", keyspace, table, comment));
+        session().execute(String.format("ALTER TABLE %s.%s ADD %s int", keyspace, table, columnName));
 
         ArgumentCaptor<TableMetadata> original = forClass(TableMetadata.class);
         ArgumentCaptor<TableMetadata> captor = forClass(TableMetadata.class);
@@ -245,9 +240,9 @@ public class SchemaRefreshDebouncerTest extends CCMTestsSupport {
      */
     @Test(groups = "short")
     public void should_debounce_and_coalesce_multiple_keyspace_creates_into_refresh_entire_schema() throws Exception {
-        String prefix = "sdacmkc";
+        String prefix = TestUtils.generateIdentifier("ks_");
         for (int i = 0; i < 3; i++) {
-            session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, prefix + i, 1));
+            session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, prefix + i, 1));
         }
 
         verify(listener, timeout(DEBOUNCE_TIME * 3).times(3)).onKeyspaceAdded(any(KeyspaceMetadata.class));
@@ -271,9 +266,9 @@ public class SchemaRefreshDebouncerTest extends CCMTestsSupport {
      */
     @Test(groups = "short")
     public void should_refresh_when_max_pending_requests_reached() throws Exception {
-        String prefix = "srwmprr";
+        String prefix = TestUtils.generateIdentifier("ks_");
         for (int i = 0; i < 5; i++) {
-            session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, prefix + i, 1));
+            session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, prefix + i, 1));
         }
 
         // Event should be processed immediately as we hit our threshold.

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaTest.java
@@ -36,7 +36,7 @@ public class SchemaTest extends CCMTestsSupport {
     private static String withOptions;
 
     @Override
-    public Collection<String> createTestFixtures() {
+    public void onTestContextInitialized() {
 
         String sparse = String.format("CREATE TABLE %s.sparse (\n"
                 + "    k text,\n"
@@ -131,7 +131,7 @@ public class SchemaTest extends CCMTestsSupport {
         allDefs.addAll(cql3.values());
         allDefs.addAll(compact.values());
         allDefs.add(withOptions);
-        return allDefs;
+        execute(allDefs);
     }
 
     private static String stripOptions(String def, boolean keepFirst) {
@@ -149,7 +149,7 @@ public class SchemaTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void schemaExportTest() {
 
-        KeyspaceMetadata metadata = cluster.getMetadata().getKeyspace(keyspace);
+        KeyspaceMetadata metadata = cluster().getMetadata().getKeyspace(keyspace);
 
         for (Map.Entry<String, String> tableEntry : cql3.entrySet()) {
             String table = tableEntry.getKey();
@@ -167,10 +167,10 @@ public class SchemaTest extends CCMTestsSupport {
     // Same remark as the preceding test
     @Test(groups = "short")
     public void schemaExportOptionsTest() {
-        TableMetadata metadata = cluster.getMetadata().getKeyspace(keyspace).getTable("with_options");
+        TableMetadata metadata = cluster().getMetadata().getKeyspace(keyspace).getTable("with_options");
 
         String withOpts = withOptions;
-        VersionNumber version = TestUtils.findHost(cluster, 1).getCassandraVersion();
+        VersionNumber version = TestUtils.findHost(cluster(), 1).getCassandraVersion();
 
         if (version.getMajor() == 2) {
             // Strip the last ';'

--- a/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
@@ -39,9 +39,9 @@ public class SessionLeakTest extends CCMTestsSupport {
         // Checking for JAVA-342
         channelMonitor = new SocketChannelMonitor();
         channelMonitor.reportAtFixedInterval(1, TimeUnit.SECONDS);
-        cluster = register(Cluster.builder()
-                .addContactPoints(ccm.addressOfNode(1).getAddress())
-                .withPort(ccm.getBinaryPort())
+        Cluster cluster = register(Cluster.builder()
+                .addContactPoints(getContactPoints().get(0))
+                .withPort(ccm().getBinaryPort())
                 .withNettyOptions(channelMonitor.nettyOptions())
                 .withQueryOptions(nonDebouncingQueryOptions())
                 .build());
@@ -50,44 +50,44 @@ public class SessionLeakTest extends CCMTestsSupport {
 
         assertThat(cluster.manager.sessions.size()).isEqualTo(0);
         // Should be 1 control connection after initialization.
-        assertOpenConnections(1);
+        assertOpenConnections(1, cluster);
 
         // ensure sessions.size() returns with 1 control connection + core pool size.
         int corePoolSize = TestUtils.numberOfLocalCoreConnections(cluster);
         Session session = cluster.connect();
 
         assertThat(cluster.manager.sessions.size()).isEqualTo(1);
-        assertOpenConnections(1 + corePoolSize);
+        assertOpenConnections(1 + corePoolSize, cluster);
 
         // ensure sessions.size() returns to 0 with only 1 active connection (the control connection)
         session.close();
         assertThat(cluster.manager.sessions.size()).isEqualTo(0);
-        assertOpenConnections(1);
+        assertOpenConnections(1, cluster);
 
         // ensure bootstrapping a node does not create additional connections
-        ccm.add(2);
-        ccm.start(2);
+        ccm().add(2);
+        ccm().start(2);
         assertThat(cluster).host(2).comesUpWithin(2, MINUTES);
 
         assertThat(cluster.manager.sessions.size()).isEqualTo(0);
-        assertOpenConnections(1);
+        assertOpenConnections(1, cluster);
 
         // ensure a new session gets registered and core connections are established
         // there should be corePoolSize more connections to accommodate for the new host.
         Session thisSession = cluster.connect();
         assertThat(cluster.manager.sessions.size()).isEqualTo(1);
-        assertOpenConnections(1 + (corePoolSize * 2));
+        assertOpenConnections(1 + (corePoolSize * 2), cluster);
 
         // ensure bootstrapping a node does not create additional connections that won't get cleaned up
         thisSession.close();
 
         assertThat(cluster.manager.sessions.size()).isEqualTo(0);
-        assertOpenConnections(1);
+        assertOpenConnections(1, cluster);
         cluster.close();
         // Ensure no channels remain open.
         channelMonitor.stop();
         channelMonitor.report();
-        assertThat(channelMonitor.openChannels(newArrayList(ccm.addressOfNode(1), ccm.addressOfNode(2))).size()).isEqualTo(0);
+        assertThat(channelMonitor.openChannels(newArrayList(ccm().addressOfNode(1), ccm().addressOfNode(2))).size()).isEqualTo(0);
     }
 
     @Test(groups = "short")
@@ -95,16 +95,16 @@ public class SessionLeakTest extends CCMTestsSupport {
         // Checking for JAVA-806
         channelMonitor = new SocketChannelMonitor();
         channelMonitor.reportAtFixedInterval(1, TimeUnit.SECONDS);
-        cluster = register(Cluster.builder()
-                .addContactPoints(ccm.addressOfNode(1).getAddress())
-                .withPort(ccm.getBinaryPort())
+        Cluster cluster = register(Cluster.builder()
+                .addContactPoints(getContactPoints().get(0))
+                .withPort(ccm().getBinaryPort())
                 .withNettyOptions(channelMonitor.nettyOptions())
                 .build());
         cluster.init();
         assertThat(cluster.manager.sessions.size()).isEqualTo(0);
         try {
             // Should be 1 control connection after initialization.
-            assertOpenConnections(1);
+            assertOpenConnections(1, cluster);
             cluster.connect("wrong_keyspace");
             fail("Should not have connected to a wrong keyspace");
         } catch (InvalidQueryException e) {
@@ -115,11 +115,11 @@ public class SessionLeakTest extends CCMTestsSupport {
         // Ensure no channels remain open.
         channelMonitor.stop();
         channelMonitor.report();
-        assertThat(channelMonitor.openChannels(ccm.addressOfNode(1), ccm.addressOfNode(2)).size()).isEqualTo(0);
+        assertThat(channelMonitor.openChannels(ccm().addressOfNode(1), ccm().addressOfNode(2)).size()).isEqualTo(0);
     }
 
-    private void assertOpenConnections(int expected) {
-        assertThat((cluster.getMetrics().getOpenConnections().getValue())).isEqualTo(expected);
-        assertThat(channelMonitor.openChannels(ccm.addressOfNode(1), ccm.addressOfNode(2)).size()).isEqualTo(expected);
+    private void assertOpenConnections(int expected, Cluster cluster) {
+        assertThat(cluster.getMetrics().getOpenConnections().getValue()).isEqualTo(expected);
+        assertThat(channelMonitor.openChannels(ccm().addressOfNode(1), ccm().addressOfNode(2)).size()).isEqualTo(expected);
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/SingleTokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SingleTokenIntegrationTest.java
@@ -35,7 +35,8 @@ public class SingleTokenIntegrationTest extends CCMTestsSupport {
      */
     @Test(groups = "short")
     public void should_return_single_non_empty_range_when_cluster_has_one_single_token() {
-        Metadata metadata = cluster.getMetadata();
+        cluster().manager.controlConnection.refreshNodeListAndTokenMap();
+        Metadata metadata = cluster().getMetadata();
         Set<TokenRange> tokenRanges = metadata.getTokenRanges();
         assertThat(tokenRanges).hasSize(1);
         TokenRange tokenRange = tokenRanges.iterator().next();
@@ -46,7 +47,7 @@ public class SingleTokenIntegrationTest extends CCMTestsSupport {
                 .isNotWrappedAround();
 
         Set<Host> hostsForRange = metadata.getReplicas(keyspace, tokenRange);
-        Host host1 = TestUtils.findHost(cluster, 1);
+        Host host1 = TestUtils.findHost(cluster(), 1);
         assertThat(hostsForRange).containsOnly(host1);
 
         ByteBuffer randomPartitionKey = Bytes.fromHexString("0xCAFEBABE");

--- a/driver-core/src/test/java/com/datastax/driver/core/StateListenerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StateListenerTest.java
@@ -35,23 +35,23 @@ public class StateListenerTest extends CCMTestsSupport {
     @Test(groups = "long")
     public void should_receive_events_when_node_states_change() throws InterruptedException {
         TestListener listener = new TestListener();
-        cluster.register(listener);
+        cluster().register(listener);
 
         listener.setExpectedEvent(ADD);
-        ccm.add(2);
-        ccm.start(2);
+        ccm().add(2);
+        ccm().start(2);
         listener.waitForEvent();
 
         listener.setExpectedEvent(DOWN);
-        ccm.forceStop(1);
+        ccm().forceStop(1);
         listener.waitForEvent();
 
         listener.setExpectedEvent(UP);
-        ccm.start(1);
+        ccm().start(1);
         listener.waitForEvent();
 
         listener.setExpectedEvent(REMOVE);
-        ccm.decommission(2);
+        ccm().decommission(2);
         listener.waitForEvent();
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/StatementWrapperTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StatementWrapperTest.java
@@ -42,10 +42,10 @@ public class StatementWrapperTest extends CCMTestsSupport {
         loadBalancingPolicy.customStatementsHandled.set(0);
 
         SimpleStatement s = new SimpleStatement("select * from system.local");
-        session.execute(s);
+        session().execute(s);
         assertThat(loadBalancingPolicy.customStatementsHandled.get()).isEqualTo(0);
 
-        session.execute(new CustomStatement(s));
+        session().execute(new CustomStatement(s));
         assertThat(loadBalancingPolicy.customStatementsHandled.get()).isEqualTo(1);
     }
 
@@ -54,10 +54,10 @@ public class StatementWrapperTest extends CCMTestsSupport {
         speculativeExecutionPolicy.customStatementsHandled.set(0);
 
         SimpleStatement s = new SimpleStatement("select * from system.local");
-        session.execute(s);
+        session().execute(s);
         assertThat(speculativeExecutionPolicy.customStatementsHandled.get()).isEqualTo(0);
 
-        session.execute(new CustomStatement(s));
+        session().execute(new CustomStatement(s));
         assertThat(speculativeExecutionPolicy.customStatementsHandled.get()).isEqualTo(1);
     }
 
@@ -70,10 +70,10 @@ public class StatementWrapperTest extends CCMTestsSupport {
         Statement s = new SimpleStatement("select * from system.local")
                 .setConsistencyLevel(ConsistencyLevel.TWO);
 
-        session.execute(s);
+        session().execute(s);
         assertThat(retryPolicy.customStatementsHandled.get()).isEqualTo(0);
 
-        session.execute(new CustomStatement(s));
+        session().execute(new CustomStatement(s));
         assertThat(retryPolicy.customStatementsHandled.get()).isEqualTo(1);
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
@@ -15,18 +15,15 @@
  */
 package com.datastax.driver.core;
 
-import com.google.common.collect.Lists;
 import org.testng.annotations.Test;
-
-import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @CCMConfig(clusterProvider = "createClusterBuilderNoDebouncing")
 public class TableMetadataTest extends CCMTestsSupport {
     @Override
-    public Collection<String> createTestFixtures() {
-        return Lists.newArrayList(
+    public void onTestContextInitialized() {
+        execute(
                 "CREATE TABLE single_quote (\n"
                         + "    c1 int PRIMARY KEY\n"
                         + ") WITH  comment = 'comment with single quote '' should work'"
@@ -35,7 +32,7 @@ public class TableMetadataTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_escape_single_quote_table_comment() {
-        TableMetadata table = cluster.getMetadata().getKeyspace(keyspace).getTable("single_quote");
+        TableMetadata table = cluster().getMetadata().getKeyspace(keyspace).getTable("single_quote");
         assertThat(table.asCQLQuery()).contains("comment with single quote '' should work");
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -37,11 +37,13 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.util.*;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
+
+import static com.datastax.driver.core.ConditionChecker.check;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * A number of static fields/methods handy for tests.
@@ -63,17 +65,13 @@ public abstract class TestUtils {
     public static final String CREATE_KEYSPACE_SIMPLE_FORMAT = "CREATE KEYSPACE %s WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : %d }";
     public static final String CREATE_KEYSPACE_GENERIC_FORMAT = "CREATE KEYSPACE %s WITH replication = { 'class' : '%s', %s }";
 
-    public static final String SIMPLE_KEYSPACE = "ks";
-    public static final String SIMPLE_TABLE = "test";
-
     public static final String CREATE_TABLE_SIMPLE_FORMAT = "CREATE TABLE %s (k text PRIMARY KEY, t text, i int, f float)";
 
     public static final String INSERT_FORMAT = "INSERT INTO %s (k, t, i, f) VALUES ('%s', '%s', %d, %f)";
+
     public static final String SELECT_ALL_FORMAT = "SELECT * FROM %s";
 
     public static final int TEST_BASE_NODE_WAIT = SystemProperties.getInt("com.datastax.driver.TEST_BASE_NODE_WAIT", 60);
-
-    private static final AtomicInteger KS_COUNTER = new AtomicInteger(1);
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static BoundStatement setBoundValue(BoundStatement bs, String name, DataType type, Object value) {
@@ -304,28 +302,20 @@ public abstract class TestUtils {
     // Wait for a node to be up and running
     // This is used because there is some delay between when a node has been
     // added through ccm and when it's actually available for querying
-    public static void waitFor(String node, Cluster cluster) {
+    public static void waitForUp(String node, Cluster cluster) {
         waitFor(node, cluster, TEST_BASE_NODE_WAIT, false);
     }
 
-    public static void waitFor(String node, Cluster cluster, int maxTry) {
-        waitFor(node, cluster, maxTry, false);
+    public static void waitForUp(String node, Cluster cluster, int timeoutSeconds) {
+        waitFor(node, cluster, timeoutSeconds, false);
     }
 
     public static void waitForDown(String node, Cluster cluster) {
         waitFor(node, cluster, TEST_BASE_NODE_WAIT * 3, true);
     }
 
-    public static void waitForDown(String node, Cluster cluster, int maxTry) {
-        waitFor(node, cluster, maxTry, true);
-    }
-
-    public static void waitForDecommission(String node, Cluster cluster) {
-        waitFor(node, cluster, TEST_BASE_NODE_WAIT / 2, true);
-    }
-
-    public static void waitForDecommission(String node, Cluster cluster, int maxTry) {
-        waitFor(node, cluster, maxTry, true);
+    public static void waitForDown(String node, Cluster cluster, int timeoutSeconds) {
+        waitFor(node, cluster, timeoutSeconds, true);
     }
 
     private static void waitFor(String node, Cluster cluster, int timeoutSeconds, boolean waitForDown) {
@@ -337,23 +327,30 @@ public abstract class TestUtils {
         // tried doing an actual query, the driver won't realize that last node is dead until
         // keep alive kicks in, but that's a fairly long time. So we cheat and trigger a force
         // the detection by forcing a request.
-        if (waitForDown) {
+        if (waitForDown)
             Futures.getUnchecked(cluster.manager.submitSchemaRefresh(null, null, null));
-        }
         if (waitForDown) {
-            ConditionChecker.awaitUntil(new HostIsDownCondition(cluster, node), timeoutSeconds * 1000);
+            check()
+                    .every(1, SECONDS)
+                    .before(timeoutSeconds, SECONDS)
+                    .that(new HostIsDown(cluster, node))
+                    .becomesTrue();
         } else {
-            ConditionChecker.awaitUntil(new HostIsUpCondition(cluster, node), timeoutSeconds * 1000);
+            check()
+                    .every(1, SECONDS)
+                    .before(timeoutSeconds, SECONDS)
+                    .that(new HostIsUp(cluster, node))
+                    .becomesTrue();
         }
     }
 
-    private static class HostIsDownCondition implements Callable<Boolean> {
+    private static class HostIsDown implements Callable<Boolean> {
 
         private final Cluster cluster;
 
         private final String ip;
 
-        public HostIsDownCondition(Cluster cluster, String ip) {
+        public HostIsDown(Cluster cluster, String ip) {
             this.cluster = cluster;
             this.ip = ip;
         }
@@ -365,13 +362,13 @@ public abstract class TestUtils {
         }
     }
 
-    private static class HostIsUpCondition implements Callable<Boolean> {
+    private static class HostIsUp implements Callable<Boolean> {
 
         private final Cluster cluster;
 
         private final String ip;
 
-        public HostIsUpCondition(Cluster cluster, String ip) {
+        public HostIsUp(Cluster cluster, String ip) {
             this.cluster = cluster;
             this.ip = ip;
         }
@@ -476,8 +473,20 @@ public abstract class TestUtils {
         return ScassandraFactory.createServer(ipOfNode(1), binaryPort, ipOfNode(1), adminPort);
     }
 
-    public static String getAvailableKeyspaceName() {
-        return SIMPLE_KEYSPACE + "_" + KS_COUNTER.getAndIncrement();
+    private static final ConcurrentMap<String, AtomicInteger> IDENTIFIERS = new ConcurrentHashMap<String, AtomicInteger>();
+
+    /**
+     * Generates a unique CQL identifier with the given prefix.
+     *
+     * @param prefix The prefix for the identifier
+     * @return a unique CQL identifier.
+     */
+    public static String generateIdentifier(String prefix) {
+        AtomicInteger seq = new AtomicInteger(0);
+        AtomicInteger previous = IDENTIFIERS.putIfAbsent(prefix, seq);
+        if (previous != null)
+            seq = previous;
+        return prefix + seq.incrementAndGet();
     }
 
     // use ports in the ephemeral range
@@ -534,11 +543,11 @@ public abstract class TestUtils {
     };
 
     public static void waitUntilPortIsUp(InetSocketAddress address) {
-        ConditionChecker.awaitUntil(address, PORT_IS_UP, TimeUnit.SECONDS.toMillis(10));
+        check().before(5, MINUTES).that(address, PORT_IS_UP).becomesTrue();
     }
 
     public static void waitUntilPortIsDown(InetSocketAddress address) {
-        ConditionChecker.awaitWhile(address, PORT_IS_UP, TimeUnit.SECONDS.toMillis(10));
+        check().before(5, MINUTES).that(address, PORT_IS_UP).becomesFalse();
     }
 
     public static boolean pingPort(InetAddress address, int port) {
@@ -608,10 +617,16 @@ public abstract class TestUtils {
     public static NettyOptions nonQuietClusterCloseOptions = new NettyOptions() {
         @Override
         public void onClusterClose(EventLoopGroup eventLoopGroup) {
-            eventLoopGroup.shutdownGracefully(0, 15, TimeUnit.SECONDS).syncUninterruptibly();
+            eventLoopGroup.shutdownGracefully(0, 15, SECONDS).syncUninterruptibly();
         }
     };
 
+    /**
+     * Executes a task and catches any exception.
+     *
+     * @param task         The task to execute.
+     * @param logException Whether to log the exception, if any.
+     */
     public static void executeNoFail(Runnable task, boolean logException) {
         try {
             task.run();
@@ -621,6 +636,12 @@ public abstract class TestUtils {
         }
     }
 
+    /**
+     * Executes a task and catches any exception.
+     *
+     * @param task         The task to execute.
+     * @param logException Whether to log the exception, if any.
+     */
     public static void executeNoFail(Callable<?> task, boolean logException) {
         try {
             task.call();
@@ -630,6 +651,11 @@ public abstract class TestUtils {
         }
     }
 
+    /**
+     * Returns the system's free memory in megabytes.
+     * <p/>
+     * This includes the free physical memory + the free swap memory.
+     */
     public static long getFreeMemoryMB() {
         OperatingSystemMXBean bean = (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
         return (bean.getFreePhysicalMemorySize() + bean.getFreeSwapSpaceSize()) / 1024 / 1024;

--- a/driver-core/src/test/java/com/datastax/driver/core/TracingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TracingTest.java
@@ -18,11 +18,8 @@ package com.datastax.driver.core;
 import com.datastax.driver.core.policies.DowngradingConsistencyRetryPolicy;
 import com.datastax.driver.core.utils.CassandraVersion;
 import com.google.common.util.concurrent.Uninterruptibles;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -40,14 +37,10 @@ public class TracingTest extends CCMTestsSupport {
     }
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Collections.singletonList("CREATE TABLE test (k text, v int, PRIMARY KEY (k, v))");
-    }
-
-    @BeforeClass(groups = "short")
-    public void initData() {
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE test (k text, v int, PRIMARY KEY (k, v))");
         for (int i = 0; i < 100; i++) {
-            session.execute(String.format("INSERT INTO test (k, v) VALUES ('%s', %d)", KEY, i));
+            execute(String.format("INSERT INTO test (k, v) VALUES ('%s', %d)", KEY, i));
         }
     }
 
@@ -61,7 +54,7 @@ public class TracingTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void should_have_a_different_tracingId_for_each_page() {
         SimpleStatement st = new SimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
-        ResultSet result = session.execute(st.setFetchSize(40).enableTracing());
+        ResultSet result = session().execute(st.setFetchSize(40).enableTracing());
         result.all();
         // sleep 10 seconds to make sure the trace will be complete
         Uninterruptibles.sleepUninterruptibly(10, TimeUnit.SECONDS);
@@ -93,7 +86,7 @@ public class TracingTest extends CCMTestsSupport {
         SimpleStatement st = new SimpleStatement(String.format("SELECT v FROM test WHERE k='%s'", KEY));
         st.setConsistencyLevel(ConsistencyLevel.THREE).enableTracing();
 
-        ResultSet result = session.execute(st);
+        ResultSet result = session().execute(st);
         // sleep 10 seconds to make sure the trace will be complete
         Uninterruptibles.sleepUninterruptibly(10, TimeUnit.SECONDS);
 

--- a/driver-core/src/test/java/com/datastax/driver/core/exceptions/ExceptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/exceptions/ExceptionsTest.java
@@ -53,35 +53,35 @@ public class ExceptionsTest extends CCMTestsSupport {
         };
 
         // Create the schema once
-        session.execute(cqlCommands[0]);
-        session.execute(cqlCommands[1]);
-        session.execute(cqlCommands[2]);
+        session().execute(cqlCommands[0]);
+        session().execute(cqlCommands[1]);
+        session().execute(cqlCommands[2]);
 
         // Try creating the keyspace again
         try {
-            session.execute(cqlCommands[0]);
+            session().execute(cqlCommands[0]);
         } catch (AlreadyExistsException e) {
             String expected = String.format("Keyspace %s already exists", keyspace.toLowerCase());
             assertEquals(e.getMessage(), expected);
             assertEquals(e.getKeyspace(), keyspace.toLowerCase());
             assertEquals(e.getTable(), null);
             assertEquals(e.wasTableCreation(), false);
-            assertEquals(e.getHost(), ccm.addressOfNode(1).getAddress());
-            assertEquals(e.getAddress(), ccm.addressOfNode(1));
+            assertEquals(e.getHost(), ccm().addressOfNode(1).getAddress());
+            assertEquals(e.getAddress(), ccm().addressOfNode(1));
         }
 
-        session.execute(cqlCommands[1]);
+        session().execute(cqlCommands[1]);
 
         // Try creating the table again
         try {
-            session.execute(cqlCommands[2]);
+            session().execute(cqlCommands[2]);
         } catch (AlreadyExistsException e) {
             // is released
             assertEquals(e.getKeyspace(), keyspace.toLowerCase());
             assertEquals(e.getTable(), table.toLowerCase());
             assertEquals(e.wasTableCreation(), true);
-            assertEquals(e.getHost(), ccm.addressOfNode(1).getAddress());
-            assertEquals(e.getAddress(), ccm.addressOfNode(1));
+            assertEquals(e.getHost(), ccm().addressOfNode(1).getAddress());
+            assertEquals(e.getAddress(), ccm().addressOfNode(1));
         }
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/CloseableLoadBalancingPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/CloseableLoadBalancingPolicyTest.java
@@ -30,8 +30,8 @@ public class CloseableLoadBalancingPolicyTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void should_be_invoked_at_shutdown() {
         try {
-            cluster.connect();
-            cluster.close();
+            cluster().connect();
+            cluster().close();
         } finally {
             assertThat(policy.wasClosed).isTrue();
         }
@@ -41,7 +41,7 @@ public class CloseableLoadBalancingPolicyTest extends CCMTestsSupport {
     public Cluster.Builder createClusterBuilder() {
         policy = new CloseMonitoringPolicy(Policies.defaultLoadBalancingPolicy());
         return Cluster.builder()
-                .addContactPoints(ccm.addressOfNode(1).getAddress())
+                .addContactPoints(getContactPoints().get(0))
                 .withLoadBalancingPolicy(policy);
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/TokenAwarePolicyTest.java
@@ -323,13 +323,13 @@ public class TokenAwarePolicyTest extends CCMTestsSupport {
         // given: a 3 node cluster with a keyspace with RF 1.
         Cluster cluster = register(Cluster.builder()
                 .withLoadBalancingPolicy(new TokenAwarePolicy(new RoundRobinPolicy()))
-                .addContactPointsWithPorts(ccm.addressOfNode(1))
-                .withPort(ccm.getBinaryPort())
+                .addContactPoints(getContactPoints().get(0))
+                .withPort(ccm().getBinaryPort())
                 .build());
         Session session = cluster.connect();
 
         String table = "composite";
-        String ks = TestUtils.getAvailableKeyspaceName();
+        String ks = TestUtils.generateIdentifier("ks_");
         session.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, ks, 1));
         session.execute("USE " + ks);
         session.execute(String.format("CREATE TABLE %s (k1 int, k2 int, i int, PRIMARY KEY ((k1, k2)))", table));

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilder21ExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilder21ExecutionTest.java
@@ -22,9 +22,6 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.utils.CassandraVersion;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.Collection;
-
 import static com.datastax.driver.core.Assertions.assertThat;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 
@@ -32,9 +29,9 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 public class QueryBuilder21ExecutionTest extends CCMTestsSupport {
 
     @Override
-    public Collection<String> createTestFixtures() {
+    public void onTestContextInitialized() {
         // Taken from http://www.datastax.com/dev/blog/cql-in-2-1
-        return Arrays.asList(
+        execute(
                 "CREATE TABLE products (id int PRIMARY KEY, description text, price int, categories set<text>, buyers list<int>, features_keys map<text, text>, features_values map<text, text>)",
                 "CREATE INDEX cat_index ON products(categories)",
                 "CREATE INDEX buyers_index ON products(buyers)",
@@ -51,11 +48,11 @@ public class QueryBuilder21ExecutionTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_handle_contains_on_set_with_index() {
-        PreparedStatement byCategory = session.prepare(select("id", "description", "categories")
+        PreparedStatement byCategory = session().prepare(select("id", "description", "categories")
                 .from("products")
                 .where(contains("categories", bindMarker("category"))));
 
-        ResultSet results = session.execute(byCategory.bind().setString("category", "hdtv"));
+        ResultSet results = session().execute(byCategory.bind().setString("category", "hdtv"));
 
         assertThat(results.getAvailableWithoutFetching()).isEqualTo(2);
         for (Row row : results) {
@@ -65,11 +62,11 @@ public class QueryBuilder21ExecutionTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_handle_contains_on_list_with_index() {
-        PreparedStatement byBuyer = session.prepare(select("id", "description", "buyers")
+        PreparedStatement byBuyer = session().prepare(select("id", "description", "buyers")
                 .from("products")
                 .where(contains("buyers", bindMarker("buyer"))));
 
-        ResultSet results = session.execute(byBuyer.bind().setInt("buyer", 4));
+        ResultSet results = session().execute(byBuyer.bind().setInt("buyer", 4));
 
         Row row = results.one();
         assertThat(row).isNotNull();
@@ -79,11 +76,11 @@ public class QueryBuilder21ExecutionTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_handle_contains_on_map_with_index() {
-        PreparedStatement byFeatures = session.prepare(select("id", "description", "features_values")
+        PreparedStatement byFeatures = session().prepare(select("id", "description", "features_values")
                 .from("products")
                 .where(contains("features_values", bindMarker("feature"))));
 
-        ResultSet results = session.execute(byFeatures.bind().setString("feature", "LED"));
+        ResultSet results = session().execute(byFeatures.bind().setString("feature", "LED"));
 
         Row row = results.one();
         assertThat(row).isNotNull();
@@ -94,11 +91,11 @@ public class QueryBuilder21ExecutionTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_handle_contains_key_on_map_with_index() {
-        PreparedStatement byFeatures = session.prepare(select("id", "description", "features_keys")
+        PreparedStatement byFeatures = session().prepare(select("id", "description", "features_keys")
                 .from("products")
                 .where(containsKey("features_keys", bindMarker("feature"))));
 
-        ResultSet results = session.execute(byFeatures.bind().setString("feature", "refresh-rate"));
+        ResultSet results = session().execute(byFeatures.bind().setString("feature", "refresh-rate"));
 
         Row row = results.one();
         assertThat(row).isNotNull();

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
@@ -18,7 +18,10 @@ package com.datastax.driver.core.querybuilder;
 import com.datastax.driver.core.*;
 import org.testng.annotations.Test;
 
-import java.util.*;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,8 +33,8 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
     private static final String TABLE1 = "test1";
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Arrays.asList(
+    public void onTestContextInitialized() {
+        execute(
                 String.format(TestUtils.CREATE_TABLE_SIMPLE_FORMAT, TABLE1),
                 "CREATE TABLE dateTest (t timestamp PRIMARY KEY)",
                 "CREATE TABLE test_coll (k int PRIMARY KEY, a list<int>, b map<int,text>, c set<text>)");
@@ -40,10 +43,10 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void executeTest() throws Exception {
 
-        session.execute(insertInto(TABLE1).value("k", "k1").value("t", "This is a test").value("i", 3).value("f", 0.42));
-        session.execute(update(TABLE1).with(set("t", "Another test")).where(eq("k", "k2")));
+        session().execute(insertInto(TABLE1).value("k", "k1").value("t", "This is a test").value("i", 3).value("f", 0.42));
+        session().execute(update(TABLE1).with(set("t", "Another test")).where(eq("k", "k2")));
 
-        List<Row> rows = session.execute(select().from(TABLE1).where(in("k", "k1", "k2"))).all();
+        List<Row> rows = session().execute(select().from(TABLE1).where(in("k", "k1", "k2"))).all();
 
         assertEquals(2, rows.size());
 
@@ -64,9 +67,9 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
     public void dateHandlingTest() throws Exception {
 
         Date d = new Date();
-        session.execute(insertInto("dateTest").value("t", d));
+        session().execute(insertInto("dateTest").value("t", d));
         String query = select().from("dateTest").where(eq(token("t"), fcall("token", d))).toString();
-        List<Row> rows = session.execute(query).all();
+        List<Row> rows = session().execute(query).all();
 
         assertEquals(1, rows.size());
 
@@ -91,9 +94,9 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
     public void batchNonBuiltStatementTest() throws Exception {
         SimpleStatement simple = new SimpleStatement("INSERT INTO " + TABLE1 + " (k, t) VALUES ('batchTest1', 'val1')");
         RegularStatement built = insertInto(TABLE1).value("k", "batchTest2").value("t", "val2");
-        session.execute(batch().add(simple).add(built));
+        session().execute(batch().add(simple).add(built));
 
-        List<Row> rows = session.execute(select().from(TABLE1).where(in("k", "batchTest1", "batchTest2"))).all();
+        List<Row> rows = session().execute(select().from(TABLE1).where(in("k", "batchTest1", "batchTest2"))).all();
         assertEquals(2, rows.size());
 
         Row r1 = rows.get(0);
@@ -108,75 +111,75 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void should_delete_list_element() throws Exception {
         //given
-        session.execute("INSERT INTO test_coll (k, a, b) VALUES (1, [1,2,3], null)");
+        session().execute("INSERT INTO test_coll (k, a, b) VALUES (1, [1,2,3], null)");
         //when
         BuiltStatement statement = delete().listElt("a", 1).from("test_coll").where(eq("k", 1));
-        session.execute(statement);
+        session().execute(statement);
         //then
-        List<Integer> actual = session.execute("SELECT a FROM test_coll WHERE k = 1").one().getList("a", Integer.class);
+        List<Integer> actual = session().execute("SELECT a FROM test_coll WHERE k = 1").one().getList("a", Integer.class);
         assertThat(actual).containsExactly(1, 3);
     }
 
     @Test(groups = "short")
     public void should_delete_list_element_with_bind_marker() throws Exception {
         //given
-        session.execute("INSERT INTO test_coll (k, a) VALUES (1, [1,2,3])");
+        session().execute("INSERT INTO test_coll (k, a) VALUES (1, [1,2,3])");
         //when
         BuiltStatement statement = delete().listElt("a", bindMarker()).from("test_coll").where(eq("k", 1));
-        PreparedStatement ps = session.prepare(statement);
-        session.execute(ps.bind(1));
+        PreparedStatement ps = session().prepare(statement);
+        session().execute(ps.bind(1));
         //then
-        List<Integer> actual = session.execute("SELECT a FROM test_coll WHERE k = 1").one().getList("a", Integer.class);
+        List<Integer> actual = session().execute("SELECT a FROM test_coll WHERE k = 1").one().getList("a", Integer.class);
         assertThat(actual).containsExactly(1, 3);
     }
 
     @Test(groups = "short")
     public void should_delete_set_element() throws Exception {
         //given
-        session.execute("INSERT INTO test_coll (k, c) VALUES (1, {'foo','bar','qix'})");
+        session().execute("INSERT INTO test_coll (k, c) VALUES (1, {'foo','bar','qix'})");
         //when
         BuiltStatement statement = delete().setElt("c", "foo").from("test_coll").where(eq("k", 1));
-        session.execute(statement);
+        session().execute(statement);
         //then
-        Set<String> actual = session.execute("SELECT c FROM test_coll WHERE k = 1").one().getSet("c", String.class);
+        Set<String> actual = session().execute("SELECT c FROM test_coll WHERE k = 1").one().getSet("c", String.class);
         assertThat(actual).containsOnly("bar", "qix");
     }
 
     @Test(groups = "short")
     public void should_delete_set_element_with_bind_marker() throws Exception {
         //given
-        session.execute("INSERT INTO test_coll (k, c) VALUES (1, {'foo','bar','qix'})");
+        session().execute("INSERT INTO test_coll (k, c) VALUES (1, {'foo','bar','qix'})");
         //when
         BuiltStatement statement = delete().setElt("c", bindMarker()).from("test_coll").where(eq("k", 1));
-        PreparedStatement ps = session.prepare(statement);
-        session.execute(ps.bind("foo"));
+        PreparedStatement ps = session().prepare(statement);
+        session().execute(ps.bind("foo"));
         //then
-        Set<String> actual = session.execute("SELECT c FROM test_coll WHERE k = 1").one().getSet("c", String.class);
+        Set<String> actual = session().execute("SELECT c FROM test_coll WHERE k = 1").one().getSet("c", String.class);
         assertThat(actual).containsOnly("bar", "qix");
     }
 
     @Test(groups = "short")
     public void should_delete_map_entry() throws Exception {
         //given
-        session.execute("INSERT INTO test_coll (k, b) VALUES (1, {1:'foo', 2:'bar'})");
+        session().execute("INSERT INTO test_coll (k, b) VALUES (1, {1:'foo', 2:'bar'})");
         //when
         BuiltStatement statement = delete().mapElt("b", 1).from("test_coll").where(eq("k", 1));
-        session.execute(statement);
+        session().execute(statement);
         //then
-        Map<Integer, String> actual = session.execute("SELECT b FROM test_coll WHERE k = 1").one().getMap("b", Integer.class, String.class);
+        Map<Integer, String> actual = session().execute("SELECT b FROM test_coll WHERE k = 1").one().getMap("b", Integer.class, String.class);
         assertThat(actual).containsExactly(entry(2, "bar"));
     }
 
     @Test(groups = "short")
     public void should_delete_map_entry_with_bind_marker() throws Exception {
         //given
-        session.execute("INSERT INTO test_coll (k, a, b) VALUES (1, null, {1:'foo', 2:'bar'})");
+        session().execute("INSERT INTO test_coll (k, a, b) VALUES (1, null, {1:'foo', 2:'bar'})");
         //when
         BuiltStatement statement = delete().mapElt("b", bindMarker()).from("test_coll").where(eq("k", 1));
-        PreparedStatement ps = session.prepare(statement);
-        session.execute(ps.bind().setInt(0, 1));
+        PreparedStatement ps = session().prepare(statement);
+        session().execute(ps.bind().setInt(0, 1));
         //then
-        Map<Integer, String> actual = session.execute("SELECT b FROM test_coll WHERE k = 1").one().getMap("b", Integer.class, String.class);
+        Map<Integer, String> actual = session().execute("SELECT b FROM test_coll WHERE k = 1").one().getMap("b", Integer.class, String.class);
         assertThat(actual).containsExactly(entry(2, "bar"));
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderUDTExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderUDTExecutionTest.java
@@ -22,8 +22,6 @@ import com.google.common.collect.Maps;
 import org.testng.annotations.Test;
 
 import java.net.InetAddress;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -35,22 +33,22 @@ import static org.testng.Assert.assertEquals;
 public class QueryBuilderUDTExecutionTest extends CCMTestsSupport {
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Arrays.asList("CREATE TYPE udt (i int, a inet)",
+    public void onTestContextInitialized() {
+        execute("CREATE TYPE udt (i int, a inet)",
                 "CREATE TABLE udtTest(k int PRIMARY KEY, t frozen<udt>, l list<frozen<udt>>, m map<int, frozen<udt>>)");
     }
 
     @Test(groups = "short")
     public void insertUdtTest() throws Exception {
-        UserType udtType = cluster.getMetadata().getKeyspace(keyspace).getUserType("udt");
+        UserType udtType = cluster().getMetadata().getKeyspace(keyspace).getUserType("udt");
         UDTValue udtValue = udtType.newValue().setInt("i", 2).setInet("a", InetAddress.getByName("localhost"));
 
         Statement insert = insertInto("udtTest").value("k", 1).value("t", udtValue);
         assertEquals(insert.toString(), "INSERT INTO udtTest (k,t) VALUES (1,{i:2, a:'127.0.0.1'});");
 
-        session.execute(insert);
+        session().execute(insert);
 
-        List<Row> rows = session.execute(select().from("udtTest").where(eq("k", 1))).all();
+        List<Row> rows = session().execute(select().from("udtTest").where(eq("k", 1))).all();
 
         assertEquals(rows.size(), 1);
 
@@ -60,16 +58,16 @@ public class QueryBuilderUDTExecutionTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_handle_collections_of_UDT() throws Exception {
-        UserType udtType = cluster.getMetadata().getKeyspace(keyspace).getUserType("udt");
+        UserType udtType = cluster().getMetadata().getKeyspace(keyspace).getUserType("udt");
         UDTValue udtValue = udtType.newValue().setInt("i", 2).setInet("a", InetAddress.getByName("localhost"));
         UDTValue udtValue2 = udtType.newValue().setInt("i", 3).setInet("a", InetAddress.getByName("localhost"));
 
         Statement insert = insertInto("udtTest").value("k", 1).value("l", ImmutableList.of(udtValue));
         assertThat(insert.toString()).isEqualTo("INSERT INTO udtTest (k,l) VALUES (1,[{i:2, a:'127.0.0.1'}]);");
 
-        session.execute(insert);
+        session().execute(insert);
 
-        List<Row> rows = session.execute(select().from("udtTest").where(eq("k", 1))).all();
+        List<Row> rows = session().execute(select().from("udtTest").where(eq("k", 1))).all();
 
         assertThat(rows.size()).isEqualTo(1);
 
@@ -83,9 +81,9 @@ public class QueryBuilderUDTExecutionTest extends CCMTestsSupport {
         assertThat(updateMap.toString())
                 .isEqualTo("UPDATE udtTest SET m=m+{0:{i:2, a:'127.0.0.1'},2:{i:3, a:'127.0.0.1'}} WHERE k=1;");
 
-        session.execute(updateMap);
+        session().execute(updateMap);
 
-        rows = session.execute(select().from("udtTest").where(eq("k", 1))).all();
+        rows = session().execute(select().from("udtTest").where(eq("k", 1))).all();
         r1 = rows.get(0);
         assertThat(r1.getMap("m", Integer.class, UDTValue.class)).isEqualTo(map);
     }

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorParamsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorParamsTest.java
@@ -20,17 +20,16 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.utils.CassandraVersion;
 import com.datastax.driver.mapping.annotations.*;
-import com.google.common.collect.Lists;
 import org.testng.annotations.Test;
-
-import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("unused")
 public class MapperAccessorParamsTest extends CCMTestsSupport {
+
     @Override
-    public Collection<String> createTestFixtures() {
-        return Lists.newArrayList(
+    public void onTestContextInitialized() {
+        execute(
                 "CREATE TABLE user ( key int primary key, gender int, home_phone text, work_phone text)",
                 "CREATE INDEX on user(gender)",
                 "CREATE TABLE user_str ( key int primary key, gender text)",
@@ -40,7 +39,7 @@ public class MapperAccessorParamsTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_allow_enum_as_int_in_accessor_params() {
-        UserAccessor accessor = new MappingManager(session)
+        UserAccessor accessor = new MappingManager(session())
                 .createAccessor(UserAccessor.class);
 
         accessor.addUser(0, Enum.FEMALE);
@@ -55,7 +54,7 @@ public class MapperAccessorParamsTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_allow_enum_as_string_in_accessor_params() {
-        UserAccessor accessor = new MappingManager(session)
+        UserAccessor accessor = new MappingManager(session())
                 .createAccessor(UserAccessor.class);
 
         accessor.addUserStr(0, Enum.FEMALE);
@@ -71,44 +70,44 @@ public class MapperAccessorParamsTest extends CCMTestsSupport {
     @Test(groups = "short")
     @CassandraVersion(major = 2.0, description = "Uses named parameters")
     public void should_allow_less_parameters_than_bind_markers_if_there_are_repeated_names() {
-        UserPhoneAccessor accessor = new MappingManager(session)
+        UserPhoneAccessor accessor = new MappingManager(session())
                 .createAccessor(UserPhoneAccessor.class);
 
-        session.execute("delete from user where key = 0");
+        session().execute("delete from user where key = 0");
         accessor.updatePhones_positional("1111", "2222", 0);
         assertPhonesEqual(0, "1111", "2222");
 
-        session.execute("delete from user where key = 0");
+        session().execute("delete from user where key = 0");
         accessor.updatePhones_named(0, "1111", "2222");
         assertPhonesEqual(0, "1111", "2222");
 
-        session.execute("delete from user where key = 0");
+        session().execute("delete from user where key = 0");
         accessor.updatePhones_fallback("1111", "2222", 0);
         assertPhonesEqual(0, "1111", "2222");
 
-        session.execute("delete from user where key = 0");
+        session().execute("delete from user where key = 0");
         accessor.updateBothPhones(0, "1111");
         assertPhonesEqual(0, "1111", "1111");
 
-        session.execute("delete from user where key = 0");
+        session().execute("delete from user where key = 0");
         accessor.updatePhones_fallback2("1111", "2222", 0);
         assertPhonesEqual(0, "1111", "2222");
     }
 
     @Test(groups = "short", expectedExceptions = RuntimeException.class)
     public void should_fail_if_not_enough_parameters() {
-        new MappingManager(session)
+        new MappingManager(session())
                 .createAccessor(UserPhoneAccessor_NotEnoughParams.class);
     }
 
     @Test(groups = "short", expectedExceptions = RuntimeException.class)
     public void should_fail_if_too_many_parameters() {
-        new MappingManager(session)
+        new MappingManager(session())
                 .createAccessor(UserPhoneAccessor_TooManyParams.class);
     }
 
     private void assertPhonesEqual(int key, String home, String work) {
-        Row row = session.execute("select * from user where key = " + key).one();
+        Row row = session().execute("select * from user where key = " + key).one();
         assertThat(row.getString("home_phone")).isEqualTo(home);
         assertThat(row.getString("work_phone")).isEqualTo(work);
     }

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorTest.java
@@ -22,23 +22,20 @@ import com.datastax.driver.core.utils.CassandraVersion;
 import com.datastax.driver.mapping.annotations.Accessor;
 import com.datastax.driver.mapping.annotations.Param;
 import com.datastax.driver.mapping.annotations.Query;
-import com.google.common.collect.Lists;
 import org.testng.annotations.Test;
-
-import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MapperAccessorTest extends CCMTestsSupport {
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Lists.newArrayList("CREATE TABLE foo (k int primary key, v text)");
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE foo (k int primary key, v text)");
     }
 
     @Test(groups = "short")
     public void should_implement_toString() {
-        SystemAccessor accessor = new MappingManager(session)
+        SystemAccessor accessor = new MappingManager(session())
                 .createAccessor(SystemAccessor.class);
 
         assertThat(accessor.toString())
@@ -47,7 +44,7 @@ public class MapperAccessorTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_implement_equals_and_hashCode() {
-        SystemAccessor accessor = new MappingManager(session)
+        SystemAccessor accessor = new MappingManager(session())
                 .createAccessor(SystemAccessor.class);
 
         assertThat(accessor).isNotEqualTo(new Object());
@@ -57,32 +54,32 @@ public class MapperAccessorTest extends CCMTestsSupport {
     @Test(groups = "short")
     @CassandraVersion(major = 2.0)
     public void should_allow_null_argument_in_accessor_when_set_by_name() {
-        FooAccessor accessor = new MappingManager(session)
+        FooAccessor accessor = new MappingManager(session())
                 .createAccessor(FooAccessor.class);
 
         accessor.insert(1, null);
-        Row row = session.execute("select * from foo where k = 1").one();
+        Row row = session().execute("select * from foo where k = 1").one();
 
         assertThat(row.getString("v")).isNull();
     }
 
     @Test(groups = "short")
     public void should_allow_null_argument_in_accessor_when_set_by_index() {
-        FooBindMarkerAccessor accessor = new MappingManager(session)
+        FooBindMarkerAccessor accessor = new MappingManager(session())
                 .createAccessor(FooBindMarkerAccessor.class);
 
         accessor.insert(1, null);
 
-        Row row = session.execute("select * from foo where k = 1").one();
+        Row row = session().execute("select * from foo where k = 1").one();
 
         assertThat(row.getString("v")).isNull();
     }
 
     @Test(groups = "short")
     public void should_allow_void_return_type_in_accessor() {
-        VoidAccessor accessor = new MappingManager(session).createAccessor(VoidAccessor.class);
+        VoidAccessor accessor = new MappingManager(session()).createAccessor(VoidAccessor.class);
         accessor.insert(1, "bar");
-        Row row = session.execute("select * from foo where k = 1").one();
+        Row row = session().execute("select * from foo where k = 1").one();
         assertThat(row.getInt("k")).isEqualTo(1);
         assertThat(row.getString("v")).isEqualTo("bar");
     }

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperCompositeKeyTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperCompositeKeyTest.java
@@ -21,17 +21,14 @@ import com.datastax.driver.mapping.annotations.PartitionKey;
 import com.datastax.driver.mapping.annotations.Table;
 import org.testng.annotations.Test;
 
-import java.util.Collection;
-import java.util.Collections;
-
 /**
  * Tests for the mapper with composite partition keys and multiple clustering columns.
  */
 public class MapperCompositeKeyTest extends CCMTestsSupport {
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Collections.singletonList("CREATE TABLE test_table (pk1 int, pk2 int, cc1 int, cc2 int, PRIMARY KEY ((pk1, pk2), cc1, cc2))");
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE test_table (pk1 int, pk2 int, cc1 int, cc2 int, PRIMARY KEY ((pk1, pk2), cc1, cc2))");
     }
 
     @SuppressWarnings("unused")
@@ -84,6 +81,6 @@ public class MapperCompositeKeyTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void testCreateMapper() throws Exception {
-        new MappingManager(session).mapper(TestTable.class);
+        new MappingManager(session()).mapper(TestTable.class);
     }
 }

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperEnumTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperEnumTest.java
@@ -19,10 +19,7 @@ import com.datastax.driver.core.CCMTestsSupport;
 import com.datastax.driver.mapping.annotations.Enumerated;
 import com.datastax.driver.mapping.annotations.PartitionKey;
 import com.datastax.driver.mapping.annotations.Table;
-import com.google.common.collect.Lists;
 import org.testng.annotations.Test;
-
-import java.util.Collection;
 
 import static org.junit.Assert.assertNull;
 
@@ -33,8 +30,8 @@ import static org.junit.Assert.assertNull;
 public class MapperEnumTest extends CCMTestsSupport {
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Lists.newArrayList("CREATE TABLE asOrdinal (k int primary key, v int)",
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE asOrdinal (k int primary key, v int)",
                 "CREATE TABLE asString (k int primary key, v text)");
     }
 
@@ -44,7 +41,7 @@ public class MapperEnumTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_handle_null_enum_as_ordinal() {
-        Mapper<AsOrdinal> mapper = new MappingManager(session).mapper(AsOrdinal.class);
+        Mapper<AsOrdinal> mapper = new MappingManager(session()).mapper(AsOrdinal.class);
 
         mapper.save(new AsOrdinal(1, null));
         AsOrdinal o = mapper.get(1);
@@ -54,7 +51,7 @@ public class MapperEnumTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_handle_null_enum_as_string() {
-        Mapper<AsString> mapper = new MappingManager(session).mapper(AsString.class);
+        Mapper<AsString> mapper = new MappingManager(session()).mapper(AsString.class);
 
         mapper.save(new AsString(1, null));
         AsString o = mapper.get(1);

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperInvalidCollectionTypesTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperInvalidCollectionTypesTest.java
@@ -20,14 +20,16 @@ import com.datastax.driver.mapping.annotations.PartitionKey;
 import com.datastax.driver.mapping.annotations.Table;
 import org.testng.annotations.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.TreeMap;
 
 @SuppressWarnings("unused")
 public class MapperInvalidCollectionTypesTest extends CCMTestsSupport {
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Arrays.asList(
+    public void onTestContextInitialized() {
+        execute(
                 "CREATE TABLE table_list (id int PRIMARY KEY, l list<int>)",
                 "CREATE TABLE table_set (id int PRIMARY KEY, s set<int>)",
                 "CREATE TABLE table_map (id int PRIMARY KEY, m map<int, int>)");
@@ -107,16 +109,16 @@ public class MapperInvalidCollectionTypesTest extends CCMTestsSupport {
 
     @Test(groups = "short", expectedExceptions = IllegalArgumentException.class)
     public void list_type_is_enforced() {
-        new MappingManager(session).mapper(InvalidList.class);
+        new MappingManager(session()).mapper(InvalidList.class);
     }
 
     @Test(groups = "short", expectedExceptions = IllegalArgumentException.class)
     public void map_type_is_enforced() {
-        new MappingManager(session).mapper(InvalidMap.class);
+        new MappingManager(session()).mapper(InvalidMap.class);
     }
 
     @Test(groups = "short", expectedExceptions = IllegalArgumentException.class)
     public void set_type_is_enforced() {
-        new MappingManager(session).mapper(InvalidSet.class);
+        new MappingManager(session()).mapper(InvalidSet.class);
     }
 }

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperNestedCollectionsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperNestedCollectionsTest.java
@@ -24,7 +24,10 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.testng.annotations.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.datastax.driver.core.Assertions.assertThat;
 
@@ -33,8 +36,8 @@ import static com.datastax.driver.core.Assertions.assertThat;
 public class MapperNestedCollectionsTest extends CCMTestsSupport {
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Lists.newArrayList(
+    public void onTestContextInitialized() {
+        execute(
                 "CREATE TYPE testType(i int, ls list<frozen<set<int>>>)",
                 "CREATE TABLE testTable (k int primary key, "
                         + "m1 map<text, frozen<map<int, int>>>, " // nested collection
@@ -44,7 +47,7 @@ public class MapperNestedCollectionsTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_map_fields_to_nested_collections() {
-        Mapper<TestTable> mapper = new MappingManager(session).mapper(TestTable.class);
+        Mapper<TestTable> mapper = new MappingManager(session()).mapper(TestTable.class);
 
         TestTable testTable = new TestTable();
         testTable.setK(1);
@@ -67,7 +70,7 @@ public class MapperNestedCollectionsTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_map_accessor_params_to_nested_collections() {
-        MappingManager manager = new MappingManager(session);
+        MappingManager manager = new MappingManager(session());
         Mapper<TestTable> mapper = manager.mapper(TestTable.class);
         TestAccessor accessor = manager.createAccessor(TestAccessor.class);
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperPrimitiveTypesTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperPrimitiveTypesTest.java
@@ -26,8 +26,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.UUID;
 
@@ -38,8 +36,8 @@ import static org.testng.Assert.assertEquals;
  */
 public class MapperPrimitiveTypesTest extends CCMTestsSupport {
 
-    public Collection<String> createTestFixtures() {
-        return Collections.singletonList("CREATE TABLE primitiveTypes ("
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE primitiveTypes ("
                 + "byteBufferCol blob primary key,"
                 + "intCol int, intWrapperCol int,"
                 + "longCol bigint, longWrapperCol bigint,"
@@ -96,7 +94,7 @@ public class MapperPrimitiveTypesTest extends CCMTestsSupport {
         primitiveTypes.setUuidCol(uuidCol);
         primitiveTypes.setTimeUuidCol(timeUuidCol);
 
-        Mapper<PrimitiveTypes> mapper = new MappingManager(session).mapper(PrimitiveTypes.class);
+        Mapper<PrimitiveTypes> mapper = new MappingManager(session()).mapper(PrimitiveTypes.class);
         mapper.save(primitiveTypes);
         PrimitiveTypes primitiveTypes2 = mapper.get(byteBufferCol);
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperSaveNullFieldsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperSaveNullFieldsTest.java
@@ -20,11 +20,8 @@ import com.datastax.driver.core.CCMTestsSupport;
 import com.datastax.driver.mapping.Mapper.Option;
 import com.datastax.driver.mapping.annotations.PartitionKey;
 import com.datastax.driver.mapping.annotations.Table;
-import com.google.common.collect.Lists;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,13 +31,13 @@ public class MapperSaveNullFieldsTest extends CCMTestsSupport {
     Mapper<User> mapper;
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Lists.newArrayList("CREATE TABLE user (login text primary key, name text, phone text)");
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE user (login text primary key, name text, phone text)");
     }
 
     @BeforeMethod(groups = "short")
     public void setup() {
-        mapper = new MappingManager(session).mapper(User.class);
+        mapper = new MappingManager(session()).mapper(User.class);
     }
 
     @Test(groups = "short")
@@ -74,7 +71,7 @@ public class MapperSaveNullFieldsTest extends CCMTestsSupport {
 
     private void should_save_null_fields(boolean nullName, boolean nullPhone, boolean saveExpected, Option... options) {
         // Start with clean data
-        session.execute("insert into user(login, name, phone) "
+        session().execute("insert into user(login, name, phone) "
                 + "values ('test_login', 'previous_name', 'previous_phone')");
 
         String newName = nullName ? null : "new_name";

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTCollectionsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTCollectionsTest.java
@@ -23,7 +23,9 @@ import com.google.common.collect.Sets;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.testng.Assert.assertEquals;
 
@@ -34,8 +36,8 @@ import static org.testng.Assert.assertEquals;
 public class MapperUDTCollectionsTest extends CCMTestsSupport {
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Arrays.asList("CREATE TYPE sub(i int)",
+    public void onTestContextInitialized() {
+        execute("CREATE TYPE sub(i int)",
                 "CREATE TABLE collection_examples (id int PRIMARY KEY, l list<frozen<sub>>, s set<frozen<sub>>, m1 map<int,frozen<sub>>, m2 map<frozen<sub>,int>, m3 map<frozen<sub>,frozen<sub>>)");
     }
 
@@ -174,7 +176,7 @@ public class MapperUDTCollectionsTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void testCollections() throws Exception {
-        Mapper<CollectionExamples> m = new MappingManager(session).mapper(CollectionExamples.class);
+        Mapper<CollectionExamples> m = new MappingManager(session()).mapper(CollectionExamples.class);
 
         CollectionExamples c = new CollectionExamples(1, 1);
         m.save(c);
@@ -184,7 +186,7 @@ public class MapperUDTCollectionsTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void testNullCollection() {
-        Mapper<CollectionExamples> m = new MappingManager(session).mapper(CollectionExamples.class);
+        Mapper<CollectionExamples> m = new MappingManager(session()).mapper(CollectionExamples.class);
 
         CollectionExamples c = new CollectionExamples(1, 1);
         c.setL(null);

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
@@ -33,14 +33,14 @@ import static org.testng.Assert.*;
 public class MapperUDTTest extends CCMTestsSupport {
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Arrays.asList("CREATE TYPE address (street text, city text, zip_code int, phones set<text>)",
+    public void onTestContextInitialized() {
+        execute("CREATE TYPE address (street text, city text, zip_code int, phones set<text>)",
                 "CREATE TABLE users (user_id uuid PRIMARY KEY, name text, mainaddress frozen<address>, other_addresses map<text,frozen<address>>)");
     }
 
     @BeforeMethod(groups = "short")
     public void clean() {
-        session.execute("TRUNCATE users");
+        session().execute("TRUNCATE users");
     }
 
     @Table(name = "users",
@@ -208,7 +208,7 @@ public class MapperUDTTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void testSimpleEntity() throws Exception {
-        Mapper<User> m = new MappingManager(session).mapper(User.class);
+        Mapper<User> m = new MappingManager(session()).mapper(User.class);
 
         User u1 = new User("Paul", new Address("12 4th Street", "Springfield", 12345, "12341343", "435423245"));
         u1.addOtherAddress("work", new Address("5 Main Street", "Springfield", 12345, "23431342"));
@@ -219,7 +219,7 @@ public class MapperUDTTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_handle_null_UDT_value() throws Exception {
-        Mapper<User> m = new MappingManager(session).mapper(User.class);
+        Mapper<User> m = new MappingManager(session()).mapper(User.class);
 
         User u1 = new User("Paul", null);
         m.save(u1);
@@ -229,9 +229,9 @@ public class MapperUDTTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void testAccessor() throws Exception {
-        MappingManager manager = new MappingManager(session);
+        MappingManager manager = new MappingManager(session());
 
-        Mapper<User> m = new MappingManager(session).mapper(User.class);
+        Mapper<User> m = new MappingManager(session()).mapper(User.class);
         User u1 = new User("Paul", new Address("12 4th Street", "Springfield", 12345, "12341343", "435423245"));
         m.save(u1);
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/SyntheticFieldsMapperTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/SyntheticFieldsMapperTest.java
@@ -25,8 +25,6 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
-import java.util.Collection;
-import java.util.Collections;
 
 import static org.testng.Assert.assertEquals;
 
@@ -34,8 +32,8 @@ import static org.testng.Assert.assertEquals;
 public class SyntheticFieldsMapperTest extends CCMTestsSupport {
 
     @Override
-    public Collection<String> createTestFixtures() {
-        return Collections.singletonList("CREATE TABLE synthetic_fields (id int PRIMARY KEY)");
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE synthetic_fields (id int PRIMARY KEY)");
     }
 
     /**
@@ -61,7 +59,7 @@ public class SyntheticFieldsMapperTest extends CCMTestsSupport {
         // Instead, it is a different Class (identity + ClassLoader), a modified version of ClassWithSyntheticField
         // Nice ClassCastException will be thrown if we try to cast it to ClassWithSyntheticField
         @SuppressWarnings("unchecked")
-        Mapper<Object> m = (Mapper<Object>) new MappingManager(session).mapper(classWithSyntheticFields);
+        Mapper<Object> m = (Mapper<Object>) new MappingManager(session()).mapper(classWithSyntheticFields);
         m.save(instance);
 
         assertEquals(m.get(42), instance);

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/UDTFieldMapperTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/UDTFieldMapperTest.java
@@ -34,11 +34,11 @@ public class UDTFieldMapperTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void udt_and_tables_with_ks_created_in_another_session_should_be_mapped() {
-        Cluster cluster = register(Cluster.builder()
-                .addContactPointsWithPorts(ccm.addressOfNode(1))
-                .withPort(ccm.getBinaryPort())
+        Cluster cluster1 = register(Cluster.builder()
+                .addContactPoints(getContactPoints().get(0))
+                .withPort(ccm().getBinaryPort())
                 .build());
-        Session session1 = cluster.connect();
+        Session session1 = cluster1.connect();
         // Create type and table
         session1.execute("create schema if not exists java_509 " +
                 "with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
@@ -48,14 +48,14 @@ public class UDTFieldMapperTest extends CCMTestsSupport {
         session1.execute("create table java_509.my_hash (" +
                 "key int primary key, " +
                 "properties map<text, frozen<java_509.my_tuple>>);");
-        cluster.close();
+        cluster1.close();
 
         // Create entities with another connection
-        cluster = register(Cluster.builder()
-                .addContactPointsWithPorts(ccm.addressOfNode(1))
-                .withPort(ccm.getBinaryPort())
+        Cluster cluster2 = register(Cluster.builder()
+                .addContactPoints(getContactPoints().get(0))
+                .withPort(ccm().getBinaryPort())
                 .build());
-        Session session2 = cluster.newSession();
+        Session session2 = cluster2.newSession();
         Mapper<MyHashWithKeyspace> hashMapper = new MappingManager(session2).mapper(MyHashWithKeyspace.class);
         hashMapper.save(new MyHashWithKeyspace(
                 1,
@@ -76,11 +76,11 @@ public class UDTFieldMapperTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void udt_and_tables_without_ks_created_in_another_session_should_be_mapped() {
-        Cluster cluster = register(Cluster.builder()
-                .addContactPointsWithPorts(ccm.addressOfNode(1))
-                .withPort(ccm.getBinaryPort())
+        Cluster cluster1 = register(Cluster.builder()
+                .addContactPoints(getContactPoints().get(0))
+                .withPort(ccm().getBinaryPort())
                 .build());
-        Session session1 = cluster.connect();
+        Session session1 = cluster1.connect();
         session1.execute("create schema if not exists java_509b " +
                 "with replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };");
         session1.execute("use java_509b");
@@ -90,14 +90,14 @@ public class UDTFieldMapperTest extends CCMTestsSupport {
         session1.execute("create table my_hash (" +
                 "key int primary key, " +
                 "properties map<text, frozen<my_tuple>>);");
-        cluster.close();
+        cluster1.close();
 
         // Create entities with another connection
-        cluster = Cluster.builder()
-                .addContactPointsWithPorts(ccm.addressOfNode(1))
-                .withPort(ccm.getBinaryPort())
-                .build();
-        Session session2 = cluster.newSession();
+        Cluster cluster2 = register(Cluster.builder()
+                .addContactPoints(getContactPoints().get(0))
+                .withPort(ccm().getBinaryPort())
+                .build());
+        Session session2 = cluster2.newSession();
 
         session2.execute("use java_509b");
         Mapper<MyHash> hashMapper = new MappingManager(session2).mapper(MyHash.class);


### PR DESCRIPTION
A few more fixes for intermittently failing tests. Nothing extraordinary, most changes consist in raising timeouts or pausing before/after tests. Note that this includes fixes for JAVA-1039 from #575 .

This PR also makes a few changes to allow CCMTestsSupport to be easily subclassed.
- Direct access to ccm, cluster and session is replaced with methods (also provides better protection against tests that would reassign these fields);
- `createTestFixtures` has been refactored into `onTestContextInitialized`, to allow e.g. graph queries to be executed at this step as well as normal queries.

The PR looks big mostly because of 183795f and 2289c5b.
