### PR TITLE
JAVA-1200: Upgrade LZ4 to 1.3.0.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -7,6 +7,7 @@
 - [bug] JAVA-1209: ProtocolOptions.getProtocolVersion() should return null instead of throwing NPE if Cluster has not
         been init'd.
 - [improvement] JAVA-1204: Update documentation to indicate tcnative version requirement.
+- [improvement] JAVA-1200: Upgrade LZ4 to 1.3.0.
 
 
 ### 3.0.2

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -6,6 +6,7 @@
 - [bug] JAVA-1213: Allow updates and inserts to BLOB column using read-only ByteBuffer.
 - [bug] JAVA-1209: ProtocolOptions.getProtocolVersion() should return null instead of throwing NPE if Cluster has not
         been init'd.
+- [improvement] JAVA-1204: Update documentation to indicate tcnative version requirement.
 
 
 ### 3.0.2

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,9 @@
 
 ### 3.0.3 (in progress)
 
+- [improvement] JAVA-1147: Upgrade Netty to 4.0.37.
+- [bug] JAVA-1213: Allow updates and inserts to BLOB column using read-only ByteBuffer.
+
 
 ### 3.0.2
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,7 @@
 
 ### 3.0.3 (in progress)
 
+- [bug] JAVA-1209: ProtocolOptions.getProtocolVersion() should return null instead of throwing NPE if Cluster has not been init'd
 
 ### 3.0.2
 

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative</artifactId>
-            <version>1.1.33.Fork10</version>
+            <version>1.1.33.Fork17</version>
             <classifier>${os.detected.classifier}</classifier>
             <scope>test</scope>
         </dependency>

