### PR TITLE
JAVA-1161 ZonedDateTime should be serialized and formatted with full information about TimeZone

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,7 @@
 
 ### 3.0.1
 
+- [bug] JAVA-1161: ZonedDateTimeCodec does not preserve timeZone, but only the offset
 - [bug] JAVA-1132: Executing bound statement with no variables results in exception with protocol v1.
 - [improvement] JAVA-1040: SimpleStatement parameters support in QueryLogger.
 - [improvement] JAVA-1151: Fail fast if HdrHistogram is not in the classpath.

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/ZonedDateTimeCodec.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/ZonedDateTimeCodec.java
@@ -19,29 +19,32 @@ import com.datastax.driver.core.*;
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 
 import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalQueries;
 import java.util.List;
 
 import static com.datastax.driver.core.ParseUtils.isLongLiteral;
 import static com.datastax.driver.core.ParseUtils.quote;
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 
 /**
  * {@link TypeCodec} that maps
- * {@link java.time.ZonedDateTime} to CQL {@code tuple<timestamp,varchar>},
+ * {@link ZonedDateTime} to CQL {@code tuple<timestamp,varchar>},
  * providing a pattern for maintaining timezone information in
  * Cassandra.
  * <p/>
  * Since Cassandra's <code>timestamp</code> type preserves only
  * milliseconds since epoch, any timezone information
  * would normally be lost. By using a
- * <code>tuple&lt;timestamp,varchar&gt;</code> a timezone ID can be
+ * <code>tuple&lt;timestamp,varchar&gt;</code> a timezone can be
  * persisted in the <code>varchar</code> field such that when the
- * value is deserialized the timezone is
- * preserved.
- * <p/>
- * <strong>IMPORTANT</strong>: this codec's {@link #format(Object) format} method formats
- * timestamps using an ISO-8601 format that includes milliseconds.
- * <strong>This format is incompatible with Cassandra versions < 2.0.9.</strong>
+ * value is deserialized the timezone is preserved.
  *
  * @see <a href="https://cassandra.apache.org/doc/cql3/CQL-2.2.html#usingtimestamps">'Working with timestamps' section of CQL specification</a>
  */
