### PR TITLE
JAVA-1193 + JAVA-1120: Refresh token and replica metadata synchronously when schema is altered.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -19,6 +19,7 @@
 - [bug] JAVA-1160: Fix NPE in VersionNumber.getPreReleaseLabels().
 - [improvement] JAVA-1126: Handle schema changes in Mapper.
 - [bug] JAVA-1193: Refresh token and replica metadata synchronously when schema is altered.
+- [bug] JAVA-1120: Skip schema refresh debouncer when checking for agreement as a result of schema change made by client.
 
 
 ### 3.0.2

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -18,6 +18,7 @@
 - [improvement] JAVA-1227: Document "SELECT *" issue with prepared statement.
 - [bug] JAVA-1160: Fix NPE in VersionNumber.getPreReleaseLabels().
 - [improvement] JAVA-1126: Handle schema changes in Mapper.
+- [bug] JAVA-1193: Refresh token and replica metadata synchronously when schema is altered.
 
 
 ### 3.0.2

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -267,15 +267,14 @@ class ControlConnection implements Connection.Owner {
 
             // We need to refresh the node list first so we know about the cassandra version of
             // the node we're connecting to.
+            // This will create the token map for the first time, but it will be incomplete
+            // due to the lack of keyspace information
             refreshNodeListAndTokenMap(connection, cluster, isInitialConnection, true);
 
+            // refresh schema will also update the token map again,
+            // this time with information about keyspaces
             logger.debug("[Control connection] Refreshing schema");
             refreshSchema(connection, null, null, null, null, cluster);
-
-            // We need to refresh the node list again;
-            // We want that because the token map was not properly initialized by the first call above,
-            // since it requires the list of keyspaces to be loaded.
-            refreshNodeListAndTokenMap(connection, cluster, false, false);
 
             return connection;
         } catch (BusyConnectionException e) {
@@ -306,11 +305,6 @@ class ControlConnection implements Connection.Owner {
             if (c == null || c.isClosed())
                 return;
             refreshSchema(c, targetType, targetKeyspace, targetName, signature, cluster);
-            // If we rebuild all from scratch or have an updated keyspace, rebuild the token map
-            // since some replication on some keyspace may have changed
-            if ((targetType == null || targetType == KEYSPACE)) {
-                cluster.submitNodeListRefresh();
-            }
         } catch (ConnectionException e) {
             logger.debug("[Control connection] Connection error while refreshing schema ({})", e.getMessage());
             signalError();
@@ -545,7 +539,8 @@ class ControlConnection implements Connection.Owner {
         connection.write(peersFuture);
 
         String partitioner = null;
-        Map<Host, Collection<String>> tokenMap = new HashMap<Host, Collection<String>>();
+        Token.Factory factory = null;
+        Map<Host, Set<Token>> tokenMap = new HashMap<Host, Set<Token>>();
 
         // Update cluster name, DC and rack for the one node we are connected to
         Row localRow = localFuture.get().one();
@@ -555,8 +550,10 @@ class ControlConnection implements Connection.Owner {
                 cluster.metadata.clusterName = clusterName;
 
             partitioner = localRow.getString("partitioner");
-            if (partitioner != null)
+            if (partitioner != null) {
                 cluster.metadata.partitioner = partitioner;
+                factory = Token.getFactory(partitioner);
+            }
 
             Host host = cluster.metadata.getHost(connection.address);
             // In theory host can't be null. However there is no point in risking a NPE in case we
@@ -565,10 +562,12 @@ class ControlConnection implements Connection.Owner {
                 logger.debug("Host in local system table ({}) unknown to us (ok if said host just got removed)", connection.address);
             } else {
                 updateInfo(host, localRow, cluster, isInitialConnection);
-                if (metadataEnabled) {
-                    Set<String> tokens = localRow.getSet("tokens", String.class);
-                    if (partitioner != null && !tokens.isEmpty())
+                if (metadataEnabled && factory != null) {
+                    Set<String> tokensStr = localRow.getSet("tokens", String.class);
+                    if (!tokensStr.isEmpty()) {
+                        Set<Token> tokens = toTokens(factory, tokensStr);
                         tokenMap.put(host, tokens);
+                    }
                 }
             }
         }
@@ -579,7 +578,7 @@ class ControlConnection implements Connection.Owner {
         List<String> cassandraVersions = new ArrayList<String>();
         List<InetAddress> broadcastAddresses = new ArrayList<InetAddress>();
         List<InetAddress> listenAddresses = new ArrayList<InetAddress>();
-        List<Set<String>> allTokens = new ArrayList<Set<String>>();
+        List<Set<Token>> allTokens = new ArrayList<Set<Token>>();
         List<String> dseVersions = new ArrayList<String>();
         List<Boolean> dseGraphEnabled = new ArrayList<Boolean>();
         List<String> dseWorkloads = new ArrayList<String>();
@@ -596,8 +595,14 @@ class ControlConnection implements Connection.Owner {
             racks.add(row.getString("rack"));
             cassandraVersions.add(row.getString("release_version"));
             broadcastAddresses.add(row.getInet("peer"));
-            if (metadataEnabled)
-                allTokens.add(row.getSet("tokens", String.class));
+            if (metadataEnabled && factory != null) {
+                Set<String> tokensStr = row.getSet("tokens", String.class);
+                Set<Token> tokens = null;
+                if (!tokensStr.isEmpty()) {
+                    tokens = toTokens(factory, tokensStr);
+                }
+                allTokens.add(tokens);
+            }
             InetAddress listenAddress = row.getColumnDefinitions().contains("listen_address") ? row.getInet("listen_address") : null;
             listenAddresses.add(listenAddress);
             String dseWorkload = row.getColumnDefinitions().contains("workload") ? row.getString("workload") : null;
@@ -640,7 +645,7 @@ class ControlConnection implements Connection.Owner {
             if (dseGraphEnabled.get(i) != null)
                 host.setDseGraphEnabled(dseGraphEnabled.get(i));
 
-            if (metadataEnabled && partitioner != null && !allTokens.get(i).isEmpty())
+            if (metadataEnabled && factory != null && allTokens.get(i) != null)
                 tokenMap.put(host, allTokens.get(i));
 
             if (isNew && !isInitialConnection)
@@ -653,8 +658,16 @@ class ControlConnection implements Connection.Owner {
             if (!host.getSocketAddress().equals(connection.address) && !foundHostsSet.contains(host.getSocketAddress()))
                 cluster.removeHost(host, isInitialConnection);
 
-        if (metadataEnabled)
-            cluster.metadata.rebuildTokenMap(partitioner, tokenMap);
+        if (metadataEnabled && factory != null && !tokenMap.isEmpty())
+            cluster.metadata.rebuildTokenMap(factory, tokenMap);
+    }
+
+    private static Set<Token> toTokens(Token.Factory factory, Set<String> tokensStr) {
+        Set<Token> tokens = new LinkedHashSet<Token>(tokensStr.size());
+        for (String tokenStr : tokensStr) {
+            tokens.add(factory.fromString(tokenStr));
+        }
+        return tokens;
     }
 
     private static boolean isValidPeer(Row peerRow, boolean logIfInvalid) {
@@ -756,13 +769,15 @@ class ControlConnection implements Connection.Owner {
     public void onUp(Host host) {
     }
 
+    public void onAdd(Host host) {
+    }
+
     public void onDown(Host host) {
         onHostGone(host);
     }
 
     public void onRemove(Host host) {
         onHostGone(host);
-        cluster.submitNodeListRefresh();
     }
 
     private void onHostGone(Host host) {
@@ -783,11 +798,4 @@ class ControlConnection implements Connection.Owner {
             backgroundReconnect(0);
     }
 
-    public void onAdd(Host host) {
-        // Refresh infos and token map if we didn't knew about that host, i.e. if we either don't have basic infos on it,
-        // or it's not part of our computed token map
-        Metadata.TokenMap tkmap = cluster.metadata.tokenMap;
-        if (host.getCassandraVersion() == null || tkmap == null || !tkmap.hosts.contains(host))
-            cluster.submitNodeListRefresh();
-    }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/EventDebouncer.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/EventDebouncer.java
@@ -164,7 +164,7 @@ class EventDebouncer<T> {
         return entry.future;
     }
 
-    private void scheduleImmediateDelivery() {
+    void scheduleImmediateDelivery() {
         cancelDelayedDelivery();
 
         while (state == State.RUNNING) {

--- a/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
@@ -63,6 +63,9 @@ abstract class SchemaParser {
                 assert rows.keyspaces != null;
                 Map<String, KeyspaceMetadata> keyspaces = buildKeyspaces(rows, cassandraVersion, cluster);
                 updateKeyspaces(metadata, metadata.keyspaces, keyspaces, targetKeyspace);
+                // If we rebuild all from scratch or have an updated keyspace, rebuild the token map
+                // since some replication on some keyspace may have changed
+                metadata.rebuildTokenMap();
             } else {
                 assert targetKeyspace != null;
                 KeyspaceMetadata keyspace = metadata.keyspaces.get(targetKeyspace);

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
@@ -42,7 +42,8 @@ import static com.datastax.driver.core.Assertions.assertThat;
 import static com.datastax.driver.core.Assertions.fail;
 import static com.datastax.driver.core.FakeHost.Behavior.THROWING_CONNECT_TIMEOUTS;
 import static com.datastax.driver.core.HostDistance.LOCAL;
-import static com.datastax.driver.core.TestUtils.*;
+import static com.datastax.driver.core.TestUtils.ipOfNode;
+import static com.datastax.driver.core.TestUtils.nonQuietClusterCloseOptions;
 import static org.mockito.Mockito.*;
 
 public class ClusterInitTest {
@@ -107,7 +108,6 @@ public class ClusterInitTest {
                     .withReconnectionPolicy(reconnectionPolicy)
                     .withPoolingOptions(poolingOptions)
                     .withProtocolVersion(TestUtils.getDesiredProtocolVersion())
-                    .withQueryOptions(nonDebouncingQueryOptions())
                     .build();
             cluster.connect();
 
@@ -228,7 +228,7 @@ public class ClusterInitTest {
         ScassandraCluster scassandraCluster = ScassandraCluster.builder()
                 .withIpPrefix(TestUtils.IP_PREFIX)
                 .withNodes(5)
-                        // For node 2, report an older version which uses protocol v1.
+                // For node 2, report an older version which uses protocol v1.
                 .forcePeerInfo(1, 2, "release_version", "1.2.19")
                 .build();
         Cluster cluster = Cluster.builder()
@@ -262,7 +262,7 @@ public class ClusterInitTest {
                 PrimingClient.builder()
                         .withHost(ipOfNode(1))
                         .withPort(scassandra.getAdminPort())
-                .build();
+                        .build();
 
         List<Map<String, ?>> rows = Lists.newArrayListWithCapacity(5);
 

--- a/driver-core/src/test/java/com/datastax/driver/core/HostMetadataIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostMetadataIntegrationTest.java
@@ -24,7 +24,6 @@ import java.net.InetAddress;
 import static com.datastax.driver.core.Assertions.assertThat;
 import static com.datastax.driver.core.CCMAccess.Workload.solr;
 import static com.datastax.driver.core.CCMAccess.Workload.spark;
-import static com.datastax.driver.core.TestUtils.nonDebouncingQueryOptions;
 import static com.datastax.driver.core.TestUtils.nonQuietClusterCloseOptions;
 
 public class HostMetadataIntegrationTest {
@@ -58,7 +57,6 @@ public class HostMetadataIntegrationTest {
         Cluster cluster = Cluster.builder()
                 .addContactPoints(ccm.addressOfNode(1).getAddress())
                 .withPort(ccm.getBinaryPort())
-                .withQueryOptions(nonDebouncingQueryOptions())
                 .build();
         try {
             cluster.connect();

--- a/driver-core/src/test/java/com/datastax/driver/core/NodeListRefreshDebouncerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/NodeListRefreshDebouncerTest.java
@@ -18,11 +18,7 @@ package com.datastax.driver.core;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.Collection;
-
 import static com.datastax.driver.core.CreateCCM.TestMode.PER_METHOD;
-import static com.datastax.driver.core.TestUtils.CREATE_KEYSPACE_SIMPLE_FORMAT;
-import static com.google.common.collect.Lists.newArrayList;
 import static org.mockito.Mockito.*;
 
 @CreateCCM(PER_METHOD)
@@ -31,21 +27,14 @@ public class NodeListRefreshDebouncerTest extends CCMTestsSupport {
 
     private static final int DEBOUNCE_TIME = 2000;
 
-    QueryOptions queryOptions;
-
-    Cluster cluster2;
-
-    Session session2;
+    private Cluster cluster2;
 
     // Control Connection to be spied.
     private ControlConnection controlConnection;
 
-    // Keyspaces to drop after test completes.
-    private Collection<String> keyspaces = newArrayList();
-
     @BeforeMethod(groups = "short")
     public void setup() {
-        queryOptions = new QueryOptions();
+        QueryOptions queryOptions = new QueryOptions();
         queryOptions.setRefreshNodeListIntervalMillis(DEBOUNCE_TIME);
         queryOptions.setMaxPendingRefreshNodeListRequests(5);
         queryOptions.setRefreshSchemaIntervalMillis(0);
@@ -55,29 +44,13 @@ public class NodeListRefreshDebouncerTest extends CCMTestsSupport {
                 .withPort(ccm().getBinaryPort())
                 .withQueryOptions(queryOptions)
                 .build());
-        session2 = cluster2.connect();
+
+        cluster2.init();
 
         // Create a spy of the Cluster's control connection and replace it with the spy.
         controlConnection = spy(cluster2.manager.controlConnection);
         cluster2.manager.controlConnection = controlConnection;
         reset(controlConnection);
-    }
-
-    /**
-     * Ensures that when a keyspace is created that refresh node list request
-     * is debounced and processed within {@link QueryOptions#getRefreshSchemaIntervalMillis()}
-     * + {@link QueryOptions#getRefreshNodeListIntervalMillis()}.
-     *
-     * @jira_ticket JAVA-657
-     * @since 2.0.11
-     */
-    @Test(groups = "short")
-    public void should_debounce_refresh_when_keyspace_created() {
-        String keyspace = "sdrwkc";
-        session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, keyspace, 1));
-        keyspaces.add(keyspace);
-
-        verify(controlConnection, timeout(DEBOUNCE_TIME + queryOptions.getRefreshSchemaIntervalMillis())).refreshNodeListAndTokenMap();
     }
 
     /**
@@ -90,16 +63,11 @@ public class NodeListRefreshDebouncerTest extends CCMTestsSupport {
      */
     @Test(groups = "short")
     public void should_refresh_when_max_pending_requests_reached() {
-        // Create keyspaces 5 times to cause
-        // refreshNodeListAndTokenMap to be called.
-        String prefix = "srwmprr";
         for (int i = 0; i < 5; i++) {
-            String keyspace = prefix + i;
-            session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, keyspace, 1));
-            keyspaces.add(keyspace);
+            cluster2.manager.submitNodeListRefresh();
         }
 
-        // add a 1 second delay to account for executor submit.
-        verify(controlConnection, timeout(1000)).refreshNodeListAndTokenMap();
+        // add delay to account for executor submit.
+        verify(controlConnection, timeout(DEBOUNCE_TIME)).refreshNodeListAndTokenMap();
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
@@ -44,7 +44,9 @@ public class SchemaChangesTest extends CCMTestsSupport {
     private static final String DROP_TABLE = "DROP TABLE %s.table1";
 
     /**
-     * The maximum time that the test will wait to check that listeners have been notified
+     * The maximum time that the test will wait to check that listeners have been notified.
+     * This threshold is intentionally set to a very high value to allow CI tests
+     * to pass.
      */
     private static final long NOTIF_TIMEOUT_MS = TimeUnit.MINUTES.toMillis(1);
 
@@ -89,7 +91,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
         cluster2.init();
 
         cluster1.register(listener1 = mock(SchemaChangeListener.class));
-        cluster1.register(listener2 = mock(SchemaChangeListener.class));
+        cluster2.register(listener2 = mock(SchemaChangeListener.class));
         listeners = Lists.newArrayList(listener1, listener2);
 
         schemaDisabledCluster.register(schemaDisabledListener = mock(SchemaChangeListener.class));
@@ -150,7 +152,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
                     .isInKeyspace(handleId(keyspace))
                     .hasName("table1");
         }
-        refreshSchema();
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace).getTable("table1")).isNotNull();
     }
@@ -166,7 +167,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
                     .isInKeyspace(handleId(keyspace))
                     .hasName("table1");
         }
-        refreshSchema();
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace).getTable("table1")).hasNoColumn("j");
         assert added != null;
@@ -183,7 +183,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
                     .hasName("table1")
                     .hasColumn("j");
         }
-        refreshSchema();
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace).getTable("table1")).hasColumn("j");
     }
@@ -198,14 +197,12 @@ public class SchemaChangesTest extends CCMTestsSupport {
                     .hasName("table1")
                     .isInKeyspace(handleId(keyspace));
         }
-        refreshSchema();
         execute(DROP_TABLE, keyspace);
         for (SchemaChangeListener listener : listeners) {
             ArgumentCaptor<TableMetadata> removed = ArgumentCaptor.forClass(TableMetadata.class);
             verify(listener, timeout(NOTIF_TIMEOUT_MS).times(1)).onTableRemoved(removed.capture());
             assertThat(removed.getValue()).hasName("table1");
         }
-        refreshSchema();
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace).getTable("table1")).isNull();
     }
@@ -221,7 +218,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
             assertThat((DataType) added.getValue())
                     .isUserType(handleId(keyspace), "type1");
         }
-        refreshSchema();
         for (Metadata m : metadatas())
             assertThat((DataType) m.getKeyspace(keyspace).getUserType("type1")).isNotNull();
     }
@@ -238,7 +234,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
             assertThat(previous.getValue().getFieldNames()).doesNotContain("j");
             assertThat(current.getValue().getFieldNames()).contains("j");
         }
-        refreshSchema();
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace).getUserType("type1").getFieldType("j")).isNotNull();
     }
