### PR TITLE
JAVA-1262: Use ParseUtils for quoting & unquoting

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -6,6 +6,7 @@
 - [improvement] JAVA-1261: Throw error when attempting to page in I/O thread.
 - [bug] JAVA-1258: Regression: Mapper cannot map a materialized view after JAVA-1126.
 - [bug] JAVA-1101: Batch and BatchStatement should consider inner statements to determine query idempotence
+- [improvement] JAVA-1262: Use ParseUtils for quoting & unquoting.
 
 
 ### 3.0.3

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -135,14 +135,7 @@ public class Metadata {
             return id.toLowerCase();
 
         // Check if it's enclosed in quotes. If it is, remove them and unescape internal double quotes
-        if (!id.isEmpty() && id.charAt(0) == '"' && id.charAt(id.length() - 1) == '"')
-            return id.substring(1, id.length() - 1).replaceAll("\"\"", "\"");
-
-        // Otherwise, just return the id.
-        // Note that this is a bit at odds with the rules explained above, because the client can pass an
-        // identifier that contains special characters, without the need to quote it.
-        // Still it's better to be lenient here rather than throwing an exception.
-        return id;
+        return ParseUtils.unDoubleQuote(id);
     }
 
     // Escape a CQL3 identifier based on its value as read from the schema
