### PR TITLE
Update testng to 6.9.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <jsr353-api.version>1.0</jsr353-api.version>
         <jsr353-ri.version>1.0.4</jsr353-ri.version>
         <!-- test dependency versions -->
-        <testng.version>6.8.8</testng.version>
+        <testng.version>6.9.10</testng.version>
         <assertj.version>1.7.0</assertj.version>
         <mockito.version>1.10.8</mockito.version>
         <commons-exec.version>1.3</commons-exec.version>


### PR DESCRIPTION
For some reason, prior to testng 6.9.7 the driver-core test suite would
take upwards of 20 seconds to create reports for.  This is fixed by
testng 6.9.7.

Found via profiling that during this time the reporter is opening and closing upwards of 12k files per second:

![screen shot 2016-08-12 at 3 33 07 pm](https://cloud.githubusercontent.com/assets/6889771/17636335/16f65968-60a2-11e6-8182-a6578a66cebb.png)

Looking at file probes, it appeared to be opening and closing the same files over and over again in the target/surefire-reports/old directory.
