### PR TITLE
JAVA-1308: CodecRegistry performance improvements

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,7 @@
 
 ### 3.2.0 (in progress)
 
+- [improvement] JAVA-1308: CodecRegistry performance improvements
 - [new feature] JAVA-1347: Add support for duration type.
 - [new feature] JAVA-1248: Implement "beta" flag for native protocol v5.
 - [new feature] JAVA-1362: Send query options flags as [int] for Protocol V5+.


### PR DESCRIPTION
- Separate the built-in codecs cache so it can be backed by a static Map instead of Guava Cache
