### PR TITLE
Support multiple workloads for DSE nodes, updateDSENodeConfig

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/CCMAccess.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMAccess.java
@@ -203,11 +203,11 @@ public interface CCMAccess extends Closeable {
     void updateNodeConfig(int n, Map<String, Object> configs);
 
     /**
-     * Sets the workload for the {@code nth} host in the CCM cluster.
+     * Sets the workload(s) for the {@code nth} host in the CCM cluster.
      *
      * @param n the node number (starting from 1).
      */
-    void setWorkload(int n, Workload workload);
+    void setWorkload(int n, Workload... workload);
 
 
     // Methods blocking until nodes are up or down

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMAccess.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMAccess.java
@@ -203,6 +203,20 @@ public interface CCMAccess extends Closeable {
     void updateNodeConfig(int n, Map<String, Object> configs);
 
     /**
+     * Updates the {@code nth} host's dse config file in the CCM cluster.
+     *
+     * @param n the node number (starting from 1).
+     */
+    void updateDSENodeConfig(int n, String key, Object value);
+
+    /**
+     * Updates the {@code nth} host's dse config file in the CCM cluster.
+     *
+     * @param n the node number (starting from 1).
+     */
+    void updateDSENodeConfig(int n, Map<String, Object> configs);
+
+    /**
      * Sets the workload(s) for the {@code nth} host in the CCM cluster.
      *
      * @param n the node number (starting from 1).

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -537,8 +537,9 @@ public class CCMBridge implements CCMAccess {
     }
 
     @Override
-    public void setWorkload(int node, Workload workload) {
-        execute(CCM_COMMAND + " node%d setworkload %s", node, workload);
+    public void setWorkload(int node, Workload... workload) {
+        String workloadStr = Joiner.on(",").join(workload);
+        execute(CCM_COMMAND + " node%d setworkload %s", node, workloadStr);
     }
 
     private String execute(String command, Object... args) {
@@ -673,7 +674,7 @@ public class CCMBridge implements CCMAccess {
         private Set<String> jvmArgs = new LinkedHashSet<String>();
         private final Map<String, Object> cassandraConfiguration = Maps.newLinkedHashMap();
         private final Map<String, Object> dseConfiguration = Maps.newLinkedHashMap();
-        private Map<Integer, Workload> workloads = new HashMap<Integer, Workload>();
+        private Map<Integer, Workload[]> workloads = new HashMap<Integer, Workload[]>();
 
         private Builder() {
             cassandraConfiguration.put("start_rpc", false);
@@ -804,10 +805,10 @@ public class CCMBridge implements CCMAccess {
          * Sets the DSE workload for a given node.
          *
          * @param node     The node to set the workload for (starting with 1).
-         * @param workload The workload (e.g. solr, spark, hadoop)
+         * @param workload The workload(s) (e.g. solr, spark, hadoop)
          * @return This builder
          */
-        public Builder withWorkload(int node, Workload workload) {
+        public Builder withWorkload(int node, Workload... workload) {
             this.workloads.put(node, workload);
             return this;
         }
@@ -833,7 +834,7 @@ public class CCMBridge implements CCMAccess {
             ccm.updateConfig(cassandraConfiguration);
             if (!dseConfiguration.isEmpty())
                 ccm.updateDSEConfig(dseConfiguration);
-            for (Map.Entry<Integer, Workload> entry : workloads.entrySet()) {
+            for (Map.Entry<Integer, Workload[]> entry : workloads.entrySet()) {
                 ccm.setWorkload(entry.getKey(), entry.getValue());
             }
             if (start)

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -537,6 +537,24 @@ public class CCMBridge implements CCMAccess {
     }
 
     @Override
+    public void updateDSENodeConfig(int n, String key, Object value) {
+        updateDSENodeConfig(n, ImmutableMap.<String, Object>builder().put(key, value).build());
+    }
+
+    @Override
+    public void updateDSENodeConfig(int n, Map<String, Object> configs) {
+        StringBuilder confStr = new StringBuilder();
+        for (Map.Entry<String, Object> entry : configs.entrySet()) {
+            confStr
+                    .append(entry.getKey())
+                    .append(":")
+                    .append(entry.getValue())
+                    .append(" ");
+        }
+        execute(CCM_COMMAND + " node%s updatedseconf %s", n, confStr);
+    }
+
+    @Override
     public void setWorkload(int node, Workload... workload) {
         String workloadStr = Joiner.on(",").join(workload);
         execute(CCM_COMMAND + " node%d setworkload %s", node, workloadStr);

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMCache.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMCache.java
@@ -191,6 +191,16 @@ public class CCMCache {
         }
 
         @Override
+        public void updateDSENodeConfig(int n, String key, Object value) {
+            ccm.updateDSENodeConfig(n, key, value);
+        }
+
+        @Override
+        public void updateDSENodeConfig(int n, Map<String, Object> configs) {
+            ccm.updateDSENodeConfig(n, configs);
+        }
+
+        @Override
         public void setWorkload(int n, Workload... workload) {
             ccm.setWorkload(n, workload);
         }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMCache.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMCache.java
@@ -191,7 +191,7 @@ public class CCMCache {
         }
 
         @Override
-        public void setWorkload(int n, Workload workload) {
+        public void setWorkload(int n, Workload... workload) {
             ccm.setWorkload(n, workload);
         }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMConfig.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMConfig.java
@@ -135,7 +135,7 @@ public @interface CCMConfig {
      *
      * @return The workloads to assign to each node.
      */
-    CCMAccess.Workload[] workloads() default {};
+    CCMWorkload[] workloads() default {};
 
     /**
      * Returns {@code true} if a {@link CCMBridge} instance should be automatically created, {@code false} otherwise.

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
@@ -361,17 +361,17 @@ public class CCMTestsSupport {
             return args;
         }
 
-        private List<Workload> workloads() {
+        private List<Workload[]> workloads() {
             int total = 0;
             for (int perDc : numberOfNodes())
                 total += perDc;
-            List<Workload> workloads = new ArrayList<Workload>(Collections.<Workload>nCopies(total, null));
+            List<Workload[]> workloads = new ArrayList<Workload[]>(Collections.<Workload[]>nCopies(total, null));
             for (int i = annotations.size() - 1; i >= 0; i--) {
                 CCMConfig ann = annotations.get(i);
-                Workload[] annWorkloads = ann.workloads();
+                CCMWorkload[] annWorkloads = ann.workloads();
                 for (int j = 0; j < annWorkloads.length; j++) {
-                    Workload workload = annWorkloads[j];
-                    workloads.set(j, workload);
+                    CCMWorkload nodeWorkloads = annWorkloads[j];
+                    workloads.set(j, nodeWorkloads.value());
                 }
             }
             return workloads;
@@ -448,9 +448,9 @@ public class CCMTestsSupport {
                 for (String arg : jvmArgs()) {
                     ccmBuilder.withJvmArgs(arg);
                 }
-                List<Workload> workloads = workloads();
+                List<Workload[]> workloads = workloads();
                 for (int i = 0; i < workloads.size(); i++) {
-                    Workload workload = workloads.get(i);
+                    Workload[] workload = workloads.get(i);
                     if (workload != null)
                         ccmBuilder.withWorkload(i + 1, workload);
                 }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
@@ -213,7 +213,7 @@ public class CCMTestsSupport {
         }
 
         @Override
-        public void setWorkload(int node, Workload workload) {
+        public void setWorkload(int node, Workload... workload) {
             throw new UnsupportedOperationException("This CCM cluster is read-only");
         }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
@@ -213,6 +213,16 @@ public class CCMTestsSupport {
         }
 
         @Override
+        public void updateDSENodeConfig(int n, String key, Object value) {
+            throw new UnsupportedOperationException("This CCM cluster is read-only");
+        }
+
+        @Override
+        public void updateDSENodeConfig(int n, Map<String, Object> configs) {
+            throw new UnsupportedOperationException("This CCM cluster is read-only");
+        }
+
+        @Override
         public void setWorkload(int node, Workload... workload) {
             throw new UnsupportedOperationException("This CCM cluster is read-only");
         }
@@ -758,6 +768,7 @@ public class CCMTestsSupport {
             }
         }
     }
+
     /**
      * Signals that the test has encountered an unexpected error.
      * <p/>

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMWorkload.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMWorkload.java
@@ -1,0 +1,37 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A set of workloads to assign to a specific node.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface CCMWorkload {
+
+    /**
+     * The workloads to assign to a specific node.
+     *
+     * @return The workloads to assign to a specifc node.
+     */
+    CCMAccess.Workload[] value() default {};
+
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/DseCCMClusterTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DseCCMClusterTest.java
@@ -17,6 +17,8 @@ package com.datastax.driver.core;
 
 import org.testng.annotations.Test;
 
+import static com.datastax.driver.core.CCMAccess.Workload.*;
+
 /**
  * A simple test to validate DSE setups.
  * <p/>
@@ -68,11 +70,21 @@ import org.testng.annotations.Test;
  * A correct example is as follows: {@code /usr/bin:/usr/local/bin:/bin:/usr/sbin:$JAVA_HOME/bin:$PATH}.
  */
 @Test(enabled = false)
-@CCMConfig(dse = true, version = "4.8.3")
+@CCMConfig(
+        dse = true,
+        numberOfNodes = 3,
+        version = "4.8.3",
+        workloads = {
+                @CCMWorkload(solr),
+                @CCMWorkload({spark, solr}),
+                @CCMWorkload({cassandra, spark})
+        }
+)
 public class DseCCMClusterTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_conenct_to_dse() throws InterruptedException {
+
     }
 
 }


### PR DESCRIPTION
Adds support for multiple workloads on a node (i.e. spark and solr on a single node).  Also adds method for calling updatedseconf on a single node as this is now supported by ccm.
