### PR TITLE
Update tests to account for retry behavior change

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/ReadTimeoutTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReadTimeoutTest.java
@@ -15,13 +15,10 @@
  */
 package com.datastax.driver.core;
 
-import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.datastax.driver.core.exceptions.OperationTimedOutException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 import static org.scassandra.http.client.PrimingRequest.queryBuilder;
 import static org.scassandra.http.client.PrimingRequest.then;
 
@@ -42,15 +39,9 @@ public class ReadTimeoutTest extends ScassandraTestBase.PerClassCluster {
         cluster.getConfiguration().getSocketOptions().setReadTimeoutMillis(10);
     }
 
-    @Test(groups = "short")
+    @Test(groups = "short", expectedExceptions = OperationTimedOutException.class)
     public void should_use_default_timeout_if_not_overridden_by_statement() {
-        try {
-            session.execute(query);
-            fail("expected a timeout");
-        } catch (NoHostAvailableException e) {
-            Throwable t = e.getErrors().values().iterator().next();
-            assertThat(t).isInstanceOf(OperationTimedOutException.class);
-        }
+        session.execute(query);
     }
 
     @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/ReusedStreamIdTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReusedStreamIdTest.java
@@ -15,7 +15,7 @@
  */
 package com.datastax.driver.core;
 
-import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import com.datastax.driver.core.exceptions.OperationTimedOutException;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -116,8 +116,8 @@ public class ReusedStreamIdTest extends CCMTestsSupport {
                         @Override
                         public void onFailure(Throwable t) {
                             semaphore.release();
-                            // NHAEs are inevitable because of low query timeouts and blocked threads.
-                            if (!(t instanceof NoHostAvailableException)) {
+                            // Timeouts are inevitable because of low query timeouts and blocked threads.
+                            if (!(t instanceof OperationTimedOutException)) {
                                 logger.error("Unexpected error encountered.", t);
                                 errorTrigger.countDown();
                             }

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/AbstractRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/AbstractRetryPolicyIntegrationTest.java
@@ -89,6 +89,8 @@ public class AbstractRetryPolicyIntegrationTest {
                         .setMaxConnectionsPerHost(HostDistance.LOCAL, 1)
                         .setHeartbeatIntervalSeconds(0))
                 .withNettyOptions(nonQuietClusterCloseOptions)
+                // Mark everything as idempotent by default so RetryPolicy is exercised.
+                .withQueryOptions(new QueryOptions().setDefaultIdempotence(true))
                 .build();
 
         session = cluster.connect();

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/IdempotenceAwareRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/IdempotenceAwareRetryPolicyIntegrationTest.java
@@ -52,7 +52,8 @@ public class IdempotenceAwareRetryPolicyIntegrationTest extends AbstractRetryPol
             query();
             fail("expected an WriteTimeoutException");
         } catch (WriteTimeoutException e) {/* expected */}
-        assertOnWriteTimeoutWasCalled(1);
+        // Should not have even been called as statement was not idempotent.
+        assertOnWriteTimeoutWasCalled(0);
         assertThat(errors.getWriteTimeouts().getCount()).isEqualTo(1);
         assertThat(errors.getRetries().getCount()).isEqualTo(0);
         assertThat(errors.getRetriesOnWriteTimeout().getCount()).isEqualTo(0);
@@ -91,7 +92,8 @@ public class IdempotenceAwareRetryPolicyIntegrationTest extends AbstractRetryPol
                         String.format("[%s] Timed out waiting for server response", host1.getSocketAddress())
                 );
             }
-            assertOnRequestErrorWasCalled(1, OperationTimedOutException.class);
+            // Should not have even been called as statement was not idempotent.
+            assertOnRequestErrorWasCalled(0, OperationTimedOutException.class);
             assertThat(errors.getClientTimeouts().getCount()).isEqualTo(1);
             assertThat(errors.getRetries().getCount()).isEqualTo(0);
             assertThat(errors.getRetriesOnClientTimeout().getCount()).isEqualTo(0);
@@ -135,7 +137,8 @@ public class IdempotenceAwareRetryPolicyIntegrationTest extends AbstractRetryPol
         } catch (DriverException e) {
             assertThat(e).isInstanceOf(exception);
         }
-        assertOnRequestErrorWasCalled(1, ServerError.class);
+        // Should not have even been called as statement was not idempotent.
+        assertOnRequestErrorWasCalled(0, ServerError.class);
         assertThat(errors.getOthers().getCount()).isEqualTo(1);
         assertThat(errors.getRetries().getCount()).isEqualTo(0);
         assertThat(errors.getRetriesOnOtherErrors().getCount()).isEqualTo(0);
@@ -183,7 +186,8 @@ public class IdempotenceAwareRetryPolicyIntegrationTest extends AbstractRetryPol
                     String.format("[%s] Connection has been closed", host1.getSocketAddress())
             );
         }
-        assertOnRequestErrorWasCalled(1, TransportException.class);
+        // Should not have even been called as statement was not idempotent.
+        assertOnRequestErrorWasCalled(0, TransportException.class);
         assertThat(errors.getRetries().getCount()).isEqualTo(0);
         assertThat(errors.getConnectionErrors().getCount()).isEqualTo(1);
         assertThat(errors.getIgnoresOnConnectionError().getCount()).isEqualTo(0);


### PR DESCRIPTION
As of JAVA-1212 (#696), non-idempotent queries are no longer retried for writes
and request errors.  Tests that expected this have been updated to
account for this.
