### PR TITLE
JAVA-1200: Upgrade LZ4 to 1.3.0.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -13,6 +13,7 @@
 - [bug] JAVA-1139: ConnectionException.getMessage() throws NPE if address is null.
 - [bug] JAVA-1202: Handle null rpc_address when checking schema agreement.
 - [improvement] JAVA-1198: Document that BoundStatement is not thread-safe.
+- [improvement] JAVA-1200: Upgrade LZ4 to 1.3.0.
 
 
 ### 3.0.2

--- a/driver-tests/osgi/pom.xml
+++ b/driver-tests/osgi/pom.xml
@@ -34,6 +34,7 @@
         <felix.version>4.6.0</felix.version>
         <!-- more recent version require JDK7+ -->
         <pax-exam.version>3.6.0</pax-exam.version>
+        <url.version>2.4.0</url.version>
         <logback.version>1.1.3</logback.version>
         <test.groups>none</test.groups>
         <!--
@@ -72,6 +73,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.5</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
             <version>${project.parent.version}</version>
@@ -95,7 +102,7 @@
 
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
-            <artifactId>pax-exam-container-native</artifactId>
+            <artifactId>pax-exam-container-forked</artifactId>
             <version>${pax-exam.version}</version>
             <scope>test</scope>
         </dependency>
@@ -104,6 +111,13 @@
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-link-mvn</artifactId>
             <version>${pax-exam.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.ops4j.pax.url</groupId>
+            <artifactId>pax-url-reference</artifactId>
+            <version>${url.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -146,12 +160,14 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
             <version>${logback.version}</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
@@ -15,6 +15,8 @@
  */
 package com.datastax.driver.osgi;
 
+import com.datastax.driver.core.CCMBridge;
+import com.datastax.driver.core.ProtocolOptions;
 import com.datastax.driver.core.TestUtils;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.options.CompositeOption;
@@ -48,6 +50,19 @@ public class BundleOptions {
         return mavenBundle("com.google.guava", "guava", "16.0.1");
     }
 
+    public static CompositeOption lz4Bundle() {
+        return new CompositeOption() {
+
+            @Override
+            public Option[] getOptions() {
+                return options(
+                        systemProperty("cassandra.compression").value(ProtocolOptions.Compression.LZ4.name()),
+                        mavenBundle("net.jpountz.lz4", "lz4", "1.3.0")
+                );
+            }
+        };
+    }
+
     public static CompositeOption nettyBundles() {
         final String nettyVersion = "4.0.33.Final";
         return new CompositeOption() {
@@ -78,12 +93,14 @@ public class BundleOptions {
                         // Delegate javax.security.cert to the parent classloader.  javax.security.cert.X509Certificate is used in
                         // io.netty.util.internal.EmptyArrays, but not directly by the driver.
                         bootDelegationPackage("javax.security.cert"),
+                        systemProperty("cassandra.version").value(CCMBridge.getCassandraVersion()),
                         systemProperty("cassandra.contactpoints").value(TestUtils.IP_PREFIX + 1),
                         systemProperty("logback.configurationFile").value("file:" + PathUtils.getBaseDir() + "/src/test/resources/logback.xml"),
                         mavenBundle("org.slf4j", "slf4j-api", "1.7.5"),
                         mavenBundle("ch.qos.logback", "logback-classic", "1.1.3"),
                         mavenBundle("ch.qos.logback", "logback-core", "1.1.3"),
                         mavenBundle("io.dropwizard.metrics", "metrics-core", "3.1.2"),
+                        mavenBundle("org.testng", "testng", "6.8.8"),
                         systemPackages("org.testng", "org.junit", "org.junit.runner", "org.junit.runner.manipulation",
                                 "org.junit.runner.notification", "com.jcabi.manifests")
                 );

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceLZ4IT.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceLZ4IT.java
@@ -1,0 +1,58 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.osgi;
+
+import com.datastax.driver.osgi.api.MailboxException;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.testng.listener.PaxExam;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static com.datastax.driver.osgi.BundleOptions.*;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+@Listeners({CCMBridgeListener.class, PaxExam.class})
+public class MailboxServiceLZ4IT extends MailboxServiceTests {
+
+    @Configuration
+    public Option[] lz4Config() {
+        return options(
+                defaultOptions(),
+                lz4Bundle(),
+                nettyBundles(),
+                guavaBundle(),
+                extrasBundle(),
+                mappingBundle(),
+                driverBundle(),
+                mailboxBundle()
+        );
+    }
+
+    /**
+     * Exercises a 'mailbox' service provided by an OSGi bundle that depends on the driver with
+     * LZ4 compression activated.
+     *
+     * @test_category packaging
+     * @expected_result Can create, retrieve and delete data using the mailbox service.
+     * @jira_ticket JAVA-1200
+     * @since 3.1.0
+     */
+    @Test(groups = "short")
+    public void test_lz4() throws MailboxException {
+        checkService();
+    }
+}

--- a/manual/compression/README.md
+++ b/manual/compression/README.md
@@ -27,7 +27,7 @@ Maven dependency:
 <dependency>
     <groupId>net.jpountz.lz4</groupId>
     <artifactId>lz4</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <netty.version>4.0.37.Final</netty.version>
         <metrics.version>3.1.2</metrics.version>
         <snappy.version>1.0.5</snappy.version>
-        <lz4.version>1.2.0</lz4.version>
+        <lz4.version>1.3.0</lz4.version>
         <hdr.version>2.1.4</hdr.version>
         <!-- driver-extras module -->
         <jackson.version>2.6.3</jackson.version>


### PR DESCRIPTION
This commit also upgrades Snappy version to 1.1.2.6 and HdrHistogram
version to 2.1.9.

Besides, it also introduces new OSGi tests to validate that the
following libraries can be used in an OSGi environment: LZ4, Snappy, and
HdrHistogram.

As these new tests rely on system properties that might be present or
not, this commit switches the Pax Exam container from "native" to
"forked", because native containers are not confined enough to isolate
system properties correctly.
