### PR TITLE
Enforce source formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,35 @@ in-depth knowledge of the codebase.
 
 ## Editor configuration
 
-We use IntelliJ IDEA with the default formatting options, with one exception: check
-"Enable formatter markers in comments" in Preferences > Editor > Code Style.
+We use Eclipse formatting conventions with a few exceptions:
+
+* Spaces instead of Tabs with 4 space indentation
+* No joining of wrapped lines (for leniency)
+* Disable auto-line wrapping (for leniency)
+* Disable formatting of comments (for leniency)
+* No spaces inserted before and after braces in array initializer
+* Indent statements within switch body
+* Add new lines after each enum constant
+
+A formatting configuration is provided in [src/formatter/java.xml](src/formatter/java.xml)
+that can be importted into both Eclipse and IntelliJ.
+
+Additionally, you may opt to use the formatting-maven-plugin to do the formatting for you
+by executing:
+
+```
+mvn formatter:format
+```
+
+In the module that you wish to do formatting for.  This is required because the formatting
+plugin doesn''t currently recurse child modules.
+
+Source format validation is done as part of the maven build and may be validated
+individually by executing:
+
+```
+mvn formatter:validate
+```
 
 Please format your code and organize imports before submitting your changes.
 

--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractTableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractTableMetadata.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.driver.core;
 
