### PR TITLE
JAVA-1204: Update documentation to indicate tcnative version requirement

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -6,6 +6,7 @@
 - [bug] JAVA-1213: Allow updates and inserts to BLOB column using read-only ByteBuffer.
 - [bug] JAVA-1209: ProtocolOptions.getProtocolVersion() should return null instead of throwing NPE if Cluster has not
         been init'd.
+- [improvement] JAVA-1204: Update documentation to indicate tcnative version requirement.
 
 
 ### 3.0.2

--- a/manual/ssl/README.md
+++ b/manual/ssl/README.md
@@ -152,8 +152,12 @@ Netty-tcnative provides the native integration with OpenSSL. Follow
 [these instructions](http://netty.io/wiki/forked-tomcat-native.html) to
 add it to your dependencies.
 
-Note that using netty-tcnative requires JDK 1.7 or above and requires the
-presence of OpenSSL on the system.  It will not fall back to the JDK implementation.
+There are known runtime incompatibilities between newer versions of
+netty-tcnative and the version of netty that the driver uses.  For best
+results, use version 1.1.33.Fork17.
+
+Using netty-tcnative requires JDK 1.7 or above and requires the presence of
+OpenSSL on the system.  It will not fall back to the JDK implementation.
 
 ##### Configuring the context
 


### PR DESCRIPTION
For [JAVA-1204](https://datastax-oss.atlassian.net/browse/JAVA-1204)

Should also apply forward to 3.0 branch.
