### PR TITLE
Ensure decode takes readerIndex() into account.

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Frame.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Frame.java
@@ -197,7 +197,7 @@ class Frame {
             if (buffer.readableBytes() < 1)
                 return;
 
-            int version = buffer.getByte(0);
+            int version = buffer.getByte(buffer.readerIndex());
             // version first bit is the "direction" of the frame (request or response)
             version = version & 0x7F;
 
@@ -223,7 +223,7 @@ class Frame {
                         return null;
 
                     // Validate the opcode (this will throw if it's not a response)
-                    Message.Response.Type.fromOpcode(buffer.getByte(opcodeOffset));
+                    Message.Response.Type.fromOpcode(buffer.getByte(buffer.readerIndex() + opcodeOffset));
 
                     ByteBuf frame = (ByteBuf) super.decode(ctx, buffer);
                     if (frame == null) {


### PR DESCRIPTION
Motivation:

Frame.Decoder and Frame.Decoder.DecoderForStreamIdSize assume that the passed in ByteBuf always should be read starting at index 0. This is not a safe assumption.

Modifications:

Not start explicit on index 0 but use readerIndex().

Result:

Correctly handle the case where the readerIndex() is not 0.