@@ -254,7 +249,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
             verify(listener, timeout(NOTIF_TIMEOUT_MS).times(1)).onUserTypeRemoved(removed.capture());
             assertThat((DataType) removed.getValue()).isUserType(handleId(keyspace), "type1");
         }
-        refreshSchema();
         for (Metadata m : metadatas())
             assertThat((DataType) m.getKeyspace(keyspace).getUserType("type1")).isNull();
     }
@@ -263,7 +257,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
     @CassandraVersion(major = 2.2)
     public void should_notify_of_function_creation(String keyspace) {
         session1.execute(String.format("CREATE FUNCTION %s.\"ID\"(i int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return i;'", keyspace));
-
         for (SchemaChangeListener listener : listeners) {
             ArgumentCaptor<FunctionMetadata> added = ArgumentCaptor.forClass(FunctionMetadata.class);
             verify(listener, timeout(NOTIF_TIMEOUT_MS).times(1)).onFunctionAdded(added.capture());
@@ -271,7 +264,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
                     .isInKeyspace(handleId(keyspace))
                     .hasSignature("\"ID\"(int)");
         }
-        refreshSchema();
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace).getFunction("\"ID\"", DataType.cint()))
                     .isNotNull();
@@ -280,47 +272,44 @@ public class SchemaChangesTest extends CCMTestsSupport {
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
     @CassandraVersion(major = 2.2)
     public void should_notify_of_function_update(String keyspace) {
-        session1.execute(String.format("CREATE TYPE IF NOT EXISTS %s.user (\"ID\" int, name text)", keyspace));
-        session1.execute(String.format("CREATE FUNCTION %s.\"ID\"(user user) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return user.getInt(\"ID\");'", keyspace));
-        refreshSchema();
-
+        session1.execute(String.format("CREATE FUNCTION %s.\"ID\"(i int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return i;'", keyspace));
+        for (SchemaChangeListener listener : listeners) {
+            ArgumentCaptor<FunctionMetadata> added = ArgumentCaptor.forClass(FunctionMetadata.class);
+            verify(listener, timeout(NOTIF_TIMEOUT_MS).times(1)).onFunctionAdded(added.capture());
+            assertThat(added.getValue())
+                    .isInKeyspace(handleId(keyspace))
+                    .hasSignature("\"ID\"(int)");
+        }
         for (Metadata m : metadatas())
-            assertThat(m.getKeyspace(keyspace).getFunction("\"ID\"", m.getKeyspace(keyspace).getUserType("user")).getBody())
-                    .isEqualTo("return user.getInt(\"ID\");");
-
-        session1.execute(String.format("CREATE OR REPLACE FUNCTION %s.\"ID\"(user user) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java "
-                + "AS 'return 1 + user.getInt(\"ID\");'", keyspace));
-
+            assertThat(m.getKeyspace(keyspace).getFunction("\"ID\"", DataType.cint()))
+                    .isNotNull();
+        session1.execute(String.format("CREATE OR REPLACE FUNCTION %s.\"ID\"(i int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return i + 1;'", keyspace));
         for (SchemaChangeListener listener : listeners) {
             ArgumentCaptor<FunctionMetadata> current = ArgumentCaptor.forClass(FunctionMetadata.class);
             ArgumentCaptor<FunctionMetadata> previous = ArgumentCaptor.forClass(FunctionMetadata.class);
             verify(listener, timeout(NOTIF_TIMEOUT_MS).times(1)).onFunctionChanged(current.capture(), previous.capture());
-            assertThat(previous.getValue()).hasBody("return user.getInt(\"ID\");");
-            assertThat(current.getValue()).hasBody("return 1 + user.getInt(\"ID\");");
+            assertThat(previous.getValue()).hasBody("return i;");
+            assertThat(current.getValue()).hasBody("return i + 1;");
         }
-        refreshSchema();
         for (Metadata m : metadatas())
-            assertThat(m.getKeyspace(keyspace).getFunction("\"ID\"", m.getKeyspace(keyspace).getUserType("user")).getBody())
-                    .isEqualTo("return 1 + user.getInt(\"ID\");");
+            assertThat(m.getKeyspace(keyspace).getFunction("\"ID\"", DataType.cint()).getBody())
+                    .isEqualTo("return i + 1;");
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
     @CassandraVersion(major = 2.2)
     public void should_notify_of_function_drop(String keyspace) {
-        session1.execute(String.format("CREATE TYPE IF NOT EXISTS %s.user (\"ID\" int, name text)", keyspace));
-        session1.execute(String.format("CREATE FUNCTION %s.\"ID\"(user user) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return user.getInt(\"ID\");'", keyspace));
+        session1.execute(String.format("CREATE FUNCTION %s.\"ID\"(i int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return i;'", keyspace));
         session1.execute(String.format("DROP FUNCTION %s.\"ID\"", keyspace));
-
         for (SchemaChangeListener listener : listeners) {
             ArgumentCaptor<FunctionMetadata> removed = ArgumentCaptor.forClass(FunctionMetadata.class);
             verify(listener, timeout(NOTIF_TIMEOUT_MS).times(1)).onFunctionRemoved(removed.capture());
             assertThat(removed.getValue())
                     .isInKeyspace(handleId(keyspace))
-                    .hasSignature("\"ID\"(user)");
+                    .hasSignature("\"ID\"(int)");
         }
-        refreshSchema();
         for (Metadata m : metadatas())
-            assertThat(m.getKeyspace(keyspace).getFunction("\"ID\"", m.getKeyspace(keyspace).getUserType("user")))
+            assertThat(m.getKeyspace(keyspace).getFunction("\"ID\"", DataType.cint()))
                     .isNull();
     }
 
@@ -330,7 +319,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
         session1.execute(String.format("CREATE FUNCTION %s.\"PLUS\"(s int, v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java"
                 + " AS 'return s+v;'", keyspace));
         session1.execute(String.format("CREATE AGGREGATE %s.\"SUM\"(int) SFUNC \"PLUS\" STYPE int INITCOND 0;", keyspace));
-
         for (SchemaChangeListener listener : listeners) {
             ArgumentCaptor<AggregateMetadata> added = ArgumentCaptor.forClass(AggregateMetadata.class);
             verify(listener, timeout(NOTIF_TIMEOUT_MS).times(1)).onAggregateAdded(added.capture());
@@ -338,7 +326,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
                     .isInKeyspace(handleId(keyspace))
                     .hasSignature("\"SUM\"(int)");
         }
-        refreshSchema();
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace).getAggregate("\"SUM\"", DataType.cint()))
                     .isNotNull();
