### PR TITLE
Disable default TestNG listeners

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,10 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.16</version>
                         <configuration>
+                            <property>
+                                <name>usedefaultlisteners</name>
+                                <value>false</value> <!-- disable default listeners as some of the html reports do a lot of File I/O -->
+                            </property>
                             <skip>true</skip>
                             <forkCount>1</forkCount>
                             <reuseForks>false</reuseForks>
@@ -375,6 +379,10 @@
                         <classpathDependencyExcludes>io.netty:netty-transport-native-epoll</classpathDependencyExcludes>
                     </classpathDependencyExcludes>
                     <properties>
+                        <property>
+                            <name>usedefaultlisteners</name>
+                            <value>false</value> <!-- disable default listeners as some of the html reports do a lot of File I/O -->
+                        </property>
                         <property>
                             <!-- Don't skip tests after a @Before method throws a SkipException -->
                             <name>configfailurepolicy</name>


### PR DESCRIPTION
TestNG old HTML reporter generates a lot of File I/O since it
open/closes files repeatedly which can cause system instability
like OS crashes rarely.  This is made worse compounded by that
each test class file is considered its own suite, which causes an
amplification of file open and closes.

Since we only use the target/surefire-reports/TEST-TestSuite.xml
file, disabling these listeners shouldn't cause any problems.

Found via profiling that during this time the reporter is opening and closing upwards of 12k files per second:

![screen shot 2016-08-12 at 3 33 07 pm](https://cloud.githubusercontent.com/assets/6889771/17636335/16f65968-60a2-11e6-8182-a6578a66cebb.png)

Looking at file probes, it appeared to be opening and closing the same files over and over again in the target/surefire-reports/old directory.