-
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 
@@ -51,14 +50,14 @@ public abstract class AbstractTableMetadata {
     protected final VersionNumber cassandraVersion;
 
     protected AbstractTableMetadata(KeyspaceMetadata keyspace,
-                                    String name,
-                                    UUID id,
-                                    List<ColumnMetadata> partitionKey,
-                                    List<ColumnMetadata> clusteringColumns,
-                                    Map<String, ColumnMetadata> columns,
-                                    TableOptionsMetadata options,
-                                    List<ClusteringOrder> clusteringOrder,
-                                    VersionNumber cassandraVersion) {
+            String name,
+            UUID id,
+            List<ColumnMetadata> partitionKey,
+            List<ColumnMetadata> clusteringColumns,
+            Map<String, ColumnMetadata> columns,
+            TableOptionsMetadata options,
+            List<ClusteringOrder> clusteringOrder,
+            VersionNumber cassandraVersion) {
         this.keyspace = keyspace;
         this.name = name;
         this.id = id;
@@ -281,7 +280,8 @@ public abstract class AbstractTableMetadata {
     private StringBuilder appendClusteringOrder(StringBuilder sb) {
         sb.append("CLUSTERING ORDER BY (");
         for (int i = 0; i < clusteringColumns.size(); i++) {
-            if (i > 0) sb.append(", ");
+            if (i > 0)
+                sb.append(", ");
             sb.append(clusteringColumns.get(i).getName()).append(' ').append(clusteringOrder.get(i));
         }
         return sb.append(')');
@@ -292,8 +292,10 @@ public abstract class AbstractTableMetadata {
         sb.append("{ ");
         boolean first = true;
         for (Map.Entry<String, String> entry : m.entrySet()) {
-            if (first) first = false;
-            else sb.append(", ");
+            if (first)
+                first = false;
+            else
+                sb.append(", ");
             sb.append('\'').append(entry.getKey()).append('\'');
             sb.append(" : ");
             try {

--- a/driver-core/src/main/java/com/datastax/driver/core/AggregateMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AggregateMetadata.java
@@ -46,8 +46,8 @@ public class AggregateMetadata {
     private final TypeCodec<Object> stateTypeCodec;
 
     private AggregateMetadata(KeyspaceMetadata keyspace, String simpleName, List<DataType> argumentTypes,
-                              String finalFuncSimpleName, String finalFuncFullName, Object initCond, DataType returnType,
-                              String stateFuncSimpleName, String stateFuncFullName, DataType stateType, TypeCodec<Object> stateTypeCodec) {
+            String finalFuncSimpleName, String finalFuncFullName, Object initCond, DataType returnType,
+            String stateFuncSimpleName, String stateFuncFullName, DataType stateType, TypeCodec<Object> stateTypeCodec) {
         this.keyspace = keyspace;
         this.simpleName = simpleName;
         this.argumentTypes = argumentTypes;

--- a/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedResultSet.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedResultSet.java
@@ -100,8 +100,8 @@ abstract class ArrayBackedResultSet implements ResultSet {
     }
 
     private static ExecutionInfo update(ExecutionInfo info, Responses.Result msg, SessionManager session,
-                                        ByteBuffer pagingState, ProtocolVersion protocolVersion, CodecRegistry codecRegistry,
-                                        Statement statement) {
+            ByteBuffer pagingState, ProtocolVersion protocolVersion, CodecRegistry codecRegistry,
+            Statement statement) {
         if (info == null)
             return null;
 
@@ -174,11 +174,11 @@ abstract class ArrayBackedResultSet implements ResultSet {
         private final ExecutionInfo info;
 
         private SinglePage(ColumnDefinitions metadata,
-                           Token.Factory tokenFactory,
-                           ProtocolVersion protocolVersion,
-                           CodecRegistry codecRegistry,
-                           Queue<List<ByteBuffer>> rows,
-                           ExecutionInfo info) {
+                Token.Factory tokenFactory,
+                ProtocolVersion protocolVersion,
+                CodecRegistry codecRegistry,
+                Queue<List<ByteBuffer>> rows,
+                ExecutionInfo info) {
             super(metadata, tokenFactory, rows.peek(), protocolVersion, codecRegistry);
             this.info = info;
             this.rows = rows;
@@ -245,13 +245,13 @@ abstract class ArrayBackedResultSet implements ResultSet {
         private final SessionManager session;
 
         private MultiPage(ColumnDefinitions metadata,
-                          Token.Factory tokenFactory,
-                          ProtocolVersion protocolVersion,
-                          CodecRegistry codecRegistry,
-                          Queue<List<ByteBuffer>> rows,
-                          ExecutionInfo info,
-                          ByteBuffer pagingState,
-                          SessionManager session) {
+                Token.Factory tokenFactory,
+                ProtocolVersion protocolVersion,
+                CodecRegistry codecRegistry,
+                Queue<List<ByteBuffer>> rows,
+                ExecutionInfo info,
+                ByteBuffer pagingState,
+                SessionManager session) {
 
             // Note: as of Cassandra 2.1.0, it turns out that the result of a CAS update is never paged, so
             // we could hard-code the result of wasApplied in this class to "true". However, we can not be sure
@@ -336,7 +336,6 @@ abstract class ArrayBackedResultSet implements ResultSet {
         private ListenableFuture<ResultSet> queryNextPage(ByteBuffer nextStart, final SettableFuture<ResultSet> future) {
 
             Statement statement = this.infos.peek().getStatement();
-
 
             assert !(statement instanceof BatchStatement);
 

--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -1300,7 +1300,6 @@ public class BoundStatement extends Statement implements SettableData<BoundState
         return wrapper.getObject(name);
     }
 
-
     /**
      * {@inheritDoc}
      */

--- a/driver-core/src/main/java/com/datastax/driver/core/ChainedResultSetFuture.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ChainedResultSetFuture.java
@@ -72,4 +72,3 @@ class ChainedResultSetFuture extends AbstractFuture<ResultSet> implements Result
         }
     }
 }
-

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1043,7 +1043,6 @@ public class Cluster implements Closeable {
             return this;
         }
 
-
         /**
          * Configures the {@link CodecRegistry} instance to use for the new cluster.
          * <p/>
@@ -1386,7 +1385,7 @@ public class Cluster implements Closeable {
                     queryOptions.getRefreshNodeListIntervalMillis(),
                     queryOptions.getMaxPendingRefreshNodeListRequests(),
                     EventDebouncer.DEFAULT_MAX_QUEUED_EVENTS
-            );
+                    );
             this.nodeRefreshRequestDebouncer = new EventDebouncer<NodeRefreshRequest>(
                     "Node refresh",
                     scheduledTasksExecutor,
@@ -1394,7 +1393,7 @@ public class Cluster implements Closeable {
                     queryOptions.getRefreshNodeIntervalMillis(),
                     queryOptions.getMaxPendingRefreshNodeRequests(),
                     EventDebouncer.DEFAULT_MAX_QUEUED_EVENTS
-            );
+                    );
             this.schemaRefreshRequestDebouncer = new EventDebouncer<SchemaRefreshRequest>(
                     "Schema refresh",
                     scheduledTasksExecutor,
@@ -1402,7 +1401,7 @@ public class Cluster implements Closeable {
                     queryOptions.getRefreshSchemaIntervalMillis(),
                     queryOptions.getMaxPendingRefreshSchemaRequests(),
                     EventDebouncer.DEFAULT_MAX_QUEUED_EVENTS
-            );
+                    );
 
             this.scheduledTasksExecutor.scheduleWithFixedDelay(new CleanupIdleConnectionsTask(), 10, 10, TimeUnit.SECONDS);
 
@@ -1477,7 +1476,8 @@ public class Cluster implements Closeable {
                 for (Host host : allHosts) {
                     // If the host is down at this stage, it's a contact point that the control connection failed to reach.
                     // Reconnection attempts are already scheduled, and the LBP and listeners have been notified above.
-                    if (host.state == Host.State.DOWN) continue;
+                    if (host.state == Host.State.DOWN)
+                        continue;
 
                     // Otherwise, we want to do the equivalent of onAdd(). But since we know for sure that no sessions or prepared
                     // statements exist at this point, we can skip some of the steps (plus this avoids scheduling concurrent pool
@@ -1645,7 +1645,7 @@ public class Cluster implements Closeable {
 
         void logClusterNameMismatch(Host host, String expectedClusterName, String actualClusterName) {
             logger.warn("Detected added or restarted Cassandra host {} but ignoring it since its cluster name '{}' does not match the one "
-                            + "currently known ({})",
+                    + "currently known ({})",
                     host, actualClusterName, expectedClusterName);
         }
 
@@ -2788,7 +2788,10 @@ public class Cluster implements Closeable {
     }
 
     private enum HostEvent {
-        UP, DOWN, ADDED, REMOVED
+        UP,
+        DOWN,
+        ADDED,
+        REMOVED
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/ClusteringOrder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ClusteringOrder.java
@@ -23,6 +23,7 @@ package com.datastax.driver.core;
  */
 public enum ClusteringOrder {
 
-    ASC, DESC;
+    ASC,
+    DESC;
 
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CodecRegistry.java
@@ -162,7 +162,7 @@ public final class CodecRegistry {
             TypeCodec.uuid(), // must be declared before TimeUUIDCodec so it gets chosen when CQL type not available
             TypeCodec.timeUUID(),
             TypeCodec.inet()
-    );
+            );
 
     /**
      * The default {@code CodecRegistry} instance.

--- a/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
@@ -193,7 +193,8 @@ public class ColumnMetadata {
             int position;
             if (version.getMajor() >= 3) {
                 position = row.getInt(POSITION); // cannot be null, -1 is used as a special value instead of null to avoid tombstones
-                if (position == -1) position = 0;
+                if (position == -1)
+                    position = 0;
             } else {
                 position = row.isNull(COMPONENT_INDEX) ? 0 : row.getInt(COMPONENT_INDEX);
             }

--- a/driver-core/src/main/java/com/datastax/driver/core/Configuration.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Configuration.java
@@ -55,13 +55,13 @@ public class Configuration {
     private final CodecRegistry codecRegistry;
 
     private Configuration(Policies policies,
-                          ProtocolOptions protocolOptions,
-                          PoolingOptions poolingOptions,
-                          SocketOptions socketOptions,
-                          MetricsOptions metricsOptions,
-                          QueryOptions queryOptions,
-                          NettyOptions nettyOptions,
-                          CodecRegistry codecRegistry) {
+            ProtocolOptions protocolOptions,
+            PoolingOptions poolingOptions,
+            SocketOptions socketOptions,
+            MetricsOptions metricsOptions,
+            QueryOptions queryOptions,
+            NettyOptions nettyOptions,
+            CodecRegistry codecRegistry) {
         this.policies = policies;
         this.protocolOptions = protocolOptions;
         this.poolingOptions = poolingOptions;
@@ -86,8 +86,7 @@ public class Configuration {
                 toCopy.getMetricsOptions(),
                 toCopy.getQueryOptions(),
                 toCopy.getNettyOptions(),
-                toCopy.getCodecRegistry()
-        );
+                toCopy.getCodecRegistry());
     }
 
     void register(Cluster.Manager manager) {

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -64,7 +64,12 @@ class Connection {
 
     private static final boolean DISABLE_COALESCING = SystemProperties.getBoolean("com.datastax.driver.DISABLE_COALESCING", false);
 
-    enum State {OPEN, TRASHED, RESURRECTING, GONE}
+    enum State {
+        OPEN,
+        TRASHED,
+        RESURRECTING,
+        GONE
+    }
 
     final AtomicReference<State> state = new AtomicReference<State>(State.OPEN);
 
@@ -189,8 +194,8 @@ class Connection {
                     Exception e = (t instanceof ConnectionException || t instanceof DriverException || t instanceof InterruptedException)
                             ? (Exception) t
                             : new ConnectionException(Connection.this.address,
-                            String.format("Unexpected error during transport initialization (%s)", t),
-                            t);
+                                    String.format("Unexpected error during transport initialization (%s)", t),
+                                    t);
                     future.setException(defunct(e));
                 }
                 return future;
@@ -402,7 +407,6 @@ class Connection {
                 Host.statesLogger.trace("Defuncting " + this, e);
             else if (Host.statesLogger.isDebugEnabled())
                 Host.statesLogger.debug("Defuncting {} because: {}", this, e.getMessage());
-
 
             Host host = factory.manager.metadata.getHost(address);
             if (host != null) {
@@ -1314,7 +1318,7 @@ class Connection {
                 pipeline.addLast("ssl", sslOptions.newSSLHandler(channel));
             }
 
-//            pipeline.addLast("debug", new LoggingHandler(LogLevel.INFO));
+            //            pipeline.addLast("debug", new LoggingHandler(LogLevel.INFO));
 
             pipeline.addLast("frameDecoder", new Frame.Decoder());
             pipeline.addLast("frameEncoder", frameEncoder);

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -262,7 +262,7 @@ class ControlConnection implements Connection.Owner {
                     ProtocolEvent.Type.TOPOLOGY_CHANGE,
                     ProtocolEvent.Type.STATUS_CHANGE,
                     ProtocolEvent.Type.SCHEMA_CHANGE
-            );
+                    );
             connection.write(new Requests.Register(evs));
 
             // We need to refresh the node list first so we know about the cassandra version of

--- a/driver-core/src/main/java/com/datastax/driver/core/DataTypeCqlNameParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataTypeCqlNameParser.java
@@ -218,7 +218,8 @@ class DataTypeCqlNameParser {
             } else if (str.charAt(startIdx) == '\'') { // custom type name included in single quotes
                 ++idx;
                 // read until closing quote.
-                while (!isEOS() && str.charAt(idx++) != '\'') { /* loop */ }
+                while (!isEOS() && str.charAt(idx++) != '\'') { /* loop */
+                }
             } else {
                 while (!isEOS() && (isIdentifierChar(str.charAt(idx)) || str.charAt(idx) == '"'))
                     ++idx;

--- a/driver-core/src/main/java/com/datastax/driver/core/EventDebouncer.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/EventDebouncer.java
@@ -66,7 +66,11 @@ class EventDebouncer<T> {
     private final Queue<Entry<T>> events;
     private final AtomicInteger eventCount;
 
-    private enum State {NEW, RUNNING, STOPPED}
+    private enum State {
+        NEW,
+        RUNNING,
+        STOPPED
+    }
 
     private volatile State state;
 
@@ -134,7 +138,7 @@ class EventDebouncer<T> {
             if (now > lastOverflowWarning + OVERFLOW_WARNING_INTERVAL) {
                 lastOverflowWarning = now;
                 logger.warn("{} debouncer enqueued more than {} events, rejecting new events. "
-                            + "This should not happen and is likely a sign that something is wrong.",
+                        + "This should not happen and is likely a sign that something is wrong.",
                         name, maxQueuedEvents);
             }
             eventCount.decrementAndGet();

--- a/driver-core/src/main/java/com/datastax/driver/core/ExecutionInfo.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ExecutionInfo.java
@@ -67,8 +67,7 @@ public class ExecutionInfo {
                 newStatement,
                 schemaInAgreement,
                 newWarnings,
-                incomingPayload
-        );
+                incomingPayload);
     }
 
     ExecutionInfo withIncomingPayload(Map<String, ByteBuffer> incomingPayload) {

--- a/driver-core/src/main/java/com/datastax/driver/core/Frame.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Frame.java
@@ -212,7 +212,7 @@ class Frame {
             private final int opcodeOffset;
 
             DecoderForStreamIdSize(int streamIdSize) {
-                super(MAX_FRAME_LENGTH, /*lengthOffset=*/ 3 + streamIdSize, 4, 0, 0, true);
+                super(MAX_FRAME_LENGTH, /*lengthOffset=*/3 + streamIdSize, 4, 0, 0, true);
                 this.opcodeOffset = 2 + streamIdSize;
             }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/FunctionMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/FunctionMetadata.java
@@ -40,12 +40,12 @@ public class FunctionMetadata {
     private final DataType returnType;
 
     private FunctionMetadata(KeyspaceMetadata keyspace,
-                             String simpleName,
-                             Map<String, DataType> arguments,
-                             String body,
-                             boolean calledOnNullInput,
-                             String language,
-                             DataType returnType) {
+            String simpleName,
+            Map<String, DataType> arguments,
+            String body,
+            boolean calledOnNullInput,
+            String language,
+            DataType returnType) {
         this.keyspace = keyspace;
         this.simpleName = simpleName;
         this.arguments = arguments;
@@ -94,7 +94,7 @@ public class FunctionMetadata {
         if (argumentNames.size() != argumentTypes.size()) {
             String fullName = Metadata.fullFunctionName(simpleName, arguments.values());
             logger.error(String.format("Error parsing definition of function %1$s.%2$s: the number of argument names and types don't match."
-                            + "Cluster.getMetadata().getKeyspace(\"%1$s\").getFunction(\"%2$s\") will be missing.",
+                    + "Cluster.getMetadata().getKeyspace(\"%1$s\").getFunction(\"%2$s\") will be missing.",
                     ksm.getName(), fullName));
             return null;
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/GettableByIndexData.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/GettableByIndexData.java
@@ -425,7 +425,6 @@ public interface GettableByIndexData {
      */
     public <K, V> Map<K, V> getMap(int i, Class<K> keysClass, Class<V> valuesClass);
 
-
     /**
      * Returns the {@code i}th value as a map.
      * <p/>

--- a/driver-core/src/main/java/com/datastax/driver/core/Host.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Host.java
@@ -52,7 +52,11 @@ public class Host {
     // specified otherwise in cassandra.yaml file.
     private volatile InetAddress listenAddress;
 
-    enum State {ADDED, DOWN, UP}
+    enum State {
+        ADDED,
+        DOWN,
+        UP
+    }
 
     volatile State state;
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/HostConnectionPool.java
@@ -72,7 +72,12 @@ class HostConnectionPool implements Connection.Owner {
 
     protected final AtomicReference<CloseFuture> closeFuture = new AtomicReference<CloseFuture>();
 
-    private enum Phase {INITIALIZING, READY, INIT_FAILED, CLOSING}
+    private enum Phase {
+        INITIALIZING,
+        READY,
+        INIT_FAILED,
+        CLOSING
+    }
 
     protected final AtomicReference<Phase> phase = new AtomicReference<Phase>(Phase.INITIALIZING);
 
@@ -405,7 +410,7 @@ class HostConnectionPool implements Connection.Owner {
             return true;
 
         // First, make sure we don't go below core connections
-        for (; ; ) {
+        for (;;) {
             int opened = open.get();
             if (opened <= options().getCoreConnectionsPerHost(hostDistance)) {
                 connection.state.set(OPEN);
@@ -429,7 +434,7 @@ class HostConnectionPool implements Connection.Owner {
     private boolean addConnectionIfUnderMaximum() {
 
         // First, make sure we don't cross the allowed limit of open connections
-        for (; ; ) {
+        for (;;) {
             int opened = open.get();
             if (opened >= options().getMaxConnectionsPerHost(hostDistance))
                 return false;

--- a/driver-core/src/main/java/com/datastax/driver/core/IndexMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/IndexMetadata.java
@@ -221,11 +221,12 @@ public class IndexMetadata {
             @Override
             public boolean apply(Map.Entry<String, String> input) {
                 return
-                        !input.getKey().equals(TARGET_OPTION_NAME) &&
-                                !input.getKey().equals(CUSTOM_INDEX_OPTION_NAME);
+                !input.getKey().equals(TARGET_OPTION_NAME) &&
+                        !input.getKey().equals(CUSTOM_INDEX_OPTION_NAME);
             }
         });
-        if (Iterables.isEmpty(filtered)) return "";
+        if (Iterables.isEmpty(filtered))
+            return "";
         StringBuilder builder = new StringBuilder();
         builder.append("WITH OPTIONS = {");
         Iterator<Map.Entry<String, String>> it = filtered.iterator();

--- a/driver-core/src/main/java/com/datastax/driver/core/MD5Digest.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/MD5Digest.java
@@ -58,4 +58,3 @@ class MD5Digest {
         return Bytes.toHexString(bytes);
     }
 }
-

--- a/driver-core/src/main/java/com/datastax/driver/core/MaterializedViewMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/MaterializedViewMetadata.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.driver.core;
 
-
 import com.google.common.base.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +61,7 @@ public class MaterializedViewMetadata extends AbstractTableMetadata {
         TableMetadata baseTable = keyspace.tables.get(tableName);
         if (baseTable == null) {
             logger.trace(String.format("Cannot find base table %s for materialized view %s.%s: "
-                            + "Cluster.getMetadata().getKeyspace(\"%s\").getView(\"%s\") will return null",
+                    + "Cluster.getMetadata().getKeyspace(\"%s\").getView(\"%s\") will return null",
                     tableName, keyspace.getName(), name, keyspace.getName(), name));
             return null;
         }
@@ -88,7 +87,7 @@ public class MaterializedViewMetadata extends AbstractTableMetadata {
             // See ControlConnection#refreshSchema for why we'd rather not probably this further. Since table options is one thing
             // that tends to change often in Cassandra, it's worth special casing this.
             logger.error(String.format("Error parsing schema options for view %s.%s: "
-                            + "Cluster.getMetadata().getKeyspace(\"%s\").getView(\"%s\").getOptions() will return null",
+                    + "Cluster.getMetadata().getKeyspace(\"%s\").getView(\"%s\").getOptions() will return null",
                     keyspace.getName(), name, keyspace.getName(), name), e);
         }
 
@@ -174,7 +173,8 @@ public class MaterializedViewMetadata extends AbstractTableMetadata {
             while (it.hasNext()) {
                 ColumnMetadata column = it.next();
                 sb.append(spaces(4, formatted)).append(Metadata.escapeId(column.getName()));
-                if (it.hasNext()) sb.append(",");
+                if (it.hasNext())
+                    sb.append(",");
                 sb.append(" ");
                 newLine(sb, formatted);
             }

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -56,7 +56,7 @@ public class Metadata {
             "local_quorum", "modify", "nan", "norecursive", "of", "on", "one", "order", "password",
             "primary", "quorum", "rename", "revoke", "schema", "select", "set", "table", "to",
             "token", "three", "truncate", "two", "unlogged", "update", "use", "using", "where", "with"
-    );
+            );
 
     Metadata(Cluster.Manager cluster) {
         this.cluster = cluster;
@@ -630,12 +630,12 @@ public class Metadata {
         private final Map<Token, Host> tokenToPrimary;
 
         private TokenMap(Token.Factory factory,
-                         List<Token> ring,
-                         Set<TokenRange> tokenRanges,
-                         Map<Token, Host> tokenToPrimary,
-                         Map<Host, Set<Token>> primaryToTokens,
-                         Map<String, Map<Token, Set<Host>>> tokenToHostsByKeyspace,
-                         Map<String, Map<Host, Set<TokenRange>>> hostsToRangesByKeyspace) {
+                List<Token> ring,
+                Set<TokenRange> tokenRanges,
+                Map<Token, Host> tokenToPrimary,
+                Map<Host, Set<Token>> primaryToTokens,
+                Map<String, Map<Token, Set<Host>>> tokenToHostsByKeyspace,
+                Map<String, Map<Host, Set<TokenRange>>> hostsToRangesByKeyspace) {
             this.factory = factory;
             this.ring = ring;
             this.tokenRanges = tokenRanges;

--- a/driver-core/src/main/java/com/datastax/driver/core/PerHostPercentileTracker.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PerHostPercentileTracker.java
@@ -73,9 +73,9 @@ public class PerHostPercentileTracker implements LatencyTracker {
     private final long intervalMs;
 
     private PerHostPercentileTracker(long highestTrackableLatencyMillis, int numberOfSignificantValueDigits,
-                                     int numberOfHosts,
-                                     int minRecordedValues,
-                                     long intervalMs) {
+            int numberOfHosts,
+            int minRecordedValues,
+            long intervalMs) {
         try {
             Histogram.class.getName();
         } catch (NoClassDefFoundError e) {
@@ -317,7 +317,7 @@ public class PerHostPercentileTracker implements LatencyTracker {
             BootstrappingException.class,
             UnpreparedException.class,
             QueryValidationException.class // query validation also happens at early stages in the coordinator
-    );
+            );
 
     @Override
     public void onRegister(Cluster cluster) {

--- a/driver-core/src/main/java/com/datastax/driver/core/PoolingOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PoolingOptions.java
@@ -120,7 +120,7 @@ public class PoolingOptions {
                     .put(MAX_REQUESTS_PER_CONNECTION_LOCAL_KEY, 1024)
                     .put(MAX_REQUESTS_PER_CONNECTION_REMOTE_KEY, 256)
                     .build()
-    );
+            );
 
     /**
      * The default value for {@link #getIdleTimeoutSeconds()} ({@value}).

--- a/driver-core/src/main/java/com/datastax/driver/core/ProtocolEvent.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ProtocolEvent.java
@@ -25,7 +25,11 @@ import static com.datastax.driver.core.SchemaElement.*;
 
 class ProtocolEvent {
 
-    enum Type {TOPOLOGY_CHANGE, STATUS_CHANGE, SCHEMA_CHANGE}
+    enum Type {
+        TOPOLOGY_CHANGE,
+        STATUS_CHANGE,
+        SCHEMA_CHANGE
+    }
 
     final Type type;
 
@@ -46,7 +50,11 @@ class ProtocolEvent {
     }
 
     static class TopologyChange extends ProtocolEvent {
-        enum Change {NEW_NODE, REMOVED_NODE, MOVED_NODE}
+        enum Change {
+            NEW_NODE,
+            REMOVED_NODE,
+            MOVED_NODE
+        }
 
         final Change change;
         final InetSocketAddress node;
@@ -72,7 +80,10 @@ class ProtocolEvent {
 
     static class StatusChange extends ProtocolEvent {
 
-        enum Status {UP, DOWN}
+        enum Status {
+            UP,
+            DOWN
+        }
 
         final Status status;
         final InetSocketAddress node;
@@ -98,7 +109,11 @@ class ProtocolEvent {
 
     static class SchemaChange extends ProtocolEvent {
 
-        enum Change {CREATED, UPDATED, DROPPED}
+        enum Change {
+            CREATED,
+            UPDATED,
+            DROPPED
+        }
 
         final Change change;
         final SchemaElement targetType;

--- a/driver-core/src/main/java/com/datastax/driver/core/ReplicationStategy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ReplicationStategy.java
@@ -196,8 +196,8 @@ abstract class ReplicationStrategy {
                     int achievedFactor = entry.getValue().size();
                     if (achievedFactor < expectedFactor && !warnedDcs.contains(dcName)) {
                         logger.warn("Error while computing token map for keyspace {} with datacenter {}: "
-                                        + "could not achieve replication factor {} (found {} replicas only), "
-                                        + "check your keyspace replication settings.",
+                                + "could not achieve replication factor {} (found {} replicas only), "
+                                + "check your keyspace replication settings.",
                                 keyspaceName, dcName, expectedFactor, achievedFactor);
                         // only warn once per DC
                         warnedDcs.add(dcName);

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -590,7 +590,7 @@ class RequestHandler {
                                 }
 
                                 logger.info("Query {} is not prepared on {}, preparing before retrying executing. "
-                                                + "Seeing this message a few times is fine, but seeing it a lot may be source of performance problems",
+                                        + "Seeing this message a few times is fine, but seeing it a lot may be source of performance problems",
                                         toPrepare.getQueryString(), connection.address);
 
                                 write(connection, prepareAndRetry(toPrepare.getQueryString()));

--- a/driver-core/src/main/java/com/datastax/driver/core/Requests.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Requests.java
@@ -270,14 +270,14 @@ class Requests {
         final long defaultTimestamp;
 
         QueryProtocolOptions(Message.Request.Type requestType,
-                             ConsistencyLevel consistency,
-                             List<ByteBuffer> positionalValues,
-                             Map<String, ByteBuffer> namedValues,
-                             boolean skipMetadata,
-                             int pageSize,
-                             ByteBuffer pagingState,
-                             ConsistencyLevel serialConsistency,
-                             long defaultTimestamp) {
+                ConsistencyLevel consistency,
+                List<ByteBuffer> positionalValues,
+                Map<String, ByteBuffer> namedValues,
+                boolean skipMetadata,
+                int pageSize,
+                ByteBuffer pagingState,
+                ConsistencyLevel serialConsistency,
+                long defaultTimestamp) {
 
             Preconditions.checkArgument(positionalValues.isEmpty() || namedValues.isEmpty());
 
@@ -474,7 +474,8 @@ class Requests {
             StringBuilder sb = new StringBuilder();
             sb.append("BATCH of [");
             for (int i = 0; i < queryOrIdList.size(); i++) {
-                if (i > 0) sb.append(", ");
+                if (i > 0)
+                    sb.append(", ");
                 sb.append(queryOrIdList.get(i)).append(" with ").append(values.get(i).size()).append(" values");
             }
             sb.append("] with options ").append(options);

--- a/driver-core/src/main/java/com/datastax/driver/core/Responses.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Responses.java
@@ -544,7 +544,11 @@ class Responses {
 
         static class SchemaChange extends Result {
 
-            enum Change {CREATED, UPDATED, DROPPED}
+            enum Change {
+                CREATED,
+                UPDATED,
+                DROPPED
+            }
 
             final Change change;
             final SchemaElement targetType;

--- a/driver-core/src/main/java/com/datastax/driver/core/ResultSet.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ResultSet.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.driver.core;
 
-
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.Iterator;

--- a/driver-core/src/main/java/com/datastax/driver/core/SchemaElement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SchemaElement.java
@@ -21,5 +21,10 @@ package com.datastax.driver.core;
  * Note that {@code VIEW} is not a valid string under protocol v4 or lower, but is included for internal use only.
  */
 enum SchemaElement {
-    KEYSPACE, TABLE, TYPE, FUNCTION, AGGREGATE, VIEW
+    KEYSPACE,
+    TABLE,
+    TYPE,
+    FUNCTION,
+    AGGREGATE,
+    VIEW
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
@@ -37,20 +37,21 @@ abstract class SchemaParser {
     private static final SchemaParser V3_PARSER = new V3SchemaParser();
 
     static SchemaParser forVersion(VersionNumber cassandraVersion) {
-        if (cassandraVersion.getMajor() >= 3) return V3_PARSER;
+        if (cassandraVersion.getMajor() >= 3)
+            return V3_PARSER;
         return V2_PARSER;
     }
 
     abstract SystemRows fetchSystemRows(Cluster cluster,
-                                        SchemaElement targetType, String targetKeyspace, String targetName, List<String> targetSignature,
-                                        Connection connection, VersionNumber cassandraVersion)
+            SchemaElement targetType, String targetKeyspace, String targetName, List<String> targetSignature,
+            Connection connection, VersionNumber cassandraVersion)
             throws ConnectionException, BusyConnectionException, ExecutionException, InterruptedException;
 
     abstract String tableNameColumn();
 
     void refresh(Cluster cluster,
-                 SchemaElement targetType, String targetKeyspace, String targetName, List<String> targetSignature,
-                 Connection connection, VersionNumber cassandraVersion)
+            SchemaElement targetType, String targetKeyspace, String targetName, List<String> targetSignature,
+            Connection connection, VersionNumber cassandraVersion)
             throws ConnectionException, BusyConnectionException, ExecutionException, InterruptedException {
 
         SystemRows rows = fetchSystemRows(cluster, targetType, targetKeyspace, targetName, targetSignature, connection, cassandraVersion);
@@ -119,7 +120,7 @@ abstract class SchemaParser {
     }
 
     private Map<String, KeyspaceMetadata> buildKeyspaces(SystemRows rows,
-                                                         VersionNumber cassandraVersion, Cluster cluster) {
+            VersionNumber cassandraVersion, Cluster cluster) {
 
         Map<String, KeyspaceMetadata> keyspaces = new LinkedHashMap<String, KeyspaceMetadata>();
         for (Row keyspaceRow : rows.keyspaces) {
@@ -181,7 +182,7 @@ abstract class SchemaParser {
                 } catch (RuntimeException e) {
                     // See #refresh for why we'd rather not propagate this further
                     logger.error(String.format("Error parsing schema for table %s.%s: "
-                                    + "Cluster.getMetadata().getKeyspace(\"%s\").getTable(\"%s\") will be missing or incomplete",
+                            + "Cluster.getMetadata().getKeyspace(\"%s\").getTable(\"%s\") will be missing or incomplete",
                             keyspace.getName(), cfName, keyspace.getName(), cfName), e);
                 }
             }
@@ -249,7 +250,7 @@ abstract class SchemaParser {
                 } catch (RuntimeException e) {
                     // See #refresh for why we'd rather not propagate this further
                     logger.error(String.format("Error parsing schema for view %s.%s: "
-                                    + "Cluster.getMetadata().getKeyspace(\"%s\").getView(\"%s\") will be missing or incomplete",
+                            + "Cluster.getMetadata().getKeyspace(\"%s\").getView(\"%s\") will be missing or incomplete",
                             keyspace.getName(), viewName, keyspace.getName(), viewName), e);
                 }
             }
@@ -485,7 +486,7 @@ abstract class SchemaParser {
         final Map<String, Map<String, List<Row>>> indexes;
 
         public SystemRows(ResultSet keyspaces, Map<String, List<Row>> tables, Map<String, Map<String, Map<String, ColumnMetadata.Raw>>> columns, Map<String, List<Row>> udts, Map<String, List<Row>> functions,
-                          Map<String, List<Row>> aggregates, Map<String, List<Row>> views, Map<String, Map<String, List<Row>>> indexes) {
+                Map<String, List<Row>> aggregates, Map<String, List<Row>> views, Map<String, Map<String, List<Row>>> indexes) {
             this.keyspaces = keyspaces;
             this.tables = tables;
             this.columns = columns;
@@ -510,8 +511,8 @@ abstract class SchemaParser {
 
         @Override
         SystemRows fetchSystemRows(Cluster cluster,
-                                   SchemaElement targetType, String targetKeyspace, String targetName, List<String> targetSignature,
-                                   Connection connection, VersionNumber cassandraVersion)
+                SchemaElement targetType, String targetKeyspace, String targetName, List<String> targetSignature,
+                Connection connection, VersionNumber cassandraVersion)
                 throws ConnectionException, BusyConnectionException, ExecutionException, InterruptedException {
 
             boolean isSchemaOrKeyspace = (targetType == null || targetType == KEYSPACE);
@@ -529,12 +530,7 @@ abstract class SchemaParser {
                     whereClause += " AND aggregate_name = '" + targetName + "' AND signature = " + LIST_OF_TEXT_CODEC.format(targetSignature);
             }
 
-            ResultSetFuture ksFuture = null,
-                    udtFuture = null,
-                    cfFuture = null,
-                    colsFuture = null,
-                    functionsFuture = null,
-                    aggregatesFuture = null;
+            ResultSetFuture ksFuture = null, udtFuture = null, cfFuture = null, colsFuture = null, functionsFuture = null, aggregatesFuture = null;
 
             ProtocolVersion protocolVersion = cluster.getConfiguration().getProtocolOptions().getProtocolVersion();
 
@@ -600,14 +596,7 @@ abstract class SchemaParser {
 
             boolean isSchemaOrKeyspace = (targetType == null || targetType == KEYSPACE);
 
-            ResultSetFuture ksFuture = null,
-                    udtFuture = null,
-                    cfFuture = null,
-                    colsFuture = null,
-                    functionsFuture = null,
-                    aggregatesFuture = null,
-                    indexesFuture = null,
-                    viewsFuture = null;
+            ResultSetFuture ksFuture = null, udtFuture = null, cfFuture = null, colsFuture = null, functionsFuture = null, aggregatesFuture = null, indexesFuture = null, viewsFuture = null;
 
             ProtocolVersion protocolVersion = cluster.getConfiguration().getProtocolOptions().getProtocolVersion();
 
@@ -662,7 +651,6 @@ abstract class SchemaParser {
             }
             return whereClause;
         }
-
 
         @Override
         protected List<Row> maybeSortUdts(List<Row> udtRows, Cluster cluster, String keyspace) {

--- a/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
@@ -55,15 +55,15 @@ public class TableMetadata extends AbstractTableMetadata {
     private final Map<String, MaterializedViewMetadata> views;
 
     private TableMetadata(KeyspaceMetadata keyspace,
-                          String name,
-                          UUID id,
-                          List<ColumnMetadata> partitionKey,
-                          List<ColumnMetadata> clusteringColumns,
-                          Map<String, ColumnMetadata> columns,
-                          Map<String, IndexMetadata> indexes,
-                          TableOptionsMetadata options,
-                          List<ClusteringOrder> clusteringOrder,
-                          VersionNumber cassandraVersion) {
+            String name,
+            UUID id,
+            List<ColumnMetadata> partitionKey,
+            List<ColumnMetadata> clusteringColumns,
+            Map<String, ColumnMetadata> columns,
+            Map<String, IndexMetadata> indexes,
+            TableOptionsMetadata options,
+            List<ClusteringOrder> clusteringOrder,
+            VersionNumber cassandraVersion) {
         super(keyspace, name, id, partitionKey, clusteringColumns, columns, options, clusteringOrder, cassandraVersion);
         this.indexes = indexes;
         this.views = new HashMap<String, MaterializedViewMetadata>();
@@ -139,7 +139,7 @@ public class TableMetadata extends AbstractTableMetadata {
             // See ControlConnection#refreshSchema for why we'd rather not probably this further. Since table options is one thing
             // that tends to change often in Cassandra, it's worth special casing this.
             logger.error(String.format("Error parsing schema options for table %s.%s: "
-                            + "Cluster.getMetadata().getKeyspace(\"%s\").getTable(\"%s\").getOptions() will return null",
+                    + "Cluster.getMetadata().getKeyspace(\"%s\").getTable(\"%s\").getOptions() will return null",
                     ksm.getName(), name, ksm.getName(), name), e);
         }
 
@@ -294,9 +294,9 @@ public class TableMetadata extends AbstractTableMetadata {
     }
 
     private static int findClusteringSize(DataTypeClassNameParser.ParseResult comparator,
-                                          Collection<ColumnMetadata.Raw> cols,
-                                          List<String> columnAliases,
-                                          VersionNumber cassandraVersion) {
+            Collection<ColumnMetadata.Raw> cols,
+            List<String> columnAliases,
+            VersionNumber cassandraVersion) {
         // In 2.0 onwards, this is relatively easy, we just find the biggest 'position' amongst the clustering columns.
         // For 1.2 however, this is slightly more subtle: we need to infer it based on whether the comparator is composite or not, and whether we have
         // regular columns or not.

--- a/driver-core/src/main/java/com/datastax/driver/core/ThreadLocalMonotonicTimestampGenerator.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ThreadLocalMonotonicTimestampGenerator.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.driver.core;
 
-
 /**
  * A timestamp generator based on {@code System.currentTimeMillis()}, with an incrementing thread-local counter
  * to generate the sub-millisecond part.

--- a/driver-core/src/main/java/com/datastax/driver/core/Token.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Token.java
@@ -85,8 +85,8 @@ public abstract class Token implements Comparable<Token> {
 
         // Base implementation for split
         protected List<BigInteger> split(BigInteger start, BigInteger range,
-                                         BigInteger ringEnd, BigInteger ringLength,
-                                         int numberOfSplits) {
+                BigInteger ringEnd, BigInteger ringLength,
+                int numberOfSplits) {
             BigInteger[] tmp = range.divideAndRemainder(BigInteger.valueOf(numberOfSplits));
             BigInteger divider = tmp[0];
             int remainder = tmp[1].intValue();

--- a/driver-core/src/main/java/com/datastax/driver/core/TupleType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TupleType.java
@@ -139,7 +139,6 @@ public class TupleType extends DataType {
         this.codecRegistry = codecRegistry;
     }
 
-
     @Override
     public int hashCode() {
         return Arrays.hashCode(new Object[]{name, types});

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeTokens.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeTokens.java
@@ -40,7 +40,9 @@ public final class TypeTokens {
      */
     public static <T> TypeToken<List<T>> listOf(Class<T> eltType) {
         // @formatter:off
-        return new TypeToken<List<T>>(){}.where(new TypeParameter<T>(){}, eltType);
+        return new TypeToken<List<T>>() {
+        }.where(new TypeParameter<T>() {
+        }, eltType);
         // @formatter:on
     }
 
@@ -55,7 +57,9 @@ public final class TypeTokens {
      */
     public static <T> TypeToken<List<T>> listOf(TypeToken<T> eltType) {
         // @formatter:off
-        return new TypeToken<List<T>>(){}.where(new TypeParameter<T>(){}, eltType);
+        return new TypeToken<List<T>>() {
+        }.where(new TypeParameter<T>() {
+        }, eltType);
         // @formatter:on
     }
 
@@ -70,7 +74,9 @@ public final class TypeTokens {
      */
     public static <T> TypeToken<Set<T>> setOf(Class<T> eltType) {
         // @formatter:off
-        return new TypeToken<Set<T>>(){}.where(new TypeParameter<T>(){}, eltType);
+        return new TypeToken<Set<T>>() {
+        }.where(new TypeParameter<T>() {
+        }, eltType);
         // @formatter:on
     }
 
@@ -85,7 +91,9 @@ public final class TypeTokens {
      */
     public static <T> TypeToken<Set<T>> setOf(TypeToken<T> eltType) {
         // @formatter:off
-        return new TypeToken<Set<T>>(){}.where(new TypeParameter<T>(){}, eltType);
+        return new TypeToken<Set<T>>() {
+        }.where(new TypeParameter<T>() {
+        }, eltType);
         // @formatter:on
     }
 
@@ -102,9 +110,12 @@ public final class TypeTokens {
      */
     public static <K, V> TypeToken<Map<K, V>> mapOf(Class<K> keyType, Class<V> valueType) {
         // @formatter:off
-        return new TypeToken<Map<K, V>>(){}
-            .where(new TypeParameter<K>(){}, keyType)
-            .where(new TypeParameter<V>(){}, valueType);
+        return new TypeToken<Map<K, V>>() {
+        }
+                .where(new TypeParameter<K>() {
+                }, keyType)
+                .where(new TypeParameter<V>() {
+                }, valueType);
         // @formatter:on
     }
 
@@ -121,9 +132,12 @@ public final class TypeTokens {
      */
     public static <K, V> TypeToken<Map<K, V>> mapOf(TypeToken<K> keyType, TypeToken<V> valueType) {
         // @formatter:off
-        return new TypeToken<Map<K, V>>(){}
-            .where(new TypeParameter<K>(){}, keyType)
-            .where(new TypeParameter<V>(){}, valueType);
+        return new TypeToken<Map<K, V>>() {
+        }
+                .where(new TypeParameter<K>() {
+                }, keyType)
+                .where(new TypeParameter<V>() {
+                }, valueType);
         // @formatter:on
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/CodecNotFoundException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/CodecNotFoundException.java
@@ -37,7 +37,7 @@ public class CodecNotFoundException extends DriverException {
         this(null, cause, cqlType, javaType);
     }
 
-    private CodecNotFoundException(String msg, Throwable cause, DataType cqlType, TypeToken<?>javaType) {
+    private CodecNotFoundException(String msg, Throwable cause, DataType cqlType, TypeToken<?> javaType) {
         super(msg, cause);
         this.cqlType = cqlType;
         this.javaType = javaType;

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/NoHostAvailableException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/NoHostAvailableException.java
@@ -97,7 +97,8 @@ public class NoHostAvailableException extends DriverException {
         int n = 0;
         boolean truncated = false;
         for (Map.Entry<InetSocketAddress, Throwable> entry : errors.entrySet()) {
-            if (n > 0) out.print(formatted ? "\n" : ", ");
+            if (n > 0)
+                out.print(formatted ? "\n" : ", ");
             out.print(entry.getKey());
             if (n < maxErrorsInMessage) {
                 if (includeStackTraces) {

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/ProtocolError.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/ProtocolError.java
@@ -43,7 +43,6 @@ public class ProtocolError extends DriverInternalError implements CoordinatorExc
         this.address = address;
     }
 
-
     /**
      * {@inheritDoc}
      */

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/ReadFailureException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/ReadFailureException.java
@@ -40,8 +40,8 @@ public class ReadFailureException extends QueryConsistencyException {
 
     public ReadFailureException(InetSocketAddress address, ConsistencyLevel consistency, int received, int required, int failed, boolean dataPresent) {
         super(address, String.format("Cassandra failure during read query at consistency %s "
-                                + "(%d responses were required but only %d replica responded, %d failed)",
-                        consistency, required, received, failed),
+                + "(%d responses were required but only %d replica responded, %d failed)",
+                consistency, required, received, failed),
                 consistency,
                 received,
                 required);

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/ReadTimeoutException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/ReadTimeoutException.java
@@ -42,8 +42,7 @@ public class ReadTimeoutException extends QueryConsistencyException {
                 String.format("Cassandra timeout during read query at consistency %s (%s)", consistency, formatDetails(received, required, dataPresent)),
                 consistency,
                 received,
-                required
-        );
+                required);
         this.dataPresent = dataPresent;
     }
 
@@ -85,8 +84,7 @@ public class ReadTimeoutException extends QueryConsistencyException {
                 getConsistencyLevel(),
                 getReceivedAcknowledgements(),
                 getRequiredAcknowledgements(),
-                wasDataRetrieved()
-        );
+                wasDataRetrieved());
     }
 
     /**
@@ -112,8 +110,7 @@ public class ReadTimeoutException extends QueryConsistencyException {
                 getConsistencyLevel(),
                 getReceivedAcknowledgements(),
                 getRequiredAcknowledgements(),
-                wasDataRetrieved()
-        );
+                wasDataRetrieved());
     }
 
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/ServerError.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/ServerError.java
@@ -41,7 +41,6 @@ public class ServerError extends DriverInternalError implements CoordinatorExcep
         this.address = address;
     }
 
-
     /**
      * {@inheritDoc}
      */

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnsupportedProtocolVersionException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnsupportedProtocolVersionException.java
@@ -71,5 +71,4 @@ public class UnsupportedProtocolVersionException extends DriverException impleme
         return new UnsupportedProtocolVersionException(address, unsupportedVersion, serverVersion, this);
     }
 
-
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/WriteFailureException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/WriteFailureException.java
@@ -40,8 +40,8 @@ public class WriteFailureException extends QueryConsistencyException {
 
     public WriteFailureException(InetSocketAddress address, ConsistencyLevel consistency, WriteType writeType, int received, int required, int failed) {
         super(address, String.format("Cassandra failure during write query at consistency %s "
-                                + "(%d responses were required but only %d replica responded, %d failed)",
-                        consistency, required, received, failed),
+                + "(%d responses were required but only %d replica responded, %d failed)",
+                consistency, required, received, failed),
                 consistency,
                 received,
                 required);
@@ -50,7 +50,7 @@ public class WriteFailureException extends QueryConsistencyException {
     }
 
     private WriteFailureException(InetSocketAddress address, String msg, Throwable cause,
-                                  ConsistencyLevel consistency, WriteType writeType, int received, int required, int failed) {
+            ConsistencyLevel consistency, WriteType writeType, int received, int required, int failed) {
         super(address, msg, cause, consistency, received, required);
         this.writeType = writeType;
         this.failed = failed;

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/WriteTimeoutException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/WriteTimeoutException.java
@@ -70,8 +70,7 @@ public class WriteTimeoutException extends QueryConsistencyException {
                 getConsistencyLevel(),
                 getWriteType(),
                 getReceivedAcknowledgements(),
-                getRequiredAcknowledgements()
-        );
+                getRequiredAcknowledgements());
     }
 
     /**
@@ -97,8 +96,7 @@ public class WriteTimeoutException extends QueryConsistencyException {
                 getConsistencyLevel(),
                 getWriteType(),
                 getReceivedAcknowledgements(),
-                getRequiredAcknowledgements()
-        );
+                getRequiredAcknowledgements());
     }
 
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/package-info.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/package-info.java
@@ -17,3 +17,4 @@
  * Exceptions thrown by the DataStax Java driver for Cassandra.
  */
 package com.datastax.driver.core.exceptions;
+

--- a/driver-core/src/main/java/com/datastax/driver/core/package-info.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/package-info.java
@@ -19,3 +19,4 @@
  * The main entry for this package is the {@link com.datastax.driver.core.Cluster} class.
  */
 package com.datastax.driver.core;
+

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicy.java
@@ -95,7 +95,7 @@ public class DowngradingConsistencyRetryPolicy implements RetryPolicy {
         // a node up in some other datacenter
         if (knownOk == 1 || currentCL == ConsistencyLevel.EACH_QUORUM)
             return RetryDecision.retry(ConsistencyLevel.ONE);
-        
+
         return RetryDecision.rethrow();
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/EC2MultiRegionAddressTranslator.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/EC2MultiRegionAddressTranslator.java
@@ -99,9 +99,9 @@ public class EC2MultiRegionAddressTranslator implements AddressTranslator {
 
     private String lookupPtrRecord(String reversedDomain) throws Exception {
         Attributes attrs = ctx.getAttributes(reversedDomain, new String[]{"PTR"});
-        for (NamingEnumeration ae = attrs.getAll(); ae.hasMoreElements(); ) {
+        for (NamingEnumeration ae = attrs.getAll(); ae.hasMoreElements();) {
             Attribute attr = (Attribute) ae.next();
-            for (Enumeration<?> vals = attr.getAll(); vals.hasMoreElements(); )
+            for (Enumeration<?> vals = attr.getAll(); vals.hasMoreElements();)
                 return vals.nextElement().toString();
         }
         return null;

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/FallthroughRetryPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/FallthroughRetryPolicy.java
@@ -74,7 +74,6 @@ public class FallthroughRetryPolicy implements RetryPolicy {
         return RetryDecision.rethrow();
     }
 
-
     @Override
     public void init(Cluster cluster) {
         // nothing to do

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/LatencyAwarePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/LatencyAwarePolicy.java
@@ -74,11 +74,11 @@ public class LatencyAwarePolicy implements ChainableLoadBalancingPolicy {
     private final long minMeasure;
 
     private LatencyAwarePolicy(LoadBalancingPolicy childPolicy,
-                               double exclusionThreshold,
-                               long scale,
-                               long retryPeriod,
-                               long updateRate,
-                               int minMeasure) {
+            double exclusionThreshold,
+            long scale,
+            long retryPeriod,
+            long updateRate,
+            int minMeasure) {
         this.childPolicy = childPolicy;
         this.retryPeriod = retryPeriod;
         this.scale = scale;
@@ -380,7 +380,7 @@ public class LatencyAwarePolicy implements ChainableLoadBalancingPolicy {
             BootstrappingException.class,
             UnpreparedException.class,
             QueryValidationException.class // query validation also happens at early stages in the coordinator
-    );
+            );
 
     private class Tracker implements LatencyTracker {
 
@@ -403,9 +403,11 @@ public class LatencyAwarePolicy implements ChainableLoadBalancingPolicy {
 
         private boolean shouldConsiderNewLatency(Statement statement, Exception exception) {
             // query was successful: always consider
-            if (exception == null) return true;
+            if (exception == null)
+                return true;
             // filter out "fast" errors
-            if (EXCLUDED_EXCEPTIONS.contains(exception.getClass())) return false;
+            if (EXCLUDED_EXCEPTIONS.contains(exception.getClass()))
+                return false;
             return true;
         }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/LoggingRetryPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/LoggingRetryPolicy.java
@@ -169,5 +169,4 @@ public class LoggingRetryPolicy implements RetryPolicy {
         logger.info(template, parameters);
     }
 
-
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/Policies.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/Policies.java
@@ -46,11 +46,11 @@ public class Policies {
     private final SpeculativeExecutionPolicy speculativeExecutionPolicy;
 
     private Policies(LoadBalancingPolicy loadBalancingPolicy,
-                     ReconnectionPolicy reconnectionPolicy,
-                     RetryPolicy retryPolicy,
-                     AddressTranslator addressTranslator,
-                     TimestampGenerator timestampGenerator,
-                     SpeculativeExecutionPolicy speculativeExecutionPolicy) {
+            ReconnectionPolicy reconnectionPolicy,
+            RetryPolicy retryPolicy,
+            AddressTranslator addressTranslator,
+            TimestampGenerator timestampGenerator,
+            SpeculativeExecutionPolicy speculativeExecutionPolicy) {
         this.loadBalancingPolicy = loadBalancingPolicy;
         this.reconnectionPolicy = reconnectionPolicy;
         this.retryPolicy = retryPolicy;

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/RetryPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/RetryPolicy.java
@@ -45,7 +45,9 @@ public interface RetryPolicy {
          * The types of retry decisions.
          */
         public enum Type {
-            RETRY, RETHROW, IGNORE
+            RETRY,
+            RETHROW,
+            IGNORE
         }
 
         private final Type type;

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/package-info.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/package-info.java
@@ -17,3 +17,4 @@
  * Policies that allow to control some of the behavior of the DataStax Java driver for Cassandra.
  */
 package com.datastax.driver.core.policies;
+

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Clause.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Clause.java
@@ -142,7 +142,6 @@ public abstract class Clause extends Utils.Appendeable {
         }
     }
 
-
     static class ContainsKeyClause extends AbstractClause {
 
         private final Object value;
@@ -171,7 +170,6 @@ public abstract class Clause extends Utils.Appendeable {
             return Utils.containsBindMarker(value);
         }
     }
-
 
     static class CompoundClause extends Clause {
         private String op;

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
@@ -48,10 +48,10 @@ public class Delete extends BuiltStatement {
     }
 
     Delete(String keyspace,
-           String table,
-           List<Object> routingKeyValues,
-           List<ColumnMetadata> partitionKey,
-           List<Selector> columns) {
+            String table,
+            List<Object> routingKeyValues,
+            List<ColumnMetadata> partitionKey,
+            List<Selector> columns) {
         super(keyspace, partitionKey, routingKeyValues);
         this.table = table;
         this.columns = columns;

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
@@ -46,9 +46,9 @@ public class Insert extends BuiltStatement {
     }
 
     Insert(String keyspace,
-           String table,
-           List<Object> routingKeyValues,
-           List<ColumnMetadata> partitionKey) {
+            String table,
+            List<Object> routingKeyValues,
+            List<ColumnMetadata> partitionKey) {
         super(keyspace, partitionKey, routingKeyValues);
         this.table = table;
         this.usings = new Options(this);

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Select.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Select.java
@@ -54,11 +54,11 @@ public class Select extends BuiltStatement {
     }
 
     Select(String keyspace,
-           String table,
-           List<Object> routingKeyValues,
-           List<ColumnMetadata> partitionKey,
-           List<Object> columnNames,
-           boolean isDistinct) {
+            String table,
+            List<Object> routingKeyValues,
+            List<ColumnMetadata> partitionKey,
+            List<Object> columnNames,
+            boolean isDistinct) {
         super(keyspace, partitionKey, routingKeyValues);
         this.table = table;
         this.isDistinct = isDistinct;

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Truncate.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Truncate.java
@@ -41,9 +41,9 @@ public class Truncate extends BuiltStatement {
     }
 
     Truncate(String keyspace,
-             String table,
-             List<Object> routingKeyValues,
-             List<ColumnMetadata> partitionKey) {
+            String table,
+            List<Object> routingKeyValues,
+            List<ColumnMetadata> partitionKey) {
         super(keyspace, partitionKey, routingKeyValues);
         this.table = table;
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
@@ -48,9 +48,9 @@ public class Update extends BuiltStatement {
     }
 
     Update(String keyspace,
-           String table,
-           List<Object> routingKeyValues,
-           List<ColumnMetadata> partitionKey) {
+            String table,
+            List<Object> routingKeyValues,
+            List<ColumnMetadata> partitionKey) {
         super(keyspace, partitionKey, routingKeyValues);
         this.table = table;
         this.assignments = new Assignments(this);

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
@@ -125,8 +125,10 @@ abstract class Utils {
         sb.append('{');
         boolean first = true;
         for (Object elt : s) {
-            if (first) first = false;
-            else sb.append(',');
+            if (first)
+                first = false;
+            else
+                sb.append(',');
             appendValue(elt, codecRegistry, sb, variables);
         }
         sb.append('}');

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/package-info.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/package-info.java
@@ -19,3 +19,4 @@
  * The main entry for this package is the {@code QueryBuilder} class.
  */
 package com.datastax.driver.core.querybuilder;
+

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/Drop.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/Drop.java
@@ -22,7 +22,11 @@ import com.google.common.base.Optional;
  */
 public class Drop extends SchemaStatement {
 
-    enum DroppedItem {TABLE, TYPE, INDEX}
+    enum DroppedItem {
+        TABLE,
+        TYPE,
+        INDEX
+    }
 
     private Optional<String> keyspaceName = Optional.absent();
     private String itemName;

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/SchemaBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/SchemaBuilder.java
@@ -167,7 +167,6 @@ public final class SchemaBuilder {
         return new Drop(keyspaceName, typeName, DroppedItem.TYPE);
     }
 
-
     // Utility methods and types: these are not method starters, but they are exposed here in order to
     // have a single entry point to all schema builder features.
 
@@ -311,14 +310,18 @@ public final class SchemaBuilder {
      * @see Create.Options#clusteringOrder(String, com.datastax.driver.core.schemabuilder.SchemaBuilder.Direction)
      */
     public enum Direction {
-        ASC, DESC
+        ASC,
+        DESC
     }
 
     /**
      * Caching strategies, for use in a CREATE or ALTER TABLE statement.
      */
     public enum Caching {
-        ALL("'all'"), KEYS_ONLY("'keys_only'"), ROWS_ONLY("'rows_only'"), NONE("'none'");
+        ALL("'all'"),
+        KEYS_ONLY("'keys_only'"),
+        ROWS_ONLY("'rows_only'"),
+        NONE("'none'");
 
         private String value;
 
@@ -335,7 +338,8 @@ public final class SchemaBuilder {
      * Key caching strategies for Cassandra 2.1, for use in a CREATE or ALTER TABLE statement.
      */
     public enum KeyCaching {
-        ALL("'all'"), NONE("'none'");
+        ALL("'all'"),
+        NONE("'none'");
         private String value;
 
         KeyCaching(String value) {

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/TableOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/TableOptions.java
@@ -806,7 +806,10 @@ public abstract class TableOptions<T extends TableOptions> extends SchemaStateme
          */
         public static class DateTieredCompactionStrategyOptions extends CompactionOptions<DateTieredCompactionStrategyOptions> {
 
-            public enum TimeStampResolution {MICROSECONDS, MILLISECONDS}
+            public enum TimeStampResolution {
+                MICROSECONDS,
+                MILLISECONDS
+            }
 
             private Optional<Integer> baseTimeSeconds = Optional.absent();
 
@@ -922,7 +925,9 @@ public abstract class TableOptions<T extends TableOptions> extends SchemaStateme
          * Compaction strategies. Possible values: SIZED_TIERED, LEVELED & DATE_TIERED
          */
         public static enum Strategy {
-            SIZED_TIERED("'SizeTieredCompactionStrategy'"), LEVELED("'LeveledCompactionStrategy'"), DATE_TIERED("'DateTieredCompactionStrategy'");
+            SIZED_TIERED("'SizeTieredCompactionStrategy'"),
+            LEVELED("'LeveledCompactionStrategy'"),
+            DATE_TIERED("'DateTieredCompactionStrategy'");
 
             private String strategyClass;
 
@@ -1014,7 +1019,10 @@ public abstract class TableOptions<T extends TableOptions> extends SchemaStateme
          * Compression algorithms. Possible values: NONE, LZ4, SNAPPY, DEFLATE
          */
         public static enum Algorithm {
-            NONE("''"), LZ4("'LZ4Compressor'"), SNAPPY("'SnappyCompressor'"), DEFLATE("'DeflateCompressor'");
+            NONE("''"),
+            LZ4("'LZ4Compressor'"),
+            SNAPPY("'SnappyCompressor'"),
+            DEFLATE("'DeflateCompressor'");
 
             private String value;
 

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/package-info.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/package-info.java
@@ -19,3 +19,4 @@
  * The main entry for this package is the {@code SchemaBuilder} class.
  */
 package com.datastax.driver.core.schemabuilder;
+

--- a/driver-core/src/main/java/com/datastax/driver/core/utils/Bytes.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/utils/Bytes.java
@@ -121,7 +121,6 @@ public final class Bytes {
             return "";
         }
 
-
         char[] array = new char[2 * (bytes.remaining())];
         return toRawHexString(bytes, array, 0);
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/utils/MoreFutures.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/utils/MoreFutures.java
@@ -33,7 +33,8 @@ public class MoreFutures {
      */
     public static abstract class SuccessCallback<V> implements FutureCallback<V> {
         @Override
-        public void onFailure(Throwable t) { /* nothing */ }
+        public void onFailure(Throwable t) { /* nothing */
+        }
     }
 
     /**
@@ -41,6 +42,7 @@ public class MoreFutures {
      */
     public static abstract class FailureCallback<V> implements FutureCallback<V> {
         @Override
-        public void onSuccess(V result) { /* nothing */ }
+        public void onSuccess(V result) { /* nothing */
+        }
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/AbstractPoliciesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AbstractPoliciesTest.java
@@ -164,7 +164,6 @@ public abstract class AbstractPoliciesTest extends CCMTestsSupport {
                 session().execute(new SimpleStatement(String.format("INSERT INTO %s(k, i) VALUES (0, 0)", tableName)).setConsistencyLevel(cl));
     }
 
-
     /**
      * Query methods that handle reads based on PreparedStatements and/or ConsistencyLevels.
      */

--- a/driver-core/src/test/java/com/datastax/driver/core/AbstractReconnectionHandlerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AbstractReconnectionHandlerTest.java
@@ -331,7 +331,8 @@ public class AbstractReconnectionHandlerTest {
      */
     static class MockReconnectionWork {
         enum ReconnectBehavior {
-            SUCCEED, THROW_EXCEPTION
+            SUCCEED,
+            THROW_EXCEPTION
         }
 
         private final CyclicBarrier barrier = new CyclicBarrier(2);

--- a/driver-core/src/test/java/com/datastax/driver/core/AggregateMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AggregateMetadataTest.java
@@ -270,8 +270,7 @@ public class AggregateMetadataTest extends CCMTestsSupport {
                         + "    zip int,"
                         + "    phones frozen<set<frozen<phone>>>,"
                         + "    location frozen<tuple<float, float>>"
-                        + ")", keyspace)
-        );
+                        + ")", keyspace));
     }
 
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
@@ -49,8 +49,7 @@ public class AsyncQueryTest extends CCMTestsSupport {
             execute(
                     String.format("create keyspace %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}", keyspace),
                     String.format("create table %s.foo(k int primary key, v int)", keyspace),
-                    String.format("insert into %s.foo (k, v) values (1, 1)", keyspace)
-            );
+                    String.format("insert into %s.foo (k, v) values (1, 1)", keyspace));
         }
     }
 
@@ -139,7 +138,7 @@ public class AsyncQueryTest extends CCMTestsSupport {
             });
             try {
                 Thread executedThread = f2.get();
-                if(executedThread != sameThread) {
+                if (executedThread != sameThread) {
                     fail("Expected a failed future, callback was executed on " + executedThread);
                 } else {
                     // Callback was invoked on the same thread, which indicates that the future completed

--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncResultSetTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncResultSetTest.java
@@ -32,8 +32,7 @@ public class AsyncResultSetTest extends CCMTestsSupport {
 
     @Override
     public void onTestContextInitialized() {
-        execute(
-                "create table ints (i int primary key)");
+        execute("create table ints (i int primary key)");
     }
 
     @BeforeMethod(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/BoundStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/BoundStatementTest.java
@@ -57,11 +57,13 @@ public class BoundStatementTest extends CCMTestsSupport {
         try {
             statement.getString(0);
             fail("Expected codec not found error");
-        } catch (CodecNotFoundException e) { /* expected */ }
+        } catch (CodecNotFoundException e) { /* expected */
+        }
 
         try {
             statement.getString(3);
             fail("Expected index error");
-        } catch (IndexOutOfBoundsException e) { /* expected */ }
+        } catch (IndexOutOfBoundsException e) { /* expected */
+        }
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMAccess.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMAccess.java
@@ -22,7 +22,14 @@ import java.util.Map;
 
 public interface CCMAccess extends Closeable {
 
-    enum Workload {cassandra, solr, hadoop, spark, cfs, graph}
+    enum Workload {
+        cassandra,
+        solr,
+        hadoop,
+        spark,
+        cfs,
+        graph
+    }
 
     // Inspection methods
 
@@ -92,7 +99,6 @@ public interface CCMAccess extends Closeable {
      * @return the address of the {@code nth} host in the cluster.
      */
     InetSocketAddress addressOfNode(int n);
-
 
     // Methods altering the whole cluster
 
@@ -222,7 +228,6 @@ public interface CCMAccess extends Closeable {
      * @param n the node number (starting from 1).
      */
     void setWorkload(int n, Workload... workload);
-
 
     // Methods blocking until nodes are up or down
 

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -997,16 +997,25 @@ public class CCMBridge implements CCMAccess {
         public boolean equals(Object o) {
             // do not include cluster name and start, only
             // properties relevant to the settings of the cluster
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             Builder builder = (Builder) o;
-            if (isDSE != builder.isDSE) return false;
-            if (!Arrays.equals(nodes, builder.nodes)) return false;
-            if (!createOptions.equals(builder.createOptions)) return false;
-            if (!jvmArgs.equals(builder.jvmArgs)) return false;
-            if (!cassandraConfiguration.equals(builder.cassandraConfiguration)) return false;
-            if (!dseConfiguration.equals(builder.dseConfiguration)) return false;
-            if (!workloads.equals(builder.workloads)) return false;
+            if (isDSE != builder.isDSE)
+                return false;
+            if (!Arrays.equals(nodes, builder.nodes))
+                return false;
+            if (!createOptions.equals(builder.createOptions))
+                return false;
+            if (!jvmArgs.equals(builder.jvmArgs))
+                return false;
+            if (!cassandraConfiguration.equals(builder.cassandraConfiguration))
+                return false;
+            if (!dseConfiguration.equals(builder.dseConfiguration))
+                return false;
+            if (!workloads.equals(builder.workloads))
+                return false;
             return version.equals(builder.version);
         }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/CaseSensitivityTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CaseSensitivityTest.java
@@ -53,5 +53,4 @@ public class CaseSensitivityTest extends CCMTestsSupport {
         assertNull(cluster().getMetadata().getKeyspace(name));
     }
 
-
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterStressTest.java
@@ -82,7 +82,7 @@ public class ClusterStressTest extends CCMTestsSupport {
     }
 
     private List<Future<CreateClusterAndCheckConnections>> createClustersConcurrently(int numberOfClusters,
-                                                                                      CountDownLatch countDownLatch) {
+            CountDownLatch countDownLatch) {
         List<Future<CreateClusterAndCheckConnections>> clusterFutures =
                 Lists.newArrayListWithCapacity(numberOfClusters);
         for (int i = 0; i < numberOfClusters; i++) {
@@ -98,7 +98,7 @@ public class ClusterStressTest extends CCMTestsSupport {
     }
 
     private List<Future<Void>> closeClustersConcurrently(List<CreateClusterAndCheckConnections> actions,
-                                                         CountDownLatch startSignal) {
+            CountDownLatch startSignal) {
         List<Future<Void>> closeFutures = Lists.newArrayListWithCapacity(actions.size());
         for (CreateClusterAndCheckConnections action : actions) {
             closeFutures.add(executorService.submit(new CloseCluster(action.cluster, action.channelMonitor,

--- a/driver-core/src/test/java/com/datastax/driver/core/CodecRegistryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CodecRegistryTest.java
@@ -258,7 +258,7 @@ public class CodecRegistryTest {
                 .accepts(javaType);
         assertThat(new CodecRegistry().codecFor(new ArrayList<Integer>()))
                 .isNotNull()
-                        // empty collections are mapped to blob codec if no CQL type provided
+                // empty collections are mapped to blob codec if no CQL type provided
                 .accepts(list(blob()))
                 .accepts(listOf(ByteBuffer.class));
         assertThat(new CodecRegistry().codecFor(cqlType, new ArrayList<Integer>()))
@@ -289,7 +289,7 @@ public class CodecRegistryTest {
                 .accepts(javaType);
         assertThat(new CodecRegistry().codecFor(new HashSet<Integer>()))
                 .isNotNull()
-                        // empty collections are mapped to blob codec if no CQL type provided
+                // empty collections are mapped to blob codec if no CQL type provided
                 .accepts(set(blob()))
                 .accepts(setOf(ByteBuffer.class));
         assertThat(new CodecRegistry().codecFor(cqlType, new HashSet<Integer>()))
@@ -320,7 +320,7 @@ public class CodecRegistryTest {
                 .accepts(javaType);
         assertThat(new CodecRegistry().codecFor(new HashMap<Integer, List<String>>()))
                 .isNotNull()
-                        // empty collections are mapped to blob codec if no CQL type provided
+                // empty collections are mapped to blob codec if no CQL type provided
                 .accepts(map(blob(), blob()))
                 .accepts(mapOf(ByteBuffer.class, ByteBuffer.class));
         assertThat(new CodecRegistry().codecFor(cqlType, new HashMap<Integer, List<String>>()))
@@ -449,8 +449,7 @@ public class CodecRegistryTest {
 
         assertThat(logs.getNext()).contains("Ignoring codec MockCodec");
         assertThat(
-                registry.codecFor(cint(), Integer.class)
-        ).isNotSameAs(newCodec);
+                registry.codecFor(cint(), Integer.class)).isNotSameAs(newCodec);
 
         stopCapturingLogs(logs);
     }
@@ -470,8 +469,7 @@ public class CodecRegistryTest {
 
         assertThat(logs.getNext()).contains("Ignoring codec MockCodec");
         assertThat(
-                registry.codecFor(list(cint()), listOf(Integer.class))
-        ).isNotSameAs(newCodec);
+                registry.codecFor(list(cint()), listOf(Integer.class))).isNotSameAs(newCodec);
 
         stopCapturingLogs(logs);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/ConditionalUpdateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ConditionalUpdateTest.java
@@ -62,11 +62,9 @@ public class ConditionalUpdateTest extends CCMTestsSupport {
         batch.add(ps.bind().setInt("k1", 1).setInt("k2", 1).setInt("old", 2).setInt("new", 3)); // will fail
         batch.add(ps.bind().setInt("k1", 1).setInt("k2", 2).setInt("old", 1).setInt("new", 3));
 
-
         ResultSet rs = session().execute(batch);
         assertFalse(rs.wasApplied());
     }
-
 
     @Test(groups = "short")
     public void multipageResultSetTest() {

--- a/driver-core/src/test/java/com/datastax/driver/core/ConnectionReleaseTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ConnectionReleaseTest.java
@@ -69,19 +69,19 @@ public class ConnectionReleaseTest extends ScassandraTestBase {
                             .withRows(ImmutableMap.of("key", 1))
                             .withFixedDelay(10000)
                             .build()
-            );
+                    );
             primingClient.prime(
                     PrimingRequest.queryBuilder()
                             .withQuery("select c from test1 where k=1")
                             .withRows(ImmutableMap.of("c", "hello"))
                             .build()
-            );
+                    );
             primingClient.prime(
                     PrimingRequest.queryBuilder()
                             .withQuery("select n from test2 where c='hello'")
                             .withRows(ImmutableMap.of("n", "world"))
                             .build()
-            );
+                    );
 
             cluster = Cluster.builder()
                     .addContactPoints(hostAddress.getAddress())
@@ -96,7 +96,6 @@ public class ConnectionReleaseTest extends ScassandraTestBase {
             // Consume all stream ids except one.
             for (int i = 0; i < StreamIdGenerator.MAX_STREAM_PER_CONNECTION_V2 - 1; i++)
                 mockFutures.add(session.executeAsync("mock query"));
-
 
             ListenableFuture<ResultSet> future = Futures.transform(session.executeAsync("select c from test1 where k=1"),
                     new AsyncFunction<ResultSet, ResultSet>() {

--- a/driver-core/src/test/java/com/datastax/driver/core/ConsistencyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ConsistencyTest.java
@@ -52,8 +52,7 @@ import static org.testng.Assert.fail;
                 "phi_convict_threshold:5",
                 "read_request_timeout_in_ms:200000",
                 "write_request_timeout_in_ms:200000"
-        }
-)
+        })
 public class ConsistencyTest extends AbstractPoliciesTest {
 
     private static final Logger logger = LoggerFactory.getLogger(ConsistencyTest.class);
@@ -203,7 +202,7 @@ public class ConsistencyTest extends AbstractPoliciesTest {
         List<ConsistencyLevel> acceptedList = Arrays.asList(
                 ConsistencyLevel.ANY,
                 ConsistencyLevel.ONE
-        );
+                );
 
         List<ConsistencyLevel> failList = Arrays.asList(
                 ConsistencyLevel.TWO,
@@ -299,13 +298,12 @@ public class ConsistencyTest extends AbstractPoliciesTest {
                 ConsistencyLevel.QUORUM,
                 ConsistencyLevel.LOCAL_QUORUM,
                 ConsistencyLevel.EACH_QUORUM
-        );
+                );
 
         List<ConsistencyLevel> failList = Arrays.asList(
                 ConsistencyLevel.THREE,
                 ConsistencyLevel.ALL
-        );
-
+                );
 
         // Test successful writes
         for (ConsistencyLevel cl : acceptedList) {
@@ -324,7 +322,7 @@ public class ConsistencyTest extends AbstractPoliciesTest {
                 List<String> acceptableErrorMessages = Arrays.asList(
                         "ANY ConsistencyLevel is only supported for writes",
                         "EACH_QUORUM ConsistencyLevel is only supported for writes"
-                );
+                        );
                 assertTrue(acceptableErrorMessages.contains(e.getMessage()), "Got unexpected message " + e.getMessage());
             }
         }
@@ -358,7 +356,6 @@ public class ConsistencyTest extends AbstractPoliciesTest {
         }
     }
 
-
     @Test(groups = "long")
     @CCMConfig(numberOfNodes = 3,
             clusterProvider = "tokenAwareRoundRobinDowngrading")
@@ -376,7 +373,7 @@ public class ConsistencyTest extends AbstractPoliciesTest {
 
         List<ConsistencyLevel> acceptedList = singletonList(
                 ConsistencyLevel.ANY
-        );
+                );
 
         List<ConsistencyLevel> failList = Arrays.asList(
                 ConsistencyLevel.ONE,
@@ -429,7 +426,7 @@ public class ConsistencyTest extends AbstractPoliciesTest {
             } catch (InvalidQueryException e) {
                 List<String> acceptableErrorMessages = singletonList(
                         "EACH_QUORUM ConsistencyLevel is only supported for writes"
-                );
+                        );
                 assertTrue(acceptableErrorMessages.contains(e.getMessage()), "Got unexpected message " + e.getMessage());
             } catch (ReadTimeoutException e) {
                 // expected to fail when the client hasn't marked the
@@ -478,7 +475,7 @@ public class ConsistencyTest extends AbstractPoliciesTest {
                 List<String> acceptableErrorMessages = Arrays.asList(
                         "ANY ConsistencyLevel is only supported for writes",
                         "EACH_QUORUM ConsistencyLevel is only supported for writes"
-                );
+                        );
                 assertTrue(acceptableErrorMessages.contains(e.getMessage()), "Got unexpected message " + e.getMessage());
             }
         }
@@ -542,7 +539,7 @@ public class ConsistencyTest extends AbstractPoliciesTest {
                 List<String> acceptableErrorMessages = Arrays.asList(
                         "ANY ConsistencyLevel is only supported for writes",
                         "EACH_QUORUM ConsistencyLevel is only supported for writes"
-                );
+                        );
                 assertTrue(acceptableErrorMessages.contains(e.getMessage()), "Got unexpected message " + e.getMessage());
             }
         }
@@ -552,8 +549,8 @@ public class ConsistencyTest extends AbstractPoliciesTest {
     @CCMConfig(
             numberOfNodes = {3, 3},
             clusterProvider = "tokenAwareRoundRobinNoShuffleDowngrading"
-    )
-    public void testRFThreeDowngradingCLTwoDCs() throws Throwable {
+            )
+            public void testRFThreeDowngradingCLTwoDCs() throws Throwable {
         createMultiDCSchema(3, 3);
         init(12, ConsistencyLevel.TWO);
         query(12, ConsistencyLevel.TWO);
@@ -577,7 +574,7 @@ public class ConsistencyTest extends AbstractPoliciesTest {
                 ConsistencyLevel.ALL,
                 ConsistencyLevel.LOCAL_QUORUM,
                 ConsistencyLevel.EACH_QUORUM
-        );
+                );
 
         List<ConsistencyLevel> failList = emptyList();
 
@@ -639,8 +636,8 @@ public class ConsistencyTest extends AbstractPoliciesTest {
     @CCMConfig(
             numberOfNodes = {3, 3},
             clusterProvider = "tokenAwareDCAwareRoundRobinNoShuffleDowngrading"
-    )
-    public void testRFThreeDowngradingCLTwoDCsDCAware() throws Throwable {
+            )
+            public void testRFThreeDowngradingCLTwoDCsDCAware() throws Throwable {
         createMultiDCSchema(3, 3);
         init(12, ConsistencyLevel.TWO);
         query(12, ConsistencyLevel.TWO);
@@ -664,7 +661,7 @@ public class ConsistencyTest extends AbstractPoliciesTest {
                 ConsistencyLevel.ALL,
                 ConsistencyLevel.LOCAL_QUORUM,
                 ConsistencyLevel.EACH_QUORUM
-        );
+                );
 
         List<ConsistencyLevel> failList = emptyList();
 

--- a/driver-core/src/test/java/com/datastax/driver/core/CustomPayloadTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CustomPayloadTest.java
@@ -46,11 +46,11 @@ public class CustomPayloadTest extends CCMTestsSupport {
         payload1 = ImmutableMap.of(
                 "k1", ByteBuffer.wrap(new byte[]{1, 2, 3}),
                 "k2", ByteBuffer.wrap(new byte[]{4, 5, 6})
-        );
+                );
         payload2 = ImmutableMap.of(
                 "k2", ByteBuffer.wrap(new byte[]{1, 2}),
                 "k3", ByteBuffer.wrap(new byte[]{3, 4})
-        );
+                );
     }
 
     // execute

--- a/driver-core/src/test/java/com/datastax/driver/core/CustomTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CustomTypeTest.java
@@ -58,8 +58,7 @@ public class CustomTypeTest extends CCMTestsSupport {
                         + "    k int PRIMARY KEY,"
                         + "    c1 list<'DynamicCompositeType(s => UTF8Type, i => Int32Type)'>,"
                         + "    c2 map<'DynamicCompositeType(s => UTF8Type, i => Int32Type)', 'DynamicCompositeType(s => UTF8Type, i => Int32Type)'>"
-                        + ")"
-        );
+                        + ")");
     }
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeCqlNameParserTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeCqlNameParserTest.java
@@ -119,8 +119,7 @@ public class DataTypeCqlNameParserTest extends CCMTestsSupport {
     public void onTestContextInitialized() {
         execute(
                 String.format("CREATE TYPE %s.\"A\" (f1 int)", keyspace),
-                String.format("CREATE TYPE %s.\"Incr,edibly\"\" EvilTy<>><<><p\"\"e\" (a frozen<\"A\">)", keyspace)
-        );
+                String.format("CREATE TYPE %s.\"Incr,edibly\"\" EvilTy<>><<><p\"\"e\" (a frozen<\"A\">)", keyspace));
     }
 
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
@@ -43,7 +43,11 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
     List<TestTable> tables = allTables();
     VersionNumber cassandraVersion;
 
-    enum StatementType {RAW_STRING, SIMPLE_WITH_PARAM, PREPARED}
+    enum StatementType {
+        RAW_STRING,
+        SIMPLE_WITH_PARAM,
+        PREPARED
+    }
 
     @Override
     public void onTestContextInitialized() {
@@ -111,22 +115,20 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
             // Since codec.deserialize will get the unboxed version for primitive check against expected unboxed value.
             assertThat(queriedValue)
                     .as("Test failure on %s statement with table:%n%s;%n" +
-                                    "insert statement:%n%s;%n",
+                            "insert statement:%n%s;%n",
                             statementType,
                             table.createStatement,
                             table.insertStatement)
                     .isEqualTo(table.expectedValue);
 
-
             // Since calling row.get* will return boxed version for primitives check against expected primitive value.
             assertThat(getValue(row, table.testColumnType))
                     .as("Test failure on %s statement with table:%n%s;%n" +
-                                    "insert statement:%n%s;%n",
+                            "insert statement:%n%s;%n",
                             statementType,
                             table.createStatement,
                             table.insertStatement)
                     .isEqualTo(table.expectedPrimitiveValue);
-
 
             session().execute(table.truncateStatement);
         }

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
@@ -209,11 +209,13 @@ public class DataTypeTest {
     @Test(groups = "unit")
     public void parseFormatSetTest() {
         String toParse = "{'Foo','Bar','Foo''bar'}";
-        Set<String> toFormat = new LinkedHashSet<String>() {{
-            add("Foo");
-            add("Bar");
-            add("Foo'bar");
-        }};
+        Set<String> toFormat = new LinkedHashSet<String>() {
+            {
+                add("Foo");
+                add("Bar");
+                add("Foo'bar");
+            }
+        };
         DataType dt = DataType.set(DataType.text());
         assertEquals(codecRegistry.codecFor(dt).parse(toParse), toFormat);
         assertEquals(codecRegistry.codecFor(dt).format(toFormat), toParse);
@@ -223,11 +225,13 @@ public class DataTypeTest {
     @Test(groups = "unit")
     public void parseFormatMapTest() {
         String toParse = "{'Foo':3,'Bar':42,'Foo''bar':-24}";
-        Map<String, Integer> toFormat = new LinkedHashMap<String, Integer>() {{
-            put("Foo", 3);
-            put("Bar", 42);
-            put("Foo'bar", -24);
-        }};
+        Map<String, Integer> toFormat = new LinkedHashMap<String, Integer>() {
+            {
+                put("Foo", 3);
+                put("Bar", 42);
+                put("Foo'bar", -24);
+            }
+        };
         DataType dt = DataType.map(DataType.text(), DataType.cint());
         assertEquals(codecRegistry.codecFor(dt).parse(toParse), toFormat);
         assertEquals(codecRegistry.codecFor(dt).format(toFormat), toParse);
@@ -244,15 +248,17 @@ public class DataTypeTest {
                 new UserType.Field("i", DataType.cint()),
                 new UserType.Field("L", DataType.list(DataType.text())),
                 new UserType.Field("s", DataType.map(DataType.cint(), udt1))
-        ), protocolVersion, codecRegistry);
+                ), protocolVersion, codecRegistry);
 
         UDTValue toFormat = udt2.newValue();
         toFormat.setString("t", "fo'o");
         toFormat.setInt("i", 3);
         toFormat.setList("\"L\"", Arrays.<String>asList("a", "b"));
-        toFormat.setMap("s", new HashMap<Integer, UDTValue>() {{
-            put(3, udt1.newValue().setBytes("a", ByteBuffer.wrap(new byte[]{1})));
-        }});
+        toFormat.setMap("s", new HashMap<Integer, UDTValue>() {
+            {
+                put(3, udt1.newValue().setBytes("a", ByteBuffer.wrap(new byte[]{1})));
+            }
+        });
 
         assertEquals(codecRegistry.codecFor(udt2).parse(toParse), toFormat);
         assertEquals(codecRegistry.codecFor(udt2).format(toFormat), toParse);
@@ -293,7 +299,8 @@ public class DataTypeTest {
             ByteBuffer badValue = ByteBuffer.allocate(4);
             codec.deserialize(badValue, version);
             fail("This should not have worked");
-        } catch (InvalidTypeException e) { /* That's what we want */ }
+        } catch (InvalidTypeException e) { /* That's what we want */
+        }
     }
 
     @Test(groups = "unit")
@@ -315,7 +322,8 @@ public class DataTypeTest {
             codec = codecRegistry.codecFor(listOfBigint);
             codec.serialize(l, version);
             fail("This should not have worked");
-        } catch (InvalidTypeException e) { /* That's what we want */ }
+        } catch (InvalidTypeException e) { /* That's what we want */
+        }
     }
 
     @Test(groups = "unit")

--- a/driver-core/src/test/java/com/datastax/driver/core/DseCCMClusterTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DseCCMClusterTest.java
@@ -78,8 +78,7 @@ import static com.datastax.driver.core.CCMAccess.Workload.*;
                 @CCMWorkload(solr),
                 @CCMWorkload({spark, solr}),
                 @CCMWorkload({cassandra, spark})
-        }
-)
+        })
 public class DseCCMClusterTest extends CCMTestsSupport {
 
     @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/FakeHost.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/FakeHost.java
@@ -29,7 +29,10 @@ import static org.assertj.core.api.Assertions.fail;
  * Fake Cassandra host that will cause a given error when the driver tries to connect to it.
  */
 public class FakeHost {
-    public enum Behavior {THROWING_CONNECT_TIMEOUTS, THROWING_OPERATION_TIMEOUTS}
+    public enum Behavior {
+        THROWING_CONNECT_TIMEOUTS,
+        THROWING_OPERATION_TIMEOUTS
+    }
 
     final String address;
     private final int port;

--- a/driver-core/src/test/java/com/datastax/driver/core/FunctionMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/FunctionMetadataTest.java
@@ -171,8 +171,7 @@ public class FunctionMetadataTest extends CCMTestsSupport {
                         + "    zip int,"
                         + "    phones frozen<set<frozen<\"Phone\">>>,"
                         + "    location frozen<tuple<float, float>>"
-                        + ")", keyspace)
-        );
+                        + ")", keyspace));
     }
 
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostConnectionPoolTest.java
@@ -144,7 +144,8 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
             try {
                 MockRequest.send(pool);
                 Assertions.fail("Expected a TimeoutException");
-            } catch (TimeoutException e) { /*expected*/}
+            } catch (TimeoutException e) { /*expected*/
+            }
         } finally {
             completeRequests(requests);
             cluster.close();
@@ -486,7 +487,6 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
         }
     }
 
-
     /**
      * Ensures that if all connections on a host are closed that the host is marked
      * down and the control connection is notified of that fact and re-established
@@ -560,7 +560,6 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
             cluster.close();
         }
     }
-
 
     /**
      * Ensures that if a connection on a host is lost that brings the number of active connections in a pool
@@ -868,7 +867,6 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
         }
     }
 
-
     /**
      * Ensures that if all connections fail on pool init that the host and subsequently the
      * control connection is not marked down.  The test also ensures that when making requests
@@ -1059,7 +1057,12 @@ public class HostConnectionPoolTest extends ScassandraTestBase.PerClassCluster {
      */
     static class MockRequest implements Connection.ResponseCallback {
 
-        enum State {START, COMPLETED, FAILED, TIMED_OUT}
+        enum State {
+            START,
+            COMPLETED,
+            FAILED,
+            TIMED_OUT
+        }
 
         final Connection connection;
         private Connection.ResponseHandler responseHandler;

--- a/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
@@ -267,7 +267,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
                 wrap("CUSTOM"), // index type
                 wrap("org.apache.cassandra.db.marshal.UTF8Type"), // validator
                 wrap("{\"foo\" : \"bar\", \"class_name\" : \"dummy.DummyIndex\"}") // index options
-        );
+                );
         Row columnRow = ArrayBackedRow.fromData(legacyColumnDefs, M3PToken.FACTORY, protocolVersion, columnData);
         Raw columnRaw = Raw.fromRow(columnRow, VersionNumber.parse("2.1"));
         ColumnMetadata column = ColumnMetadata.fromRaw(table, columnRaw, DataType.varchar());
@@ -295,8 +295,8 @@ public class IndexMetadataTest extends CCMTestsSupport {
                         "foo", "bar",
                         IndexMetadata.CUSTOM_INDEX_OPTION_NAME, "dummy.DummyIndex",
                         IndexMetadata.TARGET_OPTION_NAME, "a, b, keys(c)"
-                ), protocolVersion) // options
-        );
+                        ), protocolVersion) // options
+                );
         Row indexRow = ArrayBackedRow.fromData(indexColumnDefs, M3PToken.FACTORY, protocolVersion, indexData);
         IndexMetadata index = IndexMetadata.fromRow(table, indexRow);
         assertThat(index)
@@ -330,7 +330,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
                 wrap("KEYS"), // index type
                 wrap("org.apache.cassandra.db.marshal.BytesType"), // validator
                 wrap("null") // index options
-        );
+                );
         Row row = ArrayBackedRow.fromData(legacyColumnDefs, M3PToken.FACTORY, cluster().getConfiguration().getProtocolOptions().getProtocolVersion(), data);
         Raw raw = Raw.fromRow(row, VersionNumber.parse("2.1"));
         ColumnMetadata column = ColumnMetadata.fromRaw(table, raw, DataType.blob());

--- a/driver-core/src/test/java/com/datastax/driver/core/LargeDataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LargeDataTest.java
@@ -177,7 +177,6 @@ public class LargeDataTest extends CCMTestsSupport {
         }
     }
 
-
     /**
      * Test a wide row of size 1,000,000
      *

--- a/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyBootstrapTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyBootstrapTest.java
@@ -58,7 +58,7 @@ public class LoadBalancingPolicyBootstrapTest extends CCMTestsSupport {
         assertThat(policy.history).containsOnly(
                 entry(INIT, TestUtils.findHost(cluster, 1)),
                 entry(INIT, TestUtils.findHost(cluster, 2))
-        );
+                );
     }
 
     /**
@@ -102,13 +102,13 @@ public class LoadBalancingPolicyBootstrapTest extends CCMTestsSupport {
                 assertThat(policy.history).containsExactly(
                         entry(INIT, TestUtils.findHost(cluster, activeNode)),
                         entry(DOWN, TestUtils.findHost(cluster, nodeToStop))
-                );
+                        );
                 break;
             } else {
                 assertThat(policy.history).containsOnly(
                         entry(INIT, TestUtils.findHost(cluster, 1)),
                         entry(INIT, TestUtils.findHost(cluster, 2))
-                );
+                        );
 
                 logger.info("Could not get first contact point to fail, retrying");
 
@@ -124,7 +124,13 @@ public class LoadBalancingPolicyBootstrapTest extends CCMTestsSupport {
     }
 
     static class HistoryPolicy extends DelegatingLoadBalancingPolicy {
-        enum Action {INIT, UP, DOWN, ADD, REMOVE}
+        enum Action {
+            INIT,
+            UP,
+            DOWN,
+            ADD,
+            REMOVE
+        }
 
         static class Entry {
             final Action action;

--- a/driver-core/src/test/java/com/datastax/driver/core/LocalDateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LocalDateTest.java
@@ -82,11 +82,13 @@ public class LocalDateTest {
         try {
             fromMillisSinceEpoch(TimeUnit.DAYS.toMillis((long) Integer.MIN_VALUE - 1));
             Assertions.fail("Expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) { /*expected*/ }
+        } catch (IllegalArgumentException e) { /*expected*/
+        }
         try {
             fromMillisSinceEpoch(TimeUnit.DAYS.toMillis((long) Integer.MAX_VALUE + 1));
             Assertions.fail("Expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) { /*expected*/ }
+        } catch (IllegalArgumentException e) { /*expected*/
+        }
     }
 
     @Test(groups = "unit")
@@ -115,29 +117,35 @@ public class LocalDateTest {
         try {
             fromYearMonthDay(1970, 0, 1);
             Assertions.fail("Expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) { /*expected*/ }
+        } catch (IllegalArgumentException e) { /*expected*/
+        }
         try {
             fromYearMonthDay(1970, 13, 1);
             Assertions.fail("Expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) { /*expected*/ }
+        } catch (IllegalArgumentException e) { /*expected*/
+        }
         try {
             fromYearMonthDay(1970, 1, 0);
             Assertions.fail("Expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) { /*expected*/ }
+        } catch (IllegalArgumentException e) { /*expected*/
+        }
         try {
             fromYearMonthDay(1970, 1, 32);
             Assertions.fail("Expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) { /*expected*/ }
+        } catch (IllegalArgumentException e) { /*expected*/
+        }
 
         // Resulting date out of bounds
         try {
             fromYearMonthDay(6000000, 1, 1);
             Assertions.fail("Expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) { /*expected*/ }
+        } catch (IllegalArgumentException e) { /*expected*/
+        }
         try {
             fromYearMonthDay(-6000000, 1, 1);
             Assertions.fail("Expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) { /*expected*/ }
+        } catch (IllegalArgumentException e) { /*expected*/
+        }
     }
 
     @Test(groups = "unit")

--- a/driver-core/src/test/java/com/datastax/driver/core/M3PTokenFactoryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/M3PTokenFactoryTest.java
@@ -30,7 +30,7 @@ public class M3PTokenFactoryTest {
         assertThat(splits).containsExactly(
                 factory.fromString("-4611686018427387904"),
                 factory.fromString("0")
-        );
+                );
     }
 
     @Test(groups = "unit")
@@ -39,7 +39,7 @@ public class M3PTokenFactoryTest {
         assertThat(splits).containsExactly(
                 factory.fromString("-9223372036854775807"),
                 factory.fromString("-4611686018427387903")
-        );
+                );
     }
 
     @Test(groups = "unit")
@@ -48,7 +48,7 @@ public class M3PTokenFactoryTest {
         assertThat(splits).containsExactly(
                 factory.fromString("4"),
                 factory.fromString("8")
-        );
+                );
     }
 
     @Test(groups = "unit")
@@ -59,7 +59,7 @@ public class M3PTokenFactoryTest {
                 factory.fromString("2"),
                 factory.fromString("2"),
                 factory.fromString("2")
-        );
+                );
     }
 
     @Test(groups = "unit")
@@ -72,13 +72,13 @@ public class M3PTokenFactoryTest {
         assertThat(splits).containsExactly(
                 maxToken,
                 maxToken
-        );
+                );
 
         splits = factory.split(minToken, factory.fromString("-9223372036854775807"), 3);
         assertThat(splits).containsExactly(
                 factory.fromString("-9223372036854775807"),
                 factory.fromString("-9223372036854775807")
-        );
+                );
     }
 
     @Test(groups = "unit")
@@ -87,7 +87,7 @@ public class M3PTokenFactoryTest {
         assertThat(splits).containsExactly(
                 factory.fromString("-3074457345618258603"),
                 factory.fromString("3074457345618258602")
-        );
+                );
     }
 
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/MemoryAppender.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MemoryAppender.java
@@ -78,7 +78,8 @@ public class MemoryAppender extends WriterAppender {
         appendLock.lock();
         try {
             while (get().isEmpty()) {
-                if (nanos <= 0L) break; // timeout
+                if (nanos <= 0L)
+                    break; // timeout
                 nanos = append.awaitNanos(nanos);
             }
             return get();

--- a/driver-core/src/test/java/com/datastax/driver/core/NetworkTopologyStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/NetworkTopologyStrategyTest.java
@@ -612,7 +612,6 @@ public class NetworkTopologyStrategyTest extends AbstractReplicationStrategyTest
         assertReplicaPlacement(replicaMap, token("" + 99 * 256), currNode, socketAddress("127.0.0.0"));
     }
 
-
     @Test(groups = "unit")
     public void networkTopologyStrategyExampleTopologyTooManyReplicasTest() {
         Map<Token, Set<Host>> replicaMap = exampleStrategyTooManyReplicas.computeTokenToReplicaMap(keyspace, exampleTokenToPrimary, exampleRing);

--- a/driver-core/src/test/java/com/datastax/driver/core/OPPTokenFactoryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/OPPTokenFactoryTest.java
@@ -34,7 +34,7 @@ public class OPPTokenFactoryTest {
         assertThat(splits).containsExactly(
                 token('b'),
                 token('c')
-        );
+                );
     }
 
     @Test(groups = "unit")
@@ -48,7 +48,7 @@ public class OPPTokenFactoryTest {
         assertThat(splits).containsExactly(
                 zero,
                 zero
-        );
+                );
     }
 
     @Test(groups = "unit")

--- a/driver-core/src/test/java/com/datastax/driver/core/PagingStateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PagingStateTest.java
@@ -251,4 +251,3 @@ public class PagingStateTest extends CCMTestsSupport {
         }
     }
 }
-

--- a/driver-core/src/test/java/com/datastax/driver/core/PoolingOptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PoolingOptionsTest.java
@@ -68,7 +68,8 @@ public class PoolingOptionsTest {
         try {
             options.setProtocolVersion(ProtocolVersion.V3);
             fail("Expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) {/*expected*/}
+        } catch (IllegalArgumentException e) {/*expected*/
+        }
 
         // OK for v3 (up to 32K stream ids)
         options = new PoolingOptions().setMaxRequestsPerConnection(LOCAL, 5000);
@@ -80,7 +81,8 @@ public class PoolingOptionsTest {
         try {
             options.setProtocolVersion(ProtocolVersion.V2);
             fail("Expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) {/*expected*/}
+        } catch (IllegalArgumentException e) {/*expected*/
+        }
     }
 
     @Test(groups = "unit")
@@ -115,27 +117,32 @@ public class PoolingOptionsTest {
         try {
             options.setCoreConnectionsPerHost(LOCAL, -1);
             fail("expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) { /*expected*/ }
+        } catch (IllegalArgumentException e) { /*expected*/
+        }
         try {
             options.setMaxConnectionsPerHost(LOCAL, -1);
             fail("expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) { /*expected*/ }
+        } catch (IllegalArgumentException e) { /*expected*/
+        }
         try {
             options.setConnectionsPerHost(LOCAL, -1, 1);
             fail("expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) { /*expected*/ }
+        } catch (IllegalArgumentException e) { /*expected*/
+        }
         try {
             options.setConnectionsPerHost(LOCAL, -2, -1);
             fail("expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) { /*expected*/ }
+        } catch (IllegalArgumentException e) { /*expected*/
+        }
         try {
             options.setNewConnectionThreshold(LOCAL, -1);
             fail("expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) { /*expected*/ }
+        } catch (IllegalArgumentException e) { /*expected*/
+        }
         try {
             options.setMaxRequestsPerConnection(LOCAL, -1);
             fail("expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) { /*expected*/ }
+        } catch (IllegalArgumentException e) { /*expected*/
+        }
     }
 }
-

--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedIdTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedIdTest.java
@@ -23,9 +23,7 @@ public class PreparedIdTest extends CCMTestsSupport {
 
     @Override
     public void onTestContextInitialized() {
-        execute(
-                "CREATE TABLE foo(k1 int, k2 int, k3 int, v int, PRIMARY KEY ((k1, k2, k3)))"
-        );
+        execute("CREATE TABLE foo(k1 int, k2 int, k3 int, v int, PRIMARY KEY ((k1, k2, k3)))");
     }
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerErrorsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerErrorsTest.java
@@ -95,7 +95,7 @@ public class QueryLoggerErrorsTest extends ScassandraTestBase.PerClassCluster {
                         .withQuery(query)
                         .withThen(then().withFixedDelay(100L))
                         .build()
-        );
+                );
         // when
         session.execute(query);
         // then
@@ -119,7 +119,7 @@ public class QueryLoggerErrorsTest extends ScassandraTestBase.PerClassCluster {
                         .withQuery(query)
                         .withThen(then().withFixedDelay(100L))
                         .build()
-        );
+                );
         // when
         try {
             session.execute(query);
@@ -169,7 +169,7 @@ public class QueryLoggerErrorsTest extends ScassandraTestBase.PerClassCluster {
                         .withQuery(query)
                         .withThen(then().withResult(result))
                         .build()
-        );
+                );
         // when
         try {
             session.execute(query);

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
@@ -58,32 +58,32 @@ public class QueryLoggerTest extends CCMTestsSupport {
             }));
 
     private static final List<Object> values = Lists.transform(dataTypes, new Function<DataType, Object>() {
-                @Override
-                public Object apply(DataType type) {
-                    return getFixedValue(type);
-                }
-            }
-    );
+        @Override
+        public Object apply(DataType type) {
+            return getFixedValue(type);
+        }
+    }
+            );
 
     private static final String definitions = Joiner.on(", ").join(
             Lists.transform(dataTypes, new Function<DataType, String>() {
-                        @Override
-                        public String apply(DataType type) {
-                            return "c_" + type + " " + type;
-                        }
-                    }
-            )
-    );
+                @Override
+                public String apply(DataType type) {
+                    return "c_" + type + " " + type;
+                }
+            }
+                    )
+            );
 
     private static final String assignments = Joiner.on(", ").join(
             Lists.transform(dataTypes, new Function<DataType, String>() {
-                        @Override
-                        public String apply(DataType type) {
-                            return "c_" + type + " = ?";
-                        }
-                    }
-            )
-    );
+                @Override
+                public String apply(DataType type) {
+                    return "c_" + type + " = ?";
+                }
+            }
+                    )
+            );
 
     private Logger normal = Logger.getLogger(NORMAL_LOGGER.getName());
     private Logger slow = Logger.getLogger(SLOW_LOGGER.getName());

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryOptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryOptionsTest.java
@@ -39,7 +39,6 @@ public class QueryOptionsTest {
     Session session = null;
     Host host1, host2, host3;
 
-
     @BeforeMethod(groups = "short")
     public void beforeMethod() {
         scassandra = ScassandraCluster.builder().withNodes(3).build();

--- a/driver-core/src/test/java/com/datastax/driver/core/RPTokenFactoryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RPTokenFactoryTest.java
@@ -30,7 +30,7 @@ public class RPTokenFactoryTest {
         assertThat(splits).containsExactly(
                 factory.fromString("42535295865117307932921825928971026432"),
                 factory.fromString("85070591730234615865843651857942052864")
-        );
+                );
     }
 
     @Test(groups = "unit")
@@ -43,7 +43,7 @@ public class RPTokenFactoryTest {
         assertThat(splits).containsExactly(
                 factory.fromString("0"),
                 factory.fromString("42535295865117307932921825928971026432")
-        );
+                );
     }
 
     @Test(groups = "unit")
@@ -56,13 +56,13 @@ public class RPTokenFactoryTest {
         assertThat(splits).containsExactly(
                 maxToken,
                 maxToken
-        );
+                );
 
         splits = factory.split(minToken, factory.fromString("0"), 3);
         assertThat(splits).containsExactly(
                 factory.fromString("0"),
                 factory.fromString("0")
-        );
+                );
     }
 
     @Test(groups = "unit")
@@ -71,6 +71,6 @@ public class RPTokenFactoryTest {
         assertThat(splits).containsExactly(
                 factory.fromString("56713727820156410577229101238628035242"),
                 factory.fromString("113427455640312821154458202477256070485")
-        );
+                );
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/ReadTimeoutTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReadTimeoutTest.java
@@ -36,7 +36,7 @@ public class ReadTimeoutTest extends ScassandraTestBase.PerClassCluster {
                         .withQuery(query)
                         .withThen(then().withFixedDelay(100L))
                         .build()
-        );
+                );
 
         // Set default timeout too low
         cluster.getConfiguration().getSocketOptions().setReadTimeoutMillis(10);

--- a/driver-core/src/test/java/com/datastax/driver/core/ReconnectionPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReconnectionPolicyTest.java
@@ -96,9 +96,9 @@ public class ReconnectionPolicyTest extends AbstractPoliciesTest {
         assertTrue(schedule.nextDelayMs() == reconnectionPolicy.getMaxDelayMs());
 
         // Run integration test
-        long restartTime = 2 + 4 + 8 + 2;   // 16: 3 full cycles + 2 seconds
-        long retryTime = 30;                // 4th cycle start time
-        long breakTime = 62;                // time until next reconnection attempt
+        long restartTime = 2 + 4 + 8 + 2; // 16: 3 full cycles + 2 seconds
+        long retryTime = 30; // 4th cycle start time
+        long breakTime = 62; // time until next reconnection attempt
 
         // TODO: Try to sort out variance
         //reconnectionPolicyTest(restartTime, retryTime, breakTime);
@@ -137,9 +137,9 @@ public class ReconnectionPolicyTest extends AbstractPoliciesTest {
         assertTrue(schedule.nextDelayMs() == 10000);
 
         // Run integration test
-        long restartTime = 32;      // matches the above test
-        long retryTime = 40;        // 2nd cycle start time
-        long breakTime = 10;        // time until next reconnection attempt
+        long restartTime = 32; // matches the above test
+        long retryTime = 40; // 2nd cycle start time
+        long breakTime = 10; // time until next reconnection attempt
 
         // TODO: Try to sort out variance
         //reconnectionPolicyTest(restartTime, retryTime, breakTime);

--- a/driver-core/src/test/java/com/datastax/driver/core/RefreshConnectedHostTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RefreshConnectedHostTest.java
@@ -28,8 +28,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 @CCMConfig(
         dirtiesContext = true,
         numberOfNodes = 2,
-        createCluster = false
-)
+        createCluster = false)
 public class RefreshConnectedHostTest extends CCMTestsSupport {
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/ReplicationStrategyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReplicationStrategyTest.java
@@ -52,7 +52,7 @@ public class ReplicationStrategyTest {
         ReplicationStrategy strategy = ReplicationStrategy.create(
                 ImmutableMap.<String, String>builder()
                         .put("class", "SimpleStrategy")
-                                //no replication_factor
+                        //no replication_factor
                         .build());
 
         assertNull(strategy);

--- a/driver-core/src/test/java/com/datastax/driver/core/RequestHandlerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RequestHandlerTest.java
@@ -41,7 +41,7 @@ public class RequestHandlerTest {
                             .withRows(ImmutableMap.of("key", 1))
                             .withFixedDelay(10)
                             .build()
-            );
+                    );
 
             cluster = Cluster.builder()
                     .addContactPoint(TestUtils.ipOfNode(1))

--- a/driver-core/src/test/java/com/datastax/driver/core/SSLTestBase.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLTestBase.java
@@ -80,7 +80,10 @@ public abstract class SSLTestBase extends CCMTestsSupport {
         cluster.connect();
     }
 
-    enum SslImplementation {JDK, NETTY_OPENSSL}
+    enum SslImplementation {
+        JDK,
+        NETTY_OPENSSL
+    }
 
     /**
      * @param sslImplementation the SSL implementation to use
@@ -101,7 +104,6 @@ public abstract class SSLTestBase extends CCMTestsSupport {
             tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
             tmf.init(ks);
         }
-
 
         switch (sslImplementation) {
             case JDK:

--- a/driver-core/src/test/java/com/datastax/driver/core/ScassandraCluster.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ScassandraCluster.java
@@ -54,12 +54,11 @@ public class ScassandraCluster {
 
     private static final java.util.UUID schemaVersion = UUIDs.random();
 
-
     private final Map<Integer, Map<Integer, Map<String, Object>>> forcedPeerInfos;
 
     ScassandraCluster(Integer[] nodes, String ipPrefix, int binaryPort, int adminPort,
-                      List<Map<String, ?>> keyspaceRows,
-                      Map<Integer, Map<Integer, Map<String, Object>>> forcedPeerInfos) {
+            List<Map<String, ?>> keyspaceRows,
+            Map<Integer, Map<Integer, Map<String, Object>>> forcedPeerInfos) {
         this.ipPrefix = ipPrefix;
         this.binaryPort = binaryPort;
         this.forcedPeerInfos = forcedPeerInfos;

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaAgreementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaAgreementTest.java
@@ -86,4 +86,3 @@ public class SchemaAgreementTest extends CCMTestsSupport {
     }
 
 }
-

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesCCTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesCCTest.java
@@ -82,7 +82,6 @@ public class SchemaChangesCCTest extends CCMTestsSupport {
         verify(listener, timeout(NOTIF_TIMEOUT_MS).times(2)).onKeyspaceAdded(any(KeyspaceMetadata.class));
         verify(listener, timeout(NOTIF_TIMEOUT_MS).times(2)).onTableAdded(any(TableMetadata.class));
 
-
         KeyspaceMetadata prealteredKeyspace = cluster.getMetadata().getKeyspace("ks1");
         KeyspaceMetadata predroppedKeyspace = cluster.getMetadata().getKeyspace("ks2");
         TableMetadata prealteredTable = cluster.getMetadata().getKeyspace("ks1").getTable("tbl1");

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
@@ -79,7 +79,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
                 .withPort(ccm().getBinaryPort())
                 .withClusterName("schema-disabled")
                 .withQueryOptions(nonDebouncingQueryOptions()
-                                .setMetadataEnabled(false)
+                        .setMetadataEnabled(false)
                 ).build());
 
         schemaDisabledSession = schemaDisabledCluster.connect();
@@ -110,7 +110,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
         if (schemaDisabledCluster != null)
             schemaDisabledCluster.close();
     }
-
 
     @DataProvider(name = "existingKeyspaceName")
     public static Object[][] existingKeyspaceName() {
@@ -521,7 +520,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
                 .addContactPoints(getContactPoints())
                 .withPort(ccm().getBinaryPort())
                 .withQueryOptions(nonDebouncingQueryOptions()
-                                .setMetadataEnabled(false)
+                        .setMetadataEnabled(false)
                 ).build();
 
         try {
@@ -531,7 +530,6 @@ public class SchemaChangesTest extends CCMTestsSupport {
             cluster.close();
         }
     }
-
 
     /**
      * Ensures that calling {@link Metadata#newTokenRange(Token, Token)} on a Cluster that has schema
@@ -546,7 +544,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
                 .addContactPoints(getContactPoints())
                 .withPort(ccm().getBinaryPort())
                 .withQueryOptions(nonDebouncingQueryOptions()
-                                .setMetadataEnabled(false)
+                        .setMetadataEnabled(false)
                 ).build();
 
         try {
@@ -631,7 +629,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
                     session1.executeAsync("DROP MATERIALIZED VIEW \"CaseSensitive\".mv1"),
                     session1.executeAsync("DROP KEYSPACE lowercase2"),
                     session1.executeAsync("DROP KEYSPACE \"CaseSensitive2\"")
-            ));
+                    ));
             Futures.getUnchecked(f);
         }
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaRefreshDebouncerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaRefreshDebouncerTest.java
@@ -101,7 +101,6 @@ public class SchemaRefreshDebouncerTest extends CCMTestsSupport {
         assertThat(ksm).isNotNull().hasName(keyspace).isNotDurableWrites();
     }
 
-
     /**
      * Ensures that when a CREATED (keyspace) and CREATED (table) schema_change events are received
      * on a control connection with that table belonging to that keyspace within

--- a/driver-core/src/test/java/com/datastax/driver/core/SimpleJSONParserTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SimpleJSONParserTest.java
@@ -32,4 +32,3 @@ public class SimpleJSONParserTest {
         assertEquals(ImmutableMap.of("foo", "bar", "bar", "foo"), SimpleJSONParser.parseStringMap("{\"foo\":\"bar\",\"bar\":\"foo\"}"));
     }
 }
-

--- a/driver-core/src/test/java/com/datastax/driver/core/SimpleStatementIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SimpleStatementIntegrationTest.java
@@ -30,8 +30,7 @@ public class SimpleStatementIntegrationTest extends CCMTestsSupport {
     public void onTestContextInitialized() {
         execute(
                 "CREATE TABLE users(id int, id2 int, name text, primary key (id, id2))",
-                "INSERT INTO users(id, id2, name) VALUES (1, 2, 'test')"
-        );
+                "INSERT INTO users(id, id2, name) VALUES (1, 2, 'test')");
     }
 
     @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/SimpleStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SimpleStatementTest.java
@@ -89,11 +89,9 @@ public class SimpleStatementTest {
     @Test(groups = "unit")
     public void should_return_number_of_values() {
         assertThat(
-                new SimpleStatement("doesn't matter").valuesCount()
-        ).isEqualTo(0);
+                new SimpleStatement("doesn't matter").valuesCount()).isEqualTo(0);
         assertThat(
-                new SimpleStatement("doesn't matter", 1, 2).valuesCount()
-        ).isEqualTo(2);
+                new SimpleStatement("doesn't matter", 1, 2).valuesCount()).isEqualTo(2);
     }
 
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/SingleTokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SingleTokenIntegrationTest.java
@@ -26,8 +26,7 @@ import static com.datastax.driver.core.Assertions.assertThat;
 @CCMConfig(
         // force the initial token to a non-min value to validate that the single range will always be ]minToken, minToken]
         config = "initial_token:1",
-        clusterProvider = "createClusterBuilderNoDebouncing"
-)
+        clusterProvider = "createClusterBuilderNoDebouncing")
 public class SingleTokenIntegrationTest extends CCMTestsSupport {
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/SortingLoadBalancingPolicy.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SortingLoadBalancingPolicy.java
@@ -77,5 +77,6 @@ public class SortingLoadBalancingPolicy implements LoadBalancingPolicy {
     }
 
     @Override
-    public void close() {/*nothing to do*/}
+    public void close() {/*nothing to do*/
+    }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/SpeculativeExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SpeculativeExecutionTest.java
@@ -86,7 +86,7 @@ public class SpeculativeExecutionTest {
                 .withQuery("mock query")
                 .withRows(row("result", "result1"))
                 .build()
-        );
+                );
 
         long execStartCount = errors.getSpeculativeExecutions().getCount();
 
@@ -106,14 +106,14 @@ public class SpeculativeExecutionTest {
                 .withConsistency(Consistency.TWO)
                 .withResult(Result.read_request_timeout)
                 .build()
-        );
+                );
 
         scassandras.node(1).primingClient().prime(PrimingRequest.queryBuilder()
                 .withQuery("mock query")
                 .withConsistency(Consistency.ONE)
                 .withRows(row("result", "result1"))
                 .build()
-        );
+                );
 
         long execStartCount = errors.getSpeculativeExecutions().getCount();
         long retriesStartCount = errors.getRetriesOnUnavailable().getCount();
@@ -137,13 +137,13 @@ public class SpeculativeExecutionTest {
                 .withFixedDelay(400)
                 .withRows(row("result", "result1"))
                 .build()
-        );
+                );
 
         scassandras.node(2).primingClient().prime(PrimingRequest.queryBuilder()
                 .withQuery("mock query")
                 .withRows(row("result", "result2"))
                 .build()
-        );
+                );
         long execStartCount = errors.getSpeculativeExecutions().getCount();
 
         ResultSet rs = session.execute("mock query");

--- a/driver-core/src/test/java/com/datastax/driver/core/StateListenerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StateListenerTest.java
@@ -56,7 +56,13 @@ public class StateListenerTest extends CCMTestsSupport {
     }
 
     static class TestListener implements Host.StateListener {
-        enum Event {ADD, UP, SUSPECTED, DOWN, REMOVE}
+        enum Event {
+            ADD,
+            UP,
+            SUSPECTED,
+            DOWN,
+            REMOVE
+        }
 
         volatile CountDownLatch latch;
         volatile Event expectedEvent;

--- a/driver-core/src/test/java/com/datastax/driver/core/StatementIdempotenceTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StatementIdempotenceTest.java
@@ -116,7 +116,7 @@ public class StatementIdempotenceTest {
                 select().writeTime("v").from("foo").where(eq("k", 1)),
                 select().fcall("token", "k").from("foo").where(eq("k", 1))
 
-        );
+                );
     }
 
     private ImmutableList<BuiltStatement> nonIdempotentBuiltStatements() {
@@ -184,6 +184,6 @@ public class StatementIdempotenceTest {
                 update("foo").with(set("v", raw("foo()"))).where(eq("k", 1)),
                 update("foo").with(set("v", Lists.newArrayList(raw("foo()")))).where(eq("k", 1))
 
-        );
+                );
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
@@ -181,44 +181,44 @@ public class TableMetadataTest extends CCMTestsSupport {
         // Cassandra 3.0 +
         if (version.getMajor() > 2) {
             cql = String.format("CREATE TABLE %s.with_options (\n"
-                            + "    k text,\n"
-                            + "    c1 int,\n"
-                            + "    c2 int,\n"
-                            + "    i int,\n"
-                            + "    PRIMARY KEY (k, c1, c2)\n"
-                            + ") WITH CLUSTERING ORDER BY (c1 DESC, c2 ASC)\n"
-                            + "   AND read_repair_chance = 0.5\n"
-                            + "   AND dclocal_read_repair_chance = 0.6\n"
-                            + "   AND speculative_retry = '99.9PERCENTILE'\n"
-                            // replicate_on_write not supported anymore in 3.0
-                            + "   AND gc_grace_seconds = 42\n"
-                            + "   AND bloom_filter_fp_chance = 0.01\n"
-                            // older caching formats not supported anymore in 3.0
-                            + "   AND caching =  { 'keys' : 'ALL', 'rows_per_partition' : 10 }\n"
-                            + "   AND comment = 'My awesome table'\n"
-                            + "   AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'sstable_size_in_mb' : 15 }\n"
-                            + "   AND compression = { 'sstable_compression' : 'org.apache.cassandra.io.compress.SnappyCompressor', 'chunk_length_kb' : 128 }\n"
-                            + "   AND crc_check_chance = 0.5;", // available from C* 3.0
+                    + "    k text,\n"
+                    + "    c1 int,\n"
+                    + "    c2 int,\n"
+                    + "    i int,\n"
+                    + "    PRIMARY KEY (k, c1, c2)\n"
+                    + ") WITH CLUSTERING ORDER BY (c1 DESC, c2 ASC)\n"
+                    + "   AND read_repair_chance = 0.5\n"
+                    + "   AND dclocal_read_repair_chance = 0.6\n"
+                    + "   AND speculative_retry = '99.9PERCENTILE'\n"
+                    // replicate_on_write not supported anymore in 3.0
+                    + "   AND gc_grace_seconds = 42\n"
+                    + "   AND bloom_filter_fp_chance = 0.01\n"
+                    // older caching formats not supported anymore in 3.0
+                    + "   AND caching =  { 'keys' : 'ALL', 'rows_per_partition' : 10 }\n"
+                    + "   AND comment = 'My awesome table'\n"
+                    + "   AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'sstable_size_in_mb' : 15 }\n"
+                    + "   AND compression = { 'sstable_compression' : 'org.apache.cassandra.io.compress.SnappyCompressor', 'chunk_length_kb' : 128 }\n"
+                    + "   AND crc_check_chance = 0.5;", // available from C* 3.0
                     keyspace);
 
             // older versions
         } else {
             cql = String.format("CREATE TABLE %s.with_options (\n"
-                            + "    k text,\n"
-                            + "    c1 int,\n"
-                            + "    c2 int,\n"
-                            + "    i int,\n"
-                            + "    PRIMARY KEY (k, c1, c2)\n"
-                            + ") WITH CLUSTERING ORDER BY (c1 DESC, c2 ASC)\n"
-                            + "   AND read_repair_chance = 0.5\n"
-                            + "   AND dclocal_read_repair_chance = 0.6\n"
-                            + "   AND replicate_on_write = true\n"
-                            + "   AND gc_grace_seconds = 42\n"
-                            + "   AND bloom_filter_fp_chance = 0.01\n"
-                            + "   AND caching = 'ALL'\n"
-                            + "   AND comment = 'My awesome table'\n"
-                            + "   AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'sstable_size_in_mb' : 15 }\n"
-                            + "   AND compression = { 'sstable_compression' : 'org.apache.cassandra.io.compress.SnappyCompressor', 'chunk_length_kb' : 128 };",
+                    + "    k text,\n"
+                    + "    c1 int,\n"
+                    + "    c2 int,\n"
+                    + "    i int,\n"
+                    + "    PRIMARY KEY (k, c1, c2)\n"
+                    + ") WITH CLUSTERING ORDER BY (c1 DESC, c2 ASC)\n"
+                    + "   AND read_repair_chance = 0.5\n"
+                    + "   AND dclocal_read_repair_chance = 0.6\n"
+                    + "   AND replicate_on_write = true\n"
+                    + "   AND gc_grace_seconds = 42\n"
+                    + "   AND bloom_filter_fp_chance = 0.01\n"
+                    + "   AND caching = 'ALL'\n"
+                    + "   AND comment = 'My awesome table'\n"
+                    + "   AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'sstable_size_in_mb' : 15 }\n"
+                    + "   AND compression = { 'sstable_compression' : 'org.apache.cassandra.io.compress.SnappyCompressor', 'chunk_length_kb' : 128 };",
                     keyspace);
         }
 
@@ -389,10 +389,10 @@ public class TableMetadataTest extends CCMTestsSupport {
                     .contains("'sstable_compression' : 'org.apache.cassandra.io.compress.SnappyCompressor'")
                     .contains("'chunk_length_kb' : 128")
                     .contains("replicate_on_write = true")
-                    .doesNotContain("index_interval")  // 2.0
-                    .doesNotContain("min_index_interval")  // 2.1 +
-                    .doesNotContain("max_index_interval")  // 2.1 +
-                    .doesNotContain("speculative_retry")  // 2.0 +
+                    .doesNotContain("index_interval") // 2.0
+                    .doesNotContain("min_index_interval") // 2.1 +
+                    .doesNotContain("max_index_interval") // 2.1 +
+                    .doesNotContain("speculative_retry") // 2.0 +
                     .doesNotContain("default_time_to_live"); // 2.0 +
 
         }
@@ -411,13 +411,13 @@ public class TableMetadataTest extends CCMTestsSupport {
     public void should_parse_new_compression_options() {
         // given
         String cql = String.format("CREATE TABLE %s.new_compression_options (\n"
-                        + "    k text,\n"
-                        + "    c1 int,\n"
-                        + "    c2 int,\n"
-                        + "    i int,\n"
-                        + "    PRIMARY KEY (k, c1, c2)\n"
-                        + ") WITH CLUSTERING ORDER BY (c1 DESC, c2 ASC)\n"
-                        + "   AND compression = { 'class' : 'DeflateCompressor', 'chunk_length_in_kb' : 128 };",
+                + "    k text,\n"
+                + "    c1 int,\n"
+                + "    c2 int,\n"
+                + "    i int,\n"
+                + "    PRIMARY KEY (k, c1, c2)\n"
+                + ") WITH CLUSTERING ORDER BY (c1 DESC, c2 ASC)\n"
+                + "   AND compression = { 'class' : 'DeflateCompressor', 'chunk_length_in_kb' : 128 };",
                 keyspace);
 
         // when
@@ -434,8 +434,8 @@ public class TableMetadataTest extends CCMTestsSupport {
     public void should_escape_single_quote_table_comment() {
         // given
         String cql = String.format("CREATE TABLE %s.single_quote (\n"
-                        + "    c1 int PRIMARY KEY\n"
-                        + ") WITH  comment = 'comment with single quote '' should work'",
+                + "    c1 int PRIMARY KEY\n"
+                + ") WITH  comment = 'comment with single quote '' should work'",
                 keyspace);
         // when
         session().execute(cql);
@@ -565,8 +565,7 @@ public class TableMetadataTest extends CCMTestsSupport {
                 "DROP TABLE \"MyTable1\"",
                 "DROP TABLE \"MyTable2\"",
                 table1.asCQLQuery(),
-                table2.asCQLQuery()
-        );
+                table2.asCQLQuery());
     }
 
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/TestListener.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestListener.java
@@ -67,10 +67,7 @@ public class TestListener extends TestListenerAdapter implements IInvokedMethodL
     }
 
     static String formatIntoHHMMSS(long secondsTotal) {
-        long hours = secondsTotal / 3600,
-                remainder = secondsTotal % 3600,
-                minutes = remainder / 60,
-                seconds = remainder % 60;
+        long hours = secondsTotal / 3600, remainder = secondsTotal % 3600, minutes = remainder / 60, seconds = remainder % 60;
 
         return ((hours < 10 ? "0" : "") + hours
                 + ':' + (minutes < 10 ? "0" : "") + minutes

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -377,17 +377,23 @@ public abstract class TestUtils {
                 case TIMEUUID:
                     return UUID.fromString("FE2B4360-28C6-11E2-81C1-0800200C9A66");
                 case LIST:
-                    return new ArrayList<Object>() {{
-                        add(getFixedValue(type.getTypeArguments().get(0)));
-                    }};
+                    return new ArrayList<Object>() {
+                        {
+                            add(getFixedValue(type.getTypeArguments().get(0)));
+                        }
+                    };
                 case SET:
-                    return new HashSet<Object>() {{
-                        add(getFixedValue(type.getTypeArguments().get(0)));
-                    }};
+                    return new HashSet<Object>() {
+                        {
+                            add(getFixedValue(type.getTypeArguments().get(0)));
+                        }
+                    };
                 case MAP:
-                    return new HashMap<Object, Object>() {{
-                        put(getFixedValue(type.getTypeArguments().get(0)), getFixedValue(type.getTypeArguments().get(1)));
-                    }};
+                    return new HashMap<Object, Object>() {
+                        {
+                            put(getFixedValue(type.getTypeArguments().get(0)), getFixedValue(type.getTypeArguments().get(1)));
+                        }
+                    };
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -445,17 +451,23 @@ public abstract class TestUtils {
                 case TIMEUUID:
                     return UUID.fromString("FE2B4360-28C6-11E2-81C1-0800200C9A66");
                 case LIST:
-                    return new ArrayList<Object>() {{
-                        add(getFixedValue2(type.getTypeArguments().get(0)));
-                    }};
+                    return new ArrayList<Object>() {
+                        {
+                            add(getFixedValue2(type.getTypeArguments().get(0)));
+                        }
+                    };
                 case SET:
-                    return new HashSet<Object>() {{
-                        add(getFixedValue2(type.getTypeArguments().get(0)));
-                    }};
+                    return new HashSet<Object>() {
+                        {
+                            add(getFixedValue2(type.getTypeArguments().get(0)));
+                        }
+                    };
                 case MAP:
-                    return new HashMap<Object, Object>() {{
-                        put(getFixedValue2(type.getTypeArguments().get(0)), getFixedValue2(type.getTypeArguments().get(1)));
-                    }};
+                    return new HashMap<Object, Object>() {
+                        {
+                            put(getFixedValue2(type.getTypeArguments().get(0)), getFixedValue2(type.getTypeArguments().get(1)));
+                        }
+                    };
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/driver-core/src/test/java/com/datastax/driver/core/TimeoutStressTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TimeoutStressTest.java
@@ -72,12 +72,12 @@ public class TimeoutStressTest extends CCMTestsSupport {
     @Override
     public void onTestContextInitialized() {
         execute(
-                "create table record (\n"
-                        + "  name text,\n"
-                        + "  phone text,\n"
-                        + "  value text,\n"
-                        + "  PRIMARY KEY (name, phone)\n"
-                        + ")"
+        "create table record (\n"
+                + "  name text,\n"
+                + "  phone text,\n"
+                + "  value text,\n"
+                + "  PRIMARY KEY (name, phone)\n"
+                + ")"
 
         );
     }
@@ -143,7 +143,7 @@ public class TimeoutStressTest extends CCMTestsSupport {
                 // factor between retrieving open connections and checking the reaper.
                 if (openChannels.size() > maxConnections) {
                     logger.warn("{} of open channels: {} exceeds maximum expected: {}.  " +
-                                    "This could be because there are connections to be cleaned up in the reaper.",
+                            "This could be because there are connections to be cleaned up in the reaper.",
                             openChannels.size(), maxConnections, openChannels);
                 }
             }
@@ -206,7 +206,6 @@ public class TimeoutStressTest extends CCMTestsSupport {
             this.concurrentQueries = concurrentQueries;
             this.stopped = stopped;
         }
-
 
         @Override
         public void run() {

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
@@ -75,8 +75,7 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
                 "CREATE TABLE foo(i int primary key)",
                 "INSERT INTO foo (i) VALUES (1)",
                 "INSERT INTO foo (i) VALUES (2)",
-                "INSERT INTO foo (i) VALUES (3)"
-        );
+                "INSERT INTO foo (i) VALUES (3)");
     }
 
     /**
@@ -162,8 +161,7 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
         assertThat(token.getType()).isEqualTo(expectedTokenType);
 
         assertThat(
-                row.getPartitionKeyToken()
-        ).isEqualTo(token);
+                row.getPartitionKeyToken()).isEqualTo(token);
 
         PreparedStatement pst = session().prepare("SELECT * FROM foo WHERE token(i) = ?");
         row = session().execute(pst.bind(token)).one();
@@ -337,7 +335,7 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
                         return input.splitEvenly(10);
                     }
                 })
-        );
+                );
 
         assertOnlyOneWrapped(splitRanges);
     }
@@ -387,8 +385,7 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
 
         ProtocolVersion protocolVersion = cluster().getConfiguration().getProtocolOptions().getProtocolVersion();
         assertThat(
-                metadata.newToken(TypeCodec.cint().serialize(1, protocolVersion))
-        ).isEqualTo(expected);
+                metadata.newToken(TypeCodec.cint().serialize(1, protocolVersion))).isEqualTo(expected);
     }
 
     protected abstract Token.Factory tokenFactory();

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenRangeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenRangeTest.java
@@ -43,8 +43,7 @@ public class TokenRangeTest {
                 .intersects(tokenRange(4, 8))
                 .intersects(tokenRange(3, 9))
                 .doesNotIntersect(tokenRange(9, 10))
-                .doesNotIntersect(tokenRange(10, 11))
-        ;
+                .doesNotIntersect(tokenRange(10, 11));
         assertThat(tokenRange(9, 3))
                 .doesNotIntersect(tokenRange(5, 7))
                 .doesNotIntersect(tokenRange(7, 8))
@@ -57,8 +56,7 @@ public class TokenRangeTest {
                 .intersects(tokenRange(10, 2))
                 .intersects(tokenRange(9, 3))
                 .doesNotIntersect(tokenRange(3, 4))
-                .doesNotIntersect(tokenRange(4, 5))
-        ;
+                .doesNotIntersect(tokenRange(4, 5));
         assertThat(tokenRange(3, 3)).doesNotIntersect(tokenRange(3, 3));
 
         // Reminder: minToken serves as both lower and upper bound
@@ -68,8 +66,7 @@ public class TokenRangeTest {
                 .intersects(tokenRange(6, 4))
                 .intersects(tokenRange(2, 4))
                 .intersects(tokenRange(minToken, 4))
-                .intersects(tokenRange(minToken, 5))
-        ;
+                .intersects(tokenRange(minToken, 5));
 
         assertThat(tokenRange(5, minToken))
                 .doesNotIntersect(tokenRange(3, 4))
@@ -77,15 +74,13 @@ public class TokenRangeTest {
                 .intersects(tokenRange(6, 7))
                 .intersects(tokenRange(4, 1))
                 .intersects(tokenRange(6, minToken))
-                .intersects(tokenRange(5, minToken))
-        ;
+                .intersects(tokenRange(5, minToken));
 
         assertThat(tokenRange(minToken, minToken))
                 .intersects(tokenRange(3, 4))
                 .intersects(tokenRange(3, minToken))
                 .intersects(tokenRange(minToken, 3))
-                .doesNotIntersect(tokenRange(3, 3))
-        ;
+                .doesNotIntersect(tokenRange(3, 3));
     }
 
     @Test(groups = "unit")

--- a/driver-core/src/test/java/com/datastax/driver/core/TracingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TracingTest.java
@@ -93,4 +93,3 @@ public class TracingTest extends CCMTestsSupport {
         assertThat(result.getExecutionInfo().getQueryTrace()).isNotNull();
     }
 }
-

--- a/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
@@ -287,7 +287,6 @@ public class TupleTest extends CCMTestsSupport {
         // create table
         session().execute(String.format("CREATE TABLE mytable (k int PRIMARY KEY, %s)", Joiner.on(',').join(values)));
 
-
         int i = 0;
         // test tuple<list<datatype>>
         for (DataType datatype : DATA_TYPE_PRIMITIVES) {
@@ -418,11 +417,11 @@ public class TupleTest extends CCMTestsSupport {
 
         // create a table with multiple sizes of nested tuples
         session().execute(String.format("CREATE TABLE mytable (" +
-                        "k int PRIMARY KEY, " +
-                        "v_1 %s, " +
-                        "v_2 %s, " +
-                        "v_3 %s, " +
-                        "v_32 %s)", nestedTuplesSchemaHelper(1),
+                "k int PRIMARY KEY, " +
+                "v_1 %s, " +
+                "v_2 %s, " +
+                "v_3 %s, " +
+                "v_32 %s)", nestedTuplesSchemaHelper(1),
                 nestedTuplesSchemaHelper(2),
                 nestedTuplesSchemaHelper(3),
                 nestedTuplesSchemaHelper(32)));

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecAssert.java
@@ -71,14 +71,16 @@ public class TypeCodecAssert<T> extends AbstractAssert<TypeCodecAssert<T>, TypeC
     }
 
     public TypeCodecAssert<T> withProtocolVersion(ProtocolVersion version) {
-        if (version == null) fail("ProtocolVersion cannot be null");
+        if (version == null)
+            fail("ProtocolVersion cannot be null");
         this.version = version;
         return this;
     }
 
     @SuppressWarnings("unchecked")
     public TypeCodecAssert<T> canSerialize(Object value) {
-        if (version == null) fail("ProtocolVersion cannot be null");
+        if (version == null)
+            fail("ProtocolVersion cannot be null");
         try {
             assertThat(actual.deserialize(actual.serialize((T) value, version), version)).isEqualTo(value);
         } catch (Exception e) {
@@ -89,7 +91,8 @@ public class TypeCodecAssert<T> extends AbstractAssert<TypeCodecAssert<T>, TypeC
 
     @SuppressWarnings("unchecked")
     public TypeCodecAssert<T> cannotSerialize(Object value) {
-        if (version == null) fail("ProtocolVersion cannot be null");
+        if (version == null)
+            fail("ProtocolVersion cannot be null");
         try {
             actual.serialize((T) value, version);
             fail("Should not have been able to serialize " + value + " with " + actual);

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecCollectionsIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecCollectionsIntegrationTest.java
@@ -54,15 +54,15 @@ public class TypeCodecCollectionsIntegrationTest extends CCMTestsSupport {
     @Override
     public void onTestContextInitialized() {
         execute(
-                "CREATE TABLE IF NOT EXISTS \"myTable2\" ("
-                        + "c_int int PRIMARY KEY, "
-                        + "l_int list<int>, "
-                        + "l_bigint list<bigint>, "
-                        + "s_float set<float>, "
-                        + "s_double set<double>, "
-                        + "m_varint map<int,varint>, "
-                        + "m_decimal map<int,decimal>"
-                        + ")");
+        "CREATE TABLE IF NOT EXISTS \"myTable2\" ("
+                + "c_int int PRIMARY KEY, "
+                + "l_int list<int>, "
+                + "l_bigint list<bigint>, "
+                + "s_float set<float>, "
+                + "s_double set<double>, "
+                + "m_varint map<int,varint>, "
+                + "m_decimal map<int,decimal>"
+                + ")");
     }
 
     @BeforeMethod(groups = "short")
@@ -104,14 +104,14 @@ public class TypeCodecCollectionsIntegrationTest extends CCMTestsSupport {
                 .setList(1, l_int)
                 .setList(2, l_bigint, Long.class) // variant with element type explicitly set
                 .setSet(3, s_float)
-                .setSet(4, s_double, TypeToken.of(Double.class))  // variant with element type explicitly set
+                .setSet(4, s_double, TypeToken.of(Double.class)) // variant with element type explicitly set
                 .setMap(5, m_varint)
-                .setMap(6, m_decimal, Integer.class, BigDecimal.class)  // variant with element type explicitly set
-        );
+                .setMap(6, m_decimal, Integer.class, BigDecimal.class) // variant with element type explicitly set
+                );
         PreparedStatement ps = session().prepare(selectQuery);
         ResultSet rows = session().execute(ps.bind()
-                        .setInt(0, n_int)
-        );
+                .setInt(0, n_int)
+                );
         Row row = rows.one();
         assertRow(row);
     }
@@ -119,18 +119,18 @@ public class TypeCodecCollectionsIntegrationTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void should_use_collection_codecs_with_prepared_statements_3() {
         session().execute(session().prepare(insertQuery).bind()
-                        .setInt(0, n_int)
-                        .set(1, l_int, TypeTokens.listOf(Integer.class))
-                        .set(2, l_bigint, TypeTokens.listOf(Long.class))
-                        .set(3, s_float, TypeTokens.setOf(Float.class))
-                        .set(4, s_double, TypeTokens.setOf(Double.class))
-                        .set(5, m_varint, TypeTokens.mapOf(Integer.class, BigInteger.class))
-                        .set(6, m_decimal, TypeTokens.mapOf(Integer.class, BigDecimal.class))
-        );
+                .setInt(0, n_int)
+                .set(1, l_int, TypeTokens.listOf(Integer.class))
+                .set(2, l_bigint, TypeTokens.listOf(Long.class))
+                .set(3, s_float, TypeTokens.setOf(Float.class))
+                .set(4, s_double, TypeTokens.setOf(Double.class))
+                .set(5, m_varint, TypeTokens.mapOf(Integer.class, BigInteger.class))
+                .set(6, m_decimal, TypeTokens.mapOf(Integer.class, BigDecimal.class))
+                );
         PreparedStatement ps = session().prepare(selectQuery);
         ResultSet rows = session().execute(ps.bind()
-                        .setInt(0, n_int)
-        );
+                .setInt(0, n_int)
+                );
         Row row = rows.one();
         assertRow(row);
     }
@@ -138,18 +138,18 @@ public class TypeCodecCollectionsIntegrationTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void should_use_collection_codecs_with_built_statements() {
         session().execute(session().prepare(insertStmt).bind()
-                        .setInt(0, n_int)
-                        .set(1, l_int, TypeTokens.listOf(Integer.class))
-                        .set(2, l_bigint, TypeTokens.listOf(Long.class))
-                        .set(3, s_float, TypeTokens.setOf(Float.class))
-                        .set(4, s_double, TypeTokens.setOf(Double.class))
-                        .set(5, m_varint, TypeTokens.mapOf(Integer.class, BigInteger.class))
-                        .set(6, m_decimal, TypeTokens.mapOf(Integer.class, BigDecimal.class))
-        );
+                .setInt(0, n_int)
+                .set(1, l_int, TypeTokens.listOf(Integer.class))
+                .set(2, l_bigint, TypeTokens.listOf(Long.class))
+                .set(3, s_float, TypeTokens.setOf(Float.class))
+                .set(4, s_double, TypeTokens.setOf(Double.class))
+                .set(5, m_varint, TypeTokens.mapOf(Integer.class, BigInteger.class))
+                .set(6, m_decimal, TypeTokens.mapOf(Integer.class, BigDecimal.class))
+                );
         PreparedStatement ps = session().prepare(selectStmt);
         ResultSet rows = session().execute(ps.bind()
-                        .setInt(0, n_int)
-        );
+                .setInt(0, n_int)
+                );
         Row row = rows.one();
         assertRow(row);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecEncapsulationIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecEncapsulationIntegrationTest.java
@@ -34,12 +34,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TypeCodecEncapsulationIntegrationTest extends CCMTestsSupport {
 
     // @formatter:off
-    private static final TypeToken<NumberBox<Integer>> NUMBERBOX_OF_INTEGER_TOKEN = new TypeToken<NumberBox<Integer>>() {};
-    private static final TypeToken<NumberBox<Long>> NUMBERBOX_OF_LONG_TOKEN = new TypeToken<NumberBox<Long>>() {};
-    private static final TypeToken<NumberBox<Float>> NUMBERBOX_OF_FLOAT_TOKEN = new TypeToken<NumberBox<Float>>() {};
-    private static final TypeToken<NumberBox<Double>> NUMBERBOX_OF_DOUBLE_TOKEN = new TypeToken<NumberBox<Double>>() {};
-    private static final TypeToken<NumberBox<BigInteger>> NUMBERBOX_OF_BIGINTEGER_TOKEN = new TypeToken<NumberBox<BigInteger>>() {};
-    private static final TypeToken<NumberBox<BigDecimal>> NUMBERBOX_OF_BIGDECIMAL_TOKEN = new TypeToken<NumberBox<BigDecimal>>() {};
+    private static final TypeToken<NumberBox<Integer>> NUMBERBOX_OF_INTEGER_TOKEN = new TypeToken<NumberBox<Integer>>() {
+    };
+    private static final TypeToken<NumberBox<Long>> NUMBERBOX_OF_LONG_TOKEN = new TypeToken<NumberBox<Long>>() {
+    };
+    private static final TypeToken<NumberBox<Float>> NUMBERBOX_OF_FLOAT_TOKEN = new TypeToken<NumberBox<Float>>() {
+    };
+    private static final TypeToken<NumberBox<Double>> NUMBERBOX_OF_DOUBLE_TOKEN = new TypeToken<NumberBox<Double>>() {
+    };
+    private static final TypeToken<NumberBox<BigInteger>> NUMBERBOX_OF_BIGINTEGER_TOKEN = new TypeToken<NumberBox<BigInteger>>() {
+    };
+    private static final TypeToken<NumberBox<BigDecimal>> NUMBERBOX_OF_BIGDECIMAL_TOKEN = new TypeToken<NumberBox<BigDecimal>>() {
+    };
     // @formatter:on
 
     private final String insertQuery = "INSERT INTO \"myTable\" (c_int, c_bigint, c_float, c_double, c_varint, c_decimal) VALUES (?, ?, ?, ?, ?, ?)";
@@ -59,16 +65,15 @@ public class TypeCodecEncapsulationIntegrationTest extends CCMTestsSupport {
     @Override
     public void onTestContextInitialized() {
         execute(
-                "CREATE TABLE \"myTable\" ("
-                        + "c_int int, "
-                        + "c_bigint bigint, "
-                        + "c_float float, "
-                        + "c_double double, "
-                        + "c_varint varint, "
-                        + "c_decimal decimal, "
-                        + "PRIMARY KEY (c_int, c_bigint)"
-                        + ")"
-        );
+        "CREATE TABLE \"myTable\" ("
+                + "c_int int, "
+                + "c_bigint bigint, "
+                + "c_float float, "
+                + "c_double double, "
+                + "c_varint varint, "
+                + "c_decimal decimal, "
+                + "PRIMARY KEY (c_int, c_bigint)"
+                + ")");
     }
 
     @Override
@@ -83,7 +88,7 @@ public class TypeCodecEncapsulationIntegrationTest extends CCMTestsSupport {
                                 new NumberBoxCodec<BigInteger>(TypeCodec.varint()),
                                 new NumberBoxCodec<BigDecimal>(TypeCodec.decimal())
                         )
-        );
+                );
     }
 
     @BeforeMethod(groups = "short")
@@ -134,18 +139,18 @@ public class TypeCodecEncapsulationIntegrationTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void should_use_custom_codecs_with_prepared_statements_2() {
         session().execute(session().prepare(insertQuery).bind()
-                        .set(0, new NumberBox<Integer>(n_int), NUMBERBOX_OF_INTEGER_TOKEN)
-                        .set(1, new NumberBox<Long>(n_bigint), NUMBERBOX_OF_LONG_TOKEN)
-                        .set(2, new NumberBox<Float>(n_float), NUMBERBOX_OF_FLOAT_TOKEN)
-                        .set(3, new NumberBox<Double>(n_double), NUMBERBOX_OF_DOUBLE_TOKEN)
-                        .set(4, new NumberBox<BigInteger>(n_varint), NUMBERBOX_OF_BIGINTEGER_TOKEN)
-                        .set(5, new NumberBox<BigDecimal>(n_decimal), NUMBERBOX_OF_BIGDECIMAL_TOKEN)
-        );
+                .set(0, new NumberBox<Integer>(n_int), NUMBERBOX_OF_INTEGER_TOKEN)
+                .set(1, new NumberBox<Long>(n_bigint), NUMBERBOX_OF_LONG_TOKEN)
+                .set(2, new NumberBox<Float>(n_float), NUMBERBOX_OF_FLOAT_TOKEN)
+                .set(3, new NumberBox<Double>(n_double), NUMBERBOX_OF_DOUBLE_TOKEN)
+                .set(4, new NumberBox<BigInteger>(n_varint), NUMBERBOX_OF_BIGINTEGER_TOKEN)
+                .set(5, new NumberBox<BigDecimal>(n_decimal), NUMBERBOX_OF_BIGDECIMAL_TOKEN)
+                );
         PreparedStatement ps = session().prepare(selectQuery);
         ResultSet rows = session().execute(ps.bind()
-                        .set(0, new NumberBox<Integer>(n_int), NUMBERBOX_OF_INTEGER_TOKEN)
-                        .set(1, new NumberBox<Long>(n_bigint), NUMBERBOX_OF_LONG_TOKEN)
-        );
+                .set(0, new NumberBox<Integer>(n_int), NUMBERBOX_OF_INTEGER_TOKEN)
+                .set(1, new NumberBox<Long>(n_bigint), NUMBERBOX_OF_LONG_TOKEN)
+                );
         Row row = rows.one();
         assertRow(row);
     }
@@ -224,7 +229,9 @@ public class TypeCodecEncapsulationIntegrationTest extends CCMTestsSupport {
         protected NumberBoxCodec(TypeCodec<T> numberCodec) {
             // @formatter:off
             super(numberCodec.getCqlType(),
-                    new TypeToken<NumberBox<T>>() {}.where(new TypeParameter<T>() {}, numberCodec.getJavaType()));
+                    new TypeToken<NumberBox<T>>() {
+                    }.where(new TypeParameter<T>() {
+                    }, numberCodec.getJavaType()));
             // @formatter:on
             this.numberCodec = numberCodec;
         }

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNestedCollectionsIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNestedCollectionsIntegrationTest.java
@@ -49,25 +49,26 @@ public class TypeCodecNestedCollectionsIntegrationTest extends CCMTestsSupport {
     private List<Set<Map<MyInt, String>>> v;
 
     // @formatter:off
-    private TypeToken<List<Set<Map<MyInt, String>>>> listType = new TypeToken<List<Set<Map<MyInt, String>>>>() {};
-    private TypeToken<Set<Map<MyInt, String>>> elementsType = new TypeToken<Set<Map<MyInt, String>>>() {};
-    // @formatter:on
+    private TypeToken<List<Set<Map<MyInt, String>>>> listType = new TypeToken<List<Set<Map<MyInt, String>>>>() {
+    };
+    private TypeToken<Set<Map<MyInt, String>>> elementsType = new TypeToken<Set<Map<MyInt, String>>>() {
+    };
 
+    // @formatter:on
 
     @Override
     public void onTestContextInitialized() {
         execute(
-                "CREATE TABLE IF NOT EXISTS \"myTable\" ("
-                        + "pk int PRIMARY KEY, "
-                        + "v frozen<list<frozen<set<frozen<map<int,text>>>>>>"
-                        + ")"
-        );
+        "CREATE TABLE IF NOT EXISTS \"myTable\" ("
+                + "pk int PRIMARY KEY, "
+                + "v frozen<list<frozen<set<frozen<map<int,text>>>>>>"
+                + ")");
     }
 
     public Cluster.Builder createClusterBuilder() {
         return Cluster.builder().withCodecRegistry(
                 new CodecRegistry().register(new MyIntCodec()) // global User <-> varchar codec
-        );
+                );
     }
 
     @BeforeClass(groups = "short")
@@ -111,11 +112,11 @@ public class TypeCodecNestedCollectionsIntegrationTest extends CCMTestsSupport {
         session().execute(session().prepare(insertQuery).bind()
                 .setInt(0, pk)
                 .setList(1, v, elementsType) // variant with element type explicitly set
-        );
+                );
         PreparedStatement ps = session().prepare(selectQuery);
         ResultSet rows = session().execute(ps.bind()
-                        .setInt(0, pk)
-        );
+                .setInt(0, pk)
+                );
         Row row = rows.one();
         assertRow(row);
     }
@@ -123,13 +124,13 @@ public class TypeCodecNestedCollectionsIntegrationTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void should_work_with_prepared_statements_3() {
         session().execute(session().prepare(insertQuery).bind()
-                        .setInt(0, pk)
-                        .set(1, v, listType)
-        );
+                .setInt(0, pk)
+                .set(1, v, listType)
+                );
         PreparedStatement ps = session().prepare(selectQuery);
         ResultSet rows = session().execute(ps.bind()
-                        .setInt(0, pk)
-        );
+                .setInt(0, pk)
+                );
         Row row = rows.one();
         assertRow(row);
     }
@@ -137,13 +138,13 @@ public class TypeCodecNestedCollectionsIntegrationTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void should_work_with_built_statements() {
         session().execute(session().prepare(insertStmt).bind()
-                        .setInt(0, pk)
-                        .set(1, v, listType)
-        );
+                .setInt(0, pk)
+                .set(1, v, listType)
+                );
         PreparedStatement ps = session().prepare(selectStmt);
         ResultSet rows = session().execute(ps.bind()
-                        .setInt(0, pk)
-        );
+                .setInt(0, pk)
+                );
         Row row = rows.one();
         assertRow(row);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNestedUDTAndTupleIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNestedUDTAndTupleIntegrationTest.java
@@ -47,8 +47,7 @@ public class TypeCodecNestedUDTAndTupleIntegrationTest extends CCMTestsSupport {
                 // we receive a ResultSet
                 "INSERT INTO t1 (pk, c1) VALUES (1, {f1:{f2:{f3:'foo'}}})",
                 "INSERT INTO t1 (pk, c2) VALUES (2, ((('foo'))))",
-                "INSERT INTO t1 (pk, c3) VALUES (3, ((({f1:{f2:{f3:'foo'}}}))))"
-        );
+                "INSERT INTO t1 (pk, c3) VALUES (3, ((({f1:{f2:{f3:'foo'}}}))))");
     }
 
     @Test(groups = "short")
@@ -101,6 +100,5 @@ public class TypeCodecNestedUDTAndTupleIntegrationTest extends CCMTestsSupport {
         String f3 = udt3.getString("f3");
         assertThat(f3).isEqualTo("foo");
     }
-
 
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNumbersIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNumbersIntegrationTest.java
@@ -39,16 +39,15 @@ public class TypeCodecNumbersIntegrationTest extends CCMTestsSupport {
     @Override
     public void onTestContextInitialized() {
         execute(
-                "CREATE TABLE \"myTable\" ("
-                        + "c_int int, "
-                        + "c_bigint bigint, "
-                        + "c_float float, "
-                        + "c_double double, "
-                        + "c_varint varint, "
-                        + "c_decimal decimal, "
-                        + "PRIMARY KEY (c_int, c_bigint)"
-                        + ")"
-        );
+        "CREATE TABLE \"myTable\" ("
+                + "c_int int, "
+                + "c_bigint bigint, "
+                + "c_float float, "
+                + "c_double double, "
+                + "c_varint varint, "
+                + "c_decimal decimal, "
+                + "PRIMARY KEY (c_int, c_bigint)"
+                + ")");
     }
 
     @Test(groups = "short")
@@ -72,18 +71,18 @@ public class TypeCodecNumbersIntegrationTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void should_use_default_codecs_with_prepared_statements_2() {
         session().execute(session().prepare(insertQuery).bind()
-                        .setInt(0, n_int)
-                        .setLong(1, n_bigint)
-                        .setFloat(2, n_float)
-                        .setDouble(3, n_double)
-                        .setVarint(4, n_varint)
-                        .setDecimal(5, n_decimal)
-        );
+                .setInt(0, n_int)
+                .setLong(1, n_bigint)
+                .setFloat(2, n_float)
+                .setDouble(3, n_double)
+                .setVarint(4, n_varint)
+                .setDecimal(5, n_decimal)
+                );
         PreparedStatement ps = session().prepare(selectQuery);
         ResultSet rows = session().execute(ps.bind()
-                        .setInt(0, n_int)
-                        .setLong(1, n_bigint)
-        );
+                .setInt(0, n_int)
+                .setLong(1, n_bigint)
+                );
         Row row = rows.one();
         assertRow(row);
     }
@@ -91,18 +90,18 @@ public class TypeCodecNumbersIntegrationTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void should_use_default_codecs_with_prepared_statements_3() {
         session().execute(session().prepare(insertQuery).bind()
-                        .set(0, n_int, Integer.class)
-                        .set(1, n_bigint, Long.class)
-                        .set(2, n_float, Float.class)
-                        .set(3, n_double, Double.class)
-                        .set(4, n_varint, BigInteger.class)
-                        .set(5, n_decimal, BigDecimal.class)
-        );
+                .set(0, n_int, Integer.class)
+                .set(1, n_bigint, Long.class)
+                .set(2, n_float, Float.class)
+                .set(3, n_double, Double.class)
+                .set(4, n_varint, BigInteger.class)
+                .set(5, n_decimal, BigDecimal.class)
+                );
         PreparedStatement ps = session().prepare(selectQuery);
         ResultSet rows = session().execute(ps.bind()
-                        .setInt(0, n_int)
-                        .setLong(1, n_bigint)
-        );
+                .setInt(0, n_int)
+                .setLong(1, n_bigint)
+                );
         Row row = rows.one();
         assertRow(row);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecOverlappingJavaTypeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecOverlappingJavaTypeIntegrationTest.java
@@ -37,18 +37,17 @@ public class TypeCodecOverlappingJavaTypeIntegrationTest extends CCMTestsSupport
     @Override
     public void onTestContextInitialized() {
         execute(
-                "CREATE TABLE \"myTable\" ("
-                        + "c_int int PRIMARY KEY, "
-                        + "l_int list<int>, "
-                        + "c_text text "
-                        + ")"
-        );
+        "CREATE TABLE \"myTable\" ("
+                + "c_int int PRIMARY KEY, "
+                + "l_int list<int>, "
+                + "c_text text "
+                + ")");
     }
 
     public Cluster.Builder createClusterBuilder() {
         return Cluster.builder().withCodecRegistry(
                 new CodecRegistry().register(new IntToStringCodec())
-        );
+                );
     }
 
     @Test(groups = "short")
@@ -59,13 +58,13 @@ public class TypeCodecOverlappingJavaTypeIntegrationTest extends CCMTestsSupport
                         .setInt(0, 42)
                         .setList(1, newArrayList(42))
                         .setString(2, "42") // here we have the CQL type so VarcharCodec will be used even if IntToStringCodec accepts it
-        );
+                );
         session().execute(
                 ps.bind()
                         .setString(0, "42")
                         .setList(1, newArrayList("42"), String.class)
                         .setString(2, "42") // here we have the CQL type so VarcharCodec will be used even if IntToStringCodec accepts it
-        );
+                );
         ps = session().prepare(selectQuery);
         assertRow(session().execute(ps.bind().setInt(0, 42)).one());
         assertRow(session().execute(ps.bind().setString(0, "42")).one());

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
@@ -39,8 +39,10 @@ public class TypeCodecTest {
     public static final DataType CUSTOM_FOO = DataType.custom("com.example.FooBar");
 
     // @formatter:off
-    public static final TypeToken<List<A>> LIST_OF_A_TOKEN = new TypeToken<List<A>>() {};
-    public static final TypeToken<List<B>> LIST_OF_B_TOKEN = new TypeToken<List<B>>() {};
+    public static final TypeToken<List<A>> LIST_OF_A_TOKEN = new TypeToken<List<A>>() {
+    };
+    public static final TypeToken<List<B>> LIST_OF_B_TOKEN = new TypeToken<List<B>>() {
+    };
     // @formatter:on
 
     private CodecRegistry codecRegistry = new CodecRegistry();
@@ -204,7 +206,6 @@ public class TypeCodecTest {
         assertThat(actualB.getJavaType()).isEqualTo(expectedB.getJavaType());
     }
 
-
     @Test(groups = "unit")
     public void should_deserialize_empty_buffer_as_tuple_with_null_values() {
         CodecRegistry codecRegistry = new CodecRegistry();
@@ -223,7 +224,7 @@ public class TypeCodecTest {
                 new UserType.Field("t", DataType.text()),
                 new UserType.Field("i", DataType.cint()),
                 new UserType.Field("l", DataType.list(DataType.text()))
-        ), ProtocolVersion.NEWEST_SUPPORTED, codecRegistry);
+                ), ProtocolVersion.NEWEST_SUPPORTED, codecRegistry);
         UDTValue expected = udt.newValue();
         expected.setString("t", null);
         expected.setToNull("i");
@@ -251,7 +252,6 @@ public class TypeCodecTest {
                 .cannotSerialize(type4UUID)
                 .cannotFormat(type4UUID);
     }
-
 
     /**
      * Ensures that primitive types are correctly handled and wrapped when necessary.
@@ -361,7 +361,6 @@ public class TypeCodecTest {
             return null; // not tested
         }
     }
-
 
     class BCodec extends TypeCodec<B> {
 

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTupleIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTupleIntegrationTest.java
@@ -40,9 +40,7 @@ public class TypeCodecTupleIntegrationTest extends CCMTestsSupport {
 
     @Override
     public void onTestContextInitialized() {
-        execute(
-                "CREATE TABLE IF NOT EXISTS \"users\" (id uuid PRIMARY KEY, name text, location frozen<tuple<float,float>>)"
-        );
+        execute("CREATE TABLE IF NOT EXISTS \"users\" (id uuid PRIMARY KEY, name text, location frozen<tuple<float,float>>)");
     }
 
     @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecUDTIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecUDTIntegrationTest.java
@@ -48,8 +48,7 @@ public class TypeCodecUDTIntegrationTest extends CCMTestsSupport {
         execute(
                 "CREATE TYPE IF NOT EXISTS \"phone\" (number text, tags set<text>)",
                 "CREATE TYPE IF NOT EXISTS \"address\" (street text, zipcode int, phones list<frozen<phone>>)",
-                "CREATE TABLE IF NOT EXISTS \"users\" (id uuid PRIMARY KEY, name text, address frozen<address>)"
-        );
+                "CREATE TABLE IF NOT EXISTS \"users\" (id uuid PRIMARY KEY, name text, address frozen<address>)");
     }
 
     @Test(groups = "short")
@@ -87,8 +86,7 @@ public class TypeCodecUDTIntegrationTest extends CCMTestsSupport {
         TypeCodec<UDTValue> phoneTypeCodec = TypeCodec.userType(phoneType);
         codecRegistry
                 .register(new AddressCodec(addressTypeCodec, Address.class))
-                .register(new PhoneCodec(phoneTypeCodec, Phone.class))
-        ;
+                .register(new PhoneCodec(phoneTypeCodec, Phone.class));
         session.execute(insertQuery, uuid, "John Doe", address);
         ResultSet rows = session.execute(selectQuery, uuid);
         Row row = rows.one();

--- a/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
@@ -29,22 +29,22 @@ public class UnresolvedUserTypeTest extends CCMTestsSupport {
     @Override
     public void onTestContextInitialized() {
         execute(
-            /*
-            Creates the following acyclic graph (edges directed upwards
-            meaning "depends on"):
+                /*
+                Creates the following acyclic graph (edges directed upwards
+                meaning "depends on"):
 
-                H   G
-               / \ /\
-              F   |  E
-               \ /  /
-                D  /
-               / \/
-              B  C
-                 |
-                 A
+                    H   G
+                   / \ /\
+                  F   |  E
+                   \ /  /
+                    D  /
+                   / \/
+                  B  C
+                     |
+                     A
 
-             Topological sort order should be : GH,FE,D,CB,A
-             */
+                 Topological sort order should be : GH,FE,D,CB,A
+                 */
                 String.format("CREATE TYPE %s.h (f1 int)", keyspace),
                 String.format("CREATE TYPE %s.g (f1 int)", keyspace),
                 String.format("CREATE TYPE %s.\"F\" (f1 frozen<h>)", keyspace),
@@ -52,8 +52,7 @@ public class UnresolvedUserTypeTest extends CCMTestsSupport {
                 String.format("CREATE TYPE %s.\"D\" (f1 frozen<tuple<\"F\",g,h>>)", keyspace),
                 String.format("CREATE TYPE %s.\"C\" (f1 frozen<map<\"E\",\"D\">>)", keyspace),
                 String.format("CREATE TYPE %s.\"B\" (f1 frozen<set<\"D\">>)", keyspace),
-                String.format("CREATE TYPE %s.\"A\" (f1 frozen<\"C\">)", keyspace)
-        );
+                String.format("CREATE TYPE %s.\"A\" (f1 frozen<\"C\">)", keyspace));
     }
 
     @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/exceptions/FunctionExecutionExceptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/exceptions/FunctionExecutionExceptionTest.java
@@ -24,14 +24,12 @@ import org.testng.annotations.Test;
 @CCMConfig(config = "enable_user_defined_functions:true")
 public class FunctionExecutionExceptionTest extends CCMTestsSupport {
 
-
     @Override
     public void onTestContextInitialized() {
         execute(
                 "CREATE TABLE foo (k int primary key, i int, l list<int>)",
                 "INSERT INTO foo (k, i, l) VALUES (1, 1, [1])",
-                "CREATE FUNCTION element_at(l list<int>, i int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return (Integer) l.get(i);'"
-        );
+                "CREATE FUNCTION element_at(l list<int>, i int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return (Integer) l.get(i);'");
     }
 
     @Test(groups = "short", expectedExceptions = FunctionExecutionException.class)

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/CustomRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/CustomRetryPolicyIntegrationTest.java
@@ -63,7 +63,8 @@ public class CustomRetryPolicyIntegrationTest extends AbstractRetryPolicyIntegra
         try {
             query();
             fail("expected an UnavailableException");
-        } catch (UnavailableException e) {/*expected*/}
+        } catch (UnavailableException e) {/*expected*/
+        }
 
         assertOnUnavailableWasCalled(2);
         assertThat(errors.getRetries().getCount()).isEqualTo(1);
@@ -80,16 +81,16 @@ public class CustomRetryPolicyIntegrationTest extends AbstractRetryPolicyIntegra
         try {
             scassandras
                     .node(1).primingClient().prime(PrimingRequest.queryBuilder()
-                    .withQuery("mock query")
-                    .withThen(then().withFixedDelay(1000L).withRows(row("result", "result1")))
-                    .build());
+                            .withQuery("mock query")
+                            .withThen(then().withFixedDelay(1000L).withRows(row("result", "result1")))
+                            .build());
             try {
                 query();
                 fail("expected an OperationTimedOutException");
             } catch (OperationTimedOutException e) {
                 assertThat(e.getMessage()).isEqualTo(
                         String.format("[%s] Timed out waiting for server response", host1.getSocketAddress())
-                );
+                        );
             }
             assertOnRequestErrorWasCalled(1, OperationTimedOutException.class);
             assertThat(errors.getRetries().getCount()).isEqualTo(0);
@@ -102,7 +103,6 @@ public class CustomRetryPolicyIntegrationTest extends AbstractRetryPolicyIntegra
             cluster.getConfiguration().getSocketOptions().setReadTimeoutMillis(SocketOptions.DEFAULT_READ_TIMEOUT_MILLIS);
         }
     }
-
 
     @Test(groups = "short", dataProvider = "serverSideErrors")
     public void should_rethrow_on_server_side_error(Result error, Class<? extends DriverException> exception) {
@@ -122,7 +122,6 @@ public class CustomRetryPolicyIntegrationTest extends AbstractRetryPolicyIntegra
         assertQueried(3, 0);
     }
 
-
     @Test(groups = "short", dataProvider = "connectionErrors")
     public void should_rethrow_on_connection_error(CloseType closeType) {
         simulateError(1, closed_connection, new ClosedConnectionConfig(closeType));
@@ -132,7 +131,7 @@ public class CustomRetryPolicyIntegrationTest extends AbstractRetryPolicyIntegra
         } catch (TransportException e) {
             assertThat(e.getMessage()).isEqualTo(
                     String.format("[%s] Connection has been closed", host1.getSocketAddress())
-            );
+                    );
         }
         assertOnRequestErrorWasCalled(1, TransportException.class);
         assertThat(errors.getRetries().getCount()).isEqualTo(0);
@@ -173,9 +172,11 @@ public class CustomRetryPolicyIntegrationTest extends AbstractRetryPolicyIntegra
         }
 
         @Override
-        public void init(Cluster cluster) {/*nothing to do*/}
+        public void init(Cluster cluster) {/*nothing to do*/
+        }
 
         @Override
-        public void close() {/*nothing to do*/}
+        public void close() {/*nothing to do*/
+        }
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/DefaultRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/DefaultRetryPolicyIntegrationTest.java
@@ -46,7 +46,8 @@ public class DefaultRetryPolicyIntegrationTest extends AbstractRetryPolicyIntegr
         try {
             query();
             fail("expected a ReadTimeoutException");
-        } catch (ReadTimeoutException e) {/*expected*/ }
+        } catch (ReadTimeoutException e) {/*expected*/
+        }
 
         assertOnReadTimeoutWasCalled(1);
         assertThat(errors.getReadTimeouts().getCount()).isEqualTo(1);
@@ -64,7 +65,8 @@ public class DefaultRetryPolicyIntegrationTest extends AbstractRetryPolicyIntegr
         try {
             query();
             fail("expected a WriteTimeoutException");
-        } catch (WriteTimeoutException e) {/*expected*/}
+        } catch (WriteTimeoutException e) {/*expected*/
+        }
 
         assertOnWriteTimeoutWasCalled(1);
         assertThat(errors.getWriteTimeouts().getCount()).isEqualTo(1);
@@ -99,7 +101,8 @@ public class DefaultRetryPolicyIntegrationTest extends AbstractRetryPolicyIntegr
         try {
             query();
             fail("expected an UnavailableException");
-        } catch (UnavailableException e) {/*expected*/}
+        } catch (UnavailableException e) {/*expected*/
+        }
 
         assertOnUnavailableWasCalled(2);
         assertThat(errors.getUnavailables().getCount()).isEqualTo(2);
@@ -162,19 +165,19 @@ public class DefaultRetryPolicyIntegrationTest extends AbstractRetryPolicyIntegr
         try {
             scassandras
                     .node(1).primingClient().prime(PrimingRequest.queryBuilder()
-                    .withQuery("mock query")
-                    .withThen(then().withFixedDelay(1000L).withRows(row("result", "result1")))
-                    .build());
+                            .withQuery("mock query")
+                            .withThen(then().withFixedDelay(1000L).withRows(row("result", "result1")))
+                            .build());
             scassandras
                     .node(2).primingClient().prime(PrimingRequest.queryBuilder()
-                    .withQuery("mock query")
-                    .withThen(then().withFixedDelay(1000L).withRows(row("result", "result2")))
-                    .build());
+                            .withQuery("mock query")
+                            .withThen(then().withFixedDelay(1000L).withRows(row("result", "result2")))
+                            .build());
             scassandras
                     .node(3).primingClient().prime(PrimingRequest.queryBuilder()
-                    .withQuery("mock query")
-                    .withThen(then().withFixedDelay(1000L).withRows(row("result", "result3")))
-                    .build());
+                            .withQuery("mock query")
+                            .withThen(then().withFixedDelay(1000L).withRows(row("result", "result3")))
+                            .build());
             try {
                 query();
                 fail("expected a NoHostAvailableException");
@@ -204,7 +207,6 @@ public class DefaultRetryPolicyIntegrationTest extends AbstractRetryPolicyIntegr
         }
     }
 
-
     @Test(groups = "short", dataProvider = "serverSideErrors")
     public void should_try_next_host_on_server_side_error(Result error, Class<? extends DriverException> exception) {
         simulateError(1, error);
@@ -228,7 +230,6 @@ public class DefaultRetryPolicyIntegrationTest extends AbstractRetryPolicyIntegr
         assertQueried(2, 1);
         assertQueried(3, 1);
     }
-
 
     @Test(groups = "short", dataProvider = "connectionErrors")
     public void should_try_next_host_on_connection_error(ClosedConnectionConfig.CloseType closeType) {

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/DowngradingConsistencyRetryPolicyIntegrationTest.java
@@ -51,7 +51,6 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         };
     }
 
-
     /**
      * @return Write Types for which we expect a rethrow if used and there are no received acks.
      */
@@ -64,7 +63,6 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
                 {WriteTypePrime.CAS}
         };
     }
-
 
     /**
      * @return Write Types for which we expect an ignore if used and there are received acks.
@@ -133,7 +131,6 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         assertQueried(3, 0);
     }
 
-
     /**
      * Ensures that when handling a read timeout with {@link DowngradingConsistencyRetryPolicy} that a retry is
      * reattempted if data was not retrieved, but enough replicas were alive to handle the request.
@@ -147,7 +144,8 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         try {
             query();
             fail("expected an ReadTimeoutException");
-        } catch (ReadTimeoutException e) {/*expected*/}
+        } catch (ReadTimeoutException e) {/*expected*/
+        }
 
         assertOnReadTimeoutWasCalled(2);
         assertThat(errors.getRetries().getCount()).isEqualTo(1);
@@ -157,7 +155,6 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         assertQueried(2, 0);
         assertQueried(3, 0);
     }
-
 
     /**
      * Ensures that when handling a read timeout with {@link DowngradingConsistencyRetryPolicy} that a retry is not
@@ -173,7 +170,8 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         try {
             query();
             fail("expected a ReadTimeoutException");
-        } catch (ReadTimeoutException e) {/*expected*/ }
+        } catch (ReadTimeoutException e) {/*expected*/
+        }
 
         assertOnReadTimeoutWasCalled(1);
         assertThat(errors.getReadTimeouts().getCount()).isEqualTo(1);
@@ -183,7 +181,6 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         assertQueried(2, 0);
         assertQueried(3, 0);
     }
-
 
     /**
      * Ensures that when handling a write timeout with {@link DowngradingConsistencyRetryPolicy} that it rethrows
@@ -199,7 +196,8 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         try {
             query();
             fail("expected a WriteTimeoutException");
-        } catch (WriteTimeoutException e) {/*expected*/}
+        } catch (WriteTimeoutException e) {/*expected*/
+        }
 
         assertOnWriteTimeoutWasCalled(1);
         assertThat(errors.getWriteTimeouts().getCount()).isEqualTo(1);
@@ -209,7 +207,6 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         assertQueried(2, 0);
         assertQueried(3, 0);
     }
-
 
     /**
      * Ensures that when handling a write timeout with {@link DowngradingConsistencyRetryPolicy} that it ignores
@@ -235,7 +232,6 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         assertQueried(3, 0);
     }
 
-
     /**
      * Ensures that when handling a write timeout with {@link DowngradingConsistencyRetryPolicy} that a retry is
      * attempted on the same host if the {@link WriteType} is {@link WriteType#BATCH_LOG}.
@@ -249,7 +245,8 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         try {
             query();
             fail("expected a WriteTimeoutException");
-        } catch (WriteTimeoutException e) {/*expected*/}
+        } catch (WriteTimeoutException e) {/*expected*/
+        }
 
         assertOnWriteTimeoutWasCalled(2);
         assertThat(errors.getRetries().getCount()).isEqualTo(1);
@@ -259,7 +256,6 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         assertQueried(2, 0);
         assertQueried(3, 0);
     }
-
 
     /**
      * Ensures that when handling a write timeout with {@link DowngradingConsistencyRetryPolicy} that a retry is
@@ -290,7 +286,6 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         assertQueried(3, 0);
     }
 
-
     /**
      * Ensures that when handling an unavailable with {@link DowngradingConsistencyRetryPolicy} that a retry is
      * reattempted with a {@link ConsistencyLevel} that matches min(received acknowledgements, THREE) and is only
@@ -320,7 +315,6 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         assertQueried(3, 0);
     }
 
-
     /**
      * Ensures that when handling an unavailable with {@link DowngradingConsistencyRetryPolicy} that a retry is
      * is not reattempted if no replicas are alive.
@@ -334,7 +328,8 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         try {
             query();
             fail("expected an UnavailableException");
-        } catch (UnavailableException e) {/*expected*/}
+        } catch (UnavailableException e) {/*expected*/
+        }
 
         assertOnUnavailableWasCalled(1);
         assertThat(errors.getRetries().getCount()).isEqualTo(0);
