### PR TITLE
JAVA-1334: Provide the counterpart of the method addContactPoints that silently fail when a host is unknown

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 3.2.0
+
+- [improvement] JAVA-1334: Provide the counterpart of the method addContactPoints that silently fail when a host is unknown
+
 ### 3.1.0
 
 - [new feature] JAVA-1153: Add PER PARTITION LIMIT to Select QueryBuilder.

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -877,6 +877,39 @@ public class Cluster implements Closeable {
         }
 
         /**
+         * Adds only the contact points that could be resolved.
+         * <p/>
+         * See {@link Builder#addContactPoint} for more details on contact
+         * points.
+         *
+         * @param addresses addresses of the nodes to add as contact point.
+         * @return this Builder.
+         * @throws IllegalArgumentException if no IP address for all
+         *                                  of {@code addresses} could be found
+         * @throws SecurityException        if a security manager is present and
+         *                                  permission to resolve the host name is denied.
+         * @see Builder#addContactPoint
+         * @since 3.1.3
+         */
+        public Builder addKnownContactPointsOnly(String... addresses) {
+            boolean found = false;
+            for (String address : addresses) {
+                try {
+                    addContactPoint(address);
+                    // One host could be resolved
+                    found = true;
+                } catch (IllegalArgumentException e) {
+                    // This host could not be resolved so we log a message and keep going
+                    logger.warn("The host {} is unknown so it will be ignored", address);
+                }
+            }
+            if (!found) {
+                throw new IllegalArgumentException("All provided hosts are unknown");
+            }
+            return this;
+        }
+
+        /**
          * Adds contact points.
          * <p/>
          * See {@link Builder#addContactPoint} for more details on contact

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -889,7 +889,7 @@ public class Cluster implements Closeable {
          * @throws SecurityException        if a security manager is present and
          *                                  permission to resolve the host name is denied.
          * @see Builder#addContactPoint
-         * @since 3.1.3
+         * @since 3.2
          */
         public Builder addKnownContactPointsOnly(String... addresses) {
             boolean found = false;

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterTest.java
@@ -1,0 +1,80 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import org.testng.annotations.Test;
+
+/**
+ * Tests for {@link Cluster}.
+ *
+ * @since 3.2
+ */
+public class ClusterTest {
+
+    /**
+     * <p>
+     * Validates that we cannot add a contact point it it cannot be resolved.
+     * </p>
+     *
+     * @test_category cluster
+     * @expected_result A failure is thrown when the contact point cannot be resolved.
+     */
+    @Test(groups = "unit", expectedExceptions = IllegalArgumentException.class)
+    public void should_fail_if_cannot_resolve_address() {
+        Cluster.builder().addContactPoint("foo");
+    }
+
+    /**
+     * <p>
+     * Validates that we cannot add contact points if one cannot be resolved.
+     * </p>
+     *
+     * @test_category cluster
+     * @expected_result A failure is thrown when a contact point cannot be resolved.
+     */
+    @Test(groups = "unit", expectedExceptions = IllegalArgumentException.class)
+    public void should_fail_if_cannot_resolve_only_one_address() {
+        Cluster.builder().addContactPoints("127.0.0.1", "foo");
+    }
+
+    /**
+     * <p>
+     * Validates that we can add contact points even if we have addresses that cannot be resolved.
+     * </p>
+     *
+     * @test_category cluster
+     * @expected_result No failure is thrown as we have one contact point that can be resolved.
+     * @jira_ticket JAVA-1334
+     */
+    @Test(groups = "unit")
+    public void should_not_fail_if_cannot_resolve_all_addresses() {
+        Cluster.builder().addKnownContactPointsOnly("127.0.0.1", "foo");
+    }
+
+    /**
+     * <p>
+     * Validates that we cannot add contact points if none can be resolved.
+     * </p>
+     *
+     * @test_category cluster
+     * @expected_result A failure is thrown as no contact points can be resolved.
+     * @jira_ticket JAVA-1334
+     */
+    @Test(groups = "unit", expectedExceptions = IllegalArgumentException.class)
+    public void should_fail_if_cannot_resolve_any_addresses() {
+        Cluster.builder().addKnownContactPointsOnly("foo", "bar");
+    }
+}


### PR DESCRIPTION
Fix for https://datastax-oss.atlassian.net/browse/JAVA-1334

This PR simply provides the ability to add only the contact points that can be resolved:

- If none can be resolved then an `IllegalArgumentException` will be thrown 

- For each contact point that cannot be resolved a warning will be logged