### PR TITLE
JAVA-1233: Upgrade dependencies to latest versions

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -5,6 +5,7 @@
 - [new feature] JAVA-1153: Add PER PARTITION LIMIT to Select QueryBuilder.
 - [improvement] JAVA-743: Add JSON support to QueryBuilder.
 - [improvement] JAVA-1233: Update HdrHistogram to 2.1.9.
+- [improvement] JAVA-1233: Update Snappy to 1.1.2.6.
 
 Merged from 3.0.x branch:
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,7 +4,7 @@
 
 - [new feature] JAVA-1153: Add PER PARTITION LIMIT to Select QueryBuilder.
 - [improvement] JAVA-743: Add JSON support to QueryBuilder.
-
+- [improvement] JAVA-1233: Update HdrHistogram to 2.1.9.
 
 Merged from 3.0.x branch:
 

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
@@ -63,6 +63,19 @@ public class BundleOptions {
         };
     }
 
+    public static CompositeOption snappyBundle() {
+        return new CompositeOption() {
+
+            @Override
+            public Option[] getOptions() {
+                return options(
+                        systemProperty("cassandra.compression").value(ProtocolOptions.Compression.SNAPPY.name()),
+                        mavenBundle("org.xerial.snappy", "snappy-java", "1.1.2.6")
+                );
+            }
+        };
+    }
+
     public static CompositeOption hdrHistogramBundle() {
         return new CompositeOption() {
 

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
@@ -63,6 +63,19 @@ public class BundleOptions {
         };
     }
 
+    public static CompositeOption hdrHistogramBundle() {
+        return new CompositeOption() {
+
+            @Override
+            public Option[] getOptions() {
+                return options(
+                        systemProperty("cassandra.usePercentileSpeculativeExecutionPolicy").value("true"),
+                        mavenBundle("org.hdrhistogram", "HdrHistogram", "2.1.9")
+                );
+            }
+        };
+    }
+
     public static CompositeOption nettyBundles() {
         final String nettyVersion = "4.0.33.Final";
         return new CompositeOption() {

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceHdrHistogramIT.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceHdrHistogramIT.java
@@ -1,0 +1,58 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.osgi;
+
+import com.datastax.driver.osgi.api.MailboxException;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.testng.listener.PaxExam;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static com.datastax.driver.osgi.BundleOptions.*;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+@Listeners({CCMBridgeListener.class, PaxExam.class})
+public class MailboxServiceHdrHistogramIT extends MailboxServiceTests {
+
+    @Configuration
+    public Option[] hdrHistogramConfig() {
+        return options(
+                defaultOptions(),
+                hdrHistogramBundle(),
+                nettyBundles(),
+                guavaBundle(),
+                extrasBundle(),
+                mappingBundle(),
+                driverBundle(),
+                mailboxBundle()
+        );
+    }
+
+    /**
+     * Exercises a 'mailbox' service provided by an OSGi bundle that depends on the driver with
+     * LZ4 compression activated.
+     *
+     * @test_category packaging
+     * @expected_result Can create, retrieve and delete data using the mailbox service.
+     * @jira_ticket JAVA-1200
+     * @since 3.1.0
+     */
+    @Test(groups = "short")
+    public void test_hdr() throws MailboxException {
+        checkService();
+    }
+}

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceSnappyIT.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceSnappyIT.java
@@ -1,0 +1,58 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.osgi;
+
+import com.datastax.driver.osgi.api.MailboxException;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.testng.listener.PaxExam;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import static com.datastax.driver.osgi.BundleOptions.*;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+@Listeners({CCMBridgeListener.class, PaxExam.class})
+public class MailboxServiceSnappyIT extends MailboxServiceTests {
+
+    @Configuration
+    public Option[] snappyConfig() {
+        return options(
+                defaultOptions(),
+                snappyBundle(),
+                nettyBundles(),
+                guavaBundle(),
+                extrasBundle(),
+                mappingBundle(),
+                driverBundle(),
+                mailboxBundle()
+        );
+    }
+
+    /**
+     * Exercises a 'mailbox' service provided by an OSGi bundle that depends on the driver with
+     * LZ4 compression activated.
+     *
+     * @test_category packaging
+     * @expected_result Can create, retrieve and delete data using the mailbox service.
+     * @jira_ticket JAVA-1200
+     * @since 3.1.0
+     */
+    @Test(groups = "short")
+    public void test_snappy() throws MailboxException {
+        checkService();
+    }
+}

--- a/manual/compression/README.md
+++ b/manual/compression/README.md
@@ -68,7 +68,7 @@ Maven dependency:
 <dependency>
     <groupId>org.xerial.snappy</groupId>
     <artifactId>snappy-java</artifactId>
-    <version>1.0.5</version>
+    <version>1.1.2.6</version>
 </dependency>
 ```
 

--- a/manual/speculative_execution/README.md
+++ b/manual/speculative_execution/README.md
@@ -117,7 +117,7 @@ explicitly depend on it:
 <dependency>
   <groupId>org.hdrhistogram</groupId>
   <artifactId>HdrHistogram</artifactId>
-  <version>2.1.4</version>
+  <version>2.1.9</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <guava.version>16.0.1</guava.version>
         <netty.version>4.0.37.Final</netty.version>
         <metrics.version>3.1.2</metrics.version>
-        <snappy.version>1.0.5</snappy.version>
+        <snappy.version>1.1.2.6</snappy.version>
         <lz4.version>1.3.0</lz4.version>
         <hdr.version>2.1.9</hdr.version>
         <!-- driver-extras module -->

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <metrics.version>3.1.2</metrics.version>
         <snappy.version>1.0.5</snappy.version>
         <lz4.version>1.3.0</lz4.version>
-        <hdr.version>2.1.4</hdr.version>
+        <hdr.version>2.1.9</hdr.version>
         <!-- driver-extras module -->
         <jackson.version>2.6.3</jackson.version>
         <joda.version>2.9.1</joda.version>


### PR DESCRIPTION
Work in progress: this will need rebasing once JAVA-1200 has been merged to 3.0 (only the last two commits apply).
