### PR TITLE
JAVA-1147: Upgrade Netty to 4.0.37.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,9 @@
 
 ### 3.0.3 (in progress)
 
+- [improvement] JAVA-1147: Upgrade Netty to 4.0.37.
+- [bug] JAVA-1213: Allow updates and inserts to BLOB column using read-only ByteBuffer.
+
 
 ### 3.0.2
 

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative</artifactId>
-            <version>1.1.33.Fork10</version>
+            <version>1.1.33.Fork17</version>
             <classifier>${os.detected.classifier}</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <log4j.version>1.2.17</log4j.version>
         <slf4j-log4j12.version>1.7.6</slf4j-log4j12.version>
         <guava.version>16.0.1</guava.version>
-        <netty.version>4.0.33.Final</netty.version>
+        <netty.version>4.0.37.Final</netty.version>
         <metrics.version>3.1.2</metrics.version>
         <snappy.version>1.0.5</snappy.version>
         <lz4.version>1.2.0</lz4.version>


### PR DESCRIPTION
This commit also solves JAVA-1213: Updates and inserts to BLOB column using ReadOnly ByteBuffer fail.
