### PR TITLE
JAVA-905: Detect if many null fields are being written from Mapped objects.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -39,6 +39,7 @@
 - [improvement] JAVA-977: Preserve original cause when BuiltStatement value can't be serialized.
 - [bug] JAVA-1094: Backport TypeCodec parse and format fixes from 3.0.
 - [improvement] JAVA-852: Ignore peers with null entries during discovery.
+- [improvement] JAVA-905: Detect if many null fields are being written from Mapped objects.
 
 Merged from 2.0 branch:
 

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/Mapper.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/Mapper.java
@@ -225,10 +225,9 @@ public class Mapper<T> {
             if (cm.kind != ColumnMapper.Kind.COMPUTED && (saveNullFields || value != null)) {
                 values.put(cm, value);
             }
-            if (saveNullFields && value == null) {
+            if (saveNullFields && value == null && mapperMetrics != null) {
                 MapperMetrics.EntityMetrics metrics = mapperMetrics.getEntityMetrics(entity.getClass());
-                metrics.nullFieldsHistogram.update(1);
-                long count = metrics.nullFieldsHistogram.getCount();
+                long count = metrics.getNullFieldsCounter().incrementAndGetCount();
                 if (count > NULL_FIELDS_COUNT_WARNING_THRESHOLD) {
                     long now = System.nanoTime();
                     if (now > lastNullFieldsCountWarning + NULL_FIELDS_COUNT_WARNING_INTERVAL_NS) {
@@ -939,7 +938,7 @@ public class Mapper<T> {
 
         static class Ttl extends Option {
 
-            private int ttlValue;
+            private final int ttlValue;
 
             Ttl(int value) {
                 super(Type.TTL);
@@ -975,7 +974,7 @@ public class Mapper<T> {
 
         static class Timestamp extends Option {
 
-            private long tsValue;
+            private final long tsValue;
 
             Timestamp(long value) {
                 super(Type.TIMESTAMP);
@@ -1011,7 +1010,7 @@ public class Mapper<T> {
 
         static class ConsistencyLevelOption extends Option {
 
-            private ConsistencyLevel cl;
+            private final ConsistencyLevel cl;
 
             ConsistencyLevelOption(ConsistencyLevel cl) {
                 super(Type.CL);
@@ -1047,7 +1046,7 @@ public class Mapper<T> {
 
         static class Tracing extends Option {
 
-            private boolean tracing;
+            private final boolean tracing;
 
             Tracing(boolean tracing) {
                 super(Type.TRACING);
@@ -1084,7 +1083,7 @@ public class Mapper<T> {
 
         static class SaveNullFields extends Option {
 
-            private boolean saveNullFields;
+            private final boolean saveNullFields;
 
             SaveNullFields(boolean saveNullFields) {
                 super(SAVE_NULL_FIELDS);

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/MapperMetrics.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/MapperMetrics.java
@@ -1,0 +1,115 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.JmxReporter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SlidingTimeWindowReservoir;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.LifecycleAwareLatencyTracker;
+import com.datastax.driver.core.Statement;
+import com.google.common.base.Throwables;
+import com.google.common.cache.*;
+
+import java.util.concurrent.ExecutionException;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+/**
+ * Metrics exposed by the object mapper.
+ * <p/>
+ * The metrics exposed by this class use the <a href="http://metrics.codahale.com/">Metrics</a>
+ * library and you should refer its <a href="http://metrics.codahale.com/manual/">documentation</a>
+ * for details on how to handle the exposed metric objects.
+ * <p/>
+ * By default, metrics are exposed through JMX, which is very useful for
+ * development and browsing, but for production environments you may want to
+ * have a look at the <a href="http://metrics.codahale.com/manual/core/#reporters">reporters</a>
+ * provided by the Metrics library which could be more efficient/adapted.
+ */
+public class MapperMetrics {
+
+    static class EntityMetrics {
+
+        // TODO configurable sliding window?
+        final Histogram nullFieldsHistogram = new Histogram(new SlidingTimeWindowReservoir(5, MINUTES));
+
+    }
+
+    private final MetricRegistry registry = new MetricRegistry();
+
+    private final LoadingCache<Class<?>, EntityMetrics> metricsByEntity = CacheBuilder.newBuilder()
+            .expireAfterAccess(5, MINUTES)
+            .removalListener(new RemovalListener<Class<?>, EntityMetrics>() {
+
+                @Override
+                public void onRemoval(RemovalNotification<Class<?>, EntityMetrics> notification) {
+                    Class<?> entityClass = notification.getKey();
+                    if (entityClass != null)
+                        registry.remove(entityClass.getName() + "-null-fields");
+                }
+
+            })
+            .build(new CacheLoader<Class<?>, EntityMetrics>() {
+
+                @Override
+                public EntityMetrics load(Class<?> entityClass) throws Exception {
+                    EntityMetrics metrics = new EntityMetrics();
+                    registry.register(entityClass.getName() + "-null-fields", metrics.nullFieldsHistogram);
+                    return metrics;
+                }
+
+            });
+
+    private final JmxReporter jmxReporter;
+
+    MapperMetrics(Cluster cluster) {
+        if (cluster.getConfiguration().getMetricsOptions().isJMXReportingEnabled()) {
+            this.jmxReporter = JmxReporter.forRegistry(registry).inDomain(cluster.getClusterName() + "-mapper-metrics").build();
+            this.jmxReporter.start();
+            // a bit ugly but works
+            // a general-purpose lifecycle-aware thing would be better
+            cluster.register(new LifecycleAwareLatencyTracker() {
+                @Override
+                public void onRegister(Cluster cluster) {
+                }
+
+                @Override
+                public void onUnregister(Cluster cluster) {
+                    jmxReporter.stop();
+                }
+
+                @Override
+                public void update(Host host, Statement statement, Exception exception, long newLatencyNanos) {
+                }
+            });
+        } else {
+            this.jmxReporter = null;
+        }
+    }
+
+    public EntityMetrics getEntityMetrics(Class<?> entityClass) {
+        EntityMetrics metrics = null;
+        try {
+            metrics = metricsByEntity.get(entityClass);
+        } catch (ExecutionException e) {
+            Throwables.propagate(e);
+        }
+        return metrics;
+    }
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/MapperMetrics.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/MapperMetrics.java
@@ -52,10 +52,10 @@ public class MapperMetrics {
 
     /**
      * A simple sliding time window that keeps a global counter of events
-     * happened in the last N minutes (or whichever time unit is used.
+     * happened in the last N minutes (or whichever time unit is used).
      * <p>
      * The window is backed by an {@link AtomicReferenceArray} that acts
-     * like a circular buffer and stores individual counter for each buffer slot.
+     * like a circular buffer and stores individual counters for each buffer slot.
      * <p>
      * The accuracy depends on the buffer size, and hence on the window parameters.
      * The more time slots, the more accurate it is.
@@ -88,7 +88,7 @@ public class MapperMetrics {
          * Creates a new counter with the specified {@code windowSize}
          * and the specified {@code slotSize}; the ratio {@code windowSize / slotSize}
          * determines the accuracy of the counter: the higher the ratio is, the more
-         * accurate the counter will be.
+         * accurate the counter will be, at the cost of more memory.
          *
          * @param windowSize the window size in time units.
          * @param slotSize   the slot size in time units.
@@ -141,9 +141,10 @@ public class MapperMetrics {
                     if (i == slotToUpdate) {
                         if (current == null || now >= current.expiresAt)
                             // slot expired, reset counter
-                            update = new TimeSlot(now + windowSizeMillis, 1);
+                            update = new TimeSlot(now + windowSizeMillis, increment);
                         else
-                            update = new TimeSlot(current.expiresAt, current.count + 1);
+                            // update counter
+                            update = new TimeSlot(current.expiresAt, current.count + increment);
                     } else {
                         if (current != null && now < current.expiresAt)
                             update = current;

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/MapperMetrics.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/MapperMetrics.java
@@ -15,20 +15,21 @@
  */
 package com.datastax.driver.mapping;
 
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.JmxReporter;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Counting;
+import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.SlidingTimeWindowReservoir;
 import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.Host;
-import com.datastax.driver.core.LifecycleAwareLatencyTracker;
-import com.datastax.driver.core.Statement;
 import com.google.common.base.Throwables;
 import com.google.common.cache.*;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Metrics exposed by the object mapper.
@@ -41,68 +42,194 @@ import static java.util.concurrent.TimeUnit.MINUTES;
  * development and browsing, but for production environments you may want to
  * have a look at the <a href="http://metrics.codahale.com/manual/core/#reporters">reporters</a>
  * provided by the Metrics library which could be more efficient/adapted.
+ * <p>
+ * To disable metrics for the mapper altogether, set the system property
+ * <code>{@value DISABLE_METRICS_KEY}</code> to {@code "true"}.
  */
 public class MapperMetrics {
 
-    static class EntityMetrics {
+    public static final String DISABLE_METRICS_KEY = "com.datastax.driver.mapping.DISABLE_METRICS";
 
-        // TODO configurable sliding window?
-        final Histogram nullFieldsHistogram = new Histogram(new SlidingTimeWindowReservoir(5, MINUTES));
+    /**
+     * A simple sliding time window that keeps a global counter of events
+     * happened in the last N minutes (or whichever time unit is used.
+     * <p>
+     * The window is backed by an {@link AtomicReferenceArray} that acts
+     * like a circular buffer and stores individual counter for each buffer slot.
+     * <p>
+     * The accuracy depends on the buffer size, and hence on the window parameters.
+     * The more time slots, the more accurate it is.
+     * <p>
+     * Unfortunately implementing Counting is not enough, we need to extend Counter.
+     * See https://github.com/dropwizard/metrics/issues/703.
+     */
+    public static class SlidingTimeWindowCounter extends Counter implements Metric, Counting {
 
-    }
+        private static class TimeSlot {
 
-    private final MetricRegistry registry = new MetricRegistry();
+            final long expiresAt;
 
-    private final LoadingCache<Class<?>, EntityMetrics> metricsByEntity = CacheBuilder.newBuilder()
-            .expireAfterAccess(5, MINUTES)
-            .removalListener(new RemovalListener<Class<?>, EntityMetrics>() {
+            final long count;
 
-                @Override
-                public void onRemoval(RemovalNotification<Class<?>, EntityMetrics> notification) {
-                    Class<?> entityClass = notification.getKey();
-                    if (entityClass != null)
-                        registry.remove(entityClass.getName() + "-null-fields");
-                }
+            TimeSlot(long expiresAt, long count) {
+                this.expiresAt = expiresAt;
+                this.count = count;
+            }
 
-            })
-            .build(new CacheLoader<Class<?>, EntityMetrics>() {
+        }
 
-                @Override
-                public EntityMetrics load(Class<?> entityClass) throws Exception {
-                    EntityMetrics metrics = new EntityMetrics();
-                    registry.register(entityClass.getName() + "-null-fields", metrics.nullFieldsHistogram);
-                    return metrics;
-                }
+        private final AtomicReferenceArray<TimeSlot> window;
 
-            });
+        private final long windowSizeMillis;
 
-    private final JmxReporter jmxReporter;
+        private final long slotSizeMillis;
 
-    MapperMetrics(Cluster cluster) {
-        if (cluster.getConfiguration().getMetricsOptions().isJMXReportingEnabled()) {
-            this.jmxReporter = JmxReporter.forRegistry(registry).inDomain(cluster.getClusterName() + "-mapper-metrics").build();
-            this.jmxReporter.start();
-            // a bit ugly but works
-            // a general-purpose lifecycle-aware thing would be better
-            cluster.register(new LifecycleAwareLatencyTracker() {
-                @Override
-                public void onRegister(Cluster cluster) {
-                }
+        /**
+         * Creates a new counter with the specified {@code windowSize}
+         * and the specified {@code slotSize}; the ratio {@code windowSize / slotSize}
+         * determines the accuracy of the counter: the higher the ratio is, the more
+         * accurate the counter will be.
+         *
+         * @param windowSize the window size in time units.
+         * @param slotSize   the slot size in time units.
+         * @param unit       the time unit to use.
+         */
+        public SlidingTimeWindowCounter(long windowSize, long slotSize, TimeUnit unit) {
+            windowSizeMillis = unit.toMillis(windowSize);
+            slotSizeMillis = unit.toMillis(slotSize);
+            window = new AtomicReferenceArray<TimeSlot>((int) (windowSize / slotSize));
+        }
 
-                @Override
-                public void onUnregister(Cluster cluster) {
-                    jmxReporter.stop();
-                }
+        public long incrementAndGetCount() {
+            return incrementAndGetCount(1);
+        }
 
-                @Override
-                public void update(Host host, Statement statement, Exception exception, long newLatencyNanos) {
-                }
-            });
-        } else {
-            this.jmxReporter = null;
+        @Override
+        public long getCount() {
+            return incrementAndGetCount(0);
+        }
+
+        @Override
+        public void inc() {
+            incrementAndGetCount(1);
+        }
+
+        @Override
+        public void inc(long n) {
+            incrementAndGetCount(n);
+        }
+
+        @Override
+        public void dec() {
+            incrementAndGetCount(-1);
+        }
+
+        @Override
+        public void dec(long n) {
+            incrementAndGetCount(-n);
+        }
+
+        private long incrementAndGetCount(long increment) {
+            long count = 0;
+            long now = System.currentTimeMillis();
+            int slotToUpdate = increment == 0 ? -1 : (int) ((now / slotSizeMillis) % window.length());
+            for (int i = 0; i < window.length(); i++) {
+                TimeSlot current;
+                TimeSlot update = null;
+                do {
+                    current = window.get(i);
+                    if (i == slotToUpdate) {
+                        if (current == null || now >= current.expiresAt)
+                            // slot expired, reset counter
+                            update = new TimeSlot(now + windowSizeMillis, 1);
+                        else
+                            update = new TimeSlot(current.expiresAt, current.count + 1);
+                    } else {
+                        if (current != null && now < current.expiresAt)
+                            update = current;
+                    }
+                } while (i == slotToUpdate && !window.compareAndSet(i, current, update));
+                if (update != null)
+                    count += update.count;
+            }
+            return count;
         }
     }
 
+    /**
+     * Statistics and metrics about a given entity.
+     */
+    public static class EntityMetrics {
+
+        private final Class<?> entityClass;
+
+        private final SlidingTimeWindowCounter nullFieldsCounter;
+
+        public EntityMetrics(Class<?> entityClass, SlidingTimeWindowCounter nullFieldsCounter) {
+            this.entityClass = entityClass;
+            this.nullFieldsCounter = nullFieldsCounter;
+        }
+
+        /**
+         * @return The entity class.
+         */
+        public Class<?> getEntityClass() {
+            return entityClass;
+        }
+
+        public SlidingTimeWindowCounter getNullFieldsCounter() {
+            return nullFieldsCounter;
+        }
+
+    }
+
+    private static final AtomicInteger COUNTER = new AtomicInteger(0);
+
+    private class EntityMetricsLoader extends CacheLoader<Class<?>, EntityMetrics> {
+
+        @Override
+        public EntityMetrics load(Class<?> entityClass) throws Exception {
+            // TODO configurable sliding window?
+            // default is 5 minutes with slots of 10 seconds (30 slots)
+            EntityMetrics metrics = new EntityMetrics(entityClass, new SlidingTimeWindowCounter(300, 10, SECONDS));
+            registry.register(String.format("mapper-%s-%s-null-fields", id, entityClass.getName()), metrics.nullFieldsCounter);
+            return metrics;
+        }
+
+    }
+
+    private class EntityMetricsRemovalListener implements RemovalListener<Class<?>, EntityMetrics> {
+
+        @Override
+        public void onRemoval(RemovalNotification<Class<?>, EntityMetrics> notification) {
+            Class<?> entityClass = notification.getKey();
+            if (entityClass != null)
+                registry.remove(String.format("mapper-%s-%s-null-fields", id, entityClass.getName()));
+        }
+
+    }
+
+    private final MetricRegistry registry;
+
+    // distinguish between different instances of this class
+    private final int id;
+
+    private final LoadingCache<Class<?>, EntityMetrics> metricsByEntity = CacheBuilder.newBuilder()
+            .expireAfterAccess(5, MINUTES)
+            .removalListener(new EntityMetricsRemovalListener())
+            .build(new EntityMetricsLoader());
+
+    MapperMetrics(Cluster cluster) {
+        registry = cluster.getMetrics().getRegistry();
+        id = COUNTER.incrementAndGet();
+    }
+
+    /**
+     * Gathers metrics about the given entity class.
+     *
+     * @param entityClass the entity class to gather metrics for.
+     * @return An {@link EntityMetrics} with metrics for the given entity class.
+     */
     public EntityMetrics getEntityMetrics(Class<?> entityClass) {
         EntityMetrics metrics = null;
         try {
@@ -112,4 +239,5 @@ public class MapperMetrics {
         }
         return metrics;
     }
+
 }

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/MappingManager.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/MappingManager.java
@@ -32,6 +32,8 @@ public class MappingManager {
     private final Session session;
     final boolean isCassandraV1;
 
+    private final MapperMetrics mapperMetrics;
+
     private volatile Map<Class<?>, Mapper<?>> mappers = Collections.<Class<?>, Mapper<?>>emptyMap();
     private volatile Map<Class<?>, UDTMapper<?>> udtMappers = Collections.<Class<?>, UDTMapper<?>>emptyMap();
     private volatile Map<Class<?>, Object> accessors = Collections.<Class<?>, Object>emptyMap();
@@ -72,6 +74,7 @@ public class MappingManager {
         // which nodes might join the cluster later.
         // At least if protocol >=2 we know there won't be any 1.2 nodes ever.
         this.isCassandraV1 = (protocolVersion == ProtocolVersion.V1);
+        this.mapperMetrics = new MapperMetrics(session.getCluster());
     }
 
     /**
@@ -145,7 +148,7 @@ public class MappingManager {
                 mapper = (Mapper<T>) mappers.get(klass);
                 if (mapper == null) {
                     EntityMapper<T> entityMapper = AnnotationParser.parseEntity(klass, ReflectionMapper.factory(), this);
-                    mapper = new Mapper<T>(this, klass, entityMapper);
+                    mapper = new Mapper<T>(this, klass, entityMapper, mapperMetrics);
                     Map<Class<?>, Mapper<?>> newMappers = new HashMap<Class<?>, Mapper<?>>(mappers);
                     newMappers.put(klass, mapper);
                     mappers = newMappers;

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/SystemProperties.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/SystemProperties.java
@@ -1,0 +1,61 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Allows overriding internal settings via system properties.
+ * This is copied from com.datastax.driver.core.SystemProperties
+ * because we don't want to expose it.
+ */
+class SystemProperties {
+
+    private static final Logger logger = LoggerFactory.getLogger(SystemProperties.class);
+
+    static int getInt(String key, int defaultValue) {
+        String stringValue = System.getProperty(key);
+        if (stringValue == null) {
+            logger.debug("{} is undefined, using default value {}", key, defaultValue);
+            return defaultValue;
+        }
+        try {
+            int value = Integer.parseInt(stringValue);
+            logger.warn("{} is defined, using value {}", key, value);
+            return value;
+        } catch (NumberFormatException e) {
+            logger.warn("{} is defined but could not parse value {}, using default value {}", key, stringValue, defaultValue);
+            return defaultValue;
+        }
+    }
+
+    static boolean getBoolean(String key, boolean defaultValue) {
+        String stringValue = System.getProperty(key);
+        if (stringValue == null) {
+            logger.debug("{} is undefined, using default value {}", key, defaultValue);
+            return defaultValue;
+        }
+        try {
+            boolean value = Boolean.parseBoolean(stringValue);
+            logger.warn("{} is defined, using value {}", key, value);
+            return value;
+        } catch (NumberFormatException e) {
+            logger.warn("{} is defined but could not parse value {}, using default value {}", key, stringValue, defaultValue);
+            return defaultValue;
+        }
+    }
+}


### PR DESCRIPTION
This solution uses `SlidingTimeWindowReservoir` which, according to the docs, can have a huge memory footprint. If we go forward, we need to figure out a way to prevent this reservoir from taking up the whole heap memory.
