### PR TITLE
Use unsafesystem by default to speed up schema related tests

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -228,7 +228,12 @@ public class CCMBridge implements CCMAccess {
         this.thriftPort = thriftPort;
         this.binaryPort = binaryPort;
         this.isDSE = isDSE;
-        this.jvmArgs = jvmArgs;
+        // use unsafesystem system property by default to speed up schema changes (see: CASSANDRA-5704)
+        if(!jvmArgs.contains("-Dcassandra.unsafesystem")) {
+            this.jvmArgs = jvmArgs + " --jvm_arg=-Dcassandra.unsafesystem=true";
+        } else {
+            this.jvmArgs = jvmArgs;
+        }
         this.ccmDir = Files.createTempDir();
     }
 


### PR DESCRIPTION
From [this thread](http://www.mail-archive.com/user@cassandra.apache.org/msg49419.html) we learned about the `-Dcassandra.unsafesystem` system property introduced in 1.2.7 by [CASSANDRA-5704](https://issues.apache.org/jira/browse/CASSANDRA-5704) which forgoes a non-fast blocking flush of system tables to speed up schema changes.   For practical use this is not an option one shold use, but for the intents of our testing it should speed up tests that make and wait on schema changes.
