### PR TITLE
Define isolated profile that disables tests at parent level.

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -352,23 +352,10 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <version>2.16</version>
             <configuration>
-              <forkCount>1</forkCount>
-              <reuseForks>false</reuseForks>
-              <groups>isolated</groups>
-              <!-- Files containing tests to be included must be added here.
-                   this prevents a fork being created for each test class. -->
+              <skip>false</skip>
               <includes>
                 <include>**/SSL*Test.java</include>
               </includes>
-              <reportNameSuffix>isolated</reportNameSuffix>
-              <useFile>false</useFile>
-              <systemPropertyVariables>
-                <cassandra.version>${cassandra.version}</cassandra.version>
-                <ipprefix>${ipprefix}</ipprefix>
-              </systemPropertyVariables>
-              <classpathDependencyExcludes>
-                <classpathDependencyExcludes>io.netty:netty-transport-native-epoll</classpathDependencyExcludes>
-              </classpathDependencyExcludes>
             </configuration>
           </plugin>
         </plugins>

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorParamsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorParamsTest.java
@@ -265,9 +265,9 @@ public class MapperAccessorParamsTest extends CCMTestsSupport {
 
     @Accessor
     public interface UserPhoneAccessor_WrongParameterTypes {
-        @Query("select * from user where key IN (:keys)")
-            // WRONG, should be "where key IN :keys"
-        void findUsersBykeys(@Param("keys") List<Integer> keys);
+        @Query("select * from user where key IN (?)")
+        // WRONG, should be "where key IN ?"
+        void findUsersBykeys(List<Integer> keys);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,41 @@
         <javadoc.opts>-Xdoclint:none</javadoc.opts>
       </properties>
     </profile>
+    <profile>
+      <!-- default profile settings for 'isolated' test group, will skip tests unless overriden in child module. -->
+      <id>isolated</id>
+      <properties>
+        <env>default</env>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.16</version>
+            <configuration>
+              <skip>true</skip>
+              <forkCount>1</forkCount>
+              <reuseForks>false</reuseForks>
+              <groups>isolated</groups>
+              <reportNameSuffix>isolated</reportNameSuffix>
+              <useFile>false</useFile>
+              <systemPropertyVariables>
+                <cassandra.version>${cassandra.version}</cassandra.version>
+                <ipprefix>${ipprefix}</ipprefix>
+              </systemPropertyVariables>
+              <classpathDependencyExcludes>
+                <classpathDependencyExcludes>io.netty:netty-transport-native-epoll</classpathDependencyExcludes>
+              </classpathDependencyExcludes>
+              <!-- This requires includes to be explicitly specified by implementing classes.
+                   This is needed to prevent creating a JVM fork for each test, even those that don't
+                   have the isolated group. -->
+              <includes/>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <build>


### PR DESCRIPTION
The 'isolated' profile was introduced in driver-core a while back to run tests in their own JVM fork when needed.  This causes problems however when another submodule like driver-mapping doesn't have an isolated profile in which it will run unit tests and overwrite any existing surefire report.  This change disables tests when running with isolated group unless you override it explicitly in a module that desires to use it.