@@ -350,13 +337,17 @@ public class SchemaChangesTest extends CCMTestsSupport {
         session1.execute(String.format("CREATE FUNCTION %s.\"PLUS\"(s int, v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java"
                 + " AS 'return s+v;'", keyspace));
         session1.execute(String.format("CREATE AGGREGATE %s.\"SUM\"(int) SFUNC \"PLUS\" STYPE int INITCOND 0", keyspace));
-        refreshSchema();
+        for (SchemaChangeListener listener : listeners) {
+            ArgumentCaptor<AggregateMetadata> added = ArgumentCaptor.forClass(AggregateMetadata.class);
+            verify(listener, timeout(NOTIF_TIMEOUT_MS).times(1)).onAggregateAdded(added.capture());
+            assertThat(added.getValue())
+                    .isInKeyspace(handleId(keyspace))
+                    .hasSignature("\"SUM\"(int)");
+        }
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace).getAggregate("\"SUM\"", DataType.cint()).getInitCond())
                     .isEqualTo(0);
-
         session1.execute(String.format("CREATE OR REPLACE AGGREGATE %s.\"SUM\"(int) SFUNC \"PLUS\" STYPE int INITCOND 1", keyspace));
-
         for (SchemaChangeListener listener : listeners) {
             ArgumentCaptor<AggregateMetadata> current = ArgumentCaptor.forClass(AggregateMetadata.class);
             ArgumentCaptor<AggregateMetadata> previous = ArgumentCaptor.forClass(AggregateMetadata.class);
@@ -364,7 +355,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
             assertThat(previous.getValue()).hasInitCond(0);
             assertThat(current.getValue()).hasInitCond(1);
         }
