### PR TITLE
JAVA-866: Support tuple notation in QueryBuilder.eq/in

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -5,6 +5,7 @@
 - [bug] JAVA-1330: Add un/register for SchemaChangeListener in DelegatingCluster
 - [bug] JAVA-1351: Include Custom Payload in Request.copy.
 - [bug] JAVA-1346: Reset heartbeat only on client reads (not writes).
+- [improvement] JAVA-866: Support tuple notation in QueryBuilder.eq/in.
 
 
 ### 3.0.5

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/QueryBuilder.java
@@ -333,22 +333,25 @@ public final class QueryBuilder {
     }
 
     /**
-     * Creates an "in" where clause for a group of clustering columns.
+     * Creates an "in" where clause for a group of clustering columns (a.k.a. "multi-column IN restriction").
      * <p/>
-     * For instance, {@code in(Arrays.asList("a", "b"), Arrays.asList(Arrays.asList(1, 2), Arrays.asList("foo", "bar")))}
-     * will generate the CQL WHERE clause {@code (a, b) IN ((1, 2), ('foo', 'bar')) }.
+     * For instance, {@code in(Arrays.asList("a", "b"), Arrays.asList(Arrays.asList(1, "foo"), Arrays.asList(2, "bar")))}
+     * will generate the CQL WHERE clause {@code (a, b) IN ((1, 'foo'), (2, 'bar'))}.
+     * <p/>
+     * Each element in {@code values} must be either a {@link List list} containing exactly as many values
+     * as there are columns to match in {@code names},
+     * or a {@link #bindMarker() bind marker} – in which case, that marker is to be considered as
+     * a placeholder for one whole tuple of values to match.
      * <p/>
      * Please note that this variant is only supported starting with Cassandra 2.0.9.
      *
      * @param names  the column names
      * @param values the values
      * @return the corresponding where clause.
-     * @throws IllegalArgumentException if {@code names.size() != values.size()}.
+     * @throws IllegalArgumentException if the size of any tuple in {@code values} is not equal to {@code names.size()},
+     * or if {@code values} contains elements that are neither {@link List lists} nor {@link #bindMarker() bind markers}.
      */
-    public static Clause in(List<String> names, List<List<?>> values) {
-        if (names.size() != values.size())
-            throw new IllegalArgumentException(String.format("The number of names (%d) and values (%d) don't match", names.size(), values.size()));
-
+    public static Clause in(List<String> names, List<?> values) {
         return new Clause.CompoundInClause(names, values);
     }
 


### PR DESCRIPTION
Re-opened because the multi-column IN restrictions were incorrectly implemented.