### PR TITLE
JAVA-1113: Support Cassandra 3.4 LIKE operator in QueryBuilder.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -12,6 +12,7 @@
 - [improvement] JAVA-1136: Enable JDK signature check in module driver-extras.
 - [improvement] JAVA-866: Support tuple notation in QueryBuilder.eq/in.
 - [bug] JAVA-1140: Use same connection to check for schema agreement after a DDL query.
+- [improvement] JAVA-1113: Support Cassandra 3.4 LIKE operator in QueryBuilder.
 
 Merged from 2.1 branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
@@ -297,6 +297,17 @@ public final class QueryBuilder {
     }
 
     /**
+     * Creates a "like" where clause stating that the provided column must be equal to the provided value.
+     *
+     * @param name  the column name.
+     * @param value the value.
+     * @return the corresponding where clause.
+     */
+    public static Clause like(String name, Object value) {
+        return new Clause.SimpleClause(name, " LIKE ", value);
+    }
+
+    /**
      * Create an "in" where clause stating the provided column must be equal
      * to one of the provided values.
      *

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -143,6 +143,10 @@ public class QueryBuilderTest {
         select = select().from("foo").where(containsKey("e", "key1"));
         assertEquals(select.toString(), query);
 
+        query = "SELECT * FROM foo WHERE e LIKE 'a%';";
+        select = select().from("foo").where(like("e", "a%"));
+        assertEquals(select.toString(), query);
+
         try {
             select().countAll().from("foo").orderBy(asc("a"), desc("b")).orderBy(asc("a"), desc("b"));
             fail("Expected an IllegalStateException");


### PR DESCRIPTION
Note: the new QueryBuilder method permits a bind marker as the LIKE argument.

That's currently not supported by Cassandra, I'm trying to find out if it's a bug. If so, I'll add a warning in the QueryBuilder's javadoc; if not, I'll change the method to accept only a string.
