### PR TITLE
JAVA-1287: Add CDC to TableOptionsMetadata and Schema Builder

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -9,6 +9,7 @@
 - [bug] JAVA-1397: Handle duration as native datatype in protocol v5+.
 - [improvement] JAVA-1308: CodecRegistry performance improvements.
 - [improvement] JAVA-1241: Upgrade Netty to 4.1.x.
+- [improvement] JAVA-1287: Add CDC to TableOptionsMetadata and Schema Builder.
 
 Merged from 3.1.x branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractTableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractTableMetadata.java
@@ -269,6 +269,9 @@ public abstract class AbstractTableMetadata {
         if (cassandraVersion.getMajor() > 2) {
             and(sb, formatted).append("crc_check_chance = ").append(options.getCrcCheckChance());
         }
+        if (cassandraVersion.getMajor() > 3 || (cassandraVersion.getMajor() == 3 && cassandraVersion.getMinor() >= 8)) {
+            and(sb, formatted).append("cdc = ").append(options.isCDC());
+        }
         sb.append(';');
         return sb;
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/TableOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/TableOptions.java
@@ -67,6 +67,8 @@ public abstract class TableOptions<T extends TableOptions> extends SchemaStateme
 
     private Optional<SpeculativeRetryValue> speculativeRetry = Optional.absent();
 
+    private Optional<Boolean> cdc = Optional.absent();
+
     private List<String> customOptions = new ArrayList<String>();
 
     @SuppressWarnings("unchecked")
@@ -358,6 +360,21 @@ public abstract class TableOptions<T extends TableOptions> extends SchemaStateme
     }
 
     /**
+     * Define whether or not change data capture is enabled on this table.
+     * <p/>
+     * Note that using this option with a version of Apache Cassandra less than 3.8 will raise a syntax error.
+     * <p/>
+     * If no call is made to this method, the default value set by Cassandra is {@code false}.
+     *
+     * @param cdc Whether or not change data capture should be enabled for this table.
+     * @return this {@code TableOptions} object.
+     */
+    public T cdc(Boolean cdc) {
+        this.cdc = Optional.fromNullable(cdc);
+        return self;
+    }
+
+    /**
      * Define a free-form option as a key/value pair.
      * <p/>
      * This method is provided as a fallback if the SchemaBuilder is used with a more recent version of Cassandra that has new, unsupported options.
@@ -446,6 +463,10 @@ public abstract class TableOptions<T extends TableOptions> extends SchemaStateme
 
         if (speculativeRetry.isPresent()) {
             options.add("speculative_retry = " + speculativeRetry.get().value());
+        }
+
+        if (cdc.isPresent()) {
+            options.add("cdc = " + cdc.get());
         }
 
         options.addAll(customOptions);

--- a/driver-core/src/test/java/com/datastax/driver/core/TableMetadataCDCTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TableMetadataCDCTest.java
@@ -1,0 +1,53 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.utils.CassandraVersion;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@CCMConfig(config = {"cdc_enabled:true"})
+@CassandraVersion(major = 3.8, description = "Requires CASSANDRA-12041 added in 3.8")
+public class TableMetadataCDCTest extends CCMTestsSupport {
+
+    /**
+     * Ensures that if a table is configured with change data capture enabled that
+     * {@link TableOptionsMetadata#isCDC()} returns true for that table.
+     *
+     * @test_category metadata
+     * @jira_ticket JAVA-1287
+     * @jira_ticket CASSANDRA-12041
+     */
+    @Test(groups = "short")
+    public void should_parse_cdc_from_table_options() {
+        // given
+        // create a simple table with cdc as true.
+        String cql = String.format("CREATE TABLE %s.cdc_table (\n"
+                + "    k text,\n"
+                + "    c int,\n"
+                + "    v timeuuid,\n"
+                + "    PRIMARY KEY (k, c)\n"
+                + ") WITH cdc=true;", keyspace);
+        session().execute(cql);
+
+        // when retrieving the table's metadata.
+        TableMetadata table = cluster().getMetadata().getKeyspace(keyspace).getTable("cdc_table");
+        // then the table's options should have cdc as true.
+        assertThat(table.getOptions().isCDC()).isEqualTo(true);
+        assertThat(table.asCQLQuery(true)).contains("cdc = true");
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
@@ -234,8 +234,50 @@ public class TableMetadataTest extends CCMTestsSupport {
         assertThat(table.getColumns().get(3)).isNotNull().hasName("i").isRegularColumn().hasType(cint());
         assertThat(table);
 
-        // Cassandra 3.0 +
-        if (version.getMajor() > 2) {
+        // Cassandra 3.8 +
+        if (version.getMajor() > 3 || (version.getMajor() == 3 && version.getMinor() >= 8)) {
+
+            assertThat(table.getOptions().getReadRepairChance()).isEqualTo(0.5);
+            assertThat(table.getOptions().getLocalReadRepairChance()).isEqualTo(0.6);
+            assertThat(table.getOptions().getGcGraceInSeconds()).isEqualTo(42);
+            assertThat(table.getOptions().getBloomFilterFalsePositiveChance()).isEqualTo(0.01);
+            assertThat(table.getOptions().getComment()).isEqualTo("My awesome table");
+            assertThat(table.getOptions().getCaching()).contains(entry("keys", "ALL"));
+            assertThat(table.getOptions().getCaching()).contains(entry("rows_per_partition", "10"));
+            assertThat(table.getOptions().getCompaction()).contains(entry("class", "org.apache.cassandra.db.compaction.LeveledCompactionStrategy"));
+            assertThat(table.getOptions().getCompaction()).contains(entry("sstable_size_in_mb", "15"));
+            assertThat(table.getOptions().getCompression()).contains(entry("class", "org.apache.cassandra.io.compress.SnappyCompressor")); // sstable_compression becomes class
+            assertThat(table.getOptions().getCompression()).contains(entry("chunk_length_in_kb", "128")); // note the "in" prefix
+            assertThat(table.getOptions().getDefaultTimeToLive()).isEqualTo(0);
+            assertThat(table.getOptions().getSpeculativeRetry()).isEqualTo("99.9PERCENTILE");
+            assertThat(table.getOptions().getIndexInterval()).isNull();
+            assertThat(table.getOptions().getMinIndexInterval()).isEqualTo(128);
+            assertThat(table.getOptions().getMaxIndexInterval()).isEqualTo(2048);
+            assertThat(table.getOptions().getReplicateOnWrite()).isTrue(); // default
+            assertThat(table.getOptions().getCrcCheckChance()).isEqualTo(0.5);
+            assertThat(table.getOptions().getExtensions()).isEmpty(); // default
+            assertThat(table.asCQLQuery())
+                    .contains("read_repair_chance = 0.5")
+                    .contains("dclocal_read_repair_chance = 0.6")
+                    .contains("gc_grace_seconds = 42")
+                    .contains("bloom_filter_fp_chance = 0.01")
+                    .contains("comment = 'My awesome table'")
+                    .contains("'keys' : 'ALL'")
+                    .contains("'rows_per_partition' : 10")
+                    .contains("'class' : 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'")
+                    .contains("'sstable_size_in_mb' : 15")
+                    .contains("'class' : 'org.apache.cassandra.io.compress.SnappyCompressor'") // sstable_compression becomes class
+                    .contains("'chunk_length_in_kb' : 128") // note the "in" prefix
+                    .contains("default_time_to_live = 0")
+                    .contains("speculative_retry = '99.9PERCENTILE'")
+                    .contains("min_index_interval = 128")
+                    .contains("max_index_interval = 2048")
+                    .contains("crc_check_chance = 0.5")
+                    .contains("cdc = false")
+                    .doesNotContain(" index_interval")
+                    .doesNotContain("replicate_on_write");
+            // Cassandra 3.0 +
+        } else if (version.getMajor() > 2) {
 
             assertThat(table.getOptions().getReadRepairChance()).isEqualTo(0.5);
             assertThat(table.getOptions().getLocalReadRepairChance()).isEqualTo(0.6);
@@ -274,7 +316,8 @@ public class TableMetadataTest extends CCMTestsSupport {
                     .contains("max_index_interval = 2048")
                     .contains("crc_check_chance = 0.5")
                     .doesNotContain(" index_interval")
-                    .doesNotContain("replicate_on_write");
+                    .doesNotContain("replicate_on_write")
+                    .doesNotContain("cdc"); // 3.8+
 
             // Cassandra 2.1 and 2.2
         } else if (version.getMajor() == 2 && version.getMinor() > 0) {
@@ -315,7 +358,8 @@ public class TableMetadataTest extends CCMTestsSupport {
                     .contains("min_index_interval = 128")
                     .contains("max_index_interval = 2048")
                     .doesNotContain(" index_interval")
-                    .doesNotContain("replicate_on_write");
+                    .doesNotContain("replicate_on_write")
+                    .doesNotContain("cdc");
 
             // Cassandra 2.0
         } else if (version.getMajor() == 2 && version.getMinor() == 0) {
@@ -354,7 +398,8 @@ public class TableMetadataTest extends CCMTestsSupport {
                     .contains("speculative_retry = '99.0PERCENTILE'")
                     .contains("default_time_to_live = 0")
                     .doesNotContain("min_index_interval") // 2.1 +
-                    .doesNotContain("max_index_interval"); // 2.1 +
+                    .doesNotContain("max_index_interval") // 2.1 +
+                    .doesNotContain("cdc");
 
             // Cassandra 1.2
         } else {
@@ -393,7 +438,8 @@ public class TableMetadataTest extends CCMTestsSupport {
                     .doesNotContain("min_index_interval")  // 2.1 +
                     .doesNotContain("max_index_interval")  // 2.1 +
                     .doesNotContain("speculative_retry")  // 2.0 +
-                    .doesNotContain("default_time_to_live"); // 2.0 +
+                    .doesNotContain("default_time_to_live") // 2.0 +
+                    .doesNotContain("cdc");
 
         }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/AlterTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/AlterTest.java
@@ -107,7 +107,8 @@ public class AlterTest {
                 .populateIOCacheOnFlush(true)
                 .replicateOnWrite(true)
                 .readRepairChance(0.42)
-                .speculativeRetry(always());
+                .speculativeRetry(always())
+                .cdc(true);
 
         SchemaStatement statementWith21Caching = alterTable("test").withOptions()
                 .caching(KeyCaching.NONE, rows(100));
@@ -129,7 +130,8 @@ public class AlterTest {
                 "AND populate_io_cache_on_flush = true " +
                 "AND read_repair_chance = 0.42 " +
                 "AND replicate_on_write = true " +
-                "AND speculative_retry = 'ALWAYS'");
+                "AND speculative_retry = 'ALWAYS' " +
+                "AND cdc = true");
 
         assertThat(statementWith21Caching.getQueryString()).isEqualTo("\n\tALTER TABLE test\n\t" +
                 "WITH caching = {'keys' : 'none', 'rows_per_partition' : 100}");

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/CreateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/CreateTest.java
@@ -48,8 +48,8 @@ public class CreateTest {
 
         //Then
         assertThat(statement.getQueryString()).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
-                        "u frozen<user>,\n\t\t" +
-                        "PRIMARY KEY(u))"
+                "u frozen<user>,\n\t\t" +
+                "PRIMARY KEY(u))"
         );
     }
 
@@ -324,7 +324,8 @@ public class CreateTest {
                 .populateIOCacheOnFlush(true)
                 .readRepairChance(0.05)
                 .replicateOnWrite(true)
-                .speculativeRetry(always());
+                .speculativeRetry(always())
+                .cdc(true);
 
         //Then
         assertThat(statement.getQueryString()).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
@@ -346,7 +347,8 @@ public class CreateTest {
                 "AND populate_io_cache_on_flush = true " +
                 "AND read_repair_chance = 0.05 " +
                 "AND replicate_on_write = true " +
-                "AND speculative_retry = 'ALWAYS' AND CLUSTERING ORDER BY(col1 ASC, col2 DESC) AND COMPACT STORAGE");
+                "AND speculative_retry = 'ALWAYS' " +
+                "AND cdc = true AND CLUSTERING ORDER BY(col1 ASC, col2 DESC) AND COMPACT STORAGE");
     }
 
     @Test(groups = "unit")
@@ -482,6 +484,40 @@ public class CreateTest {
                 "name text,\n\t\t" +
                 "PRIMARY KEY(id))\n\t" +
                 "WITH speculative_retry = '12ms'");
+    }
+
+    @Test(groups = "unit")
+    public void should_create_table_with_cdc_true() throws Exception {
+        //When
+        SchemaStatement statement = createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addColumn("name", DataType.text())
+                .withOptions()
+                .cdc(true);
+
+        //Then
+        assertThat(statement.getQueryString()).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
+                "id bigint,\n\t\t" +
+                "name text,\n\t\t" +
+                "PRIMARY KEY(id))\n\t" +
+                "WITH cdc = true");
+    }
+
+    @Test(groups = "unit")
+    public void should_create_table_with_cdc_false() throws Exception {
+        //When
+        SchemaStatement statement = createTable("test")
+                .addPartitionKey("id", DataType.bigint())
+                .addColumn("name", DataType.text())
+                .withOptions()
+                .cdc(false);
+
+        //Then
+        assertThat(statement.getQueryString()).isEqualTo("\n\tCREATE TABLE test(\n\t\t" +
+                "id bigint,\n\t\t" +
+                "name text,\n\t\t" +
+                "PRIMARY KEY(id))\n\t" +
+                "WITH cdc = false");
     }
 
     @Test(groups = "unit", expectedExceptions = IllegalStateException.class,


### PR DESCRIPTION
In support of CASSANDRA-12041, add support for parsing cdc from table
options and add support for specification using schema builder.

For [JAVA-1287](https://datastax-oss.atlassian.net/browse/JAVA-1287).