-        refreshSchema();
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace).getAggregate("\"SUM\"", DataType.cint()).getInitCond())
                     .isEqualTo(1);
@@ -377,7 +367,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
                 + " AS 'return s+v;'", keyspace));
         session1.execute(String.format("CREATE AGGREGATE %s.\"SUM\"(int) SFUNC \"PLUS\" STYPE int INITCOND 0", keyspace));
         session1.execute(String.format("DROP AGGREGATE %s.\"SUM\"", keyspace));
-
         for (SchemaChangeListener listener : listeners) {
             ArgumentCaptor<AggregateMetadata> removed = ArgumentCaptor.forClass(AggregateMetadata.class);
             verify(listener, timeout(NOTIF_TIMEOUT_MS).times(1)).onAggregateRemoved(removed.capture());
@@ -385,8 +374,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
                     .isInKeyspace(handleId(keyspace))
                     .hasSignature("\"SUM\"(int)");
         }
-
-        refreshSchema();
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace).getAggregate("\"SUM\"", DataType.cint()))
                     .isNull();
@@ -397,7 +384,12 @@ public class SchemaChangesTest extends CCMTestsSupport {
     public void should_notify_of_view_creation(String keyspace) {
         session1.execute(String.format("CREATE TABLE %s.table1 (pk int PRIMARY KEY, c int)", keyspace));
         session1.execute(String.format("CREATE MATERIALIZED VIEW %s.mv1 AS SELECT c FROM %s.table1 WHERE c IS NOT NULL PRIMARY KEY (pk, c)", keyspace, keyspace));
-        refreshSchema();
+        for (SchemaChangeListener listener : listeners) {
+            ArgumentCaptor<MaterializedViewMetadata> removed = ArgumentCaptor.forClass(MaterializedViewMetadata.class);
+            verify(listener, timeout(NOTIF_TIMEOUT_MS).times(1)).onMaterializedViewAdded(removed.capture());
+            assertThat(removed.getValue())
+                    .hasName("mv1");
+        }
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace).getMaterializedView("mv1")).isNotNull();
     }
