### PR TITLE
Appveyor CI enablement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Datastax Java Driver for Apache Cassandra
 
-[![Build Status](https://travis-ci.org/datastax/java-driver.svg?branch=3.0.x)](https://travis-ci.org/datastax/java-driver)
+[![Build Status](https://travis-ci.org/datastax/java-driver.svg?branch=3.0.x)](https://travis-ci.org/datastax/java-driver) [![Build status](https://ci.appveyor.com/api/projects/status/717ysg5l1si1h3pi/branch/3.0.x?svg=true)](https://ci.appveyor.com/project/DataStax/java-driver/branch/3.0.x)
 
 *If you're reading this on github.com, please note that this is the readme
 for the development version and that some features described here might

--- a/ci/appveyor.ps1
+++ b/ci/appveyor.ps1
@@ -1,0 +1,129 @@
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$dep_dir="C:\Users\appveyor\deps"
+If (!(Test-Path $dep_dir)) {
+  Write-Host "Creating $($dep_dir)"
+  New-Item -Path $dep_dir -ItemType Directory -Force
+}
+
+$apr_platform = "Win32"
+$openssl_platform = "Win32"
+$vc_platform = "x86"
+$env:PYTHON="C:\Python27"
+$env:OPENSSL_PATH="C:\OpenSSL-Win32"
+If ($env:PLATFORM -eq "X64") {
+  $apr_platform = "x64"
+  $vc_platform = "x64"
+  $env:PYTHON="C:\Python27-x64"
+  $env:OPENSSL_PATH="C:\OpenSSL-Win64"
+}
+
+$env:JAVA_HOME="C:\Program Files\Java\jdk$($env:java_version)"
+$env:JAVA_8_HOME="C:\Program Files\Java\jdk1.8.0"
+$env:PATH="$($env:PYTHON);$($env:PYTHON)\Scripts;$($env:JAVA_HOME)\bin;$($env:OPENSSL_PATH)\bin;$($env:PATH)"
+$env:CCM_PATH="$($dep_dir)\ccm"
+
+$apr_dist_path = "$($dep_dir)\apr"
+# Build APR if it hasn't been previously built.
+If (!(Test-Path $apr_dist_path)) {
+  Write-Host "Cloning APR"
+  $apr_path = "C:\Users\appveyor\apr"
+  Start-Process git -ArgumentList "clone --branch=1.5.2 --depth=1 https://github.com/apache/apr.git $($apr_path)" -Wait -nnw
+  Write-Host "Setting Visual Studio Environment to VS 2015"
+  Push-Location "$($env:VS140COMNTOOLS)\..\..\VC"
+  cmd /c "vcvarsall.bat $vc_platform & set" |
+  foreach {
+    if ($_ -match "=") {
+      $v = $_.split("="); Set-Item -force -path "ENV:\$($v[0])"  -value "$($v[1])"
+    }
+  }
+  Pop-Location
+  Write-Host "Building APR (an error may be printed, but it will still build)"
+  Push-Location $($apr_path)
+  cmd /c nmake -f Makefile.win ARCH="$apr_platform Release" PREFIX=$($apr_dist_path) buildall install
+  Pop-Location
+  Write-Host "Done Building APR"
+}
+$env:PATH="$($apr_dist_path)\bin;$($env:PATH)"
+
+# Install Ant and Maven
+$ant_base = "$($dep_dir)\ant"
+$ant_path = "$($ant_base)\apache-ant-1.9.7"
+If (!(Test-Path $ant_path)) {
+  Write-Host "Installing Ant"
+  $ant_url = "https://www.dropbox.com/s/lgx95x1jr6s787l/apache-ant-1.9.7-bin.zip?dl=1"
+  $ant_zip = "C:\Users\appveyor\apache-ant-1.9.7-bin.zip"
+  (new-object System.Net.WebClient).DownloadFile($ant_url, $ant_zip)
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($ant_zip, $ant_base)
+}
+$env:PATH="$($ant_path)\bin;$($env:PATH)"
+
+$maven_base = "$($dep_dir)\maven"
+$maven_path = "$($maven_base)\apache-maven-3.2.5"
+If (!(Test-Path $maven_path)) {
+  Write-Host "Installing Maven"
+  $maven_url = "https://www.dropbox.com/s/fh9kffmexprsmha/apache-maven-3.2.5-bin.zip?dl=1"
+  $maven_zip = "C:\Users\appveyor\apache-maven-3.2.5-bin.zip"
+  (new-object System.Net.WebClient).DownloadFile($maven_url, $maven_zip)
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($maven_zip, $maven_base)
+}
+$env:PATH="$($maven_path)\bin;$($env:PATH)"
+
+$jdks = @("1.6.0", "1.7.0", "1.8.0")
+foreach ($jdk in $jdks) {
+  $java_dir = "C:\Program Files\Java\jdk$jdk"
+  $jce_target = "$java_dir\jre\lib\security"
+  $jce_indicator = "$jce_target\README.txt"
+  # Install Java Cryptographic Extensions, needed for SSL.
+  # If this file doesn't exist we know JCE hasn't been installed.
+  If (!(Test-Path $jce_indicator)) {
+    Write-Host "Installing JCE for $jdk"
+    $zip = "$dep_dir\jce_policy-$jdk.zip"
+    $url = "https://www.dropbox.com/s/po4308hlwulpvep/UnlimitedJCEPolicyJDK7.zip?dl=1"
+    $extract_folder = "UnlimitedJCEPolicy"
+    If ($jdk -eq "1.8.0") {
+      $url = "https://www.dropbox.com/s/al1e6e92cjdv7m7/jce_policy-8.zip?dl=1"
+      $extract_folder = "UnlimitedJCEPolicyJDK8"
+    }
+    ElseIf ($jdk -eq "1.6.0") {
+      $url = "https://www.dropbox.com/s/dhrtucxcif4n11k/jce_policy-6.zip?dl=1"
+      $extract_folder = "jce"
+    }
+    # Download zip to staging area if it doesn't exist, we do this because
+    # we extract it to the directory based on the platform and we want to cache
+    # this file so it can apply to all platforms.
+    if(!(Test-Path $zip)) {
+      (new-object System.Net.WebClient).DownloadFile($url, $zip)
+    }
+
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $jce_target)
+
+    $jcePolicyDir = "$jce_target\$extract_folder"
+    Move-Item $jcePolicyDir\* $jce_target\ -force
+    Remove-Item $jcePolicyDir
+  }
+}
+
+# Install Python Dependencies for CCM.
+Write-Host "Installing Python Dependencies for CCM"
+Start-Process python -ArgumentList "-m pip install psutil pyYaml six" -Wait -nnw
+
+# Clone ccm from git and use master.
+If (!(Test-Path $env:CCM_PATH)) {
+  Write-Host "Cloning CCM"
+  Start-Process git -ArgumentList "clone https://github.com/pcmanus/ccm.git $($env:CCM_PATH)" -Wait -nnw
+}
+
+# Copy ccm -> ccm.py so windows knows to run it.
+If (!(Test-Path $env:CCM_PATH\ccm.py)) {
+  Copy-Item "$env:CCM_PATH\ccm" "$env:CCM_PATH\ccm.py"
+}
+$env:PYTHONPATH="$($env:CCM_PATH);$($env:PYTHONPATH)"
+$env:PATH="$($env:CCM_PATH);$($env:PATH)"
+
+# Predownload cassandra version for CCM if it isn't already downloaded.
+If (!(Test-Path C:\Users\appveyor\.ccm\repository\$env:cassandra_version)) {
+  Write-Host "Preinstalling C* $($env:cassandra_version)"
+  Start-Process python -ArgumentList "$($env:CCM_PATH)\ccm.py create -v $($env:cassandra_version) -n 1 predownload" -Wait -nnw
+  Start-Process python -ArgumentList "$($env:CCM_PATH)\ccm.py remove predownload" -Wait -nnw
+}

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -1,0 +1,21 @@
+environment:
+  test_profile: default
+  cassandra_version: 3.5
+  matrix:
+    - java_version: 1.6.0
+    - java_version: 1.7.0
+    - java_version: 1.8.0
+      test_profile: short
+platform: x64
+install:
+  - ps: .\ci\appveyor.ps1
+build_script:
+  - mvn -B install -DskipTests=true
+test_script:
+  - "mvn -B -Dccm.java.home=\"%JAVA_8_HOME%\" -Dccm.maxNumberOfNodes=1 -Dcassandra.version=%cassandra_version% verify -P%test_profile%"
+on_finish:
+  - ps: .\ci\uploadtests.ps1
+cache:
+  - C:\Users\appveyor\.m2
+  - C:\Users\appveyor\.ccm\repository
+  - C:\Users\appveyor\deps -> .\ci\appveyor.ps1

--- a/ci/uploadtests.ps1
+++ b/ci/uploadtests.ps1
@@ -1,0 +1,17 @@
+$testResults=Get-ChildItem TEST-TestSuite.xml -Recurse
+
+Write-Host "Uploading test results."
+
+$url = "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)"
+$wc = New-Object 'System.Net.WebClient'
+
+foreach ($testResult in $testResults) {
+  try {
+    Write-Host -ForegroundColor Green "Uploading $testResult -> $url."
+    $wc.UploadFile($url, $testResult)
+  } catch [Net.WebException] {
+    Write-Host -ForegroundColor Red "Failed Uploading $testResult -> $url.  $_"
+  }
+}
+
+Write-Host "Done uploading test results."

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative</artifactId>
-            <version>1.1.33.Fork17</version>
+            <version>1.1.33.Fork18</version>
             <classifier>${os.detected.classifier}</classifier>
             <scope>test</scope>
         </dependency>

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -193,7 +193,7 @@ public class CCMBridge implements CCMAccess {
      *
      * @return <code>true</code> if the operating system is a Windows one, <code>false</code> otherwise.
      */
-    private static boolean isWindows() {
+    public static boolean isWindows() {
 
         String osName = System.getProperty("os.name");
         return osName != null && osName.startsWith("Windows");

--- a/driver-core/src/test/java/com/datastax/driver/core/ProtocolV1Test.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ProtocolV1Test.java
@@ -16,6 +16,7 @@
 package com.datastax.driver.core;
 
 import com.datastax.driver.core.exceptions.UnsupportedFeatureException;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import static com.datastax.driver.core.ProtocolVersion.V1;
@@ -31,6 +32,13 @@ public class ProtocolV1Test extends CCMTestsSupport {
     public Cluster.Builder createClusterBuilder() {
         return super.createClusterBuilder()
                 .withProtocolVersion(V1);
+    }
+
+    @Override
+    public void beforeTestClass(Object testInstance) throws Exception {
+        if (CCMBridge.isWindows())
+            throw new SkipException("C* 1.2 is not supported on Windows.");
+        super.beforeTestClass(testInstance);
     }
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/ReadTimeoutTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReadTimeoutTest.java
@@ -55,7 +55,7 @@ public class ReadTimeoutTest extends ScassandraTestBase.PerClassCluster {
 
     @Test(groups = "short")
     public void should_use_statement_timeout_if_overridden() {
-        Statement statement = new SimpleStatement(query).setReadTimeoutMillis(200);
+        Statement statement = new SimpleStatement(query).setReadTimeoutMillis(10000);
         session.execute(statement);
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SessionLeakTest.java
@@ -34,7 +34,7 @@ public class SessionLeakTest extends CCMTestsSupport {
 
     SocketChannelMonitor channelMonitor;
 
-    @Test(groups = "short")
+    @Test(groups = "long")
     public void connectionLeakTest() throws Exception {
         // Checking for JAVA-342
         channelMonitor = new SocketChannelMonitor();

--- a/driver-core/src/test/java/com/datastax/driver/core/SpeculativeExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SpeculativeExecutionTest.java
@@ -123,6 +123,7 @@ public class SpeculativeExecutionTest {
         ResultSet rs = session.execute(statement);
         Row row = rs.one();
 
+        assertThat(row).isNotNull();
         assertThat(row.getString("result")).isEqualTo("result1");
         assertThat(errors.getSpeculativeExecutions().getCount()).isEqualTo(execStartCount);
         assertThat(errors.getRetriesOnReadTimeout().getCount()).isEqualTo(retriesStartCount + 1);

--- a/manual/ssl/README.md
+++ b/manual/ssl/README.md
@@ -154,7 +154,7 @@ add it to your dependencies.
 
 There are known runtime incompatibilities between newer versions of
 netty-tcnative and the version of netty that the driver uses.  For best
-results, use version 1.1.33.Fork17.
+results, use version 1.1.33.Fork18.
 
 Using netty-tcnative requires JDK 1.7 or above and requires the presence of
 OpenSSL on the system.  It will not fall back to the JDK implementation.

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <assertj.version>1.7.0</assertj.version>
         <mockito.version>1.10.8</mockito.version>
         <commons-exec.version>1.3</commons-exec.version>
-        <scassandra.version>1.0.3</scassandra.version>
+        <scassandra.version>1.0.9</scassandra.version>
         <main.basedir>${project.basedir}</main.basedir>
         <ipprefix>127.0.1.</ipprefix>
         <test.groups>unit</test.groups>


### PR DESCRIPTION
- Enables Appveyor CI for running integration tests against windows.  Initial goal is to run 'short' suite against jdk8 w/ C\* 3.0.5, 'unit' suites against jdk6 and jdk7.  Takes about ~50 minutes and should run rather reliably.
- Eventually to enable daily or weekly full suite runs against C\* 2.2+ once more confidence is established.
- Provides validation in ensuring that code that requires native os calls (netty-tcnative, jnr, etc.) works on windows.  Prebuilds libapr (if not present) and uses provided openssl for validating netty-tcnative.

Changes:
- Use powershell and use `--quiet-windows` flag on start (new C\* versions require this)
- Some platform specific quoting adjustments since windows is fickle about spaces.
- Some refactoring in `HostConnectionPoolTest` using `ConditionChecker` to ensure pools grow/shrink.
- Mark some tests as long that should be as they require multi-node clusters or take a long time.
- Add `exactRequired` field to `CassandraVersion` and `DseVersion` annotations to indicate that a test requires a specific version of Cassandra to run.
- Upgrade netty-tcnative test dependency from 1.1.33.Fork17 to 1.1.33.Fork18 as Fork17 does not work on windows.
- Upgrade scassandra to 1.0.9 (reduced thread count improves test stability on windows).
