### PR TITLE
JAVA-1101: Batch and BatchStatement should consider inner statements to determine query idempotence

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,7 @@
 
 ### 3.0.3 (in progress)
 
+- [bug] JAVA-1101: Batch and BatchStatement should consider inner statements to determine query idempotence
 
 ### 3.0.2
 

--- a/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
@@ -243,6 +243,14 @@ public class BatchStatement extends Statement {
         return null;
     }
 
+    @Override
+    public Boolean isIdempotent() {
+        if (idempotent != null) {
+            return idempotent;
+        }
+        return isBatchIdempotent(statements);
+    }
+
     void ensureAllSet() {
         for (Statement statement : statements)
             if (statement instanceof BoundStatement)

--- a/driver-core/src/main/java/com/datastax/driver/core/Statement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Statement.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -498,11 +499,22 @@ public abstract class Statement {
      * {@link QueryOptions#getDefaultIdempotence()}.
      * <p/>
      * By default, this method returns {@code null} for all statements, except for
-     * {@link BuiltStatement}s, where the value will be inferred from the query: if it updates
-     * counters, prepends/appends to a list, or uses a function call or
+     * <ul>
+     * <li>{@link BuiltStatement} - value will be inferred  from the query: if it updates counters,
+     * prepends/appends to a list, or uses a function call or
      * {@link com.datastax.driver.core.querybuilder.QueryBuilder#raw(String)} anywhere in an inserted value,
      * the result will be {@code false}; otherwise it will be {@code true}.
-     * In all cases, calling {@link #setIdempotent(boolean)} forces a value that overrides every other mechanism.
+     * </li>
+     * <li>
+     *     {@link com.datastax.driver.core.querybuilder.Batch} and {@link BatchStatement}:
+     *     <ol>
+     *     <li>If any statement in batch has isIdempotent() false - return false</li>
+     *     <li>If no statements with isIdempotent() false, but some have isIdempotent() null - return null</li>
+     *     <li>Otherwise - return true</li>
+     *     </ol>
+     * </li>
+     * </ul>
+     * In all cases, calling {@link #setIdempotent(boolean)} forces a value that overrides calculated value.
      * <p/>
      * Note that when a statement is prepared ({@link Session#prepare(String)}), its idempotence flag will be propagated
      * to all {@link PreparedStatement}s created from it.
@@ -565,5 +577,29 @@ public abstract class Statement {
     public Statement setOutgoingPayload(Map<String, ByteBuffer> payload) {
         this.outgoingPayload = payload == null ? null : ImmutableMap.copyOf(payload);
         return this;
+    }
+
+    protected static Boolean isBatchIdempotent(Collection<? extends Statement> statements)
+    {
+        boolean hasNullIdempotentStatements = false;
+        boolean hasNotIdempotentStatements = false;
+        for (Statement statement : statements) {
+            Boolean innerIdempotent = statement.isIdempotent();
+            if (innerIdempotent == null) {
+                hasNullIdempotentStatements = true;
+            }
+            else if (!innerIdempotent) {
+                hasNotIdempotentStatements = true;
+            }
+        }
+        if (hasNotIdempotentStatements) {
+            return false;
+        }
+        else if (hasNullIdempotentStatements) {
+            return null;
+        }
+        else {
+            return true;
+        }
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Batch.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Batch.java
@@ -15,10 +15,7 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import com.datastax.driver.core.CodecRegistry;
-import com.datastax.driver.core.ProtocolVersion;
-import com.datastax.driver.core.RegularStatement;
-import com.datastax.driver.core.SimpleStatement;
+import com.datastax.driver.core.*;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -173,6 +170,14 @@ public class Batch extends BuiltStatement {
     @Override
     public String getKeyspace() {
         return statements.isEmpty() ? null : statements.get(0).getKeyspace();
+    }
+
+    @Override
+    public Boolean isIdempotent() {
+        if (idempotent != null) {
+            return idempotent;
+        }
+        return isBatchIdempotent(statements);
     }
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/AbstractIdempotencyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AbstractIdempotencyTest.java
@@ -1,0 +1,177 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.querybuilder.Batch;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+import static org.testng.Assert.assertNull;
+
+public abstract class AbstractIdempotencyTest {
+    
+    protected abstract TestBatch createBatch();
+
+    /**
+     * Unify Batch and BatchStatement to avoid duplicating all tests
+     */
+    protected interface TestBatch {
+        //Batch only accepts RegularStatement, so we use it for common interface
+        void add(RegularStatement statement);
+        Boolean isIdempotent();
+        void setIdempotent(boolean idempotent);
+    }
+    
+    @Test(groups = "unit")
+    public void isIdempotent_should_return_true_if_no_statements_added() {
+        TestBatch batch = createBatch();
+        assertTrue(batch.isIdempotent());
+    }
+
+    @Test(groups = "unit")
+    public void isIdempotent_should_return_true_if_all_statements_are_idempotent() {
+        TestBatch batch = createBatch();
+        assertTrue(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(true));
+        assertTrue(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(true));
+        assertTrue(batch.isIdempotent());
+    }
+
+    @Test(groups = "unit")
+    public void isIdempotent_should_return_false_if_any_statements_is_nonidempotent() {
+        TestBatch batch = createBatch();
+        assertTrue(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(true));
+        assertTrue(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(false));
+        assertFalse(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(true));
+        assertFalse(batch.isIdempotent());
+    }
+
+    @Test(groups = "unit")
+    public void isIdempotent_should_return_null_if_no_nonidempotent_statements_and_some_are_nullidempotent() {
+        TestBatch batch = createBatch();
+        assertTrue(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(true));
+        assertTrue(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(null));
+        assertNull(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(true));
+        assertNull(batch.isIdempotent());
+    }
+
+    @Test(groups = "unit")
+    public void isIdempotent_should_return_false_if_both_nonidempotent_and_nullidempotent_statements_present() {
+        TestBatch batch = createBatch();
+        assertTrue(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(true));
+        assertTrue(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(null));
+        assertNull(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(false));
+        assertFalse(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(true));
+        assertFalse(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(null));
+        assertFalse(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(false));
+        assertFalse(batch.isIdempotent());
+    }
+
+    @Test(groups = "unit")
+    public void isIdempotent_should_return_override_flag_if_no_statements_added() {
+        TestBatch batch = createBatch();
+        assertTrue(batch.isIdempotent());
+
+        batch.setIdempotent(false);
+        assertFalse(batch.isIdempotent());
+    }
+
+    @Test(groups = "unit")
+    public void isIdempotent_should_return_override_flag_if_calculated_idempotency_true() {
+        TestBatch batch = createBatch();
+        assertTrue(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(true));
+        assertTrue(batch.isIdempotent());
+
+        batch.setIdempotent(false);
+        assertFalse(batch.isIdempotent());
+    }
+
+    @Test(groups = "unit")
+    public void isIdempotent_should_return_override_flag_if_calculated_idempotency_null() {
+        TestBatch batch = createBatch();
+        assertTrue(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(null));
+        assertNull(batch.isIdempotent());
+
+        batch.setIdempotent(false);
+        assertFalse(batch.isIdempotent());
+    }
+
+    @Test(groups = "unit")
+    public void isIdempotent_should_return_override_flag_if_calculated_idempotency_false() {
+        TestBatch batch = createBatch();
+        assertTrue(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(false));
+        assertFalse(batch.isIdempotent());
+
+        batch.setIdempotent(true);
+        assertTrue(batch.isIdempotent());
+    }
+
+    @Test(groups = "unit")
+    public void isIdempotent_should_return_override_flag_if_calculated_idempotency_equals_override_value() {
+        TestBatch batch = createBatch();
+        assertTrue(batch.isIdempotent());
+
+        batch.add(statementWithIdempotency(false));
+        assertFalse(batch.isIdempotent());
+
+        batch.setIdempotent(false);
+        assertFalse(batch.isIdempotent());
+    }
+
+    private RegularStatement statementWithIdempotency(Boolean idempotency) {
+        RegularStatement statement = new SimpleStatement("fake statement");
+        if (idempotency != null) {
+            statement.setIdempotent(idempotency);
+            assertEquals(statement.isIdempotent(), idempotency);
+        } else {
+            assertNull(statement.isIdempotent());
+        }
+        return statement;
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/BatchStatementIdempotencyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/BatchStatementIdempotencyTest.java
@@ -1,0 +1,44 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+public class BatchStatementIdempotencyTest extends AbstractIdempotencyTest {
+
+    @Override
+    protected TestBatch createBatch() {
+        return new TestBatchStatementWrapper();
+    }
+
+    static class TestBatchStatementWrapper implements TestBatch {
+
+        private final BatchStatement batch = new BatchStatement();
+
+        @Override
+        public void add(RegularStatement statement) {
+            batch.add(statement);
+        }
+
+        @Override
+        public Boolean isIdempotent() {
+            return batch.isIdempotent();
+        }
+
+        @Override
+        public void setIdempotent(boolean idempotent) {
+            batch.setIdempotent(idempotent);
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/BatchIdempotencyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/BatchIdempotencyTest.java
@@ -1,0 +1,47 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.querybuilder;
+
+import com.datastax.driver.core.AbstractIdempotencyTest;
+import com.datastax.driver.core.RegularStatement;
+
+public class BatchIdempotencyTest extends AbstractIdempotencyTest {
+
+    @Override
+    protected AbstractIdempotencyTest.TestBatch createBatch() {
+        return new TestBatchWrapper();
+    }
+
+    static class TestBatchWrapper implements TestBatch {
+
+        private final Batch batch = QueryBuilder.batch();
+
+        @Override
+        public void add(RegularStatement statement) {
+            batch.add(statement);
+        }
+
+        @Override
+        public Boolean isIdempotent() {
+            return batch.isIdempotent();
+        }
+
+        @Override
+        public void setIdempotent(boolean idempotent) {
+            batch.setIdempotent(idempotent);
+        }
+    }
+}


### PR DESCRIPTION
BatchStatement and Batch now share common algorithm for isIdempotent():
1. If any statement in batch is non-idempotent - whole batch is non idempotent
2. If no non-idempotent statements, but some have isIdempotent=null then
   batch has null idempotency
3. Otherwise batch is idempotent