@@ -407,12 +399,26 @@ public class SchemaChangesTest extends CCMTestsSupport {
     public void should_notify_of_view_update(String keyspace) {
         session1.execute(String.format("CREATE TABLE %s.table1 (pk int PRIMARY KEY, c int)", keyspace));
         session1.execute(String.format("CREATE MATERIALIZED VIEW %s.mv1 AS SELECT c FROM %s.table1 WHERE c IS NOT NULL PRIMARY KEY (pk, c) WITH compaction = { 'class' : 'SizeTieredCompactionStrategy' }", keyspace, keyspace));
-        refreshSchema();
+        for (SchemaChangeListener listener : listeners) {
+            ArgumentCaptor<MaterializedViewMetadata> removed = ArgumentCaptor.forClass(MaterializedViewMetadata.class);
+            verify(listener, timeout(NOTIF_TIMEOUT_MS).times(1)).onMaterializedViewAdded(removed.capture());
+            assertThat(removed.getValue())
+                    .hasName("mv1");
+            assertThat(removed.getValue().getOptions().getCompaction().get("class"))
+                    .contains("SizeTieredCompactionStrategy");
+        }
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace).getMaterializedView("mv1").getOptions().getCompaction().get("class")).contains("SizeTieredCompactionStrategy");
-
         session1.execute(String.format("ALTER MATERIALIZED VIEW %s.mv1 WITH compaction = { 'class' : 'LeveledCompactionStrategy' }", keyspace));