@@ -358,19 +353,19 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         try {
             scassandras
                     .node(1).primingClient().prime(PrimingRequest.queryBuilder()
-                    .withQuery("mock query")
-                    .withThen(then().withFixedDelay(1000L).withRows(row("result", "result1")))
-                    .build());
+                            .withQuery("mock query")
+                            .withThen(then().withFixedDelay(1000L).withRows(row("result", "result1")))
+                            .build());
             scassandras
                     .node(2).primingClient().prime(PrimingRequest.queryBuilder()
-                    .withQuery("mock query")
-                    .withThen(then().withFixedDelay(1000L).withRows(row("result", "result2")))
-                    .build());
+                            .withQuery("mock query")
+                            .withThen(then().withFixedDelay(1000L).withRows(row("result", "result2")))
+                            .build());
             scassandras
                     .node(3).primingClient().prime(PrimingRequest.queryBuilder()
-                    .withQuery("mock query")
-                    .withThen(then().withFixedDelay(1000L).withRows(row("result", "result3")))
-                    .build());
+                            .withQuery("mock query")
+                            .withThen(then().withFixedDelay(1000L).withRows(row("result", "result3")))
+                            .build());
             try {
                 query();
                 Assertions.fail("expected a NoHostAvailableException");
@@ -399,7 +394,6 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
             cluster.getConfiguration().getSocketOptions().setReadTimeoutMillis(SocketOptions.DEFAULT_READ_TIMEOUT_MILLIS);
         }
     }
