### PR TITLE
JAVA-1292: Adjusted frame length error breaks ability to read data

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -12,6 +12,8 @@
 - [bug] JAVA-1283: Don't cache failed query preparations in the mapper.
 - [improvement] JAVA-1277: Expose AbstractSession.checkNotInEventLoop.
 - [bug] JAVA-1272: BuiltStatement not able to print its query string if it contains mapped UDTs.
+- [bug] JAVA-1292: 'Adjusted frame length' error breaks driver's ability to read data.
+- [improvement] JAVA-1293: Make DecoderForStreamIdSize.MAX_FRAME_LENGTH configurable.
 
 
 ### 3.0.3

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -323,6 +323,7 @@
                                 <include>**/SSL*Test.java</include>
                                 <include>**/ControlConnectionTest.java</include>
                                 <include>**/ExtendedPeerCheckDisabledTest.java</include>
+                                <include>**/FrameLengthTest.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/driver-core/src/main/java/com/datastax/driver/core/Frame.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Frame.java
@@ -16,6 +16,7 @@
 package com.datastax.driver.core;
 
 import com.datastax.driver.core.exceptions.DriverInternalError;
+import com.datastax.driver.core.exceptions.FrameTooLongException;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -189,42 +190,44 @@ class Frame {
     }
 
     static final class Decoder extends ByteToMessageDecoder {
-        static final DecoderForStreamIdSize decoderV1 = new DecoderForStreamIdSize(1);
-        static final DecoderForStreamIdSize decoderV3 = new DecoderForStreamIdSize(2);
+        private DecoderForStreamIdSize decoder;
 
         @Override
         protected void decode(ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws Exception {
             if (buffer.readableBytes() < 1)
                 return;
 
-            int version = buffer.getByte(buffer.readerIndex());
-            // version first bit is the "direction" of the frame (request or response)
-            version = version & 0x7F;
+            // Initialize sub decoder on first message.  No synchronization needed as
+            // decode is always called from same thread.
+            if (decoder == null) {
+                int version = buffer.getByte(buffer.readerIndex());
+                // version first bit is the "direction" of the frame (request or response)
+                version = version & 0x7F;
+                decoder = new DecoderForStreamIdSize(version, version >= 3 ? 2 : 1);
+            }
 
-            DecoderForStreamIdSize decoder = (version >= 3) ? decoderV3 : decoderV1;
             Object frame = decoder.decode(ctx, buffer);
             if (frame != null)
                 out.add(frame);
         }
 
         static class DecoderForStreamIdSize extends LengthFieldBasedFrameDecoder {
-            private static final int MAX_FRAME_LENGTH = 256 * 1024 * 1024; // 256 MB
-            private final int opcodeOffset;
+            // The maximum response frame length allowed.  Note that C* does not currently restrict the length of its responses (CASSANDRA-12630).
+            private static final int MAX_FRAME_LENGTH = SystemProperties.getInt("com.datastax.driver.NATIVE_TRANSPORT_MAX_FRAME_SIZE_IN_MB", 256) * 1024 * 1024; // 256 MB
+            private final int protocolVersion;
 
-            DecoderForStreamIdSize(int streamIdSize) {
+            DecoderForStreamIdSize(int protocolVersion, int streamIdSize) {
                 super(MAX_FRAME_LENGTH, /*lengthOffset=*/ 3 + streamIdSize, 4, 0, 0, true);
-                this.opcodeOffset = 2 + streamIdSize;
+                this.protocolVersion = protocolVersion;
             }
 
             @Override
             protected Object decode(ChannelHandlerContext ctx, ByteBuf buffer) throws Exception {
+                // Capture current index in case we need to get the stream id.
+                // If a TooLongFrameException is thrown the readerIndex will advance to the end of
+                // the buffer (or past the frame) so we need the position as we entered this method.
+                int curIndex = buffer.readerIndex();
                 try {
-                    if (buffer.readableBytes() < opcodeOffset + 1)
-                        return null;
-
-                    // Validate the opcode (this will throw if it's not a response)
-                    Message.Response.Type.fromOpcode(buffer.getByte(buffer.readerIndex() + opcodeOffset));
-
                     ByteBuf frame = (ByteBuf) super.decode(ctx, buffer);
                     if (frame == null) {
                         return null;
@@ -232,11 +235,17 @@ class Frame {
                     // Do not deallocate `frame` just yet, because it is stored as Frame.body and will be used
                     // in Message.ProtocolDecoder or Frame.Decompressor if compression is enabled (we deallocate
                     // it there).
-                    return Frame.create(frame);
+                    Frame theFrame = Frame.create(frame);
+                    // Validate the opcode (this will throw if it's not a response)
+                    Message.Response.Type.fromOpcode(theFrame.header.opcode);
+                    return theFrame;
                 } catch (CorruptedFrameException e) {
                     throw new DriverInternalError(e);
                 } catch (TooLongFrameException e) {
-                    throw new DriverInternalError(e);
+                    int streamId = protocolVersion > 2 ?
+                            buffer.getShort(curIndex + 2) :
+                            buffer.getByte(curIndex + 2);
+                    throw new FrameTooLongException(streamId);
                 }
             }
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/FrameTooLongException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/FrameTooLongException.java
@@ -1,0 +1,50 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core.exceptions;
+
+/**
+ * Indicates that the response frame for a request exceeded
+ * {@link com.datastax.driver.core.Frame.Decoder.DecoderForStreamIdSize#MAX_FRAME_LENGTH}
+ * (default: 256MB, configurable via com.datastax.driver.NATIVE_TRANSPORT_MAX_FRAME_SIZE_IN_MB
+ * system property) and thus was not parsed.
+ */
+public class FrameTooLongException extends DriverException {
+
+    private static final long serialVersionUID = 0;
+
+    private final int streamId;
+
+    public FrameTooLongException(int streamId) {
+        this(streamId, null);
+    }
+
+    private FrameTooLongException(int streamId, Throwable cause) {
+        super("Response frame exceeded maximum allowed length", cause);
+        this.streamId = streamId;
+    }
+
+    /**
+     * @return The stream id associated with the frame that caused this exception.
+     */
+    public int getStreamId() {
+        return streamId;
+    }
+
+    @Override
+    public FrameTooLongException copy() {
+        return new FrameTooLongException(streamId, this);
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/FrameLengthTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/FrameLengthTest.java
@@ -1,0 +1,121 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.exceptions.FrameTooLongException;
+import com.datastax.driver.core.querybuilder.Insert;
+import com.datastax.driver.core.schemabuilder.Create;
+import com.datastax.driver.core.schemabuilder.SchemaBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Random;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+@CCMConfig(numberOfNodes = 2)
+public class FrameLengthTest extends CCMTestsSupport {
+
+    Logger logger = LoggerFactory.getLogger(FrameLengthTest.class);
+
+    private static final String tableName = "blob_table";
+    private static final int colCount = 256;
+    private static final int rowsPerPartitionCount = 4;
+    private static final int partitionCount = 1;
+    private static final int bytesPerCol = 1024;
+
+    @BeforeClass(groups = {"isolated"})
+    public void beforeTestClass() throws Exception {
+        // Set max frame size to 1MB to make it easier to manifest frame length error.
+        System.setProperty("com.datastax.driver.NATIVE_TRANSPORT_MAX_FRAME_SIZE_IN_MB", "1");
+        super.beforeTestClass();
+    }
+
+    @Override
+    public void onTestContextInitialized() {
+        logger.info("Creating table {} with {} {}-byte blob columns", tableName, colCount, bytesPerCol);
+        Random random = new Random();
+        // Create table
+        Create create = SchemaBuilder.createTable(tableName).addPartitionKey("k", DataType.cint()).addClusteringColumn("c", DataType.cint());
+        for (int i = 0; i < colCount; i++) {
+            create.addColumn("col" + i, DataType.blob());
+        }
+        execute(create.getQueryString());
+
+        // build prepared statement.
+        Insert insert = insertInto(tableName).value("k", bindMarker()).value("c", bindMarker());
+        for (int i = 0; i < colCount; i++) {
+            insert = insert.value("col" + i, bindMarker());
+        }
+
+        PreparedStatement prepared = session().prepare(insert);
+
+        // Insert rows.
+        logger.info("Inserting data for {} partitions.", partitionCount);
+        for (int i = 0; i < partitionCount; i++) {
+            logger.info("Inserting {} rows in partition {}", rowsPerPartitionCount, i);
+            for (int r = 0; r < rowsPerPartitionCount; r++) {
+                BoundStatement stmt = prepared.bind();
+                stmt.setInt("k", i);
+                stmt.setInt("c", r);
+                for (int c = 0; c < colCount; c++) {
+                    byte[] b = new byte[bytesPerCol];
+                    random.nextBytes(b);
+                    ByteBuffer in = ByteBuffer.wrap(b);
+                    stmt.setBytes("col" + c, in);
+                }
+                session().execute(stmt);
+            }
+        }
+        logger.info("Done loading {}", tableName);
+    }
+
+    /**
+     * Validates that if a frame is received that exceeds NATIVE_TRANSPORT_MAX_FRAME_SIZE_IN_MB that
+     * the driver is able to recover, not lose host connectivity and make further queries.  It
+     * configures NATIVE_TRANSPORT_MAX_FRAME_SIZE_IN_MB to 1 MB to make the error easier to reproduce.
+     *
+     * @jira_ticket JAVA-1292
+     * @jira_ticket JAVA-1293
+     * @test_category connection
+     */
+    @Test(groups = "isolated")
+    public void should_throw_exception_when_frame_exceeds_configured_max() {
+        try {
+            session().execute(select().from(tableName).where(eq("k", 0)));
+            fail("Exception expected");
+        } catch (FrameTooLongException ftle) {
+            // Expected.
+        }
+
+        // Both hosts should remain up.
+        Collection<Host> hosts = session().getState().getConnectedHosts();
+        assertThat(hosts).hasSize(2).extractingResultOf("isUp").containsOnly(true);
+
+        // Should be able to make a query that is less than the max frame size.
+        // Execute multiple time to exercise all hosts.
+        for (int i = 0; i < 10; i++) {
+            ResultSet result = session().execute(select().from(tableName).where(eq("k", 0)).and(eq("c", 0)));
+            assertThat(result.getAvailableWithoutFetching()).isEqualTo(1);
+        }
+    }
+}


### PR DESCRIPTION
For [JAVA-1292](https://datastax-oss.atlassian.net/browse/JAVA-1292)

Also addresses [JAVA-1293](https://datastax-oss.atlassian.net/browse/JAVA-1293): Make `DecoderForStreamId.MAX_FRAME_LENGTH` configurable by adding a SystemProperty `com.datastax.driver.NATIVE_TRANSPORT_MAX_FRAME_SIZE_IN_MB` which defaults to 256.

Should also consider backporting to 2.1.x