-        refreshSchema();
+        for (SchemaChangeListener listener : listeners) {
+            ArgumentCaptor<MaterializedViewMetadata> current = ArgumentCaptor.forClass(MaterializedViewMetadata.class);
+            ArgumentCaptor<MaterializedViewMetadata> previous = ArgumentCaptor.forClass(MaterializedViewMetadata.class);
+            verify(listener, timeout(NOTIF_TIMEOUT_MS).times(1)).onMaterializedViewChanged(current.capture(), previous.capture());
+            assertThat(previous.getValue().getOptions().getCompaction().get("class"))
+                    .contains("SizeTieredCompactionStrategy");
+            assertThat(current.getValue().getOptions().getCompaction().get("class"))
+                    .contains("LeveledCompactionStrategy");
+        }
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace).getMaterializedView("mv1").getOptions().getCompaction().get("class")).contains("LeveledCompactionStrategy");
     }
@@ -423,7 +429,12 @@ public class SchemaChangesTest extends CCMTestsSupport {
         session1.execute(String.format("CREATE TABLE %s.table1 (pk int PRIMARY KEY, c int)", keyspace));
         session1.execute(String.format("CREATE MATERIALIZED VIEW %s.mv1 AS SELECT c FROM %s.table1 WHERE c IS NOT NULL PRIMARY KEY (pk, c)", keyspace, keyspace));
         session1.execute(String.format("DROP MATERIALIZED VIEW %s.mv1", keyspace));
-        refreshSchema();
+        for (SchemaChangeListener listener : listeners) {
+            ArgumentCaptor<MaterializedViewMetadata> removed = ArgumentCaptor.forClass(MaterializedViewMetadata.class);
+            verify(listener, timeout(NOTIF_TIMEOUT_MS).times(1)).onMaterializedViewRemoved(removed.capture());
+            assertThat(removed.getValue())
+                    .hasName("mv1");
+        }
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace).getMaterializedView("mv1")).isNull();
     }