-
 
     /**
      * Ensures that when handling a server error defined in {@link #serverSideErrors} with
@@ -433,7 +427,6 @@ public class DowngradingConsistencyRetryPolicyIntegrationTest extends AbstractRe
         assertQueried(2, 1);
         assertQueried(3, 1);
     }
-
 
     /**
      * Ensures that when handling a connection error caused by the connection closing during a request in a way

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/EC2MultiRegionAddressTranslatorTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/EC2MultiRegionAddressTranslatorTest.java
@@ -79,19 +79,17 @@ public class EC2MultiRegionAddressTranslatorTest {
     public void should_build_reversed_domain_name_for_ip_v4() throws Exception {
         InetAddress address = InetAddress.getByName("192.0.2.5");
         assertThat(
-                EC2MultiRegionAddressTranslator.reverse(address)
-        ).isEqualTo(
+                EC2MultiRegionAddressTranslator.reverse(address)).isEqualTo(
                 "5.2.0.192.in-addr.arpa"
-        );
+                );
     }
 
     @Test(groups = "unit")
     public void should_build_reversed_domain_name_for_ip_v6() throws Exception {
         InetAddress address = InetAddress.getByName("2001:db8::567:89ab");
         assertThat(
-                EC2MultiRegionAddressTranslator.reverse(address)
-        ).isEqualTo(
+                EC2MultiRegionAddressTranslator.reverse(address)).isEqualTo(
                 "b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa"
-        );
+                );
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/FallthroughRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/FallthroughRetryPolicyIntegrationTest.java
@@ -41,7 +41,8 @@ public class FallthroughRetryPolicyIntegrationTest extends AbstractRetryPolicyIn
         try {
             query();
             fail("expected a ReadTimeoutException");
-        } catch (ReadTimeoutException e) {/*expected*/ }
+        } catch (ReadTimeoutException e) {/*expected*/
+        }
 
         assertOnReadTimeoutWasCalled(1);
         assertThat(errors.getRetriesOnReadTimeout().getCount()).isEqualTo(0);
