### PR TITLE
Update jenkins jobs to run long suites against primary branches nightly

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,3 +1,21 @@
+schedules:
+  commit:
+    # Run short suite on commit with enough C* versions to get full protocol version coverage.
+    schedule: per_commit
+    matrix:
+      exclude:
+        - java: [openjdk6, oraclejdk7]
+        - cassandra: ['2.2', '3.0']
+    env_vars: |
+      TEST_GROUP="short"
+  nightly:
+    # Run full suite nightly on change for all primary branches if they have changes.
+    schedule: nightly
+    branches:
+      # regex matches primary branch format (2.1, 3.x, 3.0.x, 3.1.x, etc).
+      include: ["/\\d+(\\.[\\dx]+)+/"]
+    env_vars: |
+      TEST_GROUP="long"
 java:
   - openjdk6
   - oraclejdk7
@@ -10,11 +28,11 @@ cassandra:
   - 2.1
   - 2.2
   - 3.0
-  - 3.4
+  - 3.9
 build:
   - type: maven
     version: 3.2.5
-    goals: verify --fail-never -Plong
+    goals: verify --fail-never -P$TEST_GROUP
     properties: |
       com.datastax.driver.TEST_BASE_NODE_WAIT=120
       com.datastax.driver.NEW_NODE_DELAY_SECONDS=100

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
@@ -498,20 +498,22 @@ public class MapperUDTTest extends CCMTestsSupport {
             mapper.save(user);
             fail("Expected InvalidQueryException");
         } catch (InvalidQueryException e) {
-            assertThat(e.getMessage()).isEqualTo("Unknown identifier mainaddress");
+            // Error message varies by C* version.
+            assertThat(e.getMessage()).isIn("Unknown identifier mainaddress", "Undefined column name mainaddress");
         }
         try {
             mapper.get(user.getUserId());
             fail("Expected InvalidQueryException");
         } catch (InvalidQueryException e) {
-            assertThat(e.getMessage()).isEqualTo("Undefined name mainaddress in selection clause");
+            // Error message varies by C* version.
+            assertThat(e.getMessage()).isIn("Undefined name mainaddress in selection clause", "Undefined column name mainaddress");
         }
         // trying to use a new mapper
         try {
             manager.mapper(User.class);
             fail("Expected IllegalArgumentException");
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage()).isEqualTo(String.format("Column \"mainaddress\" does not exist in table %s.users", keyspace));
+            assertThat(e.getMessage()).isIn(String.format("Column \"mainaddress\" does not exist in table %s.users", keyspace));
         }
     }
 
@@ -621,7 +623,6 @@ public class MapperUDTTest extends CCMTestsSupport {
             this.province = province;
         }
     }
-
 
     /**
      * Ensures that when attempting to create a {@link TypeCodec} from a class that has a field that does not exist in


### PR DESCRIPTION
Reduces the amount of activity on jenkins by running only short suites on commit against enough C\* versions to get full coverage.

Long suites are ran against primary branches (3.x, 3.0.x, 2.1, etc.) nightly if they change.

Previously on commit of any branch the full long suite would be ran against C\* 1.2, 2.0, 2.1, 2.2, 3.0, 3.7 and JDK versions 6, 7, 8, which created 18 builds that each took up to 2 hours.

With this change, on commit 'short' suite will be ran against C\* 1.2, 2.0, 3.0, 3.7 on jdk8, this takes around 30 minutes.

A separate job gets created for each primary branch (when they have the build.yaml change) that runs the full matrix and long suite nightly, but only if that branch changed during the day.   If someone wants to they can still trigger this build manually.

The build.yaml change needs to be made on every primary branch for it to take affect for all of them.  If this is approved i'll go back and cherry-pick onto each branch.

This is open to discussion as well if you'd like to increase/reduce the build matrix / test configuration per commit/nightly/etc.
