### PR TITLE
JAVA-1237: Add JSON examples

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
@@ -94,7 +94,7 @@ public class Insert extends BuiltStatement {
      * @param name  the name of the column to insert/update.
      * @param value the value to insert/update for {@code name}.
      * @return this INSERT statement.
-     * @throws IllegalStateException if this method is called and the {@link #json(String)}
+     * @throws IllegalStateException if this method is called and the {@link #json(Object)}
      *                               method has been called before, because it's not possible
      *                               to mix {@code INSERT JSON} syntax with regular {@code INSERT} syntax.
      */
@@ -118,7 +118,7 @@ public class Insert extends BuiltStatement {
      *               in {@code names}.
      * @return this INSERT statement.
      * @throws IllegalArgumentException if {@code names.length != values.length}.
-     * @throws IllegalStateException    if this method is called and the {@link #json(String)}
+     * @throws IllegalStateException    if this method is called and the {@link #json(Object)}
      *                                  method has been called before, because it's not possible
      *                                  to mix {@code INSERT JSON} syntax with regular {@code INSERT} syntax.
      */
@@ -135,7 +135,7 @@ public class Insert extends BuiltStatement {
      *               in {@code names}.
      * @return this INSERT statement.
      * @throws IllegalArgumentException if {@code names.size() != values.size()}.
-     * @throws IllegalStateException    if this method is called and the {@link #json(String)}
+     * @throws IllegalStateException    if this method is called and the {@link #json(Object)}
      *                                  method has been called before, because it's not possible
      *                                  to mix {@code INSERT JSON} syntax with regular {@code INSERT} syntax.
      */
@@ -156,20 +156,30 @@ public class Insert extends BuiltStatement {
     }
 
     /**
-     * Inserts the provided JSON string, using the {@code INSERT INTO ... JSON} syntax introduced
+     * Inserts the provided object, using the {@code INSERT INTO ... JSON} syntax introduced
      * in Cassandra 2.2.
      * <p/>
-     * With INSERT statements, the new {@code JSON} keyword can be used to enable inserting a
-     * JSON encoded map as a single row.
+     * With INSERT statements, the new {@code JSON} keyword can be used to enable inserting a JSON
+     * structure as a single row.
      * <p/>
-     * <strong>The provided JSON string will be appended to the query string as is.
-     * It should NOT be surrounded by single quotes.</strong>
+     * The provided object can be of the following types:
+     * <ol>
+     * <li>A raw string. In this case, it will be appended to the query string as is.
+     * <strong>It should NOT be surrounded by single quotes.</strong>
      * Its format should generally match that returned by a
      * {@code SELECT JSON} statement on the same table.
-     * <p/>
-     * Note that it is not possible to insert function calls nor bind markers in the JSON string.
+     * Note that it is not possible to insert function calls nor bind markers in a JSON string.</li>
+     * <li>A {@link QueryBuilder#bindMarker() bind marker}. In this case, the statement is meant to be prepared
+     * and no JSON string will be appended to the query string, only a bind marker for the whole JSON parameter.</li>
+     * <li>Any object that can be serialized to JSON. Such objects can be used provided that
+     * a matching {@link com.datastax.driver.core.TypeCodec codec} is registered with the
+     * {@link CodecRegistry} in use. This allows the usage of JSON libraries, such
+     * as the <a href="https://jcp.org/en/jsr/detail?id=353">Java API for JSON processing</a>,
+     * the popular <a href="http://wiki.fasterxml.com/JacksonHome">Jackson</a> library, or
+     * Google's <a href="https://github.com/google/gson">Gson</a> library, for instance.</li>
+     * </ol>
      * <h3>Case-sensitive column names</h3>
-     * Users are required to handle case-sensitive column names
+     * When passing raw strings to this method, users are required to handle case-sensitive column names
      * by surrounding them with double quotes.
      * <p/>
      * For example, to insert into a table with two columns named “myKey” and “value”,
@@ -182,7 +192,8 @@ public class Insert extends BuiltStatement {
      * INSERT INTO mytable JSON '{"\"myKey\"": 0, "value": 0}';
      * </pre>
      * <h3>Escaping quotes in column values</h3>
-     * Double quotes should be escaped with a backslash, but single quotes should be escaped in
+     * When passing raw strings to this method, double quotes should be escaped with a backslash,
+     * but single quotes should be escaped in
      * the CQL manner, i.e. by another single quote. For example, the column value
      * {@code foo"'bar} should be inserted in the JSON string
      * as {@code "foo\"''bar"}.
@@ -191,7 +202,7 @@ public class Insert extends BuiltStatement {
      * Any columns which are omitted from the JSON string will be defaulted to a {@code NULL} value
      * (which will result in a tombstone being created).
      *
-     * @param json the JSON string, or a bind marker.
+     * @param json the JSON string, or a bind marker, or a JSON object handled by a specific {@link com.datastax.driver.core.TypeCodec codec}.
      * @return this INSERT statement.
      * @throws IllegalStateException if this method is called and any of the {@code value} or {@code values}
      *                               methods have been called before, because it's not possible

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
@@ -1057,23 +1057,39 @@ public final class QueryBuilder {
      * Support for JSON functions has been added in Cassandra 2.2.
      * The {@code fromJson()} function is similar to {@code INSERT JSON} statements,
      * but applies to a single column value instead of the entire row, and
-     * converts a JSON-encoded string into the normal Cassandra column value.
+     * converts a JSON object into the normal Cassandra column value.
      * <p/>
      * It may be used in {@code INSERT} and {@code UPDATE} statements,
      * but NOT in the selection clause of a {@code SELECT} statement.
      * <p/>
-     * <strong>The provided JSON string will be appended to the query string as is.
-     * It should NOT be surrounded by single quotes.</strong>
+     * The provided object can be of the following types:
+     * <ol>
+     * <li>A raw string. In this case, it will be appended to the query string as is.
+     * <strong>It should NOT be surrounded by single quotes.</strong>
+     * Its format should generally match that returned by a
+     * {@code SELECT JSON} statement on the same table.
+     * Note that it is not possible to insert function calls nor bind markers in a JSON string.</li>
+     * <li>A {@link QueryBuilder#bindMarker() bind marker}. In this case, the statement is meant to be prepared
+     * and no JSON string will be appended to the query string, only a bind marker for the whole JSON parameter.</li>
+     * <li>Any object that can be serialized to JSON. Such objects can be used provided that
+     * a matching {@link com.datastax.driver.core.TypeCodec codec} is registered with the
+     * {@link com.datastax.driver.core.CodecRegistry CodecRegistry} in use. This allows the usage of JSON libraries, such
+     * as the <a href="https://jcp.org/en/jsr/detail?id=353">Java API for JSON processing</a>,
+     * the popular <a href="http://wiki.fasterxml.com/JacksonHome">Jackson</a> library, or
+     * Google's <a href="https://github.com/google/gson">Gson</a> library, for instance.</li>
+     * </ol>
      * <p/>
-     * String values should be enclosed in double quotes.
-     * Double quotes appearing inside strings should be escaped with a backslash,
+     * When passing raw strings to this method, the following rules apply:
+     * <ol>
+     * <li>String values should be enclosed in double quotes.</li>
+     * <li>Double quotes appearing inside strings should be escaped with a backslash,
      * but single quotes should be escaped in
      * the CQL manner, i.e. by another single quote. For example, the column value
      * {@code foo"'bar} should be inserted in the JSON string
-     * as {@code "foo\"''bar"}.
-     * <p/>
-     * Note that it is not possible to insert function calls nor bind markers in the JSON string.
+     * as {@code "foo\"''bar"}.</li>
+     * </ol>
      *
+     * @param json the JSON string, or a bind marker, or a JSON object handled by a specific {@link com.datastax.driver.core.TypeCodec codec}.
      * @return the function call.
      * @see <a href="http://cassandra.apache.org/doc/cql3/CQL-2.2.html#json">JSON Support for CQL</a>
      * @see <a href="http://www.datastax.com/dev/blog/whats-new-in-cassandra-2-2-json-support">JSON Support in Cassandra 2.2</a>

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -42,9 +42,25 @@
         </dependency>
 
         <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-extras</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- driver logs -->
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.1.3</version>
+            <scope>runtime</scope>
         </dependency>
 
     </dependencies>

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -55,6 +55,21 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+            <version>${jsr353-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>${jsr353-ri.version}</version>
+            <optional>true</optional>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- driver logs -->
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/driver-examples/src/main/java/com/datastax/driver/examples/basic/CreateAndPopulateKeyspace.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/basic/CreateAndPopulateKeyspace.java
@@ -27,7 +27,7 @@ import com.datastax.driver.core.Session;
  * - a Cassandra cluster is running and accessible through the contacts points identified by CONTACT_POINTS and PORT.
  * <p/>
  * Side effects:
- * - creates a new keyspace "simplex" in the cluster. It a keyspace with this name already exists, it will be reused;
+ * - creates a new keyspace "simplex" in the cluster. If a keyspace with this name already exists, it will be reused;
  * - creates two tables "simplex.songs" and "simplex.playlists". If they exist already, they will be reused;
  * - inserts a row in each table.
  *

--- a/driver-examples/src/main/java/com/datastax/driver/examples/datatypes/Blobs.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/datatypes/Blobs.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * - FILE references an existing file.
  * <p/>
  * Side effects:
- * - creates a new keyspace "examples" in the cluster. It a keyspace with this name already exists, it will be reused;
+ * - creates a new keyspace "examples" in the cluster. If a keyspace with this name already exists, it will be reused;
  * - creates a table "examples.blobs". If it already exists, it will be reused;
  * - inserts data in the table.
  */

--- a/driver-examples/src/main/java/com/datastax/driver/examples/json/JacksonJsonColumn.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/json/JacksonJsonColumn.java
@@ -1,0 +1,170 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.examples.json;
+
+import com.datastax.driver.core.*;
+import com.datastax.driver.extras.codecs.json.JacksonJsonCodec;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+
+/**
+ * Illustrates how to map a single table column of type {@code VARCHAR},
+ * containing JSON payloads, into a Java object using
+ * the <a href="http://wiki.fasterxml.com/JacksonHome">Jackson</a> library.
+ * <p/>
+ * This example makes usage of a custom {@link TypeCodec codec},
+ * {@link JacksonJsonCodec}, which is declared in the driver-extras module.
+ * If you plan to follow this example, make sure to include the following
+ * Maven dependencies in your project:
+ * <pre>{@code
+ * <dependency>
+ *     <groupId>com.datastax.cassandra</groupId>
+ *     <artifactId>cassandra-driver-extras</artifactId>
+ *     <version>${driver.version}</version>
+ * </dependency>
+ *
+ * <dependency>
+ *     <groupId>com.fasterxml.jackson.core</groupId>
+ *     <artifactId>jackson-databind</artifactId>
+ *     <version>${jackson.version}</version>
+ * </dependency>
+ * }</pre>
+ * This example also uses the {@link com.datastax.driver.core.querybuilder.QueryBuilder QueryBuilder};
+ * for examples using the "core" API, see {@link PlainTextJson} (they are easily translatable to the
+ * queries in this class).
+ * <p/>
+ * Preconditions:
+ * - a Cassandra cluster is running and accessible through the contacts points identified by CONTACT_POINTS and PORT;
+ * <p/>
+ * Side effects:
+ * - creates a new keyspace "examples" in the cluster. If a keyspace with this name already exists, it will be reused;
+ * - creates a table "examples.json_jackson_column". If it already exists, it will be reused;
+ * - inserts data in the table.
+ */
+public class JacksonJsonColumn {
+
+    static String[] CONTACT_POINTS = {"127.0.0.1"};
+    static int PORT = 9042;
+
+    public static void main(String[] args) {
+        Cluster cluster = null;
+        try {
+
+            // A codec to convert JSON payloads into User instances;
+            // this codec is declared in the driver-extras module
+            TypeCodec<User> userCodec = new JacksonJsonCodec<User>(User.class);
+
+            cluster = Cluster.builder()
+                    .addContactPoints(CONTACT_POINTS).withPort(PORT)
+                    .withCodecRegistry(new CodecRegistry().register(userCodec))
+                    .build();
+
+            Session session = cluster.connect();
+
+            createSchema(session);
+            insertJsonColumn(session);
+            selectJsonColumn(session);
+
+        } finally {
+            if (cluster != null) cluster.close();
+        }
+    }
+
+    private static void createSchema(Session session) {
+        session.execute("CREATE KEYSPACE IF NOT EXISTS examples " +
+                "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+        session.execute("CREATE TABLE IF NOT EXISTS examples.json_jackson_column(" +
+                "id int PRIMARY KEY, json text)");
+    }
+
+    // Mapping a User instance to a table column
+    private static void insertJsonColumn(Session session) {
+
+        User alice = new User("alice", 30);
+        User bob = new User("bob", 35);
+
+        // Build and execute a simple statement
+        Statement stmt = insertInto("examples", "json_jackson_column")
+                .value("id", 1)
+                // the User object will be converted into a String and persisted into the VARCHAR column "json"
+                .value("json", alice);
+        session.execute(stmt);
+
+        // The JSON object can be a bound value if the statement is prepared
+        // (we use a local variable here for the sake of example, but in a real application you would cache and reuse
+        // the prepared statement)
+        PreparedStatement pst = session.prepare(
+                insertInto("examples", "json_jackson_column")
+                        .value("id", bindMarker("id"))
+                        .value("json", bindMarker("json")));
+        session.execute(pst.bind()
+                .setInt("id", 2)
+                .set("json", bob, User.class));
+    }
+
+    // Retrieving User instances from a table column
+    private static void selectJsonColumn(Session session) {
+
+        Statement stmt = select()
+                .from("examples", "json_jackson_column")
+                .where(in("id", 1, 2));
+
+        ResultSet rows = session.execute(stmt);
+
+        for (Row row : rows) {
+            int id = row.getInt("id");
+            // retrieve the JSON payload and convert it to a User instance
+            User user = row.get("json", User.class);
+            // it is also possible to retrieve the raw JSON payload
+            String json = row.getString("json");
+            System.out.printf("Retrieved row:%n" +
+                            "id           %d%n" +
+                            "user         %s%n" +
+                            "user (raw)   %s%n%n",
+                    id, user, json);
+
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class User {
+
+        private final String name;
+
+        private final int age;
+
+        @JsonCreator
+        public User(@JsonProperty("name") String name, @JsonProperty("age") int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s (%s)", name, age);
+        }
+    }
+}

--- a/driver-examples/src/main/java/com/datastax/driver/examples/json/JacksonJsonFunction.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/json/JacksonJsonFunction.java
@@ -1,0 +1,214 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.examples.json;
+
+import com.datastax.driver.core.*;
+import com.datastax.driver.extras.codecs.json.JacksonJsonCodec;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+
+/**
+ * Illustrates how to map a single table column of an arbitrary type
+ * to a Java object using
+ * the <a href="http://wiki.fasterxml.com/JacksonHome">Jackson</a> library,
+ * and leveraging the {@code toJson()} and {@code fromJson()} functions
+ * introduced in Cassandra 2.2.
+ * <p/>
+ * This example makes usage of a custom {@link TypeCodec codec},
+ * {@link JacksonJsonCodec}, which is declared in the driver-extras module.
+ * If you plan to follow this example, make sure to include the following
+ * Maven dependencies in your project:
+ * <pre>{@code
+ * <dependency>
+ *     <groupId>com.datastax.cassandra</groupId>
+ *     <artifactId>cassandra-driver-extras</artifactId>
+ *     <version>${driver.version}</version>
+ * </dependency>
+ *
+ * <dependency>
+ *     <groupId>com.fasterxml.jackson.core</groupId>
+ *     <artifactId>jackson-databind</artifactId>
+ *     <version>${jackson.version}</version>
+ * </dependency>
+ * }</pre>
+ * This example also uses the {@link com.datastax.driver.core.querybuilder.QueryBuilder QueryBuilder};
+ * for examples using the "core" API, see {@link PlainTextJson} (they are easily translatable to the
+ * queries in this class).
+ * <p/>
+ * Preconditions:
+ * - a Cassandra cluster is running and accessible through the contacts points identified by CONTACT_POINTS and PORT;
+ * <p/>
+ * Side effects:
+ * - creates a new keyspace "examples" in the cluster. If a keyspace with this name already exists, it will be reused;
+ * - creates a user-defined type (UDT) "examples.json_jackson_function_user". If it already exists, it will be reused;
+ * - creates a table "examples.json_jackson_function". If it already exists, it will be reused;
+ * - inserts data in the table.
+ *
+ * @see <a href="http://www.datastax.com/dev/blog/whats-new-in-cassandra-2-2-json-support">What’s New in Cassandra 2.2: JSON Support</a>
+ */
+public class JacksonJsonFunction {
+
+    static String[] CONTACT_POINTS = {"127.0.0.1"};
+    static int PORT = 9042;
+
+    public static void main(String[] args) {
+        Cluster cluster = null;
+        try {
+
+            // A codec to convert JSON payloads into User instances;
+            // this codec is declared in the driver-extras module
+            TypeCodec<User> userCodec = new JacksonJsonCodec<User>(User.class);
+
+            // A codec to convert generic JSON payloads into JsonNode instances
+            TypeCodec<JsonNode> jsonNodeCodec = new JacksonJsonCodec<JsonNode>(JsonNode.class);
+
+            cluster = Cluster.builder()
+                    .addContactPoints(CONTACT_POINTS).withPort(PORT)
+                    .withCodecRegistry(new CodecRegistry()
+                            .register(userCodec)
+                            .register(jsonNodeCodec))
+                    .build();
+
+            Session session = cluster.connect();
+
+            createSchema(session);
+            insertFromJson(session);
+            selectToJson(session);
+
+        } finally {
+            if (cluster != null) cluster.close();
+        }
+    }
+
+    private static void createSchema(Session session) {
+        session.execute("CREATE KEYSPACE IF NOT EXISTS examples " +
+                "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+        session.execute("CREATE TYPE IF NOT EXISTS examples.json_jackson_function_user(" +
+                "name text, age int)");
+        session.execute("CREATE TABLE IF NOT EXISTS examples.json_jackson_function(" +
+                "id int PRIMARY KEY, user frozen<json_jackson_function_user>, scores map<varchar,float>)");
+    }
+
+    // Mapping JSON payloads to table columns of arbitrary types,
+    // using fromJson() function
+    private static void insertFromJson(Session session) {
+
+        User alice = new User("alice", 30);
+        User bob = new User("bob", 35);
+
+        ObjectNode aliceScores = JsonNodeFactory.instance.objectNode()
+                .put("call_of_duty", 4.8)
+                .put("pokemon_go", 9.7);
+        ObjectNode bobScores = JsonNodeFactory.instance.objectNode()
+                .put("zelda", 8.3)
+                .put("pokemon_go", 12.4);
+
+        // Build and execute a simple statement
+        Statement stmt = insertInto("examples", "json_jackson_function")
+                .value("id", 1)
+                // client-side, the User object will be converted into a JSON String;
+                // then, server-side, the fromJson() function will convert that JSON string
+                // into an instance of the json_jackson_function_user user-defined type (UDT),
+                // which will be persisted into the column "user"
+                .value("user", fromJson(alice))
+                // same thing, but this time converting from
+                // a generic JsonNode to a JSON string, then from this string to a map<varchar,float>
+                .value("scores", fromJson(aliceScores));
+        session.execute(stmt);
+
+        // The JSON object can be a bound value if the statement is prepared
+        // (we use a local variable here for the sake of example, but in a real application you would cache and reuse
+        // the prepared statement)
+        PreparedStatement pst = session.prepare(
+                insertInto("examples", "json_jackson_function")
+                        .value("id", bindMarker("id"))
+                        .value("user", fromJson(bindMarker("user")))
+                        .value("scores", fromJson(bindMarker("scores"))));
+        session.execute(pst.bind()
+                .setInt("id", 2)
+                .set("user", bob, User.class)
+                // note that the codec requires that the type passed to the set() method
+                // be always JsonNode, and not a subclass of it, such as ObjectNode
+                .set("scores", bobScores, JsonNode.class));
+    }
+
+    // Retrieving JSON payloads from table columns of arbitrary types,
+    // using toJson() function
+    private static void selectToJson(Session session) {
+
+        Statement stmt = select()
+                .column("id")
+                .toJson("user").as("user")
+                .toJson("scores").as("scores")
+                .from("examples", "json_jackson_function")
+                .where(in("id", 1, 2));
+
+        ResultSet rows = session.execute(stmt);
+
+        for (Row row : rows) {
+            int id = row.getInt("id");
+            // retrieve the JSON payload and convert it to a User instance
+            User user = row.get("user", User.class);
+            // it is also possible to retrieve the raw JSON payload
+            String userJson = row.getString("user");
+            // retrieve the JSON payload and convert it to a JsonNode instance
+            // note that the codec requires that the type passed to the get() method
+            // be always JsonNode, and not a subclass of it, such as ObjectNode
+            JsonNode scores = row.get("scores", JsonNode.class);
+            // it is also possible to retrieve the raw JSON payload
+            String scoresJson = row.getString("scores");
+            System.out.printf("Retrieved row:%n" +
+                            "id           %d%n" +
+                            "user         %s%n" +
+                            "user (raw)   %s%n" +
+                            "scores       %s%n" +
+                            "scores (raw) %s%n%n",
+                    id, user, userJson, scores, scoresJson);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class User {
+
+        private final String name;
+
+        private final int age;
+
+        @JsonCreator
+        public User(@JsonProperty("name") String name, @JsonProperty("age") int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s (%s)", name, age);
+        }
+    }
+}

--- a/driver-examples/src/main/java/com/datastax/driver/examples/json/JacksonJsonRow.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/json/JacksonJsonRow.java
@@ -1,0 +1,165 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.examples.json;
+
+import com.datastax.driver.core.*;
+import com.datastax.driver.extras.codecs.json.JacksonJsonCodec;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+
+/**
+ * Illustrates how to map an entire table row to a Java object using
+ * the <a href="http://wiki.fasterxml.com/JacksonHome">Jackson</a> library,
+ * and leveraging the {@code SELECT JSON} and {@code INSERT JSON} syntaxes
+ * introduced in Cassandra 2.2.
+ * <p/>
+ * This example makes usage of a custom {@link TypeCodec codec},
+ * {@link JacksonJsonCodec}, which is declared in the driver-extras module.
+ * If you plan to follow this example, make sure to include the following
+ * Maven dependencies in your project:
+ * <pre>{@code
+ * <dependency>
+ *     <groupId>com.datastax.cassandra</groupId>
+ *     <artifactId>cassandra-driver-extras</artifactId>
+ *     <version>${driver.version}</version>
+ * </dependency>
+ *
+ * <dependency>
+ *     <groupId>com.fasterxml.jackson.core</groupId>
+ *     <artifactId>jackson-databind</artifactId>
+ *     <version>${jackson.version}</version>
+ * </dependency>
+ * }</pre>
+ * This example also uses the {@link com.datastax.driver.core.querybuilder.QueryBuilder QueryBuilder};
+ * for examples using the "core" API, see {@link PlainTextJson} (they are easily translatable to the
+ * queries in this class).
+ * <p/>
+ * Preconditions:
+ * - a Cassandra 2.2+ cluster is running and accessible through the contacts points identified by CONTACT_POINTS and PORT;
+ * <p/>
+ * Side effects:
+ * - creates a new keyspace "examples" in the cluster. If a keyspace with this name already exists, it will be reused;
+ * - creates a table "examples.json_jackson_row". If it already exists, it will be reused;
+ * - inserts data in the table.
+ *
+ * @see <a href="http://www.datastax.com/dev/blog/whats-new-in-cassandra-2-2-json-support">What’s New in Cassandra 2.2: JSON Support</a>
+ */
+public class JacksonJsonRow {
+
+    static String[] CONTACT_POINTS = {"127.0.0.1"};
+    static int PORT = 9042;
+
+    public static void main(String[] args) {
+        Cluster cluster = null;
+        try {
+
+            // A codec to convert JSON payloads into User instances;
+            // this codec is declared in the driver-extras module
+            TypeCodec<User> userCodec = new JacksonJsonCodec<User>(User.class);
+
+            cluster = Cluster.builder()
+                    .addContactPoints(CONTACT_POINTS).withPort(PORT)
+                    .withCodecRegistry(new CodecRegistry().register(userCodec))
+                    .build();
+
+            Session session = cluster.connect();
+
+            createSchema(session);
+            insertJsonRow(session);
+            selectJsonRow(session);
+
+        } finally {
+            if (cluster != null) cluster.close();
+        }
+    }
+
+    private static void createSchema(Session session) {
+        session.execute("CREATE KEYSPACE IF NOT EXISTS examples " +
+                "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+        session.execute("CREATE TABLE IF NOT EXISTS examples.json_jackson_row(" +
+                "id int PRIMARY KEY, name text, age int)");
+    }
+
+    // Mapping a User instance to a table row using INSERT JSON
+    private static void insertJsonRow(Session session) {
+        // Build and execute a simple statement
+        Statement stmt = insertInto("examples", "json_jackson_row")
+                .json(new User(1, "alice", 30));
+        session.execute(stmt);
+
+        // The JSON object can be a bound value if the statement is prepared
+        // (we use a local variable here for the sake of example, but in a real application you would cache and reuse
+        // the prepared statement)
+        PreparedStatement pst = session.prepare(
+                insertInto("examples", "json_jackson_row").json(bindMarker("user")));
+        session.execute(pst.bind()
+                .set("user", new User(2, "bob", 35), User.class));
+    }
+
+    // Retrieving User instances from table rows using SELECT JSON
+    private static void selectJsonRow(Session session) {
+
+        // Reading the whole row as a JSON object
+        Statement stmt = select().json()
+                .from("examples", "json_jackson_row")
+                .where(in("id", 1, 2));
+
+        ResultSet rows = session.execute(stmt);
+
+        for (Row row : rows) {
+            // SELECT JSON returns only one column for each row, of type VARCHAR,
+            // containing the row as a JSON payload
+            User user = row.get(0, User.class);
+            System.out.printf("Retrieved user: %s%n", user);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class User {
+
+        private final int id;
+
+        private final String name;
+
+        private final int age;
+
+        @JsonCreator
+        public User(@JsonProperty("id") int id, @JsonProperty("name") String name, @JsonProperty("age") int age) {
+            this.id = id;
+            this.name = name;
+            this.age = age;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s (id %d, age %d)", name, id, age);
+        }
+    }
+}

--- a/driver-examples/src/main/java/com/datastax/driver/examples/json/Jsr353JsonColumn.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/json/Jsr353JsonColumn.java
@@ -1,0 +1,164 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.examples.json;
+
+import com.datastax.driver.core.*;
+import com.datastax.driver.extras.codecs.json.Jsr353JsonCodec;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonStructure;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+
+/**
+ * Illustrates how to map a single table column of type {@code VARCHAR},
+ * containing JSON payloads, into a Java object using
+ * the <a href="https://jcp.org/en/jsr/detail?id=353">Java API for JSON processing</a>.
+ * <p/>
+ * This example makes usage of a custom {@link TypeCodec codec},
+ * {@link Jsr353JsonCodec}, which is declared in the driver-extras module.
+ * If you plan to follow this example, make sure to include the following
+ * Maven dependencies in your project:
+ * <pre>{@code
+ * <dependency>
+ *     <groupId>com.datastax.cassandra</groupId>
+ *     <artifactId>cassandra-driver-extras</artifactId>
+ *     <version>${driver.version}</version>
+ * </dependency>
+ *
+ * <dependency>
+ *     <groupId>javax.json</groupId>
+ *     <artifactId>javax.json-api</artifactId>
+ *     <version>${jsr353-api.version}</version>
+ * </dependency>
+ *
+ * <dependency>
+ *     <groupId>org.glassfish</groupId>
+ *     <artifactId>javax.json</artifactId>
+ *     <version>${jsr353-ri.version}</version>
+ *     <scope>runtime</scope>
+ * </dependency>
+ * }</pre>
+ * This example also uses the {@link com.datastax.driver.core.querybuilder.QueryBuilder QueryBuilder};
+ * for examples using the "core" API, see {@link PlainTextJson} (they are easily translatable to the
+ * queries in this class).
+ * <p/>
+ * Preconditions:
+ * - a Cassandra cluster is running and accessible through the contacts points identified by CONTACT_POINTS and PORT;
+ * <p/>
+ * Side effects:
+ * - creates a new keyspace "examples" in the cluster. If a keyspace with this name already exists, it will be reused;
+ * - creates a table "examples.json_jsr353_column". If it already exists, it will be reused;
+ * - inserts data in the table.
+ */
+public class Jsr353JsonColumn {
+
+    static String[] CONTACT_POINTS = {"127.0.0.1"};
+    static int PORT = 9042;
+
+    public static void main(String[] args) {
+        Cluster cluster = null;
+        try {
+
+            // A codec to convert JSON payloads into JsonObject instances;
+            // this codec is declared in the driver-extras module
+            Jsr353JsonCodec userCodec = new Jsr353JsonCodec();
+
+            cluster = Cluster.builder()
+                    .addContactPoints(CONTACT_POINTS).withPort(PORT)
+                    .withCodecRegistry(new CodecRegistry().register(userCodec))
+                    .build();
+
+            Session session = cluster.connect();
+
+            createSchema(session);
+            insertJsonColumn(session);
+            selectJsonColumn(session);
+
+        } finally {
+            if (cluster != null) cluster.close();
+        }
+    }
+
+    private static void createSchema(Session session) {
+        session.execute("CREATE KEYSPACE IF NOT EXISTS examples " +
+                "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+        session.execute("CREATE TABLE IF NOT EXISTS examples.json_jsr353_column(" +
+                "id int PRIMARY KEY, json text)");
+    }
+
+    // Mapping a JSON object to a table column
+    private static void insertJsonColumn(Session session) {
+
+        JsonObject alice = Json.createObjectBuilder()
+                .add("name", "alice")
+                .add("age", 30)
+                .build();
+
+        JsonObject bob = Json.createObjectBuilder()
+                .add("name", "bob")
+                .add("age", 35)
+                .build();
+
+        // Build and execute a simple statement
+        Statement stmt = insertInto("examples", "json_jsr353_column")
+                .value("id", 1)
+                // the JSON object will be converted into a String and persisted into the VARCHAR column "json"
+                .value("json", alice);
+        session.execute(stmt);
+
+        // The JSON object can be a bound value if the statement is prepared
+        // (we use a local variable here for the sake of example, but in a real application you would cache and reuse
+        // the prepared statement)
+        PreparedStatement pst = session.prepare(
+                insertInto("examples", "json_jsr353_column")
+                        .value("id", bindMarker("id"))
+                        .value("json", bindMarker("json")));
+        session.execute(pst.bind()
+                .setInt("id", 2)
+                // note that the codec requires that the type passed to the set() method
+                // be always JsonStructure, and not a subclass of it, such as JsonObject
+                .set("json", bob, JsonStructure.class));
+    }
+
+    // Retrieving JSON objects from a table column
+    private static void selectJsonColumn(Session session) {
+
+        Statement stmt = select()
+                .from("examples", "json_jsr353_column")
+                .where(in("id", 1, 2));
+
+        ResultSet rows = session.execute(stmt);
+
+        for (Row row : rows) {
+            int id = row.getInt("id");
+            // retrieve the JSON payload and convert it to a JsonObject instance
+            // note that the codec requires that the type passed to the get() method
+            // be always JsonStructure, and not a subclass of it, such as JsonObject,
+            // hence the need to downcast to JsonObject manually
+            JsonObject user = (JsonObject) row.get("json", JsonStructure.class);
+            // it is also possible to retrieve the raw JSON payload
+            String json = row.getString("json");
+            System.out.printf("Retrieved row:%n" +
+                            "id           %d%n" +
+                            "user         %s%n" +
+                            "user (raw)   %s%n%n",
+                    id, user, json);
+        }
+    }
+
+}

--- a/driver-examples/src/main/java/com/datastax/driver/examples/json/Jsr353JsonFunction.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/json/Jsr353JsonFunction.java
@@ -1,0 +1,201 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.examples.json;
+
+import com.datastax.driver.core.*;
+import com.datastax.driver.extras.codecs.json.Jsr353JsonCodec;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonStructure;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+
+/**
+ * Illustrates how to map a single table column of an arbitrary type
+ * to a Java object using
+ * the <a href="https://jcp.org/en/jsr/detail?id=353">Java API for JSON processing</a>,
+ * and leveraging the {@code toJson()} and {@code fromJson()} functions
+ * introduced in Cassandra 2.2.
+ * <p/>
+ * This example makes usage of a custom {@link TypeCodec codec},
+ * {@link Jsr353JsonCodec}, which is declared in the driver-extras module.
+ * If you plan to follow this example, make sure to include the following
+ * Maven dependencies in your project:
+ * <pre>{@code
+ * <dependency>
+ *     <groupId>com.datastax.cassandra</groupId>
+ *     <artifactId>cassandra-driver-extras</artifactId>
+ *     <version>${driver.version}</version>
+ * </dependency>
+ *
+ * <dependency>
+ *     <groupId>javax.json</groupId>
+ *     <artifactId>javax.json-api</artifactId>
+ *     <version>${jsr353-api.version}</version>
+ * </dependency>
+ *
+ * <dependency>
+ *     <groupId>org.glassfish</groupId>
+ *     <artifactId>javax.json</artifactId>
+ *     <version>${jsr353-ri.version}</version>
+ *     <scope>runtime</scope>
+ * </dependency>
+ * }</pre>
+ * This example also uses the {@link com.datastax.driver.core.querybuilder.QueryBuilder QueryBuilder};
+ * for examples using the "core" API, see {@link PlainTextJson} (they are easily translatable to the
+ * queries in this class).
+ * <p/>
+ * Preconditions:
+ * - a Cassandra cluster is running and accessible through the contacts points identified by CONTACT_POINTS and PORT;
+ * <p/>
+ * Side effects:
+ * - creates a new keyspace "examples" in the cluster. If a keyspace with this name already exists, it will be reused;
+ * - creates a user-defined type (UDT) "examples.json_jsr353_function_user". If it already exists, it will be reused;
+ * - creates a table "examples.json_jsr353_function". If it already exists, it will be reused;
+ * - inserts data in the table.
+ *
+ * @see <a href="http://www.datastax.com/dev/blog/whats-new-in-cassandra-2-2-json-support">What’s New in Cassandra 2.2: JSON Support</a>
+ */
+public class Jsr353JsonFunction {
+
+    static String[] CONTACT_POINTS = {"127.0.0.1"};
+    static int PORT = 9042;
+
+    public static void main(String[] args) {
+        Cluster cluster = null;
+        try {
+
+            // A codec to convert JSON payloads into JsonObject instances;
+            // this codec is declared in the driver-extras module
+            Jsr353JsonCodec userCodec = new Jsr353JsonCodec();
+
+            cluster = Cluster.builder()
+                    .addContactPoints(CONTACT_POINTS).withPort(PORT)
+                    .withCodecRegistry(new CodecRegistry()
+                            .register(userCodec))
+                    .build();
+
+            Session session = cluster.connect();
+
+            createSchema(session);
+            insertFromJson(session);
+            selectToJson(session);
+
+        } finally {
+            if (cluster != null) cluster.close();
+        }
+    }
+
+    private static void createSchema(Session session) {
+        session.execute("CREATE KEYSPACE IF NOT EXISTS examples " +
+                "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+        session.execute("CREATE TYPE IF NOT EXISTS examples.json_jsr353_function_user(" +
+                "name text, age int)");
+        session.execute("CREATE TABLE IF NOT EXISTS examples.json_jsr353_function(" +
+                "id int PRIMARY KEY, user frozen<json_jsr353_function_user>, scores map<varchar,float>)");
+    }
+
+    // Mapping JSON payloads to table columns of arbitrary types,
+    // using fromJson() function
+    private static void insertFromJson(Session session) {
+
+        JsonObject alice = Json.createObjectBuilder()
+                .add("name", "alice")
+                .add("age", 30)
+                .build();
+
+        JsonObject bob = Json.createObjectBuilder()
+                .add("name", "bob")
+                .add("age", 35)
+                .build();
+
+        JsonObject aliceScores = Json.createObjectBuilder()
+                .add("call_of_duty", 4.8)
+                .add("pokemon_go", 9.7)
+                .build();
+
+        JsonObject bobScores = Json.createObjectBuilder()
+                .add("zelda", 8.3)
+                .add("pokemon_go", 12.4)
+                .build();
+
+        // Build and execute a simple statement
+        Statement stmt = insertInto("examples", "json_jsr353_function")
+                .value("id", 1)
+                // client-side, the JsonObject will be converted into a JSON String;
+                // then, server-side, the fromJson() function will convert that JSON string
+                // into an instance of the json_jsr353_function_user user-defined type (UDT),
+                // which will be persisted into the column "user"
+                .value("user", fromJson(alice))
+                // same thing, but this time converting from
+                // a JsonObject to a JSON string, then from this string to a map<varchar,float>
+                .value("scores", fromJson(aliceScores));
+        session.execute(stmt);
+
+        // The JSON object can be a bound value if the statement is prepared
+        // (we use a local variable here for the sake of example, but in a real application you would cache and reuse
+        // the prepared statement)
+        PreparedStatement pst = session.prepare(
+                insertInto("examples", "json_jsr353_function")
+                        .value("id", bindMarker("id"))
+                        .value("user", fromJson(bindMarker("user")))
+                        .value("scores", fromJson(bindMarker("scores"))));
+        session.execute(pst.bind()
+                .setInt("id", 2)
+                // note that the codec requires that the type passed to the set() method
+                // be always JsonStructure, and not a subclass of it, such as JsonObject
+                .set("user", bob, JsonStructure.class)
+                .set("scores", bobScores, JsonStructure.class));
+    }
+
+    // Retrieving JSON payloads from table columns of arbitrary types,
+    // using toJson() function
+    private static void selectToJson(Session session) {
+
+        Statement stmt = select()
+                .column("id")
+                .toJson("user").as("user")
+                .toJson("scores").as("scores")
+                .from("examples", "json_jsr353_function")
+                .where(in("id", 1, 2));
+
+        ResultSet rows = session.execute(stmt);
+
+        for (Row row : rows) {
+            int id = row.getInt("id");
+            // retrieve the JSON payload and convert it to a JsonObject instance
+            // note that the codec requires that the type passed to the get() method
+            // be always JsonStructure, and not a subclass of it, such as JsonObject,
+            // hence the need to downcast to JsonObject manually
+            JsonObject user = (JsonObject) row.get("user", JsonStructure.class);
+            // it is also possible to retrieve the raw JSON payload
+            String userJson = row.getString("user");
+            // retrieve the JSON payload and convert it to a JsonObject instance
+            JsonObject scores = (JsonObject) row.get("scores", JsonStructure.class);
+            // it is also possible to retrieve the raw JSON payload
+            String scoresJson = row.getString("scores");
+            System.out.printf("Retrieved row:%n" +
+                            "id           %d%n" +
+                            "user         %s%n" +
+                            "user (raw)   %s%n" +
+                            "scores       %s%n" +
+                            "scores (raw) %s%n%n",
+                    id, user, userJson, scores, scoresJson);
+        }
+    }
+
+}

--- a/driver-examples/src/main/java/com/datastax/driver/examples/json/Jsr353JsonRow.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/json/Jsr353JsonRow.java
@@ -1,0 +1,159 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.examples.json;
+
+import com.datastax.driver.core.*;
+import com.datastax.driver.extras.codecs.json.Jsr353JsonCodec;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonStructure;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+
+/**
+ * Illustrates how to map an entire table row to a Java object using
+ * the <a href="https://jcp.org/en/jsr/detail?id=353">Java API for JSON processing</a>,
+ * and leveraging the {@code SELECT JSON} and {@code INSERT JSON} syntaxes
+ * introduced in Cassandra 2.2.
+ * <p/>
+ * This example makes usage of a custom {@link TypeCodec codec},
+ * {@link Jsr353JsonCodec}, which is declared in the driver-extras module.
+ * If you plan to follow this example, make sure to include the following
+ * Maven dependencies in your project:
+ * <pre>{@code
+ * <dependency>
+ *     <groupId>com.datastax.cassandra</groupId>
+ *     <artifactId>cassandra-driver-extras</artifactId>
+ *     <version>${driver.version}</version>
+ * </dependency>
+ *
+ * <dependency>
+ *     <groupId>javax.json</groupId>
+ *     <artifactId>javax.json-api</artifactId>
+ *     <version>${jsr353-api.version}</version>
+ * </dependency>
+ *
+ * <dependency>
+ *     <groupId>org.glassfish</groupId>
+ *     <artifactId>javax.json</artifactId>
+ *     <version>${jsr353-ri.version}</version>
+ *     <scope>runtime</scope>
+ * </dependency>
+ * }</pre>
+ * This example also uses the {@link com.datastax.driver.core.querybuilder.QueryBuilder QueryBuilder};
+ * for examples using the "core" API, see {@link PlainTextJson} (they are easily translatable to the
+ * queries in this class).
+ * <p/>
+ * Preconditions:
+ * - a Cassandra 2.2+ cluster is running and accessible through the contacts points identified by CONTACT_POINTS and PORT;
+ * <p/>
+ * Side effects:
+ * - creates a new keyspace "examples" in the cluster. If a keyspace with this name already exists, it will be reused;
+ * - creates a table "examples.json_jsr353_row". If it already exists, it will be reused;
+ * - inserts data in the table.
+ *
+ * @see <a href="http://www.datastax.com/dev/blog/whats-new-in-cassandra-2-2-json-support">What’s New in Cassandra 2.2: JSON Support</a>
+ */
+public class Jsr353JsonRow {
+
+    static String[] CONTACT_POINTS = {"127.0.0.1"};
+    static int PORT = 9042;
+
+    public static void main(String[] args) {
+        Cluster cluster = null;
+        try {
+
+            // A codec to convert JSON payloads into JsonObject instances;
+            // this codec is declared in the driver-extras module
+            Jsr353JsonCodec userCodec = new Jsr353JsonCodec();
+
+            cluster = Cluster.builder()
+                    .addContactPoints(CONTACT_POINTS).withPort(PORT)
+                    .withCodecRegistry(new CodecRegistry().register(userCodec))
+                    .build();
+
+            Session session = cluster.connect();
+
+            createSchema(session);
+            insertJsonRow(session);
+            selectJsonRow(session);
+
+        } finally {
+            if (cluster != null) cluster.close();
+        }
+    }
+
+    private static void createSchema(Session session) {
+        session.execute("CREATE KEYSPACE IF NOT EXISTS examples " +
+                "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+        session.execute("CREATE TABLE IF NOT EXISTS examples.json_jsr353_row(" +
+                "id int PRIMARY KEY, name text, age int)");
+    }
+
+    // Mapping a User instance to a table row using INSERT JSON
+    private static void insertJsonRow(Session session) {
+
+        JsonObject alice = Json.createObjectBuilder()
+                .add("id", 1)
+                .add("name", "alice")
+                .add("age", 30)
+                .build();
+
+        JsonObject bob = Json.createObjectBuilder()
+                .add("id", 2)
+                .add("name", "bob")
+                .add("age", 35)
+                .build();
+
+        // Build and execute a simple statement
+        Statement stmt = insertInto("examples", "json_jsr353_row")
+                .json(alice);
+        session.execute(stmt);
+
+        // The JSON object can be a bound value if the statement is prepared
+        // (we use a local variable here for the sake of example, but in a real application you would cache and reuse
+        // the prepared statement)
+        PreparedStatement pst = session.prepare(
+                insertInto("examples", "json_jsr353_row").json(bindMarker("user")));
+        session.execute(pst.bind()
+                // note that the codec requires that the type passed to the set() method
+                // be always JsonStructure, and not a subclass of it, such as JsonObject
+                .set("user", bob, JsonStructure.class));
+    }
+
+    // Retrieving User instances from table rows using SELECT JSON
+    private static void selectJsonRow(Session session) {
+
+        // Reading the whole row as a JSON object
+        Statement stmt = select().json()
+                .from("examples", "json_jsr353_row")
+                .where(in("id", 1, 2));
+
+        ResultSet rows = session.execute(stmt);
+
+        for (Row row : rows) {
+            // SELECT JSON returns only one column for each row, of type VARCHAR,
+            // containing the row as a JSON payload.
+            // Note that the codec requires that the type passed to the get() method
+            // be always JsonStructure, and not a subclass of it, such as JsonObject,
+            // hence the need to downcast to JsonObject manually
+            JsonObject user = (JsonObject) row.get(0, JsonStructure.class);
+            System.out.printf("Retrieved user: %s%n", user);
+        }
+    }
+
+}

--- a/driver-examples/src/main/java/com/datastax/driver/examples/json/PlainTextJson.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/json/PlainTextJson.java
@@ -28,7 +28,7 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
  * PORT;
  * <p/>
  * Side effects:
- * - creates a new keyspace "examples" in the cluster. It a keyspace with this name already exists, it will be reused;
+ * - creates a new keyspace "examples" in the cluster. If a keyspace with this name already exists, it will be reused;
  * - creates a table "examples.querybuilder_json". If it already exists, it will be reused;
  * - inserts data in the table.
  *

--- a/driver-examples/src/main/java/com/datastax/driver/examples/json/PlainTextJson.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/json/PlainTextJson.java
@@ -1,0 +1,152 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.examples.json;
+
+import com.datastax.driver.core.*;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+
+/**
+ * Illustrates basic JSON support with plain JSON strings. For more advanced examples using complex objects and custom
+ * codecs, refer to the other examples in this package.
+ * <p/>
+ * Preconditions:
+ * - a Cassandra 2.2+ cluster is running and accessible through the contacts points identified by CONTACT_POINTS and
+ * PORT;
+ * <p/>
+ * Side effects:
+ * - creates a new keyspace "examples" in the cluster. It a keyspace with this name already exists, it will be reused;
+ * - creates a table "examples.querybuilder_json". If it already exists, it will be reused;
+ * - inserts data in the table.
+ *
+ * @see <a href="http://www.datastax.com/dev/blog/whats-new-in-cassandra-2-2-json-support">What’s New in Cassandra 2.2: JSON Support</a>
+ */
+public class PlainTextJson {
+
+    static String[] CONTACT_POINTS = {"127.0.0.1"};
+    static int PORT = 9042;
+
+    public static void main(String[] args) {
+        Cluster cluster = null;
+        try {
+            cluster = Cluster.builder()
+                    .addContactPoints(CONTACT_POINTS).withPort(PORT)
+                    .build();
+            Session session = cluster.connect();
+
+            createSchema(session);
+
+            insertWithCoreApi(session);
+            selectWithCoreApi(session);
+
+            insertWithQueryBuilder(session);
+            selectWithQueryBuilder(session);
+        } finally {
+            if (cluster != null) cluster.close();
+        }
+    }
+
+    private static void createSchema(Session session) {
+        session.execute("CREATE KEYSPACE IF NOT EXISTS examples " +
+                "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+        session.execute("CREATE TABLE IF NOT EXISTS examples.querybuilder_json(" +
+                "id int PRIMARY KEY, name text, specs map<text, text>)");
+    }
+
+    /**
+     * Demonstrates data insertion with the "core" API, i.e. providing the full query strings.
+     */
+    private static void insertWithCoreApi(Session session) {
+        // Bind in a simple statement:
+        session.execute("INSERT INTO examples.querybuilder_json JSON ?",
+                "{ \"id\": 1, \"name\": \"Mouse\", \"specs\": { \"color\": \"silver\" } }");
+
+        // Bind in a prepared statement:
+        // (we use a local variable here for the sake of example, but in a real application you would cache and reuse
+        // the prepared statement)
+        PreparedStatement pst = session.prepare("INSERT INTO examples.querybuilder_json JSON :payload");
+        session.execute(pst.bind()
+                .setString("payload", "{ \"id\": 2, \"name\": \"Keyboard\", \"specs\": { \"layout\": \"qwerty\" } }"));
+
+        // fromJson lets you provide individual columns as JSON:
+        session.execute("INSERT INTO examples.querybuilder_json " +
+                        "(id, name, specs)  VALUES (?, ?, fromJson(?))",
+                3, "Screen", "{ \"size\": \"24-inch\" }");
+    }
+
+    /**
+     * Demonstrates data retrieval with the "core" API, i.e. providing the full query strings.
+     */
+    private static void selectWithCoreApi(Session session) {
+        // Reading the whole row as a JSON object:
+        Row row = session.execute("SELECT JSON * FROM examples.querybuilder_json WHERE id = ?", 1).one();
+        System.out.printf("Entry #1 as JSON: %s%n", row.getString("[json]"));
+
+        // Extracting a particular column as JSON:
+        row = session.execute("SELECT id, toJson(specs) AS json_specs FROM examples.querybuilder_json WHERE id = ?", 2)
+                .one();
+        System.out.printf("Entry #%d's specs as JSON: %s%n",
+                row.getInt("id"), row.getString("json_specs"));
+    }
+
+    /**
+     * Same as {@link #insertWithCoreApi(Session)}, but using {@link com.datastax.driver.core.querybuilder.QueryBuilder}
+     * to construct the queries.
+     */
+    private static void insertWithQueryBuilder(Session session) {
+        // Simple statement:
+        Statement stmt = insertInto("examples", "querybuilder_json")
+                .json("{ \"id\": 1, \"name\": \"Mouse\", \"specs\": { \"color\": \"silver\" } }");
+        session.execute(stmt);
+
+        // Prepare and bind:
+        // (again, cache the prepared statement in a real application)
+        PreparedStatement pst = session.prepare(
+                insertInto("examples", "querybuilder_json").json(bindMarker("payload")));
+        session.execute(pst.bind()
+                .setString("payload", "{ \"id\": 2, \"name\": \"Keyboard\", \"specs\": { \"layout\": \"qwerty\" } }"));
+
+        // fromJson on a single column:
+        stmt = insertInto("examples", "querybuilder_json")
+                .value("id", 3)
+                .value("name", "Screen")
+                .value("specs", fromJson("{ \"size\": \"24-inch\" }"));
+        session.execute(stmt);
+    }
+
+    /**
+     * Same as {@link #selectWithCoreApi(Session)}, but using {@link com.datastax.driver.core.querybuilder.QueryBuilder}
+     * to construct the queries.
+     */
+    private static void selectWithQueryBuilder(Session session) {
+        // Reading the whole row as a JSON object:
+        Statement stmt = select().json()
+                .from("examples", "querybuilder_json")
+                .where(eq("id", 1));
+        Row row = session.execute(stmt).one();
+        System.out.printf("Entry #1 as JSON: %s%n", row.getString("[json]"));
+
+        // Extracting a particular column as JSON:
+        stmt = select()
+                .column("id")
+                .toJson("specs").as("json_specs")
+                .from("examples", "querybuilder_json")
+                .where(eq("id", 2));
+        row = session.execute(stmt).one();
+        System.out.printf("Entry #%d's specs as JSON: %s%n",
+                row.getInt("id"), row.getString("json_specs"));
+    }
+}

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/json/JacksonJsonCodec.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/json/JacksonJsonCodec.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.google.common.reflect.TypeToken;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -50,10 +51,47 @@ import java.nio.ByteBuffer;
  */
 public class JacksonJsonCodec<T> extends TypeCodec<T> {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
-    public JacksonJsonCodec(Class<T> javaType) {
+    /**
+     * Creates a new instance for the provided {@code javaClass},
+     * using a default, newly-allocated {@link ObjectMapper}.
+     *
+     * @param javaClass the Java class this codec maps to.
+     */
+    public JacksonJsonCodec(Class<T> javaClass) {
+        this(javaClass, new ObjectMapper());
+    }
+
+    /**
+     * Creates a new instance for the provided {@code javaType},
+     * using a default, newly-allocated {@link ObjectMapper}.
+     *
+     * @param javaType the Java type this codec maps to.
+     */
+    public JacksonJsonCodec(TypeToken<T> javaType) {
+        this(javaType, new ObjectMapper());
+    }
+
+    /**
+     * Creates a new instance for the provided {@code javaClass},
+     * and using the provided {@link ObjectMapper}.
+     *
+     * @param javaClass the Java class this codec maps to.
+     */
+    public JacksonJsonCodec(Class<T> javaClass, ObjectMapper objectMapper) {
+        this(TypeToken.of(javaClass), objectMapper);
+    }
+
+    /**
+     * Creates a new instance for the provided {@code javaType},
+     * and using the provided {@link ObjectMapper}.
+     *
+     * @param javaType the Java type this codec maps to.
+     */
+    public JacksonJsonCodec(TypeToken<T> javaType, ObjectMapper objectMapper) {
         super(DataType.varchar(), javaType);
+        this.objectMapper = objectMapper;
     }
 
     @Override

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/json/Jsr353JsonCodec.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/json/Jsr353JsonCodec.java
@@ -65,7 +65,7 @@ import java.util.Map;
  *   <artifactId>javax.json-api</artifactId>
  *   <version>1.0</version>
  * </dependency>
- * <p/>
+ *
  * <dependency>
  *   <groupId>org.glassfish</groupId>
  *   <artifactId>javax.json</artifactId>
@@ -79,10 +79,18 @@ public class Jsr353JsonCodec extends TypeCodec<JsonStructure> {
 
     private final JsonWriterFactory writerFactory;
 
+    /**
+     * Creates a new instance using a default configuration.
+     */
     public Jsr353JsonCodec() {
         this(null);
     }
 
+    /**
+     * Creates a new instance using the provided configuration.
+     *
+     * @param config A map of provider-specific configuration properties. May be empty or {@code null}.
+     */
     public Jsr353JsonCodec(Map<String, ?> config) {
         super(DataType.varchar(), JsonStructure.class);
         readerFactory = Json.createReaderFactory(config);

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/Jsr353JsonCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/Jsr353JsonCodecTest.java
@@ -70,7 +70,7 @@ public class Jsr353JsonCodecTest extends CCMTestsSupport {
     @Override
     public Cluster.Builder createClusterBuilder() {
         return Cluster.builder().withCodecRegistry(
-                new CodecRegistry().register(jsonCodec) // global User <-> varchar codec
+                new CodecRegistry().register(jsonCodec) // global JsonStructure <-> varchar codec
         );
     }
 


### PR DESCRIPTION
This is a low-hanging fruit and it would be nice to have in 3.1.0 since JAVA-743 was also introduced in that version.
I've initialized the example with the raw string variants, I think it would also be nice to include similar examples with custom types and the Jackson codec (see #715). driver-examples will have to depend on driver-extras, but I don't see any issue with that.
@adutra could you take a look at it tomorrow if you have time?
