### PR TITLE
Allow to set default value when getting primitive type value is null

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractGettableByIndexData.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractGettableByIndexData.java
@@ -96,10 +96,18 @@ abstract class AbstractGettableByIndexData implements GettableByIndexData {
      */
     @Override
     public boolean getBool(int i) {
+         return getBool(i, false);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getBool(int i, boolean defaultValue) {
         ByteBuffer value = getValue(i);
         TypeCodec<Boolean> codec = codecFor(i, Boolean.class);
         if (codec instanceof TypeCodec.PrimitiveBooleanCodec)
-            return ((TypeCodec.PrimitiveBooleanCodec) codec).deserializeNoBoxing(value, protocolVersion);
+            return ((TypeCodec.PrimitiveBooleanCodec) codec).deserializeNoBoxing(value, protocolVersion, defaultValue);
         else
             return codec.deserialize(value, protocolVersion);
     }
@@ -109,10 +117,18 @@ abstract class AbstractGettableByIndexData implements GettableByIndexData {
      */
     @Override
     public byte getByte(int i) {
+    	return getByte(i, (byte)0);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public byte getByte(int i, byte defaultValue) {
         ByteBuffer value = getValue(i);
         TypeCodec<Byte> codec = codecFor(i, Byte.class);
         if (codec instanceof TypeCodec.PrimitiveByteCodec)
-            return ((TypeCodec.PrimitiveByteCodec) codec).deserializeNoBoxing(value, protocolVersion);
+            return ((TypeCodec.PrimitiveByteCodec) codec).deserializeNoBoxing(value, protocolVersion, defaultValue);
         else
             return codec.deserialize(value, protocolVersion);
     }
@@ -122,10 +138,18 @@ abstract class AbstractGettableByIndexData implements GettableByIndexData {
      */
     @Override
     public short getShort(int i) {
+        return getShort(i, (short)0);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public short getShort(int i, short defaultValue) {
         ByteBuffer value = getValue(i);
         TypeCodec<Short> codec = codecFor(i, Short.class);
         if (codec instanceof TypeCodec.PrimitiveShortCodec)
-            return ((TypeCodec.PrimitiveShortCodec) codec).deserializeNoBoxing(value, protocolVersion);
+            return ((TypeCodec.PrimitiveShortCodec) codec).deserializeNoBoxing(value, protocolVersion, defaultValue);
         else
             return codec.deserialize(value, protocolVersion);
     }
@@ -135,10 +159,20 @@ abstract class AbstractGettableByIndexData implements GettableByIndexData {
      */
     @Override
     public int getInt(int i) {
+    	return getInt(i, 0);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getInt(int i, int defaultValue) {
         ByteBuffer value = getValue(i);
+        if(value.remaining()==0)
+        	return 0;
         TypeCodec<Integer> codec = codecFor(i, Integer.class);
         if (codec instanceof TypeCodec.PrimitiveIntCodec)
-            return ((TypeCodec.PrimitiveIntCodec) codec).deserializeNoBoxing(value, protocolVersion);
+            return ((TypeCodec.PrimitiveIntCodec) codec).deserializeNoBoxing(value, protocolVersion, defaultValue);
         else
             return codec.deserialize(value, protocolVersion);
     }
@@ -148,10 +182,18 @@ abstract class AbstractGettableByIndexData implements GettableByIndexData {
      */
     @Override
     public long getLong(int i) {
+        return getLong(i, 0);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getLong(int i, long defaultValue) {
         ByteBuffer value = getValue(i);
         TypeCodec<Long> codec = codecFor(i, Long.class);
         if (codec instanceof TypeCodec.PrimitiveLongCodec)
-            return ((TypeCodec.PrimitiveLongCodec) codec).deserializeNoBoxing(value, protocolVersion);
+            return ((TypeCodec.PrimitiveLongCodec) codec).deserializeNoBoxing(value, protocolVersion, defaultValue);
         else
             return codec.deserialize(value, protocolVersion);
     }
@@ -192,10 +234,17 @@ abstract class AbstractGettableByIndexData implements GettableByIndexData {
      */
     @Override
     public float getFloat(int i) {
+        return getFloat(i, 0);
+    }
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public float getFloat(int i, float defaultValue) {
         ByteBuffer value = getValue(i);
         TypeCodec<Float> codec = codecFor(i, Float.class);
         if (codec instanceof TypeCodec.PrimitiveFloatCodec)
-            return ((TypeCodec.PrimitiveFloatCodec) codec).deserializeNoBoxing(value, protocolVersion);
+            return ((TypeCodec.PrimitiveFloatCodec) codec).deserializeNoBoxing(value, protocolVersion, defaultValue);
         else
             return codec.deserialize(value, protocolVersion);
     }
@@ -205,10 +254,18 @@ abstract class AbstractGettableByIndexData implements GettableByIndexData {
      */
     @Override
     public double getDouble(int i) {
+        return getDouble(i, 0);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public double getDouble(int i, double defaultValue) {
         ByteBuffer value = getValue(i);
         TypeCodec<Double> codec = codecFor(i, Double.class);
         if (codec instanceof TypeCodec.PrimitiveDoubleCodec)
-            return ((TypeCodec.PrimitiveDoubleCodec) codec).deserializeNoBoxing(value, protocolVersion);
+            return ((TypeCodec.PrimitiveDoubleCodec) codec).deserializeNoBoxing(value, protocolVersion, defaultValue);
         else
             return codec.deserialize(value, protocolVersion);
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractGettableData.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractGettableData.java
@@ -62,6 +62,14 @@ public abstract class AbstractGettableData extends AbstractGettableByIndexData i
     public boolean getBool(String name) {
         return getBool(getIndexOf(name));
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getBool(String name, boolean defaultValue) {
+        return getBool(getIndexOf(name), defaultValue);
+    }
 
     /**
      * {@inheritDoc}
@@ -69,6 +77,14 @@ public abstract class AbstractGettableData extends AbstractGettableByIndexData i
     @Override
     public byte getByte(String name) {
         return getByte(getIndexOf(name));
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public byte getByte(String name, byte defaultValue) {
+        return getByte(getIndexOf(name), defaultValue);
     }
 
     /**
@@ -78,6 +94,14 @@ public abstract class AbstractGettableData extends AbstractGettableByIndexData i
     public short getShort(String name) {
         return getShort(getIndexOf(name));
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public short getShort(String name, short defaultValue) {
+        return getShort(getIndexOf(name), defaultValue);
+    }
 
     /**
      * {@inheritDoc}
@@ -86,6 +110,14 @@ public abstract class AbstractGettableData extends AbstractGettableByIndexData i
     public int getInt(String name) {
         return getInt(getIndexOf(name));
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getInt(String name, int defaultValue) {
+        return getInt(getIndexOf(name), defaultValue);
+    }
 
     /**
      * {@inheritDoc}
@@ -93,6 +125,14 @@ public abstract class AbstractGettableData extends AbstractGettableByIndexData i
     @Override
     public long getLong(String name) {
         return getLong(getIndexOf(name));
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getLong(String name, long defaultValue) {
+        return getLong(getIndexOf(name), defaultValue);
     }
 
     /**
@@ -126,6 +166,14 @@ public abstract class AbstractGettableData extends AbstractGettableByIndexData i
     public float getFloat(String name) {
         return getFloat(getIndexOf(name));
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public float getFloat(String name, float defaultValue) {
+        return getFloat(getIndexOf(name), defaultValue);
+    }
 
     /**
      * {@inheritDoc}
@@ -133,6 +181,14 @@ public abstract class AbstractGettableData extends AbstractGettableByIndexData i
     @Override
     public double getDouble(String name) {
         return getDouble(getIndexOf(name));
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public double getDouble(String name, double defaultValue) {
+        return getDouble(getIndexOf(name), defaultValue);
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -886,6 +886,14 @@ public class BoundStatement extends Statement implements SettableData<BoundState
     public boolean getBool(int i) {
         return wrapper.getBool(i);
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getBool(int i, boolean defaultValue) {
+        return wrapper.getBool(i, defaultValue);
+    }
 
     /**
      * {@inheritDoc}
@@ -893,6 +901,14 @@ public class BoundStatement extends Statement implements SettableData<BoundState
     @Override
     public boolean getBool(String name) {
         return wrapper.getBool(name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getBool(String name, boolean defaultValue) {
+        return wrapper.getBool(name, defaultValue);
     }
 
     /**
@@ -907,8 +923,25 @@ public class BoundStatement extends Statement implements SettableData<BoundState
      * {@inheritDoc}
      */
     @Override
+    public byte getByte(int i, byte defaultValue) {
+        return wrapper.getByte(i, defaultValue);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public byte getByte(String name) {
         return wrapper.getByte(name);
+    }
+    
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public byte getByte(String name, byte defaultValue) {
+        return wrapper.getByte(name, defaultValue);
     }
 
     /**
@@ -917,6 +950,14 @@ public class BoundStatement extends Statement implements SettableData<BoundState
     @Override
     public short getShort(int i) {
         return wrapper.getShort(i);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public short getShort(int i, short defaultValue) {
+        return wrapper.getShort(i, defaultValue);
     }
 
     /**
@@ -931,8 +972,24 @@ public class BoundStatement extends Statement implements SettableData<BoundState
      * {@inheritDoc}
      */
     @Override
+    public short getShort(String name, short defaultValue) {
+        return wrapper.getShort(name, defaultValue);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public int getInt(int i) {
         return wrapper.getInt(i);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getInt(int i, int defaultValue) {
+        return wrapper.getInt(i, defaultValue);
     }
 
     /**
@@ -942,6 +999,14 @@ public class BoundStatement extends Statement implements SettableData<BoundState
     public int getInt(String name) {
         return wrapper.getInt(name);
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getInt(String name, int defaultValue) {
+        return wrapper.getInt(name, defaultValue);
+    }
 
     /**
      * {@inheritDoc}
@@ -950,6 +1015,14 @@ public class BoundStatement extends Statement implements SettableData<BoundState
     public long getLong(int i) {
         return wrapper.getLong(i);
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getLong(int i, long defaultValue) {
+        return wrapper.getLong(i, defaultValue);
+    }
 
     /**
      * {@inheritDoc}
@@ -957,6 +1030,14 @@ public class BoundStatement extends Statement implements SettableData<BoundState
     @Override
     public long getLong(String name) {
         return wrapper.getLong(name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getLong(String name, long defaultValue) {
+        return wrapper.getLong(name, defaultValue);
     }
 
     /**
@@ -1014,6 +1095,14 @@ public class BoundStatement extends Statement implements SettableData<BoundState
     public float getFloat(int i) {
         return wrapper.getFloat(i);
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public float getFloat(int i, float defaultValue) {
+        return wrapper.getFloat(i, defaultValue);
+    }
 
     /**
      * {@inheritDoc}
@@ -1027,8 +1116,24 @@ public class BoundStatement extends Statement implements SettableData<BoundState
      * {@inheritDoc}
      */
     @Override
+    public float getFloat(String name, float defaultValue) {
+        return wrapper.getFloat(name, defaultValue);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public double getDouble(int i) {
         return wrapper.getDouble(i);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public double getDouble(int i, double defaultValue) {
+        return wrapper.getDouble(i, defaultValue);
     }
 
     /**
@@ -1037,6 +1142,14 @@ public class BoundStatement extends Statement implements SettableData<BoundState
     @Override
     public double getDouble(String name) {
         return wrapper.getDouble(name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public double getDouble(String name, double defaultValue) {
+        return wrapper.getDouble(name, defaultValue);
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/GettableByIndexData.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/GettableByIndexData.java
@@ -54,6 +54,22 @@ public interface GettableByIndexData {
      *                                   type to a boolean.
      */
     public boolean getBool(int i);
+    
+    /**
+     * Returns the {@code i}th value as a boolean.
+     * <p/>
+     * This method uses the {@link CodecRegistry} to find a codec to convert the underlying CQL type to a Java {@code boolean}
+     * (for CQL type {@code boolean}, this will be the built-in codec).
+     *
+     * @param i the index ({@code 0 <= i < size()}) to retrieve.
+     * @param defaultValue the default returned value if the value is NULL.
+     * @return the boolean value of the {@code i}th element. If the value is NULL, {@code defaultValue} is returned.
+     * If you need to distinguish NULL and false values, check first with {@link #isNull(int)} or use {@code get(i, Boolean.class)}.
+     * @throws IndexOutOfBoundsException if {@code i} is not a valid index for this object.
+     * @throws CodecNotFoundException    if there is no registered codec to convert the element's CQL
+     *                                   type to a boolean.
+     */
+    public boolean getBool(int i, boolean defaultValue);
 
     /**
      * Returns the {@code i}th value as a byte.
@@ -69,6 +85,23 @@ public interface GettableByIndexData {
      *                                   type to a byte.
      */
     public byte getByte(int i);
+    
+    /**
+     * Returns the {@code i}th value as a byte.
+     * <p/>
+     * This method uses the {@link CodecRegistry} to find a codec to convert the underlying CQL type to a Java {@code byte}
+     * (for CQL type {@code tinyint}, this will be the built-in codec).
+     *
+     * @param i the index ({@code 0 <= i < size()}) to retrieve.
+     * @param defaultValue the default returned value if the value is NULL.
+     * @return the value of the {@code i}th element as a byte. If the value is NULL, {@code defaultValue} is returned.
+     * If you need to distinguish NULL and 0, check first with {@link #isNull(int)} or use {@code get(i, Byte.class)}.
+     * @throws IndexOutOfBoundsException if {@code i} is not a valid index for this object.
+     * @throws CodecNotFoundException    if there is no registered codec to convert the element's CQL
+     *                                   type to a byte.
+     */
+    public byte getByte(int i, byte defaultValue);
+
 
     /**
      * Returns the {@code i}th value as a short.
@@ -84,6 +117,22 @@ public interface GettableByIndexData {
      *                                   type to a short.
      */
     public short getShort(int i);
+    
+    /**
+     * Returns the {@code i}th value as a short.
+     * <p/>
+     * This method uses the {@link CodecRegistry} to find a codec to convert the underlying CQL type to a Java {@code short}
+     * (for CQL type {@code smallint}, this will be the built-in codec).
+     *
+     * @param i the index ({@code 0 <= i < size()}) to retrieve.
+     * @param defaultValue the default returned value if the value is NULL.
+     * @return the value of the {@code i}th element as a short. If the value is NULL, {@code defaultValue} is returned.
+     * If you need to distinguish NULL and 0, check first with {@link #isNull(int)} or use {@code get(i, Short.class)}.
+     * @throws IndexOutOfBoundsException if {@code i} is not a valid index for this object.
+     * @throws CodecNotFoundException    if there is no registered codec to convert the element's CQL
+     *                                   type to a short.
+     */
+    public short getShort(int i, short defaultValue);
 
     /**
      * Returns the {@code i}th value as an integer.
@@ -99,6 +148,22 @@ public interface GettableByIndexData {
      *                                   type to an int.
      */
     public int getInt(int i);
+    
+    /**
+     * Returns the {@code i}th value as an integer.
+     * <p/>
+     * This method uses the {@link CodecRegistry} to find a codec to convert the underlying CQL type to a Java {@code int}
+     * (for CQL type {@code int}, this will be the built-in codec).
+     *
+     * @param i the index ({@code 0 <= i < size()}) to retrieve.
+     * @param defaultValue the default returned value if the value is NULL.
+     * @return the value of the {@code i}th element as an integer. If the value is NULL, {@code defaultValue} is returned.
+     * If you need to distinguish NULL and 0, check first with {@link #isNull(int)} or use {@code get(i, Integer.class)}.
+     * @throws IndexOutOfBoundsException if {@code i} is not a valid index for this object.
+     * @throws CodecNotFoundException    if there is no registered codec to convert the element's CQL
+     *                                   type to an int.
+     */
+	public int getInt(int i, int defaultValue);
 
     /**
      * Returns the {@code i}th value as a long.
@@ -114,6 +179,22 @@ public interface GettableByIndexData {
      *                                   type to a long.
      */
     public long getLong(int i);
+    
+    /**
+     * Returns the {@code i}th value as a long.
+     * <p/>
+     * This method uses the {@link CodecRegistry} to find a codec to convert the underlying CQL type to a Java {@code byte}
+     * (for CQL types {@code bigint} and {@code counter}, this will be the built-in codec).
+     *
+     * @param i the index ({@code 0 <= i < size()}) to retrieve.
+     * @param defaultValue the default returned value if the value is NULL.
+     * @return the value of the {@code i}th element as a long. If the value is NULL, {@code defaultValue} is returned.
+     * If you need to distinguish NULL and 0L, check first with {@link #isNull(int)} or use {@code get(i, Long.class)}.
+     * @throws IndexOutOfBoundsException if {@code i} is not a valid index for this object.
+     * @throws CodecNotFoundException    if there is no registered codec to convert the element's CQL
+     *                                   type to a long.
+     */    
+    public long getLong(int i, long defaultValue);
 
     /**
      * Returns the {@code i}th value as a date.
@@ -174,6 +255,23 @@ public interface GettableByIndexData {
      *                                   type to a float.
      */
     public float getFloat(int i);
+    
+    /**
+     * Returns the {@code i}th value as a float.
+     * <p/>
+     * This method uses the {@link CodecRegistry} to find a codec to convert the underlying CQL type to a Java {@code float}
+     * (for CQL type {@code float}, this will be the built-in codec).
+     *
+     * @param i the index ({@code 0 <= i < size()}) to retrieve.
+     * @param defaultValue the default returned value if the value is NULL.
+     * @return the value of the {@code i}th element as a float. If the value is NULL, {@code defaultValue} is returned.
+     * If you need to distinguish NULL and 0.0f, check first with {@link #isNull(int)} or use {@code get(i, Float.class)}.
+     * @throws IndexOutOfBoundsException if {@code i} is not a valid index for this object.
+     * @throws CodecNotFoundException    if there is no registered codec to convert the element's CQL
+     *                                   type to a float.
+     */
+    public float getFloat(int i, float defaultValue);
+
 
     /**
      * Returns the {@code i}th value as a double.
@@ -189,6 +287,23 @@ public interface GettableByIndexData {
      *                                   type to a double.
      */
     public double getDouble(int i);
+    
+    /**
+     * Returns the {@code i}th value as a double.
+     * <p/>
+     * This method uses the {@link CodecRegistry} to find a codec to convert the underlying CQL type to a Java {@code double}
+     * (for CQL type {@code double}, this will be the built-in codec).
+     *
+     * @param i the index ({@code 0 <= i < size()}) to retrieve.
+     * @param defaultValue the default returned value if the value is NULL.
+     * @return the value of the {@code i}th element as a double. If the value is NULL, {@code defaultValue} is returned.
+     * If you need to distinguish NULL and 0.0, check first with {@link #isNull(int)} or use {@code get(i, Double.class)}.
+     * @throws IndexOutOfBoundsException if {@code i} is not a valid index for this object.
+     * @throws CodecNotFoundException    if there is no registered codec to convert the element's CQL
+     *                                   type to a double.
+     */    
+    public double getDouble(int i, double defaultValue);
+
 
     /**
      * Returns the {@code i}th value as a {@code ByteBuffer}.

--- a/driver-core/src/main/java/com/datastax/driver/core/GettableByNameData.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/GettableByNameData.java
@@ -53,6 +53,22 @@ public interface GettableByNameData {
      *                                  type to a boolean.
      */
     public boolean getBool(String name);
+    
+    /**
+     * Returns the value for {@code name} as a boolean.
+     * <p/>
+     * This method uses the {@link CodecRegistry} to find a codec to convert the underlying CQL type to a Java {@code boolean}
+     * (for CQL type {@code boolean}, this will be the built-in codec).
+     *
+     * @param name the name to retrieve.
+     * @param defaultValue the default returned value if the value is NULL.
+     * @return the boolean value for {@code name}. If the value is NULL, {@code defaultValue} is returned.
+     * If you need to distinguish NULL and false values, check first with {@link #isNull(String)} or use {@code get(name, Boolean.class)}.
+     * @throws IllegalArgumentException if {@code name} is not valid name for this object.
+     * @throws CodecNotFoundException   if there is no registered codec to convert the underlying CQL
+     *                                  type to a boolean.
+     */
+    public boolean getBool(String name, boolean defaultValue);
 
     /**
      * Returns the value for {@code name} as a byte.
@@ -69,6 +85,23 @@ public interface GettableByNameData {
      *                                  type to a byte.
      */
     public byte getByte(String name);
+    
+    /**
+     * Returns the value for {@code name} as a byte.
+     * <p/>
+     * This method uses the {@link CodecRegistry} to find a codec to convert the underlying CQL type to a Java {@code byte}
+     * (for CQL type {@code tinyint}, this will be the built-in codec).
+     *
+     * @param name the name to retrieve.
+     * @param defaultValue the default returned value if the value is NULL.
+     * @return the value for {@code name} as a byte. If the value is NULL, {@code defaultValue} is returned.
+     * If you need to distinguish NULL and 0, check first with {@link #isNull(String)} or use {@code get(name, Byte.class)}.
+     * {@code 0} is returned.
+     * @throws IllegalArgumentException if {@code name} is not valid name for this object.
+     * @throws CodecNotFoundException   if there is no registered codec to convert the underlying CQL
+     *                                  type to a byte.
+     */
+    public byte getByte(String name, byte defaultValue);
 
     /**
      * Returns the value for {@code name} as a short.
@@ -85,6 +118,23 @@ public interface GettableByNameData {
      *                                  type to a short.
      */
     public short getShort(String name);
+    
+    /**
+     * Returns the value for {@code name} as a short.
+     * <p/>
+     * This method uses the {@link CodecRegistry} to find a codec to convert the underlying CQL type to a Java {@code short}
+     * (for CQL type {@code smallint}, this will be the built-in codec).
+     *
+     * @param name the name to retrieve.     
+     * @param defaultValue the default returned value if the value is NULL.
+     * @return the value for {@code name} as a short. If the value is NULL, {@code defaultValue} is returned.
+     * If you need to distinguish NULL and 0, check first with {@link #isNull(String)} or use {@code get(name, Short.class)}.
+     * {@code 0} is returned.
+     * @throws IllegalArgumentException if {@code name} is not valid name for this object.
+     * @throws CodecNotFoundException   if there is no registered codec to convert the underlying CQL
+     *                                  type to a short.
+     */
+    public short getShort(String name, short defaultValue);
 
     /**
      * Returns the value for {@code name} as an integer.
@@ -101,6 +151,23 @@ public interface GettableByNameData {
      *                                  type to an int.
      */
     public int getInt(String name);
+    
+    /**
+     * Returns the value for {@code name} as an integer.
+     * <p/>
+     * This method uses the {@link CodecRegistry} to find a codec to convert the underlying CQL type to a Java {@code int}
+     * (for CQL type {@code int}, this will be the built-in codec).
+     *
+     * @param name the name to retrieve.
+     * @param defaultValue the default returned value if the value is NULL.
+     * @return the value for {@code name} as an integer. If the value is NULL, {@code defaultValue} is returned.
+     * If you need to distinguish NULL and 0, check first with {@link #isNull(String)} or use {@code get(name, Integer.class)}.
+     * {@code 0} is returned.
+     * @throws IllegalArgumentException if {@code name} is not valid name for this object.
+     * @throws CodecNotFoundException   if there is no registered codec to convert the underlying CQL
+     *                                  type to an int.
+     */
+    public int getInt(String name, int defaultValue);
 
     /**
      * Returns the value for {@code name} as a long.
@@ -116,6 +183,22 @@ public interface GettableByNameData {
      *                                  type to a long.
      */
     public long getLong(String name);
+
+    /**
+     * Returns the value for {@code name} as a long.
+     * <p/>
+     * This method uses the {@link CodecRegistry} to find a codec to convert the underlying CQL type to a Java {@code byte}
+     * (for CQL types {@code bigint} and {@code counter}, this will be the built-in codec).
+     *
+     * @param name the name to retrieve.
+     * @param defaultValue the default returned value if the value is NULL.
+     * @return the value for {@code name} as a long. If the value is NULL, {@code defaultValue} is returned.
+     * If you need to distinguish NULL and 0L, check first with {@link #isNull(String)} or use {@code get(name, Long.class)}.
+     * @throws IllegalArgumentException if {@code name} is not valid name for this object.
+     * @throws CodecNotFoundException   if there is no registered codec to convert the underlying CQL
+     *                                  type to a long.
+     */
+    public long getLong(String name, long defaultValue);
 
     /**
      * Returns the value for {@code name} as a date.
@@ -176,6 +259,22 @@ public interface GettableByNameData {
      *                                  type to a float.
      */
     public float getFloat(String name);
+    
+    /**
+     * Returns the value for {@code name} as a float.
+     * <p/>
+     * This method uses the {@link CodecRegistry} to find a codec to convert the underlying CQL type to a Java {@code float}
+     * (for CQL type {@code float}, this will be the built-in codec).
+     *
+     * @param name the name to retrieve.
+     * @param defaultValue the default returned value if the value is NULL.
+     * @return the value for {@code name} as a float. If the value is NULL, {@code defaultValue} is returned.
+     * If you need to distinguish NULL and 0.0f, check first with {@link #isNull(String)} or use {@code get(name, Float.class)}.
+     * @throws IllegalArgumentException if {@code name} is not valid name for this object.
+     * @throws CodecNotFoundException   if there is no registered codec to convert the underlying CQL
+     *                                  type to a float.
+     */
+    public float getFloat(String name, float defaultValue);
 
     /**
      * Returns the value for {@code name} as a double.
@@ -191,6 +290,22 @@ public interface GettableByNameData {
      *                                  type to a double.
      */
     public double getDouble(String name);
+    
+    /**
+     * Returns the value for {@code name} as a double.
+     * <p/>
+     * This method uses the {@link CodecRegistry} to find a codec to convert the underlying CQL type to a Java {@code double}
+     * (for CQL type {@code double}, this will be the built-in codec).
+     *
+     * @param name the name to retrieve.
+     * @param defaultValue the default returned value if the value is NULL.
+     * @return the value for {@code name} as a double. If the value is NULL, {@code defaultValue} is returned.
+     * If you need to distinguish NULL and 0.0, check first with {@link #isNull(String)} or use {@code get(name, Double.class)}.
+     * @throws IllegalArgumentException if {@code name} is not valid name for this object.
+     * @throws CodecNotFoundException   if there is no registered codec to convert the underlying CQL
+     *                                  type to a double.
+     */
+    public double getDouble(String name, double defaultValue);
 
     /**
      * Returns the value for {@code name} as a ByteBuffer.

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
@@ -649,6 +649,8 @@ public abstract class TypeCodec<T> {
         public abstract ByteBuffer serializeNoBoxing(boolean v, ProtocolVersion protocolVersion);
 
         public abstract boolean deserializeNoBoxing(ByteBuffer v, ProtocolVersion protocolVersion);
+       
+        public abstract boolean deserializeNoBoxing(ByteBuffer v, ProtocolVersion protocolVersion, boolean defaultValue);
 
         @Override
         public ByteBuffer serialize(Boolean value, ProtocolVersion protocolVersion) {
@@ -674,6 +676,8 @@ public abstract class TypeCodec<T> {
         public abstract ByteBuffer serializeNoBoxing(byte v, ProtocolVersion protocolVersion);
 
         public abstract byte deserializeNoBoxing(ByteBuffer v, ProtocolVersion protocolVersion);
+        
+        public abstract byte deserializeNoBoxing(ByteBuffer v, ProtocolVersion protocolVersion, byte defaultValue);
 
         @Override
         public ByteBuffer serialize(Byte value, ProtocolVersion protocolVersion) {
@@ -699,6 +703,8 @@ public abstract class TypeCodec<T> {
         public abstract ByteBuffer serializeNoBoxing(short v, ProtocolVersion protocolVersion);
 
         public abstract short deserializeNoBoxing(ByteBuffer v, ProtocolVersion protocolVersion);
+        
+        public abstract short deserializeNoBoxing(ByteBuffer v, ProtocolVersion protocolVersion, short defaultValue);
 
         @Override
         public ByteBuffer serialize(Short value, ProtocolVersion protocolVersion) {
@@ -724,6 +730,8 @@ public abstract class TypeCodec<T> {
         public abstract ByteBuffer serializeNoBoxing(int v, ProtocolVersion protocolVersion);
 
         public abstract int deserializeNoBoxing(ByteBuffer v, ProtocolVersion protocolVersion);
+        
+        public abstract int deserializeNoBoxing(ByteBuffer v, ProtocolVersion protocolVersion, int defaultValue);
 
         @Override
         public ByteBuffer serialize(Integer value, ProtocolVersion protocolVersion) {
@@ -750,6 +758,8 @@ public abstract class TypeCodec<T> {
 
         public abstract long deserializeNoBoxing(ByteBuffer v, ProtocolVersion protocolVersion);
 
+        public abstract long deserializeNoBoxing(ByteBuffer v, ProtocolVersion protocolVersion, long defaultValue);
+        
         @Override
         public ByteBuffer serialize(Long value, ProtocolVersion protocolVersion) {
             return value == null ? null : serializeNoBoxing(value, protocolVersion);
@@ -774,6 +784,8 @@ public abstract class TypeCodec<T> {
         public abstract ByteBuffer serializeNoBoxing(float v, ProtocolVersion protocolVersion);
 
         public abstract float deserializeNoBoxing(ByteBuffer v, ProtocolVersion protocolVersion);
+        
+        public abstract float deserializeNoBoxing(ByteBuffer v, ProtocolVersion protocolVersion, float defaultValue);
 
         @Override
         public ByteBuffer serialize(Float value, ProtocolVersion protocolVersion) {
@@ -799,6 +811,8 @@ public abstract class TypeCodec<T> {
         public abstract ByteBuffer serializeNoBoxing(double v, ProtocolVersion protocolVersion);
 
         public abstract double deserializeNoBoxing(ByteBuffer v, ProtocolVersion protocolVersion);
+        
+        public abstract double deserializeNoBoxing(ByteBuffer v, ProtocolVersion protocolVersion, double defaultValue);
 
         @Override
         public ByteBuffer serialize(Double value, ProtocolVersion protocolVersion) {
@@ -941,13 +955,18 @@ public abstract class TypeCodec<T> {
         }
 
         @Override
-        public long deserializeNoBoxing(ByteBuffer bytes, ProtocolVersion protocolVersion) {
+        public long deserializeNoBoxing(ByteBuffer bytes, ProtocolVersion protocolVersion, long defaultValue) {
             if (bytes == null || bytes.remaining() == 0)
-                return 0;
+                return defaultValue;
             if (bytes.remaining() != 8)
                 throw new InvalidTypeException("Invalid 64-bits long value, expecting 8 bytes but got " + bytes.remaining());
 
             return bytes.getLong(bytes.position());
+        }
+
+        @Override
+        public long deserializeNoBoxing(ByteBuffer bytes, ProtocolVersion protocolVersion) {
+            return deserializeNoBoxing(bytes,protocolVersion,0);
         }
     }
 
@@ -1086,8 +1105,13 @@ public abstract class TypeCodec<T> {
 
         @Override
         public boolean deserializeNoBoxing(ByteBuffer bytes, ProtocolVersion protocolVersion) {
+            return deserializeNoBoxing(bytes, protocolVersion, false);
+        }
+        
+        @Override
+        public boolean deserializeNoBoxing(ByteBuffer bytes, ProtocolVersion protocolVersion, boolean defaultValue) {
             if (bytes == null || bytes.remaining() == 0)
-                return false;
+                return defaultValue;
             if (bytes.remaining() != 1)
                 throw new InvalidTypeException("Invalid boolean value, expecting 1 byte but got " + bytes.remaining());
 
@@ -1190,8 +1214,13 @@ public abstract class TypeCodec<T> {
 
         @Override
         public double deserializeNoBoxing(ByteBuffer bytes, ProtocolVersion protocolVersion) {
+            return deserializeNoBoxing(bytes, protocolVersion, 0);
+        }
+        
+        @Override
+        public double deserializeNoBoxing(ByteBuffer bytes, ProtocolVersion protocolVersion, double defaultValue) {
             if (bytes == null || bytes.remaining() == 0)
-                return 0;
+                return defaultValue;
             if (bytes.remaining() != 8)
                 throw new InvalidTypeException("Invalid 64-bits double value, expecting 8 bytes but got " + bytes.remaining());
 
@@ -1235,8 +1264,13 @@ public abstract class TypeCodec<T> {
 
         @Override
         public float deserializeNoBoxing(ByteBuffer bytes, ProtocolVersion protocolVersion) {
+            return deserializeNoBoxing(bytes, protocolVersion, 0f);
+        }
+        
+        @Override
+        public float deserializeNoBoxing(ByteBuffer bytes, ProtocolVersion protocolVersion, float defaultValue) {
             if (bytes == null || bytes.remaining() == 0)
-                return 0;
+                return defaultValue;
             if (bytes.remaining() != 4)
                 throw new InvalidTypeException("Invalid 32-bits float value, expecting 4 bytes but got " + bytes.remaining());
 
@@ -1330,8 +1364,13 @@ public abstract class TypeCodec<T> {
 
         @Override
         public byte deserializeNoBoxing(ByteBuffer bytes, ProtocolVersion protocolVersion) {
+            return deserializeNoBoxing(bytes, protocolVersion, (byte)0);
+        }
+        
+        @Override
+        public byte deserializeNoBoxing(ByteBuffer bytes, ProtocolVersion protocolVersion, byte defaultValue) {
             if (bytes == null || bytes.remaining() == 0)
-                return 0;
+                return defaultValue;
             if (bytes.remaining() != 1)
                 throw new InvalidTypeException("Invalid 8-bits integer value, expecting 1 byte but got " + bytes.remaining());
 
@@ -1375,8 +1414,13 @@ public abstract class TypeCodec<T> {
 
         @Override
         public short deserializeNoBoxing(ByteBuffer bytes, ProtocolVersion protocolVersion) {
+            return deserializeNoBoxing(bytes, protocolVersion, (short)0);
+        }
+        
+        @Override
+        public short deserializeNoBoxing(ByteBuffer bytes, ProtocolVersion protocolVersion, short defaultValue) {
             if (bytes == null || bytes.remaining() == 0)
-                return 0;
+                return defaultValue;
             if (bytes.remaining() != 2)
                 throw new InvalidTypeException("Invalid 16-bits integer value, expecting 2 bytes but got " + bytes.remaining());
 
@@ -1420,8 +1464,13 @@ public abstract class TypeCodec<T> {
 
         @Override
         public int deserializeNoBoxing(ByteBuffer bytes, ProtocolVersion protocolVersion) {
+        	return deserializeNoBoxing(bytes, protocolVersion, 0);
+        }
+        
+        @Override
+        public int deserializeNoBoxing(ByteBuffer bytes, ProtocolVersion protocolVersion, int defaultValue) {
             if (bytes == null || bytes.remaining() == 0)
-                return 0;
+                return defaultValue;
             if (bytes.remaining() != 4)
                 throw new InvalidTypeException("Invalid 32-bits integer value, expecting 4 bytes but got " + bytes.remaining());
 


### PR DESCRIPTION
Motivation:

When we got primitive type such as calling getInt(int i),
we would get ‘0’ when the value is null. We can’t set the default value
if the value is null when expected the value isn't 0/false .
If we want to distinguish 0 and null , we should use isNull() or get(i,
Integer.class). It isn’t convenient for coding.
So add new methods to allow to setting the default value when got value
is Null.

Modifications:

add extra new methods with default value such as: 
public int getInt(int i, int defaultValue);

Result:

More flexible and convenient.