@@ -57,7 +58,8 @@ public class FallthroughRetryPolicyIntegrationTest extends AbstractRetryPolicyIn
         try {
             query();
             fail("expected a WriteTimeoutException");
-        } catch (WriteTimeoutException e) {/*expected*/}
+        } catch (WriteTimeoutException e) {/*expected*/
+        }
 
         assertOnWriteTimeoutWasCalled(1);
         assertThat(errors.getRetriesOnWriteTimeout().getCount()).isEqualTo(0);
@@ -73,7 +75,8 @@ public class FallthroughRetryPolicyIntegrationTest extends AbstractRetryPolicyIn
         try {
             query();
             fail("expected an UnavailableException");
-        } catch (UnavailableException e) {/*expected*/}
+        } catch (UnavailableException e) {/*expected*/
+        }
 
         assertOnUnavailableWasCalled(1);
         assertThat(errors.getRetriesOnUnavailable().getCount()).isEqualTo(0);
@@ -88,16 +91,16 @@ public class FallthroughRetryPolicyIntegrationTest extends AbstractRetryPolicyIn
         try {
             scassandras
                     .node(1).primingClient().prime(PrimingRequest.queryBuilder()
-                    .withQuery("mock query")
-                    .withThen(then().withFixedDelay(1000L).withRows(row("result", "result1")))
-                    .build());
+                            .withQuery("mock query")
+                            .withThen(then().withFixedDelay(1000L).withRows(row("result", "result1")))
+                            .build());
             try {
                 query();
                 Fail.fail("expected an OperationTimedOutException");
             } catch (OperationTimedOutException e) {
                 assertThat(e.getMessage()).isEqualTo(
                         String.format("[%s] Timed out waiting for server response", host1.getSocketAddress())
-                );
+                        );
             }
             assertOnRequestErrorWasCalled(1, OperationTimedOutException.class);
             assertThat(errors.getRetries().getCount()).isEqualTo(0);
