### PR TITLE
JAVA-1109: Document SSLOptions changes in upgrade guide.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -7,6 +7,7 @@
 - [improvement] JAVA-1151: Fail fast if HdrHistogram is not in the classpath.
 - [improvement] JAVA-1154: Allow individual Statement to cancel the read timeout.
 - [bug] JAVA-1074: Fix documentation around default timestamp generator.
+- [improvement] JAVA-1109: Document SSLOptions changes in upgrade guide.
 
 Merged from 2.1 branch:
 

--- a/manual/ssl/README.md
+++ b/manual/ssl/README.md
@@ -125,8 +125,11 @@ configuration on the `SSLEngine` (for example hostname verification).
 #### Netty
 
 [NettySSLOptions] allows you to use Netty's `SslContext` instead of
-the JDK directly. The advantage is that Netty can use OpenSSL if
-available, which provides better performance.
+the JDK directly. The advantage is that Netty can use OpenSSL directly,
+which provides better performance and generates less garbage.  A disadvantage of
+using the OpenSSL provider is that it requires platform-specific dependencies,
+unlike the JDK provider.
+
 
 ##### Converting your client certificates for OpenSSL
 
@@ -149,7 +152,8 @@ Netty-tcnative provides the native integration with OpenSSL. Follow
 [these instructions](http://netty.io/wiki/forked-tomcat-native.html) to
 add it to your dependencies.
 
-Note that using netty-tcnative requires JDK 1.7 or above.
+Note that using netty-tcnative requires JDK 1.7 or above and requires the
+presence of OpenSSL on the system.  It will not fall back to the JDK implementation.
 
 ##### Configuring the context
 

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -269,6 +269,10 @@ We've also seized the opportunity to remove code that was deprecated in 2.1.
     Again, this is due to the fact that secondary indexes have been completely redesigned 
     in Cassandra 3.0.
 
+29. `SSLOptions` has been refactored to allow the option to choose between JDK and Netty-based
+    SSL implementations.  See [JAVA-841](https://datastax-oss.atlassian.net/browse/JAVA-841) and
+    the [SSL documentation](../manual/ssl) for more details.
+
 
 ### 2.1.8
 


### PR DESCRIPTION
Also clarify pros/cons of using netty-tcnative.
