### PR TITLE
JAVA-1321: Wrong OSGi dependency version for Guava

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 3.1.1 (in progress)
+
+- [bug] JAVA-1321: Wrong OSGi dependency version for Guava.
+
+
 ### 3.1.0
 
 - [new feature] JAVA-1153: Add PER PARTITION LIMIT to Select QueryBuilder.

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -200,7 +200,7 @@
                         <_include>-osgi.bnd</_include>
                         <Import-Package>
                             <!-- JNR does not provide OSGi bundles, so exclude it; the driver can live without it -->
-                            <![CDATA[com.google.common*;version="[14.0,20)",!jnr.*,*]]></Import-Package>
+                            <![CDATA[com.google.common*;version="[${guava.version},20)",!jnr.*,*]]></Import-Package>
                     </instructions>
                     <supportedProjectTypes>
                         <supportedProjectType>jar</supportedProjectType>
@@ -224,7 +224,7 @@
                                     JNR does not provide OSGi bundles, so exclude it; the driver can live without it
                                     Explicitly import javax.security.cert because it's required by Netty, but Netty has been explicitly excluded
                                     -->
-                                    <![CDATA[com.google.common.*;version="[14.0,19)",!jnr.*,!io.netty.*,javax.security.cert,*]]></Import-Package>
+                                    <![CDATA[com.google.common.*;version="[${guava.version},20)",!jnr.*,!io.netty.*,javax.security.cert,*]]></Import-Package>
                                 <Private-Package>com.datastax.shaded.*</Private-Package>
                             </instructions>
                         </configuration>


### PR DESCRIPTION
Changed required Guava version back to 16.0
