### PR TITLE
Set appveyor os to 'Previous Visual Studio 2015' temporarily.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 3.0.4 (in progress)
+
+
 ### 3.0.3
 
 - [improvement] JAVA-1147: Upgrade Netty to 4.0.37.

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -10,12 +10,14 @@ os: Previous Visual Studio 2015
 platform: x64
 install:
   - ps: .\ci\appveyor.ps1
+  - ps: .\ci\hardwareinfo.ps1
 build_script:
   - mvn -B install -DskipTests=true
 test_script:
   - "mvn -B -Dccm.java.home=\"%JAVA_8_HOME%\" -Dccm.maxNumberOfNodes=1 -Dcassandra.version=%cassandra_version% verify -P%test_profile%"
 on_finish:
   - ps: .\ci\uploadtests.ps1
+  - ps: .\ci\hardwareinfo.ps1
 cache:
   - C:\Users\appveyor\.m2
   - C:\Users\appveyor\.ccm\repository

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -6,6 +6,7 @@ environment:
     - java_version: 1.7.0
     - java_version: 1.8.0
       test_profile: short
+os: Previous Visual Studio 2015
 platform: x64
 install:
   - ps: .\ci\appveyor.ps1

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   test_profile: default
-  cassandra_version: 3.5
+  cassandra_version: 3.7
   matrix:
     - java_version: 1.6.0
     - java_version: 1.7.0

--- a/ci/hardwareinfo.ps1
+++ b/ci/hardwareinfo.ps1
@@ -1,0 +1,20 @@
+# Local System Information v3
+# Shows details of currently running PC
+# Thom McKiernan 11/09/2014
+# Taken from: https://community.spiceworks.com/scripts/show/1831-get-computer-system-and-hardware-information
+$computerSystem = Get-CimInstance CIM_ComputerSystem
+$computerOS = Get-CimInstance CIM_OperatingSystem
+$computerCPU = Get-CimInstance CIM_Processor
+$computerHDD = Get-CimInstance Win32_LogicalDisk -Filter "DeviceID = 'C:'"
+$javaVersion =  & java.exe -version 2>&1
+$java8Version = & 'C:\Program Files\Java\jdk1.8.0\bin\java.exe' -version 2>&1
+
+Write-Host "System Information for: " $computerSystem.Name -BackgroundColor DarkCyan
+"CPU: " + $computerCPU.Name
+"HDD Capacity: "  + "{0:N2}" -f ($computerHDD.Size/1GB) + "GB"
+"HDD Space: " + "{0:P2}" -f ($computerHDD.FreeSpace/$computerHDD.Size) + " Free (" + "{0:N2}" -f ($computerHDD.FreeSpace/1GB) + "GB)"
+"RAM: " + "{0:N2}" -f ($computerSystem.TotalPhysicalMemory/1GB) + "GB"
+"Operating System: " + $computerOS.caption + ", Service Pack: " + $computerOS.ServicePackMajorVersion
+
+Write-Host "Java Version (for build): " $javaVersion
+Write-Host "Java Version (for cassandra): " $java8Version


### PR DESCRIPTION
[CASSANDRA-12278](https://issues.apache.org/jira/browse/CASSANDRA-12278) prevents C\* from working with j8u100+.  Previous image
has an older version of the JDK.

Also log hardwareinfo and update to cassandra 3.7.
