### PR TITLE
Update clirr-ignores.xml with false positives due to optional compilation of JDK8-only classes.

### DIFF
--- a/clirr-ignores.xml
+++ b/clirr-ignores.xml
@@ -9,4 +9,35 @@
   * add new differences if needed. Difference types are explained at http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html
 -->
 <differences>
+
+    <difference>
+        <differenceType>8001</differenceType> <!-- class removed -->
+        <className>com/datastax/driver/extras/codecs/jdk8/InstantCodec</className>
+        <justification>This class is only present if the project was compiled with JDK 8+</justification>
+    </difference>
+
+    <difference>
+        <differenceType>8001</differenceType> <!-- class removed -->
+        <className>com/datastax/driver/extras/codecs/jdk8/LocalDateCodec</className>
+        <justification>This class is only present if the project was compiled with JDK 8+</justification>
+    </difference>
+
+    <difference>
+        <differenceType>8001</differenceType> <!-- class removed -->
+        <className>com/datastax/driver/extras/codecs/jdk8/LocalTimeCodec</className>
+        <justification>This class is only present if the project was compiled with JDK 8+</justification>
+    </difference>
+
+    <difference>
+        <differenceType>8001</differenceType> <!-- class removed -->
+        <className>com/datastax/driver/extras/codecs/jdk8/OptionalCodec</className>
+        <justification>This class is only present if the project was compiled with JDK 8+</justification>
+    </difference>
+
+    <difference>
+        <differenceType>8001</differenceType> <!-- class removed -->
+        <className>com/datastax/driver/extras/codecs/jdk8/ZonedDateTimeCodec</className>
+        <justification>This class is only present if the project was compiled with JDK 8+</justification>
+    </difference>
+
 </differences>


### PR DESCRIPTION
Builds of 3.0 branch done with JDKs older than 8 are currently failing with the following output:

```
[INFO] --- clirr-maven-plugin:2.7:check (default) @ cassandra-driver-extras ---
[INFO] Comparing to version: 3.0.0
[INFO] Downloading: http://repo.maven.apache.org/maven2/com/datastax/cassandra/cassandra-driver-extras/3.0.0/cassandra-driver-extras-3.0.0.jar
[INFO] Downloaded: http://repo.maven.apache.org/maven2/com/datastax/cassandra/cassandra-driver-extras/3.0.0/cassandra-driver-extras-3.0.0.jar (56 KB at 5524.9 KB/sec)
[INFO] Downloading: http://repo.maven.apache.org/maven2/com/datastax/cassandra/cassandra-driver-extras/3.0.0/cassandra-driver-extras-3.0.0.pom
[INFO] Downloaded: http://repo.maven.apache.org/maven2/com/datastax/cassandra/cassandra-driver-extras/3.0.0/cassandra-driver-extras-3.0.0.pom (10 KB at 901.8 KB/sec)
[ERROR] 8001: com.datastax.driver.extras.codecs.jdk8.InstantCodec: Class com.datastax.driver.extras.codecs.jdk8.InstantCodec removed
[ERROR] 8001: com.datastax.driver.extras.codecs.jdk8.LocalDateCodec: Class com.datastax.driver.extras.codecs.jdk8.LocalDateCodec removed
[ERROR] 8001: com.datastax.driver.extras.codecs.jdk8.LocalTimeCodec: Class com.datastax.driver.extras.codecs.jdk8.LocalTimeCodec removed
[ERROR] 8001: com.datastax.driver.extras.codecs.jdk8.OptionalCodec: Class com.datastax.driver.extras.codecs.jdk8.OptionalCodec removed
```

This is due to the fact that these classes are not compiled if the project is being compiled with JDK 6 or 7.
