### PR TITLE
JAVA-1263: Eliminate unnecessary memory copies in FrameCompressor implementations

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -15,6 +15,7 @@
 - [bug] JAVA-1292: 'Adjusted frame length' error breaks driver's ability to read data.
 - [improvement] JAVA-1293: Make DecoderForStreamIdSize.MAX_FRAME_LENGTH configurable.
 - [improvement] JAVA-1053: Add a metric for authentication errors
+- [improvement] JAVA-1263: Eliminate unnecessary memory copies in FrameCompressor implementations.
 
 
 ### 3.0.3

--- a/clirr-ignores.xml
+++ b/clirr-ignores.xml
@@ -56,4 +56,16 @@
         <justification>This class is only present if the project was compiled with JDK 8+</justification>
     </difference>
 
+    <difference>
+        <differenceType>8001</differenceType> <!-- class removed -->
+        <className>com/datastax/driver/core/FrameCompressor$SnappyCompressor</className>
+        <justification>False positive, the enclosing class is package-private so this was never exposed</justification>
+    </difference>
+
+    <difference>
+        <differenceType>8001</differenceType> <!-- class removed -->
+        <className>com/datastax/driver/core/FrameCompressor$LZ4Compressor</className>
+        <justification>False positive, the enclosing class is package-private so this was never exposed</justification>
+    </difference>
+
 </differences>

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -324,6 +324,7 @@
                                 <include>**/ControlConnectionTest.java</include>
                                 <include>**/ExtendedPeerCheckDisabledTest.java</include>
                                 <include>**/FrameLengthTest.java</include>
+                                <include>**/HeapCompressionTest.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/driver-core/src/main/java/com/datastax/driver/core/FrameCompressor.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/FrameCompressor.java
@@ -15,249 +15,28 @@
  */
 package com.datastax.driver.core;
 
