### PR TITLE
JAVA-1285: QueryBuilder routing key auto-discovery should handle case-sensitive column names.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@
 - [bug] JAVA-1101: Batch and BatchStatement should consider inner statements to determine query idempotence
 - [improvement] JAVA-1262: Use ParseUtils for quoting & unquoting.
 - [improvement] JAVA-1275: Use Netty's default thread factory
+- [bug] JAVA-1285: QueryBuilder routing key auto-discovery should handle case-sensitive column names.
 
 
 ### 3.0.3

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
@@ -21,7 +21,6 @@ import com.datastax.driver.core.policies.RetryPolicy;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -228,7 +227,7 @@ public abstract class BuiltStatement extends RegularStatement {
             return;
 
         for (int i = 0; i < partitionKey.size(); i++) {
-            if (name.equals(partitionKey.get(i).getName())) {
+            if (Utils.handleId(name).equals(partitionKey.get(i).getName())) {
                 routingKeyValues.set(i, value);
                 return;
             }

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Utils.java
@@ -32,7 +32,39 @@ import static com.google.common.base.Preconditions.checkNotNull;
 // Static utilities private to the query builder
 abstract class Utils {
 
+    private static final Pattern alphanumeric = Pattern.compile("\\w+"); // this includes _
     private static final Pattern cnamePattern = Pattern.compile("\\w+(?:\\[.+\\])?");
+
+    /**
+     * Deal with case sensitivity for a given element id (keyspace, table, column, etc.)
+     *
+     * This method is used to convert identifiers provided by the client (through methods such as getKeyspace(String)),
+     * to the format used internally by the driver.
+     *
+     * We expect client-facing APIs to behave like cqlsh, that is:
+     * - identifiers that are mixed-case or contain special characters should be quoted.
+     * - unquoted identifiers will be lowercased: getKeyspace("Foo") will look for a keyspace named "foo"
+     *
+     * Copied from {@link Metadata#handleId(String)} to avoid making it public.
+     */
+    static String handleId(String id) {
+        // Shouldn't really happen for this method, but no reason to fail here
+        if (id == null)
+            return null;
+
+        if (alphanumeric.matcher(id).matches())
+            return id.toLowerCase();
+
+        // Check if it's enclosed in quotes. If it is, remove them and unescape internal double quotes
+        if (!id.isEmpty() && id.charAt(0) == '"' && id.charAt(id.length() - 1) == '"')
+            return id.substring(1, id.length() - 1).replaceAll("\"\"", "\"");
+
+        // Otherwise, just return the id.
+        // Note that this is a bit at odds with the rules explained above, because the client can pass an
+        // identifier that contains special characters, without the need to quote it.
+        // Still it's better to be lenient here rather than throwing an exception.
+        return id;
+    }
 
     static StringBuilder joinAndAppend(StringBuilder sb, CodecRegistry codecRegistry, String separator, List<? extends Appendeable> values, List<Object> variables) {
         for (int i = 0; i < values.size(); i++) {

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderRoutingKeyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderRoutingKeyTest.java
@@ -23,17 +23,22 @@ import java.nio.ByteBuffer;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 @CCMConfig(clusterProvider = "createClusterBuilderNoDebouncing")
 public class QueryBuilderRoutingKeyTest extends CCMTestsSupport {
 
     private static final String TABLE_TEXT = "test_text";
     private static final String TABLE_INT = "test_int";
+    private static final String TABLE_CASE = "test_case";
+    private static final String TABLE_CASE_QUOTED = "test_case_quoted";
 
     @Override
     public void onTestContextInitialized() {
         execute(String.format("CREATE TABLE %s (k text PRIMARY KEY, a int, b int)", TABLE_TEXT),
-                String.format("CREATE TABLE %s (k int PRIMARY KEY, a int, b int)", TABLE_INT));
+                String.format("CREATE TABLE %s (k int PRIMARY KEY, a int, b int)", TABLE_INT),
+                String.format("CREATE TABLE %s (theKey int PRIMARY KEY, a int, b int)", TABLE_CASE),
+                String.format("CREATE TABLE %s (\"theKey\" int PRIMARY KEY, a int, b int, \"tHEkEY\" int)", TABLE_CASE_QUOTED));
     }
 
     @Test(groups = "short")
@@ -56,6 +61,64 @@ public class QueryBuilderRoutingKeyTest extends CCMTestsSupport {
         assertEquals(row.getString("k"), txt);
         assertEquals(row.getInt("a"), 1);
         assertEquals(row.getInt("b"), 2);
+    }
+
+    @Test(groups = "short")
+    public void routingKeyColumnCaseSensitivityTest() throws Exception {
+
+        BuiltStatement query;
+        TableMetadata table = cluster().getMetadata().getKeyspace(keyspace).getTable(TABLE_CASE);
+        assertNotNull(table);
+        ProtocolVersion protocolVersion = cluster().getConfiguration().getProtocolOptions().getProtocolVersion();
+        CodecRegistry codecRegistry = CodecRegistry.DEFAULT_INSTANCE;
+
+        query = insertInto(table).values(new String[]{"theKey", "a", "b"}, new Object[]{42, 1, 2});
+        ByteBuffer bb = ByteBuffer.allocate(4);
+        bb.putInt(0, 42);
+        assertEquals(query.getRoutingKey(protocolVersion, codecRegistry), bb);
+        session().execute(query);
+
+        query = select().from(table).where(eq("theKey", 42));
+        assertEquals(query.getRoutingKey(protocolVersion, codecRegistry), bb);
+        Row row = session().execute(query).one();
+        assertEquals(row.getInt("theKey"), 42);
+        assertEquals(row.getInt("a"), 1);
+        assertEquals(row.getInt("b"), 2);
+
+        query = insertInto(table).values(new String[]{"ThEkEy", "a", "b"}, new Object[]{42, 1, 2});
+        bb = ByteBuffer.allocate(4);
+        bb.putInt(0, 42);
+        assertEquals(query.getRoutingKey(protocolVersion, codecRegistry), bb);
+        session().execute(query);
+
+        query = select().from(table).where(eq("ThEkEy", 42));
+        assertEquals(query.getRoutingKey(protocolVersion, codecRegistry), bb);
+        row = session().execute(query).one();
+        assertEquals(row.getInt("theKey"), 42);
+        assertEquals(row.getInt("a"), 1);
+        assertEquals(row.getInt("b"), 2);
+    }
+
+    @Test(groups = "short")
+    public void routingKeyColumnCaseSensitivityForQuotedIdentifiersTest() throws Exception {
+
+        BuiltStatement query;
+        TableMetadata table = cluster().getMetadata().getKeyspace(keyspace).getTable(TABLE_CASE_QUOTED);
+        assertNotNull(table);
+        ProtocolVersion protocolVersion = cluster().getConfiguration().getProtocolOptions().getProtocolVersion();
+        CodecRegistry codecRegistry = CodecRegistry.DEFAULT_INSTANCE;
+
+        query = insertInto(table).values(new String[]{"\"theKey\"", "a", "b", "\"tHEkEY\""}, new Object[]{42, 1, 2, 3});
+        ByteBuffer bb = ByteBuffer.allocate(4);
+        bb.putInt(0, 42);
+        assertEquals(query.getRoutingKey(protocolVersion, codecRegistry), bb);
+
+        query = insertInto(table).values(new String[]{"theKey", "a", "b", "\"tHEkEY\""}, new Object[]{42, 1, 2, 3});
+        assertNull(query.getRoutingKey(protocolVersion, codecRegistry));
+
+        query = insertInto(table).values(new String[]{"theKey", "a", "b", "theKey"}, new Object[]{42, 1, 2, 3});
+        assertNull(query.getRoutingKey(protocolVersion, codecRegistry));
+
     }
 
     @Test(groups = "short")


### PR DESCRIPTION
This is the same as #743 but targeting 3.0.x.
