### PR TITLE
JAVA-1038: Fetch node info by rpc_address if it has a broadcast_address which is not in system.peers.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -16,6 +16,7 @@
 - [improvement] JAVA-630: Don't process DOWN events for nodes that have active connections.
 - [improvement] JAVA-851: Improve UUIDs javadoc with regard to user-provided timestamps.
 - [improvement] JAVA-979: Update javadoc for RegularStatement toString() and getQueryString() to indicate that consistency level and other parameters are not maintained in the query string.
+- [improvement] JAVA-1038: Fetch node info by rpc_address if its broadcast_address is not in system.peers.
 
 Merged from 2.0 branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -448,7 +448,14 @@ class ControlConnection implements Host.StateListener, Connection.Owner {
                     ? new DefaultResultSetFuture(null, cluster.protocolVersion(), new Requests.Query(SELECT_LOCAL))
                     : new DefaultResultSetFuture(null, cluster.protocolVersion(), new Requests.Query(SELECT_PEERS + " WHERE peer='" + host.listenAddress.getHostAddress() + '\''));
             c.write(future);
-            return future.get().one();
+            Row row = future.get().one();
+            if (row != null) {
+                return row;
+            } else {
+                logger.debug("Could not find peer with broadcast address {}, " +
+                        "falling back to a full system.peers scan to fetch info for {} " +
+                        "(this can happen if the broadcast address changed)", host.listenAddress, host);
+            }
         }
 
         // We have to fetch the whole peers table and find the host we're looking for

--- a/driver-core/src/test/java/com/datastax/driver/core/ScassandraCluster.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ScassandraCluster.java
@@ -259,7 +259,7 @@ public class ScassandraCluster {
         start(cluster, ipSuffix(dc, node));
     }
 
-    private List<Long> getTokensForDC(int dc) {
+    public List<Long> getTokensForDC(int dc) {
         // Offset DCs by dc * 100 to ensure unique tokens.
         int offset = (dc - 1) * 100;
         int dcNodeCount = nodes(dc).size();
@@ -367,7 +367,7 @@ public class ScassandraCluster {
                 : defaultValue;
     }
 
-    static final org.scassandra.http.client.types.ColumnMetadata[] SELECT_PEERS = {
+    public static final org.scassandra.http.client.types.ColumnMetadata[] SELECT_PEERS = {
             column("peer", INET),
             column("rpc_address", INET),
             column("data_center", TEXT),
@@ -376,7 +376,7 @@ public class ScassandraCluster {
             column("tokens", set(TEXT))
     };
 
-    static final org.scassandra.http.client.types.ColumnMetadata[] SELECT_LOCAL = {
+    public static final org.scassandra.http.client.types.ColumnMetadata[] SELECT_LOCAL = {
             column("key", TEXT),
             column("bootstrapped", TEXT),
             column("broadcast_address", INET),


### PR DESCRIPTION
This supersedes #550 .