--- a/driver-core/src/main/java/com/datastax/driver/core/ProtocolOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ProtocolOptions.java
@@ -165,7 +165,7 @@ public class ProtocolOptions {
      * nodes that do not support this protocol version will be ignored.
      */
     public ProtocolVersion getProtocolVersion() {
-        return manager.connectionFactory.protocolVersion;
+        return manager == null || manager.connectionFactory == null ? null : manager.connectionFactory.protocolVersion;
     }
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/ProtocolOptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ProtocolOptionsTest.java
@@ -1,0 +1,42 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+public class ProtocolOptionsTest extends CCMTestsSupport {
+
+    /**
+     * @jira_ticket JAVA-1209
+     */
+    @Test(groups = "unit")
+    public void getProtocolVersion_should_return_null_if_not_connected() {
+        Cluster cluster = Cluster.builder().addContactPoint("127.0.0.1").build();
+        assertNull(cluster.getConfiguration().getProtocolOptions().getProtocolVersion());
+    }
+
+    /**
+     * @jira_ticket JAVA-1209
+     */
+    @Test(groups = "short")
+    public void getProtocolVersion_should_return_version() throws InterruptedException {
+        ProtocolVersion version = cluster().getConfiguration().getProtocolOptions().getProtocolVersion();
+        assertNotNull(version);
+    }
+}

--- a/driver-tests/osgi/pom.xml
+++ b/driver-tests/osgi/pom.xml
@@ -34,6 +34,7 @@
         <felix.version>4.6.0</felix.version>
         <!-- more recent version require JDK7+ -->
         <pax-exam.version>3.6.0</pax-exam.version>
+        <url.version>2.4.0</url.version>
         <logback.version>1.1.3</logback.version>
         <test.groups>none</test.groups>
         <!--
@@ -95,7 +96,7 @@
 
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
-            <artifactId>pax-exam-container-native</artifactId>
+            <artifactId>pax-exam-container-forked</artifactId>
             <version>${pax-exam.version}</version>
             <scope>test</scope>
         </dependency>
@@ -104,6 +105,13 @@
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-link-mvn</artifactId>
             <version>${pax-exam.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.ops4j.pax.url</groupId>
+            <artifactId>pax-url-reference</artifactId>
+            <version>${url.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -146,12 +154,14 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
             <version>${logback.version}</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/driver-tests/osgi/src/main/java/com/datastax/driver/osgi/impl/Activator.java
+++ b/driver-tests/osgi/src/main/java/com/datastax/driver/osgi/impl/Activator.java
@@ -15,10 +15,7 @@
  */
 package com.datastax.driver.osgi.impl;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.CodecRegistry;
-import com.datastax.driver.core.Metadata;
-import com.datastax.driver.core.Session;
+import com.datastax.driver.core.*;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.datastax.driver.extras.codecs.date.SimpleTimestampCodec;
 import com.datastax.driver.osgi.api.MailboxService;
@@ -47,10 +44,16 @@ public class Activator implements BundleActivator {
         }
         keyspace = Metadata.quote(keyspace);
 
-        cluster = Cluster.builder()
+        Cluster.Builder builder = Cluster.builder()
                 .addContactPoints(contactPoints)
-                .withCodecRegistry(new CodecRegistry().register(SimpleTimestampCodec.instance))
-                .build();
+                .withCodecRegistry(new CodecRegistry().register(SimpleTimestampCodec.instance));
+
+        String compression = context.getProperty("cassandra.compression");
+        if (compression != null) {
+            builder.withCompression(ProtocolOptions.Compression.valueOf(compression));
+        }
+
+        cluster = builder.build();
 
         Session session;
         try {

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.driver.osgi;
 
+import com.datastax.driver.core.ProtocolOptions;
 import com.datastax.driver.core.TestUtils;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.options.CompositeOption;
@@ -46,6 +47,19 @@ public class BundleOptions {
 
     public static MavenArtifactProvisionOption guavaBundle() {
         return mavenBundle("com.google.guava", "guava", "16.0.1");
+    }
+
+    public static CompositeOption lz4Bundle() {
+        return new CompositeOption() {
+
+            @Override
+            public Option[] getOptions() {
+                return options(
+                        systemProperty("cassandra.compression").value(ProtocolOptions.Compression.LZ4.name()),
+                        mavenBundle("net.jpountz.lz4", "lz4", "1.3.0")
+                );
+            }
+        };
     }
 
     public static CompositeOption nettyBundles() {
@@ -84,6 +98,7 @@ public class BundleOptions {
                         mavenBundle("ch.qos.logback", "logback-classic", "1.1.3"),
                         mavenBundle("ch.qos.logback", "logback-core", "1.1.3"),
                         mavenBundle("io.dropwizard.metrics", "metrics-core", "3.1.2"),
+                        mavenBundle("org.testng", "testng", "6.8.8"),
                         systemPackages("org.testng", "org.junit", "org.junit.runner", "org.junit.runner.manipulation",
                                 "org.junit.runner.notification", "com.jcabi.manifests")
                 );

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceLZ4IT.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceLZ4IT.java
@@ -1,0 +1,57 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.osgi;
+
+import com.datastax.driver.osgi.api.MailboxException;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.testng.listener.PaxExam;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static com.datastax.driver.osgi.BundleOptions.*;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+@Listeners({CCMBridgeListener.class, PaxExam.class})
+public class MailboxServiceLZ4IT extends MailboxServiceTests {
+
+    @Configuration
+    public Option[] lz4Config() {
+        return options(
+                defaultOptions(),
+                lz4Bundle(),
+                guavaBundle(),
+                extrasBundle(),
+                mappingBundle(),
+                driverBundle(true),
+                mailboxBundle()
+        );
+    }
+
+    /**
+     * Exercises a 'mailbox' service provided by an OSGi bundle that depends on the driver with
+     * LZ4 compression activated.
+     *
+     * @test_category packaging
+     * @expected_result Can create, retrieve and delete data using the mailbox service.
+     * @jira_ticket JAVA-1200
+     * @since 3.1.0
+     */
+    @Test(groups = "short")
+    public void test_lz4() throws MailboxException {
+        checkService();
+    }
+}

--- a/manual/compression/README.md
+++ b/manual/compression/README.md
@@ -27,7 +27,7 @@ Maven dependency:
 <dependency>
     <groupId>net.jpountz.lz4</groupId>
     <artifactId>lz4</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
 </dependency>
 ```
 
@@ -68,7 +68,7 @@ Maven dependency:
 <dependency>
     <groupId>org.xerial.snappy</groupId>
     <artifactId>snappy-java</artifactId>
-    <version>1.0.5</version>
+    <version>1.1.2.6</version>
 </dependency>
 ```
 

--- a/manual/speculative_execution/README.md
+++ b/manual/speculative_execution/README.md
@@ -117,7 +117,7 @@ explicitly depend on it:
 <dependency>
   <groupId>org.hdrhistogram</groupId>
   <artifactId>HdrHistogram</artifactId>
-  <version>2.1.4</version>
+  <version>2.1.6</version>
 </dependency>
 ```
 

--- a/manual/ssl/README.md
+++ b/manual/ssl/README.md
@@ -152,8 +152,12 @@ Netty-tcnative provides the native integration with OpenSSL. Follow
 [these instructions](http://netty.io/wiki/forked-tomcat-native.html) to
 add it to your dependencies.
 
-Note that using netty-tcnative requires JDK 1.7 or above and requires the
-presence of OpenSSL on the system.  It will not fall back to the JDK implementation.
+There are known runtime incompatibilities between newer versions of
+netty-tcnative and the version of netty that the driver uses.  For best
+results, use version 1.1.33.Fork17.
+
+Using netty-tcnative requires JDK 1.7 or above and requires the presence of
+OpenSSL on the system.  It will not fall back to the JDK implementation.
 
 ##### Configuring the context
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,9 +53,9 @@
         <guava.version>16.0.1</guava.version>
         <netty.version>4.0.37.Final</netty.version>
         <metrics.version>3.1.2</metrics.version>
-        <snappy.version>1.0.5</snappy.version>
-        <lz4.version>1.2.0</lz4.version>
-        <hdr.version>2.1.4</hdr.version>
+        <snappy.version>1.1.2.6</snappy.version>
+        <lz4.version>1.3.0</lz4.version>
+        <hdr.version>2.1.9</hdr.version>
         <!-- driver-extras module -->
         <jackson.version>2.6.3</jackson.version>
         <joda.version>2.9.1</joda.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <log4j.version>1.2.17</log4j.version>
         <slf4j-log4j12.version>1.7.6</slf4j-log4j12.version>
         <guava.version>16.0.1</guava.version>
-        <netty.version>4.0.33.Final</netty.version>
+        <netty.version>4.0.37.Final</netty.version>
         <metrics.version>3.1.2</metrics.version>
         <snappy.version>1.0.5</snappy.version>
         <lz4.version>1.2.0</lz4.version>


### PR DESCRIPTION
This PR also introduces a new OSGi test to validate that LZ4 bundle can be used in an OSGi environment.

In order to make this possible, I had to cherry-pick 3 commits from the 3.0.x branch:
1. 5ea6407 JAVA-1133: Add OSGi headers to cassandra-driver-extras.
2. 4d8f9b3 JAVA-1069: Bootstrap driver-examples module.
3. 297bcbc JAVA-1150: Add example and FAQ entry about ByteBuffer/BLOB.

Once these commits make into 3.0 branch then they can be safely deleted from this PR.