@@ -436,7 +447,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
             verify(listener, timeout(NOTIF_TIMEOUT_MS).times(1)).onKeyspaceAdded(added.capture());
             assertThat(added.getValue()).hasName(handleId(keyspace));
         }
-        refreshSchema();
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace)).isNotNull();
     }
@@ -451,7 +461,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
             assertThat(added.getValue()).hasName(handleId(keyspace));
         }
         assert added != null;
-        refreshSchema();
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace).isDurableWrites()).isTrue();
         execute(ALTER_KEYSPACE, keyspace);
@@ -466,7 +475,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
                     .hasName(handleId(keyspace))
                     .isNotDurableWrites();
         }
-        refreshSchema();
         for (Metadata m : metadatas())
             assertThat(m.getKeyspace(keyspace)).isNotDurableWrites();
     }
@@ -474,14 +482,11 @@ public class SchemaChangesTest extends CCMTestsSupport {
     @Test(groups = "short", dataProvider = "newKeyspaceName")
     public void should_notify_of_keyspace_drop(String keyspace) throws InterruptedException {
         execute(CREATE_KEYSPACE, keyspace);
-        ArgumentCaptor<KeyspaceMetadata> added = null;
         for (SchemaChangeListener listener : listeners) {
-            added = ArgumentCaptor.forClass(KeyspaceMetadata.class);
+            ArgumentCaptor<KeyspaceMetadata> added = ArgumentCaptor.forClass(KeyspaceMetadata.class);
             verify(listener, timeout(NOTIF_TIMEOUT_MS).times(1)).onKeyspaceAdded(added.capture());
             assertThat(added.getValue()).hasName(handleId(keyspace));
         }
-        assert added != null;
-        refreshSchema();
         for (Metadata m : metadatas())
             assertThat(m.getReplicas(keyspace, Bytes.fromHexString("0xCAFEBABE"))).isNotEmpty();
         execute(CREATE_TABLE, keyspace); // to test table drop notifications
@@ -497,13 +502,11 @@ public class SchemaChangesTest extends CCMTestsSupport {
             assertThat(ks.getValue())
                     .hasName(handleId(keyspace));
         }
-        refreshSchema();
         for (Metadata m : metadatas()) {
             assertThat(m.getKeyspace(keyspace)).isNull();
             assertThat(m.getReplicas(keyspace, Bytes.fromHexString("0xCAFEBABE"))).isEmpty();
         }
     }
-
 
     /**
      * Ensures that calling {@link Metadata#newToken(String)} on a Cluster that has schema
@@ -588,7 +591,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
             schemaDisabledCluster.getConfiguration().getQueryOptions().setMetadataEnabled(true);
 
             verify(schemaDisabledControlConnection, after(1000)).refreshSchema(null, null, null, null);
-            verify(schemaDisabledControlConnection).refreshNodeListAndTokenMap();
 
             // Ensure that there is schema metadata.
             assertThat(schemaDisabledCluster.getMetadata().getKeyspace(keyspace)).isNotNull();
@@ -604,7 +606,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
             reset(schemaDisabledControlConnection);
             schemaDisabledCluster.getConfiguration().getQueryOptions().setMetadataEnabled(true);
             verify(schemaDisabledControlConnection, after(1000).never()).refreshSchema(null, null, null, null);
-            verify(schemaDisabledControlConnection, never()).refreshNodeListAndTokenMap();
         } finally {
             // Reset listener mock to not count it's interactions in this test.
             reset(schemaDisabledListener);
@@ -642,14 +643,5 @@ public class SchemaChangesTest extends CCMTestsSupport {
     private List<Metadata> metadatas() {
         return Lists.newArrayList(cluster1.getMetadata(), cluster2.getMetadata());
     }
-
-    @SuppressWarnings("unchecked")
-    private void refreshSchema() {
-        Futures.getUnchecked(
-                Futures.successfulAsList(
-                        cluster1.manager.submitSchemaRefresh(null, null, null, null),
-                        cluster2.manager.submitSchemaRefresh(null, null, null, null)));
-    }
-
 
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaRefreshDebouncerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaRefreshDebouncerTest.java
@@ -17,7 +17,6 @@ package com.datastax.driver.core;
 
 import org.mockito.ArgumentCaptor;
 import org.testng.SkipException;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -249,6 +248,8 @@ public class SchemaRefreshDebouncerTest extends CCMTestsSupport {
         String prefix = TestUtils.generateIdentifier("ks_");
         for (int i = 0; i < 3; i++) {
             session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, prefix + i, 1));
+            // check that the metadata is immediately up-to-date for the client that issued the DDL statement
+            assertThat(cluster().getMetadata().getKeyspace(prefix + i)).isNotNull();
         }
 
         verify(listener, timeout(DEBOUNCE_TIME * 3).times(3)).onKeyspaceAdded(any(KeyspaceMetadata.class));
@@ -275,6 +276,8 @@ public class SchemaRefreshDebouncerTest extends CCMTestsSupport {
         String prefix = TestUtils.generateIdentifier("ks_");
         for (int i = 0; i < 5; i++) {
             session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, prefix + i, 1));
+            // check that the metadata is immediately up-to-date for the client that issued the DDL statement
+            assertThat(cluster().getMetadata().getKeyspace(prefix + i)).isNotNull();
         }
 
         // Event should be processed immediately as we hit our threshold.

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
@@ -61,8 +61,7 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
         return Cluster.builder()
                 .addContactPoints(getContactPoints().get(0))
                 .withPort(ccm().getBinaryPort())
-                .withLoadBalancingPolicy(lbp)
-                .withQueryOptions(TestUtils.nonDebouncingQueryOptions());
+                .withLoadBalancingPolicy(lbp);
     }
 
     @Override

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAsyncTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAsyncTest.java
@@ -71,7 +71,7 @@ public class MapperAsyncTest extends CCMTestsSupport {
         // create a second cluster to perform everything asynchronously,
         // including session initialization
         Cluster cluster2 = register(
-                createClusterBuilderNoDebouncing()
+                createClusterBuilder()
                         .addContactPoints(getContactPoints())
                         .withPort(ccm().getBinaryPort())
                         .build());


### PR DESCRIPTION
I'm also including a fix for JAVA-1120 in the same PR as the affected code is pretty much the same.

Note that I don't have specific tests for JAVA-1120 but I did benchmark quickly the creation of 50 tables with default debouncer options. Without the fix it takes in avg. 50 secs on my laptop; with the fix, it takes 3 secs in avg.

The 3rd commit brings minor enhancements to `SchemaChangesTest`: missing assertions and verifications basically.
