### PR TITLE
JAVA-1261: Throw error when attempting to page in I/O thread

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,8 @@
 ### 3.0.4 (in progress)
 
 - [improvement] JAVA-1246: Driver swallows the real exception in a few cases
+- [improvement] JAVA-1261: Throw error when attempting to page in I/O thread.
+
 
 ### 3.0.3
 

--- a/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedResultSet.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedResultSet.java
@@ -307,6 +307,7 @@ abstract class ArrayBackedResultSet implements ResultSet {
                 // We need to know if there is more result, so fetch the next page and
                 // wait on it.
                 try {
+                    session.checkNotInEventLoop();
                     Uninterruptibles.getUninterruptibly(fetchMoreResults());
                 } catch (ExecutionException e) {
                     throw DriverThrowables.propagateCause(e);

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -673,10 +673,11 @@ class SessionManager extends AbstractSession {
         for (EventExecutor executor : connectionFactory.eventLoopGroup) {
             if (executor.inEventLoop()) {
                 throw new IllegalStateException(
-                        "Detected a synchronous Session call (execute() or prepare()) on an I/O thread, " +
-                                "this can cause deadlocks or unpredictable behavior. " +
-                                "Make sure your Future callbacks only use async calls, or schedule them on a " +
-                                "different executor.");
+                        "Detected a synchronous call on an I/O thread, this can cause deadlocks or unpredictable " +
+                                "behavior. This generally happens when a Future callback calls a synchronous Session " +
+                                "method (execute() or prepare()), or iterates a result set past the fetch size " +
+                                "(causing an internal synchronous fetch of the next page of results). " +
+                                "Avoid this in your callbacks, or schedule them on a different executor.");
             }
         }
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
@@ -16,6 +16,7 @@
 package com.datastax.driver.core;
 
 import com.datastax.driver.core.exceptions.InvalidQueryException;
+import com.datastax.driver.core.utils.CassandraVersion;
 import com.google.common.base.Function;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
@@ -144,6 +145,7 @@ public class AsyncQueryTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
+    @CassandraVersion(major = 2.0, description = "Paging is not supported until 2.0")
     public void should_fail_when_auto_paging_on_io_thread() throws Exception {
         for (int i = 0; i < 1000; i++) {
             Statement statement = new SimpleStatement("select v from asyncquerytest.foo where k = 1");

--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
@@ -49,7 +49,7 @@ public class AsyncQueryTest extends CCMTestsSupport {
             execute(
                     String.format("create keyspace %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}", keyspace),
                     String.format("create table %s.foo(k int, v int, primary key (k, v))", keyspace));
-            for (int v = 0; v < 100; v++)
+            for (int v = 1; v <= 100; v++)
                 execute(String.format("insert into %s.foo (k, v) values (1, %d)", keyspace, v));
         }
     }


### PR DESCRIPTION
Iterating a result set past the current page triggers a blocking call
for the next page. This should never be done in a Netty I/O thread (for
example by iterating in a future callback), because it can deadlock.

Similar to JAVA-1182, we throw an error so that client code can detect
this mistake early.
