### PR TITLE
JAVA-1248: Implement "beta" flag for native protocol v5.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,7 @@
 ### 3.2.0 (in progress)
 
 - [new feature] JAVA-1347: Add support for duration type.
+- [new feature] JAVA-1248: Implement "beta" flag for native protocol v5.
 
 
 ### 3.1.3

--- a/driver-core/src/main/java/com/datastax/driver/core/CodecUtils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CodecUtils.java
@@ -67,6 +67,7 @@ public final class CodecUtils {
                 return getUnsignedShort(input);
             case V3:
             case V4:
+            case V5:
                 return input.getInt();
             default:
                 throw version.unsupported();
@@ -91,6 +92,7 @@ public final class CodecUtils {
                 break;
             case V3:
             case V4:
+            case V5:
                 output.putInt(size);
                 break;
             default:
@@ -129,6 +131,7 @@ public final class CodecUtils {
                 break;
             case V3:
             case V4:
+            case V5:
                 if (value == null) {
                     output.putInt(-1);
                 } else {
@@ -214,6 +217,7 @@ public final class CodecUtils {
                 return 2;
             case V3:
             case V4:
+            case V5:
                 return 4;
             default:
                 throw version.unsupported();
@@ -230,6 +234,7 @@ public final class CodecUtils {
                 return 2 + elemSize;
             case V3:
             case V4:
+            case V5:
                 return value == null ? 4 : 4 + value.remaining();
             default:
                 throw version.unsupported();

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -273,6 +273,7 @@ class Connection {
                             case V2:
                             case V3:
                             case V4:
+                            case V5:
                                 return authenticateV2(authenticator, protocolVersion, initExecutor);
                             default:
                                 throw defunct(protocolVersion.unsupported());
@@ -1389,6 +1390,7 @@ class Connection {
         private static final Message.ProtocolEncoder messageEncoderV2 = new Message.ProtocolEncoder(ProtocolVersion.V2);
         private static final Message.ProtocolEncoder messageEncoderV3 = new Message.ProtocolEncoder(ProtocolVersion.V3);
         private static final Message.ProtocolEncoder messageEncoderV4 = new Message.ProtocolEncoder(ProtocolVersion.V4);
+        private static final Message.ProtocolEncoder messageEncoderV5 = new Message.ProtocolEncoder(ProtocolVersion.V5);
         private static final Frame.Encoder frameEncoder = new Frame.Encoder();
 
         private final ProtocolVersion protocolVersion;
@@ -1451,6 +1453,8 @@ class Connection {
                     return messageEncoderV3;
                 case V4:
                     return messageEncoderV4;
+                case V5:
+                    return messageEncoderV5;
                 default:
                     throw new DriverInternalError("Unsupported protocol version " + protocolVersion);
             }

--- a/driver-core/src/main/java/com/datastax/driver/core/Frame.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Frame.java
@@ -111,6 +111,7 @@ class Frame {
                 return fullFrame.readByte();
             case V3:
             case V4:
+            case V5:
                 return fullFrame.readShort();
             default:
                 throw version.unsupported();
@@ -153,6 +154,7 @@ class Frame {
                     return 8;
                 case V3:
                 case V4:
+                case V5:
                     return 9;
                 default:
                     throw version.unsupported();
@@ -164,7 +166,8 @@ class Frame {
             COMPRESSED,
             TRACING,
             CUSTOM_PAYLOAD,
-            WARNING;
+            WARNING,
+            USE_BETA;
 
             static EnumSet<Flag> deserialize(int flags) {
                 EnumSet<Flag> set = EnumSet.noneOf(Flag.class);
@@ -277,6 +280,7 @@ class Frame {
                     break;
                 case V3:
                 case V4:
+                case V5:
                     header.writeShort(streamId);
                     break;
                 default:

--- a/driver-core/src/main/java/com/datastax/driver/core/Message.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Message.java
@@ -314,6 +314,8 @@ abstract class Message {
             EnumSet<Frame.Header.Flag> flags = EnumSet.noneOf(Frame.Header.Flag.class);
             if (request.isTracingRequested())
                 flags.add(Frame.Header.Flag.TRACING);
+            if (protocolVersion == ProtocolVersion.NEWEST_BETA)
+                flags.add(Frame.Header.Flag.USE_BETA);
             Map<String, ByteBuffer> customPayload = request.getCustomPayload();
             if (customPayload != null) {
                 if (protocolVersion.compareTo(ProtocolVersion.V4) < 0)

--- a/driver-core/src/main/java/com/datastax/driver/core/ProtocolEvent.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ProtocolEvent.java
@@ -132,6 +132,7 @@ class ProtocolEvent {
                     return new SchemaChange(change, targetType, targetKeyspace, targetName, targetSignature);
                 case V3:
                 case V4:
+                case V5:
                     change = CBUtil.readEnumValue(Change.class, bb);
                     targetType = CBUtil.readEnumValue(SchemaElement.class, bb);
                     targetKeyspace = CBUtil.readString(bb);

--- a/driver-core/src/main/java/com/datastax/driver/core/ProtocolVersion.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ProtocolVersion.java
@@ -29,12 +29,15 @@ public enum ProtocolVersion {
     V1("1.2.0", 1),
     V2("2.0.0", 2),
     V3("2.1.0", 3),
-    V4("2.2.0", 4);
+    V4("2.2.0", 4),
+    V5("3.10.0", 5);
 
     /**
      * The most recent protocol version supported by the driver.
      */
     public static final ProtocolVersion NEWEST_SUPPORTED = V4;
+
+    public static final ProtocolVersion NEWEST_BETA = V5;
 
     private final VersionNumber minCassandraVersion;
     private final int asInt;

--- a/driver-core/src/main/java/com/datastax/driver/core/Requests.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Requests.java
@@ -326,6 +326,7 @@ class Requests {
                 case V2:
                 case V3:
                 case V4:
+                case V5:
                     CBUtil.writeConsistencyLevel(consistency, dest);
                     dest.writeByte((byte) QueryFlag.serialize(flags));
                     if (flags.contains(QueryFlag.VALUES)) {
@@ -360,6 +361,7 @@ class Requests {
                 case V2:
                 case V3:
                 case V4:
+                case V5:
                     int size = 0;
                     size += CBUtil.sizeOfConsistencyLevel(consistency);
                     size += 1; // flags
@@ -510,6 +512,7 @@ class Requests {
                     break;
                 case V3:
                 case V4:
+                case V5:
                     CBUtil.writeConsistencyLevel(consistency, dest);
                     dest.writeByte((byte) QueryFlag.serialize(flags));
                     if (flags.contains(QueryFlag.SERIAL_CONSISTENCY))
@@ -528,6 +531,7 @@ class Requests {
                     return CBUtil.sizeOfConsistencyLevel(consistency);
                 case V3:
                 case V4:
+                case V5:
                     int size = 0;
                     size += CBUtil.sizeOfConsistencyLevel(consistency);
                     size += 1; // flags

--- a/driver-core/src/main/java/com/datastax/driver/core/Responses.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Responses.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.util.*;
 
 import static com.datastax.driver.core.ProtocolVersion.V4;
+import static com.datastax.driver.core.ProtocolVersion.V5;
 import static com.datastax.driver.core.SchemaElement.*;
 
 class Responses {
@@ -518,6 +519,7 @@ class Responses {
                         case V2:
                         case V3:
                         case V4:
+                        case V5:
                             return Rows.Metadata.decode(body, version, codecRegistry);
                         default:
                             throw version.unsupported();
@@ -571,6 +573,7 @@ class Responses {
                             return new SchemaChange(change, targetType, targetKeyspace, targetName, targetSignature);
                         case V3:
                         case V4:
+                        case V5:
                             change = CBUtil.readEnumValue(Change.class, body);
                             targetType = CBUtil.readEnumValue(SchemaElement.class, body);
                             targetKeyspace = CBUtil.readString(body);

--- a/driver-core/src/main/java/com/datastax/driver/core/StreamIdGenerator.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/StreamIdGenerator.java
@@ -46,6 +46,7 @@ class StreamIdGenerator {
                 return 1;
             case V3:
             case V4:
+            case V5:
                 return 2;
             default:
                 throw version.unsupported();

--- a/driver-core/src/test/java/com/datastax/driver/core/ProtocolBetaVersionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ProtocolBetaVersionTest.java
@@ -1,0 +1,137 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import org.testng.annotations.Test;
+
+import static com.datastax.driver.core.ProtocolVersion.V4;
+import static com.datastax.driver.core.ProtocolVersion.V5;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Tests for the new USE_BETA flag introduced in protocol v5
+ * and Cassandra 3.10.
+ */
+@CCMConfig(version = "3.10")
+public class ProtocolBetaVersionTest extends CCMTestsSupport {
+
+    /**
+     * Verifies that the cluster builder fails when version is explicitly set and user attempts to set beta flag.
+     *
+     * @jira_ticket JAVA-1248
+     */
+    @Test(groups = "short")
+    public void should_not_initialize_when_version_explicitly_required_and_beta_flag_is_set() throws Exception {
+        try {
+            Cluster.builder()
+                    .addContactPoints(getContactPoints())
+                    .withPort(ccm().getBinaryPort())
+                    .withProtocolVersion(V4)
+                    .allowBetaProtocolVersion()
+                    .build();
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).isEqualTo("Can't use beta flag with initial protocol version of V4");
+        }
+    }
+
+    /**
+     * Verifies that the cluster builder fails when beta flag is set and user attempts to pass a version explicitly.
+     *
+     * @jira_ticket JAVA-1248
+     */
+    @Test(groups = "short")
+    public void should_not_initialize_when_beta_flag_is_set_and_version_explicitly_required() throws Exception {
+        try {
+            Cluster.builder()
+                    .addContactPoints(getContactPoints())
+                    .withPort(ccm().getBinaryPort())
+                    .allowBetaProtocolVersion()
+                    .withProtocolVersion(V4)
+                    .build();
+            fail("Expected IllegalStateException");
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage()).isEqualTo("Can not set the version explicitly if `allowBetaProtocolVersion` was used.");
+        }
+    }
+
+    /**
+     * Verifies that the driver CANNOT connect to 3.10 with the following combination of options:
+     * Version V5
+     * Flag UNSET
+     *
+     * @jira_ticket JAVA-1248
+     */
+    @Test(groups = "short")
+    public void should_not_connect_when_beta_version_explicitly_required_and_flag_not_set() throws Exception {
+        try {
+            Cluster.builder()
+                    .addContactPoints(getContactPoints())
+                    .withPort(ccm().getBinaryPort())
+                    .withProtocolVersion(V5)
+                    .build();
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).startsWith("Can not use V5 protocol version. Newest supported protocol version is: V4");
+        }
+    }
+
+    /**
+     * Verifies that the driver can connect to 3.10 with the following combination of options:
+     * Version UNSET
+     * Flag SET
+     * Expected version: V5
+     *
+     * @jira_ticket JAVA-1248
+     */
+    @Test(groups = "short")
+    public void should_connect_with_beta_when_no_version_explicitly_required_and_flag_set() throws Exception {
+        // Note: when the driver's ProtocolVersion.NEWEST_SUPPORTED will be incremented to V6 or higher
+        // a renegotiation will start taking place here and will downgrade the version from V6 to V5,
+        // but the test should remain valid
+        Cluster cluster = Cluster.builder()
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
+                .allowBetaProtocolVersion()
+                // no version explicitly required -> renegotiation allowed
+                .build();
+        cluster.connect();
+        assertThat(cluster.getConfiguration().getProtocolOptions().getProtocolVersion()).isEqualTo(V5);
+    }
+
+    /**
+     * Verifies that the driver can connect to 3.10 with the following combination of options:
+     * Version UNSET
+     * Flag UNSET
+     * Expected version: V4
+     *
+     * @jira_ticket JAVA-1248
+     */
+    @Test(groups = "short")
+    public void should_connect_after_renegotiation_when_no_version_explicitly_required_and_flag_not_set() throws Exception {
+        // Note: when the driver's ProtocolVersion.NEWEST_SUPPORTED will be incremented to V6 or higher
+        // the renegotiation will start downgrading the version from V6 to V4 instead of V5 to V4,
+        // but the test should remain valid
+        Cluster cluster = Cluster.builder()
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
+                // no version explicitly required -> renegotiation allowed
+                .build();
+        cluster.connect();
+        assertThat(cluster.getConfiguration().getProtocolOptions().getProtocolVersion()).isEqualTo(V4);
+    }
+}


### PR DESCRIPTION
@adutra hey I've addressed the comments you've had [here](https://github.com/datastax/java-driver/commit/ee3e855a989575f33191040e0fe991e3339b7977) (did a force-push, so there's no direct link anymore). 

Unfortunately, since Cassandra version is not yet released, I had to hardcode the `install-dir` for CCM.

Thank you for the help.