@@ -50,86 +53,139 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class ZonedDateTimeCodec extends TypeCodec.AbstractTupleCodec<java.time.ZonedDateTime> {
 
     /**
-     * A {@link java.time.format.DateTimeFormatter} that parses (most) of
+     * The default {@link DateTimeFormatter} that parses (most) of
      * the ISO formats accepted in CQL.
      */
-    private static final java.time.format.DateTimeFormatter FORMATTER = new java.time.format.DateTimeFormatterBuilder()
-            .parseCaseSensitive()
-            .parseStrict()
-            .append(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE)
-            .optionalStart()
-            .appendLiteral('T')
-            .appendValue(java.time.temporal.ChronoField.HOUR_OF_DAY, 2)
-            .appendLiteral(':')
-            .appendValue(java.time.temporal.ChronoField.MINUTE_OF_HOUR, 2)
-            .optionalEnd()
-            .optionalStart()
-            .appendLiteral(':')
-            .appendValue(java.time.temporal.ChronoField.SECOND_OF_MINUTE, 2)
-            .optionalEnd()
-            .optionalStart()
-            .appendFraction(java.time.temporal.ChronoField.NANO_OF_SECOND, 0, 9, true)
-            .optionalEnd()
-            .optionalStart()
-            .appendZoneOrOffsetId()
-            .optionalEnd()
-            .toFormatter()
-            .withZone(java.time.ZoneOffset.UTC);
+    private static final DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = ISO_DATE_TIME.withZone(ZoneOffset.UTC);
 
-    private static final java.time.format.DateTimeFormatter ZONE_FORMATTER = java.time.format.DateTimeFormatter.ofPattern("xxx");
+    /**
+     * The default {@link DateTimeFormatter} to parse and format zones.
+     */
+    private static final DateTimeFormatter DEFAULT_ZONE_FORMATTER = new DateTimeFormatterBuilder()
+        .optionalStart()
+        .appendOffset("+HH:MM", "+00:00")
+        .optionalEnd()
+        .optionalStart()
+        .appendLiteral('[')
+        .parseCaseSensitive()
+        .appendZoneRegionId()
+        .appendLiteral(']')
+        .toFormatter();
 
+    private final DateTimeFormatter dateTimeFormatter;
+
+    private final DateTimeFormatter zoneFormatter;
+
+    /**
+     * Creates a new {@link ZonedDateTimeCodec} for the given tuple
+     * and with default {@link DateTimeFormatter formatters} for
+     * both the timestamp and the zone components.
+     * <p>
+     * The default formatters produce literals of the following form:
+     * <ol>
+     * <li>Timestamp component: an ISO-8601 full date and time pattern, including at least: year,
+     * month, day, hour and minutes, and optionally, seconds and milliseconds (see below),
+     * followed by the zone ID {@code Z} (UTC),
+     * e.g. {@code 2010-06-30T02:01Z} or {@code 2010-06-30T01:20:47.999Z};
+     * note that timestamp components are always expressed in UTC time, hence the zone ID {@code Z}.</li>
+     * <li>Zone component: a zone offset such as {@code -07:00}, optionally followed by a zone ID such as
+     * {@code [Europe/Paris]}, if this information is available; note that zone IDs
+     * are not part of the ISO-8601 standard and are usually not required, unless your application
+     * needs to take into account daylight savings time changes.</li>
+     * </ol>
+     * <p>
+     * <strong>IMPORTANT</strong>
+     * <p>
+     * 1) The default timestamp formatter produces CQl literals
+     * that may include milliseconds.
+     * <strong>This literal format is incompatible with Cassandra < 2.0.9.</strong>
+     * <p>
+     * 2) Even if the ISO-8601 standard accepts timestamps with nanosecond precision,
+     * Cassandra timestamps have millisecond precision; therefore, any sub-millisecond
+     * value set on a {@link ZonedDateTime} will be lost when persisted to Cassandra.
+     *
+     * @param tupleType The tuple type this codec should handle.
+     *                  It must be a {@code tuple<timestamp,varchar>}.
+     * @throws IllegalArgumentException if the provided tuple type is not a {@code tuple<timestamp,varchar>}.
+     */
     public ZonedDateTimeCodec(TupleType tupleType) {
-        super(tupleType, java.time.ZonedDateTime.class);
+        this(tupleType, DEFAULT_DATE_TIME_FORMATTER, DEFAULT_ZONE_FORMATTER);
+    }
+
+    /**
+     * Creates a new {@link ZonedDateTimeCodec} for the given tuple
+     * and with the provided {@link DateTimeFormatter formatters} for
+     * the timestamp and the zone components of the tuple.
+     * <p>
+     * Use this constructor if you intend to customize the way the codec
+     * parses and formats timestamps and zones. Beware that Cassandra only accepts
+     * timestamp literals in some of the most common ISO-8601 formats;
+     * attempting to use non-standard formats could result in invalid CQL literals.
+     *
+     * @param tupleType         The tuple type this codec should handle.
+     *                          It must be a {@code tuple<timestamp,varchar>}.
+     * @param dateTimeFormatter The {@link DateTimeFormatter} to use
+     *                          to parse and format the timestamp component of the tuple.
+     *                          This formatter should be configured to always format timestamps in UTC
+     *                          (see {@link DateTimeFormatter#withZone(java.time.ZoneId)}.
+     * @param zoneFormatter     The {@link DateTimeFormatter} to use
+     *                          to parse and format the zone component of the tuple.
+     * @throws IllegalArgumentException if the provided tuple type is not a {@code tuple<timestamp,varchar>}.
+     */
+    public ZonedDateTimeCodec(TupleType tupleType, DateTimeFormatter dateTimeFormatter, DateTimeFormatter zoneFormatter) {
+        super(tupleType, ZonedDateTime.class);
+        this.dateTimeFormatter = dateTimeFormatter;
+        this.zoneFormatter = zoneFormatter;
         List<DataType> types = tupleType.getComponentTypes();
         checkArgument(
-                types.size() == 2 && types.get(0).equals(DataType.timestamp()) && types.get(1).equals(DataType.varchar()),
-                "Expected tuple<timestamp,varchar>, got %s",
-                tupleType);
+            types.size() == 2 && types.get(0).equals(DataType.timestamp()) && types.get(1).equals(DataType.varchar()),
+            "Expected tuple<timestamp,varchar>, got %s",
+            tupleType);
     }
 
     @Override
