### PR TITLE
JAVA-630: Don't process DOWN events for nodes that have active connec…

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -13,6 +13,7 @@
 - [improvement] JAVA-843: Disable frozen checks in mapper.
 - [improvement] JAVA-833: Improve message when a nested type can't be serialized.
 - [improvement] JAVA-1011: Expose PoolingOptions default values.
+- [improvement] JAVA-630: Don't process DOWN events for nodes that have active connections.
 
 Merged from 2.0 branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/ConvictionPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ConvictionPolicy.java
@@ -53,6 +53,8 @@ abstract class ConvictionPolicy {
 
     abstract boolean canReconnectNow();
 
+    abstract boolean hasActiveConnections();
+
     /**
      * Simple factory interface to allow creating {@link ConvictionPolicy} instances.
      */
@@ -130,6 +132,11 @@ abstract class ConvictionPolicy {
                     System.nanoTime() >= nextReconnectionTime;
             Host.statesLogger.trace("canReconnectNow={}", canReconnectNow);
             return canReconnectNow;
+        }
+
+        @Override
+        boolean hasActiveConnections() {
+            return openConnections.get() > 0;
         }
 
         static class Factory implements ConvictionPolicy.Factory {


### PR DESCRIPTION
…tions.

Tested manually:
- 3-node ccm cluster on localhost
- start a Java program with a host listener that logs events
- block all gossip to simulate control host isolation: `sudo ./tcpkill -i lo0 dst port 7000`

I tried various combinations:
- initialized cluster with no session: should always process down events (no pooled connections)
- with connected session: should ignore down events (hosts have working pooled connections)
- use whitelist policy to ignore one node: should always process down events for that node