@@ -110,7 +113,6 @@ public class FallthroughRetryPolicyIntegrationTest extends AbstractRetryPolicyIn
             cluster.getConfiguration().getSocketOptions().setReadTimeoutMillis(SocketOptions.DEFAULT_READ_TIMEOUT_MILLIS);
         }
     }
-
 
     @Test(groups = "short", dataProvider = "serverSideErrors")
     public void should_rethrow_on_server_side_error(Result error, Class<? extends DriverException> exception) {
@@ -130,7 +132,6 @@ public class FallthroughRetryPolicyIntegrationTest extends AbstractRetryPolicyIn
         assertQueried(3, 0);
     }
 
-
     @Test(groups = "short", dataProvider = "connectionErrors")
     public void should_rethrow_on_connection_error(CloseType closeType) {
         simulateError(1, Result.closed_connection, new ClosedConnectionConfig(closeType));
@@ -140,7 +141,7 @@ public class FallthroughRetryPolicyIntegrationTest extends AbstractRetryPolicyIn
         } catch (TransportException e) {
             assertThat(e.getMessage()).isEqualTo(
                     String.format("[%s] Connection has been closed", host1.getSocketAddress())
-            );
+                    );
         }
         assertOnRequestErrorWasCalled(1, TransportException.class);
         assertThat(errors.getRetries().getCount()).isEqualTo(0);

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/IdempotenceAwareRetryPolicyIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/IdempotenceAwareRetryPolicyIntegrationTest.java
@@ -51,7 +51,8 @@ public class IdempotenceAwareRetryPolicyIntegrationTest extends AbstractRetryPol
         try {
             query();
             fail("expected an WriteTimeoutException");
-        } catch (WriteTimeoutException e) {/* expected */}
+        } catch (WriteTimeoutException e) {/* expected */
+        }
         assertOnWriteTimeoutWasCalled(1);
         assertThat(errors.getWriteTimeouts().getCount()).isEqualTo(1);
         assertThat(errors.getRetries().getCount()).isEqualTo(0);
@@ -80,16 +81,16 @@ public class IdempotenceAwareRetryPolicyIntegrationTest extends AbstractRetryPol
         try {
             scassandras
                     .node(1).primingClient().prime(PrimingRequest.queryBuilder()
-                    .withQuery("mock query")
-                    .withThen(then().withFixedDelay(1000L).withRows(row("result", "result1")))
-                    .build());
+                            .withQuery("mock query")
+                            .withThen(then().withFixedDelay(1000L).withRows(row("result", "result1")))
+                            .build());
             try {
                 query();
                 fail("expected an OperationTimedOutException");
             } catch (OperationTimedOutException e) {
                 assertThat(e.getMessage()).isEqualTo(
                         String.format("[%s] Timed out waiting for server response", host1.getSocketAddress())
-                );
+                        );
             }
             assertOnRequestErrorWasCalled(1, OperationTimedOutException.class);
             assertThat(errors.getClientTimeouts().getCount()).isEqualTo(1);
@@ -109,9 +110,9 @@ public class IdempotenceAwareRetryPolicyIntegrationTest extends AbstractRetryPol
         try {
             scassandras
                     .node(1).primingClient().prime(PrimingRequest.queryBuilder()
-                    .withQuery("mock query")
-                    .withThen(then().withFixedDelay(1000L).withRows(row("result", "result1")))
-                    .build());
+                            .withQuery("mock query")
+                            .withThen(then().withFixedDelay(1000L).withRows(row("result", "result1")))
+                            .build());
             session.execute(new SimpleStatement("mock query").setIdempotent(true));
             assertOnRequestErrorWasCalled(1, OperationTimedOutException.class);
             assertThat(errors.getClientTimeouts().getCount()).isEqualTo(1);
@@ -124,7 +125,6 @@ public class IdempotenceAwareRetryPolicyIntegrationTest extends AbstractRetryPol
             cluster.getConfiguration().getSocketOptions().setReadTimeoutMillis(SocketOptions.DEFAULT_READ_TIMEOUT_MILLIS);
         }
     }
-
 
     @Test(groups = "short", dataProvider = "serverSideErrors")
     public void should_not_retry_on_server_error_if_statement_non_idempotent(Result error, Class<? extends DriverException> exception) {
@@ -169,7 +169,6 @@ public class IdempotenceAwareRetryPolicyIntegrationTest extends AbstractRetryPol
         assertQueried(3, 1);
     }
 
-
     @Test(groups = "short", dataProvider = "connectionErrors")
     public void should_not_retry_on_connection_error_if_statement_non_idempotent(ClosedConnectionConfig.CloseType closeType) {
         simulateError(1, closed_connection, new ClosedConnectionConfig(closeType));
@@ -181,7 +180,7 @@ public class IdempotenceAwareRetryPolicyIntegrationTest extends AbstractRetryPol
         } catch (TransportException e) {
             assertThat(e.getMessage()).isEqualTo(
                     String.format("[%s] Connection has been closed", host1.getSocketAddress())
-            );
+                    );
         }
         assertOnRequestErrorWasCalled(1, TransportException.class);
         assertThat(errors.getRetries().getCount()).isEqualTo(0);
@@ -192,7 +191,6 @@ public class IdempotenceAwareRetryPolicyIntegrationTest extends AbstractRetryPol
         assertQueried(2, 0);
         assertQueried(3, 0);
     }
-
 
     @Test(groups = "short", dataProvider = "connectionErrors")
     public void should_retry_on_connection_error_if_statement_idempotent(ClosedConnectionConfig.CloseType closeType) {
@@ -236,7 +234,6 @@ public class IdempotenceAwareRetryPolicyIntegrationTest extends AbstractRetryPol
 
         Mockito.verify(innerPolicyMock).close();
     }