-    protected java.time.ZonedDateTime newInstance() {
+    protected ZonedDateTime newInstance() {
         return null;
     }
 
     @Override
-    protected ByteBuffer serializeField(java.time.ZonedDateTime source, int index, ProtocolVersion protocolVersion) {
+    protected ByteBuffer serializeField(ZonedDateTime source, int index, ProtocolVersion protocolVersion) {
         if (index == 0) {
             long millis = source.toInstant().toEpochMilli();
             return bigint().serializeNoBoxing(millis, protocolVersion);
         }
         if (index == 1) {
-            return varchar().serialize(ZONE_FORMATTER.format(source.getOffset()), protocolVersion);
+            return varchar().serialize(zoneFormatter.format(source), protocolVersion);
         }
         throw new IndexOutOfBoundsException("Tuple index out of bounds. " + index);
     }
 
     @Override
-    protected java.time.ZonedDateTime deserializeAndSetField(ByteBuffer input, java.time.ZonedDateTime target, int index, ProtocolVersion protocolVersion) {
+    protected ZonedDateTime deserializeAndSetField(ByteBuffer input, ZonedDateTime target, int index, ProtocolVersion protocolVersion) {
         if (index == 0) {
             long millis = bigint().deserializeNoBoxing(input, protocolVersion);
-            return java.time.Instant.ofEpochMilli(millis).atZone(java.time.ZoneOffset.UTC);
+            return Instant.ofEpochMilli(millis).atZone(ZoneOffset.UTC);
         }
         if (index == 1) {
             String zoneId = varchar().deserialize(input, protocolVersion);
-            return target.withZoneSameInstant(java.time.ZoneId.of(zoneId));
+            return target.withZoneSameInstant(zoneFormatter.parse(zoneId, TemporalQueries.zone()));
         }
         throw new IndexOutOfBoundsException("Tuple index out of bounds. " + index);
     }
 
     @Override
-    protected String formatField(java.time.ZonedDateTime value, int index) {
+    protected String formatField(ZonedDateTime value, int index) {
         if (index == 0) {
-            return quote(FORMATTER.format(value));
+            return quote(dateTimeFormatter.format(value));
         }
         if (index == 1) {
-            return quote(ZONE_FORMATTER.format(value.getOffset()));
+            return quote(zoneFormatter.format(value));
         }
         throw new IndexOutOfBoundsException("Tuple index out of bounds. " + index);
     }
 
     @Override
-    protected java.time.ZonedDateTime parseAndSetField(String input, java.time.ZonedDateTime target, int index) {
+    protected ZonedDateTime parseAndSetField(String input, ZonedDateTime target, int index) {
         if (index == 0) {
             // strip enclosing single quotes, if any
             if (ParseUtils.isQuoted(input))
@@ -137,20 +193,20 @@ public class ZonedDateTimeCodec extends TypeCodec.AbstractTupleCodec<java.time.Z
             if (isLongLiteral(input)) {
                 try {
                     long millis = Long.parseLong(input);
-                    return java.time.ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli(millis), java.time.ZoneOffset.UTC);
+                    return ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC);
                 } catch (NumberFormatException e) {
                     throw new InvalidTypeException(String.format("Cannot parse timestamp value from \"%s\"", input));
                 }
             }
             try {
-                return java.time.ZonedDateTime.from(FORMATTER.parse(input));
-            } catch (java.time.format.DateTimeParseException e) {
+                return ZonedDateTime.from(dateTimeFormatter.parse(input));
+            } catch (DateTimeParseException e) {
                 throw new InvalidTypeException(String.format("Cannot parse timestamp value from \"%s\"", target));
             }
         }
         if (index == 1) {
             String zoneId = varchar().parse(input);
-            return target.withZoneSameInstant(java.time.ZoneId.of(zoneId));
+            return target.withZoneSameInstant(zoneFormatter.parse(zoneId, TemporalQueries.zone()));
         }
         throw new IndexOutOfBoundsException("Tuple index out of bounds. " + index);
     }

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/jdk8/ZonedDateTimeCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/jdk8/ZonedDateTimeCodecTest.java
@@ -20,21 +20,18 @@ import com.datastax.driver.core.TupleType;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 import static com.datastax.driver.core.DataType.timestamp;
 import static com.datastax.driver.core.DataType.varchar;
 import static com.datastax.driver.core.ProtocolVersion.V4;
 import static com.google.common.collect.Lists.newArrayList;
-import static java.time.Instant.ofEpochMilli;
-import static java.time.Instant.parse;
-import static java.time.ZoneOffset.UTC;
-import static java.time.ZonedDateTime.ofInstant;
+import static java.time.ZonedDateTime.parse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("Since15")
 public class ZonedDateTimeCodecTest {
 
     private final TupleType tupleType = mock(TupleType.class);
@@ -42,30 +39,47 @@ public class ZonedDateTimeCodecTest {
     @DataProvider(name = "ZonedDateTimeCodecTest.parse")
     public Object[][] parseParameters() {
         return new Object[][]{
-                {null, null},
-                {"", null},
-                {"NULL", null},
-                {"(0                         ,'+01:00')", ofInstant(ofEpochMilli(0), ZoneOffset.of("+01:00"))},
-                {"(1277860847999             ,'+01:00')", ofInstant(parse("2010-06-30T01:20:47.999Z"), ZoneOffset.of("+01:00"))},
-                {"('2010-06-30T01:20Z'       ,'+01:00')", ofInstant(parse("2010-06-30T01:20:00.000Z"), ZoneOffset.of("+01:00"))},
-                {"('2010-06-30T01:20:47Z'    ,'+01:00')", ofInstant(parse("2010-06-30T01:20:47.000Z"), ZoneOffset.of("+01:00"))},
-                {"('2010-06-30T01:20:47.999Z','+01:00')", ofInstant(parse("2010-06-30T01:20:47.999Z"), ZoneOffset.of("+01:00"))}
+            {null, null},
+            {"", null},
+            {"NULL", null},
+            //@formatter:off
+            // timestamps as milliseconds since the Epoch, offsets without zone id
+            {"(0                         ,'+01:00')"                , parse("1970-01-01T01:00:00.000+01:00")},
+            {"(1277860847999             ,'+01:00')"                , parse("2010-06-30T02:20:47.999+01:00")},
+            // timestamps as valid CQL literals with different precisions
+            {"('2010-06-30T01:20Z'       ,'+01:00')"                , parse("2010-06-30T02:20:00.000+01:00")},
+            {"('2010-06-30T01:20:47Z'    ,'+01:00')"                , parse("2010-06-30T02:20:47.000+01:00")},
+            {"('2010-06-30T01:20:47.999Z','+01:00')"                , parse("2010-06-30T02:20:47.999+01:00")},
+            // zone id without offset with different previsions
+            {"('2016-04-06T19:01Z'       ,'[Asia/Vientiane]')"      , parse("2016-04-07T02:01:00.000+07:00[Asia/Vientiane]")},
+            {"('2016-04-06T19:01:32Z'    ,'[Asia/Vientiane]')"      , parse("2016-04-07T02:01:32.000+07:00[Asia/Vientiane]")},
+            {"('2016-04-06T19:01:32.999Z','[Asia/Vientiane]')"      , parse("2016-04-07T02:01:32.999+07:00[Asia/Vientiane]")},
+            // offset and zone id both specified
+            {"(0                         ,'+07:00[Asia/Vientiane]')", parse("1970-01-01T07:00:00.000+07:00[Asia/Vientiane]")},
+            {"('2016-04-06T19:01:32.999Z','+07:00[Asia/Vientiane]')", parse("2016-04-07T02:01:32.999+07:00[Asia/Vientiane]")},
+            //@formatter:on
         };
     }
 
     @DataProvider(name = "ZonedDateTimeCodecTest.format")
     public Object[][] formatParameters() {
         return new Object[][]{
-                {null, "NULL"},
-                {ofInstant(ofEpochMilli(0), UTC), "('1970-01-01T00:00:00Z','+00:00')"},
-                {ZonedDateTime.parse("2010-06-30T01:20:47.999+01:00"), "('2010-06-30T00:20:47.999Z','+01:00')"}
+            {null, "NULL"},
+            //@formatter:off
+            {parse("1970-01-01T00:00Z")                     , "('1970-01-01T00:00:00Z','+00:00')"},
+            {parse("1970-01-01T00:00:00Z")                  , "('1970-01-01T00:00:00Z','+00:00')"},
+            {parse("1970-01-01T00:00:00.000Z")              , "('1970-01-01T00:00:00Z','+00:00')"},
+            {parse("2010-06-30T01:20+01:00")                , "('2010-06-30T00:20:00Z','+01:00')"},
+            {parse("2010-06-30T01:20:47+01:00")             , "('2010-06-30T00:20:47Z','+01:00')"},
+            {parse("2010-06-30T01:20:47.999+01:00")         , "('2010-06-30T00:20:47.999Z','+01:00')"},
+            {parse("2016-04-07T02:01+07:00[Asia/Vientiane]"), "('2016-04-06T19:01:00Z','+07:00[Asia/Vientiane]')"}
+            //@formatter:on
         };
     }
 
     @Test(groups = "unit", dataProvider = "ZonedDateTimeCodecTest.parse")
     public void should_parse_valid_formats(String input, ZonedDateTime expected) {
         // given
-        TupleType tupleType = mock(TupleType.class);
         when(tupleType.getComponentTypes()).thenReturn(newArrayList(timestamp(), varchar()));
         ZonedDateTimeCodec codec = new ZonedDateTimeCodec(tupleType);
         // when


### PR DESCRIPTION
The java driver failed to serialize / deserialize dates like : 

```
ZonedDateTime.parse("2016-04-07T02:01+07:00[Asia/Vientiane]")
```

Basicaly the timeZone is lost, and this line fails : 

```
Assertions.assertThat(codec).withProtocolVersion(V4).canSerialize(input);
```

Note that timeZone is Important when modifying date. For instance French timeZone (Central Europe Time) changes of offset 2 times a year. If I want to know time in France 48 h later, answer might be in CET timeZone +47h, +48h or +49h, leading to different results. With only offset, this information is lost.
