### PR TITLE
JAVA-1257: Implement a customizable StatementFormatter.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -15,6 +15,7 @@
 - [improvement] JAVA-1328: Provide compatibility with Guava 20.
 - [improvement] JAVA-1247: Disable idempotence warnings.
 - [improvement] JAVA-1286: Support setting and retrieving udt fields in QueryBuilder.
+- [new feature] JAVA-1257: Implement a customizable StatementFormatter.
 
 Merged from 3.1.x branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
@@ -61,8 +61,6 @@ public class BatchStatement extends Statement {
         COUNTER
     }
 
-    ;
-
     final Type batchType;
     private final List<Statement> statements = new ArrayList<Statement>();
 

--- a/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
@@ -80,6 +80,54 @@ public class BatchStatement extends Statement {
         this.batchType = batchType;
     }
 
+    /**
+     * Returns the type of this batch statement.
+     *
+     * @return the type of this batch statement.
+     */
+    public Type getBatchType() {
+        return batchType;
+    }
+
+    /**
+     * The number of values for this statement, or zero, if this
+     * statement does not have values.
+     *
+     * @return the number of values.
+     */
+    public int valuesCount() {
+        return valuesCount(CodecRegistry.DEFAULT_INSTANCE);
+    }
+
+    /**
+     * The number of values for this statement, or zero, if this
+     * statement does not have values.
+     *
+     * @param codecRegistry the codec registry that will be used if the actual
+     *                      implementation needs to serialize Java objects in the
+     *                      process of determining if the query has values.
+     *                      Note that it might be possible to use the no-arg
+     *                      {@link #valuesCount()} depending on the type of
+     *                      statement this is called on.
+     * @return the number of values.
+     */
+    public int valuesCount(CodecRegistry codecRegistry) {
+        int count = 0;
+        for (Statement statement : statements) {
+            if (statement instanceof StatementWrapper)
+                statement = ((StatementWrapper) statement).getWrappedStatement();
+            if (statement instanceof RegularStatement) {
+                   count +=  ((RegularStatement) statement).valuesCount(codecRegistry);
+            } else {
+                // We handle BatchStatement in add() so ...
+                assert statement instanceof BoundStatement;
+                BoundStatement st = (BoundStatement) statement;
+                count += st.wrapper.values.length;
+            }
+        }
+        return count;
+    }
+
     IdAndValues getIdAndValues(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
         IdAndValues idAndVals = new IdAndValues(statements.size());
         for (Statement statement : statements) {

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1655,7 +1655,11 @@ public class Cluster implements Closeable {
 
         void reportQuery(Host host, Statement statement, Exception exception, long latencyNanos) {
             for (LatencyTracker tracker : latencyTrackers) {
-                tracker.update(host, statement, exception, latencyNanos);
+                try {
+                    tracker.update(host, statement, exception, latencyNanos);
+                } catch (Exception e) {
+                    logger.error(String.format("Tracker %s threw exception: %s", tracker, e.getMessage()), e);
+                }
             }
         }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/EnhancedQueryLogger.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/EnhancedQueryLogger.java
@@ -1,0 +1,471 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+/**
+ * A configurable {@link LatencyTracker} that logs all executed statements.
+ * <p/>
+ * Typically, client applications would instantiate one single query logger (using its {@link Builder builder}),
+ * configure it and register it on the relevant {@link Cluster} instance, e.g.:
+ * <p/>
+ * <pre>
+ * Cluster cluster = ...
+ * EnhancedQueryLogger queryLogger = EnhancedQueryLogger.builder()
+ *     .withConstantThreshold(...)
+ *     .build();
+ * cluster.register(queryLogger);
+ * </pre>
+ * <p/>
+ * Refer to the {@link Builder} documentation for more information on
+ * configuration settings for the query logger.
+ * <p/>
+ * Once registered, the query logger will log every statement executed by the driver;
+ * note that it will never log null statements nor any special statement used internally by the driver.
+ * <p/>
+ * There is one log for each request to a Cassandra node; because the driver sometimes retries the same statement on multiple nodes,
+ * a single statement execution (for example, a single call to {@link Session#execute(Statement)}) can produce multiple logs on
+ * different nodes.
+ * <p/>
+ * For more flexibility, the query logger uses 3 different {@link Logger} instances:
+ * <p/>
+ * <ol>
+ * <li>{@link #NORMAL_LOGGER}: used to log normal queries, i.e., queries that completed successfully
+ * within a configurable threshold in milliseconds.</li>
+ * <li>{@link #SLOW_LOGGER}: used to log slow queries, i.e., queries that completed successfully
+ * but that took longer than a configurable threshold in milliseconds to complete.</li>
+ * <li>{@link #ERROR_LOGGER}: used to log unsuccessful queries, i.e.,
+ * queries that did not completed normally and threw an exception.
+ * Note this this logger will also print the full stack trace of the reported exception.</li>
+ * </ol>
+ * <p/>
+ * The appropriate logger is chosen according to the following algorithm:
+ * <ol>
+ * <li>if an exception has been thrown: use {@link #ERROR_LOGGER};</li>
+ * <li>otherwise, if the reported latency is greater than the configured threshold in milliseconds: use {@link #SLOW_LOGGER};</li>
+ * <li>otherwise, use {@link #NORMAL_LOGGER}.</li>
+ * </ol>
+ * <p/>
+ * All loggers are activated by setting their levels to {@code DEBUG} or {@code TRACE} (including {@link #ERROR_LOGGER}).
+ * If the level is set to {@code TRACE}, then the query parameters (if any) will be logged as well (names and actual values).
+ * <p/>
+ * <strong>Constant thresholds vs. Dynamic thresholds</strong>
+ * <p/>
+ * Currently the EnhancedQueryLogger can track slow queries in two different ways:
+ * using a {@link Builder#withConstantThreshold(long)} constant threshold} in milliseconds (which is the default
+ * behavior), or using a {@link Builder#withDynamicThreshold(PercentileTracker, double) dynamic threshold}
+ * based on latency percentiles.
+ * <p/>
+ * This class is thread-safe.
+ *
+ * @since 3.2.0
+ */
+public abstract class EnhancedQueryLogger implements LatencyTracker {
+
+    /**
+     * The default latency threshold in milliseconds beyond which queries are considered 'slow'
+     * and logged as such by the driver.
+     */
+    public static final long DEFAULT_SLOW_QUERY_THRESHOLD_MS = 5000;
+
+    /**
+     * The default latency percentile beyond which queries are considered 'slow'
+     * and logged as such by the driver.
+     */
+    public static final double DEFAULT_SLOW_QUERY_THRESHOLD_PERCENTILE = 99.0;
+
+    // Loggers
+
+    /**
+     * The logger used to log normal queries, i.e., queries that completed successfully
+     * within a configurable threshold in milliseconds.
+     * <p/>
+     * This logger is activated by setting its level to {@code DEBUG} or {@code TRACE}.
+     * Additionally, if the level is set to {@code TRACE}, then the query parameters (if any)
+     * will be logged.
+     * <p/>
+     * The name of this logger is {@code com.datastax.driver.core.QueryLogger.NORMAL}.
+     */
+    public static final Logger NORMAL_LOGGER = LoggerFactory.getLogger("com.datastax.driver.core.QueryLogger.NORMAL");
+
+    /**
+     * The logger used to log slow queries, i.e., queries that completed successfully
+     * but whose execution time exceeded a configurable threshold in milliseconds.
+     * <p/>
+     * This logger is activated by setting its level to {@code DEBUG} or {@code TRACE}.
+     * Additionally, if the level is set to {@code TRACE}, then the query parameters (if any)
+     * will be logged.
+     * <p/>
+     * The name of this logger is {@code com.datastax.driver.core.QueryLogger.SLOW}.
+     */
+    public static final Logger SLOW_LOGGER = LoggerFactory.getLogger("com.datastax.driver.core.QueryLogger.SLOW");
+
+    /**
+     * The logger used to log unsuccessful queries, i.e., queries that did not complete normally and threw an exception.
+     * <p/>
+     * This logger is activated by setting its level to {@code DEBUG} or {@code TRACE}.
+     * Additionally, if the level is set to {@code TRACE}, then the query parameters (if any)
+     * will be logged.
+     * <p/>
+     * Note this this logger will also print the full stack trace of the reported exception.
+     * <p/>
+     * The name of this logger is {@code com.datastax.driver.core.QueryLogger.ERROR}.
+     */
+    public static final Logger ERROR_LOGGER = LoggerFactory.getLogger("com.datastax.driver.core.QueryLogger.ERROR");
+
+    // Message templates
+
+    private static final String NORMAL_TEMPLATE = "[%s] [%s] Query completed normally, took %s ms: %s";
+
+    private static final String SLOW_TEMPLATE_MILLIS = "[%s] [%s] Query too slow, took %s ms: %s";
+
+    private static final String SLOW_TEMPLATE_PERCENTILE = "[%s] [%s] Query too slow, took %s ms (%s percentile = %s ms): %s";
+
+    private static final String ERROR_TEMPLATE = "[%s] [%s] Query error after %s ms: %s";
+
+    protected volatile Cluster cluster;
+
+    private final StatementFormatter formatter;
+
+    private EnhancedQueryLogger(StatementFormatter formatter) {
+        this.formatter = formatter;
+    }
+
+    /**
+     * Creates a new {@link EnhancedQueryLogger.Builder} instance.
+     * <p/>
+     * This is a convenience method for {@code new EnhancedQueryLogger.Builder()}.
+     *
+     * @return the new EnhancedQueryLogger builder.
+     * @throws NullPointerException if {@code cluster} is {@code null}.
+     */
+    public static EnhancedQueryLogger.Builder builder() {
+        return new EnhancedQueryLogger.Builder();
+    }
+
+    @Override
+    public void onRegister(Cluster cluster) {
+        this.cluster = cluster;
+    }
+
+    @Override
+    public void onUnregister(Cluster cluster) {
+        // nothing to do
+    }
+
+    /**
+     * A QueryLogger that uses a constant threshold in milliseconds
+     * to track slow queries.
+     * This implementation is the default.
+     */
+    public static class ConstantThresholdQueryLogger extends EnhancedQueryLogger {
+
+        private volatile long slowQueryLatencyThresholdMillis;
+
+        private ConstantThresholdQueryLogger(long slowQueryLatencyThresholdMillis, StatementFormatter formatter) {
+            super(formatter);
+            this.setSlowQueryLatencyThresholdMillis(slowQueryLatencyThresholdMillis);
+        }
+
+        /**
+         * Return the threshold in milliseconds beyond which queries are considered 'slow'
+         * and logged as such by the driver.
+         * The default value is {@link #DEFAULT_SLOW_QUERY_THRESHOLD_MS}.
+         *
+         * @return The threshold in milliseconds beyond which queries are considered 'slow'
+         * and logged as such by the driver.
+         */
+        public long getSlowQueryLatencyThresholdMillis() {
+            return slowQueryLatencyThresholdMillis;
+        }
+
+        /**
+         * Set the threshold in milliseconds beyond which queries are considered 'slow'
+         * and logged as such by the driver.
+         *
+         * @param slowQueryLatencyThresholdMillis Slow queries threshold in milliseconds.
+         *                                        It must be strictly positive.
+         * @throws IllegalArgumentException if {@code slowQueryLatencyThresholdMillis <= 0}.
+         */
+        public void setSlowQueryLatencyThresholdMillis(long slowQueryLatencyThresholdMillis) {
+            if (slowQueryLatencyThresholdMillis <= 0)
+                throw new IllegalArgumentException("Invalid slowQueryLatencyThresholdMillis, should be > 0, got " + slowQueryLatencyThresholdMillis);
+            this.slowQueryLatencyThresholdMillis = slowQueryLatencyThresholdMillis;
+        }
+
+        @Override
+        protected void maybeLogNormalOrSlowQuery(Host host, Statement statement, long latencyMs) {
+            if (latencyMs > slowQueryLatencyThresholdMillis) {
+                maybeLogSlowQuery(host, statement, latencyMs);
+            } else {
+                maybeLogNormalQuery(host, statement, latencyMs);
+            }
+        }
+
+        protected void maybeLogSlowQuery(Host host, Statement statement, long latencyMs) {
+            if (SLOW_LOGGER.isDebugEnabled()) {
+                String statementAsString = statementAsString(statement, SLOW_LOGGER);
+                logQuery(SLOW_LOGGER, SLOW_TEMPLATE_MILLIS, null, cluster.getClusterName(), host, latencyMs, statementAsString);
+            }
+        }
+    }
+
+    /**
+     * A QueryLogger that uses a dynamic threshold in milliseconds
+     * to track slow queries.
+     * <p/>
+     * Dynamic thresholds are based on per-host latency percentiles, as computed
+     * by {@link PercentileTracker}.
+     */
+    public static class DynamicThresholdQueryLogger extends EnhancedQueryLogger {
+
+        private volatile double slowQueryLatencyThresholdPercentile;
+
+        private volatile PercentileTracker percentileLatencyTracker;
+
+        private DynamicThresholdQueryLogger(double slowQueryLatencyThresholdPercentile,
+                                            PercentileTracker percentileLatencyTracker,
+                                            StatementFormatter formatter) {
+            super(formatter);
+            this.setSlowQueryLatencyThresholdPercentile(slowQueryLatencyThresholdPercentile);
+            this.setPercentileLatencyTracker(percentileLatencyTracker);
+        }
+
+        /**
+         * Return the percentile tracker to use for recording per-host latency histograms.
+         * Cannot be {@code null}.
+         *
+         * @return the percentile tracker to use.
+         */
+        public PercentileTracker getPercentileLatencyTracker() {
+            return percentileLatencyTracker;
+        }
+
+        /**
+         * Set the percentile tracker to use for recording per-host latency histograms.
+         * Cannot be {@code null}.
+         *
+         * @param percentileLatencyTracker the percentile tracker instance to use.
+         * @throws IllegalArgumentException if {@code percentileLatencyTracker == null}.
+         */
+        public void setPercentileLatencyTracker(PercentileTracker percentileLatencyTracker) {
+            if (percentileLatencyTracker == null)
+                throw new IllegalArgumentException("perHostPercentileLatencyTracker cannot be null");
+            this.percentileLatencyTracker = percentileLatencyTracker;
+        }
+
+        /**
+         * Return the threshold percentile beyond which queries are considered 'slow'
+         * and logged as such by the driver.
+         * The default value is {@link #DEFAULT_SLOW_QUERY_THRESHOLD_PERCENTILE}.
+         *
+         * @return threshold percentile beyond which queries are considered 'slow'
+         * and logged as such by the driver.
+         */
+        public double getSlowQueryLatencyThresholdPercentile() {
+            return slowQueryLatencyThresholdPercentile;
+        }
+
+        /**
+         * Set the threshold percentile beyond which queries are considered 'slow'
+         * and logged as such by the driver.
+         *
+         * @param slowQueryLatencyThresholdPercentile Slow queries threshold percentile.
+         *                                            It must be comprised between 0 inclusive and 100 exclusive.
+         * @throws IllegalArgumentException if {@code slowQueryLatencyThresholdPercentile < 0 || slowQueryLatencyThresholdPercentile >= 100}.
+         */
+        public void setSlowQueryLatencyThresholdPercentile(double slowQueryLatencyThresholdPercentile) {
+            if (slowQueryLatencyThresholdPercentile < 0.0 || slowQueryLatencyThresholdPercentile >= 100.0)
+                throw new IllegalArgumentException("Invalid slowQueryLatencyThresholdPercentile, should be >= 0 and < 100, got " + slowQueryLatencyThresholdPercentile);
+            this.slowQueryLatencyThresholdPercentile = slowQueryLatencyThresholdPercentile;
+        }
+
+        @Override
+        protected void maybeLogNormalOrSlowQuery(Host host, Statement statement, long latencyMs) {
+            long threshold = percentileLatencyTracker.getLatencyAtPercentile(host, statement, null, slowQueryLatencyThresholdPercentile);
+            if (threshold >= 0 && latencyMs > threshold) {
+                maybeLogSlowQuery(host, statement, latencyMs, threshold);
+            } else {
+                maybeLogNormalQuery(host, statement, latencyMs);
+            }
+        }
+
+        protected void maybeLogSlowQuery(Host host, Statement statement, long latencyMs, long threshold) {
+            if (SLOW_LOGGER.isDebugEnabled()) {
+                String statementAsString = statementAsString(statement, SLOW_LOGGER);
+                logQuery(SLOW_LOGGER, SLOW_TEMPLATE_PERCENTILE, null, cluster.getClusterName(), host, latencyMs,
+                        slowQueryLatencyThresholdPercentile, threshold, statementAsString);
+            }
+        }
+
+        @Override
+        public void onRegister(Cluster cluster) {
+            super.onRegister(cluster);
+            cluster.register(percentileLatencyTracker);
+        }
+
+        // Don't unregister the latency tracker in onUnregister, we can't guess if it's being used by another component
+        // or not.
+    }
+
+    /**
+     * Helper class to build {@link EnhancedQueryLogger} instances with a fluent API.
+     */
+    public static class Builder {
+
+        private StatementFormatter formatter = StatementFormatter.DEFAULT_INSTANCE;
+
+        private long slowQueryLatencyThresholdMillis = DEFAULT_SLOW_QUERY_THRESHOLD_MS;
+
+        private double slowQueryLatencyThresholdPercentile = DEFAULT_SLOW_QUERY_THRESHOLD_PERCENTILE;
+
+        private PercentileTracker percentileLatencyTracker;
+
+        private boolean constantThreshold = true;
+
+        /**
+         * Enables slow query latency tracking based on constant thresholds.
+         * <p/>
+         * Note: You should either use constant thresholds
+         * or {@link #withDynamicThreshold(PercentileTracker, double) dynamic thresholds},
+         * not both.
+         *
+         * @param slowQueryLatencyThresholdMillis The threshold in milliseconds beyond which queries are considered 'slow'
+         *                                        and logged as such by the driver.
+         *                                        The default value is {@link #DEFAULT_SLOW_QUERY_THRESHOLD_MS}
+         * @return this {@link Builder} instance (for method chaining).
+         */
+        public Builder withConstantThreshold(long slowQueryLatencyThresholdMillis) {
+            this.slowQueryLatencyThresholdMillis = slowQueryLatencyThresholdMillis;
+            constantThreshold = true;
+            return this;
+        }
+
+        /**
+         * Enables slow query latency tracking based on dynamic thresholds.
+         * <p/>
+         * Dynamic thresholds are based on latency percentiles, as computed by {@link PercentileTracker}.
+         * <p/>
+         * Note: You should either use {@link #withConstantThreshold(long) constant thresholds} or
+         * dynamic thresholds, not both.
+         *
+         * @param percentileLatencyTracker            the {@link PercentileTracker} instance to use for recording
+         *                                            latency histograms. Cannot be {@code null}.
+         *                                            It will get {@link Cluster#register(LatencyTracker) registered}
+         *                                            with the cluster at the same time as this logger.
+         * @param slowQueryLatencyThresholdPercentile Slow queries threshold percentile.
+         *                                            It must be comprised between 0 inclusive and 100 exclusive.
+         *                                            The default value is {@link #DEFAULT_SLOW_QUERY_THRESHOLD_PERCENTILE}
+         * @return this {@link Builder} instance (for method chaining).
+         */
+        public Builder withDynamicThreshold(PercentileTracker percentileLatencyTracker,
+                                            double slowQueryLatencyThresholdPercentile) {
+            this.percentileLatencyTracker = percentileLatencyTracker;
+            this.slowQueryLatencyThresholdPercentile = slowQueryLatencyThresholdPercentile;
+            constantThreshold = false;
+            return this;
+        }
+
+        /**
+         * Sets the {@link StatementFormatter formatter} to use
+         * to format logged statements.
+         * <p/>
+         * If this method is not called, then the
+         * {@link StatementFormatter#DEFAULT_INSTANCE default formatter}
+         * will be used.
+         *
+         * @param formatter the {@link StatementFormatter formatter} to use.
+         * @return this {@link Builder} instance (for method chaining).
+         */
+        public Builder withStatementFormatter(StatementFormatter formatter) {
+            this.formatter = formatter;
+            return this;
+        }
+
+        /**
+         * Builds the {@link EnhancedQueryLogger} instance.
+         *
+         * @return the {@link EnhancedQueryLogger} instance.
+         */
+        public EnhancedQueryLogger build() {
+            if (constantThreshold) {
+                return new ConstantThresholdQueryLogger(slowQueryLatencyThresholdMillis, formatter);
+            } else {
+                return new DynamicThresholdQueryLogger(slowQueryLatencyThresholdPercentile,
+                        percentileLatencyTracker, formatter);
+            }
+        }
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void update(Host host, Statement statement, Exception exception, long newLatencyNanos) {
+        if (cluster == null)
+            throw new IllegalStateException("This method should only be called after the logger has been registered with a cluster");
+
+        if (statement instanceof StatementWrapper)
+            statement = ((StatementWrapper) statement).getWrappedStatement();
+
+        long latencyMs = NANOSECONDS.toMillis(newLatencyNanos);
+        if (exception == null) {
+            maybeLogNormalOrSlowQuery(host, statement, latencyMs);
+        } else {
+            maybeLogErrorQuery(host, statement, exception, latencyMs);
+        }
+    }
+
+    protected abstract void maybeLogNormalOrSlowQuery(Host host, Statement statement, long latencyMs);
+
+    protected void maybeLogNormalQuery(Host host, Statement statement, long latencyMs) {
+        if (NORMAL_LOGGER.isDebugEnabled()) {
+            String statementAsString = statementAsString(statement, NORMAL_LOGGER);
+            logQuery(NORMAL_LOGGER, NORMAL_TEMPLATE, null, cluster.getClusterName(), host, latencyMs, statementAsString);
+        }
+    }
+
+    protected void maybeLogErrorQuery(Host host, Statement statement, Exception exception, long latencyMs) {
+        if (ERROR_LOGGER.isDebugEnabled()) {
+            String statementAsString = statementAsString(statement, ERROR_LOGGER);
+            logQuery(ERROR_LOGGER, ERROR_TEMPLATE, exception, cluster.getClusterName(), host, latencyMs, statementAsString);
+        }
+    }
+
+    protected void logQuery(Logger logger, String template, Exception exception, Object... templateParameters) {
+        String message = String.format(template, templateParameters);
+        if (logger.isTraceEnabled()) {
+            logger.trace(message, exception);
+        } else {
+            logger.debug(message, exception);
+        }
+    }
+
+    protected String statementAsString(Statement statement, Logger logger) {
+        ProtocolVersion protocolVersion = cluster.getConfiguration().getProtocolOptions().getProtocolVersion();
+        CodecRegistry codecRegistry = cluster.getConfiguration().getCodecRegistry();
+        StatementFormatter.StatementFormatVerbosity verbosity = logger.isTraceEnabled() ?
+                StatementFormatter.StatementFormatVerbosity.EXTENDED :
+                StatementFormatter.StatementFormatVerbosity.NORMAL;
+        return formatter.format(statement, verbosity, protocolVersion, codecRegistry);
+    }
+
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/PercentileTracker.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PercentileTracker.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Set;
 import java.util.concurrent.*;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.concurrent.TimeUnit.*;
@@ -39,7 +40,7 @@ import static java.util.concurrent.TimeUnit.*;
  * determined by {@link #computeKey(Host, Statement, Exception)}.
  * <p/>
  * This class is used by percentile-aware components such as
- * {@link QueryLogger.Builder#withDynamicThreshold(PercentileTracker, double)}  QueryLogger} and
+ * {@link EnhancedQueryLogger.Builder#withDynamicThreshold(PercentileTracker, double)}  QueryLogger} and
  * {@link com.datastax.driver.core.policies.PercentileSpeculativeExecutionPolicy}.
  * <p/>
  * It uses <a href="http://hdrhistogram.github.io/HdrHistogram/">HdrHistogram</a> to record latencies:

--- a/driver-core/src/main/java/com/datastax/driver/core/QueryLogger.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/QueryLogger.java
@@ -87,7 +87,11 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  * This class is thread-safe.
  *
  * @since 2.0.10
+ * @deprecated since 3.2.0, use the more easily configurable {@link EnhancedQueryLogger} instead.
+ * This class might be removed in a future major version.
  */
+@SuppressWarnings("DeprecatedIsStillUsed")
+@Deprecated
 public abstract class QueryLogger implements LatencyTracker {
 
     /**
@@ -230,6 +234,7 @@ public abstract class QueryLogger implements LatencyTracker {
      * This implementation is the default and should be preferred to {@link DynamicThresholdQueryLogger}
      * which is still in beta state.
      */
+    @Deprecated
     public static class ConstantThresholdQueryLogger extends QueryLogger {
 
         private volatile long slowQueryLatencyThresholdMillis;
@@ -289,6 +294,7 @@ public abstract class QueryLogger implements LatencyTracker {
      * Dynamic thresholds are based on per-host latency percentiles, as computed
      * by {@link PercentileTracker}.
      */
+    @Deprecated
     public static class DynamicThresholdQueryLogger extends QueryLogger {
 
         private volatile double slowQueryLatencyThresholdPercentile;

--- a/driver-core/src/main/java/com/datastax/driver/core/RegularStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RegularStatement.java
@@ -189,21 +189,4 @@ public abstract class RegularStatement extends Statement {
         return hasValues(CodecRegistry.DEFAULT_INSTANCE);
     }
 
-    /**
-     * Returns this statement as a CQL query string.
-     * <p/>
-     * It is important to note that the query string is merely
-     * a CQL representation of this statement, but it does
-     * <em>not</em> convey all the information stored in {@link Statement}
-     * objects.
-     * <p/>
-     * See the javadocs of {@link #getQueryString()} for more information.
-     *
-     * @return this statement as a CQL query string.
-     * @see #getQueryString()
-     */
-    @Override
-    public String toString() {
-        return getQueryString();
-    }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/RegularStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RegularStatement.java
@@ -189,4 +189,38 @@ public abstract class RegularStatement extends Statement {
         return hasValues(CodecRegistry.DEFAULT_INSTANCE);
     }
 
+    /**
+     * The number of values for this statement, or zero, if this
+     * statement does not have values.
+     * <p/>
+     * This implementation simply delegates to {@link #valuesCount(CodecRegistry)}.
+     *
+     * @return the number of values.
+     * @see #valuesCount(CodecRegistry)
+     */
+    public int valuesCount() {
+        return valuesCount(CodecRegistry.DEFAULT_INSTANCE);
+    }
+
+    /**
+     * The number of values for this statement, or zero, if this
+     * statement does not have values.
+     * <p/>
+     * The default implementation simply counts the number of items
+     * returned by {@link #getValues(ProtocolVersion, CodecRegistry)}.
+     * Subclasses may wish to override this method if they have a more efficient
+     * way to count the number of values.
+     *
+     * @param codecRegistry the codec registry that will be used if the actual
+     *                      implementation needs to serialize Java objects in the
+     *                      process of determining if the query has values.
+     *                      Note that it might be possible to use the no-arg
+     *                      {@link #valuesCount()} depending on the type of
+     *                      statement this is called on.
+     * @return the number of values.
+     */
+    public int valuesCount(CodecRegistry codecRegistry) {
+        return getValues(ProtocolVersion.NEWEST_SUPPORTED, codecRegistry).length;
+    }
+
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/SimpleStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SimpleStatement.java
@@ -152,12 +152,7 @@ public class SimpleStatement extends RegularStatement {
         return convert(namedValues, protocolVersion, codecRegistry);
     }
 
-    /**
-     * The number of values for this statement, that is the size of the array
-     * that will be returned by {@code getValues}.
-     *
-     * @return the number of values.
-     */
+    @Override
     public int valuesCount() {
         if (values != null)
             return values.length;
@@ -165,6 +160,11 @@ public class SimpleStatement extends RegularStatement {
             return namedValues.size();
         else
             return 0;
+    }
+
+    @Override
+    public int valuesCount(CodecRegistry codecRegistry) {
+        return valuesCount();
     }
 
     @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/Statement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Statement.java
@@ -596,4 +596,17 @@ public abstract class Statement {
         }
         return (hasNullIdempotentStatements) ? null : true;
     }
+
+    @Override
+    public String toString() {
+        try {
+            return StatementFormatter.DEFAULT_INSTANCE.format(
+                    this,
+                    StatementFormatter.StatementFormatVerbosity.EXTENDED,
+                    ProtocolVersion.NEWEST_SUPPORTED,
+                    CodecRegistry.DEFAULT_INSTANCE);
+        } catch (StatementFormatter.StatementFormatException e) {
+            return super.toString();
+        }
+    }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/StatementFormatter.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/StatementFormatter.java
@@ -1,0 +1,1194 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.querybuilder.BuiltStatement;
+import com.datastax.driver.core.schemabuilder.SchemaStatement;
+import com.google.common.collect.ImmutableMap;
+
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.datastax.driver.core.StatementFormatter.StatementWriter.*;
+
+/**
+ * A component to format instances of {@link Statement}.
+ * <p/>
+ * Its main method is the {@link #format(Statement, StatementFormatVerbosity, ProtocolVersion, CodecRegistry) format}
+ * method. It can format statements with different levels of verbosity,
+ * which in turn determines which elements to include in the formatted string
+ * (query string, bound values, custom payloads, inner statements for batches, etc.).
+ * <p/>
+ * {@code StatementFormatter} also provides safeguards to prevent overwhelming your logs
+ * with large query strings, queries with considerable amounts of parameters,
+ * batch queries with several inner statements, etc.
+ * <p/>
+ * For most users, the {@link #DEFAULT_INSTANCE} should be just fine.
+ * However, {@code StatementFormatter} is fully customizable.
+ * To build a customized formatter, use the {@link #builder()} method
+ * as follows:
+ * <pre>{@code
+ * StatementFormatter formatter = StatementFormatter.builder()
+ *      // customize formatter settings
+ *      .withMaxBoundValues(42)
+ *      .build()
+ * }</pre>
+ * It is also possible to take full control over how a specific kind
+ * of statement should be formatted.
+ * To do this, simply implement a {@link StatementPrinter StatementPrinter}:
+ * <pre>{@code
+ * class MyCustomStatement extends StatementWrapper {...}
+ *
+ * class MyCustomStatementPrinter implements StatementPrinter<MyCustomStatement> {
+ *      public Class<MyCustomStatement> getSupportedStatementClass() {
+ *           return MyCustomStatement.class;
+ *      }
+ *      public void print(CustomStatement statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+ *           // go crazy
+ *      }
+ * }
+ * }</pre>
+ * Then add it to the resulting formatter as follows:
+ * <pre>{@code
+ * StatementFormatter formatter = StatementFormatter.builder()
+ *      .addStatementPrinter(new MyCustomStatementPrinter())
+ *      .build()
+ * }</pre>
+ * The driver ships with a set of printers that handle
+ * all the built-in statement types. It is possible to completely override them
+ * by simply providing a {@code StatementPrinter} for the type of
+ * {@code Statement} that you wish to override, using the same method outlined above.
+ * <p/>
+ * Instances of this class are thread-safe.
+ */
+public final class StatementFormatter {
+
+    public static final StatementFormatter DEFAULT_INSTANCE = StatementFormatter.builder().build();
+
+    /**
+     * Creates a new {@link StatementFormatter.Builder} instance.
+     *
+     * @return the new StatementFormatter builder.
+     */
+    public static StatementFormatter.Builder builder() {
+        return new StatementFormatter.Builder();
+    }
+
+    /**
+     * The desired statement format verbosity.
+     * <p/>
+     * This should be used as a guideline as to how much information
+     * about the statement should be extracted and formatted.
+     */
+    public enum StatementFormatVerbosity {
+
+        // the enum order matters
+
+        /**
+         * Formatters should only print a basic information in summarized form.
+         */
+        ABRIDGED,
+
+        /**
+         * Formatters should print basic information in summarized form,
+         * and the statement's query string, if available.
+         * <p/>
+         * For batch statements, this verbosity level should
+         * allow formatters to print information about the batch's
+         * inner statements.
+         */
+        NORMAL,
+
+        /**
+         * Formatters should print full information, including
+         * the statement's query string, if available,
+         * and the statement's bound values, if available.
+         */
+        EXTENDED
+
+    }
+
+    /**
+     * A statement printer is responsible for printing a specific type of {@link Statement statement},
+     * with a given {@link StatementFormatVerbosity verbosity level},
+     * and using a given {@link StatementWriter statement writer}.
+     *
+     * @param <S> The type of statement that this printer handles
+     */
+    public interface StatementPrinter<S extends Statement> {
+
+        /**
+         * The concrete {@link Statement} subclass that this printer handles.
+         * <p/>
+         * In case of subtype polymorphism, if this printer
+         * handles more than one concrete subclass,
+         * the most specific common ancestor should be returned here.
+         *
+         * @return The concrete {@link Statement} subclass that this printer handles.
+         */
+        Class<S> getSupportedStatementClass();
+
+        /**
+         * Prints the given {@link Statement statement},
+         * using the given {@link StatementWriter statement writer} and
+         * the given {@link StatementFormatVerbosity verbosity level}.
+         *
+         * @param statement the statement to print
+         * @param out       the writer to use
+         * @param verbosity the verbosity to use
+         */
+        void print(S statement, StatementWriter out, StatementFormatVerbosity verbosity);
+
+    }
+
+    /**
+     * Thrown when a {@link StatementFormatter} encounters an error
+     * while formatting a {@link Statement}.
+     */
+    public static class StatementFormatException extends RuntimeException {
+
+        private final Statement statement;
+        private final StatementFormatVerbosity verbosity;
+        private final ProtocolVersion protocolVersion;
+        private final CodecRegistry codecRegistry;
+
+        public StatementFormatException(Statement statement, StatementFormatVerbosity verbosity, ProtocolVersion protocolVersion, CodecRegistry codecRegistry, Throwable t) {
+            super(t);
+            this.statement = statement;
+            this.verbosity = verbosity;
+            this.protocolVersion = protocolVersion;
+            this.codecRegistry = codecRegistry;
+        }
+
+        /**
+         * @return The statement that failed to format.
+         */
+        public Statement getStatement() {
+            return statement;
+        }
+
+        /**
+         * @return The requested verbosity.
+         */
+        public StatementFormatVerbosity getVerbosity() {
+            return verbosity;
+        }
+
+        /**
+         * @return The protocol version in use.
+         */
+        public ProtocolVersion getProtocolVersion() {
+            return protocolVersion;
+        }
+
+        /**
+         * @return The codec registry in use.
+         */
+        public CodecRegistry getCodecRegistry() {
+            return codecRegistry;
+        }
+    }
+
+    /**
+     * A set of user-defined limitation rules that {@link StatementPrinter printers}
+     * should strive to comply with when formatting statements.
+     * <p/>
+     * Limits defined in this class should be considered on a per-statement basis;
+     * i.e. if the maximum query string length is 100 and the statement to format
+     * is a {@link BatchStatement} with 5 inner statements, each inner statement
+     * should be allowed to print a maximum of 100 characters of its query string.
+     * <p/>
+     * This class is NOT thread-safe.
+     */
+    public static final class StatementFormatterLimits {
+
+        /**
+         * A special value that conveys the notion of "unlimited".
+         * All fields in this class accept this value.
+         */
+        public static final int UNLIMITED = -1;
+
+        public final int maxQueryStringLength;
+        public final int maxBoundValueLength;
+        public final int maxBoundValues;
+        public final int maxInnerStatements;
+        public final int maxOutgoingPayloadEntries;
+        public final int maxOutgoingPayloadValueLength;
+
+        private StatementFormatterLimits(int maxQueryStringLength, int maxBoundValueLength, int maxBoundValues, int maxInnerStatements, int maxOutgoingPayloadEntries, int maxOutgoingPayloadValueLength) {
+            this.maxQueryStringLength = maxQueryStringLength;
+            this.maxBoundValueLength = maxBoundValueLength;
+            this.maxBoundValues = maxBoundValues;
+            this.maxInnerStatements = maxInnerStatements;
+            this.maxOutgoingPayloadEntries = maxOutgoingPayloadEntries;
+            this.maxOutgoingPayloadValueLength = maxOutgoingPayloadValueLength;
+        }
+    }
+
+    /**
+     * A registry for {@link StatementPrinter statement printers}.
+     * <p/>
+     * This class is thread-safe.
+     */
+    public static final class StatementPrinterRegistry {
+
+        private static final Map<Class<?>, StatementPrinter<?>> BUILT_IN_PRINTERS =
+                ImmutableMap.<Class<?>, StatementPrinter<?>>builder()
+                        .put(Statement.class, new DefaultStatementPrinter())
+                        .put(SimpleStatement.class, new SimpleStatementPrinter())
+                        .put(RegularStatement.class, new RegularStatementPrinter())
+                        .put(BuiltStatement.class, new BuiltStatementPrinter())
+                        .put(SchemaStatement.class, new SchemaStatementPrinter())
+                        .put(BoundStatement.class, new BoundStatementPrinter())
+                        .put(BatchStatement.class, new BatchStatementPrinter())
+                        .put(StatementWrapper.class, new StatementWrapperPrinter())
+                        .build();
+
+        private final ConcurrentMap<Class<?>, StatementPrinter<?>> printers =
+                new ConcurrentHashMap<Class<?>, StatementPrinter<?>>();
+
+        private StatementPrinterRegistry() {
+        }
+
+        /**
+         * Attempts to locate the best {@link StatementPrinter printer} for the given
+         * statement.
+         * <p/>
+         * The registry first tries to locate a user-defined printer that is capable of
+         * printing the given statement; if none is found, then built-in printers
+         * will be used.
+         *
+         * @param statement The statement find a printer for.
+         * @return The best {@link StatementPrinter printer} for the given
+         * statement. Cannot be {@code null}.
+         */
+        @SuppressWarnings("unchecked")
+        public <S extends Statement> StatementPrinter<? super S> findPrinter(S statement) {
+            StatementPrinter<?> printer = lookupPrinter(statement, printers);
+            if (printer == null)
+                printer = lookupPrinter(statement, BUILT_IN_PRINTERS);
+            assert printer != null;
+            return (StatementPrinter<? super S>) printer;
+        }
+
+        private static StatementPrinter<?> lookupPrinter(Statement statement, Map<Class<?>, StatementPrinter<?>> map) {
+            StatementPrinter<?> printer = null;
+            for (Class<?> key = statement.getClass(); printer == null && key != null; key = key.getSuperclass()) {
+                printer = map.get(key);
+            }
+            return printer;
+        }
+
+        private <S extends Statement> void register(StatementPrinter<S> printer) {
+            printers.put(printer.getSupportedStatementClass(), printer);
+        }
+
+    }
+
+    /**
+     * This class exposes utility methods to help
+     * {@link StatementPrinter statement printers} in formatting
+     * a statement.
+     * <p/>
+     * Instances of this class are designed to format one single statement;
+     * they keep internal counters such as the current number of printed bound values,
+     * and for this reason, they should not be reused to format more than one statement.
+     * When formatting more than one statement (e.g. when formatting a {@link BatchStatement} and its children),
+     * one should call {@link #createChildWriter()} to create child instances of the main writer
+     * to format each individual statement.
+     * <p/>
+     * This class is NOT thread-safe.
+     */
+    public static final class StatementWriter implements Appendable {
+
+        public static final String summaryStart = " [";
+        public static final String summaryEnd = "]";
+        public static final String boundValuesCount = "%s bound values";
+        public static final String statementsCount = "%s inner statements";
+        public static final String queryStringStart = ": ";
+        public static final String queryStringEnd = " ";
+        public static final String boundValuesStart = "{ ";
+        public static final String boundValuesEnd = " }";
+        public static final String outgoingPayloadStart = "< ";
+        public static final String outgoingPayloadEnd = " >";
+        public static final String truncatedOutput = "...";
+        public static final String nullValue = "<NULL>";
+        public static final String unsetValue = "<UNSET>";
+        public static final String listElementSeparator = ", ";
+        public static final String nameValueSeparator = " : ";
+
+        private static final int MAX_EXCEEDED = -2;
+
+        private final StringBuilder buffer;
+        private final StatementPrinterRegistry printerRegistry;
+        private final StatementFormatterLimits limits;
+        private final ProtocolVersion protocolVersion;
+        private final CodecRegistry codecRegistry;
+        private int remainingQueryStringChars;
+        private int remainingBoundValues;
+
+        private StatementWriter(StringBuilder buffer,
+                                StatementPrinterRegistry printerRegistry,
+                                StatementFormatterLimits limits,
+                                ProtocolVersion protocolVersion,
+                                CodecRegistry codecRegistry) {
+            this.buffer = buffer;
+            this.printerRegistry = printerRegistry;
+            this.limits = limits;
+            this.protocolVersion = protocolVersion;
+            this.codecRegistry = codecRegistry;
+            remainingQueryStringChars = limits.maxQueryStringLength == StatementFormatterLimits.UNLIMITED
+                    ? Integer.MAX_VALUE
+                    : limits.maxQueryStringLength;
+            remainingBoundValues = limits.maxBoundValues == StatementFormatterLimits.UNLIMITED
+                    ? Integer.MAX_VALUE
+                    : limits.maxBoundValues;
+        }
+
+        /**
+         * Creates and returns a child {@link StatementWriter}.
+         * <p/>
+         * A child writer shares the same buffer as its parent, but has its own independent state.
+         * It is most useful when dealing with inner statements in batches (each inner statement should
+         * use a child writer).
+         *
+         * @return a child {@link StatementWriter}.
+         */
+        public StatementWriter createChildWriter() {
+            return new StatementWriter(buffer, printerRegistry, limits, protocolVersion, codecRegistry);
+        }
+
+        /**
+         * @return The {@link StatementPrinterRegistry printer registry}.
+         */
+        public StatementPrinterRegistry getPrinterRegistry() {
+            return printerRegistry;
+        }
+
+        /**
+         * @return The current limits.
+         */
+        public StatementFormatterLimits getLimits() {
+            return limits;
+        }
+
+        /**
+         * @return The protocol version in use.
+         */
+        public ProtocolVersion getProtocolVersion() {
+            return protocolVersion;
+        }
+
+        /**
+         * @return The codec registry version in use.
+         */
+        public CodecRegistry getCodecRegistry() {
+            return codecRegistry;
+        }
+
+        /**
+         * @return The number of remaining query string characters that can be printed
+         * without exceeding the maximum allowed length.
+         */
+        public int getRemainingQueryStringChars() {
+            return remainingQueryStringChars;
+        }
+
+        /**
+         * @return The number of remaining bound values per statement that can be printed
+         * without exceeding the maximum allowed number.
+         */
+        public int getRemainingBoundValues() {
+            return remainingBoundValues;
+        }
+
+        /**
+         * @return {@code true} if the maximum query string length is exceeded, {@code false} otherwise.
+         */
+        public boolean maxQueryStringLengthExceeded() {
+            return remainingQueryStringChars == MAX_EXCEEDED;
+        }
+
+        /**
+         * @return {@code true} if the maximum number of bound values per statement is exceeded, {@code false} otherwise.
+         */
+        public boolean maxAppendedBoundValuesExceeded() {
+            return remainingBoundValues == MAX_EXCEEDED;
+        }
+
+        @Override
+        public StatementWriter append(CharSequence csq) {
+            buffer.append(csq);
+            return this;
+        }
+
+        @Override
+        public StatementWriter append(CharSequence csq, int start, int end) {
+            buffer.append(csq, start, end);
+            return this;
+        }
+
+        @Override
+        public StatementWriter append(char c) {
+            buffer.append(c);
+            return this;
+        }
+
+        public StatementWriter append(Object obj) {
+            buffer.append(obj);
+            return this;
+        }
+
+        public StatementWriter append(String str) {
+            buffer.append(str);
+            return this;
+        }
+
+        /**
+         * Appends the statement's class name and hash code, as done by {@link Object#toString()}.
+         *
+         * @param statement The statement to format.
+         * @return this
+         */
+        public StatementWriter appendClassNameAndHashCode(Statement statement) {
+            String fqcn = statement.getClass().getName();
+            if (fqcn.startsWith("com.datastax.driver.core.querybuilder"))
+                fqcn = "BuiltStatement";
+            if (fqcn.startsWith("com.datastax.driver.core.schemabuilder"))
+                fqcn = "SchemaStatement";
+            else if (fqcn.startsWith("com.datastax.driver.core."))
+                fqcn = fqcn.substring(25);
+            buffer.append(fqcn);
+            buffer.append('@');
+            buffer.append(Integer.toHexString(statement.hashCode()));
+            return this;
+        }
+
+        /**
+         * Appends the given fragment as a query string fragment.
+         * <p>
+         * This method can be called multiple times, in case the printer
+         * needs to compute the query string by pieces.
+         * <p>
+         * This methods also keeps track of the amount of characters used so far
+         * to print the query string, and automatically detects when
+         * the query string exceeds {@link StatementFormatterLimits#maxQueryStringLength the maximum length},
+         * in which case it truncates the output.
+         *
+         * @param queryStringFragment The query string fragment to append
+         * @return this writer (for method chaining).
+         */
+        public StatementWriter appendQueryStringFragment(String queryStringFragment) {
+            if (maxQueryStringLengthExceeded())
+                return this;
+            else if (queryStringFragment.isEmpty())
+                return this;
+            else if (limits.maxQueryStringLength == StatementFormatterLimits.UNLIMITED)
+                buffer.append(queryStringFragment);
+            else if (queryStringFragment.length() > remainingQueryStringChars) {
+                if (remainingQueryStringChars > 0) {
+                    queryStringFragment = queryStringFragment.substring(0, remainingQueryStringChars);
+                    buffer.append(queryStringFragment);
+                }
+                buffer.append(truncatedOutput);
+                remainingQueryStringChars = MAX_EXCEEDED;
+            } else {
+                buffer.append(queryStringFragment);
+                remainingQueryStringChars -= queryStringFragment.length();
+            }
+            return this;
+        }
+
+        /**
+         * Appends the statement's outgoing payload.
+         *
+         * @param outgoingPayload The payload to append
+         * @return this
+         */
+        public StatementWriter appendOutgoingPayload(Map<String, ByteBuffer> outgoingPayload) {
+            int remaining = limits.maxOutgoingPayloadEntries;
+            Iterator<Map.Entry<String, ByteBuffer>> it = outgoingPayload.entrySet().iterator();
+            if (it.hasNext()) {
+                buffer.append(outgoingPayloadStart);
+                while (it.hasNext()) {
+                    if (limits.maxOutgoingPayloadEntries != StatementFormatterLimits.UNLIMITED && remaining == 0) {
+                        buffer.append(truncatedOutput);
+                        break;
+                    }
+                    Map.Entry<String, ByteBuffer> entry = it.next();
+                    String name = entry.getKey();
+                    buffer.append(name);
+                    buffer.append(nameValueSeparator);
+                    ByteBuffer value = entry.getValue();
+                    String formatted;
+                    boolean lengthExceeded = false;
+                    if (value == null) {
+                        formatted = nullValue;
+                    } else {
+                        if (limits.maxOutgoingPayloadValueLength != StatementFormatterLimits.UNLIMITED) {
+                            // prevent large blobs from being converted to strings
+                            lengthExceeded = value.remaining() > limits.maxOutgoingPayloadValueLength;
+                            if (lengthExceeded)
+                                value = (ByteBuffer) value.duplicate().limit(limits.maxOutgoingPayloadValueLength);
+                        }
+                        formatted = TypeCodec.blob().format(value);
+                    }
+                    buffer.append(formatted);
+                    if (lengthExceeded)
+                        buffer.append(truncatedOutput);
+                    if (it.hasNext())
+                        buffer.append(listElementSeparator);
+                    if (limits.maxOutgoingPayloadEntries != StatementFormatterLimits.UNLIMITED)
+                        remaining--;
+                }
+                buffer.append(outgoingPayloadEnd);
+            }
+            return this;
+        }
+
+        public StatementWriter appendBoundValue(int index, ByteBuffer serialized, DataType type) {
+            if (maxAppendedBoundValuesExceeded())
+                return this;
+            return appendBoundValue(Integer.toString(index), serialized, type);
+        }
+
+        public StatementWriter appendBoundValue(String name, ByteBuffer serialized, DataType type) {
+            if (maxAppendedBoundValuesExceeded())
+                return this;
+            TypeCodec<Object> codec = codecRegistry.codecFor(type);
+            Object value = codec.deserialize(serialized, protocolVersion);
+            return appendBoundValue(name, value, type);
+        }
+
+        public StatementWriter appendBoundValue(int index, Object value, DataType type) {
+            if (maxAppendedBoundValuesExceeded())
+                return this;
+            return appendBoundValue(Integer.toString(index), value, type);
+        }
+
+        public StatementWriter appendBoundValue(String name, Object value, DataType type) {
+            if (maxAppendedBoundValuesExceeded())
+                return this;
+            if (value == null) {
+                doAppendBoundValue(name, nullValue);
+                return this;
+            } else if (value instanceof ByteBuffer && limits.maxBoundValueLength != StatementFormatterLimits.UNLIMITED) {
+                ByteBuffer byteBuffer = (ByteBuffer) value;
+                int maxBufferLengthInBytes = Math.max(2, limits.maxBoundValueLength / 2) - 1;
+                boolean bufferLengthExceeded = byteBuffer.remaining() > maxBufferLengthInBytes;
+                // prevent large blobs from being converted to strings
+                if (bufferLengthExceeded) {
+                    byteBuffer = (ByteBuffer) byteBuffer.duplicate().limit(maxBufferLengthInBytes);
+                    // force usage of blob codec as any other codec would probably fail to format
+                    // a cropped byte buffer anyway
+                    String formatted = TypeCodec.blob().format(byteBuffer);
+                    doAppendBoundValue(name, formatted);
+                    buffer.append(truncatedOutput);
+                    return this;
+                }
+            }
+            TypeCodec<Object> codec = type == null ? codecRegistry.codecFor(value) : codecRegistry.codecFor(type, value);
+            doAppendBoundValue(name, codec.format(value));
+            return this;
+        }
+
+        public StatementWriter appendUnsetBoundValue(int index) {
+            return appendUnsetBoundValue(Integer.toString(index));
+        }
+
+        public StatementWriter appendUnsetBoundValue(String name) {
+            doAppendBoundValue(name, unsetValue);
+            return this;
+        }
+
+        private void doAppendBoundValue(String name, String value) {
+            if (maxAppendedBoundValuesExceeded())
+                return;
+            if (remainingBoundValues == 0) {
+                buffer.append(truncatedOutput);
+                remainingBoundValues = MAX_EXCEEDED;
+                return;
+            }
+            boolean lengthExceeded = false;
+            if (limits.maxBoundValueLength != StatementFormatterLimits.UNLIMITED && value.length() > limits.maxBoundValueLength) {
+                value = value.substring(0, limits.maxBoundValueLength);
+                lengthExceeded = true;
+            }
+            if (name != null) {
+                buffer.append(name);
+                buffer.append(nameValueSeparator);
+            }
+            buffer.append(value);
+            if (lengthExceeded)
+                buffer.append(truncatedOutput);
+            if (limits.maxBoundValues != StatementFormatterLimits.UNLIMITED)
+                remainingBoundValues--;
+        }
+
+        @Override
+        public String toString() {
+            return buffer.toString();
+        }
+
+    }
+
+    /**
+     * A common parent class for {@link StatementPrinter} implementations.
+     * <p/>
+     * This class assumes a common formatting pattern comprised of the following
+     * sections:
+     * <ol>
+     * <li>Header: this section should contain two subsections:
+     * <ol>
+     *     <li>The actual statement class and the statement's hash code;</li>
+     *     <li>The statement "summary"; examples of typical information
+     *     that could be included here are: the statement's consistency level;
+     *     its default timestamp; its idempotence flag; the number of bound values; etc.</li>
+     * </ol>
+     * </li>
+     * <li>Query String: this section should print the statement's query string, if it is available;
+     * this section is only enabled if the verbosity is {@link StatementFormatVerbosity#NORMAL NORMAL} or higher;</li>
+     * <li>Bound Values: this section should print the statement's bound values, if available;
+     * this section is only enabled if the verbosity is {@link StatementFormatVerbosity#EXTENDED EXTENDED};</li>
+     * <li>Outgoing Payload: this section should print the statement's outgoing payload, if available;
+     * this section is only enabled if the verbosity is {@link StatementFormatVerbosity#EXTENDED EXTENDED};</li>
+     * <li>Footer: an optional section, empty by default.</li>
+     * </ol>
+     */
+    public static class StatementPrinterBase<S extends Statement> implements StatementPrinter<S> {
+
+        private final Class<S> supportedStatementClass;
+
+        protected StatementPrinterBase(Class<S> supportedStatementClass) {
+            this.supportedStatementClass = supportedStatementClass;
+        }
+
+        @Override
+        public Class<S> getSupportedStatementClass() {
+            return supportedStatementClass;
+        }
+
+        @Override
+        public void print(S statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+            printHeader(statement, out, verbosity);
+            if (verbosity.compareTo(StatementFormatVerbosity.NORMAL) >= 0) {
+                printQueryString(statement, out, verbosity);
+                if (verbosity.compareTo(StatementFormatVerbosity.EXTENDED) >= 0) {
+                    printBoundValues(statement, out, verbosity);
+                    printOutgoingPayload(statement, out, verbosity);
+                }
+            }
+            printFooter(statement, out, verbosity);
+        }
+
+        protected void printHeader(S statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+            out.appendClassNameAndHashCode(statement);
+            out.append(summaryStart);
+            printSummary(statement, out, verbosity);
+            out.append(summaryEnd);
+        }
+
+        protected void printSummary(S statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+            Boolean idempotent = statement.isIdempotent();
+            ConsistencyLevel consistencyLevel = statement.getConsistencyLevel();
+            out.append(String.format("idempotent=%s", idempotent == null ? unsetValue : idempotent));
+            out.append(listElementSeparator);
+            out.append(String.format("CL=%s", consistencyLevel == null ? unsetValue : consistencyLevel));
+            if (verbosity.compareTo(StatementFormatVerbosity.NORMAL) > 0) {
+                ConsistencyLevel serialConsistencyLevel = statement.getSerialConsistencyLevel();
+                long defaultTimestamp = statement.getDefaultTimestamp();
+                int readTimeoutMillis = statement.getReadTimeoutMillis();
+                out.append(listElementSeparator);
+                out.append(String.format("SCL=%s", serialConsistencyLevel == null ? unsetValue : serialConsistencyLevel));
+                out.append(listElementSeparator);
+                out.append(String.format("defaultTimestamp=%s", defaultTimestamp == Long.MIN_VALUE ? unsetValue : defaultTimestamp));
+                out.append(listElementSeparator);
+                out.append(String.format("readTimeoutMillis=%s", readTimeoutMillis == Integer.MIN_VALUE ? unsetValue : readTimeoutMillis));
+            }
+        }
+
+        protected void printQueryString(S statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+        }
+
+        protected void printBoundValues(S statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+        }
+
+        protected void printOutgoingPayload(S statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+            Map<String, ByteBuffer> outgoingPayload = statement.getOutgoingPayload();
+            if (outgoingPayload != null)
+                out.appendOutgoingPayload(outgoingPayload);
+        }
+
+        protected void printFooter(S statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+        }
+
+    }
+
+    /**
+     * Common parent class for {@link StatementPrinter} implementations dealing with subclasses of {@link RegularStatement}.
+     */
+    public abstract static class AbstractRegularStatementPrinter<S extends RegularStatement> extends StatementPrinterBase<S> {
+
+        protected AbstractRegularStatementPrinter(Class<S> supportedStatementClass) {
+            super(supportedStatementClass);
+        }
+
+        @Override
+        protected void printQueryString(S statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+            out.append(queryStringStart);
+            out.appendQueryStringFragment(statement.getQueryString(out.getCodecRegistry()));
+            out.append(queryStringEnd);
+        }
+
+    }
+
+    public static class SimpleStatementPrinter extends AbstractRegularStatementPrinter<SimpleStatement> {
+
+        public SimpleStatementPrinter() {
+            super(SimpleStatement.class);
+        }
+
+        @Override
+        protected void printSummary(SimpleStatement statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+            super.printSummary(statement, out, verbosity);
+            out.append(listElementSeparator);
+            out.append(String.format(boundValuesCount, statement.valuesCount()));
+        }
+
+        @Override
+        protected void printBoundValues(SimpleStatement statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+            if (statement.valuesCount() > 0) {
+                out.append(boundValuesStart);
+                if (statement.usesNamedValues()) {
+                    boolean first = true;
+                    for (String valueName : statement.getValueNames()) {
+                        if (first)
+                            first = false;
+                        else
+                            out.append(listElementSeparator);
+                        out.appendBoundValue(valueName, statement.getObject(valueName), null);
+                        if (out.maxAppendedBoundValuesExceeded())
+                            break;
+                    }
+                } else {
+                    for (int i = 0; i < statement.valuesCount(); i++) {
+                        if (i > 0)
+                            out.append(listElementSeparator);
+                        out.appendBoundValue(i, statement.getObject(i), null);
+                        if (out.maxAppendedBoundValuesExceeded())
+                            break;
+                    }
+                }
+                out.append(boundValuesEnd);
+            }
+        }
+
+    }
+
+    public static class BuiltStatementPrinter extends AbstractRegularStatementPrinter<BuiltStatement> {
+
+        public BuiltStatementPrinter() {
+            super(BuiltStatement.class);
+        }
+
+        @Override
+        protected void printSummary(BuiltStatement statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+            super.printSummary(statement, out, verbosity);
+            out.append(listElementSeparator);
+            out.append(String.format(boundValuesCount, statement.valuesCount(out.getCodecRegistry())));
+        }
+
+        @Override
+        protected void printBoundValues(BuiltStatement statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+            if (statement.valuesCount(out.getCodecRegistry()) > 0) {
+                out.append(boundValuesStart);
+                // BuiltStatement does not use named values
+                for (int i = 0; i < statement.valuesCount(out.getCodecRegistry()); i++) {
+                    if (i > 0)
+                        out.append(listElementSeparator);
+                    out.appendBoundValue(i, statement.getObject(i), null);
+                    if (out.maxAppendedBoundValuesExceeded())
+                        break;
+                }
+                out.append(boundValuesEnd);
+            }
+        }
+
+    }
+
+    public static class BoundStatementPrinter extends StatementPrinterBase<BoundStatement> {
+
+        public BoundStatementPrinter() {
+            super(BoundStatement.class);
+        }
+
+        @Override
+        protected void printSummary(BoundStatement statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+            super.printSummary(statement, out, verbosity);
+            out.append(listElementSeparator);
+            ColumnDefinitions metadata = statement.preparedStatement().getVariables();
+            out.append(String.format(boundValuesCount, metadata.size()));
+        }
+
+        @Override
+        protected void printQueryString(BoundStatement statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+            out.append(queryStringStart);
+                out.appendQueryStringFragment(statement.preparedStatement().getQueryString());
+            out.append(queryStringEnd);
+        }
+
+        @Override
+        protected void printBoundValues(BoundStatement statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+            if (statement.preparedStatement().getVariables().size() > 0) {
+                out.append(boundValuesStart);
+                ColumnDefinitions metadata = statement.preparedStatement().getVariables();
+                if (metadata.size() > 0) {
+                    for (int i = 0; i < metadata.size(); i++) {
+                        if (i > 0)
+                            out.append(listElementSeparator);
+                        if (statement.isSet(i))
+                            out.appendBoundValue(metadata.getName(i), statement.wrapper.values[i], metadata.getType(i));
+                        else
+                            out.appendUnsetBoundValue(metadata.getName(i));
+                        if (out.maxAppendedBoundValuesExceeded())
+                            break;
+                    }
+                }
+                out.append(boundValuesEnd);
+            }
+        }
+
+    }
+
+    public static class BatchStatementPrinter implements StatementPrinter<BatchStatement> {
+
+        @Override
+        public Class<BatchStatement> getSupportedStatementClass() {
+            return BatchStatement.class;
+        }
+
+        @Override
+        public void print(BatchStatement statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+            out.appendClassNameAndHashCode(statement);
+            out.append(summaryStart);
+            out.append(getBatchType(statement));
+            out.append(listElementSeparator);
+            out.append(String.format(statementsCount, statement.size()));
+            out.append(listElementSeparator);
+            int totalBoundValuesCount = 0;
+            for (List<ByteBuffer> values : getValues(statement, out)) {
+                totalBoundValuesCount += values.size();
+            }
+            out.append(String.format(boundValuesCount, totalBoundValuesCount));
+            out.append(summaryEnd);
+            if (verbosity.compareTo(StatementFormatVerbosity.NORMAL) >= 0 && out.getLimits().maxInnerStatements > 0) {
+                out.append(' ');
+                int i = 1;
+                for (Statement stmt : statement.getStatements()) {
+                    if (i > 1)
+                        out.append(listElementSeparator);
+                    if (i > out.getLimits().maxInnerStatements) {
+                        out.append(truncatedOutput);
+                        break;
+                    }
+                    out.append(i++);
+                    out.append(listElementSeparator);
+                    StatementPrinter<? super Statement> printer = out.getPrinterRegistry().findPrinter(stmt);
+                    printer.print(stmt, out.createChildWriter(), verbosity);
+                }
+            }
+        }
+
+        protected BatchStatement.Type getBatchType(BatchStatement statement) {
+            return statement.batchType;
+        }
+
+        protected List<List<ByteBuffer>> getValues(BatchStatement statement, StatementWriter out) {
+            return statement.getIdAndValues(out.getProtocolVersion(), out.getCodecRegistry()).values;
+        }
+
+    }
+
+    public static class StatementWrapperPrinter implements StatementPrinter<StatementWrapper> {
+
+        @Override
+        public Class<StatementWrapper> getSupportedStatementClass() {
+            return StatementWrapper.class;
+        }
+
+        @Override
+        public void print(StatementWrapper statement, StatementWriter out, StatementFormatVerbosity verbosity) {
+            Statement wrappedStatement = statement.getWrappedStatement();
+            StatementPrinter<? super Statement> printer = out.getPrinterRegistry().findPrinter(wrappedStatement);
+            printer.print(wrappedStatement, out, verbosity);
+        }
+
+    }
+
+    public static class SchemaStatementPrinter extends AbstractRegularStatementPrinter<SchemaStatement> {
+
+        public SchemaStatementPrinter() {
+            super(SchemaStatement.class);
+        }
+
+    }
+
+    public static class RegularStatementPrinter extends AbstractRegularStatementPrinter<RegularStatement> {
+
+        public RegularStatementPrinter() {
+            super(RegularStatement.class);
+        }
+
+    }
+
+    public static class DefaultStatementPrinter extends StatementPrinterBase<Statement> {
+
+        public DefaultStatementPrinter() {
+            super(Statement.class);
+        }
+
+    }
+
+    /**
+     * Helper class to build {@link StatementFormatter} instances with a fluent API.
+     */
+    public static class Builder {
+
+        public static final int DEFAULT_MAX_QUERY_STRING_LENGTH = 500;
+        public static final int DEFAULT_MAX_BOUND_VALUE_LENGTH = 50;
+        public static final int DEFAULT_MAX_BOUND_VALUES = 10;
+        public static final int DEFAULT_MAX_INNER_STATEMENTS = 5;
+        public static final int DEFAULT_MAX_OUTGOING_PAYLOAD_ENTRIES = 10;
+        public static final int DEFAULT_MAX_OUTGOING_PAYLOAD_VALUE_LENGTH = 50;
+
+        private int maxQueryStringLength = DEFAULT_MAX_QUERY_STRING_LENGTH;
+        private int maxBoundValueLength = DEFAULT_MAX_BOUND_VALUE_LENGTH;
+        private int maxBoundValues = DEFAULT_MAX_BOUND_VALUES;
+        private int maxInnerStatements = DEFAULT_MAX_INNER_STATEMENTS;
+        private int maxOutgoingPayloadEntries = DEFAULT_MAX_OUTGOING_PAYLOAD_ENTRIES;
+        private int maxOutgoingPayloadValueLength = DEFAULT_MAX_OUTGOING_PAYLOAD_VALUE_LENGTH;
+
+        private final List<StatementPrinter<?>> printers = new ArrayList<StatementPrinter<?>>();
+
+        private Builder() {
+        }
+
+        /**
+         * Adds a new {@link StatementPrinter} to the list of available statement
+         * printers.
+         * <p/>
+         * Note that built-in printers handle
+         * all the driver built-in {@link Statement} subclasses.
+         * Calling this method is only useful if you need to handle a special
+         * subclass of {@link Statement}.
+         * <p/>
+         * Also note that registering two or more printers for the
+         * same kind of statement will result in the last one being used.
+         *
+         * @param printer The {@link StatementPrinter} to add.
+         * @return this (for method chaining).
+         */
+        public Builder addStatementPrinter(StatementPrinter<?> printer) {
+            printers.add(printer);
+            return this;
+        }
+
+        /**
+         * Adds the given {@link StatementPrinter}s to the list of available statement
+         * printers.
+         * <p/>
+         * Note that built-in printers are always registered by default and they handle
+         * all the driver built-in {@link Statement} subclasses.
+         * Calling this method is only useful if you need to handle a special
+         * subclass of {@link Statement}; otherwise, the built-in printers should be enough.
+         *
+         * @param printers The {@link StatementPrinter}s to add.
+         * @return this (for method chaining).
+         */
+        public Builder addStatementPrinters(StatementPrinter<?>... printers) {
+            this.printers.addAll(Arrays.asList(printers));
+            return this;
+        }
+
+        /**
+         * Sets the maximum length allowed for query strings.
+         * The default is {@value DEFAULT_MAX_QUERY_STRING_LENGTH}.
+         * <p/>
+         * If the query string length exceeds this threshold,
+         * printers should truncate it.
+         *
+         * @param maxQueryStringLength the maximum length allowed for query strings.
+         * @throws IllegalArgumentException if the value is not > 0, or {@value StatementFormatterLimits#UNLIMITED} (unlimited).
+         * @return this (for method chaining).
+         */
+        public Builder withMaxQueryStringLength(int maxQueryStringLength) {
+            if (maxQueryStringLength <= 0 && maxQueryStringLength != StatementFormatterLimits.UNLIMITED)
+                throw new IllegalArgumentException("Invalid maxQueryStringLength, should be > 0 or -1 (unlimited), got " + maxQueryStringLength);
+            this.maxQueryStringLength = maxQueryStringLength;
+            return this;
+        }
+
+        /**
+         * Sets the maximum length, in numbers of printed characters,
+         * allowed for a single bound value.
+         * The default is {@value DEFAULT_MAX_BOUND_VALUE_LENGTH}.
+         * <p/>
+         * If the bound value length exceeds this threshold,
+         * printers should truncate it.
+         *
+         * @param maxBoundValueLength the maximum length, in numbers of printed characters,
+         *                            allowed for a single bound value.
+         * @throws IllegalArgumentException if the value is not > 0, or {@value StatementFormatterLimits#UNLIMITED} (unlimited).
+         * @return this (for method chaining).
+         */
+        public Builder withMaxBoundValueLength(int maxBoundValueLength) {
+            if (maxBoundValueLength <= 0 && maxBoundValueLength != StatementFormatterLimits.UNLIMITED)
+                throw new IllegalArgumentException("Invalid maxBoundValueLength, should be > 0 or -1 (unlimited), got " + maxBoundValueLength);
+            this.maxBoundValueLength = maxBoundValueLength;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of printed bound values.
+         * The default is {@value DEFAULT_MAX_BOUND_VALUES}.
+         * <p/>
+         * If the number of bound values exceeds this threshold,
+         * printers should truncate it.
+         *
+         * @param maxBoundValues the maximum number of printed bound values.
+         * @throws IllegalArgumentException if the value is not > 0, or {@value StatementFormatterLimits#UNLIMITED} (unlimited).
+         * @return this (for method chaining).
+         */
+        public Builder withMaxBoundValues(int maxBoundValues) {
+            if (maxBoundValues <= 0 && maxBoundValues != StatementFormatterLimits.UNLIMITED)
+                throw new IllegalArgumentException("Invalid maxBoundValues, should be > 0 or -1 (unlimited), got " + maxBoundValues);
+            this.maxBoundValues = maxBoundValues;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of printed inner statements
+         * of a {@link BatchStatement}.
+         * The default is {@value DEFAULT_MAX_INNER_STATEMENTS}.
+         * Setting this value to zero should disable the printing
+         * of inner statements.
+         * <p/>
+         * If the number of inner statements exceeds this threshold,
+         * printers should truncate it.
+         * <p/>
+         * If the statement to format is not a batch statement,
+         * then this withting should be ignored.
+         *
+         * @param maxInnerStatements the maximum number of printed inner statements
+         *                           of a {@link BatchStatement}.
+         * @throws IllegalArgumentException if the value is not >= 0, or {@value StatementFormatterLimits#UNLIMITED} (unlimited).
+         * @return this (for method chaining).
+         */
+        public Builder withMaxInnerStatements(int maxInnerStatements) {
+            if (maxInnerStatements < 0 && maxInnerStatements != StatementFormatterLimits.UNLIMITED)
+                throw new IllegalArgumentException("Invalid maxInnerStatements, should be >= 0 or -1 (unlimited), got " + maxInnerStatements);
+            this.maxInnerStatements = maxInnerStatements;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of printed outgoing payload entries.
+         * The default is {@value DEFAULT_MAX_OUTGOING_PAYLOAD_ENTRIES}.
+         * <p/>
+         * If the number of entries exceeds this threshold,
+         * printers should truncate it.
+         *
+         * @param maxOutgoingPayloadEntries the maximum number of printed outgoing payload entries.
+         * @throws IllegalArgumentException if the value is not > 0, or {@value StatementFormatterLimits#UNLIMITED} (unlimited).
+         * @return this (for method chaining).
+         */
+        public Builder withMaxOutgoingPayloadEntries(int maxOutgoingPayloadEntries) {
+            if (maxOutgoingPayloadEntries <= 0 && maxOutgoingPayloadEntries != StatementFormatterLimits.UNLIMITED)
+                throw new IllegalArgumentException("Invalid maxOutgoingPayloadEntries, should be > 0 or -1 (unlimited), got " + maxOutgoingPayloadEntries);
+            this.maxOutgoingPayloadEntries = maxOutgoingPayloadEntries;
+            return this;
+        }
+
+        /**
+         * Sets the maximum length, in bytes, allowed for a single outgoing payload value.
+         * The default is {@value DEFAULT_MAX_OUTGOING_PAYLOAD_VALUE_LENGTH}.
+         * <p/>
+         * If the payload value length in bytes exceeds this threshold,
+         * printers should truncate it.
+         *
+         * @param maxOutgoingPayloadValueLength the maximum length, in bytes, allowed for a single outgoing payload value.
+         * @throws IllegalArgumentException if the value is not > 0, or {@value StatementFormatterLimits#UNLIMITED} (unlimited).
+         * @return this (for method chaining).
+         */
+        public Builder withMaxOutgoingPayloadValueLength(int maxOutgoingPayloadValueLength) {
+            if (maxOutgoingPayloadValueLength <= 0 && maxOutgoingPayloadValueLength != StatementFormatterLimits.UNLIMITED)
+                throw new IllegalArgumentException("Invalid maxOutgoingPayloadValueLength, should be > 0 or -1 (unlimited), got " + maxOutgoingPayloadValueLength);
+            this.maxOutgoingPayloadValueLength = maxOutgoingPayloadValueLength;
+            return this;
+        }
+
+        /**
+         * Builds the {@link StatementFormatter} instance.
+         *
+         * @return the {@link StatementFormatter} instance.
+         */
+        public StatementFormatter build() {
+            StatementPrinterRegistry registry = new StatementPrinterRegistry();
+            for (StatementPrinter<?> printer : printers) {
+                registry.register(printer);
+            }
+            StatementFormatterLimits limits = new StatementFormatterLimits(
+                    maxQueryStringLength, maxBoundValueLength, maxBoundValues, maxInnerStatements, maxOutgoingPayloadEntries, maxOutgoingPayloadValueLength);
+            return new StatementFormatter(registry, limits);
+        }
+
+    }
+
+    private final StatementPrinterRegistry printerRegistry;
+    private final StatementFormatterLimits limits;
+
+    private StatementFormatter(StatementPrinterRegistry printerRegistry, StatementFormatterLimits limits) {
+        this.printerRegistry = printerRegistry;
+        this.limits = limits;
+    }
+
+    /**
+     * Formats the given {@link Statement statement}.
+     *
+     * @param statement       The statement to format.
+     * @param verbosity       The verbosity to use.
+     * @param protocolVersion The protocol version in use.
+     * @param codecRegistry   The codec registry in use.
+     * @return The statement as a formatted string.
+     * @throws StatementFormatException if the formatting failed.
+     */
+    public <S extends Statement> String format(
+            S statement, StatementFormatVerbosity verbosity,
+            ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
+        try {
+            StatementPrinter<? super S> printer = printerRegistry.findPrinter(statement);
+            assert printer != null : "Could not find printer for statement class " + statement.getClass();
+            StatementWriter out = new StatementWriter(new StringBuilder(), printerRegistry, limits, protocolVersion, codecRegistry);
+            printer.print(statement, out, verbosity);
+            return out.toString();
+        } catch (RuntimeException e) {
+            throw new StatementFormatException(statement, verbosity, protocolVersion, codecRegistry, e);
+        }
+    }
+
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/StatementWrapper.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/StatementWrapper.java
@@ -69,7 +69,12 @@ public abstract class StatementWrapper extends Statement {
         this.wrapped = wrapped;
     }
 
-    Statement getWrappedStatement() {
+    /**
+     * Returns the wrapped {@link Statement}.
+     *
+     * @return the wrapped {@link Statement}.
+     */
+    public Statement getWrappedStatement() {
         // Protect against multiple levels of wrapping (even though there is no practical reason for that)
         return (wrapped instanceof StatementWrapper)
                 ? ((StatementWrapper) wrapped).getWrappedStatement()

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
@@ -111,16 +111,7 @@ public abstract class BuiltStatement extends RegularStatement {
         return cache;
     }
 
-    /**
-     * The number of values for this statement, or zero, if this
-     * statement does not have values.
-     * @param codecRegistry the codec registry that will be used if the statement must be
-     *                      rebuilt in order to determine if it has values, and Java objects
-     *                      must be inlined in the process (see {@link BuiltStatement} for
-     *                      more explanations on why this is so).
-     *
-     * @return the number of values.
-     */
+    @Override
     public int valuesCount(CodecRegistry codecRegistry) {
         maybeRebuildCache(codecRegistry);
         if (values != null)

--- a/driver-core/src/test/java/com/datastax/driver/core/EnhancedQueryLoggerErrorsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/EnhancedQueryLoggerErrorsTest.java
@@ -28,7 +28,6 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static com.datastax.driver.core.QueryLogger.builder;
 import static org.apache.log4j.Level.DEBUG;
 import static org.apache.log4j.Level.INFO;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,22 +37,21 @@ import static org.scassandra.http.client.PrimingRequest.then;
 import static org.scassandra.http.client.Result.*;
 
 /**
- * Tests for {@link QueryLogger} using Scassandra.
+ * Tests for {@link EnhancedQueryLogger} using Scassandra.
  * Contains only tests for exceptions (client timeout, read timeout, unavailable...);
- * other tests can be found in {@link QueryLoggerTest}.
+ * other tests can be found in {@link EnhancedQueryLoggerTest}.
  */
-@SuppressWarnings("deprecation")
-public class QueryLoggerErrorsTest extends ScassandraTestBase.PerClassCluster {
+public class EnhancedQueryLoggerErrorsTest extends ScassandraTestBase.PerClassCluster {
 
-    private Logger slow = Logger.getLogger(QueryLogger.SLOW_LOGGER.getName());
-    private Logger error = Logger.getLogger(QueryLogger.ERROR_LOGGER.getName());
+    private Logger slow = Logger.getLogger(EnhancedQueryLogger.SLOW_LOGGER.getName());
+    private Logger error = Logger.getLogger(EnhancedQueryLogger.ERROR_LOGGER.getName());
 
     private MemoryAppender slowAppender;
     private MemoryAppender errorAppender;
 
     private Cluster cluster = null;
     private Session session = null;
-    private QueryLogger queryLogger = null;
+    private EnhancedQueryLogger queryLogger = null;
     private Level originalError;
     private Level originalSlow;
 
@@ -90,7 +88,7 @@ public class QueryLoggerErrorsTest extends ScassandraTestBase.PerClassCluster {
     public void should_log_queries_beyond_constant_threshold() throws Exception {
         // given
         slow.setLevel(DEBUG);
-        queryLogger = builder()
+        queryLogger = EnhancedQueryLogger.builder()
                 .withConstantThreshold(10)
                 .build();
         cluster.register(queryLogger);
@@ -115,7 +113,7 @@ public class QueryLoggerErrorsTest extends ScassandraTestBase.PerClassCluster {
     public void should_log_queries_beyond_dynamic_threshold() throws Exception {
         // given
         slow.setLevel(DEBUG);
-        queryLogger = builder()
+        queryLogger = EnhancedQueryLogger.builder()
                 .withDynamicThreshold(ClusterWidePercentileTracker.builder(1000)
                         .withMinRecordedValues(100)
                         .withInterval(1, TimeUnit.SECONDS).build(), 99)
@@ -164,7 +162,7 @@ public class QueryLoggerErrorsTest extends ScassandraTestBase.PerClassCluster {
     public void should_log_timed_out_queries() throws Exception {
         // given
         error.setLevel(DEBUG);
-        queryLogger = builder().build();
+        queryLogger = EnhancedQueryLogger.builder().build();
         cluster.register(queryLogger);
         cluster.getConfiguration().getSocketOptions().setReadTimeoutMillis(1);
         String query = "SELECT foo FROM bar";
@@ -215,7 +213,7 @@ public class QueryLoggerErrorsTest extends ScassandraTestBase.PerClassCluster {
     public void should_log_exception_from_the_given_result(Result result, Class<? extends Exception> expectedException) throws Exception {
         // given
         error.setLevel(DEBUG);
-        queryLogger = builder().build();
+        queryLogger = EnhancedQueryLogger.builder().build();
         cluster.register(queryLogger);
         String query = "SELECT foo FROM bar";
         primingClient.prime(

--- a/driver-core/src/test/java/com/datastax/driver/core/EnhancedQueryLoggerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/EnhancedQueryLoggerTest.java
@@ -514,7 +514,7 @@ public class EnhancedQueryLoggerTest extends CCMTestsSupport {
                 .contains(ipOfNode(1))
                 .contains(query)
                 .contains("pk : 42")
-                .contains("c_text : <UNSET>");
+                .contains("c_text : <?>");
     }
 
     @Test(groups = "short")
@@ -683,7 +683,7 @@ public class EnhancedQueryLoggerTest extends CCMTestsSupport {
                 .contains(ipOfNode(1))
                 .doesNotContain(query1)
                 .doesNotContain(query2)
-                .contains("2 inner statements");
+                .contains("2 stmts");
     }
 
     @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/StatementFormatterTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StatementFormatterTest.java
@@ -129,11 +129,17 @@ public class StatementFormatterTest {
     @Test(groups = "unit")
     public void should_format_simple_statement() throws Exception {
         StatementFormatter formatter = StatementFormatter.builder().build();
-        Statement statement = new SimpleStatement("SELECT * FROM t WHERE c1 = ? AND c2 = ?", "foo", 42);
+        Statement statement = new SimpleStatement("SELECT * FROM t WHERE c1 = ? AND c2 = ?", "foo", 42)
+                .setIdempotent(true)
+                .setConsistencyLevel(ConsistencyLevel.QUORUM)
+                .setSerialConsistencyLevel(ConsistencyLevel.SERIAL)
+                .setDefaultTimestamp(12345L)
+                .setReadTimeoutMillis(12345);
         String s = formatter.format(statement, EXTENDED, version, codecRegistry);
         assertThat(s)
                 .contains("SimpleStatement@")
-                .contains("2 bound values")
+                .contains("IDP : true, CL : QUORUM, SCL : SERIAL, DTS : 12345, RTM : 12345")
+                .contains("2 values")
                 .contains("SELECT * FROM t WHERE c1 = ? AND c2 = ?")
                 .contains("{ 0 : 'foo', 1 : 42 }");
     }
@@ -146,7 +152,12 @@ public class StatementFormatterTest {
         String s = formatter.format(statement, EXTENDED, version, codecRegistry);
         assertThat(s)
                 .contains("SimpleStatement@")
-                .contains("2 bound values")
+                .doesNotContain("IDP")
+                .doesNotContain("CL")
+                .doesNotContain("SCL")
+                .doesNotContain("DTS")
+                .doesNotContain("RTM")
+                .contains("2 values")
                 .contains("SELECT * FROM t WHERE c1 = ? AND c2 = ?")
                 .contains("{ c1 : 'foo', c2 : 42 }");
     }
@@ -158,7 +169,7 @@ public class StatementFormatterTest {
         String s = formatter.format(statement, EXTENDED, version, codecRegistry);
         assertThat(s)
                 .contains("SimpleStatement@")
-                .contains("0 bound values")
+                .contains("0 values")
                 .contains("SELECT * FROM t WHERE c1 = 42")
                 .doesNotContain("{");
     }
@@ -170,7 +181,7 @@ public class StatementFormatterTest {
         String s = formatter.format(statement, EXTENDED, version, codecRegistry);
         assertThat(s)
                 .contains("BuiltStatement@")
-                .contains("2 bound values")
+                .contains("2 values")
                 .contains("SELECT * FROM t WHERE c1=? AND c2=42 AND c3=?")
                 .contains("{ 0 : 'foo', 1 : false }");
     }
@@ -199,9 +210,9 @@ public class StatementFormatterTest {
         String s = formatter.format(statement, EXTENDED, version, codecRegistry);
         assertThat(s)
                 .contains("BoundStatement@")
-                .contains("3 bound values")
+                .contains("3 values")
                 .contains("SELECT * FROM t WHERE c1 = ? AND c2 = ? AND c3 = ?")
-                .contains("{ c1 : 'foo', c2 : <NULL>, c3 : <UNSET> }");
+                .contains("{ c1 : 'foo', c2 : <NULL>, c3 : <?> }");
     }
 
     @Test(groups = "unit")
@@ -217,10 +228,10 @@ public class StatementFormatterTest {
         String s = formatter.format(statement, EXTENDED, version, codecRegistry);
         assertThat(s)
                 .contains("BatchStatement@")
-                .contains("[UNLOGGED, 3 inner statements, 6 bound values]")
-                .contains(formatter.format(inner1, EXTENDED, version, codecRegistry))
-                .contains(formatter.format(inner2, EXTENDED, version, codecRegistry))
-                .contains(formatter.format(inner3, EXTENDED, version, codecRegistry));
+                .contains("[UNLOGGED, 3 stmts, 6 values]")
+                .contains("1 : " + formatter.format(inner1, EXTENDED, version, codecRegistry))
+                .contains("2 : " + formatter.format(inner2, EXTENDED, version, codecRegistry))
+                .contains("3 : " + formatter.format(inner3, EXTENDED, version, codecRegistry));
     }
 
     @Test(groups = "unit")
@@ -231,7 +242,7 @@ public class StatementFormatterTest {
         String s = formatter.format(statement, EXTENDED, version, codecRegistry);
         assertThat(s)
                 .contains("SimpleStatement@")
-                .contains("0 bound values")
+                .contains("0 values")
                 .contains("SELECT * FROM t WHERE c1 = 42")
                 .doesNotContain("{");
     }
@@ -245,7 +256,12 @@ public class StatementFormatterTest {
         String s = formatter.format(statement, ABRIDGED, version, codecRegistry);
         assertThat(s)
                 .contains("SimpleStatement@")
-                .contains("2 bound values")
+                .doesNotContain("IDP")
+                .doesNotContain("CL")
+                .doesNotContain("SCL")
+                .doesNotContain("RTM")
+                .doesNotContain("DTP")
+                .contains("2 values")
                 .doesNotContain("SELECT * FROM t WHERE c1 = ? AND c2 = ?")
                 .doesNotContain("{ 0 : 'foo', 1 : 42 }");
     }
@@ -257,7 +273,13 @@ public class StatementFormatterTest {
         String s = formatter.format(statement, NORMAL, version, codecRegistry);
         assertThat(s)
                 .contains("SimpleStatement@")
-                .contains("2 bound values")
+                .doesNotContain("IDP")
+                .doesNotContain("CL")
+                .doesNotContain("SCL")
+                .doesNotContain("SCL")
+                .doesNotContain("RTM")
+                .doesNotContain("DTP")
+                .contains("2 values")
                 .contains("SELECT * FROM t WHERE c1 = ? AND c2 = ?")
                 .doesNotContain("{ 0 : 'foo', 1 : 42 }");
     }
@@ -336,7 +358,7 @@ public class StatementFormatterTest {
         String s = formatter.format(statement, EXTENDED, version, codecRegistry);
         assertThat(s)
                 .contains("BatchStatement@")
-                .contains("[UNLOGGED, 3 inner statements, 6 bound values]")
+                .contains("[UNLOGGED, 3 stmts, 6 values]")
                 .contains(formatter.format(inner1, EXTENDED, version, codecRegistry))
                 .contains(formatter.format(inner2, EXTENDED, version, codecRegistry))
                 .doesNotContain(formatter.format(inner3, EXTENDED, version, codecRegistry))

--- a/driver-core/src/test/java/com/datastax/driver/core/StatementFormatterTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StatementFormatterTest.java
@@ -1,0 +1,559 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.querybuilder.BuiltStatement;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
+import com.datastax.driver.core.schemabuilder.SchemaBuilder;
+import com.datastax.driver.core.schemabuilder.SchemaStatement;
+import com.datastax.driver.core.utils.Bytes;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.datastax.driver.core.StatementFormatter.StatementFormatVerbosity.*;
+import static com.datastax.driver.core.StatementFormatter.StatementFormatterLimits.UNLIMITED;
+import static com.datastax.driver.core.TestUtils.getFixedValue;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
+import static com.datastax.driver.core.schemabuilder.SchemaBuilder.createTable;
+import static com.google.common.base.Strings.repeat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @jira_ticket JAVA-1257
+ */
+public class StatementFormatterTest {
+
+    private static final List<DataType> dataTypes = new ArrayList<DataType>(
+            Sets.filter(TestUtils.allPrimitiveTypes(ProtocolVersion.NEWEST_SUPPORTED), new Predicate<DataType>() {
+                @Override
+                public boolean apply(DataType type) {
+                    return type != DataType.counter();
+                }
+            }));
+
+
+    private final ProtocolVersion version = ProtocolVersion.NEWEST_SUPPORTED;
+
+    private final CodecRegistry codecRegistry = CodecRegistry.DEFAULT_INSTANCE;
+
+    // Basic Tests
+
+    @Test(groups = "unit")
+    public void should_format_statement() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder().build();
+        Statement statement = new Statement() {
+            @Override
+            public ByteBuffer getRoutingKey(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
+                return null;
+            }
+
+            @Override
+            public String getKeyspace() {
+                return null;
+            }
+        };
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("StatementFormatterTest$");
+    }
+
+    @Test(groups = "unit")
+    public void should_format_regular_statement() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder().build();
+        Statement statement = new RegularStatement() {
+            @Override
+            public ByteBuffer getRoutingKey(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
+                return null;
+            }
+
+            @Override
+            public String getKeyspace() {
+                return null;
+            }
+
+            @Override
+            public String getQueryString(CodecRegistry codecRegistry) {
+                return "this is the query string";
+            }
+
+            @Override
+            public ByteBuffer[] getValues(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
+                return null;
+            }
+
+            @Override
+            public Map<String, ByteBuffer> getNamedValues(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
+                return null;
+            }
+
+            @Override
+            public boolean hasValues(CodecRegistry codecRegistry) {
+                return false;
+            }
+
+            @Override
+            public boolean usesNamedValues() {
+                return false;
+            }
+        };
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("StatementFormatterTest")
+                .contains("this is the query string");
+    }
+
+    @Test(groups = "unit")
+    public void should_format_simple_statement() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder().build();
+        Statement statement = new SimpleStatement("SELECT * FROM t WHERE c1 = ? AND c2 = ?", "foo", 42);
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("SimpleStatement@")
+                .contains("2 bound values")
+                .contains("SELECT * FROM t WHERE c1 = ? AND c2 = ?")
+                .contains("{ 0 : 'foo', 1 : 42 }");
+    }
+
+    @Test(groups = "unit")
+    public void should_format_simple_statement_with_named_values() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder().build();
+        Statement statement = new SimpleStatement("SELECT * FROM t WHERE c1 = ? AND c2 = ?",
+                ImmutableMap.<String, Object>of("c1", "foo", "c2", 42));
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("SimpleStatement@")
+                .contains("2 bound values")
+                .contains("SELECT * FROM t WHERE c1 = ? AND c2 = ?")
+                .contains("{ c1 : 'foo', c2 : 42 }");
+    }
+
+    @Test(groups = "unit")
+    public void should_format_statement_without_values() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder().build();
+        Statement statement = new SimpleStatement("SELECT * FROM t WHERE c1 = 42");
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("SimpleStatement@")
+                .contains("0 bound values")
+                .contains("SELECT * FROM t WHERE c1 = 42")
+                .doesNotContain("{");
+    }
+
+    @Test(groups = "unit")
+    public void should_format_built_statement() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder().build();
+        Statement statement = select().from("t").where(eq("c1", "foo")).and(eq("c2", 42)).and(eq("c3", false));
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("BuiltStatement@")
+                .contains("2 bound values")
+                .contains("SELECT * FROM t WHERE c1=? AND c2=42 AND c3=?")
+                .contains("{ 0 : 'foo', 1 : false }");
+    }
+
+    @Test(groups = "unit")
+    public void should_format_schema_statement() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder().build();
+        Statement statement = createTable("t")
+                .addPartitionKey("c1", DataType.cint())
+                .addClusteringColumn("c2", DataType.varchar())
+                .addColumn("c3", DataType.cboolean());
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("SchemaStatement@")
+                .contains("CREATE TABLE t(\n" +
+                        "\t\tc1 int,\n" +
+                        "\t\tc2 varchar,\n" +
+                        "\t\tc3 boolean,\n" +
+                        "\t\tPRIMARY KEY(c1, c2))");
+    }
+
+    @Test(groups = "unit")
+    public void should_format_bound_statement() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder().build();
+        BoundStatement statement = newBoundStatementMock();
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("BoundStatement@")
+                .contains("3 bound values")
+                .contains("SELECT * FROM t WHERE c1 = ? AND c2 = ? AND c3 = ?")
+                .contains("{ c1 : 'foo', c2 : <NULL>, c3 : <UNSET> }");
+    }
+
+    @Test(groups = "unit")
+    public void should_format_batch_statement() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder().build();
+        BatchStatement statement = new BatchStatement(BatchStatement.Type.UNLOGGED);
+        Statement inner1 = newBoundStatementMock();
+        Statement inner2 = new SimpleStatement("SELECT * FROM t WHERE c1 = ? AND c2 = ?", "foo", 42);
+        Statement inner3 = select().from("t").where(eq("c1", "foo")).and(eq("c2", 42));
+        statement.add(inner1);
+        statement.add(inner2);
+        statement.add(inner3);
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("BatchStatement@")
+                .contains("[UNLOGGED, 3 inner statements, 6 bound values]")
+                .contains(formatter.format(inner1, EXTENDED, version, codecRegistry))
+                .contains(formatter.format(inner2, EXTENDED, version, codecRegistry))
+                .contains(formatter.format(inner3, EXTENDED, version, codecRegistry));
+    }
+
+    @Test(groups = "unit")
+    public void should_format_wrapped_statement() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder().build();
+        Statement statement = new StatementWrapper(new SimpleStatement("SELECT * FROM t WHERE c1 = 42")) {
+        };
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("SimpleStatement@")
+                .contains("0 bound values")
+                .contains("SELECT * FROM t WHERE c1 = 42")
+                .doesNotContain("{");
+    }
+
+    // Verbosity
+
+    @Test(groups = "unit")
+    public void should_format_with_abridged_verbosity() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder().build();
+        Statement statement = new SimpleStatement("SELECT * FROM t WHERE c1 = ? AND c2 = ?", "foo", 42);
+        String s = formatter.format(statement, ABRIDGED, version, codecRegistry);
+        assertThat(s)
+                .contains("SimpleStatement@")
+                .contains("2 bound values")
+                .doesNotContain("SELECT * FROM t WHERE c1 = ? AND c2 = ?")
+                .doesNotContain("{ 0 : 'foo', 1 : 42 }");
+    }
+
+    @Test(groups = "unit")
+    public void should_format_with_normal_verbosity() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder().build();
+        Statement statement = new SimpleStatement("SELECT * FROM t WHERE c1 = ? AND c2 = ?", "foo", 42);
+        String s = formatter.format(statement, NORMAL, version, codecRegistry);
+        assertThat(s)
+                .contains("SimpleStatement@")
+                .contains("2 bound values")
+                .contains("SELECT * FROM t WHERE c1 = ? AND c2 = ?")
+                .doesNotContain("{ 0 : 'foo', 1 : 42 }");
+    }
+
+    // Limits
+
+    @Test(groups = "unit")
+    public void should_truncate_query_string() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder()
+                .withMaxQueryStringLength(7)
+                .build();
+        SimpleStatement statement = new SimpleStatement("123456789");
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("1234567...");
+    }
+
+    @Test(groups = "unit")
+    public void should_not_truncate_query_string_when_unlimited() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder()
+                .withMaxQueryStringLength(UNLIMITED)
+                .build();
+        String query = repeat("a", 5000);
+        SimpleStatement statement = new SimpleStatement(query);
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains(query);
+    }
+
+    @Test(groups = "unit")
+    public void should_not_print_more_bound_values_than_max() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder()
+                .withMaxBoundValues(2)
+                .build();
+        SimpleStatement statement = new SimpleStatement("query", 0, 1, 2, 3);
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("{ 0 : 0, 1 : 1, ... }");
+    }
+
+    @Test(groups = "unit")
+    public void should_truncate_bound_value() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder()
+                .withMaxBoundValueLength(4)
+                .build();
+        SimpleStatement statement = new SimpleStatement("query", "12345");
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("{ 0 : '123... }");
+    }
+
+    @Test(groups = "unit")
+    public void should_truncate_bound_value_byte_buffer() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder()
+                .withMaxBoundValueLength(4)
+                .build();
+        SimpleStatement statement = new SimpleStatement("query", Bytes.fromHexString("0xCAFEBABE"));
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("{ 0 : 0xca... }");
+    }
+
+    @Test(groups = "unit")
+    public void should_truncate_inner_statements() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder()
+                .withMaxInnerStatements(2)
+                .withMaxBoundValues(2)
+                .build();
+        BatchStatement statement = new BatchStatement(BatchStatement.Type.UNLOGGED);
+        Statement inner1 = newBoundStatementMock();
+        Statement inner2 = new SimpleStatement("SELECT * FROM t WHERE c1 = ? AND c2 = ?", "foo", 42);
+        Statement inner3 = select().from("t").where(eq("c1", "foo")).and(eq("c2", 42));
+        statement.add(inner1);
+        statement.add(inner2);
+        statement.add(inner3);
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("BatchStatement@")
+                .contains("[UNLOGGED, 3 inner statements, 6 bound values]")
+                .contains(formatter.format(inner1, EXTENDED, version, codecRegistry))
+                .contains(formatter.format(inner2, EXTENDED, version, codecRegistry))
+                .doesNotContain(formatter.format(inner3, EXTENDED, version, codecRegistry))
+                // test that max bound values is reset for each inner statement
+                .contains("{ c1 : 'foo', c2 : <NULL>, ... }")
+                .contains("{ 0 : 'foo', 1 : 42 }")
+                .doesNotContain("{ c1 : 'foo', c2 : 42 }")
+                .contains("...");
+    }
+
+    @Test(groups = "unit")
+    public void should_not_print_more_payload_entries_than_max() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder()
+                .withMaxOutgoingPayloadEntries(2)
+                .build();
+        ImmutableMap<String, ByteBuffer> payload = ImmutableMap.<String, ByteBuffer>builder()
+                .put("foo", Bytes.fromHexString("0xCAFE"))
+                .put("bar", Bytes.fromHexString("0xBABE"))
+                .put("qix", Bytes.fromHexString("0xFFFF"))
+                .build();
+        Statement statement = new SimpleStatement("query").setOutgoingPayload(payload);
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("< foo : 0xcafe, bar : 0xbabe, ... >");
+    }
+
+    @Test(groups = "unit")
+    public void should_truncate_payload_entry() throws Exception {
+        StatementFormatter formatter = StatementFormatter.builder()
+                .withMaxOutgoingPayloadValueLength(3)
+                .build();
+        ImmutableMap<String, ByteBuffer> payload = ImmutableMap.<String, ByteBuffer>builder()
+                .put("foo", Bytes.fromHexString("0xCAFEBABE"))
+                .build();
+        Statement statement = new SimpleStatement("query").setOutgoingPayload(payload);
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .contains("< foo : 0xcafeba... >");
+    }
+
+    // Custom printers
+
+    private static class CustomStatement extends Statement {
+
+        @Override
+        public ByteBuffer getRoutingKey(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
+            return null;
+        }
+
+        @Override
+        public String getKeyspace() {
+            return null;
+        }
+
+    }
+
+    private static class CustomStatementPrinter implements StatementFormatter.StatementPrinter<CustomStatement> {
+
+        @Override
+        public Class<CustomStatement> getSupportedStatementClass() {
+            return CustomStatement.class;
+        }
+
+        @Override
+        public void print(CustomStatement statement, StatementFormatter.StatementWriter out, StatementFormatter.StatementFormatVerbosity verbosity) {
+            out.append("This is a statement with a ");
+            // also incidentally test multiple appends to the query string
+            out.appendQueryStringFragment("QUERY");
+            out.appendQueryStringFragment("STR");
+            out.appendQueryStringFragment("ING");
+        }
+
+    }
+
+    @Test(groups = "unit")
+    public void should_use_custom_printer() throws Exception {
+        CustomStatement statement = new CustomStatement();
+        StatementFormatter formatter = StatementFormatter.builder()
+                .withMaxQueryStringLength(5)
+                .addStatementPrinter(new CustomStatementPrinter()).build();
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        assertThat(s)
+                .isEqualTo("This is a statement with a QUERY...");
+    }
+
+    @Test(groups = "unit")
+    public void should_override_default_printer_with_concrete_class() throws Exception {
+        SimpleStatement statement = new SimpleStatement("select * from system.local");
+        final String customAppend = "Used custom simple statement formatter";
+        StatementFormatter formatter = StatementFormatter.builder()
+                .addStatementPrinter(new StatementFormatter.StatementPrinter<SimpleStatement>() {
+
+                    @Override
+                    public Class<SimpleStatement> getSupportedStatementClass() {
+                        return SimpleStatement.class;
+                    }
+
+                    @Override
+                    public void print(SimpleStatement statement, StatementFormatter.StatementWriter out, StatementFormatter.StatementFormatVerbosity verbosity) {
+                        out.appendQueryStringFragment(statement.getQueryString());
+                        out.append(", ");
+                        out.append(customAppend);
+                    }
+                })
+                .build();
+
+        String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+        System.out.println(s);
+        assertThat(s)
+                .isEqualTo(statement.getQueryString() + ", " + customAppend);
+
+    }
+
+    @Test(groups = "unit")
+    public void should_override_default_printer_with_ancestor_class() throws Exception {
+        SimpleStatement simpleStatement = new SimpleStatement("select * from system.local");
+        BuiltStatement builtStatement = QueryBuilder.select().from("system", "peers");
+        SchemaStatement schemaStatement = SchemaBuilder.createTable("x", "y").addPartitionKey("z", DataType.cint());
+        BatchStatement batchStatement = new BatchStatement();
+        final String customAppend = "Used custom statement formatter";
+        StatementFormatter formatter = StatementFormatter.builder()
+                .addStatementPrinter(new StatementFormatter.StatementPrinter<RegularStatement>() {
+
+                    @Override
+                    public Class<RegularStatement> getSupportedStatementClass() {
+                        return RegularStatement.class;
+                    }
+
+                    @Override
+                    public void print(RegularStatement statement, StatementFormatter.StatementWriter out, StatementFormatter.StatementFormatVerbosity verbosity) {
+                        out.appendQueryStringFragment(statement.getQueryString());
+                        out.append(", ");
+                        out.append(customAppend);
+                    }
+                })
+                .build();
+
+        // BatchStatement is not a regular statement so it should not be impacted.
+        String s = formatter.format(batchStatement, EXTENDED, version, codecRegistry);
+        assertThat(s).doesNotContain(customAppend);
+
+        for (RegularStatement statement : Lists.newArrayList(simpleStatement, builtStatement, schemaStatement)) {
+            // Should use custom formatter for RegularStatement implementations.
+            s = formatter.format(statement, EXTENDED, version, codecRegistry);
+            assertThat(s)
+                    .isEqualTo(statement.getQueryString() + ", " + customAppend);
+        }
+
+    }
+
+    // Data types
+
+    @Test(groups = "short")
+    public void should_log_all_parameter_types_simple_statements() throws Exception {
+        String query = "UPDATE test SET c1 = ? WHERE pk = 42";
+        StatementFormatter formatter = StatementFormatter.builder()
+                .withMaxBoundValueLength(UNLIMITED)
+                .build();
+        for (DataType type : dataTypes) {
+            Object value = getFixedValue(type);
+            SimpleStatement statement = new SimpleStatement(query, value);
+            String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+            // time cannot be used with simple statements
+            TypeCodec<Object> codec = codecRegistry.codecFor(type.equals(DataType.time()) ? DataType.bigint() : type, value);
+            assertThat(s).contains(codec.format(value));
+        }
+    }
+
+    @Test(groups = "short")
+    public void should_log_all_parameter_types_bound_statements() throws Exception {
+        String query = "UPDATE test SET c1 = ? WHERE pk = 42";
+        StatementFormatter formatter = StatementFormatter.builder()
+                .withMaxBoundValueLength(UNLIMITED)
+                .build();
+        for (DataType type : dataTypes) {
+            Object value = getFixedValue(type);
+            BoundStatement statement = newBoundStatementMock(query, type);
+            TypeCodec<Object> codec = codecRegistry.codecFor(type, value);
+            statement.set(0, value, codec);
+            String s = formatter.format(statement, EXTENDED, version, codecRegistry);
+            assertThat(s).contains(codec.format(value));
+        }
+    }
+
+    private BoundStatement newBoundStatementMock() {
+        PreparedStatement ps = mock(PreparedStatement.class);
+        ColumnDefinitions cd = mock(ColumnDefinitions.class);
+        PreparedId pid = new PreparedId(null, cd, null, null, version);
+        when(ps.getVariables()).thenReturn(cd);
+        when(ps.getPreparedId()).thenReturn(pid);
+        when(ps.getCodecRegistry()).thenReturn(codecRegistry);
+        when(ps.getQueryString()).thenReturn("SELECT * FROM t WHERE c1 = ? AND c2 = ? AND c3 = ?");
+        when(cd.size()).thenReturn(3);
+        when(cd.getName(0)).thenReturn("c1");
+        when(cd.getName(1)).thenReturn("c2");
+        when(cd.getName(2)).thenReturn("c3");
+        when(cd.getType(0)).thenReturn(DataType.varchar());
+        when(cd.getType(1)).thenReturn(DataType.cint());
+        when(cd.getType(2)).thenReturn(DataType.cboolean());
+        BoundStatement statement = new BoundStatement(ps);
+        statement.setString(0, "foo");
+        statement.setToNull(1);
+        return statement;
+    }
+
+    private BoundStatement newBoundStatementMock(String queryString, DataType type) {
+        PreparedStatement ps = mock(PreparedStatement.class);
+        ColumnDefinitions cd = mock(ColumnDefinitions.class);
+        PreparedId pid = new PreparedId(null, cd, null, null, version);
+        when(ps.getVariables()).thenReturn(cd);
+        when(ps.getPreparedId()).thenReturn(pid);
+        when(ps.getCodecRegistry()).thenReturn(codecRegistry);
+        when(ps.getQueryString()).thenReturn(queryString);
+        when(cd.size()).thenReturn(1);
+        when(cd.getName(0)).thenReturn("c1");
+        when(cd.getType(0)).thenReturn(type);
+        return new BoundStatement(ps);
+    }
+
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
@@ -45,10 +45,10 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
                 "CREATE TABLE dateTest (t timestamp PRIMARY KEY)",
                 "CREATE TABLE test_coll (k int PRIMARY KEY, a list<int>, b map<int,text>, c set<text>)",
                 "CREATE TABLE test_ppl (a int, b int, c int, PRIMARY KEY (a, b))",
-                insertInto(TABLE2).value("k", "cast_t").value("t", "a").value("i", 1).value("f", 1.1).toString(),
-                insertInto(TABLE2).value("k", "cast_t").value("t", "b").value("i", 2).value("f", 2.5).toString(),
-                insertInto(TABLE2).value("k", "cast_t").value("t", "c").value("i", 3).value("f", 3.7).toString(),
-                insertInto(TABLE2).value("k", "cast_t").value("t", "d").value("i", 4).value("f", 5.0).toString()
+                String.format("INSERT INTO %s (k, t, i, f) VALUES ('cast_t', 'a', 1, 1.1)", TABLE2),
+                String.format("INSERT INTO %s (k, t, i, f) VALUES ('cast_t', 'b', 2, 2.5)", TABLE2),
+                String.format("INSERT INTO %s (k, t, i, f) VALUES ('cast_t', 'c', 3, 3.7)", TABLE2),
+                String.format("INSERT INTO %s (k, t, i, f) VALUES ('cast_t', 'd', 4, 5.0)", TABLE2)
         );
         // for per partition limit tests
         for (int i = 0; i < 5; i++) {
@@ -86,8 +86,8 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
 
         Date d = new Date();
         session().execute(insertInto("dateTest").value("t", d));
-        String query = select().from("dateTest").where(eq(token("t"), fcall("token", d))).toString();
-        List<Row> rows = session().execute(query).all();
+        Statement stmt = select().from("dateTest").where(eq(token("t"), fcall("token", d)));
+        List<Row> rows = session().execute(stmt).all();
 
         assertEquals(1, rows.size());
 

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
@@ -38,13 +38,13 @@ public class QueryBuilderITest extends CCMTestsSupport {
     @Test(groups = "short")
     public void remainingDeleteTests() throws Exception {
 
-        Statement query;
+        BuiltStatement query;
         TableMetadata table = cluster().getMetadata().getKeyspace(keyspace).getTable(TABLE_TEXT);
         assertNotNull(table);
 
         String expected = String.format("DELETE k FROM %s.test_text;", keyspace);
         query = delete("k").from(table);
-        assertEquals(query.toString(), expected);
+        assertEquals(query.getQueryString(), expected);
         try {
             session().execute(query);
             fail();
@@ -57,7 +57,7 @@ public class QueryBuilderITest extends CCMTestsSupport {
     public void selectInjectionTests() throws Exception {
 
         String query;
-        Statement select;
+        BuiltStatement select;
         PreparedStatement ps;
         BoundStatement bs;
 
@@ -65,9 +65,9 @@ public class QueryBuilderITest extends CCMTestsSupport {
 
         query = "SELECT * FROM foo WHERE k=?;";
         select = select().all().from("foo").where(eq("k", bindMarker()));
-        ps = session().prepare(select.toString());
+        ps = session().prepare(select.getQueryString());
         bs = ps.bind();
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
         session().execute(bs.setString("k", "4 AND c=5"));
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderRoutingKeyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderRoutingKeyTest.java
@@ -169,7 +169,7 @@ public class QueryBuilderRoutingKeyTest extends CCMTestsSupport {
                 .add(insertInto(table).values(new String[]{"k", "a"}, new Object[]{42, 1}))
                 .add(update(table).using(ttl(400)));
         assertEquals(batch.getRoutingKey(protocolVersion, codecRegistry), bb);
-        assertEquals(batch.toString(), batch_query);
+        assertEquals(batch.getQueryString(), batch_query);
         // TODO: rs = session().execute(batch); // Not guaranteed to be valid CQL
 
         batch_query = "BEGIN BATCH ";
@@ -177,7 +177,7 @@ public class QueryBuilderRoutingKeyTest extends CCMTestsSupport {
         batch_query += "APPLY BATCH;";
         batch = batch(query);
         assertEquals(batch.getRoutingKey(protocolVersion, codecRegistry), bb);
-        assertEquals(batch.toString(), batch_query);
+        assertEquals(batch.getQueryString(), batch_query);
         // TODO: rs = session().execute(batch); // Not guaranteed to be valid CQL
 
         batch_query = "BEGIN BATCH ";
@@ -185,7 +185,7 @@ public class QueryBuilderRoutingKeyTest extends CCMTestsSupport {
         batch_query += "APPLY BATCH;";
         batch = batch().add(select().from("foo").where(eq("k", 42)));
         assertEquals(batch.getRoutingKey(protocolVersion, codecRegistry), null);
-        assertEquals(batch.toString(), batch_query);
+        assertEquals(batch.getQueryString(), batch_query);
         // TODO: rs = session().execute(batch); // Not guaranteed to be valid CQL
 
         batch_query = "BEGIN BATCH USING TIMESTAMP 42 ";
@@ -193,7 +193,7 @@ public class QueryBuilderRoutingKeyTest extends CCMTestsSupport {
         batch_query += "APPLY BATCH;";
         batch = batch().using(timestamp(42)).add(insertInto("foo", "bar").value("a", 123));
         assertEquals(batch.getRoutingKey(protocolVersion, codecRegistry), null);
-        assertEquals(batch.toString(), batch_query);
+        assertEquals(batch.getQueryString(), batch_query);
         // TODO: rs = session().execute(batch); // Not guaranteed to be valid CQL
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -46,117 +46,117 @@ public class QueryBuilderTest {
     public void selectTest() throws Exception {
 
         String query;
-        Statement select;
+        BuiltStatement select;
 
-        query = "SELECT * FROM foo WHERE k=4 AND c>'a' AND c<='z';";
+        query = "SELECT * FROM foo WHERE k=4 AND c>? AND c<=?;";
         select = select().all().from("foo").where(eq("k", 4)).and(gt("c", "a")).and(lte("c", "z"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         // Ensure where() and where(...) are equal
         select = select().all().from("foo").where().and(eq("k", 4)).and(gt("c", "a")).and(lte("c", "z"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
-        query = "SELECT a,b,\"C\" FROM foo WHERE a IN ('127.0.0.1','127.0.0.3') AND \"C\"='foo' ORDER BY a ASC,b DESC LIMIT 42;";
+        query = "SELECT a,b,\"C\" FROM foo WHERE a IN (?,?) AND \"C\"=? ORDER BY a ASC,b DESC LIMIT 42;";
         select = select("a", "b", quote("C")).from("foo")
                 .where(in("a", InetAddress.getByName("127.0.0.1"), InetAddress.getByName("127.0.0.3")))
                 .and(eq(quote("C"), "foo"))
                 .orderBy(asc("a"), desc("b"))
                 .limit(42);
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT writetime(a),ttl(a) FROM foo ALLOW FILTERING;";
         select = select().writeTime("a").ttl("a").from("foo").allowFiltering();
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT DISTINCT longName AS a,ttl(longName) AS ttla FROM foo LIMIT :limit;";
         select = select().distinct().column("longName").as("a").ttl("longName").as("ttla").from("foo").limit(bindMarker("limit"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT DISTINCT longName AS a,ttl(longName) AS ttla FROM foo WHERE k IN () LIMIT :limit;";
         select = select().distinct().column("longName").as("a").ttl("longName").as("ttla").from("foo").where(in("k")).limit(bindMarker("limit"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT * FROM foo WHERE bar=:barmark AND baz=:bazmark LIMIT :limit;";
         select = select().all().from("foo").where().and(eq("bar", bindMarker("barmark"))).and(eq("baz", bindMarker("bazmark"))).limit(bindMarker("limit"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT a FROM foo WHERE k IN ();";
         select = select("a").from("foo").where(in("k"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT a FROM foo WHERE k IN ?;";
         select = select("a").from("foo").where(in("k", bindMarker()));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT DISTINCT a FROM foo WHERE k=1;";
         select = select("a").distinct().from("foo").where(eq("k", 1));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT DISTINCT a,b FROM foo WHERE k=1;";
         select = select("a", "b").distinct().from("foo").where(eq("k", 1));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT count(*) FROM foo;";
         select = select().countAll().from("foo");
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT intToBlob(b) FROM foo;";
         select = select().fcall("intToBlob", column("b")).from("foo");
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT * FROM foo WHERE k>42 LIMIT 42;";
         select = select().all().from("foo").where(gt("k", 42)).limit(42);
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT * FROM foo WHERE token(k)>token(42);";
         select = select().all().from("foo").where(gt(token("k"), fcall("token", 42)));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT * FROM foo2 WHERE token(a,b)>token(42,101);";
         select = select().all().from("foo2").where(gt(token("a", "b"), fcall("token", 42, 101)));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
-        query = "SELECT * FROM words WHERE w='):,ydL ;O,D';";
+        query = "SELECT * FROM words WHERE w=?;";
         select = select().all().from("words").where(eq("w", "):,ydL ;O,D"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
-        query = "SELECT * FROM words WHERE w='WA(!:gS)r(UfW';";
+        query = "SELECT * FROM words WHERE w=?;";
         select = select().all().from("words").where(eq("w", "WA(!:gS)r(UfW"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         Date date = new Date();
         date.setTime(1234325);
-        query = "SELECT * FROM foo WHERE d=1234325;";
+        query = "SELECT * FROM foo WHERE d=?;";
         select = select().all().from("foo").where(eq("d", date));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
-        query = "SELECT * FROM foo WHERE b=0xcafebabe;";
+        query = "SELECT * FROM foo WHERE b=?;";
         select = select().all().from("foo").where(eq("b", Bytes.fromHexString("0xCAFEBABE")));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
-        query = "SELECT * FROM foo WHERE e CONTAINS 'text';";
+        query = "SELECT * FROM foo WHERE e CONTAINS ?;";
         select = select().from("foo").where(contains("e", "text"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
-        query = "SELECT * FROM foo WHERE e CONTAINS KEY 'key1';";
+        query = "SELECT * FROM foo WHERE e CONTAINS KEY ?;";
         select = select().from("foo").where(containsKey("e", "key1"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT CAST(writetime(country) AS text) FROM artists LIMIT 2;";
         select = select().cast(fcall("writetime", column("country")), DataType.text()).from("artists").limit(2);
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT avg(CAST(v AS float)) FROM e;";
         select = select().fcall("avg", cast(column("v"), DataType.cfloat())).from("e");
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT CAST(writetime(country) AS text) FROM artists LIMIT 2;";
         select = select().raw("CAST(writetime(country) AS text)").from("artists").limit(2);
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
-        query = "SELECT * FROM foo WHERE e LIKE 'a%';";
+        query = "SELECT * FROM foo WHERE e LIKE ?;";
         select = select().from("foo").where(like("e", "a%"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         try {
             select().countAll().from("foo").orderBy(asc("a"), desc("b")).orderBy(asc("a"), desc("b"));
@@ -199,9 +199,9 @@ public class QueryBuilderTest {
     public void insertTest() throws Exception {
 
         String query;
-        Statement insert;
+        BuiltStatement insert;
 
-        query = "INSERT INTO foo (a,b,\"C\",d) VALUES (123,'127.0.0.1','foo''bar',{'x':3,'y':2}) USING TIMESTAMP 42 AND TTL 24;";
+        query = "INSERT INTO foo (a,b,\"C\",d) VALUES (123,?,?,{'x':3,'y':2}) USING TIMESTAMP 42 AND TTL 24;";
         insert = insertInto("foo")
                 .value("a", 123)
                 .value("b", InetAddress.getByName("127.0.0.1"))
@@ -211,13 +211,13 @@ public class QueryBuilderTest {
                     put("y", 2);
                 }})
                 .using(timestamp(42)).and(ttl(24));
-        assertEquals(insert.toString(), query);
+        assertEquals(insert.getQueryString(), query);
 
         query = "INSERT INTO foo (a,b) VALUES (2,null);";
         insert = insertInto("foo")
                 .value("a", 2)
                 .value("b", null);
-        assertEquals(insert.toString(), query);
+        assertEquals(insert.getQueryString(), query);
 
         query = "INSERT INTO foo (a,b) VALUES ({2,3,4},3.4) USING TTL 24 AND TIMESTAMP 42;";
         insert = insertInto("foo").values(new String[]{"a", "b"}, new Object[]{new TreeSet<Integer>() {{
@@ -225,7 +225,7 @@ public class QueryBuilderTest {
             add(3);
             add(4);
         }}, 3.4}).using(ttl(24)).and(timestamp(42));
-        assertEquals(insert.toString(), query);
+        assertEquals(insert.getQueryString(), query);
 
         query = "INSERT INTO foo.bar (a,b) VALUES ({2,3,4},3.4) USING TTL ? AND TIMESTAMP ?;";
         insert = insertInto("foo", "bar")
@@ -236,7 +236,7 @@ public class QueryBuilderTest {
                 }}, 3.4})
                 .using(ttl(bindMarker()))
                 .and(timestamp(bindMarker()));
-        assertEquals(insert.toString(), query);
+        assertEquals(insert.getQueryString(), query);
 
         // commutative result of TIMESTAMP
         query = "INSERT INTO foo.bar (a,b,c) VALUES ({2,3,4},3.4,123) USING TIMESTAMP 42;";
@@ -248,7 +248,7 @@ public class QueryBuilderTest {
                     add(4);
                 }}, 3.4})
                 .value("c", 123);
-        assertEquals(insert.toString(), query);
+        assertEquals(insert.getQueryString(), query);
 
         // commutative result of value() and values()
         query = "INSERT INTO foo (c,a,b) VALUES (123,{2,3,4},3.4) USING TIMESTAMP 42;";
@@ -260,7 +260,7 @@ public class QueryBuilderTest {
                     add(3);
                     add(4);
                 }}, 3.4});
-        assertEquals(insert.toString(), query);
+        assertEquals(insert.getQueryString(), query);
 
         try {
             insertInto("foo").values(new String[]{"a", "b"}, new Object[]{1, 2, 3});
@@ -272,7 +272,7 @@ public class QueryBuilderTest {
         // CAS test
         query = "INSERT INTO foo (k,x) VALUES (0,1) IF NOT EXISTS;";
         insert = insertInto("foo").value("k", 0).value("x", 1).ifNotExists();
-        assertEquals(insert.toString(), query);
+        assertEquals(insert.getQueryString(), query);
 
         // Tuples: see QueryBuilderTupleExecutionTest
         // UDT: see QueryBuilderExecutionTest
@@ -283,23 +283,23 @@ public class QueryBuilderTest {
     public void updateTest() throws Exception {
 
         String query;
-        Statement update;
+        BuiltStatement update;
 
         query = "UPDATE foo.bar USING TIMESTAMP 42 SET a=12,b=[3,2,1],c=c+3 WHERE k=2;";
         update = update("foo", "bar").using(timestamp(42)).with(set("a", 12)).and(set("b", Arrays.asList(3, 2, 1))).and(incr("c", 3)).where(eq("k", 2));
-        assertEquals(update.toString(), query);
+        assertEquals(update.getQueryString(), query);
 
         query = "UPDATE foo SET b=null WHERE k=2;";
         update = update("foo").where().and(eq("k", 2)).with(set("b", null));
-        assertEquals(update.toString(), query);
+        assertEquals(update.getQueryString(), query);
 
-        query = "UPDATE foo SET a[2]='foo',b=[3,2,1]+b,c=c-{'a'} WHERE k=2 AND l='foo' AND m<4 AND n>=1;";
+        query = "UPDATE foo SET a[2]=?,b=[3,2,1]+b,c=c-? WHERE k=2 AND l=? AND m<4 AND n>=1;";
         update = update("foo").with(setIdx("a", 2, "foo")).and(prependAll("b", Arrays.asList(3, 2, 1))).and(remove("c", "a")).where(eq("k", 2)).and(eq("l", "foo")).and(lt("m", 4)).and(gte("n", 1));
-        assertEquals(update.toString(), query);
+        assertEquals(update.getQueryString(), query);
 
-        query = "UPDATE foo SET b=[3]+b,c=c+['a'],d=d+[1,2,3],e=e-[1];";
+        query = "UPDATE foo SET b=[3]+b,c=c+?,d=d+[1,2,3],e=e-[1];";
         update = update("foo").with().and(prepend("b", 3)).and(append("c", "a")).and(appendAll("d", Arrays.asList(1, 2, 3))).and(discard("e", 1));
-        assertEquals(update.toString(), query);
+        assertEquals(update.getQueryString(), query);
 
         query = "UPDATE foo SET b=b-[1,2,3],c=c+{1},d=d+{2,3,4};";
         update = update("foo").with(discardAll("b", Arrays.asList(1, 2, 3))).and(add("c", 1)).and(addAll("d", new TreeSet<Integer>() {{
@@ -307,9 +307,9 @@ public class QueryBuilderTest {
             add(3);
             add(4);
         }}));
-        assertEquals(update.toString(), query);
+        assertEquals(update.getQueryString(), query);
 
-        query = "UPDATE foo SET b=b-{2,3,4},c['k']='v',d=d+{'x':3,'y':2};";
+        query = "UPDATE foo SET b=b-{2,3,4},c[?]=?,d=d+{'x':3,'y':2};";
         update = update("foo").with(removeAll("b", new TreeSet<Integer>() {{
             add(2);
             add(3);
@@ -320,27 +320,27 @@ public class QueryBuilderTest {
                     put("x", 3);
                     put("y", 2);
                 }}));
-        assertEquals(update.toString(), query);
+        assertEquals(update.getQueryString(), query);
 
         query = "UPDATE foo USING TTL 400;";
         update = update("foo").using(ttl(400));
-        assertEquals(update.toString(), query);
+        assertEquals(update.getQueryString(), query);
 
-        query = "UPDATE foo SET a=" + new BigDecimal(3.2) + ",b=42 WHERE k=2;";
+        query = "UPDATE foo SET a=?,b=? WHERE k=2;";
         update = update("foo").with(set("a", new BigDecimal(3.2))).and(set("b", new BigInteger("42"))).where(eq("k", 2));
-        assertEquals(update.toString(), query);
+        assertEquals(update.getQueryString(), query);
 
-        query = "UPDATE foo USING TIMESTAMP 42 SET b=[3,2,1]+b WHERE k=2 AND l='foo';";
+        query = "UPDATE foo USING TIMESTAMP 42 SET b=[3,2,1]+b WHERE k=2 AND l=?;";
         update = update("foo").where().and(eq("k", 2)).and(eq("l", "foo")).with(prependAll("b", Arrays.asList(3, 2, 1))).using(timestamp(42));
-        assertEquals(update.toString(), query);
+        assertEquals(update.getQueryString(), query);
 
         // Test commutative USING
         update = update("foo").where().and(eq("k", 2)).and(eq("l", "foo")).using(timestamp(42)).with(prependAll("b", Arrays.asList(3, 2, 1)));
-        assertEquals(update.toString(), query);
+        assertEquals(update.getQueryString(), query);
 
         // Test commutative USING
         update = update("foo").using(timestamp(42)).where(eq("k", 2)).and(eq("l", "foo")).with(prependAll("b", Arrays.asList(3, 2, 1)));
-        assertEquals(update.toString(), query);
+        assertEquals(update.getQueryString(), query);
 
         try {
             update("foo").using(ttl(-400));
@@ -352,49 +352,49 @@ public class QueryBuilderTest {
         // CAS test
         query = "UPDATE foo SET x=4 WHERE k=0 IF x=1;";
         update = update("foo").with(set("x", 4)).where(eq("k", 0)).onlyIf(eq("x", 1));
-        assertEquals(update.toString(), query);
+        assertEquals(update.getQueryString(), query);
 
         // IF EXISTS CAS test
         update = update("foo").with(set("x", 3)).where(eq("k", 2)).ifExists();
-        assertThat(update.toString()).isEqualTo("UPDATE foo SET x=3 WHERE k=2 IF EXISTS;");
+        assertThat(update.getQueryString()).isEqualTo("UPDATE foo SET x=3 WHERE k=2 IF EXISTS;");
     }
 
     @Test(groups = "unit")
     public void deleteTest() throws Exception {
 
         String query;
-        Statement delete;
+        BuiltStatement delete;
 
         query = "DELETE a,b,c FROM foo USING TIMESTAMP 0 WHERE k=1;";
         delete = delete("a", "b", "c").from("foo").using(timestamp(0)).where(eq("k", 1));
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
 
-        query = "DELETE a[3],b['foo'],c FROM foo WHERE k=1;";
+        query = "DELETE a[3],b[?],c FROM foo WHERE k=1;";
         delete = delete().listElt("a", 3).mapElt("b", "foo").column("c").from("foo").where(eq("k", 1));
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
 
         query = "DELETE a[?],b[?],c FROM foo WHERE k=1;";
         delete = delete().listElt("a", bindMarker()).mapElt("b", bindMarker()).column("c").from("foo").where(eq("k", 1));
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
 
         // Invalid CQL, testing edge case
         query = "DELETE a,b,c FROM foo;";
         delete = delete("a", "b", "c").from("foo");
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
 
-        query = "DELETE FROM foo USING TIMESTAMP 1240003134 WHERE k='value';";
+        query = "DELETE FROM foo USING TIMESTAMP 1240003134 WHERE k=?;";
         delete = delete().all().from("foo").using(timestamp(1240003134L)).where(eq("k", "value"));
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
         delete = delete().from("foo").using(timestamp(1240003134L)).where(eq("k", "value"));
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
 
         query = "DELETE a,b,c FROM foo.bar USING TIMESTAMP 1240003134 WHERE k=1;";
         delete = delete("a", "b", "c").from("foo", "bar").where().and(eq("k", 1)).using(timestamp(1240003134L));
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
 
-        query = "DELETE FROM foo.bar WHERE k1='foo' AND k2=1;";
+        query = "DELETE FROM foo.bar WHERE k1=? AND k2=1;";
         delete = delete().from("foo", "bar").where(eq("k1", "foo")).and(eq("k2", 1));
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
 
         try {
             delete().column("a").all().from("foo");
@@ -410,29 +410,29 @@ public class QueryBuilderTest {
             assertEquals(e.getMessage(), "Invalid timestamp, must be positive");
         }
 
-        query = "DELETE FROM foo.bar WHERE k1='foo' IF EXISTS;";
+        query = "DELETE FROM foo.bar WHERE k1=? IF EXISTS;";
         delete = delete().from("foo", "bar").where(eq("k1", "foo")).ifExists();
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
 
-        query = "DELETE FROM foo.bar WHERE k1='foo' IF a=1 AND b=2;";
+        query = "DELETE FROM foo.bar WHERE k1=? IF a=1 AND b=2;";
         delete = delete().from("foo", "bar").where(eq("k1", "foo")).onlyIf(eq("a", 1)).and(eq("b", 2));
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
 
         query = "DELETE FROM foo WHERE k=:key;";
         delete = delete().from("foo").where(eq("k", bindMarker("key")));
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
     }
 
     @Test(groups = "unit")
     @SuppressWarnings("serial")
     public void batchTest() throws Exception {
         String query;
-        Statement batch;
+        BuiltStatement batch;
 
         query = "BEGIN BATCH USING TIMESTAMP 42 ";
         query += "INSERT INTO foo (a,b) VALUES ({2,3,4},3.4);";
-        query += "UPDATE foo SET a[2]='foo',b=[3,2,1]+b,c=c-{'a'} WHERE k=2;";
-        query += "DELETE a[3],b['foo'],c FROM foo WHERE k=1;";
+        query += "UPDATE foo SET a[2]=?,b=[3,2,1]+b,c=c-? WHERE k=2;";
+        query += "DELETE a[3],b[?],c FROM foo WHERE k=1;";
         query += "APPLY BATCH;";
         batch = batch()
                 .add(insertInto("foo").values(new String[]{"a", "b"}, new Object[]{new TreeSet<Integer>() {{
@@ -443,22 +443,22 @@ public class QueryBuilderTest {
                 .add(update("foo").with(setIdx("a", 2, "foo")).and(prependAll("b", Arrays.asList(3, 2, 1))).and(remove("c", "a")).where(eq("k", 2)))
                 .add(delete().listElt("a", 3).mapElt("b", "foo").column("c").from("foo").where(eq("k", 1)))
                 .using(timestamp(42));
-        assertEquals(batch.toString(), query);
+        assertEquals(batch.getQueryString(), query);
 
         // Test passing batch(statement)
         query = "BEGIN BATCH ";
         query += "DELETE a[3] FROM foo WHERE k=1;";
         query += "APPLY BATCH;";
         batch = batch(delete().listElt("a", 3).from("foo").where(eq("k", 1)));
-        assertEquals(batch.toString(), query);
+        assertEquals(batch.getQueryString(), query);
 
-        assertEquals(batch().toString(), "BEGIN BATCH APPLY BATCH;");
+        assertEquals(batch().getQueryString(), "BEGIN BATCH APPLY BATCH;");
     }
 
     @Test(groups = "unit")
     public void batchCounterTest() throws Exception {
         String query;
-        Statement batch;
+        BuiltStatement batch;
 
         // Test value increments
         query = "BEGIN COUNTER BATCH USING TIMESTAMP 42 ";
@@ -471,7 +471,7 @@ public class QueryBuilderTest {
                 .add(update("foo").with(incr("b", 2)))
                 .add(update("foo").with(incr("c", 3)))
                 .using(timestamp(42));
-        assertEquals(batch.toString(), query);
+        assertEquals(batch.getQueryString(), query);
 
         // Test single increments
         query = "BEGIN COUNTER BATCH USING TIMESTAMP 42 ";
@@ -484,7 +484,7 @@ public class QueryBuilderTest {
                 .add(update("foo").with(incr("b")))
                 .add(update("foo").with(incr("c")))
                 .using(timestamp(42));
-        assertEquals(batch.toString(), query);
+        assertEquals(batch.getQueryString(), query);
 
         // Test value decrements
         query = "BEGIN COUNTER BATCH USING TIMESTAMP 42 ";
@@ -497,7 +497,7 @@ public class QueryBuilderTest {
                 .add(update("foo").with(decr("b", 2)))
                 .add(update("foo").with(decr("c", 3)))
                 .using(timestamp(42));
-        assertEquals(batch.toString(), query);
+        assertEquals(batch.getQueryString(), query);
 
         // Test single decrements
         query = "BEGIN COUNTER BATCH USING TIMESTAMP 42 ";
@@ -510,7 +510,7 @@ public class QueryBuilderTest {
                 .add(update("foo").with(decr("b")))
                 .add(update("foo").with(decr("c")))
                 .using(timestamp(42));
-        assertEquals(batch.toString(), query);
+        assertEquals(batch.getQueryString(), query);
 
         // Test negative decrements and negative increments
         query = "BEGIN COUNTER BATCH USING TIMESTAMP 42 ";
@@ -523,7 +523,7 @@ public class QueryBuilderTest {
                 .add(update("foo").with(incr("b", -2)))
                 .add(update("foo").with(decr("c", 3)))
                 .using(timestamp(42));
-        assertEquals(batch.toString(), query);
+        assertEquals(batch.getQueryString(), query);
     }
 
     @Test(groups = "unit", expectedExceptions = {IllegalArgumentException.class})
@@ -538,92 +538,92 @@ public class QueryBuilderTest {
     @Test(groups = "unit")
     public void markerTest() throws Exception {
         String query;
-        Statement insert;
+        BuiltStatement insert;
 
         query = "INSERT INTO test (k,c) VALUES (0,?);";
         insert = insertInto("test")
                 .value("k", 0)
                 .value("c", bindMarker());
-        assertEquals(insert.toString(), query);
+        assertEquals(insert.getQueryString(), query);
     }
 
     @Test(groups = "unit")
     public void rawEscapingTest() throws Exception {
 
         String query;
-        Statement select;
+        BuiltStatement select;
 
-        query = "SELECT * FROM t WHERE c='C''est la vie!';";
+        query = "SELECT * FROM t WHERE c=?;";
         select = select().from("t").where(eq("c", "C'est la vie!"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT * FROM t WHERE c=C'est la vie!;";
         select = select().from("t").where(eq("c", raw("C'est la vie!")));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT * FROM t WHERE c=now();";
         select = select().from("t").where(eq("c", fcall("now")));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT * FROM t WHERE c='now()';";
         select = select().from("t").where(eq("c", raw("'now()'")));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
     }
 
     @Test(groups = "unit")
     public void selectInjectionTests() throws Exception {
 
         String query;
-        Statement select;
+        BuiltStatement select;
 
         query = "SELECT * FROM \"foo WHERE k=4\";";
         select = select().all().from("foo WHERE k=4");
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
-        query = "SELECT * FROM foo WHERE k='4 AND c=5';";
+        query = "SELECT * FROM foo WHERE k=?;";
         select = select().all().from("foo").where(eq("k", "4 AND c=5"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
-        query = "SELECT * FROM foo WHERE k='4'' AND c=''5';";
+        query = "SELECT * FROM foo WHERE k=?;";
         select = select().all().from("foo").where(eq("k", "4' AND c='5"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
-        query = "SELECT * FROM foo WHERE k='4'' OR ''1''=''1';";
+        query = "SELECT * FROM foo WHERE k=?;";
         select = select().all().from("foo").where(eq("k", "4' OR '1'='1"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
-        query = "SELECT * FROM foo WHERE k='4; --test comment;';";
+        query = "SELECT * FROM foo WHERE k=?;";
         select = select().all().from("foo").where(eq("k", "4; --test comment;"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT \"*\" FROM foo;";
         select = select("*").from("foo");
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
-        query = "SELECT a,b FROM foo WHERE a IN ('b','c''); --comment');";
+        query = "SELECT a,b FROM foo WHERE a IN (?,?);";
         select = select("a", "b").from("foo").where(in("a", "b", "c'); --comment"));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         // User Injection?
         query = "SELECT * FROM bar; --(b) FROM foo;";
         select = select().fcall("* FROM bar; --", column("b")).from("foo");
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT writetime(\"a) FROM bar; --\"),ttl(a) FROM foo ALLOW FILTERING;";
         select = select().writeTime("a) FROM bar; --").ttl("a").from("foo").allowFiltering();
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT writetime(a),ttl(\"a) FROM bar; --\") FROM foo ALLOW FILTERING;";
         select = select().writeTime("a").ttl("a) FROM bar; --").from("foo").allowFiltering();
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT * FROM foo WHERE \"k=1 OR k\">42 LIMIT 42;";
         select = select().all().from("foo").where(gt("k=1 OR k", 42)).limit(42);
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT * FROM foo WHERE token(\"k)>0 OR token(k\")>token(42);";
         select = select().all().from("foo").where(gt(token("k)>0 OR token(k"), fcall("token", 42)));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
     }
 
     @Test(groups = "unit")
@@ -631,86 +631,82 @@ public class QueryBuilderTest {
     public void insertInjectionTest() throws Exception {
 
         String query;
-        Statement insert;
+        BuiltStatement insert;
 
-        query = "INSERT INTO foo (a) VALUES ('123); --comment');";
+        query = "INSERT INTO foo (a) VALUES (?);";
         insert = insertInto("foo").value("a", "123); --comment");
-        assertEquals(insert.toString(), query);
+        assertEquals(insert.getQueryString(), query);
 
         query = "INSERT INTO foo (\"a,b\") VALUES (123);";
         insert = insertInto("foo").value("a,b", 123);
-        assertEquals(insert.toString(), query);
+        assertEquals(insert.getQueryString(), query);
 
-        query = "INSERT INTO foo (a,b) VALUES ({'2''} space','3','4'},3.4) USING TTL 24 AND TIMESTAMP 42;";
+        query = "INSERT INTO foo (a,b) VALUES (?,3.4) USING TTL 24 AND TIMESTAMP 42;";
         insert = insertInto("foo").values(new String[]{"a", "b"}, new Object[]{new TreeSet<String>() {{
             add("2'} space");
             add("3");
             add("4");
         }}, 3.4}).using(ttl(24)).and(timestamp(42));
-        assertEquals(insert.toString(), query);
+        assertEquals(insert.getQueryString(), query);
     }
 
     @Test(groups = "unit")
     public void updateInjectionTest() throws Exception {
 
         String query;
-        Statement update;
+        BuiltStatement update;
 
-        query = "UPDATE foo.bar USING TIMESTAMP 42 SET a=12 WHERE k='2 OR 1=1';";
+        query = "UPDATE foo.bar USING TIMESTAMP 42 SET a=12 WHERE k=?;";
         update = update("foo", "bar").using(timestamp(42)).with(set("a", 12)).where(eq("k", "2 OR 1=1"));
-        assertEquals(update.toString(), query);
+        assertEquals(update.getQueryString(), query);
 
-        query = "UPDATE foo SET b='null WHERE k=1; --comment' WHERE k=2;";
+        query = "UPDATE foo SET b=? WHERE k=2;";
         update = update("foo").where().and(eq("k", 2)).with(set("b", "null WHERE k=1; --comment"));
-        assertEquals(update.toString(), query);
+        assertEquals(update.getQueryString(), query);
 
         query = "UPDATE foo USING TIMESTAMP 42 SET \"b WHERE k=1; --comment\"=[3,2,1]+\"b WHERE k=1; --comment\" WHERE k=2;";
         update = update("foo").where().and(eq("k", 2)).with(prependAll("b WHERE k=1; --comment", Arrays.asList(3, 2, 1))).using(timestamp(42));
-        assertEquals(update.toString(), query);
+        assertEquals(update.getQueryString(), query);
     }
 
     @Test(groups = "unit")
     public void deleteInjectionTests() throws Exception {
 
         String query;
-        Statement delete;
+        BuiltStatement delete;
 
         query = "DELETE FROM \"foo WHERE k=4\";";
         delete = delete().from("foo WHERE k=4");
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
 
-        query = "DELETE FROM foo WHERE k='4 AND c=5';";
+        query = "DELETE FROM foo WHERE k=?;";
         delete = delete().from("foo").where(eq("k", "4 AND c=5"));
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
 
-        query = "DELETE FROM foo WHERE k='4'' AND c=''5';";
-        delete = delete().from("foo").where(eq("k", "4' AND c='5"));
-        assertEquals(delete.toString(), query);
+        query = "DELETE FROM foo WHERE k=?;";
+        delete = delete().from("foo").where(eq("k", "4' AND c='4'' OR ''1''=''1';"));
+        assertEquals(delete.getQueryString(), query);
 
-        query = "DELETE FROM foo WHERE k='4'' OR ''1''=''1';";
-        delete = delete().from("foo").where(eq("k", "4' OR '1'='1"));
-        assertEquals(delete.toString(), query);
-
-        query = "DELETE FROM foo WHERE k='4; --test comment;';";
+        query = "DELETE FROM foo WHERE k=?;";
         delete = delete().from("foo").where(eq("k", "4; --test comment;"));
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
 
         query = "DELETE \"*\" FROM foo;";
         delete = delete("*").from("foo");
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
 
-        query = "DELETE a,b FROM foo WHERE a IN ('b','c''); --comment');";
+        query = "DELETE a,b FROM foo WHERE a IN (?,?);";
         delete = delete("a", "b").from("foo")
                 .where(in("a", "b", "c'); --comment"));
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
 
         query = "DELETE FROM foo WHERE \"k=1 OR k\">42;";
         delete = delete().from("foo").where(gt("k=1 OR k", 42));
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
 
         query = "DELETE FROM foo WHERE token(\"k)>0 OR token(k\")>token(42);";
         delete = delete().from("foo").where(gt(token("k)>0 OR token(k"), fcall("token", 42)));
-        assertEquals(delete.toString(), query);
+        assertEquals(delete.getQueryString(), query);
     }
 
     @Test(groups = "unit")
@@ -720,7 +716,7 @@ public class QueryBuilderTest {
         upd.setConsistencyLevel(ConsistencyLevel.QUORUM);
         upd.enableTracing();
 
-        Statement query = upd.using(timestamp(42)).with(set("a", 12)).and(incr("c", 3)).where(eq("k", 2));
+        BuiltStatement query = upd.using(timestamp(42)).with(set("a", 12)).and(incr("c", 3)).where(eq("k", 2));
 
         assertEquals(query.getConsistencyLevel(), ConsistencyLevel.QUORUM);
         assertTrue(query.isTracing());
@@ -735,61 +731,61 @@ public class QueryBuilderTest {
 
     @Test(groups = "unit")
     public void truncateTest() throws Exception {
-        assertEquals(truncate("foo").toString(), "TRUNCATE foo;");
-        assertEquals(truncate("foo", quote("Bar")).toString(), "TRUNCATE foo.\"Bar\";");
+        assertEquals(truncate("foo").getQueryString(), "TRUNCATE foo;");
+        assertEquals(truncate("foo", quote("Bar")).getQueryString(), "TRUNCATE foo.\"Bar\";");
     }
 
     @Test(groups = "unit")
     public void quotingTest() {
-        assertEquals(select().from("Metrics", "epochs").toString(),
+        assertEquals(select().from("Metrics", "epochs").getQueryString(),
                 "SELECT * FROM Metrics.epochs;");
-        assertEquals(select().from("Metrics", quote("epochs")).toString(),
+        assertEquals(select().from("Metrics", quote("epochs")).getQueryString(),
                 "SELECT * FROM Metrics.\"epochs\";");
-        assertEquals(select().from(quote("Metrics"), "epochs").toString(),
+        assertEquals(select().from(quote("Metrics"), "epochs").getQueryString(),
                 "SELECT * FROM \"Metrics\".epochs;");
-        assertEquals(select().from(quote("Metrics"), quote("epochs")).toString(),
+        assertEquals(select().from(quote("Metrics"), quote("epochs")).getQueryString(),
                 "SELECT * FROM \"Metrics\".\"epochs\";");
 
-        assertEquals(insertInto("Metrics", "epochs").toString(),
+        assertEquals(insertInto("Metrics", "epochs").getQueryString(),
                 "INSERT INTO Metrics.epochs () VALUES ();");
-        assertEquals(insertInto("Metrics", quote("epochs")).toString(),
+        assertEquals(insertInto("Metrics", quote("epochs")).getQueryString(),
                 "INSERT INTO Metrics.\"epochs\" () VALUES ();");
-        assertEquals(insertInto(quote("Metrics"), "epochs").toString(),
+        assertEquals(insertInto(quote("Metrics"), "epochs").getQueryString(),
                 "INSERT INTO \"Metrics\".epochs () VALUES ();");
-        assertEquals(insertInto(quote("Metrics"), quote("epochs")).toString(),
+        assertEquals(insertInto(quote("Metrics"), quote("epochs")).getQueryString(),
                 "INSERT INTO \"Metrics\".\"epochs\" () VALUES ();");
     }
 
     @Test(groups = "unit")
     public void compoundWhereClauseTest() throws Exception {
         String query;
-        Statement select;
+        BuiltStatement select;
 
-        query = "SELECT * FROM foo WHERE k=4 AND (c1,c2)=('a',2);";
+        query = "SELECT * FROM foo WHERE k=4 AND (c1,c2)=(?,2);";
         select = select().all().from("foo").where(eq("k", 4)).and(eq(Arrays.asList("c1", "c2"), Arrays.<Object>asList("a", 2)));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
-        query = "SELECT * FROM foo WHERE k=4 AND (c1,c2)>('a',2);";
+        query = "SELECT * FROM foo WHERE k=4 AND (c1,c2)>(?,2);";
         select = select().all().from("foo").where(eq("k", 4)).and(gt(Arrays.asList("c1", "c2"), Arrays.<Object>asList("a", 2)));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
-        query = "SELECT * FROM foo WHERE k=4 AND (c1,c2)>=('a',2) AND (c1,c2)<('b',0);";
+        query = "SELECT * FROM foo WHERE k=4 AND (c1,c2)>=(?,2) AND (c1,c2)<(?,0);";
         select = select().all().from("foo").where(eq("k", 4)).and(gte(Arrays.asList("c1", "c2"), Arrays.<Object>asList("a", 2)))
                 .and(lt(Arrays.asList("c1", "c2"), Arrays.<Object>asList("b", 0)));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
-        query = "SELECT * FROM foo WHERE k=4 AND (c1,c2)<=('a',2);";
+        query = "SELECT * FROM foo WHERE k=4 AND (c1,c2)<=(?,2);";
         select = select().all().from("foo").where(eq("k", 4)).and(lte(Arrays.asList("c1", "c2"), Arrays.<Object>asList("a", 2)));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
-        query = "SELECT * FROM foo WHERE k=4 AND (c1,c2) IN ((1,'foo'),(2,'bar'),(3,'qix'));";
+        query = "SELECT * FROM foo WHERE k=4 AND (c1,c2) IN ((1,?),(2,?),(3,?));";
         List<String> names = ImmutableList.of("c1", "c2");
         List<?> values = ImmutableList.<List<?>>of(
                 ImmutableList.of(1, "foo"),
                 ImmutableList.of(2, "bar"),
                 ImmutableList.of(3, "qix"));
         select = select().all().from("foo").where(eq("k", 4)).and(in(names, values));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         query = "SELECT * FROM foo WHERE k=4 AND (c1,c2) IN ((1,'foo'),(2,?),?);";
         names = ImmutableList.of("c1", "c2");
@@ -798,14 +794,14 @@ public class QueryBuilderTest {
                 ImmutableList.of(2, bindMarker()),
                 bindMarker());
         select = select().all().from("foo").where(eq("k", 4)).and(in(names, values));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
 
         // special case, single element list with bind marker should be (?) instead of ((?))
         query = "SELECT * FROM foo WHERE k=4 AND (c1) IN (?);";
         names = ImmutableList.of("c1");
         values = ImmutableList.of(ImmutableList.of(bindMarker()));
         select = select().all().from("foo").where(eq("k", 4)).and(in(names, values));
-        assertEquals(select.toString(), query);
+        assertEquals(select.getQueryString(), query);
     }
 
     @Test(groups = "unit", expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Too many values for IN clause, the maximum allowed is 65535")
@@ -862,28 +858,28 @@ public class QueryBuilderTest {
     @Test(groups = "unit")
     public void should_handle_nested_collections() {
         String query;
-        Statement statement;
+        BuiltStatement statement;
 
         query = "UPDATE foo SET l=[[1],[2]] WHERE k=1;";
         ImmutableList<ImmutableList<Integer>> list = ImmutableList.of(ImmutableList.of(1), ImmutableList.of(2));
         statement = update("foo").with(set("l", list)).where(eq("k", 1));
-        assertThat(statement.toString()).isEqualTo(query);
+        assertThat(statement.getQueryString()).isEqualTo(query);
 
         query = "UPDATE foo SET m={1:[[1],[2]],2:[[1],[2]]} WHERE k=1;";
         statement = update("foo").with(set("m", ImmutableMap.of(1, list, 2, list))).where(eq("k", 1));
-        assertThat(statement.toString()).isEqualTo(query);
+        assertThat(statement.getQueryString()).isEqualTo(query);
 
         query = "UPDATE foo SET m=m+{1:[[1],[2]],2:[[1],[2]]} WHERE k=1;";
         statement = update("foo").with(putAll("m", ImmutableMap.of(1, list, 2, list))).where(eq("k", 1));
-        assertThat(statement.toString()).isEqualTo(query);
+        assertThat(statement.getQueryString()).isEqualTo(query);
 
         query = "UPDATE foo SET l=[[1]]+l WHERE k=1;";
         statement = update("foo").with(prepend("l", ImmutableList.of(1))).where(eq("k", 1));
-        assertThat(statement.toString()).isEqualTo(query);
+        assertThat(statement.getQueryString()).isEqualTo(query);
 
         query = "UPDATE foo SET l=[[1],[2]]+l WHERE k=1;";
         statement = update("foo").with(prependAll("l", list)).where(eq("k", 1));
-        assertThat(statement.toString()).isEqualTo(query);
+        assertThat(statement.getQueryString()).isEqualTo(query);
     }
 
     @Test(groups = "unit", expectedExceptions = InvalidQueryException.class)
@@ -916,18 +912,18 @@ public class QueryBuilderTest {
     public void should_quote_complex_column_names() {
         // A column name can be anything as long as it's quoted, so "foo.bar" is a valid name
         String query = "SELECT * FROM foo WHERE \"foo.bar\"=1;";
-        Statement statement = select().from("foo").where(eq(quote("foo.bar"), 1));
+        BuiltStatement statement = select().from("foo").where(eq(quote("foo.bar"), 1));
 
-        assertThat(statement.toString()).isEqualTo(query);
+        assertThat(statement.getQueryString()).isEqualTo(query);
     }
 
     @Test(groups = "unit")
     public void should_quote_column_names_with_escaped_quotes() {
         // A column name can include quotes as long as it is escaped with another set of quotes, so "foo""bar" is a valid name.
         String query = "SELECT * FROM foo WHERE \"foo \"\" bar\"=1;";
-        Statement statement = select().from("foo").where(eq(quote("foo \" bar"), 1));
+        BuiltStatement statement = select().from("foo").where(eq(quote("foo \" bar"), 1));
 
-        assertThat(statement.toString()).isEqualTo(query);
+        assertThat(statement.getQueryString()).isEqualTo(query);
     }
 
     @Test(groups = "unit")
@@ -1035,29 +1031,29 @@ public class QueryBuilderTest {
     @Test(groups = "unit")
     public void should_handle_per_partition_limit_clause() {
         assertThat(
-                select().all().from("foo").perPartitionLimit(2).toString())
+                select().all().from("foo").perPartitionLimit(2).getQueryString())
                 .isEqualTo("SELECT * FROM foo PER PARTITION LIMIT 2;");
         assertThat(
-                select().all().from("foo").perPartitionLimit(bindMarker()).toString())
+                select().all().from("foo").perPartitionLimit(bindMarker()).getQueryString())
                 .isEqualTo("SELECT * FROM foo PER PARTITION LIMIT ?;");
         assertThat(
-                select().all().from("foo").perPartitionLimit(bindMarker("limit")).toString())
+                select().all().from("foo").perPartitionLimit(bindMarker("limit")).getQueryString())
                 .isEqualTo("SELECT * FROM foo PER PARTITION LIMIT :limit;");
         assertThat(
-                select().all().from("foo").perPartitionLimit(2).limit(bindMarker()).toString())
+                select().all().from("foo").perPartitionLimit(2).limit(bindMarker()).getQueryString())
                 .isEqualTo("SELECT * FROM foo PER PARTITION LIMIT 2 LIMIT ?;");
         assertThat(
-                select().all().from("foo").where(in("a", 2, 4)).perPartitionLimit(2).limit(3).toString())
+                select().all().from("foo").where(in("a", 2, 4)).perPartitionLimit(2).limit(3).getQueryString())
                 .isEqualTo("SELECT * FROM foo WHERE a IN (2,4) PER PARTITION LIMIT 2 LIMIT 3;");
         assertThat(
-                select().all().from("foo").where(eq("a", bindMarker())).perPartitionLimit(bindMarker()).limit(3).toString())
+                select().all().from("foo").where(eq("a", bindMarker())).perPartitionLimit(bindMarker()).limit(3).getQueryString())
                 .isEqualTo("SELECT * FROM foo WHERE a=? PER PARTITION LIMIT ? LIMIT 3;");
         assertThat(
-                select().all().from("foo").where(eq("a", bindMarker())).orderBy(desc("b")).perPartitionLimit(2).limit(3).toString())
+                select().all().from("foo").where(eq("a", bindMarker())).orderBy(desc("b")).perPartitionLimit(2).limit(3).getQueryString())
                 .isEqualTo("SELECT * FROM foo WHERE a=? ORDER BY b DESC PER PARTITION LIMIT 2 LIMIT 3;");
         assertThat(
                 select().all().from("foo").where(eq("a", bindMarker())).and(gt("b", bindMarker()))
-                        .orderBy(desc("b")).perPartitionLimit(bindMarker()).limit(3).allowFiltering().toString())
+                        .orderBy(desc("b")).perPartitionLimit(bindMarker()).limit(3).allowFiltering().getQueryString())
                 .isEqualTo("SELECT * FROM foo WHERE a=? AND b>? ORDER BY b DESC PER PARTITION LIMIT ? LIMIT 3 ALLOW FILTERING;");
         try {
             select().distinct().all().from("foo").perPartitionLimit(3);
@@ -1082,58 +1078,58 @@ public class QueryBuilderTest {
     @Test(groups = "unit")
     public void should_handle_select_json() throws Exception {
         assertThat(
-                select().json().from("users").toString())
+                select().json().from("users").getQueryString())
                 .isEqualTo("SELECT JSON * FROM users;");
         assertThat(
-                select("id", "age").json().from("users").toString())
+                select("id", "age").json().from("users").getQueryString())
                 .isEqualTo("SELECT JSON id,age FROM users;");
         assertThat(
-                select().json().column("id").writeTime("age").ttl("state").as("ttl").from("users").toString())
+                select().json().column("id").writeTime("age").ttl("state").as("ttl").from("users").getQueryString())
                 .isEqualTo("SELECT JSON id,writetime(age),ttl(state) AS ttl FROM users;");
         assertThat(
-                select().distinct().json().column("id").from("users").toString())
+                select().distinct().json().column("id").from("users").getQueryString())
                 .isEqualTo("SELECT JSON DISTINCT id FROM users;"); // note that the correct syntax is JSON DISTINCT
     }
 
     @Test(groups = "unit")
     public void should_handle_insert_json() throws Exception {
         assertThat(
-                insertInto("example").json("{\"id\": 0, \"tupleval\": [1, \"abc\"], \"numbers\": [1, 2, 3], \"letters\": [\"a\", \"b\", \"c\"]}").toString())
-                .isEqualTo("INSERT INTO example JSON '{\"id\": 0, \"tupleval\": [1, \"abc\"], \"numbers\": [1, 2, 3], \"letters\": [\"a\", \"b\", \"c\"]}';");
+                insertInto("example").json("{\"id\": 0, \"tupleval\": [1, \"abc\"], \"numbers\": [1, 2, 3], \"letters\": [\"a\", \"b\", \"c\"]}").getQueryString())
+                .isEqualTo("INSERT INTO example JSON ?;");
         assertThat(
-                insertInto("users").json("{\"id\": \"user123\", \"\\\"Age\\\"\": 42, \"\\\"State\\\"\": \"TX\"}").toString())
-                .isEqualTo("INSERT INTO users JSON '{\"id\": \"user123\", \"\\\"Age\\\"\": 42, \"\\\"State\\\"\": \"TX\"}';");
-        assertThat(
-                insertInto("users").json(bindMarker()).toString())
+                insertInto("users").json("{\"id\": \"user123\", \"\\\"Age\\\"\": 42, \"\\\"State\\\"\": \"TX\"}").getQueryString())
                 .isEqualTo("INSERT INTO users JSON ?;");
         assertThat(
-                insertInto("users").json(bindMarker("json")).toString())
+                insertInto("users").json(bindMarker()).getQueryString())
+                .isEqualTo("INSERT INTO users JSON ?;");
+        assertThat(
+                insertInto("users").json(bindMarker("json")).getQueryString())
                 .isEqualTo("INSERT INTO users JSON :json;");
     }
 
     @Test(groups = "unit")
     public void should_handle_to_json() throws Exception {
         assertThat(
-                select().toJson("id").as("id").toJson("age").as("age").from("users").toString())
+                select().toJson("id").as("id").toJson("age").as("age").from("users").getQueryString())
                 .isEqualTo("SELECT toJson(id) AS id,toJson(age) AS age FROM users;");
         assertThat(
-                select().distinct().toJson("id").as("id").from("users").toString())
+                select().distinct().toJson("id").as("id").from("users").getQueryString())
                 .isEqualTo("SELECT DISTINCT toJson(id) AS id FROM users;");
     }
 
     @Test(groups = "unit")
     public void should_handle_from_json() throws Exception {
         assertThat(
-                update("users").with(set("age", fromJson("42"))).where(eq("id", fromJson("\"user123\""))).toString())
-                .isEqualTo("UPDATE users SET age=fromJson('42') WHERE id=fromJson('\"user123\"');");
+                update("users").with(set("age", fromJson("42"))).where(eq("id", fromJson("\"user123\""))).getQueryString())
+                .isEqualTo("UPDATE users SET age=fromJson(?) WHERE id=fromJson(?);");
         assertThat(
-                insertInto("users").value("id", fromJson("\"user123\"")).value("age", fromJson("42")).toString())
-                .isEqualTo("INSERT INTO users (id,age) VALUES (fromJson('\"user123\"'),fromJson('42'));");
+                insertInto("users").value("id", fromJson("\"user123\"")).value("age", fromJson("42")).getQueryString())
+                .isEqualTo("INSERT INTO users (id,age) VALUES (fromJson(?),fromJson(?));");
         assertThat(
-                insertInto("users").value("id", fromJson(bindMarker())).toString())
+                insertInto("users").value("id", fromJson(bindMarker())).getQueryString())
                 .isEqualTo("INSERT INTO users (id) VALUES (fromJson(?));");
         assertThat(
-                insertInto("users").value("id", fromJson(bindMarker("id"))).toString())
+                insertInto("users").value("id", fromJson(bindMarker("id"))).getQueryString())
                 .isEqualTo("INSERT INTO users (id) VALUES (fromJson(:id));");
     }
 
@@ -1180,19 +1176,21 @@ public class QueryBuilderTest {
      * a required custom codec.
      * The expectation is that if the codec is not registered,
      * then the query string should contain bind markers for all variables;
-     * if however all codecs are properly registered, then
+     * if however all codecs are properly registered,
+     * and we explicitly call {@code setForceNoValues(true)}, then
      * the query string should contain all variables inlined and formatted properly.
      *
      * @jira_ticket JAVA-1272
      */
     @Test(groups = "unit")
     public void should_inline_custom_codec() throws Exception {
+        CodecRegistry codecRegistry = new CodecRegistry();
         assertThat(
-                insertInto("users").value("id", new Foo(42)).toString())
+                insertInto("users").value("id", new Foo(42)).getQueryString(codecRegistry))
                 .isEqualTo("INSERT INTO users (id) VALUES (?);");
-        CodecRegistry.DEFAULT_INSTANCE.register(new FooCodec());
+        codecRegistry.register(new FooCodec());
         assertThat(
-                insertInto("users").value("id", new Foo(42)).toString())
+                insertInto("users").value("id", new Foo(42)).setForceNoValues(true).getQueryString(codecRegistry))
                 .isEqualTo("INSERT INTO users (id) VALUES (42);");
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTupleExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTupleExecutionTest.java
@@ -34,10 +34,10 @@ public class QueryBuilderTupleExecutionTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_handle_tuple() throws Exception {
-        String query = "INSERT INTO foo (k,x) VALUES (0,(1));";
+        String query = "INSERT INTO foo (k,x) VALUES (0,?);";
         TupleType tupleType = cluster().getMetadata().newTupleType(cint());
         BuiltStatement insert = insertInto("foo").value("k", 0).value("x", tupleType.newValue(1));
-        assertEquals(insert.toString(), query);
+        assertEquals(insert.getQueryString(), query);
     }
 
     @SuppressWarnings("deprecation")
@@ -45,11 +45,11 @@ public class QueryBuilderTupleExecutionTest extends CCMTestsSupport {
     public void should_handle_collections_of_tuples() {
         String query;
         BuiltStatement statement;
-        query = "UPDATE foo SET l=[(1,2)] WHERE k=1;";
+        query = "UPDATE foo SET l=? WHERE k=1;";
         TupleType tupleType = cluster().getMetadata().newTupleType(cint(), cint());
         List<TupleValue> list = ImmutableList.of(tupleType.newValue(1, 2));
         statement = update("foo").with(set("l", list)).where(eq("k", 1));
-        assertThat(statement.toString()).isEqualTo(query);
+        assertThat(statement.getQueryString()).isEqualTo(query);
     }
 
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderUDTExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderUDTExecutionTest.java
@@ -44,8 +44,8 @@ public class QueryBuilderUDTExecutionTest extends CCMTestsSupport {
         UserType udtType = cluster().getMetadata().getKeyspace(keyspace).getUserType("udt");
         UDTValue udtValue = udtType.newValue().setInt("i", 2).setInet("a", InetAddress.getByName("localhost"));
 
-        Statement insert = insertInto("udtTest").value("k", 1).value("t", udtValue);
-        assertEquals(insert.toString(), "INSERT INTO udtTest (k,t) VALUES (1,{i:2,a:'127.0.0.1'});");
+        BuiltStatement insert = insertInto("udtTest").value("k", 1).value("t", udtValue);
+        assertEquals(insert.getQueryString(), "INSERT INTO udtTest (k,t) VALUES (1,?);");
 
         session().execute(insert);
 
@@ -63,8 +63,8 @@ public class QueryBuilderUDTExecutionTest extends CCMTestsSupport {
         UDTValue udtValue = udtType.newValue().setInt("i", 2).setInet("a", InetAddress.getByName("localhost"));
         UDTValue udtValue2 = udtType.newValue().setInt("i", 3).setInet("a", InetAddress.getByName("localhost"));
 
-        Statement insert = insertInto("udtTest").value("k", 1).value("l", ImmutableList.of(udtValue));
-        assertThat(insert.toString()).isEqualTo("INSERT INTO udtTest (k,l) VALUES (1,[{i:2,a:'127.0.0.1'}]);");
+        BuiltStatement insert = insertInto("udtTest").value("k", 1).value("l", ImmutableList.of(udtValue));
+        assertThat(insert.getQueryString()).isEqualTo("INSERT INTO udtTest (k,l) VALUES (1,?);");
 
         session().execute(insert);
 
@@ -78,8 +78,8 @@ public class QueryBuilderUDTExecutionTest extends CCMTestsSupport {
         Map<Integer, UDTValue> map = Maps.newHashMap();
         map.put(0, udtValue);
         map.put(2, udtValue2);
-        Statement updateMap = update("udtTest").with(putAll("m", map)).where(eq("k", 1));
-        assertThat(updateMap.toString())
+        BuiltStatement updateMap = update("udtTest").with(putAll("m", map)).where(eq("k", 1));
+        assertThat(updateMap.getQueryString())
                 .isEqualTo("UPDATE udtTest SET m=m+{0:{i:2,a:'127.0.0.1'},2:{i:3,a:'127.0.0.1'}} WHERE k=1;");
 
         session().execute(updateMap);

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/Jsr353JsonCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/Jsr353JsonCodecTest.java
@@ -53,10 +53,10 @@ public class Jsr353JsonCodecTest extends CCMTestsSupport {
         execute(
                 "CREATE TABLE t1 (c1 text, c2 text, PRIMARY KEY (c1, c2))",
                 String.format("CREATE TABLE %s (k text, \"miXeD\" text, i int, f float, PRIMARY KEY (k, \"miXeD\"))", TABLE1),
-                insertInto(TABLE1).value("k", "key0").value(quote("miXeD"), "a").value("i", 1).value("f", 1.1).toString(),
-                insertInto(TABLE1).value("k", "key0").value(quote("miXeD"), "b").value("i", 2).value("f", 2.5).toString(),
-                insertInto(TABLE1).value("k", "key0").value(quote("miXeD"), "c").value("i", 3).value("f", 3.7).toString(),
-                insertInto(TABLE1).value("k", "key0").value(quote("miXeD"), "d").value("i", 4).value("f", 5.0).toString()
+                String.format("INSERT INTO %s (k, \"miXeD\", i, f) VALUES ('key0', 'a', 1, 1.1)", TABLE1),
+                String.format("INSERT INTO %s (k, \"miXeD\", i, f) VALUES ('key0', 'b', 2, 2.5)", TABLE1),
+                String.format("INSERT INTO %s (k, \"miXeD\", i, f) VALUES ('key0', 'c', 3, 3.7)", TABLE1),
+                String.format("INSERT INTO %s (k, \"miXeD\", i, f) VALUES ('key0', 'd', 4, 5.0)", TABLE1)
         );
 
         if (ccm().getProtocolVersion().compareTo(ProtocolVersion.V3) >= 0) {

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/QueryType.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/QueryType.java
@@ -43,7 +43,7 @@ enum QueryType {
                 if (opt.isIncludedInQuery())
                     opt.appendTo(usings);
             }
-            return insert.toString();
+            return insert.getQueryString(manager.getSession().getCluster().getConfiguration().getCodecRegistry());
         }
 
     },
@@ -75,7 +75,7 @@ enum QueryType {
 
             for (Mapper.Option opt : options)
                 opt.checkValidFor(QueryType.GET, manager);
-            return select.toString();
+            return select.getQueryString(manager.getSession().getCluster().getConfiguration().getCodecRegistry());
         }
     },
 
@@ -94,7 +94,7 @@ enum QueryType {
                 if (opt.isIncludedInQuery())
                     opt.appendTo(usings);
                     }
-            return delete.toString();
+            return delete.getQueryString(manager.getSession().getCluster().getConfiguration().getCodecRegistry());
         }
     };
 

--- a/manual/logging/README.md
+++ b/manual/logging/README.md
@@ -152,7 +152,7 @@ then set the `com.datastax.driver.core.QueryLogger.SLOW` logger to DEBUG, e.g. w
 The `EnhancedQueryLogger` would then print messages such as this for every slow query:
 
 ```
-DEBUG [cluster1] [/127.0.0.1:9042] Query too slow, took 329 ms: BoundStatement@2a929abf [idempotent=<UNSET>, CL=<UNSET>, 1 bound values]: SELECT * FROM users WHERE user_id=?;
+DEBUG [cluster1] [/127.0.0.1:9042] Query too slow, took 329 ms: BoundStatement@2a929abf [1 values]: SELECT * FROM users WHERE user_id=?;
 ```
 
 As you can see, the query string is logged but actual bound values are not; if you want them to be logged as well, 
@@ -168,7 +168,7 @@ At this level, the `EnhancedQueryLogger` prints statements with maximum verbosit
 it would then print messages such as this for every slow query:
 
 ```
-TRACE [cluster1] [/127.0.0.1:9042] Query too slow, took 329 ms: BoundStatement@34d2ff60 [idempotent=<UNSET>, CL=<UNSET>, SCL=<UNSET>, defaultTimestamp=<UNSET>, readTimeoutMillis=<UNSET>, 1 bound values]: SELECT * FROM users WHERE user_id=? { user_id : 42 }
+TRACE [cluster1] [/127.0.0.1:9042] Query too slow, took 329 ms: BoundStatement@34d2ff60 [1 values]: SELECT * FROM users WHERE user_id=? { user_id : 42 }
 
 ```
 
@@ -183,6 +183,77 @@ which in turn determines which elements to include in the formatted string
 
 `StatementFormatter` also provides safeguards to prevent overwhelming your logs with large query strings, 
 queries with considerable amounts of parameters, batch queries with several inner statements, etc. 
+
+With default settings, the `StatementFormatter` formats statements using a
+common formatting pattern comprised of the following sections:
+
+1. The actual statement class and the statement's hash code;
+2. If verbosity is NORMAL or higher, a summary consisting of some of the statement's characteristics such as: 
+    1. The number of bound values, if known.
+    2. The number of inner statements, if known (only applicable for batch statements).
+    3. Idempotence flag ("IDP"), if set and verbosity is EXTENDED. 
+    4. Consistency level ("CL"), if set and verbosity is EXTENDED.
+    5. Serial consistency level ("SCL"), if set and verbosity is EXTENDED.
+    6. Default timestamp ("DTS"), if set and verbosity is EXTENDED.
+    7. Read timeout in milliseconds ("RTM"), if set and verbosity is EXTENDED.
+2. The statement's query string, if available and the verbosity is NORMAL or higher.
+3. The statement's bound values, if available and the verbosity is EXTENDED.
+4. The statement's outgoing payload, if available and the verbosity is EXTENDED.
+
+Here is an example of how the same statements would be printed in different verbosity levels:
+
+```java
+Session session = ...;
+StatementFormatter formatter = StatementFormatter.DEFAULT_INSTANCE;
+
+// 1) regular statements
+Statement stmt1 = new SimpleStatement("INSERT INTO t (c1, c2, c3) VALUES (?, ?, ?)", "foo", 42, null)
+        .setIdempotent(true)
+        .setConsistencyLevel(ConsistencyLevel.LOCAL_ONE)
+        .setSerialConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL)
+        .setDefaultTimestamp(new Date().getTime())
+        .setReadTimeoutMillis(20000);
+
+// 2) query builder statements
+Statement stmt2 = insertInto("t").value("c1", "foo").value("c2", 42).value("c3", false);
+
+// 3) bound statements
+Statement stmt3 = session.prepare("INSERT INTO t (c1, c2, c3) VALUES (?, ?, ?)").bind("foo", null /*, unset */);
+
+// 4) batch statements
+BatchStatement stmt4 = new BatchStatement(BatchStatement.Type.UNLOGGED)
+        .add(stmt1)
+        .add(stmt2)
+        .add(stmt3);
+for (Statement stmt : Arrays.asList(stmt1, stmt2, stmt3, stmt4)) {
+    System.out.println(formatter.format(stmt, ABRIDGED, version, codecRegistry));
+    System.out.println(formatter.format(stmt, NORMAL, version, codecRegistry));
+    System.out.println(formatter.format(stmt, EXTENDED, version, codecRegistry));
+    System.out.println();
+}
+```
+
+The above would produce an output similar to the one below:
+
+```
+SimpleStatement@258e2e41 [3 values]
+SimpleStatement@258e2e41 [3 values]: INSERT INTO t (c1, c2, c3) VALUES (?, ?, ?)
+SimpleStatement@258e2e41 [3 values, IDP : true, CL : LOCAL_ONE, SCL : LOCAL_SERIAL, DTS : 1487865254945, RTM : 20000]: INSERT INTO t (c1, c2, c3) VALUES (?, ?, ?) { 0 : 'foo', 1 : 42, 2 : <NULL> }
+
+BuiltStatement@4fe767f3 [2 values]
+BuiltStatement@4fe767f3 [2 values]: INSERT INTO t (c1,c2,c3) VALUES (?,42,?);
+BuiltStatement@4fe767f3 [2 values, IDP : true]: INSERT INTO t (c1,c2,c3) VALUES (?,42,?); { 0 : 'foo', 1 : false }
+
+BoundStatement@2805c96b [3 values]
+BoundStatement@2805c96b [3 values]: INSERT INTO t (c1, c2, c3) VALUES (?, ?, ?)
+BoundStatement@2805c96b [3 values, IDP : false]: INSERT INTO t (c1, c2, c3) VALUES (?, ?, ?) { c1 : 'foo', c2 : <NULL>, c3 : <?> }
+
+BatchStatement@184cf7cf [UNLOGGED, 3 stmts]
+BatchStatement@184cf7cf [UNLOGGED, 3 stmts] 1 : SimpleStatement@258e2e41 [3 values]: INSERT INTO t (c1, c2, c3) VALUES (?, ?, ?), 2 : BuiltStatement@4fe767f3 [2 values]: INSERT INTO t (c1,c2,c3) VALUES (?,42,?);, 3 : BoundStatement@2805c96b [3 values]: INSERT INTO t (c1, c2, c3) VALUES (?, ?, ?)
+BatchStatement@184cf7cf [UNLOGGED, 3 stmts, 8 values] 1 : SimpleStatement@258e2e41 [3 values, IDP : true, CL : LOCAL_ONE, SCL : LOCAL_SERIAL, DTS : 1487865254945, RTM : 20000]: INSERT INTO t (c1, c2, c3) VALUES (?, ?, ?) { 0 : 'foo', 1 : 42, 2 : <NULL> }, 2 : BuiltStatement@4fe767f3 [2 values, IDP : true]: INSERT INTO t (c1,c2,c3) VALUES (?,42,?); { 0 : 'foo', 1 : false }, 3 : BoundStatement@2805c96b [3 values, IDP : false]: INSERT INTO t (c1, c2, c3) VALUES (?, ?, ?) { c1 : 'foo', c2 : <NULL>, c3 : <?> }
+```
+
+Note that null values are printed as `<NULL>` and unset values are printed as `<?>`.
 
 And finally, `StatementFormatter` also allows you to implement your own formatting rules, should you need full control
 over what needs to be formatted and how.

--- a/manual/logging/README.md
+++ b/manual/logging/README.md
@@ -113,28 +113,26 @@ and provide hints about what's going wrong.
 
 ### Logging query latencies
 
-The `QueryLogger` provides clients with the ability to log queries
-executed by the driver, and especially, it allows client to track slow
+The `EnhancedQueryLogger` class provides clients with the ability to log queries
+executed by the driver, and especially, it allows clients to track slow
 queries, i.e. queries that take longer to complete than a configured
 threshold in milliseconds.
 
-To turn on this feature, you first need to instantiate and register a `QueryLogger` instance:
+To turn on this feature, you first need to instantiate and register an `EnhancedQueryLogger` instance:
 
 ```java
 Cluster cluster = ...
-QueryLogger queryLogger = QueryLogger.builder()
+EnhancedQueryLogger queryLogger = EnhancedQueryLogger.builder()
     .withConstantThreshold(...)
-    .withMaxQueryStringLength(...)
 .build();
 cluster.register(queryLogger);
 ```
 
-Note that `QueryLogger` instances are thread-safe and can be shared cluster-wide. 
-Besides, you can adjust several parameters such as the maximum query string length to be printed, 
-the maximum number of parameters to print, etc. Refer to the 
-`QueryLogger` [API docs][query_logger] for more information.
+Note that `EnhancedQueryLogger` instances are thread-safe and can be shared cluster-wide. 
+Besides, you can adjust several parameters. Refer to the 
+`EnhancedQueryLogger` [API docs][query_logger] for more information.
 
-Secondly, you need to adjust your logging framework to accept log messages from the `QueryLogger`. The `QueryLogger`
+Secondly, you need to adjust your logging framework to accept log messages from the `EnhancedQueryLogger`. The `EnhancedQueryLogger`
 uses 3 different loggers:
 
 * `com.datastax.driver.core.QueryLogger.NORMAL` : Used to log normal queries, i.e., queries that completed successfully within a configurable threshold in milliseconds.
@@ -142,7 +140,7 @@ uses 3 different loggers:
 * `com.datastax.driver.core.QueryLogger.ERROR`: Used to log unsuccessful queries, i.e., queries that did not complete normally and threw an exception. Note this this logger will also print the full stack trace of the reported exception.
 
 You need to set the above loggers to DEBUG level to turn them on. E.g. to track queries
-that take more than 300 ms to complete, configure your `QueryLogger` with that threshold (see above), 
+that take more than 300 ms to complete, configure your `EnhancedQueryLogger` with that threshold (see above), 
 then set the `com.datastax.driver.core.QueryLogger.SLOW` logger to DEBUG, e.g. with Log4J:
 
 ```xml
@@ -151,14 +149,14 @@ then set the `com.datastax.driver.core.QueryLogger.SLOW` logger to DEBUG, e.g. w
   </logger>
 ```
 
-The `QueryLogger` would then print messages such as this for every slow query:
+The `EnhancedQueryLogger` would then print messages such as this for every slow query:
 
 ```
-DEBUG [cluster1] [/127.0.0.1:9042] Query too slow, took 329 ms: SELECT * FROM users WHERE user_id=?;
+DEBUG [cluster1] [/127.0.0.1:9042] Query too slow, took 329 ms: BoundStatement@2a929abf [idempotent=<UNSET>, CL=<UNSET>, 1 bound values]: SELECT * FROM users WHERE user_id=?;
 ```
 
-As you can see, actual query parameters are not logged; if you want them to be printed as well, set the `com.datastax.driver.core.QueryLogger.SLOW` logger
-to TRACE instead, e.g. with Log4J:
+As you can see, the query string is logged but actual bound values are not; if you want them to be logged as well, 
+set the `com.datastax.driver.core.QueryLogger.SLOW` logger to TRACE instead, e.g. with Log4J:
 
 ```xml
   <logger name="com.datastax.driver.core.QueryLogger.SLOW">
@@ -166,25 +164,38 @@ to TRACE instead, e.g. with Log4J:
   </logger>
 ```
 
-The `QueryLogger` would then print messages such as this for every slow query:
+At this level, the `EnhancedQueryLogger` prints statements with maximum verbosity; 
+it would then print messages such as this for every slow query:
 
 ```
-TRACE [cluster1] [/127.0.0.1:9042] Query too slow, took 329 ms: SELECT * FROM users WHERE user_id=? [user_id=42];
+TRACE [cluster1] [/127.0.0.1:9042] Query too slow, took 329 ms: BoundStatement@34d2ff60 [idempotent=<UNSET>, CL=<UNSET>, SCL=<UNSET>, defaultTimestamp=<UNSET>, readTimeoutMillis=<UNSET>, 1 bound values]: SELECT * FROM users WHERE user_id=? { user_id : 42 }
+
 ```
 
-Be careful when logging large query strings (specially batches) and/or queries with considerable amounts of parameters. 
-See the `QueryLogger` [API docs][query_logger] for examples of how to truncate the printed message when necessary.
+#### Formatting statements
+
+The `EnhancedQueryLogger` uses another component, namely the `StatementFormatter` class, 
+to actually format and print executed statements.
+ 
+`StatementFormatter` can format statements with different levels of verbosity, 
+which in turn determines which elements to include in the formatted string 
+(query string, bound values, custom payloads, inner statements for batches, etc.). 
+
+`StatementFormatter` also provides safeguards to prevent overwhelming your logs with large query strings, 
+queries with considerable amounts of parameters, batch queries with several inner statements, etc. 
+
+And finally, `StatementFormatter` also allows you to implement your own formatting rules, should you need full control
+over what needs to be formatted and how.
+
+See the `StatementFormatter` [API docs][statement_formatter] for guidelines about how to customize `StatementFormatter`.
 
 #### Constant vs Dynamic thresholds
 
-Currently the `QueryLogger` can be configured to track slow queries using either 
+Currently the `EnhancedQueryLogger` can be configured to track slow queries using either 
 a constant threshold in milliseconds (which is the default behavior), or 
 a dynamic threshold based on per-host latency percentiles, as computed by `PerHostPercentileTracker`.
 
-**Dynamic thresholds are still a beta feature: they haven't been extensively 
-tested yet, and the API is still subject to change.**
-
-Refer to the `QueryLogger` [API docs][query_logger] for an example of usage.
+Refer to the `EnhancedQueryLogger` [API docs][query_logger] for an example of usage.
 
 ### Performance Tips
 
@@ -302,4 +313,5 @@ It also turns on slow query tracing as described above.
 </log4j:configuration>
 ```
 
-[query_logger]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/QueryLogger.html
+[query_logger]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/EnhancedQueryLogger.html
+[statement_formatter]:http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/StatementFormatter.html

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -17,6 +17,16 @@ In 3.1.0, the driver would log a warning the first time it would skip
 a retry for a non-idempotent request; this warning has now been 
 removed as users should now have adjusted their applications accordingly.
 
+[JAVA-1257](https://datastax-oss.atlassian.net/browse/JAVA-1257) has deprecated the `QueryLogger`
+class and users are now encouraged to use `EnhancedQueryLogger` instead, which makes it easier for
+users to customize the way statements are logged. 
+Please note that `QueryLogger` class might be removed in a future major release.
+
+[JAVA-1257](https://datastax-oss.atlassian.net/browse/JAVA-1257) also modifies the behavior 
+of `Statement.toString()`. This method now returns more information about the statement 
+than just its query string. Users should not assume anymore that `Statement.toString()` 
+will return a valid CQL statement. To retrieve the statement's query string, use 
+`RegularStatement.getQueryString()` instead.
 
 ### 3.1.0
 
@@ -131,7 +141,7 @@ We've also seized the opportunity to remove code that was deprecated in 2.1.
       for `null` inputs.
 
 3.  The driver now depends on Guava 16.0.1 (instead of 14.0.1).
-    This update has been mainly motivated by Guava's [Issue #1635](https://github.com/google/guava/issues/1635),
+    This update has been mainly motivated by Guava's [Issue #1635](https://code.google.com/p/guava-libraries/issues/detail?id=1635),
     which affects `TypeToken`, and hence all `TypeCodec` implementations handling parameterized types.
 
 4.  `UDTMapper` (the type previously used to convert `@UDT`-annotated


### PR DESCRIPTION
Note to reviewers:

* The core functionality is in `StatementFormatter`. It is only new code and should not introduce regressions in any way.
* This PR also introduces `EnhancedQueryLogger`, an equivalent to `QueryLogger` where the formatting tasks are delegated to `StatementFormatter`.
* This PR also refactors `Statement.toString()`. I see a huge advantage in having a common system to print statements. The problem is that it was implicitly assumed so far that `toString()` would print the query string, but that assumption is now broken. Users willing to retrieve the query string should always call `getQueryString()`. I updated the upgrade guide accordingly.