### PR TITLE
JAVA-1275: Use Netty's default thread factory

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -7,6 +7,7 @@
 - [bug] JAVA-1258: Regression: Mapper cannot map a materialized view after JAVA-1126.
 - [bug] JAVA-1101: Batch and BatchStatement should consider inner statements to determine query idempotence
 - [improvement] JAVA-1262: Use ParseUtils for quoting & unquoting.
+- [improvement] JAVA-1275: Use Netty's default thread factory
 
 
 ### 3.0.3

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -25,6 +25,7 @@ import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.*;
 import com.google.common.util.concurrent.*;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1515,7 +1516,14 @@ public class Cluster implements Closeable {
         }
 
         ThreadFactory threadFactory(String name) {
-            return new ThreadFactoryBuilder().setNameFormat(clusterName + "-" + name + "-%d").build();
+            return new ThreadFactoryBuilder()
+                    .setNameFormat(clusterName + "-" + name + "-%d")
+                    // Back with Netty's thread factory in order to create FastThreadLocalThread instances. This allows
+                    // an optimization around ThreadLocals (we could use DefaultThreadFactory directly but it creates
+                    // slightly different thread names, so keep we keep a ThreadFactoryBuilder wrapper for backward
+                    // compatibility).
+                    .setThreadFactory(new DefaultThreadFactory("ignored name"))
+                    .build();
         }
 
         private ListeningExecutorService makeExecutor(int threads, String name, LinkedBlockingQueue<Runnable> workQueue) {

--- a/driver-core/src/main/java/com/datastax/driver/core/NettyOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/NettyOptions.java
@@ -89,7 +89,10 @@ public class NettyOptions {
      *
      * @param threadFactory The {@link ThreadFactory} to use when creating a new {@code EventLoopGroup} instance;
      *                      The driver will provide its own internal thread factory here.
-     *                      It is safe to ignore it and use another thread factory.
+     *                      It is safe to ignore it and use another thread factory. Note however that for optimal
+     *                      performance it is recommended to use a factory that returns
+     *                      {@link io.netty.util.concurrent.FastThreadLocalThread} instances (such as Netty's
+     *                      {@link java.util.concurrent.Executors.DefaultThreadFactory}).
      * @return the {@code EventLoopGroup} instance to use.
      */
     public EventLoopGroup eventLoopGroup(ThreadFactory threadFactory) {
@@ -205,7 +208,10 @@ public class NettyOptions {
      *
      * @param threadFactory The {@link ThreadFactory} to use when creating a new {@link HashedWheelTimer} instance;
      *                      The driver will provide its own internal thread factory here.
-     *                      It is safe to ignore it and use another thread factory.
+     *                      It is safe to ignore it and use another thread factory. Note however that for optimal
+     *                      performance it is recommended to use a factory that returns
+     *                      {@link io.netty.util.concurrent.FastThreadLocalThread} instances (such as Netty's
+     *                      {@link java.util.concurrent.Executors.DefaultThreadFactory}).
      * @return the {@link Timer} instance to use.
      */
     public Timer timer(ThreadFactory threadFactory) {


### PR DESCRIPTION
This makes all of our threads instances of Netty's
FastThreadLocalThread, which allows an optimization of ThreadLocal
variables.