-
 
     /**
      * Retries everything on the next host.

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/LatencyAwarePolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/LatencyAwarePolicyTest.java
@@ -69,7 +69,7 @@ public class LatencyAwarePolicyTest extends ScassandraTestBase {
                 queryBuilder()
                         .withQuery(query)
                         .build()
-        );
+                );
         LatencyAwarePolicy latencyAwarePolicy = LatencyAwarePolicy.builder(new RoundRobinPolicy())
                 .withMininumMeasurements(1)
                 .build();
@@ -108,7 +108,7 @@ public class LatencyAwarePolicyTest extends ScassandraTestBase {
                         .withQuery(query)
                         .withResult(unavailable)
                         .build()
-        );
+                );
         LatencyAwarePolicy latencyAwarePolicy = LatencyAwarePolicy.builder(new RoundRobinPolicy())
                 .withMininumMeasurements(1)
                 .build();
@@ -152,7 +152,7 @@ public class LatencyAwarePolicyTest extends ScassandraTestBase {
                         .withQuery(query)
                         .withResult(read_request_timeout)
                         .build()
-        );
+                );
 
         LatencyAwarePolicy latencyAwarePolicy = LatencyAwarePolicy.builder(new RoundRobinPolicy())
                 .withMininumMeasurements(1)

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilder21ExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilder21ExecutionTest.java
@@ -42,8 +42,7 @@ public class QueryBuilder21ExecutionTest extends CCMTestsSupport {
                 "INSERT INTO products(id, description, price, categories, buyers, features_keys, features_values) " +
                         "VALUES (29412, '32-inch LED HDTV (black)', 929, {'tv', 'hdtv'}, [1,2,3], {'screen' : '32-inch', 'techno' : 'LED'}, {'screen' : '32-inch', 'techno' : 'LED'})",
                 "INSERT INTO products(id, description, price, categories, buyers, features_keys, features_values) " +
-                        "VALUES (38471, '32-inch LCD TV', 110, {'tv', 'used'}, [2,4], {'screen' : '32-inch', 'techno' : 'LCD'}, {'screen' : '32-inch', 'techno' : 'LCD'})"
-        );
+                        "VALUES (38471, '32-inch LCD TV', 110, {'tv', 'used'}, [2,4], {'screen' : '32-inch', 'techno' : 'LCD'}, {'screen' : '32-inch', 'techno' : 'LCD'})");
     }
 
     @Test(groups = "short")
@@ -87,7 +86,6 @@ public class QueryBuilder21ExecutionTest extends CCMTestsSupport {
         assertThat(row.getInt("id")).isEqualTo(29412);
         assertThat(row.getMap("features_values", String.class, String.class)).containsEntry("techno", "LED");
     }
-
 
     @Test(groups = "short")
     public void should_handle_contains_key_on_map_with_index() {

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
@@ -46,8 +46,7 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
                 insertInto(TABLE2).value("k", "cast_t").value("t", "a").value("i", 1).value("f", 1.1).toString(),
                 insertInto(TABLE2).value("k", "cast_t").value("t", "b").value("i", 2).value("f", 2.5).toString(),
                 insertInto(TABLE2).value("k", "cast_t").value("t", "c").value("i", 3).value("f", 3.7).toString(),
-                insertInto(TABLE2).value("k", "cast_t").value("t", "d").value("i", 4).value("f", 5.0).toString()
-        );
+                insertInto(TABLE2).value("k", "cast_t").value("t", "d").value("i", 4).value("f", 5.0).toString());
     }
 
     @Test(groups = "short")
@@ -280,7 +279,7 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
         session().execute(createTable(table).addPartitionKey("k", DataType.text())
                 .addClusteringColumn("cc", DataType.cint())
                 .addColumn("n", DataType.text())
-        );
+                );
         session().execute(String.format(
                 "CREATE CUSTOM INDEX on %s (n) USING 'org.apache.cassandra.index.sasi.SASIIndex';", table));
         session().execute(insertInto(table).value("k", "a").value("cc", 0).value("n", "Hello World"));

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
@@ -136,11 +136,13 @@ public class QueryBuilderITest extends CCMTestsSupport {
         assertEquals(insert.toString(), query);
 
         query = "INSERT INTO foo (a,b) VALUES ({'2''} space','3','4'},3.4) USING TTL 24 AND TIMESTAMP 42;";
-        insert = insertInto("foo").values(new String[]{"a", "b"}, new Object[]{new TreeSet<String>() {{
-            add("2'} space");
-            add("3");
-            add("4");
-        }}, 3.4}).using(ttl(24)).and(timestamp(42));
+        insert = insertInto("foo").values(new String[]{"a", "b"}, new Object[]{new TreeSet<String>() {
+            {
+                add("2'} space");
+                add("3");
+                add("4");
+            }
+        }, 3.4}).using(ttl(24)).and(timestamp(42));
         assertEquals(insert.toString(), query);
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -207,10 +207,12 @@ public class QueryBuilderTest {
                 .value("a", 123)
                 .value("b", InetAddress.getByName("127.0.0.1"))
                 .value(quote("C"), "foo'bar")
-                .value("d", new TreeMap<String, Integer>() {{
-                    put("x", 3);
-                    put("y", 2);
-                }})
+                .value("d", new TreeMap<String, Integer>() {
+                    {
+                        put("x", 3);
+                        put("y", 2);
+                    }
+                })
                 .using(timestamp(42)).and(ttl(24));
         assertEquals(insert.toString(), query);
 
@@ -221,20 +223,24 @@ public class QueryBuilderTest {
         assertEquals(insert.toString(), query);
 
         query = "INSERT INTO foo (a,b) VALUES ({2,3,4},3.4) USING TTL 24 AND TIMESTAMP 42;";
-        insert = insertInto("foo").values(new String[]{"a", "b"}, new Object[]{new TreeSet<Integer>() {{
-            add(2);
-            add(3);
-            add(4);
-        }}, 3.4}).using(ttl(24)).and(timestamp(42));
+        insert = insertInto("foo").values(new String[]{"a", "b"}, new Object[]{new TreeSet<Integer>() {
+            {
+                add(2);
+                add(3);
+                add(4);
+            }
+        }, 3.4}).using(ttl(24)).and(timestamp(42));
         assertEquals(insert.toString(), query);
 
         query = "INSERT INTO foo.bar (a,b) VALUES ({2,3,4},3.4) USING TTL ? AND TIMESTAMP ?;";
         insert = insertInto("foo", "bar")
-                .values(new String[]{"a", "b"}, new Object[]{new TreeSet<Integer>() {{
-                    add(2);
-                    add(3);
-                    add(4);
-                }}, 3.4})
+                .values(new String[]{"a", "b"}, new Object[]{new TreeSet<Integer>() {
+                    {
+                        add(2);
+                        add(3);
+                        add(4);
+                    }
+                }, 3.4})
                 .using(ttl(bindMarker()))
                 .and(timestamp(bindMarker()));
         assertEquals(insert.toString(), query);
@@ -243,11 +249,13 @@ public class QueryBuilderTest {
         query = "INSERT INTO foo.bar (a,b,c) VALUES ({2,3,4},3.4,123) USING TIMESTAMP 42;";
         insert = insertInto("foo", "bar")
                 .using(timestamp(42))
-                .values(new String[]{"a", "b"}, new Object[]{new TreeSet<Integer>() {{
-                    add(2);
-                    add(3);
-                    add(4);
-                }}, 3.4})
+                .values(new String[]{"a", "b"}, new Object[]{new TreeSet<Integer>() {
+                    {
+                        add(2);
+                        add(3);
+                        add(4);
+                    }
+                }, 3.4})
                 .value("c", 123);
         assertEquals(insert.toString(), query);
 
@@ -256,11 +264,13 @@ public class QueryBuilderTest {
         insert = insertInto("foo")
                 .using(timestamp(42))
                 .value("c", 123)
-                .values(new String[]{"a", "b"}, new Object[]{new TreeSet<Integer>() {{
-                    add(2);
-                    add(3);
-                    add(4);
-                }}, 3.4});
+                .values(new String[]{"a", "b"}, new Object[]{new TreeSet<Integer>() {
+                    {
+                        add(2);
+                        add(3);
+                        add(4);
+                    }
+                }, 3.4});
         assertEquals(insert.toString(), query);
 
         try {
@@ -303,24 +313,30 @@ public class QueryBuilderTest {
         assertEquals(update.toString(), query);
 
         query = "UPDATE foo SET b=b-[1,2,3],c=c+{1},d=d+{2,3,4};";
-        update = update("foo").with(discardAll("b", Arrays.asList(1, 2, 3))).and(add("c", 1)).and(addAll("d", new TreeSet<Integer>() {{
-            add(2);
-            add(3);
-            add(4);
-        }}));
+        update = update("foo").with(discardAll("b", Arrays.asList(1, 2, 3))).and(add("c", 1)).and(addAll("d", new TreeSet<Integer>() {
+            {
+                add(2);
+                add(3);
+                add(4);
+            }
+        }));
         assertEquals(update.toString(), query);
 
         query = "UPDATE foo SET b=b-{2,3,4},c['k']='v',d=d+{'x':3,'y':2};";
-        update = update("foo").with(removeAll("b", new TreeSet<Integer>() {{
-            add(2);
-            add(3);
-            add(4);
-        }}))
+        update = update("foo").with(removeAll("b", new TreeSet<Integer>() {
+            {
+                add(2);
+                add(3);
+                add(4);
+            }
+        }))
                 .and(put("c", "k", "v"))
-                .and(putAll("d", new TreeMap<String, Integer>() {{
-                    put("x", 3);
-                    put("y", 2);
-                }}));
+                .and(putAll("d", new TreeMap<String, Integer>() {
+                    {
+                        put("x", 3);
+                        put("y", 2);
+                    }
+                }));
         assertEquals(update.toString(), query);
 
         query = "UPDATE foo USING TTL 400;";
@@ -436,11 +452,13 @@ public class QueryBuilderTest {
         query += "DELETE a[3],b['foo'],c FROM foo WHERE k=1;";
         query += "APPLY BATCH;";
         batch = batch()
-                .add(insertInto("foo").values(new String[]{"a", "b"}, new Object[]{new TreeSet<Integer>() {{
-                    add(2);
-                    add(3);
-                    add(4);
-                }}, 3.4}))
+                .add(insertInto("foo").values(new String[]{"a", "b"}, new Object[]{new TreeSet<Integer>() {
+                    {
+                        add(2);
+                        add(3);
+                        add(4);
+                    }
+                }, 3.4}))
                 .add(update("foo").with(setIdx("a", 2, "foo")).and(prependAll("b", Arrays.asList(3, 2, 1))).and(remove("c", "a")).where(eq("k", 2)))
                 .add(delete().listElt("a", 3).mapElt("b", "foo").column("c").from("foo").where(eq("k", 1)))
                 .using(timestamp(42));
@@ -643,11 +661,13 @@ public class QueryBuilderTest {
         assertEquals(insert.toString(), query);
 
         query = "INSERT INTO foo (a,b) VALUES ({'2''} space','3','4'},3.4) USING TTL 24 AND TIMESTAMP 42;";
-        insert = insertInto("foo").values(new String[]{"a", "b"}, new Object[]{new TreeSet<String>() {{
-            add("2'} space");
-            add("3");
-            add("4");
-        }}, 3.4}).using(ttl(24)).and(timestamp(42));
+        insert = insertInto("foo").values(new String[]{"a", "b"}, new Object[]{new TreeSet<String>() {
+            {
+                add("2'} space");
+                add("3");
+                add("4");
+            }
+        }, 3.4}).using(ttl(24)).and(timestamp(42));
         assertEquals(insert.toString(), query);
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/CreateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/CreateTest.java
@@ -48,9 +48,9 @@ public class CreateTest {
 
         //Then
         assertThat(statement.getQueryString()).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
-                        "u frozen<user>,\n\t\t" +
-                        "PRIMARY KEY(u))"
-        );
+                "u frozen<user>,\n\t\t" +
+                "PRIMARY KEY(u))"
+                );
     }
 
     @Test(groups = "unit", expectedExceptions = IllegalStateException.class)

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/SchemaBuilderIT.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/SchemaBuilderIT.java
@@ -36,13 +36,13 @@ public class SchemaBuilderIT extends CCMTestsSupport {
     public void should_modify_table_metadata() {
         // Create a table
         session().execute(SchemaBuilder.createTable("ks", "TableMetadata")
-                        .addPartitionKey("a", DataType.cint())
-                        .addPartitionKey("b", DataType.cint())
-                        .addClusteringColumn("c", DataType.cint())
-                        .addClusteringColumn("d", DataType.cint())
-                        .withOptions()
-                        .compactStorage()
-        );
+                .addPartitionKey("a", DataType.cint())
+                .addPartitionKey("b", DataType.cint())
+                .addClusteringColumn("c", DataType.cint())
+                .addClusteringColumn("d", DataType.cint())
+                .withOptions()
+                .compactStorage()
+                );
 
         // Modify the table metadata
         session().execute(SchemaBuilder.alterTable("TableMetadata")
@@ -132,24 +132,24 @@ public class SchemaBuilderIT extends CCMTestsSupport {
     public void should_create_a_table_and_a_udt() {
         // Create a UDT and a table
         session().execute(SchemaBuilder.createType("MyUDT")
-                        .ifNotExists()
-                        .addColumn("x", DataType.cint())
-        );
+                .ifNotExists()
+                .addColumn("x", DataType.cint())
+                );
         UDTType myUDT = UDTType.frozen("MyUDT");
         session().execute(SchemaBuilder.createTable("ks", "CreateTable")
-                        .ifNotExists()
-                        .addPartitionKey("a", DataType.cint())
-                        .addUDTPartitionKey("b", myUDT)
-                        .addClusteringColumn("c", DataType.ascii())
-                        .addUDTClusteringColumn("d", myUDT)
-                        .addUDTColumn("e", myUDT)
-                        .addStaticColumn("f", DataType.bigint())
-                        .addUDTStaticColumn("g", myUDT)
-                        .addUDTListColumn("h", myUDT)
-                        .addUDTMapColumn("i", DataType.cboolean(), myUDT)
-                        .addUDTMapColumn("j", myUDT, DataType.cboolean())
-                        .addUDTSetColumn("k", myUDT)
-        );
+                .ifNotExists()
+                .addPartitionKey("a", DataType.cint())
+                .addUDTPartitionKey("b", myUDT)
+                .addClusteringColumn("c", DataType.ascii())
+                .addUDTClusteringColumn("d", myUDT)
+                .addUDTColumn("e", myUDT)
+                .addStaticColumn("f", DataType.bigint())
+                .addUDTStaticColumn("g", myUDT)
+                .addUDTListColumn("h", myUDT)
+                .addUDTMapColumn("i", DataType.cboolean(), myUDT)
+                .addUDTMapColumn("j", myUDT, DataType.cboolean())
+                .addUDTSetColumn("k", myUDT)
+                );
 
         // Check columns a to k
         ResultSet rows = session().execute(
@@ -178,18 +178,18 @@ public class SchemaBuilderIT extends CCMTestsSupport {
     public void should_add_and_drop_a_column() {
         // Create a table, add a column to it with an alter table statement and delete that column
         session().execute(SchemaBuilder.createTable("ks", "DropColumn")
-                        .ifNotExists()
-                        .addPartitionKey("a", DataType.cint())
-        );
+                .ifNotExists()
+                .addPartitionKey("a", DataType.cint())
+                );
 
         // Add and then drop a column
         session().execute(SchemaBuilder.alterTable("ks", "DropColumn")
-                        .addColumn("b")
-                        .type(DataType.cint())
-        );
+                .addColumn("b")
+                .type(DataType.cint())
+                );
         session().execute(SchemaBuilder.alterTable("ks", "DropColumn")
-                        .dropColumn("b")
-        );
+                .dropColumn("b")
+                );
 
         // Check that only column a exist
         ResultSet rows = session().execute(
@@ -202,7 +202,7 @@ public class SchemaBuilderIT extends CCMTestsSupport {
     }
 
     private void verifyNextColumnDefinition(Iterator<Row> rowIterator, String columnName, String type,
-                                            String... validatorFragments) {
+            String... validatorFragments) {
         Row rowA = rowIterator.next();
         assertThat(rowA.getString("column_name")).isEqualTo(columnName);
         assertThat(rowA.getString("type")).isEqualTo(type);
@@ -215,8 +215,8 @@ public class SchemaBuilderIT extends CCMTestsSupport {
     public void should_drop_a_table() {
         // Create a table
         session().execute(SchemaBuilder.createTable("ks", "DropTable")
-                        .addPartitionKey("a", DataType.cint())
-        );
+                .addPartitionKey("a", DataType.cint())
+                );
 
         // Drop the table
         session().execute(SchemaBuilder.dropTable("ks", "DropTable"));
@@ -235,20 +235,20 @@ public class SchemaBuilderIT extends CCMTestsSupport {
     public void should_create_an_index() {
         // Create a table
         session().execute(SchemaBuilder.createTable("ks", "CreateIndex")
-                        .addPartitionKey("a", DataType.cint())
-                        .addClusteringColumn("b", DataType.cint())
-                        .addColumn("c", DataType.map(DataType.cint(), DataType.cint()))
-        );
+                .addPartitionKey("a", DataType.cint())
+                .addClusteringColumn("b", DataType.cint())
+                .addColumn("c", DataType.map(DataType.cint(), DataType.cint()))
+                );
 
         // Create an index on a regular column of the table
         session().execute(SchemaBuilder.createIndex("ks_Index")
-                        .onTable("ks", "CreateIndex")
-                        .andColumn("b")
-        );
+                .onTable("ks", "CreateIndex")
+                .andColumn("b")
+                );
         session().execute(SchemaBuilder.createIndex("ks_IndexOnMap")
-                        .onTable("ks", "CreateIndex")
-                        .andKeysOfColumn("c")
-        );
+                .onTable("ks", "CreateIndex")
+                .andKeysOfColumn("c")
+                );
 
         // Verify that the indexes exist on the right columns
         ResultSet rows = session().execute(
@@ -264,7 +264,7 @@ public class SchemaBuilderIT extends CCMTestsSupport {
     }
 
     private void verifyNextIndexDefinition(Iterator<Row> iterator, String name, String options, String type,
-                                           int index) {
+            int index) {
         Row nextIndex = iterator.next();
         assertThat(nextIndex.getString("index_name")).isEqualTo(name);
         assertThat(nextIndex.getString("index_options")).isEqualTo(options);
@@ -276,18 +276,18 @@ public class SchemaBuilderIT extends CCMTestsSupport {
     public void should_drop_an_index() {
         // Create a table
         session().execute(SchemaBuilder.createTable("ks", "DropIndex")
-                        .addPartitionKey("a", DataType.cint())
-                        .addClusteringColumn("b", DataType.cint())
-        );
+                .addPartitionKey("a", DataType.cint())
+                .addClusteringColumn("b", DataType.cint())
+                );
 
         // Create an index
         // Note: we have to pick a lower-case name because Cassandra uses the CamelCase index name at creation
         // but a lowercase index name at deletion
         // See : https://issues.apache.org/jira/browse/CASSANDRA-8365
         session().execute(SchemaBuilder.createIndex("ks_index")
-                        .onTable("ks", "DropIndex")
-                        .andColumn("b")
-        );
+                .onTable("ks", "DropIndex")
+                .andColumn("b")
+                );
 
         // Verify that the PK index and the secondary indexes both exist
         assertThat(numberOfIndexedColumns()).isEqualTo(1);

--- a/driver-core/src/test/java/com/datastax/driver/core/utils/SocketChannelMonitor.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/utils/SocketChannelMonitor.java
@@ -138,7 +138,7 @@ public class SocketChannelMonitor implements Runnable, Closeable {
             Iterable<SocketChannel> closed = Iterables.filter(channels, Predicates.not(openChannels));
 
             logger.debug("Channel states: {} open, {} closed, live {}, total sockets created " +
-                            "(including those that don't match filter) {}.",
+                    "(including those that don't match filter) {}.",
                     Iterables.size(open),
                     Iterables.size(closed),
                     Iterables.size(channels),

--- a/driver-core/src/test/java/com/datastax/driver/core/utils/UUIDsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/utils/UUIDsTest.java
@@ -124,25 +124,32 @@ public class UUIDsTest {
         int o2Pos = o2.position();
 
         int d = (o1.get(o1Pos + 6) & 0xF) - (o2.get(o2Pos + 6) & 0xF);
-        if (d != 0) return d;
+        if (d != 0)
+            return d;
 
         d = (o1.get(o1Pos + 7) & 0xFF) - (o2.get(o2Pos + 7) & 0xFF);
-        if (d != 0) return d;
+        if (d != 0)
+            return d;
 
         d = (o1.get(o1Pos + 4) & 0xFF) - (o2.get(o2Pos + 4) & 0xFF);
-        if (d != 0) return d;
+        if (d != 0)
+            return d;
 
         d = (o1.get(o1Pos + 5) & 0xFF) - (o2.get(o2Pos + 5) & 0xFF);
-        if (d != 0) return d;
+        if (d != 0)
+            return d;
 
         d = (o1.get(o1Pos) & 0xFF) - (o2.get(o2Pos) & 0xFF);
-        if (d != 0) return d;
+        if (d != 0)
+            return d;
 
         d = (o1.get(o1Pos + 1) & 0xFF) - (o2.get(o2Pos + 1) & 0xFF);
-        if (d != 0) return d;
+        if (d != 0)
+            return d;
 
         d = (o1.get(o1Pos + 2) & 0xFF) - (o2.get(o2Pos + 2) & 0xFF);
-        if (d != 0) return d;
+        if (d != 0)
+            return d;
 
         return (o1.get(o1Pos + 3) & 0xFF) - (o2.get(o2Pos + 3) & 0xFF);
     }

--- a/driver-examples/src/main/java/com/datastax/driver/examples/datatypes/Blobs.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/datatypes/Blobs.java
@@ -63,7 +63,8 @@ public class Blobs {
             insertConcurrent(session);
             insertFromAndRetrieveToFile(session);
         } finally {
-            if (cluster != null) cluster.close();
+            if (cluster != null)
+                cluster.close();
         }
     }
 
@@ -247,7 +248,8 @@ public class Blobs {
             try {
                 inputStream.close();
             } catch (IOException e) {
-                if (!threw) throw e; // else preserve original exception
+                if (!threw)
+                    throw e; // else preserve original exception
             }
     }
 }

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/arrays/package-info.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/arrays/package-info.java
@@ -20,3 +20,4 @@
  * serializing between CQL lists and Java arrays.
  */
 package com.datastax.driver.extras.codecs.arrays;
+

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/date/package-info.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/date/package-info.java
@@ -20,3 +20,4 @@
  * serializing between CQL temporal types and Java primitive types.
  */
 package com.datastax.driver.extras.codecs.date;
+

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/enums/package-info.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/enums/package-info.java
@@ -20,3 +20,4 @@
  * serializing between CQL types and Java enums.
  */
 package com.datastax.driver.extras.codecs.enums;
+

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/guava/OptionalCodec.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/guava/OptionalCodec.java
@@ -47,7 +47,9 @@ public class OptionalCodec<T> extends MappingCodec<Optional<T>, T> {
 
     public OptionalCodec(TypeCodec<T> codec, Predicate<T> isAbsent) {
         // @formatter:off
-        super(codec, new TypeToken<Optional<T>>() {}.where(new TypeParameter<T>() {}, codec.getJavaType()));
+        super(codec, new TypeToken<Optional<T>>() {
+        }.where(new TypeParameter<T>() {
+        }, codec.getJavaType()));
         // @formatter:on
         this.isAbsent = isAbsent;
     }

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/guava/package-info.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/guava/package-info.java
@@ -20,3 +20,4 @@
  * serializing between CQL types and Guava-specific Java types.
  */
 package com.datastax.driver.extras.codecs.guava;
+

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/InstantCodec.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/InstantCodec.java
@@ -76,7 +76,6 @@ public class InstantCodec extends TypeCodec<java.time.Instant> {
     private static final java.time.format.DateTimeFormatter FORMATTER = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxxx")
             .withZone(java.time.ZoneOffset.UTC);
 
-
     private InstantCodec() {
         super(DataType.timestamp(), java.time.Instant.class);
     }

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/OptionalCodec.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/OptionalCodec.java
@@ -48,7 +48,9 @@ public class OptionalCodec<T> extends MappingCodec<java.util.Optional<T>, T> {
 
     public OptionalCodec(TypeCodec<T> codec, java.util.function.Predicate<T> isAbsent) {
         // @formatter:off
-        super(codec, new TypeToken<java.util.Optional<T>>() {}.where(new TypeParameter<T>() {}, codec.getJavaType()));
+        super(codec, new TypeToken<java.util.Optional<T>>() {
+        }.where(new TypeParameter<T>() {
+        }, codec.getJavaType()));
         // @formatter:on
         this.isAbsent = isAbsent;
     }

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/package-info.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/jdk8/package-info.java
@@ -26,3 +26,4 @@
  * at runtime.
  */
 package com.datastax.driver.extras.codecs.jdk8;
+

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/joda/package-info.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/joda/package-info.java
@@ -33,3 +33,4 @@
  * }</pre>
  */
 package com.datastax.driver.extras.codecs.joda;
+

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/json/package-info.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/json/package-info.java
@@ -20,3 +20,4 @@
  * serializing JSON structures.
  */
 package com.datastax.driver.extras.codecs.json;
+

--- a/driver-extras/src/main/java/com/datastax/driver/extras/codecs/package-info.java
+++ b/driver-extras/src/main/java/com/datastax/driver/extras/codecs/package-info.java
@@ -53,3 +53,4 @@
  * </table>
  */
 package com.datastax.driver.extras.codecs;
+

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/arrays/ArrayCodecsTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/arrays/ArrayCodecsTest.java
@@ -53,8 +53,7 @@ public class ArrayCodecsTest extends CCMTestsSupport {
                         + "[1.0, 2.0, 3.0], "
                         + "[4.0, 5.0, 6.0], "
                         + "['a', 'b', 'c'] "
-                        + ")"
-        );
+                        + ")");
     }
 
     @Override
@@ -66,7 +65,7 @@ public class ArrayCodecsTest extends CCMTestsSupport {
                         .register(FloatArrayCodec.instance)
                         .register(DoubleArrayCodec.instance)
                         .register(stringArrayCodec)
-        );
+                );
     }
 
     @DataProvider(name = "ArrayCodecsTest-serializing")

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/date/SimpleDateCodecsTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/date/SimpleDateCodecsTest.java
@@ -39,13 +39,13 @@ public class SimpleDateCodecsTest extends CCMTestsSupport {
     @Override
     public void onTestContextInitialized() {
         execute(
-                "CREATE TABLE IF NOT EXISTS foo ("
-                        + "c1 text PRIMARY KEY, "
-                        + "cdate date, "
-                        + "ctimestamp timestamp, "
-                        + "cdates frozen<list<date>>, "
-                        + "ctimestamps frozen<map<text,timestamp>> "
-                        + ")");
+        "CREATE TABLE IF NOT EXISTS foo ("
+                + "c1 text PRIMARY KEY, "
+                + "cdate date, "
+                + "ctimestamp timestamp, "
+                + "cdates frozen<list<date>>, "
+                + "ctimestamps frozen<map<text,timestamp>> "
+                + ")");
     }
 
     @BeforeClass(groups = "short")
@@ -55,7 +55,6 @@ public class SimpleDateCodecsTest extends CCMTestsSupport {
                 .register(SimpleDateCodec.instance)
                 .register(SimpleTimestampCodec.instance);
     }
