### PR TITLE
Various integration test fixes

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/CCMCache.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMCache.java
@@ -271,10 +271,10 @@ public class CCMCache {
             // CCM nodes are started with -Xms500M -Xmx500M
             // and allocate up to 100MB non-heap memory in the general case,
             // to be conservative we treat 1 "slot" as 800Mb.
-            // We leave 2 slots out to avoid starving system memory,
+            // We leave 3 slots out to avoid starving system memory,
             // and we pick a value with a minimum of 1 slot and a maximum of 8 slots.
-            // For example, an 8GB VM with ~6.5GB currently available heap will yield 6 slots ((6500/800) - 2 = 6).
-            long slotsAvailable = (freeMemoryMB / ONE_CCM_NODE_MB) - 2;
+            // For example, an 8GB VM with ~6.5GB currently available heap will yield 5 slots ((6500/800) - 3 = 5).
+            long slotsAvailable = (freeMemoryMB / ONE_CCM_NODE_MB) - 3;
             maximumWeight = Math.min(8, Math.max(1, slotsAvailable));
         } else {
             maximumWeight = Integer.parseInt(numberOfNodes);

--- a/driver-core/src/test/java/com/datastax/driver/core/HostAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostAssert.java
@@ -20,9 +20,11 @@ import com.datastax.driver.core.Host.StateListener;
 import com.datastax.driver.core.policies.LoadBalancingPolicy;
 import org.assertj.core.api.AbstractAssert;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static com.datastax.driver.core.ConditionChecker.check;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -72,9 +74,18 @@ public class HostAssert extends AbstractAssert<HostAssert, Host> {
     }
 
     public HostAssert isNotReconnectingFromDown() {
-        assertThat(actual.getReconnectionAttemptFuture() != null && !actual.getReconnectionAttemptFuture().isDone())
-                .isFalse();
-        return this;
+        // Ensure that host is not attempting a reconnect.  Because of JAVA-970 we cannot
+        // be sure that there is a race and another pool is created before the host is marked down so we
+        // check to see it stops after 30 seconds.
+        // TODO: Change this to check only once if JAVA-970 is fixed.
+        check().before(30, TimeUnit.SECONDS).that(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                // Whether or not host is down and reconnection attempt is in progress.
+                return actual.getReconnectionAttemptFuture() != null && !actual.getReconnectionAttemptFuture().isDone();
+            }
+        }).becomesFalse();
+        return this.isDown();
     }
 
     public HostAssert comesUpWithin(long duration, TimeUnit unit) {

--- a/driver-examples/osgi/pom.xml
+++ b/driver-examples/osgi/pom.xml
@@ -220,6 +220,21 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>short</id>
+            <properties>
+                <test.groups>unit,short</test.groups>
+                <test.skip>false</test.skip>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>long</id>
+            <properties>
+                <test.groups>unit,short,long</test.groups>
+                <test.skip>false</test.skip>
+            </properties>
+        </profile>
     </profiles>
 
     <licenses>


### PR DESCRIPTION
Fixes a few integration test issues:
- Relax RecommissionedNodeTests check for reconnecting from down criteria a bit because of [JAVA-970](https://datastax-oss.atlassian.net/browse/JAVA-970).
- OSGi tests were not running on 2.1, backported changes from [JAVA-1133](https://datastax-oss.atlassian.net/browse/JAVA-1133) here to get them working again.
- Reserve an extra slot to relax memory pressure from running CCM clusters.  Particularly in the case of C\* 3.0.X+ it appears we need more memory than usual and sometimes the VM in CI runs out of memory.

It would be really nice if we could get these changes merged into 2.1 and subsequently 3.0.X to be included in 3.0.1.   Assigning 3.0.1 milestone to make that desire more visible :)
