### PR TITLE
JAVA-1182: Throw error when synchronous call made on I/O thread.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,7 @@
 ### 2.0.12.2 (in progress)
 
 - [bug] JAVA-1179: Request objects should be copied when executed.
+- [improvement] JAVA-1182: Throw error when synchronous call made on I/O thread.
 
 
 ### 2.0.12.1
@@ -10,6 +11,7 @@
 - [bug] JAVA-994: Don't call on(Up|Down|Add|Remove) methods if Cluster is closed/closing.
 - [improvement] JAVA-805: Document that metrics are null until Cluster is initialized.
 - [bug] JAVA-1072: Ensure defunct connections are properly evicted from the pool.
+
 
 ### 2.0.12
 

--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractSession.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractSession.java
@@ -51,6 +51,7 @@ public abstract class AbstractSession implements Session, AsyncInitSession {
      */
     @Override
     public ResultSet execute(Statement statement) {
+        checkNotInEventLoop();
         return executeAsync(statement).getUninterruptibly();
     }
 
@@ -75,6 +76,7 @@ public abstract class AbstractSession implements Session, AsyncInitSession {
      */
     @Override
     public PreparedStatement prepare(String query) {
+        checkNotInEventLoop();
         try {
             return Uninterruptibles.getUninterruptibly(prepareAsync(query));
         } catch (ExecutionException e) {
@@ -87,6 +89,7 @@ public abstract class AbstractSession implements Session, AsyncInitSession {
      */
     @Override
     public PreparedStatement prepare(RegularStatement statement) {
+        checkNotInEventLoop();
         try {
             return Uninterruptibles.getUninterruptibly(prepareAsync(statement));
         } catch (ExecutionException e) {
@@ -131,5 +134,14 @@ public abstract class AbstractSession implements Session, AsyncInitSession {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
+    }
+
+    /**
+     * Checks that the current thread is not one of the Netty I/O threads used by the driver.
+     * <p/>
+     * This is called from the synchronous methods of this class to prevent deadlock issues.
+     */
+    protected void checkNotInEventLoop() {
+        // This method is concrete only to avoid a breaking change. See subclass for the actual implementation.
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -679,7 +679,7 @@ class Connection {
 
         public final Timer timer;
 
-        private final EventLoopGroup eventLoopGroup;
+        final EventLoopGroup eventLoopGroup;
         private final Class<? extends Channel> channelClass;
 
         private final ChannelGroup allChannels = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);

--- a/driver-core/src/main/java/com/datastax/driver/core/SystemProperties.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SystemProperties.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Allows overriding internal settings via system properties.
  * <p/>
- * Warning: this is meant for integration tests only, NOT FOR PRODUCTION USE.
+ * This is generally reserved for tests or "expert" usage.
  */
 class SystemProperties {
     private static final Logger logger = LoggerFactory.getLogger(SystemProperties.class);
@@ -34,7 +34,7 @@ class SystemProperties {
         }
         try {
             int value = Integer.parseInt(stringValue);
-            logger.warn("{} is defined, using value {}", key, value);
+            logger.info("{} is defined, using value {}", key, value);
             return value;
         } catch (NumberFormatException e) {
             logger.warn("{} is defined but could not parse value {}, using default value {}", key, stringValue, defaultValue);
@@ -50,7 +50,7 @@ class SystemProperties {
         }
         try {
             boolean value = Boolean.parseBoolean(stringValue);
-            logger.warn("{} is defined, using value {}", key, value);
+            logger.info("{} is defined, using value {}", key, value);
             return value;
         } catch (NumberFormatException e) {
             logger.warn("{} is defined but could not parse value {}, using default value {}", key, stringValue, defaultValue);

--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
@@ -17,6 +17,7 @@ package com.datastax.driver.core;
 
 import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.*;
 import org.testng.annotations.DataProvider;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -126,6 +128,26 @@ public class AsyncQueryTest extends CCMBridge.PerClassSingleNodeCluster {
             assertThat(e.getCause())
                     .isInstanceOf(InvalidQueryException.class)
                     .hasMessage("Keyspace 'wrong_keyspace' does not exist");
+        }
+    }
+
+    @Test(groups = "short")
+    public void should_fail_when_synchronous_call_on_io_thread() throws Exception {
+        ResultSetFuture f = session.executeAsync("select release_version from system.local");
+        ListenableFuture<Void> f2 = Futures.transform(f, new Function<ResultSet, Void>() {
+            @Override
+            public Void apply(ResultSet input) {
+                session.execute("select release_version from system.local");
+                return null;
+            }
+        });
+        try {
+            f2.get();
+            fail("Expected a failed future");
+        } catch (Exception e) {
+            assertThat(Throwables.getRootCause(e))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Detected a synchronous Session call");
         }
     }
 


### PR DESCRIPTION
Note: for cases where the error cannot be propagated, like `Futures.addCallback`, Guava will log the error with java.util.logging. I'm not sure if we can/should do anything about that, or just expect that client apps will properly monitor those logs or catch the error before.
