### PR TITLE
Fix NativeClock's javadoc

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Clock.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Clock.java
@@ -82,7 +82,7 @@ class SystemClock implements Clock {
  * to get the current time, which is good enough an accuracy for our purpose (see CASSANDRA-6106).
  * <p/>
  * This reduces the cost of the call to {@link NativeClock#currentTimeMicros()} to levels comparable
- * to those of a call to {@link System#currentTimeMillis()}.
+ * to those of a call to {@link System#nanoTime()}.
  */
 class NativeClock implements Clock {
 


### PR DESCRIPTION
`currentTimeMicros`'s cost is comparable to `System#nanoTime`, not `System#currentTimeMillis`