-
 
     /**
      * <p>

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/enums/EnumCodecsTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/enums/EnumCodecsTest.java
@@ -73,8 +73,7 @@ public class EnumCodecsTest extends CCMTestsSupport {
                         + "foobars map<int,text>, "
                         + "tup frozen<tuple<int,varchar>>, "
                         + "udt frozen<udt1>,"
-                        + "primary key (pk, foo))"
-        );
+                        + "primary key (pk, foo))");
     }
 
     @Override
@@ -83,7 +82,7 @@ public class EnumCodecsTest extends CCMTestsSupport {
                 new CodecRegistry()
                         .register(new EnumOrdinalCodec<Foo>(Foo.class))
                         .register(new EnumNameCodec<Bar>(Bar.class))
-        );
+                );
     }
 
     @BeforeMethod(groups = "short")
@@ -118,19 +117,19 @@ public class EnumCodecsTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void should_use_enum_codecs_with_prepared_statements_2() {
         session().execute(session().prepare(insertQuery).bind()
-                        .setInt(0, pk)
-                        .set(1, FOO_1, Foo.class)
-                        .setList(2, foos, Foo.class)
-                        .set(3, BAR_1, Bar.class)
-                        .set(4, bars, TypeTokens.setOf(Bar.class))
-                        .setMap(5, foobars, Foo.class, Bar.class)
-                        .setTupleValue(6, tupleValue)
-                        .setUDTValue(7, udtValue)
-        );
+                .setInt(0, pk)
+                .set(1, FOO_1, Foo.class)
+                .setList(2, foos, Foo.class)
+                .set(3, BAR_1, Bar.class)
+                .set(4, bars, TypeTokens.setOf(Bar.class))
+                .setMap(5, foobars, Foo.class, Bar.class)
+                .setTupleValue(6, tupleValue)
+                .setUDTValue(7, udtValue)
+                );
         PreparedStatement ps = session().prepare(selectQuery);
         ResultSet rows = session().execute(ps.bind()
-                        .setInt(0, pk)
-        );
+                .setInt(0, pk)
+                );
         Row row = rows.one();
         assertRow(row);
     }
@@ -191,7 +190,7 @@ public class EnumCodecsTest extends CCMTestsSupport {
         assertThat(row.getObject(1)).isEqualTo(FOO_1.ordinal()); // uses the built-in IntCodec because CQL type is int
         assertThat(row.getInt("foo")).isEqualTo(FOO_1.ordinal()); // uses the built-in IntCodec
         assertThat(row.get(1, Integer.class)).isEqualTo(FOO_1.ordinal()); // forces IntCodec
-        assertThat(row.get("foo", Foo.class)).isEqualTo(FOO_1);  // forces EnumOrdinalCodec
+        assertThat(row.get("foo", Foo.class)).isEqualTo(FOO_1); // forces EnumOrdinalCodec
 
         assertThat(row.getObject(2)).isEqualTo(newArrayList(FOO_1.ordinal(), FOO_2.ordinal())); // uses the built-in ListCodec(IntCodec) because CQL type is list<int>
         assertThat(row.getList(2, Integer.class)).isEqualTo(newArrayList(FOO_1.ordinal(), FOO_2.ordinal()));
@@ -315,13 +314,14 @@ public class EnumCodecsTest extends CCMTestsSupport {
 
     }
 
-
     enum Foo {
-        FOO_1, FOO_2
+        FOO_1,
+        FOO_2
     }
 
     enum Bar {
-        BAR_1, BAR_2
+        BAR_1,
+        BAR_2
     }
 
 }

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/jdk8/Jdk8TimeCodecsTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/jdk8/Jdk8TimeCodecsTest.java
@@ -47,17 +47,17 @@ public class Jdk8TimeCodecsTest extends CCMTestsSupport {
     @Override
     public void onTestContextInitialized() {
         execute(
-                "CREATE TABLE IF NOT EXISTS foo ("
-                        + "c1 text PRIMARY KEY, "
-                        + "cdate date, "
-                        + "ctime time, "
-                        + "ctimestamp timestamp, "
-                        + "ctuple tuple<timestamp,varchar>, "
-                        + "cdates frozen<list<date>>, "
-                        + "ctimes frozen<set<time>>, "
-                        + "ctimestamps frozen<map<text,timestamp>>, "
-                        + "ctuples frozen<map<tuple<timestamp,varchar>,varchar>>"
-                        + ")");
+        "CREATE TABLE IF NOT EXISTS foo ("
+                + "c1 text PRIMARY KEY, "
+                + "cdate date, "
+                + "ctime time, "
+                + "ctimestamp timestamp, "
+                + "ctuple tuple<timestamp,varchar>, "
+                + "cdates frozen<list<date>>, "
+                + "ctimes frozen<set<time>>, "
+                + "ctimestamps frozen<map<text,timestamp>>, "
+                + "ctuples frozen<map<tuple<timestamp,varchar>,varchar>>"
+                + ")");
     }
 
     @BeforeClass(groups = "short")

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/joda/JodaTimeCodecsTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/joda/JodaTimeCodecsTest.java
@@ -48,17 +48,17 @@ public class JodaTimeCodecsTest extends CCMTestsSupport {
     @Override
     public void onTestContextInitialized() {
         execute(
-                "CREATE TABLE IF NOT EXISTS foo ("
-                        + "c1 text PRIMARY KEY, "
-                        + "cdate date, "
-                        + "ctime time, "
-                        + "ctimestamp timestamp, "
-                        + "ctuple tuple<timestamp,varchar>, "
-                        + "cdates frozen<list<date>>, "
-                        + "ctimes frozen<set<time>>, "
-                        + "ctimestamps frozen<map<text,timestamp>>, "
-                        + "ctuples frozen<map<tuple<timestamp,varchar>,varchar>>"
-                        + ")");
+        "CREATE TABLE IF NOT EXISTS foo ("
+                + "c1 text PRIMARY KEY, "
+                + "cdate date, "
+                + "ctime time, "
+                + "ctimestamp timestamp, "
+                + "ctuple tuple<timestamp,varchar>, "
+                + "cdates frozen<list<date>>, "
+                + "ctimes frozen<set<time>>, "
+                + "ctimestamps frozen<map<text,timestamp>>, "
+                + "ctuples frozen<map<tuple<timestamp,varchar>,varchar>>"
+                + ")");
     }
 
     @BeforeClass(groups = "short")

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/joda/LocalTimeCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/joda/LocalTimeCodecTest.java
@@ -69,5 +69,4 @@ public class LocalTimeCodecTest {
         assertThat(actual).isEqualTo(expected);
     }
 
-
 }

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/JacksonJsonCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/JacksonJsonCodecTest.java
@@ -50,16 +50,14 @@ public class JacksonJsonCodecTest extends CCMTestsSupport {
 
     @Override
     public void onTestContextInitialized() {
-        execute(
-                "CREATE TABLE t1 (c1 text, c2 text, c3 list<text>, PRIMARY KEY (c1, c2))"
-        );
+        execute("CREATE TABLE t1 (c1 text, c2 text, c3 list<text>, PRIMARY KEY (c1, c2))");
     }
 
     @Override
     public Cluster.Builder createClusterBuilder() {
         return Cluster.builder().withCodecRegistry(
                 new CodecRegistry().register(jsonCodec) // global User <-> varchar codec
-        );
+                );
     }
 
     @Test(groups = "unit")
@@ -137,18 +135,18 @@ public class JacksonJsonCodecTest extends CCMTestsSupport {
     @Test(groups = "short")
     public void should_use_custom_codec_with_prepared_statements_2() {
         session().execute(session().prepare(insertQuery).bind()
-                        .setString(0, notAJsonString)
-                        .set(1, alice, User.class)
-                        .setList(2, bobAndCharlie, User.class)
-        );
+                .setString(0, notAJsonString)
+                .set(1, alice, User.class)
+                .setList(2, bobAndCharlie, User.class)
+                );
         PreparedStatement ps = session().prepare(selectQuery);
         ResultSet rows = session().execute(ps.bind()
-                        .setString(0, notAJsonString)
-                                // this set() method conveys information about the java type of alice
-                                // so the registry will look for a codec accepting varchar <-> User
-                                // and will find jsonCodec because it is the only matching one
-                        .set(1, alice, User.class)
-        );
+                .setString(0, notAJsonString)
+                // this set() method conveys information about the java type of alice
+                // so the registry will look for a codec accepting varchar <-> User
+                // and will find jsonCodec because it is the only matching one
+                .set(1, alice, User.class)
+                );
         Row row = rows.one();
         assertRow(row);
     }

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/Jsr353JsonCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/Jsr353JsonCodecTest.java
@@ -45,16 +45,14 @@ public class Jsr353JsonCodecTest extends CCMTestsSupport {
 
     @Override
     public void onTestContextInitialized() {
-        execute(
-                "CREATE TABLE t1 (c1 text, c2 text, PRIMARY KEY (c1, c2))"
-        );
+        execute("CREATE TABLE t1 (c1 text, c2 text, PRIMARY KEY (c1, c2))");
     }
 
     @Override
     public Cluster.Builder createClusterBuilder() {
         return Cluster.builder().withCodecRegistry(
                 new CodecRegistry().register(jsonCodec) // global User <-> varchar codec
-        );
+                );
     }
 
     @DataProvider(name = "Jsr353JsonCodecTest")
@@ -133,14 +131,14 @@ public class Jsr353JsonCodecTest extends CCMTestsSupport {
     @Test(groups = "short", dataProvider = "Jsr353JsonCodecTest")
     public void should_use_custom_codec_with_prepared_statements_2(JsonStructure object) throws IOException {
         session().execute(session().prepare(insertQuery).bind()
-                        .setString(0, notAJsonString)
-                        .set(1, object, JsonStructure.class)
-        );
+                .setString(0, notAJsonString)
+                .set(1, object, JsonStructure.class)
+                );
         PreparedStatement ps = session().prepare(selectQuery);
         ResultSet rows = session().execute(ps.bind()
-                        .setString(0, notAJsonString)
-                        .set(1, object, JsonStructure.class)
-        );
+                .setString(0, notAJsonString)
+                .set(1, object, JsonStructure.class)
+                );
         Row row = rows.one();
         assertRow(row, object);
     }

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/AccessorInvocationHandler.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/AccessorInvocationHandler.java
@@ -68,4 +68,3 @@ class AccessorInvocationHandler<T> implements InvocationHandler {
         return method.invoke(args == null ? NO_ARGS : args);
     }
 }
-

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
@@ -64,7 +64,7 @@ class AnnotationParser {
                         "Error creating mapper for class %s, the @%s annotation declares no default keyspace, and the session is not currently logged to any keyspace",
                         entityClass.getSimpleName(),
                         Table.class.getSimpleName()
-                ));
+                        ));
         }
 
         EntityMapper<T> mapper = factory.create(entityClass, ksName, tableName, writeConsistency, readConsistency);
@@ -147,7 +147,7 @@ class AnnotationParser {
                         "Error creating UDT codec for class %s, the @%s annotation declares no default keyspace, and the session is not currently logged to any keyspace",
                         udtClass.getSimpleName(),
                         UDT.class.getSimpleName()
-                ));
+                        ));
         }
 
         UserType userType = mappingManager.getSession().getCluster().getMetadata().getKeyspace(ksName).getUserType(udtName);
@@ -277,7 +277,7 @@ class AnnotationParser {
             throw new IllegalArgumentException(String.format(
                     "Cannot create an instance of custom codec %s for field %s",
                     codecClass, field
-            ), e);
+                    ), e);
         }
     }
 

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/ColumnMapper.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/ColumnMapper.java
@@ -24,7 +24,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 abstract class ColumnMapper<T> {
 
-    enum Kind {PARTITION_KEY, CLUSTERING_COLUMN, REGULAR, COMPUTED}
+    enum Kind {
+        PARTITION_KEY,
+        CLUSTERING_COLUMN,
+        REGULAR,
+        COMPUTED
+    }
 
     private final String columnName;
     private final String alias;

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/Mapper.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/Mapper.java
@@ -835,7 +835,13 @@ public class Mapper<T> {
      */
     public static abstract class Option {
 
-        enum Type {TTL, TIMESTAMP, CL, TRACING, SAVE_NULL_FIELDS}
+        enum Type {
+            TTL,
+            TIMESTAMP,
+            CL,
+            TRACING,
+            SAVE_NULL_FIELDS
+        }
 
         final Type type;
 

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/MethodMapper.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/MethodMapper.java
@@ -102,12 +102,12 @@ class MethodMapper {
 
         if (method.getParameterTypes().length < names.size())
             throw new IllegalArgumentException(String.format("Not enough arguments for method %s, "
-                            + "found %d but it should be at least the number of unique bind parameter names in the @Query (%d)",
+                    + "found %d but it should be at least the number of unique bind parameter names in the @Query (%d)",
                     method.getName(), method.getParameterTypes().length, names.size()));
 
         if (method.getParameterTypes().length > variables.size())
             throw new IllegalArgumentException(String.format("Too many arguments for method %s, "
-                            + "found %d but it should be at most the number of bind parameters in the @Query (%d)",
+                    + "found %d but it should be at most the number of bind parameters in the @Query (%d)",
                     method.getName(), method.getParameterTypes().length, variables.size()));
 
         // TODO could go further, e.g. check that the types match, inspect @Param annotations to check that all names are bound...
@@ -195,7 +195,7 @@ class MethodMapper {
                 throw new IllegalArgumentException(String.format(
                         "Cannot create instance of codec %s for parameter %s",
                         codecClass, (paramName == null) ? paramIdx : paramName
-                ), e);
+                        ), e);
             }
         }
 

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/QueryType.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/QueryType.java
@@ -30,7 +30,13 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 
 class QueryType {
 
-    private enum Kind {SAVE, GET, DEL, SLICE, REVERSED_SLICE}
+    private enum Kind {
+        SAVE,
+        GET,
+        DEL,
+        SLICE,
+        REVERSED_SLICE
+    }
 
     private final Kind kind;
 

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/Computed.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/Computed.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.driver.mapping.annotations;
 
-
 import com.datastax.driver.mapping.Mapper;
 
 import java.lang.annotation.ElementType;

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorParamsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorParamsTest.java
@@ -36,8 +36,7 @@ public class MapperAccessorParamsTest extends CCMTestsSupport {
                 "CREATE TABLE user ( key int primary key, gender int, home_phone text, work_phone text)",
                 "CREATE INDEX on user(gender)",
                 "CREATE TABLE user_str ( key int primary key, gender text)",
-                "CREATE INDEX on user_str(gender)"
-        );
+                "CREATE INDEX on user_str(gender)");
     }
 
     @Test(groups = "short")
@@ -99,7 +98,8 @@ public class MapperAccessorParamsTest extends CCMTestsSupport {
     }
 
     enum Enum {
-        MALE, FEMALE
+        MALE,
+        FEMALE
     }
 
     /**
@@ -209,7 +209,7 @@ public class MapperAccessorParamsTest extends CCMTestsSupport {
     @Accessor
     public interface UserPhoneAccessor_WrongParameterTypes {
         @Query("select * from user where key IN (?)")
-            // WRONG, should be "where key IN ?"
+        // WRONG, should be "where key IN ?"
         void findUsersBykeys(List<Integer> keys);
     }
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAsyncTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAsyncTest.java
@@ -51,8 +51,7 @@ public class MapperAsyncTest extends CCMTestsSupport {
     public void onTestContextInitialized() {
         execute(
                 String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, KEYSPACE, 1),
-                String.format("CREATE TABLE %s.users (user_id uuid PRIMARY KEY, name text, email text)", KEYSPACE)
-        );
+                String.format("CREATE TABLE %s.users (user_id uuid PRIMARY KEY, name text, email text)", KEYSPACE));
     }
 
     /**

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperCustomCodecTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperCustomCodecTest.java
@@ -52,8 +52,7 @@ public class MapperCustomCodecTest extends CCMTestsSupport {
                 // nested UDT
                 // both UDT fields and non-UDT elements in the collection are mapped to custom types
                 "CREATE TABLE data3(i int primary key, data map<int, frozen<holder>>)",
-                "INSERT INTO data3 (i, data) values (1, {1: {i: 1, l: 11}})"
-        );
+                "INSERT INTO data3 (i, data) values (1, {1: {i: 1, l: 11}})");
     }
 
     @Override
@@ -339,7 +338,7 @@ public class MapperCustomCodecTest extends CCMTestsSupport {
 
         @Query("update data1 set l = :l where i = :i")
         void setL(@Param("i") int i,
-                  @Param(value = "l", codec = CustomLong.Codec.class) CustomLong l);
+                @Param(value = "l", codec = CustomLong.Codec.class) CustomLong l);
     }
 
     @Accessor
@@ -347,7 +346,7 @@ public class MapperCustomCodecTest extends CCMTestsSupport {
 
         @Query("update data1 set l = :l where i = :i")
         void setL(@Param("i") int i,
-                  @Param(value = "l", codec = NoDefaultConstructorCodec.class) long l);
+                @Param(value = "l", codec = NoDefaultConstructorCodec.class) long l);
     }
 
     @Accessor
@@ -358,7 +357,7 @@ public class MapperCustomCodecTest extends CCMTestsSupport {
 
         @Query("update data1 set l = :l where i = :i")
         void setL(@Param("i") int i,
-                  @Param(value = "l", codec = OptionalOfString.class) Optional<Long> l);
+                @Param(value = "l", codec = OptionalOfString.class) Optional<Long> l);
     }
 
     @UDT(name = "holder")
@@ -569,7 +568,9 @@ public class MapperCustomCodecTest extends CCMTestsSupport {
         public OptionalCodec(TypeCodec<T> codec) {
             // @formatter:off
             super(codec,
-                    new TypeToken<Optional<T>>() {}.where(new TypeParameter<T>() {}, codec.getJavaType()));
+                    new TypeToken<Optional<T>>() {
+                    }.where(new TypeParameter<T>() {
+                    }, codec.getJavaType()));
             // @formatter:on
             this.isAbsent = new Predicate<T>() {
                 @Override

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperDefaultKeyspaceTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperDefaultKeyspaceTest.java
@@ -108,7 +108,6 @@ public class MapperDefaultKeyspaceTest extends CCMTestsSupport {
         manager.udtCodec(GroupName.class);
     }
 
-
     /*
      * An entity that does not specify a keyspace in its @Table annotation. When a keyspace is
      * not specified, the mapper uses the session's logged in keyspace.

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperMaterializedViewTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperMaterializedViewTest.java
@@ -32,7 +32,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @CassandraVersion(major = 3.0)
 public class MapperMaterializedViewTest extends CCMTestsSupport {
 
-
     @Override
     public void onTestContextInitialized() {
         // Example schema taken from: http://www.datastax.com/dev/blog/new-in-cassandra-3-0-materialized-views
@@ -69,8 +68,7 @@ public class MapperMaterializedViewTest extends CCMTestsSupport {
                 "INSERT INTO scores (user, game, year, month, day, score) VALUES ('jbellis', 'Coup', 2015, 6, 20, 3500)",
                 "INSERT INTO scores (user, game, year, month, day, score) VALUES ('jbellis', 'Checkers', 2015, 6, 20, 1200)",
                 "INSERT INTO scores (user, game, year, month, day, score) VALUES ('jbellis', 'Chess', 2015, 6, 21, 3500)",
-                "INSERT INTO scores (user, game, year, month, day, score) VALUES ('pcmanus', 'Chess', 2015, 1, 25, 3200)"
-        );
+                "INSERT INTO scores (user, game, year, month, day, score) VALUES ('pcmanus', 'Chess', 2015, 1, 25, 3200)");
     }
 
     private ScoreAccessor accessor;

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperPrimitiveTypes22Test.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperPrimitiveTypes22Test.java
@@ -75,7 +75,6 @@ public class MapperPrimitiveTypes22Test extends CCMTestsSupport {
         assertEquals(primitiveTypes2.getShortWrapperCol(), shortWrapperCol);
     }
 
-
     @Table(name = "primitiveTypes22")
     public static class PrimitiveTypes22 {
         @PartitionKey

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperTest.java
@@ -73,7 +73,8 @@ public class MapperTest extends CCMTestsSupport {
 
         private String name;
         private String email;
-        @Column // not strictly required, but we want to check that the annotation works without a name
+        @Column
+        // not strictly required, but we want to check that the annotation works without a name
         private int year;
 
         public User() {
@@ -156,7 +157,6 @@ public class MapperTest extends CCMTestsSupport {
         @PartitionKey
         @Column(name = "user_id")
         private UUID userId;
-
 
         private Set<String> tags;
 
@@ -262,7 +262,7 @@ public class MapperTest extends CCMTestsSupport {
         // somehow, but well, not a huge deal.
         @Query("SELECT * FROM posts WHERE user_id=:userId AND post_id=:postId")
         Post getOne(@Param("userId") UUID userId,
-                    @Param("postId") UUID postId);
+                @Param("postId") UUID postId);
 
         // Note that the following method will be asynchronous (it will use executeAsync
         // underneath) because it's return type is a ListenableFuture. Similarly, we know
@@ -502,7 +502,6 @@ public class MapperTest extends CCMTestsSupport {
         Statement deleteQuery = mapper.deleteQuery(u.getUserId());
         assertThat(saveQuery.isIdempotent()).isTrue();
     }
-
 
     @Table(name = "users")
     public static class UserUnknownColumn {

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
@@ -151,7 +151,8 @@ public class MapperUDTTest extends CCMTestsSupport {
         // Dummy constant to test that static fields are properly ignored
         public static final int FOO = 1;
 
-        @Field // not strictly required, but we want to check that the annotation works without a name
+        @Field
+        // not strictly required, but we want to check that the annotation works without a name
         private String city;
 
         // Declared out of order compared to the UDT definition, to make sure that we serialize fields in the correct order (JAVA-884)
@@ -619,7 +620,6 @@ public class MapperUDTTest extends CCMTestsSupport {
             this.province = province;
         }
     }
-
 
     /**
      * Ensures that when attempting to create a {@link TypeCodec} from a class that has a field that does not exist in

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/SyntheticFieldsMapperTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/SyntheticFieldsMapperTest.java
@@ -136,8 +136,10 @@ public class SyntheticFieldsMapperTest extends CCMTestsSupport {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
 
             ClassWithSyntheticField that = (ClassWithSyntheticField) o;
 

--- a/driver-tests/osgi/src/main/java/com/datastax/driver/osgi/api/MailboxMessage.java
+++ b/driver-tests/osgi/src/main/java/com/datastax/driver/osgi/api/MailboxMessage.java
@@ -90,8 +90,10 @@ public class MailboxMessage {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         MailboxMessage that = (MailboxMessage) o;
         return date == that.date &&
                 Objects.equal(recipient, that.recipient) &&

--- a/driver-tests/osgi/src/main/java/com/datastax/driver/osgi/impl/Activator.java
+++ b/driver-tests/osgi/src/main/java/com/datastax/driver/osgi/impl/Activator.java
@@ -120,7 +120,7 @@ public class Activator implements BundleActivator {
             Exception in thread "threadDeathWatcher-2-1" java.lang.NoClassDefFoundError: xxx
             Caused by: java.lang.ClassNotFoundException: Unable to load class 'xxx' because the bundle wiring for xxx is no longer valid.
             Although ugly, they are harmless and can be safely ignored.
-            */
+             */
             Thread.sleep(1000);
         }
     }

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
@@ -57,8 +57,7 @@ public class BundleOptions {
             public Option[] getOptions() {
                 return options(
                         systemProperty("cassandra.compression").value(ProtocolOptions.Compression.LZ4.name()),
-                        mavenBundle("net.jpountz.lz4", "lz4", "1.3.0")
-                );
+                        mavenBundle("net.jpountz.lz4", "lz4", "1.3.0"));
             }
         };
     }
@@ -74,8 +73,7 @@ public class BundleOptions {
                         mavenBundle("io.netty", "netty-codec", nettyVersion),
                         mavenBundle("io.netty", "netty-common", nettyVersion),
                         mavenBundle("io.netty", "netty-handler", nettyVersion),
-                        mavenBundle("io.netty", "netty-transport", nettyVersion)
-                );
+                        mavenBundle("io.netty", "netty-transport", nettyVersion));
             }
         };
     }
@@ -102,8 +100,7 @@ public class BundleOptions {
                         mavenBundle("io.dropwizard.metrics", "metrics-core", "3.1.2"),
                         mavenBundle("org.testng", "testng", "6.8.8"),
                         systemPackages("org.testng", "org.junit", "org.junit.runner", "org.junit.runner.manipulation",
-                                "org.junit.runner.notification", "com.jcabi.manifests")
-                );
+                                "org.junit.runner.notification", "com.jcabi.manifests"));
             }
         };
     }

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceDefaultIT.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceDefaultIT.java
@@ -37,8 +37,7 @@ public class MailboxServiceDefaultIT extends MailboxServiceTests {
                 driverBundle(),
                 extrasBundle(),
                 mappingBundle(),
-                mailboxBundle()
-        );
+                mailboxBundle());
     }
 
     /**

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceGuava17IT.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceGuava17IT.java
@@ -37,8 +37,7 @@ public class MailboxServiceGuava17IT extends MailboxServiceTests {
                 driverBundle(),
                 mappingBundle(),
                 extrasBundle(),
-                mailboxBundle()
-        );
+                mailboxBundle());
     }
 
     /**

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceGuava18IT.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceGuava18IT.java
@@ -37,8 +37,7 @@ public class MailboxServiceGuava18IT extends MailboxServiceTests {
                 driverBundle(),
                 extrasBundle(),
                 mappingBundle(),
-                mailboxBundle()
-        );
+                mailboxBundle());
     }
 
     /**

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceGuava19IT.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceGuava19IT.java
@@ -37,8 +37,7 @@ public class MailboxServiceGuava19IT extends MailboxServiceTests {
                 driverBundle(),
                 extrasBundle(),
                 mappingBundle(),
-                mailboxBundle()
-        );
+                mailboxBundle());
     }
 
     /**

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceLZ4IT.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceLZ4IT.java
@@ -38,8 +38,7 @@ public class MailboxServiceLZ4IT extends MailboxServiceTests {
                 extrasBundle(),
                 mappingBundle(),
                 driverBundle(),
-                mailboxBundle()
-        );
+                mailboxBundle());
     }
 
     /**

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceShadedIT.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceShadedIT.java
@@ -36,8 +36,7 @@ public class MailboxServiceShadedIT extends MailboxServiceTests {
                 extrasBundle(),
                 mappingBundle(),
                 driverBundle(true),
-                mailboxBundle()
-        );
+                mailboxBundle());
     }
 
     /**

--- a/driver-tests/stress/src/main/java/com/datastax/driver/stress/AsynchronousConsumer.java
+++ b/driver-tests/stress/src/main/java/com/datastax/driver/stress/AsynchronousConsumer.java
@@ -38,8 +38,8 @@ public class AsynchronousConsumer implements Consumer {
     private final Reporter reporter;
 
     public AsynchronousConsumer(Session session,
-                                QueryGenerator requests,
-                                Reporter reporter) {
+            QueryGenerator requests,
+            Reporter reporter) {
         this.session = session;
         this.requests = requests;
         this.reporter = reporter;

--- a/driver-tests/stress/src/main/java/com/datastax/driver/stress/BlockingConsumer.java
+++ b/driver-tests/stress/src/main/java/com/datastax/driver/stress/BlockingConsumer.java
@@ -28,8 +28,8 @@ public class BlockingConsumer implements Consumer {
     private final Reporter reporter;
 
     public BlockingConsumer(Session session,
-                            QueryGenerator requests,
-                            Reporter reporter) {
+            QueryGenerator requests,
+            Reporter reporter) {
         this.session = session;
         this.requests = requests;
         this.reporter = reporter;

--- a/driver-tests/stress/src/main/java/com/datastax/driver/stress/Generators.java
+++ b/driver-tests/stress/src/main/java/com/datastax/driver/stress/Generators.java
@@ -86,7 +86,8 @@ public class Generators {
 
             try {
                 session.execute("DROP KEYSPACE stress;");
-            } catch (QueryValidationException e) { /* Fine, ignore */ }
+            } catch (QueryValidationException e) { /* Fine, ignore */
+            }
 
             session.execute("CREATE KEYSPACE stress WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }");
 
@@ -123,7 +124,8 @@ public class Generators {
                     StringBuilder sb = new StringBuilder();
                     sb.append("UPDATE standard1 SET ");
                     for (int i = 0; i < columnsPerRow; ++i) {
-                        if (i > 0) sb.append(", ");
+                        if (i > 0)
+                            sb.append(", ");
                         sb.append('C').append(i).append("='").append(Bytes.toHexString(makeValue(valueSize))).append('\'');
                     }
                     sb.append(" WHERE key = ").append(prefix | iteration);
@@ -141,7 +143,8 @@ public class Generators {
             StringBuilder sb = new StringBuilder();
             sb.append("UPDATE standard1 SET ");
             for (int i = 0; i < columnsPerRow; ++i) {
-                if (i > 0) sb.append(", ");
+                if (i > 0)
+                    sb.append(", ");
                 sb.append('C').append(i).append("=?");
             }
             sb.append(" WHERE key = ?");

--- a/driver-tests/stress/src/main/java/com/datastax/driver/stress/Stress.java
+++ b/driver-tests/stress/src/main/java/com/datastax/driver/stress/Stress.java
@@ -49,19 +49,21 @@ public class Stress {
     }
 
     private static OptionParser defaultParser() {
-        OptionParser parser = new OptionParser() {{
-            accepts("h", "Show this help message");
-            accepts("n", "Number of requests to perform (default: unlimited)").withRequiredArg().ofType(Integer.class);
-            accepts("t", "Level of concurrency to use").withRequiredArg().ofType(Integer.class).defaultsTo(50);
-            accepts("async", "Make asynchronous requests instead of blocking ones");
-            accepts("ip", "The hosts ip to connect to").withRequiredArg().ofType(String.class).defaultsTo("127.0.0.1");
-            accepts("report-file", "The name of csv file to use for reporting results").withRequiredArg().ofType(String.class).defaultsTo("last.csv");
-            accepts("print-delay", "The delay in seconds at which to report on the console").withRequiredArg().ofType(Integer.class).defaultsTo(5);
-            accepts("compression", "Use compression (SNAPPY)");
-            accepts("connections-per-host", "The number of connections per hosts (default: based on the number of threads)").withRequiredArg().ofType(Integer.class);
-            accepts("consistency-level", "Consistency level").withRequiredArg().withValuesConvertedBy(new ConsistencyLevelConverter())
-                    .ofType(ConsistencyLevel.class).defaultsTo(ConsistencyLevel.LOCAL_ONE);
-        }};
+        OptionParser parser = new OptionParser() {
+            {
+                accepts("h", "Show this help message");
+                accepts("n", "Number of requests to perform (default: unlimited)").withRequiredArg().ofType(Integer.class);
+                accepts("t", "Level of concurrency to use").withRequiredArg().ofType(Integer.class).defaultsTo(50);
+                accepts("async", "Make asynchronous requests instead of blocking ones");
+                accepts("ip", "The hosts ip to connect to").withRequiredArg().ofType(String.class).defaultsTo("127.0.0.1");
+                accepts("report-file", "The name of csv file to use for reporting results").withRequiredArg().ofType(String.class).defaultsTo("last.csv");
+                accepts("print-delay", "The delay in seconds at which to report on the console").withRequiredArg().ofType(Integer.class).defaultsTo(5);
+                accepts("compression", "Use compression (SNAPPY)");
+                accepts("connections-per-host", "The number of connections per hosts (default: based on the number of threads)").withRequiredArg().ofType(Integer.class);
+                accepts("consistency-level", "Consistency level").withRequiredArg().withValuesConvertedBy(new ConsistencyLevelConverter())
+                        .ofType(ConsistencyLevel.class).defaultsTo(ConsistencyLevel.LOCAL_ONE);
+            }
+        };
         String msg = "Where <generator> can be one of " + generators.keySet() + '\n'
                 + "You can get more help on a particular generator with: stress <generator> -h";
         parser.formatHelpWith(Help.formatFor("<generator>", msg));

--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,31 @@
                     </execution>
                 </executions>
             </plugin>
+            <!--
+            To update source formatting run:
+            mvn formatter:format
+            -->
+            <plugin>
+                <groupId>com.marvinformatics.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+                <version>1.4.0</version>
+                <configuration>
+                    <configFile>${main.basedir}/src/formatter/java.xml</configFile>
+                    <configJsFile>${main.basedir}/src/formatter/java.xml</configJsFile>
+                    <lineEnding>LF</lineEnding> <!-- linux style line endings -->
+                    <compilerCompliance>${java.version}</compilerCompliance> 
+                    <compilerTargetPlatform>${java.version}</compilerTargetPlatform>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-format</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>validate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>

--- a/src/formatter/java.xml
+++ b/src/formatter/java.xml
@@ -1,0 +1,329 @@
+<!--
+
+         Copyright (C) 2012-2015 DataStax Inc.
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+-->
+<profiles version="12">
+<profile kind="CodeFormatterProfile" name="Java Driver Conventions" version="12">
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.compiler.source" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="1000"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+</profile>
+</profiles>


### PR DESCRIPTION
Based on discussion, here is a pull request that enforces source formatting.   This uses [formatter-maven-plugin](https://github.com/revelc/formatter-maven-plugin) which uses eclipse to validate and update source formatting.

I attempted to find a happy medium between eclipse defaults and the formatting standards we were currently using.  The end result is that the changes weren't too dramatic compared to our current standards.

This format is the same as the Eclipse standards with the following exceptions:
- Spaces instead of Tabs with 4 space indentation
- No joining of wrapped lines (for leniency)
- Disable auto-line wrapping (for leniency)
- Disable formatting of comments (for leniency)
- No spaces inserted before and after braces in array initializer
- Indent statements within switch body
- Add new lines after each enum constant

The last two could be removed, it would result in changes of a lot of our code, but would get us closer to the Eclipse conventions (not sure how important that is).

The remaining naunces between the existing format and this new one:
- For some reason parentheses are aligned with arguments if they are on a line on their own.  i.e. see `CodecRegistry`.   I can change this so parenthesis are joined with the last argument, which is how a lot of our code already is.
- Spacing alignment on constructor/method definition after 1st new line is now indented 8 characters instead of aligned with the 1st parentheses. Not sure (yet) if there is a way to align that with eclipse formatting.  i.e. `AbstractTableMetadata` constructor.
- Enum constants are now declared one line a piece.  Some of our code did this already (i.e. DataType) while others didn't.

Some other notes:
- Using version 1.4.0 of the plugin instead of 1.8.0 (the latest).  This is for JDK 6 support.
- When using `mvn formatter:format` it has to be run in each module individually since it doesn't recurse sub modules like validate does for some reason.