@@ -217,7 +210,7 @@ public class Metadata {
      * or even {@link Cluster#connect(String)}.
      */
     public static String quote(String id) {
-        return '"' + id.replace("\"", "\"\"") + '"';
+        return ParseUtils.doubleQuote(id);
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/ParseUtils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ParseUtils.java
@@ -232,7 +232,7 @@ public abstract class ParseUtils {
      * by single quotes, and {@code false} otherwise.
      */
     public static boolean isQuoted(String value) {
-        return value != null && value.length() > 1 && value.charAt(0) == '\'' && value.charAt(value.length() - 1) == '\'';
+        return isQuoted(value, '\'');
     }
 
     /**
@@ -243,7 +243,7 @@ public abstract class ParseUtils {
      * @return The quoted string.
      */
     public static String quote(String value) {
-        return '\'' + replaceChar(value, '\'', "''") + '\'';
+        return quote(value, '\'');
     }
 
     /**
@@ -254,9 +254,41 @@ public abstract class ParseUtils {
      * @return The unquoted string.
      */
     public static String unquote(String value) {
-        if (!isQuoted(value))
-            return value;
-        return value.substring(1, value.length() - 1).replace("''", "'");
+        return unquote(value, '\'');
+    }
+
+    /**
+     * Return {@code true} if the given string is surrounded
+     * by double quotes, and {@code false} otherwise.
+     *
+     * @param value The string to inspect.
+     * @return {@code true} if the given string is surrounded
+     * by double quotes, and {@code false} otherwise.
+     */
+    public static boolean isDoubleQuoted(String value) {
+        return isQuoted(value, '\"');
+    }
+
+    /**
+     * Double quote the given string; double quotes are escaped.
+     * If the given string is null, this method returns a quoted empty string ({@code ""}).
+     *
+     * @param value The value to double quote.
+     * @return The double quoted string.
+     */
+    public static String doubleQuote(String value) {
+        return quote(value, '"');
+    }
+
+    /**
+     * Unquote the given string if it is double quoted; double quotes are unescaped.
+     * If the given string is not double quoted, it is returned without any modification.
+     *
+     * @param value The string to un-double quote.
+     * @return The un-double quoted string.
+     */
+    public static String unDoubleQuote(String value) {
+        return unquote(value, '"');
     }
 
     /**
@@ -428,45 +460,129 @@ public abstract class ParseUtils {
     }
 
     /**
-     * Simple method to replace a single character.
-     * {@code String.replace()} is a bit too inefficient (see JAVA-67).
-     * This methods is specially useful for escaping single quotes
-     * in CQL strings:
-     * <p/>
-     * <pre>{@code
-     * ParseUtils.replaceChar(value, '\'', "''");
-     * }</pre>
+     * Return {@code true} if the given string is surrounded
+     * by the quote character given, and {@code false} otherwise.
      *
-     * @param text        The text.
-     * @param search      The character to search for.
-     * @param replacement The replacement.
-     * @return The text with all occurrences of {@code search} replaced with {@code replacement}.
+     * @param value The string to inspect.
+     * @return {@code true} if the given string is surrounded
+     * by the quote character, and {@code false} otherwise.
      */
-    private static String replaceChar(String text, char search, String replacement) {
+    private static boolean isQuoted(String value, char quoteChar) {
+        return value != null && value.length() > 1
+                && value.charAt(0) == quoteChar && value.charAt(value.length() - 1) == quoteChar;
+    }
+
+    /**
+     * @param quoteChar " or '
+     * @return A quoted empty string.
+     */
+    private static String emptyQuoted(char quoteChar) {
+        // don't handle non quote characters, this is done so that these are interned and don't create
+        // repeated empty quoted strings.
+        assert quoteChar == '"' || quoteChar == '\'';
+        if (quoteChar == '"')
+            return "\"\"";
+        else
+            return "''";
+    }
+
+
+    /**
+     * Quotes text and escapes any existing quotes in the text.
+     * {@code String.replace()} is a bit too inefficient (see JAVA-67, JAVA-1262).
+     *
+     * @param text      The text.
+     * @param quoteChar The character to use as a quote.
+     * @return The text with surrounded in quotes with all existing quotes escaped with (i.e. ' becomes '')
+     */
+    private static String quote(String text, char quoteChar) {
         if (text == null || text.isEmpty())
-            return "";
+            return emptyQuoted(quoteChar);
 
         int nbMatch = 0;
         int start = -1;
         do {
-            start = text.indexOf(search, start + 1);
+            start = text.indexOf(quoteChar, start + 1);
             if (start != -1)
                 ++nbMatch;
         } while (start != -1);
 
+        // no quotes found that need to be escaped, simply surround in quotes and return.
         if (nbMatch == 0)
-            return text;
+            return quoteChar + text + quoteChar;
 
-        int newLength = text.length() + nbMatch * (replacement.length() - 1);
+        // 2 for beginning and end quotes.
+        // length for original text
+        // nbMatch for escape characters to add to quotes to be escaped.
+        int newLength = 2 + text.length() + nbMatch;
         char[] result = new char[newLength];
-        int newIdx = 0;
+        result[0] = quoteChar;
+        result[newLength - 1] = quoteChar;
+        int newIdx = 1;
         for (int i = 0; i < text.length(); i++) {
             char c = text.charAt(i);
-            if (c == search) {
-                for (int r = 0; r < replacement.length(); r++)
-                    result[newIdx++] = replacement.charAt(r);
+            if (c == quoteChar) {
+                // escape quote with another occurrence.
+                result[newIdx++] = c;
+                result[newIdx++] = c;
             } else {
                 result[newIdx++] = c;
+            }
+        }
+        return new String(result);
+    }
+
+    /**
+     * Unquotes text and unescapes non surrounding quotes.
+     * {@code String.replace()} is a bit too inefficient (see JAVA-67, JAVA-1262).
+     *
+     * @param text      The text
+     * @param quoteChar The character to use as a quote.
+     * @return The text with surrounding quotes removed and non surrounding quotes unescaped (i.e. '' becomes ')
+     */
+    private static String unquote(String text, char quoteChar) {
+        if (!isQuoted(text, quoteChar))
+            return text;
+
+        if (text.length() == 2)
+            return "";
+
+        String search = emptyQuoted(quoteChar);
+        int nbMatch = 0;
+        int start = -1;
+        do {
+            start = text.indexOf(search, start + 2);
+            // ignore the second to last character occurrence, as the last character is a quote.
+            if (start != -1 && start != text.length() - 2)
+                ++nbMatch;
+        } while (start != -1);
+
+        // no escaped quotes found, simply remove surrounding quotes and return.
+        if (nbMatch == 0)
+            return text.substring(1, text.length() - 1);
+
+        // length of the new string will be its current length - the number of occurrences.
+        int newLength = text.length() - nbMatch - 2;
+        char[] result = new char[newLength];
+        int newIdx = 0;
+        // track whenever a quoteChar is encountered and the previous character is not a quoteChar.
+        boolean firstFound = false;
+        for (int i = 1; i < text.length() - 1; i++) {
+            char c = text.charAt(i);
+            if (c == quoteChar) {
+                if (firstFound) {
+                    // The previous character was a quoteChar, don't add this to result, this action in
+                    // effect removes consecutive quotes.
+                    firstFound = false;
+                } else {
+                    // found a quoteChar and the previous character was not a quoteChar, include in result.
+                    firstFound = true;
+                    result[newIdx++] = c;
+                }
+            } else {
+                // non quoteChar encountered, include in result.
+                result[newIdx++] = c;
+                firstFound = false;
             }
         }
         return new String(result);

--- a/driver-core/src/test/java/com/datastax/driver/core/ParseUtilsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ParseUtilsTest.java
@@ -43,6 +43,9 @@ public class ParseUtilsTest {
         assertThat(ParseUtils.unquote("'foo'")).isEqualTo("foo");
         assertThat(ParseUtils.unquote(" 'foo' ")).isEqualTo(" 'foo' "); // considered unquoted
         assertThat(ParseUtils.unquote("'''foo'''")).isEqualTo("'foo'");
+        assertThat(ParseUtils.unquote("'''")).isEqualTo("'");
+        assertThat(ParseUtils.unquote("''foo'")).isEqualTo("'foo");
+        assertThat(ParseUtils.unquote("'foo''")).isEqualTo("foo'");
     }
 
     @Test(groups = "unit")
@@ -58,6 +61,48 @@ public class ParseUtilsTest {
         assertThat(ParseUtils.isQuoted("'foo'")).isTrue();
         assertThat(ParseUtils.isQuoted(" 'foo' ")).isFalse(); // considered unquoted
         assertThat(ParseUtils.isQuoted("'''foo'''")).isTrue();
+    }
+
+    @Test(groups = "unit")
+    public void testDoubleQuote() {
+        assertThat(ParseUtils.doubleQuote(null)).isEqualTo("\"\"");
+        assertThat(ParseUtils.doubleQuote("")).isEqualTo("\"\"");
+        assertThat(ParseUtils.doubleQuote(" ")).isEqualTo("\" \"");
+        assertThat(ParseUtils.doubleQuote("foo")).isEqualTo("\"foo\"");
+        assertThat(ParseUtils.doubleQuote(" \"foo\" ")).isEqualTo("\" \"\"foo\"\" \"");
+    }
+
+    @Test(groups = "unit")
+    public void testDoubleUnquote() {
+        assertThat(ParseUtils.unDoubleQuote(null)).isNull();
+        assertThat(ParseUtils.unDoubleQuote("")).isEqualTo("");
+        assertThat(ParseUtils.unDoubleQuote(" ")).isEqualTo(" ");
+        assertThat(ParseUtils.unDoubleQuote("\"")).isEqualTo("\""); // malformed string left untouched
+        assertThat(ParseUtils.unDoubleQuote("foo")).isEqualTo("foo");
+        assertThat(ParseUtils.unDoubleQuote("\"\"")).isEqualTo("");
+        assertThat(ParseUtils.unDoubleQuote("\" \"")).isEqualTo(" ");
+        assertThat(ParseUtils.unDoubleQuote("\"foo")).isEqualTo("\"foo"); // malformed string left untouched
+        assertThat(ParseUtils.unDoubleQuote("\"foo\"")).isEqualTo("foo");
+        assertThat(ParseUtils.unDoubleQuote(" \"foo\" ")).isEqualTo(" \"foo\" "); // considered unquoted
+        assertThat(ParseUtils.unDoubleQuote("\"\"\"foo\"\"\"")).isEqualTo("\"foo\"");
+        assertThat(ParseUtils.unDoubleQuote("\"\"\"")).isEqualTo("\"");
+        assertThat(ParseUtils.unDoubleQuote("\"\"foo\"")).isEqualTo("\"foo");
+        assertThat(ParseUtils.unDoubleQuote("\"foo\"\"")).isEqualTo("foo\"");
+    }
+
+    @Test(groups = "unit")
+    public void testIsDoubleQuoted() {
+        assertThat(ParseUtils.isDoubleQuoted(null)).isFalse();
+        assertThat(ParseUtils.isDoubleQuoted("")).isFalse();
+        assertThat(ParseUtils.isDoubleQuoted(" ")).isFalse();
+        assertThat(ParseUtils.isDoubleQuoted("\"")).isFalse(); // malformed string considered unquoted
+        assertThat(ParseUtils.isDoubleQuoted("foo")).isFalse();
+        assertThat(ParseUtils.isDoubleQuoted("\"\"")).isTrue();
+        assertThat(ParseUtils.isDoubleQuoted("\" \"")).isTrue();
+        assertThat(ParseUtils.isDoubleQuoted("\"foo")).isFalse(); // malformed string considered unquoted
+        assertThat(ParseUtils.isDoubleQuoted("\"foo\"")).isTrue();
+        assertThat(ParseUtils.isDoubleQuoted(" \"foo\" ")).isFalse(); // considered unquoted
+        assertThat(ParseUtils.isDoubleQuoted("\"\"\"foo\"\"\"")).isTrue();
     }
 
 }


### PR DESCRIPTION
For [JAVA-1262](https://datastax-oss.atlassian.net/browse/JAVA-1262)

Metadata.handleId and quote use String.replace or replaceAll, which each
create a lot of garbage as they compile a Pattern each time.  Instead
use ParseUtils.quote and unquote for quoting and unquoting.

Adds doubleQuote, unDoubleQuote, and isDoubleQuoted as analogs to the
single quoted counterparts in ParseUtils.

Memory allocation difference running a 5,000,000 write cassandra-stress:

| configuration | Metadata.quote() | Metadata.handleId() | total | % of total |
| --- | --- | --- | --- | --- |
| 3.0.x | 3.18GB | 3.77GB | 43.54GB | 15.96% |
| java1262 | 496.47MB | 1.30GB | 36.69GB | 4.87% |

A good portion of Metadata.handleId() (880.63 MB) is from pattern checking for determining whether or not to lowercase a non-quoted string.
