### PR TITLE
JAVA-1242: Fix driver-core dependency in driver-stress

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -20,6 +20,7 @@
 - [improvement] JAVA-1126: Handle schema changes in Mapper.
 - [bug] JAVA-1193: Refresh token and replica metadata synchronously when schema is altered.
 - [bug] JAVA-1120: Skip schema refresh debouncer when checking for agreement as a result of schema change made by client.
+- [improvement] JAVA-1242: Fix driver-core dependency in driver-stress
 
 
 ### 3.0.2

--- a/driver-tests/stress/pom.xml
+++ b/driver-tests/stress/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>3.0.3-SNAPSHOT</version>
+            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Depend on ${project.parent.version} instead of an explicit version for
consistency with the rest of modules.
