### PR TITLE
Override copy() in CodecNotFoundException and remove JDK-specific behavior dependency in test.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/CodecNotFoundException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/CodecNotFoundException.java
@@ -30,13 +30,15 @@ public class CodecNotFoundException extends DriverException {
     private final TypeToken<?> javaType;
 
     public CodecNotFoundException(String msg, DataType cqlType, TypeToken<?> javaType) {
-        super(msg);
-        this.cqlType = cqlType;
-        this.javaType = javaType;
+        this(msg, null, cqlType, javaType);
     }
 
     public CodecNotFoundException(Throwable cause, DataType cqlType, TypeToken<?> javaType) {
-        super(cause);
+        this(null, cause, cqlType, javaType);
+    }
+
+    private CodecNotFoundException(String msg, Throwable cause, DataType cqlType, TypeToken<?>javaType) {
+        super(msg, cause);
         this.cqlType = cqlType;
         this.javaType = javaType;
     }
@@ -47,5 +49,10 @@ public class CodecNotFoundException extends DriverException {
 
     public TypeToken<?> getJavaType() {
         return javaType;
+    }
+
+    @Override
+    public CodecNotFoundException copy() {
+        return new CodecNotFoundException(getMessage(), getCause(), getCqlType(), getJavaType());
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
@@ -30,10 +30,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.datastax.driver.core.BatchStatement.Type.COUNTER;
 import static com.datastax.driver.core.BatchStatement.Type.UNLOGGED;
@@ -895,7 +892,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
         cluster().register(queryLogger);
         // when
         String query = "UPDATE test SET c_int = :c_int WHERE pk = :pk";
-        Map<String, Object> namedValues = new HashMap<String, Object>();
+        Map<String, Object> namedValues = new LinkedHashMap<String, Object>();
         namedValues.put("c_int", 123456);
         namedValues.put("pk", 42);
         SimpleStatement ss = new SimpleStatement(query, namedValues);
@@ -905,8 +902,8 @@ public class QueryLoggerTest extends CCMTestsSupport {
         assertThat(line)
                 .contains("Query completed normally")
                 .contains(ipOfNode(1))
-                .contains("pk:42")
-                .doesNotContain("c_int:123456")
+                .contains("c_int:123456")
+                .doesNotContain("pk:42")
                 .contains(FURTHER_PARAMS_OMITTED);
     }
 


### PR DESCRIPTION
Just a small test adjustment.

This is needed because the Exception is propagated as the query is now done in a separate thread (JAVA-1070).