-import com.datastax.driver.core.exceptions.DriverInternalError;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import net.jpountz.lz4.LZ4Factory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.xerial.snappy.Snappy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
 abstract class FrameCompressor {
 
-    private static final Logger logger = LoggerFactory.getLogger(FrameCompressor.class);
+    abstract Frame compress(Frame frame) throws IOException;
 
-    public abstract Frame compress(Frame frame) throws IOException;
+    abstract Frame decompress(Frame frame) throws IOException;
 
-    public abstract Frame decompress(Frame frame) throws IOException;
-
-    public static class SnappyCompressor extends FrameCompressor {
-
-        public static final SnappyCompressor instance;
-
-        static {
-            SnappyCompressor i;
-            try {
-                i = new SnappyCompressor();
-            } catch (NoClassDefFoundError e) {
-                i = null;
-                logger.warn("Cannot find Snappy class, you should make sure the Snappy library is in the classpath if you intend to use it. Snappy compression will not be available for the protocol.");
-            } catch (Throwable e) {
-                i = null;
-                logger.warn("Error loading Snappy library ({}). Snappy compression will not be available for the protocol.", e.toString());
-            }
-            instance = i;
-        }
-
-        private SnappyCompressor() {
-            // this would throw java.lang.NoClassDefFoundError if Snappy class
-            // wasn't found at runtime which should be processed by the calling method
-            Snappy.getNativeLibraryVersion();
-        }
-
-        @Override
-        public Frame compress(Frame frame) throws IOException {
-            ByteBuf input = frame.body;
-            int maxCompressedLength = Snappy.maxCompressedLength(input.readableBytes());
-
-            final ByteBuf frameBody;
-            if (input.isDirect()) {
-                // If the input is direct we will allocate a direct output buffer as well as this will allow us to use
-                // Snappy.compress(ByteBuffer, ByteBuffer) and so eliminate memory copies.
-                ByteBuf output = input.alloc().directBuffer(maxCompressedLength);
-                try {
-                    // Using internalNioBuffer(...) as we only hold the reference in this method and so can
-                    // reduce Object allocations.
-                    ByteBuffer in = input.internalNioBuffer(input.readerIndex(), input.readableBytes());
-                    // Increase reader index.
-                    input.readerIndex(input.writerIndex());
-
-                    ByteBuffer out = output.internalNioBuffer(output.writerIndex(), output.writableBytes());
-                    int written = Snappy.compress(in, out);
-                    // Set the writer index so the amount of written bytes is reflected
-                    output.writerIndex(output.writerIndex() + written);
-                    frameBody = output;
-                } catch (IOException e) {
-                    // release output buffer so we not leak and rethrow exception.
-                    output.release();
-                    throw e;
-                }
-            } else {
-                int inOffset = input.arrayOffset() + input.readerIndex();
-                byte[] in = input.array();
-                int len = input.readableBytes();
-                // Increase reader index.
-                input.readerIndex(input.writerIndex());
-
-                // Allocate a heap buffer from the ByteBufAllocator as we may use a PooledByteBufAllocator and so
-                // can eliminate the overhead of allocate a new byte[].
-                ByteBuf output = input.alloc().heapBuffer(maxCompressedLength);
-                try {
-                    // Calculate the correct offset.
-                    int offset = output.arrayOffset() + output.writerIndex();
-                    byte[] out = output.array();
-                    int written = Snappy.compress(in, inOffset, len, out, offset);
-
-                    // Increase the writerIndex with the written bytes.
-                    output.writerIndex(output.writerIndex() + written);
-                    frameBody = output;
-                } catch (IOException e) {
-                    // release output buffer so we not leak and rethrow exception.
-                    output.release();
-                    throw e;
-                }
-            }
-            return frame.with(frameBody);
-        }
-
-        @Override
-        public Frame decompress(Frame frame) throws IOException {
-            ByteBuf input = frame.body;
-            final ByteBuf frameBody;
-
-            if (input.isDirect()) {
-                // Using internalNioBuffer(...) as we only hold the reference in this method and so can
-                // reduce Object allocations.
-                ByteBuffer in = input.internalNioBuffer(input.readerIndex(), input.readableBytes());
-                // Increase reader index.
-                input.readerIndex(input.writerIndex());
-
-                if (!Snappy.isValidCompressedBuffer(in))
-                    throw new DriverInternalError("Provided frame does not appear to be Snappy compressed");
-
-                // If the input is direct we will allocate a direct output buffer as well as this will allow us to use
-                // Snappy.compress(ByteBuffer, ByteBuffer) and so eliminate memory copies.
-                ByteBuf output = frame.body.alloc().directBuffer(Snappy.uncompressedLength(in));
-                try {
-                    ByteBuffer out = output.internalNioBuffer(output.writerIndex(), output.writableBytes());
-
-                    int size = Snappy.uncompress(in, out);
-                    // Set the writer index so the amount of written bytes is reflected
-                    output.writerIndex(output.writerIndex() + size);
-                    frameBody = output;
-                } catch (IOException e) {
-                    // release output buffer so we not leak and rethrow exception.
-                    output.release();
-                    throw e;
-                }
-            } else {
-                // Not a direct buffer so use byte arrays...
-                int inOffset = input.arrayOffset() + input.readerIndex();
-                byte[] in = input.array();
-                int len = input.readableBytes();
-                // Increase reader index.
-                input.readerIndex(input.writerIndex());
-
-                if (!Snappy.isValidCompressedBuffer(in, inOffset, len))
-                    throw new DriverInternalError("Provided frame does not appear to be Snappy compressed");
-
-                // Allocate a heap buffer from the ByteBufAllocator as we may use a PooledByteBufAllocator and so
-                // can eliminate the overhead of allocate a new byte[].
-                ByteBuf output = input.alloc().heapBuffer(Snappy.uncompressedLength(in, inOffset, len));
-                try {
-                    // Calculate the correct offset.
-                    int offset = output.arrayOffset() + output.writerIndex();
-                    byte[] out = output.array();
-                    int written = Snappy.uncompress(in, inOffset, len, out, offset);
-
-                    // Increase the writerIndex with the written bytes.
-                    output.writerIndex(output.writerIndex() + written);
-                    frameBody = output;
-                } catch (IOException e) {
-                    // release output buffer so we not leak and rethrow exception.
-                    output.release();
-                    throw e;
-                }
-            }
-            return frame.with(frameBody);
-        }
+    protected static ByteBuffer inputNioBuffer(ByteBuf buf) {
+        // Using internalNioBuffer(...) as we only hold the reference in this method and so can
+        // reduce Object allocations.
+        int index = buf.readerIndex();
+        int len = buf.readableBytes();
+        return buf.nioBufferCount() == 1 ? buf.internalNioBuffer(index, len) : buf.nioBuffer(index, len);
     }
 
-    public static class LZ4Compressor extends FrameCompressor {
-
-        public static final LZ4Compressor instance;
-
-        static {
-            LZ4Compressor i;
-            try {
-                i = new LZ4Compressor();
-            } catch (NoClassDefFoundError e) {
-                i = null;
-                logger.warn("Cannot find LZ4 class, you should make sure the LZ4 library is in the classpath if you intend to use it. LZ4 compression will not be available for the protocol.");
-            } catch (Throwable e) {
-                i = null;
-                logger.warn("Error loading LZ4 library ({}). LZ4 compression will not be available for the protocol.", e.toString());
-            }
-            instance = i;
-        }
-
-        private static final int INTEGER_BYTES = 4;
-        private final net.jpountz.lz4.LZ4Compressor compressor;
-        private final net.jpountz.lz4.LZ4FastDecompressor decompressor;
-
-        private LZ4Compressor() {
-            final LZ4Factory lz4Factory = LZ4Factory.fastestInstance();
-            logger.info("Using {}", lz4Factory.toString());
-            compressor = lz4Factory.fastCompressor();
-            decompressor = lz4Factory.fastDecompressor();
-        }
-
-        @Override
-        public Frame compress(Frame frame) throws IOException {
-            ByteBuf input = frame.body;
-            // Using internalNioBuffer(...) as we only hold the reference in this method and so can
-            // reduce Object allocations.
-            ByteBuffer in = inputNioBuffer(input, input.readerIndex(), input.readableBytes());
-
-            int maxCompressedLength = compressor.maxCompressedLength(in.remaining());
-            ByteBuf output = input.alloc().directBuffer(INTEGER_BYTES + maxCompressedLength);
-            try {
-                output.writeInt(in.remaining());
-                // Using internalNioBuffer(...) as we only hold the reference in this method and so can
-                // reduce Object allocations.
-                ByteBuffer out = output.internalNioBuffer(output.writerIndex(), output.writableBytes());
-                int written = compressor.compress(in, in.position(), in.remaining(), out, out.position(), out.remaining());
-                // Set the writer index so the amount of written bytes is reflected
-                output.writerIndex(output.writerIndex() + written);
-                return frame.with(output);
-            } catch (Exception e) {
-                // release output buffer so we not leak and rethrow exception.
-                output.release();
-                throw new IOException(e);
-            }
-        }
-
-        @Override
-        public Frame decompress(Frame frame) throws IOException {
-            ByteBuf input = frame.body;
-            int readable = input.readableBytes();
-            int uncompressedLength = input.readInt();
-            ByteBuffer in = inputNioBuffer(input, input.readerIndex(), input.readableBytes());
-            input.readerIndex(input.writerIndex());
-            ByteBuf output = input.alloc().directBuffer(uncompressedLength);
-            try {
-                ByteBuffer out = output.internalNioBuffer(output.writerIndex(), output.writableBytes());
-                int read = decompressor.decompress(in, in.position(), out, out.position(), out.remaining());
-                if (read != readable - INTEGER_BYTES)
-                    throw new IOException("Compressed lengths mismatch");
-
-                // Set the writer index so the amount of written bytes is reflected
-                output.writerIndex(output.writerIndex() + uncompressedLength);
-                return frame.with(output);
-            } catch (Exception e) {
-                // release output buffer so we not leak and rethrow exception.
-                output.release();
-                throw new IOException(e);
-            }
-        }
-
-        private static ByteBuffer inputNioBuffer(ByteBuf buf, int index, int len) {
-            // Using internalNioBuffer(...) as we only hold the reference in this method and so can
-            // reduce Object allocations.
-            return buf.nioBufferCount() == 1 ? buf.internalNioBuffer(index, len) : buf.nioBuffer(index, len);
-        }
+    protected static ByteBuffer outputNioBuffer(ByteBuf buf) {
+        int index = buf.writerIndex();
+        int len = buf.writableBytes();
+        return buf.nioBufferCount() == 1 ? buf.internalNioBuffer(index, len) : buf.nioBuffer(index, len);
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/LZ4Compressor.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/LZ4Compressor.java
@@ -1,0 +1,182 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import io.netty.buffer.ByteBuf;
+import net.jpountz.lz4.LZ4Factory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+class LZ4Compressor extends FrameCompressor {
+
+    private static final Logger logger = LoggerFactory.getLogger(LZ4Compressor.class);
+
+    static final LZ4Compressor instance;
+
+    static {
+        LZ4Compressor i;
+        try {
+            i = new LZ4Compressor();
+        } catch (NoClassDefFoundError e) {
+            i = null;
+            logger.warn("Cannot find LZ4 class, you should make sure the LZ4 library is in the classpath if you intend to use it. LZ4 compression will not be available for the protocol.");
+        } catch (Throwable e) {
+            i = null;
+            logger.warn("Error loading LZ4 library ({}). LZ4 compression will not be available for the protocol.", e.toString());
+        }
+        instance = i;
+    }
+
+    private static final int INTEGER_BYTES = 4;
+    private final net.jpountz.lz4.LZ4Compressor compressor;
+    private final net.jpountz.lz4.LZ4FastDecompressor decompressor;
+
+    private LZ4Compressor() {
+        final LZ4Factory lz4Factory = LZ4Factory.fastestInstance();
+        logger.info("Using {}", lz4Factory.toString());
+        compressor = lz4Factory.fastCompressor();
+        decompressor = lz4Factory.fastDecompressor();
+    }
+
+    @Override
+    Frame compress(Frame frame) throws IOException {
+        ByteBuf input = frame.body;
+
+        // TODO: JAVA-1306: Use the same API calls for direct and heap buffers when LZ4 updated.
+        ByteBuf frameBody = input.isDirect() ? compressDirect(input) : compressHeap(input);
+        return frame.with(frameBody);
+    }
+
+    private ByteBuf compressDirect(ByteBuf input) throws IOException {
+        int maxCompressedLength = compressor.maxCompressedLength(input.readableBytes());
+        // If the input is direct we will allocate a direct output buffer as well as this will allow us to use
+        // LZ4Compressor.compress and so eliminate memory copies.
+        ByteBuf output = input.alloc().directBuffer(INTEGER_BYTES + maxCompressedLength);
+        try {
+            ByteBuffer in = inputNioBuffer(input);
+            // Increase reader index.
+            input.readerIndex(input.writerIndex());
+
+            output.writeInt(in.remaining());
+
+            ByteBuffer out = outputNioBuffer(output);
+            int written = compressor.compress(in, in.position(), in.remaining(), out, out.position(), out.remaining());
+            // Set the writer index so the amount of written bytes is reflected
+            output.writerIndex(output.writerIndex() + written);
+        } catch (Exception e) {
+            // release output buffer so we not leak and rethrow exception.
+            output.release();
+            throw new IOException(e);
+        }
+        return output;
+    }
+
+    private ByteBuf compressHeap(ByteBuf input) throws IOException {
+        int maxCompressedLength = compressor.maxCompressedLength(input.readableBytes());
+
+        // Not a direct buffer so use byte arrays...
+        int inOffset = input.arrayOffset() + input.readerIndex();
+        byte[] in = input.array();
+        int len = input.readableBytes();
+        // Increase reader index.
+        input.readerIndex(input.writerIndex());
+
+        // Allocate a heap buffer from the ByteBufAllocator as we may use a PooledByteBufAllocator and so
+        // can eliminate the overhead of allocate a new byte[].
+        ByteBuf output = input.alloc().heapBuffer(INTEGER_BYTES + maxCompressedLength);
+        try {
+            output.writeInt(len);
+            // calculate the correct offset.
+            int offset = output.arrayOffset() + output.writerIndex();
+            byte[] out = output.array();
+            int written = compressor.compress(in, inOffset, len, out, offset);
+
+            // Set the writer index so the amount of written bytes is reflected
+            output.writerIndex(output.writerIndex() + written);
+        } catch (Exception e) {
+            // release output buffer so we not leak and rethrow exception.
+            output.release();
+            throw new IOException(e);
+        }
+        return output;
+    }
+
+    @Override
+    Frame decompress(Frame frame) throws IOException {
+        ByteBuf input = frame.body;
+
+        // TODO: JAVA-1306: Use the same API calls for direct and heap buffers when LZ4 updated.
+        ByteBuf frameBody = input.isDirect() ? decompressDirect(input) : decompressHeap(input);
+        return frame.with(frameBody);
+    }
+
+    private ByteBuf decompressDirect(ByteBuf input) throws IOException {
+        // If the input is direct we will allocate a direct output buffer as well as this will allow us to use
+        // LZ4Compressor.decompress and so eliminate memory copies.
+        int readable = input.readableBytes();
+        int uncompressedLength = input.readInt();
+        ByteBuffer in = inputNioBuffer(input);
+        // Increase reader index.
+        input.readerIndex(input.writerIndex());
+        ByteBuf output = input.alloc().directBuffer(uncompressedLength);
+        try {
+            ByteBuffer out = outputNioBuffer(output);
+            int read = decompressor.decompress(in, in.position(), out, out.position(), out.remaining());
+            if (read != readable - INTEGER_BYTES)
+                throw new IOException("Compressed lengths mismatch");
+
+            // Set the writer index so the amount of written bytes is reflected
+            output.writerIndex(output.writerIndex() + uncompressedLength);
+        } catch (Exception e) {
+            // release output buffer so we not leak and rethrow exception.
+            output.release();
+            throw new IOException(e);
+        }
+        return output;
+    }
+
+    private ByteBuf decompressHeap(ByteBuf input) throws IOException {
+        // Not a direct buffer so use byte arrays...
+        byte[] in = input.array();
+        int len = input.readableBytes();
+        int uncompressedLength = input.readInt();
+        int inOffset = input.arrayOffset() + input.readerIndex();
+        // Increase reader index.
+        input.readerIndex(input.writerIndex());
+
+        // Allocate a heap buffer from the ByteBufAllocator as we may use a PooledByteBufAllocator and so
+        // can eliminate the overhead of allocate a new byte[].
+        ByteBuf output = input.alloc().heapBuffer(uncompressedLength);
+        try {
+            int offset = output.arrayOffset() + output.writerIndex();
+            byte out[] = output.array();
+            int read = decompressor.decompress(in, inOffset, out, offset, uncompressedLength);
+            if (read != len - INTEGER_BYTES)
+                throw new IOException("Compressed lengths mismatch");
+
+            // Set the writer index so the amount of written bytes is reflected
+            output.writerIndex(output.writerIndex() + uncompressedLength);
+        } catch (Exception e) {
+            // release output buffer so we not leak and rethrow exception.
+            output.release();
+            throw new IOException(e);
+        }
+        return output;
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/ProtocolOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ProtocolOptions.java
@@ -41,7 +41,7 @@ public class ProtocolOptions {
         SNAPPY("snappy") {
             @Override
             FrameCompressor compressor() {
-                return FrameCompressor.SnappyCompressor.instance;
+                return SnappyCompressor.instance;
             }
         },
         /**
@@ -50,7 +50,7 @@ public class ProtocolOptions {
         LZ4("lz4") {
             @Override
             FrameCompressor compressor() {
-                return FrameCompressor.LZ4Compressor.instance;
+                return LZ4Compressor.instance;
             }
         };
 

--- a/driver-core/src/main/java/com/datastax/driver/core/SnappyCompressor.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SnappyCompressor.java
@@ -1,0 +1,170 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.exceptions.DriverInternalError;
+import io.netty.buffer.ByteBuf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xerial.snappy.Snappy;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+class SnappyCompressor extends FrameCompressor {
+
+    private static final Logger logger = LoggerFactory.getLogger(SnappyCompressor.class);
+
+    static final SnappyCompressor instance;
+
+    static {
+        SnappyCompressor i;
+        try {
+            i = new SnappyCompressor();
+        } catch (NoClassDefFoundError e) {
+            i = null;
+            logger.warn("Cannot find Snappy class, you should make sure the Snappy library is in the classpath if you intend to use it. Snappy compression will not be available for the protocol.");
+        } catch (Throwable e) {
+            i = null;
+            logger.warn("Error loading Snappy library ({}). Snappy compression will not be available for the protocol.", e.toString());
+        }
+        instance = i;
+    }
+
+    private SnappyCompressor() {
+        // this would throw java.lang.NoClassDefFoundError if Snappy class
+        // wasn't found at runtime which should be processed by the calling method
+        Snappy.getNativeLibraryVersion();
+    }
+
+    @Override
+    Frame compress(Frame frame) throws IOException {
+        ByteBuf input = frame.body;
+        ByteBuf frameBody = input.isDirect() ? compressDirect(input) : compressHeap(input);
+        return frame.with(frameBody);
+    }
+
+    private ByteBuf compressDirect(ByteBuf input) throws IOException {
+        int maxCompressedLength = Snappy.maxCompressedLength(input.readableBytes());
+        // If the input is direct we will allocate a direct output buffer as well as this will allow us to use
+        // Snappy.compress(ByteBuffer, ByteBuffer) and so eliminate memory copies.
+        ByteBuf output = input.alloc().directBuffer(maxCompressedLength);
+        try {
+            ByteBuffer in = inputNioBuffer(input);
+            // Increase reader index.
+            input.readerIndex(input.writerIndex());
+
+            ByteBuffer out = outputNioBuffer(output);
+            int written = Snappy.compress(in, out);
+            // Set the writer index so the amount of written bytes is reflected
+            output.writerIndex(output.writerIndex() + written);
+        } catch (IOException e) {
+            // release output buffer so we not leak and rethrow exception.
+            output.release();
+            throw e;
+        }
+        return output;
+    }
+
+    private ByteBuf compressHeap(ByteBuf input) throws IOException {
+        int maxCompressedLength = Snappy.maxCompressedLength(input.readableBytes());
+        int inOffset = input.arrayOffset() + input.readerIndex();
+        byte[] in = input.array();
+        int len = input.readableBytes();
+        // Increase reader index.
+        input.readerIndex(input.writerIndex());
+
+        // Allocate a heap buffer from the ByteBufAllocator as we may use a PooledByteBufAllocator and so
+        // can eliminate the overhead of allocate a new byte[].
+        ByteBuf output = input.alloc().heapBuffer(maxCompressedLength);
+        try {
+            // Calculate the correct offset.
+            int offset = output.arrayOffset() + output.writerIndex();
+            byte[] out = output.array();
+            int written = Snappy.compress(in, inOffset, len, out, offset);
+
+            // Increase the writerIndex with the written bytes.
+            output.writerIndex(output.writerIndex() + written);
+        } catch (IOException e) {
+            // release output buffer so we not leak and rethrow exception.
+            output.release();
+            throw e;
+        }
+        return output;
+    }
+
+    @Override
+    Frame decompress(Frame frame) throws IOException {
+        ByteBuf input = frame.body;
+        ByteBuf frameBody = input.isDirect() ? decompressDirect(input) : decompressHeap(input);
+        return frame.with(frameBody);
+    }
+
+    private ByteBuf decompressDirect(ByteBuf input) throws IOException {
+        ByteBuffer in = inputNioBuffer(input);
+        // Increase reader index.
+        input.readerIndex(input.writerIndex());
+
+        if (!Snappy.isValidCompressedBuffer(in))
+            throw new DriverInternalError("Provided frame does not appear to be Snappy compressed");
+
+        // If the input is direct we will allocate a direct output buffer as well as this will allow us to use
+        // Snappy.compress(ByteBuffer, ByteBuffer) and so eliminate memory copies.
+        ByteBuf output = input.alloc().directBuffer(Snappy.uncompressedLength(in));
+        try {
+            ByteBuffer out = outputNioBuffer(output);
+
+            int size = Snappy.uncompress(in, out);
+            // Set the writer index so the amount of written bytes is reflected
+            output.writerIndex(output.writerIndex() + size);
+        } catch (IOException e) {
+            // release output buffer so we not leak and rethrow exception.
+            output.release();
+            throw e;
+        }
+        return output;
+    }
+
+    private ByteBuf decompressHeap(ByteBuf input) throws IOException {
+        // Not a direct buffer so use byte arrays...
+        int inOffset = input.arrayOffset() + input.readerIndex();
+        byte[] in = input.array();
+        int len = input.readableBytes();
+        // Increase reader index.
+        input.readerIndex(input.writerIndex());
+
+        if (!Snappy.isValidCompressedBuffer(in, inOffset, len))
+            throw new DriverInternalError("Provided frame does not appear to be Snappy compressed");
+
+        // Allocate a heap buffer from the ByteBufAllocator as we may use a PooledByteBufAllocator and so
+        // can eliminate the overhead of allocate a new byte[].
+        ByteBuf output = input.alloc().heapBuffer(Snappy.uncompressedLength(in, inOffset, len));
+        try {
+            // Calculate the correct offset.
+            int offset = output.arrayOffset() + output.writerIndex();
+            byte[] out = output.array();
+            int written = Snappy.uncompress(in, inOffset, len, out, offset);
+
+            // Increase the writerIndex with the written bytes.
+            output.writerIndex(output.writerIndex() + written);
+        } catch (IOException e) {
+            // release output buffer so we not leak and rethrow exception.
+            output.release();
+            throw e;
+        }
+        return output;
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/CompressionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CompressionTest.java
@@ -1,0 +1,55 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import java.util.Locale;
+
+import static com.datastax.driver.core.SessionTest.checkExecuteResultSet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CompressionTest extends CCMTestsSupport {
+
+    private static String TABLE = "test";
+
+    public void onTestContextInitialized() {
+        execute(String.format("CREATE TABLE %s (k text PRIMARY KEY, t text, i int, f float)", TABLE));
+    }
+
+    void compressionTest(ProtocolOptions.Compression compression) {
+        cluster().getConfiguration().getProtocolOptions().setCompression(compression);
+        try {
+            Session compressedSession = cluster().connect(keyspace);
+
+            // Simple calls to all versions of the execute/executeAsync methods
+            String key = "execute_compressed_test_" + compression;
+            ResultSet rs = compressedSession.execute(String.format(Locale.US, "INSERT INTO %s (k, t, i, f) VALUES ('%s', '%s', %d, %f)", TABLE, key, "foo", 42, 24.03f));
+            assertThat(rs.isExhausted()).isTrue();
+
+            String SELECT_ALL = String.format(TestUtils.SELECT_ALL_FORMAT + " WHERE k = '%s'", TABLE, key);
+
+            // execute
+            checkExecuteResultSet(compressedSession.execute(SELECT_ALL), key);
+            checkExecuteResultSet(compressedSession.execute(new SimpleStatement(SELECT_ALL).setConsistencyLevel(ConsistencyLevel.ONE)), key);
+
+            // executeAsync
+            checkExecuteResultSet(compressedSession.executeAsync(SELECT_ALL).getUninterruptibly(), key);
+            checkExecuteResultSet(compressedSession.executeAsync(new SimpleStatement(SELECT_ALL).setConsistencyLevel(ConsistencyLevel.ONE)).getUninterruptibly(), key);
+
+        } finally {
+            cluster().getConfiguration().getProtocolOptions().setCompression(ProtocolOptions.Compression.NONE);
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/DirectCompressionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DirectCompressionTest.java
@@ -1,0 +1,47 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.utils.CassandraVersion;
+import org.testng.annotations.Test;
+
+public class DirectCompressionTest extends CompressionTest {
+
+    /**
+     * Validates that a session can be established using snappy compression and executes some queries that inserts and
+     * retrieves data using that session().
+     *
+     * @test_category connection:compression
+     * @expected_result session established and queries made successfully using it.
+     */
+    @Test(groups = "short")
+    public void should_function_with_snappy_compression() throws Exception {
+        compressionTest(ProtocolOptions.Compression.SNAPPY);
+    }
+
+    /**
+     * Validates that a session can be established using lz4 compression and executes some queries that inserts and
+     * retrieves data using that session().
+     *
+     * @test_category connection:compression
+     * @expected_result session established and queries made successfully using it.
+     */
+    @Test(groups = "short")
+    @CassandraVersion(major = 2.0)
+    public void should_function_with_lz4_compression() throws Exception {
+        compressionTest(ProtocolOptions.Compression.LZ4);
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/HeapCompressionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HeapCompressionTest.java
@@ -1,0 +1,54 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.utils.CassandraVersion;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class HeapCompressionTest extends CompressionTest {
+
+    @BeforeClass(groups = "isolated")
+    public void beforeTestClass() throws Exception {
+        // Configure with noPreferDirect and noUnsafe to force heap buffers.
+        System.setProperty("io.netty.noPreferDirect", "true");
+        System.setProperty("io.netty.noUnsafe", "true");
+        super.beforeTestClass();
+    }
+
+    /**
+     * Validates that snappy compression still works when using heap buffers.
+     *
+     * @test_category connection:compression
+     * @expected_result session established and queries made successfully using it.
+     */
+    @Test(groups = "isolated")
+    public void should_function_with_snappy_compression() throws Exception {
+        compressionTest(ProtocolOptions.Compression.SNAPPY);
+    }
+
+    /**
+     * Validates that lz4 compression still works when using heap buffers.
+     *
+     * @test_category connection:compression
+     * @expected_result session established and queries made successfully using it.
+     */
+    @Test(groups = "isolated")
+    @CassandraVersion(major = 2.0)
+    public void should_function_with_lz4_compression() throws Exception {
+        compressionTest(ProtocolOptions.Compression.LZ4);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <comparisonVersion>3.0.2</comparisonVersion>
+                    <comparisonVersion>3.0.3</comparisonVersion>
                     <ignoredDifferencesFile>../clirr-ignores.xml</ignoredDifferencesFile>
                 </configuration>
                 <!--


### PR DESCRIPTION
cherry-picked commits from #727 and #726 with changes:
- Add heap buffer path for LZ4.
- Seperate out direct and heap compression code.
- Use inputNioBuffer and outputNioBuffer for having a standard way of accessing internalNioBuffer (if possible).
- Add isolated tests for heap compression path.
