### PR TITLE
JAVA-1086: Support Cassandra 3.2 CAST function in QueryBuilder.

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -10,6 +10,7 @@ cassandra:
   - 2.1
   - 2.2
   - 3.0
+  - 3.4
 build:
   - type: maven
     version: 3.2.5

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -13,6 +13,7 @@
 - [improvement] JAVA-866: Support tuple notation in QueryBuilder.eq/in.
 - [bug] JAVA-1140: Use same connection to check for schema agreement after a DDL query.
 - [improvement] JAVA-1113: Support Cassandra 3.4 LIKE operator in QueryBuilder.
+- [improvement] JAVA-1086: Support Cassandra 3.2 CAST function in QueryBuilder.
 
 Merged from 2.1 branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.driver.core.querybuilder;
 
+import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.TableMetadata;
@@ -1006,6 +1007,17 @@ public final class QueryBuilder {
      */
     public static Object fcall(String name, Object... parameters) {
         return new Utils.FCall(name, parameters);
+    }
+
+    /**
+     * Creates a Cast of a column using the given dataType.
+     *
+     * @param column     the column to cast.
+     * @param dataType   the data type to cast to.
+     * @return the casted column.
+     */
+    public static Object cast(Object column, DataType dataType) {
+        return new Utils.Cast(column, dataType);
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
@@ -15,10 +15,7 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import com.datastax.driver.core.CodecRegistry;
-import com.datastax.driver.core.ProtocolVersion;
-import com.datastax.driver.core.Token;
-import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.core.*;
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 
 import java.math.BigDecimal;
@@ -78,6 +75,11 @@ abstract class Utils {
                 appendValue(fcall.parameters[i], codecRegistry, sb, variables);
             }
             sb.append(')');
+        } else if (value instanceof Cast) {
+            Cast cast = (Cast) value;
+            sb.append("CAST(");
+            appendName(cast.column, codecRegistry, sb);
+            sb.append(" AS ").append(cast.targetType).append(")");
         } else if (value instanceof CName) {
             appendName(((CName) value).name, codecRegistry, sb);
         } else if (value instanceof RawString) {
@@ -264,6 +266,11 @@ abstract class Utils {
             Alias alias = (Alias) name;
             appendName(alias.column, codecRegistry, sb);
             sb.append(" AS ").append(alias.alias);
+        } else if (name instanceof Cast) {
+            Cast cast = (Cast) name;
+            sb.append("CAST(");
+            appendName(cast.column, codecRegistry, sb);
+            sb.append(" AS ").append(cast.targetType).append(")");
         } else if (name instanceof RawString) {
             sb.append(((RawString) name).str);
         } else {
@@ -424,6 +431,21 @@ abstract class Utils {
         @Override
         public String toString() {
             return String.format("%s AS %s", column, alias);
+        }
+    }
+
+    static class Cast {
+        private final Object column;
+        private final DataType targetType;
+
+        Cast(Object column, DataType targetType) {
+            this.column = column;
+            this.targetType = targetType;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("CAST(%s AS %s)", column, targetType);
         }
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
@@ -34,13 +34,20 @@ import static org.testng.Assert.*;
 public class QueryBuilderExecutionTest extends CCMTestsSupport {
 
     private static final String TABLE1 = "test1";
+    private static final String TABLE2 = "test2";
 
     @Override
     public void onTestContextInitialized() {
         execute(
                 String.format("CREATE TABLE %s (k text PRIMARY KEY, t text, i int, f float)", TABLE1),
+                String.format("CREATE TABLE %s (k text, t text, i int, f float, PRIMARY KEY (k, t))", TABLE2),
                 "CREATE TABLE dateTest (t timestamp PRIMARY KEY)",
-                "CREATE TABLE test_coll (k int PRIMARY KEY, a list<int>, b map<int,text>, c set<text>)");
+                "CREATE TABLE test_coll (k int PRIMARY KEY, a list<int>, b map<int,text>, c set<text>)",
+                insertInto(TABLE2).value("k", "cast_t").value("t", "a").value("i", 1).value("f", 1.1).toString(),
+                insertInto(TABLE2).value("k", "cast_t").value("t", "b").value("i", 2).value("f", 2.5).toString(),
+                insertInto(TABLE2).value("k", "cast_t").value("t", "c").value("i", 3).value("f", 3.7).toString(),
+                insertInto(TABLE2).value("k", "cast_t").value("t", "d").value("i", 4).value("f", 5.0).toString()
+        );
     }
 
     @Test(groups = "short")
@@ -183,6 +190,75 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
         //then
         Map<Integer, String> actual = session().execute("SELECT b FROM test_coll WHERE k = 1").one().getMap("b", Integer.class, String.class);
         assertThat(actual).containsExactly(entry(2, "bar"));
+    }
+
+    /**
+     * Validates that {@link QueryBuilder} may be used to create a query that casts a column from one type to another,
+     * i.e.:
+     * <p/>
+     * <code>select CAST(f as int) as fint, i from table2 where k='cast_t'</code>
+     * <p/>
+     * and validates that the query executes successfully with the anticipated results.
+     *
+     * @jira_ticket JAVA-1086
+     * @test_category queries:builder
+     * @since 3.0.1
+     */
+    @Test(groups = "short")
+    @CassandraVersion(major = 3.2)
+    public void should_support_cast_function_on_column() {
+        //when
+        ResultSet r = session().execute(select().cast("f", DataType.cint()).as("fint").column("i").from(TABLE2).where(eq("k", "cast_t")));
+        //then
+        assertThat(r.getAvailableWithoutFetching()).isEqualTo(4);
+        for (Row row : r) {
+            Integer i = row.getInt("i");
+            assertThat(row.getColumnDefinitions().getType("fint")).isEqualTo(DataType.cint());
+            Integer f = row.getInt("fint");
+            switch (i) {
+                case 1:
+                    assertThat(f).isEqualTo(1);
+                    break;
+                case 2:
+                    assertThat(f).isEqualTo(2);
+                    break;
+                case 3:
+                    assertThat(f).isEqualTo(3);
+                    break;
+                case 4:
+                    assertThat(f).isEqualTo(5);
+                    break;
+                default:
+                    fail("Unexpected values: " + i + "," + f);
+            }
+        }
+    }
+
+    /**
+     * Validates that {@link QueryBuilder} may be used to create a query that makes an aggregate function call, casting
+     * the column(s) that the function operates on from one type to another.
+     * i.e.:
+     * <p/>
+     * <code>select avg(CAST(i as float)) as iavg from table2 where k='cast_t'</code>
+     * <p/>
+     * and validates that the query executes successfully with the anticipated results.
+     *
+     * @jira_ticket JAVA-1086
+     * @test_category queries:builder
+     * @since 3.0.1
+     */
+    @Test(groups = "short")
+    @CassandraVersion(major = 3.2)
+    public void should_support_fcall_on_cast_column() {
+        //when
+        ResultSet ar = session().execute(select().fcall("avg", cast(column("i"), DataType.cfloat())).as("iavg").from(TABLE2).where(eq("k", "cast_t")));
+        //then
+        assertThat(ar.getAvailableWithoutFetching()).isEqualTo(1);
+        Row row = ar.one();
+        assertThat(row.getColumnDefinitions().getType("iavg")).isEqualTo(DataType.cfloat());
+        Float f = row.getFloat("iavg");
+        // (1.0+2.0+3.0+4.0) / 4 = 2.5
+        assertThat(f).isEqualTo(2.5f);
     }
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -143,6 +143,18 @@ public class QueryBuilderTest {
         select = select().from("foo").where(containsKey("e", "key1"));
         assertEquals(select.toString(), query);
 
+        query = "SELECT CAST(writetime(country) AS text) FROM artists LIMIT 2;";
+        select = select().cast(fcall("writetime", column("country")), DataType.text()).from("artists").limit(2);
+        assertEquals(select.toString(), query);
+
+        query = "SELECT avg(CAST(v AS float)) FROM e;";
+        select = select().fcall("avg", cast(column("v"), DataType.cfloat())).from("e");
+        assertEquals(select.toString(), query);
+
+        query = "SELECT CAST(writetime(country) AS text) FROM artists LIMIT 2;";
+        select = select().raw("CAST(writetime(country) AS text)").from("artists").limit(2);
+        assertEquals(select.toString(), query);
+
         query = "SELECT * FROM foo WHERE e LIKE 'a%';";
         select = select().from("foo").where(like("e", "a%"));
         assertEquals(select.toString(), query);

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/QueryType.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/QueryType.java
@@ -78,7 +78,7 @@ class QueryType {
                 Select.Selection selection = select();
                 for (ColumnMapper cm : mapper.allColumns()) {
                     Select.SelectionOrAlias column = (cm.kind == ColumnMapper.Kind.COMPUTED)
-                            ? ((Select.SelectionOrAlias) selection).raw(cm.getColumnName())
+                            ? selection.raw(cm.getColumnName())
                             : selection.column(cm.getColumnName());
 
                     if (cm.getAlias() == null) {


### PR DESCRIPTION
I found a way to add methods to `select()` without breaking binary compatibility, so I seized the opportunity to also add `select().raw()` (which will provide a workaround for missing query builder features in the future).
