### PR TITLE
IF_NOT_EXISTS mapper option for SAVE queries.

### DIFF
--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/QueryType.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/QueryType.java
@@ -69,8 +69,10 @@ class QueryType {
                 Insert.Options usings = insert.using();
                 for (Mapper.Option opt : options) {
                     opt.checkValidFor(QueryType.SAVE, manager);
-                    if (opt.isIncludedInQuery())
+                    if (opt.isIncludedInQuery()) {
+                        opt.applyTo(insert);
                         opt.appendTo(usings);
+                    }
                 }
                 return insert.toString();
             }

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperIfNotExistsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperIfNotExistsTest.java
@@ -1,0 +1,97 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.core.CCMTestsSupport;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("unused")
+public class MapperIfNotExistsTest extends CCMTestsSupport {
+
+    Mapper<User> mapper;
+
+    @Override
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE user (login text primary key, v int)");
+    }
+
+    @BeforeMethod(groups = "short")
+    public void setup() {
+        mapper = new MappingManager(session()).mapper(User.class);
+    }
+
+    @Test(groups = "short")
+    void should_not_insert_if_not_exists_specified() {
+        insertAndVerifyApplied("user1", 1, true, true);
+        insertAndVerifyApplied("user1", 2, true, false);
+        assertThat(mapper.get("user1").v).isEqualTo(1);
+    }
+
+    @Test(groups = "short")
+    void should_insert_if_not_exist_not_specified() {
+        insertAndVerifyApplied("user1", 1, false, true);
+        insertAndVerifyApplied("user1", 2, false, true);
+        assertThat(mapper.get("user1").v).isEqualTo(2);
+    }
+
+    private void insertAndVerifyApplied(String username, int v, boolean ifNotExists, boolean expectedWasApplied) {
+        User user = new User(username, v);
+        List<Mapper.Option> options = new ArrayList<Mapper.Option>();
+        Statement statement = mapper.saveQuery(user, Mapper.Option.ifNotExists(ifNotExists));
+        assertThat(session().execute(statement).wasApplied()).isEqualTo(expectedWasApplied);
+    }
+
+
+    @Table(name = "user")
+    public static class User {
+        @PartitionKey
+        private String login;
+        private int v;
+
+        public User() {
+        }
+
+        public User(String login, int v) {
+            this.login = login;
+            this.v = v;
+        }
+
+        public String getLogin() {
+            return login;
+        }
+
+        public void setLogin(String login) {
+            this.login = login;
+        }
+
+        public int getV() {
+            return v;
+        }
+
+        public void setV(int v) {
+            this.v = v;
+        }
+    }
+}


### PR DESCRIPTION
Added IF_NOT_EXISTS mapper option for save operations.

Useful in cases when you want to insert something atomically, but you are not sure it exists or not. And your app logic actually depends on  whether it was inserted or not. 

You still can build Insert by hands, but this way looks much much prettier.

For example, user registration process, your User table has PrimaryKey `username`. You try to register  user, but if 'it exists', e.g. wasApplied returned false - you tell about that on UI with error/warning "User already exists". Until try to insert, you'd never know that.
