### PR TITLE
JAVA-1310: Implementation of MapperConfiguration and basic behavior

### DIFF
--- a/clirr-ignores.xml
+++ b/clirr-ignores.xml
@@ -147,4 +147,18 @@
         <justification>False positive, the enclosing class is package-private so this was never exposed</justification>
     </difference>
 
+    <difference>
+        <differenceType>7012</differenceType> <!-- method added to interface -->
+        <className>com/datastax/driver/mapping/annotations/Table</className>
+        <method>java.lang.String[] transientProperties()</method>
+        <justification>False positive, it's an annotation and the new method has a default value</justification>
+    </difference>
+
+    <difference>
+        <differenceType>7012</differenceType> <!-- method added to interface -->
+        <className>com/datastax/driver/mapping/annotations/UDT</className>
+        <method>java.lang.String[] transientProperties()</method>
+        <justification>False positive, it's an annotation and the new method has a default value</justification>
+    </difference>
+
 </differences>

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
@@ -212,7 +212,7 @@ class AnnotationParser {
             propertyMappers.put(propertyMapper.columnName, propertyMapper);
         }
 
-        return new MappedUDTCodec<T>(userType, udtClass, propertyMappers, mappingManager);
+        return new MappedUDTCodec<T>(userType, udtClass, configuration, propertyMappers, mappingManager);
     }
 
     static <T> AccessorMapper<T> parseAccessor(Class<T> accClass, MappingManager mappingManager, MapperConfiguration configuration) {

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/MappedUDTCodec.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/MappedUDTCodec.java
@@ -29,13 +29,15 @@ import java.util.Map;
 class MappedUDTCodec<T> extends TypeCodec.AbstractUDTCodec<T> {
     private final UserType cqlUserType;
     private final Class<T> udtClass;
+    private final MapperConfiguration configuration;
     private final Map<String, PropertyMapper> columnMappers;
     private final CodecRegistry codecRegistry;
 
-    MappedUDTCodec(UserType cqlUserType, Class<T> udtClass, Map<String, PropertyMapper> columnMappers, MappingManager mappingManager) {
+    MappedUDTCodec(UserType cqlUserType, Class<T> udtClass, MapperConfiguration configuration, Map<String, PropertyMapper> columnMappers, MappingManager mappingManager) {
         super(cqlUserType, udtClass);
         this.cqlUserType = cqlUserType;
         this.udtClass = udtClass;
+        this.configuration = configuration;
         this.columnMappers = columnMappers;
         this.codecRegistry = mappingManager.getSession().getCluster().getConfiguration().getCodecRegistry();
     }
@@ -47,6 +49,10 @@ class MappedUDTCodec<T> extends TypeCodec.AbstractUDTCodec<T> {
 
     Class<T> getUdtClass() {
         return udtClass;
+    }
+
+    MapperConfiguration getConfiguration() {
+        return configuration;
     }
 
     @Override

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/MapperConfiguration.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/MapperConfiguration.java
@@ -1,0 +1,336 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+/**
+ * The configuration of the mapper.
+ * It configures the following categories:
+ * Property scan configurations:
+ * <ul>
+ * <li>Transient property names (added on top of properties annotated with {@code Transient} or
+ * property names that appear in {@code Table} or {@code UDT} annotations.</li>
+ * <li>Property scan scope: whether or not to scan properties by getters/setters, whether or not
+ * to scan properties by class fields.</li>
+ * <li>Property mapping strategy: whether to scan fields that are not blacklisted (opt-out), meaning
+ * that unless a property is explicitly annotated with {@code Transient} it will be mapped, or to scan
+ * fields that are not white-listed (opt-in), meaning that unless a property is explicitly annotated
+ * with either {@code PartitionKey} or {@code ClusteringColumn} or {@code Column} or
+ * {@code com.datastax.driver.mapping.annotations.Field} or {@code Computed} it won't be mapped.</li>
+ * <li>Hierarchy scan strategy: defines how to scan for properties in parent classes - if
+ * hierarchyScanEnabled set to false - parent classes will not be scanned at all.
+ * if scanOnlyAnnotatedClasses set to true, only parents annotated with table classes
+ * ({@code Table}, {@code UDT}, {@code Accessor}) will be scanned. And lastly - deepestAllowedAncestor
+ * will define the deepest parent class to scan - which default to {@code Object.class}</li>
+ * </ul>
+ * This is also where you get the configured settings, though those cannot be changed
+ * (they are set during the built of the Mapper object).
+ */
+public class MapperConfiguration {
+
+    private PropertyScanConfiguration propertyScanConfiguration;
+
+    public MapperConfiguration() {
+        this.propertyScanConfiguration = new PropertyScanConfiguration();
+    }
+
+    public MapperConfiguration(MapperConfiguration toCopy) {
+        this.propertyScanConfiguration = new PropertyScanConfiguration(toCopy.propertyScanConfiguration);
+    }
+
+    /**
+     * Returns the property scanning configuration
+     *
+     * @return the property scanning configuration
+     */
+    public PropertyScanConfiguration getPropertyScanConfiguration() {
+        return propertyScanConfiguration;
+    }
+
+    /**
+     * Sets the property scanning configuration
+     *
+     * @param propertyScanConfiguration property scanning configuration to use
+     * @return the MapperConfiguration to enable builder pattern
+     */
+    public MapperConfiguration setPropertyScanConfiguration(PropertyScanConfiguration propertyScanConfiguration) {
+        this.propertyScanConfiguration = propertyScanConfiguration;
+        return this;
+    }
+
+    public static class PropertyScanConfiguration {
+
+        private Collection<String> excludedProperties;
+
+        private PropertyScanScope propertyScanScope;
+
+        private PropertyMappingStrategy propertyMappingStrategy;
+
+        private HierarchyScanStrategy hierarchyScanStrategy;
+
+        public PropertyScanConfiguration() {
+            this.excludedProperties = new HashSet<String>();
+            this.propertyScanScope = new PropertyScanScope();
+            this.propertyMappingStrategy = PropertyMappingStrategy.BLACK_LIST;
+            this.hierarchyScanStrategy = new HierarchyScanStrategy();
+        }
+
+        public PropertyScanConfiguration(PropertyScanConfiguration toCopy) {
+            this.excludedProperties = toCopy.excludedProperties;
+            this.propertyScanScope = new PropertyScanScope(toCopy.propertyScanScope);
+            this.propertyMappingStrategy = toCopy.propertyMappingStrategy;
+            this.hierarchyScanStrategy = new HierarchyScanStrategy(toCopy.hierarchyScanStrategy);
+        }
+
+        /**
+         * Returns a collection of properties to exclude from mapping
+         *
+         * @return a collection of properties to exclude from mapping
+         */
+        public Collection<String> getExcludedProperties() {
+            return excludedProperties;
+        }
+
+        /**
+         * Sets a collection of properties to exclude from mapping
+         *
+         * @param excludedProperties a collection of properties to exclude from mapping
+         * @return the PropertyScanConfiguration to enable builder pattern
+         */
+        public PropertyScanConfiguration setExcludedProperties(Collection<String> excludedProperties) {
+            this.excludedProperties = excludedProperties;
+            return this;
+        }
+
+        /**
+         * Returns the property scan scope settings
+         *
+         * @return the property scan scope settings
+         */
+        public PropertyScanScope getPropertyScanScope() {
+            return propertyScanScope;
+        }
+
+        /**
+         * Sets the property scan scope settings
+         *
+         * @param propertyScanScope property scan scope settings object to use
+         * @return the PropertyScanConfiguration to enable builder pattern
+         */
+        public PropertyScanConfiguration setPropertyScanScope(PropertyScanScope propertyScanScope) {
+            this.propertyScanScope = propertyScanScope;
+            return this;
+        }
+
+        /**
+         * Returns the PropertyMappingStrategy of the mapper.
+         * e.g. whether to scan fields that are not blacklisted (opt-out), meaning
+         * that unless a property is explicitly annotated with {@code Transient} it will be mapped, or to scan
+         * fields that are not white-listed (opt-in), meaning that unless a property is explicitly annotated
+         * with either {@code PartitionKey} or {@code ClusteringColumn} or {@code Column} or
+         * {@code com.datastax.driver.mapping.annotations.Field} or {@code Computed} it won't be mapped.
+         *
+         * @return the PropertyMappingStrategy of the mapper
+         */
+        public PropertyMappingStrategy getPropertyMappingStrategy() {
+            return propertyMappingStrategy;
+        }
+
+        /**
+         * Sets the PropertyMappingStrategy of the mapper.
+         *
+         * @param propertyMappingStrategy PropertyMappingStrategy to use
+         * @return the PropertyScanConfiguration to enable builder pattern
+         */
+        public PropertyScanConfiguration setPropertyMappingStrategy(PropertyMappingStrategy propertyMappingStrategy) {
+            this.propertyMappingStrategy = propertyMappingStrategy;
+            return this;
+        }
+
+        /**
+         * Returns the HierarchyScanStrategy settings of the mapper
+         *
+         * @return the HierarchyScanStrategy settings of the mapper
+         */
+        public HierarchyScanStrategy getHierarchyScanStrategy() {
+            return hierarchyScanStrategy;
+        }
+
+        /**
+         * Sets the HierarchyScanStrategy settings of the mapper
+         *
+         * @param hierarchyScanStrategy HierarchyScanStrategy settings to use
+         * @return the PropertyScanConfiguration to enable builder pattern
+         */
+        public PropertyScanConfiguration setHierarchyScanStrategy(HierarchyScanStrategy hierarchyScanStrategy) {
+            this.hierarchyScanStrategy = hierarchyScanStrategy;
+            return this;
+        }
+
+    }
+
+    public static class PropertyScanScope {
+
+        private boolean scanFields;
+
+        private boolean scanGetters;
+
+        public PropertyScanScope() {
+            this.scanFields = true;
+            this.scanGetters = true;
+        }
+
+        public PropertyScanScope(PropertyScanScope toCopy) {
+            this.scanFields = toCopy.scanFields;
+            this.scanGetters = toCopy.scanGetters;
+        }
+
+        /**
+         * Returns whether or not the scope include class fields
+         *
+         * @return whether or not the scope include class fields
+         */
+        public boolean isScanFields() {
+            return scanFields;
+        }
+
+        /**
+         * Set whether or not the scope include class fields
+         *
+         * @param scanFields    whether or not the scope include class fields
+         * @return the PropertyScanScope to enable builder pattern
+         */
+        public PropertyScanScope setScanFields(boolean scanFields) {
+            this.scanFields = scanFields;
+            return this;
+        }
+
+        /**
+         * Returns whether or not the scope include class getters
+         *
+         * @return whether or not the scope include class getters
+         */
+        public boolean isScanGetters() {
+            return scanGetters;
+        }
+
+        /**
+         * Set whether or not the scope include class getters
+         *
+         * @param scanGetters whether or not the scope include class getters
+         * @return the PropertyScanScope to enable builder pattern
+         */
+        public PropertyScanScope setScanGetters(boolean scanGetters) {
+            this.scanGetters = scanGetters;
+            return this;
+        }
+
+    }
+
+    public static class HierarchyScanStrategy {
+
+        private boolean hierarchyScanEnabled;
+
+        private boolean scanOnlyAnnotatedClasses;
+
+        private Class<?> deepestAllowedAncestor;
+
+        public HierarchyScanStrategy() {
+            this.hierarchyScanEnabled = true;
+            this.scanOnlyAnnotatedClasses = false;
+            this.deepestAllowedAncestor = Object.class;
+        }
+
+        public HierarchyScanStrategy(HierarchyScanStrategy toCopy) {
+            this.hierarchyScanEnabled = toCopy.hierarchyScanEnabled;
+            this.scanOnlyAnnotatedClasses = toCopy.scanOnlyAnnotatedClasses;
+            this.deepestAllowedAncestor = toCopy.deepestAllowedAncestor;
+        }
+
+        /**
+         * Returns whether or not the strategy allows scanning of parent classes
+         *
+         * @return whether or not the strategy allows scanning of parent classes
+         */
+        public boolean isHierarchyScanEnabled() {
+            return hierarchyScanEnabled;
+        }
+
+        /**
+         * Sets whether or not the strategy allows scanning of parent classes
+         *
+         * @param hierarchyScanEnabled whether or not the strategy allows scanning of parent classes
+         * @return the HierarchyScanStrategy to enable builder pattern
+         */
+        public HierarchyScanStrategy setHierarchyScanEnabled(boolean hierarchyScanEnabled) {
+            this.hierarchyScanEnabled = hierarchyScanEnabled;
+            return this;
+        }
+
+        /**
+         * Returns whether or not the strategy allows scanning of all parent classes or only those
+         * annotated with {@code Table} or {@code UDT} or {@code Accessor}
+         *
+         * @return whether or not the strategy allows scanning of all parent classes or only those
+         * annotated with {@code Table} or {@code UDT} or {@code Accessor}
+         */
+        public boolean isScanOnlyAnnotatedClasses() {
+            return scanOnlyAnnotatedClasses;
+        }
+
+        /**
+         * Sets whether or not the strategy allows scanning of all parent classes or only those
+         * annotated with {@code Table} or {@code UDT} or {@code Accessor}
+         *
+         * @param scanOnlyAnnotatedClasses whether or not the strategy allows scanning of
+         *                                 all parent classes or only those annotated with
+         *                                 {@code Table} or {@code UDT} or {@code Accessor}
+         * @return the HierarchyScanStrategy to enable builder pattern
+         */
+        public HierarchyScanStrategy setScanOnlyAnnotatedClasses(boolean scanOnlyAnnotatedClasses) {
+            this.scanOnlyAnnotatedClasses = scanOnlyAnnotatedClasses;
+            return this;
+        }
+
+        /**
+         * Returns the deepest parent class to the strategy allows to scan
+         * (which default to {@code Object.class})
+         *
+         * @return the deepest parent class to the strategy allows to scan
+         * (which default to {@code Object.class})
+         */
+        public Class<?> getDeepestAllowedAncestor() {
+            return deepestAllowedAncestor;
+        }
+
+        /**
+         * Sets the deepest parent class to the strategy allows to scan
+         *
+         * @param deepestAllowedAncestor the deepest parent class to the strategy allows to scan
+         * @return the HierarchyScanStrategy to enable builder pattern
+         */
+        public HierarchyScanStrategy setDeepestAllowedAncestor(Class<?> deepestAllowedAncestor) {
+            this.deepestAllowedAncestor = deepestAllowedAncestor;
+            return this;
+        }
+
+    }
+
+    public enum PropertyMappingStrategy {BLACK_LIST, WHITE_LIST}
+
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/MappingManager.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/MappingManager.java
@@ -32,6 +32,7 @@ public class MappingManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(MappingManager.class);
 
     private final Session session;
+    private final MapperConfiguration defaultConfiguration;
     final boolean isCassandraV1;
 
     private volatile Map<Class<?>, Mapper<?>> mappers = Collections.emptyMap();
@@ -39,7 +40,8 @@ public class MappingManager {
     private volatile Map<Class<?>, Object> accessors = Collections.emptyMap();
 
     /**
-     * Creates a new {@code MappingManager} using the provided {@code Session}.
+     * Creates a new {@code MappingManager} using the provided {@code Session} with default
+     * {@code MapperConfiguration}.
      * <p/>
      * Note that this constructor forces the initialization of the session (see
      * {@link #MappingManager(Session, ProtocolVersion)} if that is a problem for you).
@@ -56,7 +58,8 @@ public class MappingManager {
     }
 
     /**
-     * Creates a new {@code MappingManager} using the provided {@code Session}.
+     * Creates a new {@code MappingManager} using the provided {@code Session} with default
+     * {@code MapperConfiguration}.
      * <p/>
      * This constructor is only provided for backward compatibility: before 2.1.7, {@code MappingManager} could be
      * built from an uninitialized session; since 2.1.7, the mapper needs to know the active protocol version to
@@ -68,7 +71,39 @@ public class MappingManager {
      * @since 2.1.7
      */
     public MappingManager(Session session, ProtocolVersion protocolVersion) {
+        this(session, new MapperConfiguration(), protocolVersion);
+    }
+
+    /**
+     * Creates a new {@code MappingManager} using the provided {@code Session} with custom configuration
+     * to be inherited to each instantiated mapper.
+     * <p/>
+     * Note that this constructor forces the initialization of the session (see
+     * {@link #MappingManager(Session, ProtocolVersion)} if that is a problem for you).
+     *
+     * @param session the {@code Session} to use.
+     * @param configuration the {@code MapperConfiguration} to use be used as default for instantiated mappers.
+     */
+    public MappingManager(Session session, MapperConfiguration configuration) {
+        this(session, configuration, getProtocolVersion(session));
+    }
+
+    /**
+     * Creates a new {@code MappingManager} using the provided {@code Session} with default
+     * {@code MapperConfiguration}.
+     * <p/>
+     * This constructor is only provided for backward compatibility: before 2.1.7, {@code MappingManager} could be
+     * built from an uninitialized session; since 2.1.7, the mapper needs to know the active protocol version to
+     * adapt its internal requests, so {@link #MappingManager(Session)} will now initialize the session if needed.
+     * If you rely on the session not being initialized, use this constructor and provide the version manually.
+     *
+     * @param session the {@code Session} to use.
+     * @param configuration the {@code MapperConfiguration} to use be used as default for instantiated mappers.
+     * @param protocolVersion the protocol version that will be used with this session.
+     */
+    public MappingManager(Session session, MapperConfiguration configuration, ProtocolVersion protocolVersion) {
         this.session = session;
+        this.defaultConfiguration = configuration;
         // This is not strictly correct because we could connect to C* 2.0 with the v1 protocol.
         // But mappers need to make a decision early so that generated queries are compatible, and we don't know in advance
         // which nodes might join the cluster later.
@@ -137,7 +172,7 @@ public class MappingManager {
                     for (Class<?> udtClass : udtClasses) {
                         // try to register an updated version of the previous codec
                         try {
-                            getUDTCodec(udtClass);
+                            getUDTCodec(udtClass, defaultConfiguration); // TODO - this will update with default configuration even though previously loaded with a custom one. Solution may be to pass the MappedUDTCodec it's configuration on creation time, and then at this point we are able to get it from the previous instance
                         } catch (Exception e) {
                             LOGGER.error("Could not update mapping for @UDT annotated " + udtClass, e);
                         }
@@ -165,7 +200,7 @@ public class MappingManager {
 
     /**
      * Creates a {@code Mapper} for the provided class (that must be annotated by a
-     * {@link Table} annotation).
+     * {@link Table} annotation) with default {@code MapperConfiguration}.
      * <p/>
      * The {@code MappingManager} only ever keeps one Mapper for each class, and so calling this
      * method multiple times on the same class will always return the same object.
@@ -179,12 +214,32 @@ public class MappingManager {
      * @return the {@code Mapper} object for class {@code klass}.
      */
     public <T> Mapper<T> mapper(Class<T> klass) {
-        return getMapper(klass);
+        return getMapper(klass, defaultConfiguration);
+    }
+
+    /**
+     * Creates a {@code Mapper} for the provided class (that must be annotated by a
+     * {@link Table} annotation) with given {@code MapperConfiguration}.
+     * <p/>
+     * The {@code MappingManager} only ever keeps one Mapper for each class, and so calling this
+     * method multiple times on the same class will always return the same object.
+     * <p/>
+     * If the type of any field in the class is an {@link UDT}-annotated classes, a codec for that
+     * class will automatically be created and registered with the underlying {@code Cluster}.
+     * This works recursively with UDTs nested in other UDTs or in collections.
+     *
+     * @param <T>   the type of the class to map.
+     * @param klass the (annotated) class for which to return the mapper.
+     * @param configuration the configuration to be loaded to the mapper.
+     * @return the {@code Mapper} object for class {@code klass}.
+     */
+    public <T> Mapper<T> mapper(Class<T> klass, MapperConfiguration configuration) {
+        return getMapper(klass, configuration);
     }
 
     /**
      * Creates a {@code TypeCodec} for the provided class (that must be annotated by
-     * a {@link UDT} annotation).
+     * a {@link UDT} annotation) with default {@code MapperConfiguration}.
      * <p/>
      * This method also registers the codec against the underlying {@code Cluster}.
      * In addition, the codecs for any nested UDTs will also be created and registered.
@@ -198,12 +253,32 @@ public class MappingManager {
      * @return the codec that maps the provided class to the corresponding user-defined type.
      */
     public <T> TypeCodec<T> udtCodec(Class<T> klass) {
-        return getUDTCodec(klass);
+        return getUDTCodec(klass, defaultConfiguration);
+    }
+
+    /**
+     * Creates a {@code TypeCodec} for the provided class (that must be annotated by
+     * a {@link UDT} annotation) with given {@code MapperConfiguration}.
+     * <p/>
+     * This method also registers the codec against the underlying {@code Cluster}.
+     * In addition, the codecs for any nested UDTs will also be created and registered.
+     * <p/>
+     * You don't need to call this method explicitly if you already call {@link #mapper(Class)}
+     * for a class that references this UDT class (creating a mapper will automatically
+     * process all UDTs that it uses).
+     *
+     * @param <T>   the type of the class to map.
+     * @param klass the (annotated) class for which to return the codec.
+     * @param configuration the configuration to be used.
+     * @return the codec that maps the provided class to the corresponding user-defined type.
+     */
+    public <T> TypeCodec<T> udtCodec(Class<T> klass, MapperConfiguration configuration) {
+        return getUDTCodec(klass, configuration);
     }
 
     /**
      * Creates an accessor object based on the provided interface (that must be annotated by
-     * a {@link Accessor} annotation).
+     * a {@link Accessor} annotation) with default {@code MapperConfiguration}.
      * <p/>
      * The {@code MappingManager} only ever keep one Accessor for each class, and so calling this
      * method multiple time on the same class will always return the same object.
@@ -213,17 +288,34 @@ public class MappingManager {
      * @return the accessor object for class {@code klass}.
      */
     public <T> T createAccessor(Class<T> klass) {
-        return getAccessor(klass);
+        return getAccessor(klass, defaultConfiguration);
+    }
+
+    /**
+     * Creates an accessor object based on the provided interface (that must be annotated by
+     * a {@link Accessor} annotation) with given {@code MapperConfiguration}.
+     * <p/>
+     * The {@code MappingManager} only ever keep one Accessor for each class, and so calling this
+     * method multiple time on the same class will always return the same object.
+     *
+     * @param <T>   the type of the accessor class.
+     * @param klass the (annotated) class for which to create an accessor object.
+     * @param configuration the configuration to be used.
+     * @return the accessor object for class {@code klass}.
+     */
+    public <T> T createAccessor(Class<T> klass, MapperConfiguration configuration) {
+        return getAccessor(klass, configuration);
     }
 
     @SuppressWarnings("unchecked")
-    private <T> Mapper<T> getMapper(Class<T> klass) {
+    private <T> Mapper<T> getMapper(Class<T> klass, MapperConfiguration configuration) {
+        configuration = new MapperConfiguration(configuration);
         Mapper<T> mapper = (Mapper<T>) mappers.get(klass);
         if (mapper == null) {
             synchronized (mappers) {
                 mapper = (Mapper<T>) mappers.get(klass);
                 if (mapper == null) {
-                    EntityMapper<T> entityMapper = AnnotationParser.parseEntity(klass, this);
+                    EntityMapper<T> entityMapper = AnnotationParser.parseEntity(klass, this, configuration);
                     mapper = new Mapper<T>(this, klass, entityMapper);
                     Map<Class<?>, Mapper<?>> newMappers = new HashMap<Class<?>, Mapper<?>>(mappers);
                     newMappers.put(klass, mapper);
@@ -235,13 +327,14 @@ public class MappingManager {
     }
 
     @SuppressWarnings("unchecked")
-    <T> TypeCodec<T> getUDTCodec(Class<T> mappedClass) {
+    <T> TypeCodec<T> getUDTCodec(Class<T> mappedClass, MapperConfiguration configuration) {
+        configuration = new MapperConfiguration(configuration);
         MappedUDTCodec<T> codec = (MappedUDTCodec<T>) udtCodecs.get(mappedClass);
         if (codec == null) {
             synchronized (udtCodecs) {
                 codec = (MappedUDTCodec<T>) udtCodecs.get(mappedClass);
                 if (codec == null) {
-                    codec = AnnotationParser.parseUDT(mappedClass, this);
+                    codec = AnnotationParser.parseUDT(mappedClass, this, configuration);
                     session.getCluster().getConfiguration().getCodecRegistry().register(codec);
 
                     HashMap<Class<?>, MappedUDTCodec<?>> newCodecs = new HashMap<Class<?>, MappedUDTCodec<?>>(udtCodecs);
@@ -253,14 +346,20 @@ public class MappingManager {
         return codec;
     }
 
+
+    <T> TypeCodec<T> getUDTCodec(Class<T> mappedClass) {
+        return getUDTCodec(mappedClass, defaultConfiguration);
+    }
+
     @SuppressWarnings("unchecked")
-    private <T> T getAccessor(Class<T> klass) {
+    private <T> T getAccessor(Class<T> klass, MapperConfiguration configuration) {
+        configuration = new MapperConfiguration(configuration);
         T accessor = (T) accessors.get(klass);
         if (accessor == null) {
             synchronized (accessors) {
                 accessor = (T) accessors.get(klass);
                 if (accessor == null) {
-                    AccessorMapper<T> mapper = AnnotationParser.parseAccessor(klass, this);
+                    AccessorMapper<T> mapper = AnnotationParser.parseAccessor(klass, this, configuration);
                     mapper.prepare(this);
                     accessor = mapper.createProxy();
                     Map<Class<?>, Object> newAccessors = new HashMap<Class<?>, Object>(accessors);

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/MappingManager.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/MappingManager.java
@@ -158,23 +158,23 @@ public class MappingManager {
             @Override
             public void onUserTypeChanged(UserType current, UserType previous) {
                 synchronized (udtCodecs) {
-                    Set<Class<?>> udtClasses = new HashSet<Class<?>>();
+                    Set<MappedUDTCodec<?>> deletedCodecs = new HashSet<MappedUDTCodec<?>>();
                     Iterator<MappedUDTCodec<?>> it = udtCodecs.values().iterator();
                     while (it.hasNext()) {
                         MappedUDTCodec<?> codec = it.next();
                         if (previous.equals(codec.getCqlType())) {
                             LOGGER.warn("User type {} has been altered; existing mappers for @UDT annotated {} might not work properly anymore",
                                     previous, codec.getUdtClass());
-                            udtClasses.add(codec.getUdtClass());
+                            deletedCodecs.add(codec);
                             it.remove();
                         }
                     }
-                    for (Class<?> udtClass : udtClasses) {
+                    for (MappedUDTCodec<?> deletedCodec : deletedCodecs) {
                         // try to register an updated version of the previous codec
                         try {
-                            getUDTCodec(udtClass, defaultConfiguration); // TODO - this will update with default configuration even though previously loaded with a custom one. Solution may be to pass the MappedUDTCodec it's configuration on creation time, and then at this point we are able to get it from the previous instance
+                            getUDTCodec(deletedCodec.getUdtClass(), deletedCodec.getConfiguration());
                         } catch (Exception e) {
-                            LOGGER.error("Could not update mapping for @UDT annotated " + udtClass, e);
+                            LOGGER.error("Could not update mapping for @UDT annotated " + deletedCodec.getUdtClass(), e);
                         }
                     }
                 }

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperConfigurationHierarchyScanStrategyTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperConfigurationHierarchyScanStrategyTest.java
@@ -31,7 +31,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * - configure max depth ancestor
  */
 public class MapperConfigurationHierarchyScanStrategyTest extends CCMTestsSupport {
-    private MappingManager mappingManager;
 
     @Override
     public void onTestContextInitialized() {
@@ -39,13 +38,9 @@ public class MapperConfigurationHierarchyScanStrategyTest extends CCMTestsSuppor
         execute("INSERT INTO foo (k, v) VALUES (1, 1)");
     }
 
-    @BeforeClass(groups = "short")
-    public void setup() {
-        mappingManager = new MappingManager(session());
-    }
-
     @Test(groups = "short")
     public void should_not_inherit_properties() {
+        MappingManager mappingManager = new MappingManager(session());
         MapperConfiguration conf = new MapperConfiguration();
         MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
         MapperConfiguration.HierarchyScanStrategy scanStrategy = new MapperConfiguration.HierarchyScanStrategy();
@@ -81,6 +76,7 @@ public class MapperConfigurationHierarchyScanStrategyTest extends CCMTestsSuppor
 
     @Test(groups = "short")
     public void should_inherit_only_boo() {
+        MappingManager mappingManager = new MappingManager(session());
         MapperConfiguration conf = new MapperConfiguration();
         MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
         MapperConfiguration.HierarchyScanStrategy scanStrategy = new MapperConfiguration.HierarchyScanStrategy();
@@ -132,6 +128,7 @@ public class MapperConfigurationHierarchyScanStrategyTest extends CCMTestsSuppor
 
     @Test(groups = "short")
     public void ignore_non_annotated_classes() {
+        MappingManager mappingManager = new MappingManager(session());
         MapperConfiguration conf = new MapperConfiguration();
         MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
         MapperConfiguration.HierarchyScanStrategy scanStrategy = new MapperConfiguration.HierarchyScanStrategy();

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperConfigurationHierarchyScanStrategyTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperConfigurationHierarchyScanStrategyTest.java
@@ -1,0 +1,183 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.core.CCMTestsSupport;
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for JAVA-1310 - validate ability configure ancestor property scanning:
+ * - disable
+ * - force class annotations
+ * - configure max depth ancestor
+ */
+public class MapperConfigurationHierarchyScanStrategyTest extends CCMTestsSupport {
+    private MappingManager mappingManager;
+
+    @Override
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE foo (k int primary key, v int)");
+        execute("INSERT INTO foo (k, v) VALUES (1, 1)");
+    }
+
+    @BeforeClass(groups = "short")
+    public void setup() {
+        mappingManager = new MappingManager(session());
+    }
+
+    @Test(groups = "short")
+    public void should_not_inherit_properties() {
+        MapperConfiguration conf = new MapperConfiguration();
+        MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
+        MapperConfiguration.HierarchyScanStrategy scanStrategy = new MapperConfiguration.HierarchyScanStrategy();
+        scanStrategy.setHierarchyScanEnabled(false);
+        scanConf.setHierarchyScanStrategy(scanStrategy);
+        conf.setPropertyScanConfiguration(scanConf);
+        mappingManager.mapper(Foo1.class, conf);
+    }
+
+    @Table(name = "foo")
+    public static class Boo1 {
+
+        @Column(name = "notAColumn")
+        private int notAColumn;
+
+    }
+
+    @Table(name = "foo")
+    public static class Foo1 extends Boo1 {
+
+        @PartitionKey
+        private int k;
+
+        public int getK() {
+            return k;
+        }
+
+        public void setK(int k) {
+            this.k = k;
+        }
+
+    }
+
+    @Test(groups = "short")
+    public void should_inherit_only_boo() {
+        MapperConfiguration conf = new MapperConfiguration();
+        MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
+        MapperConfiguration.HierarchyScanStrategy scanStrategy = new MapperConfiguration.HierarchyScanStrategy();
+        scanStrategy.setDeepestAllowedAncestor(Boo2.class);
+        scanConf.setHierarchyScanStrategy(scanStrategy);
+        conf.setPropertyScanConfiguration(scanConf);
+        Mapper<Foo2> mapper = mappingManager.mapper(Foo2.class, conf);
+        assertThat(mapper.get(1).getV()).isEqualTo(1);
+    }
+
+    @Table(name = "foo")
+    public static class Goo2 {
+
+        @Column(name = "notAColumn")
+        private int notAColumn;
+
+    }
+
+    @Table(name = "foo")
+    public static class Boo2 extends Goo2 {
+
+        private int v;
+
+        public int getV() {
+            return v;
+        }
+
+        public void setV(int v) {
+            this.v = v;
+        }
+
+    }
+
+    @Table(name = "foo")
+    public static class Foo2 extends Boo2 {
+
+        @PartitionKey
+        private int k;
+
+        public int getK() {
+            return k;
+        }
+
+        public void setK(int k) {
+            this.k = k;
+        }
+
+    }
+
+    @Test(groups = "short")
+    public void ignore_non_annotated_classes() {
+        MapperConfiguration conf = new MapperConfiguration();
+        MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
+        MapperConfiguration.HierarchyScanStrategy scanStrategy = new MapperConfiguration.HierarchyScanStrategy();
+        scanStrategy.setScanOnlyAnnotatedClasses(true);
+        scanConf.setHierarchyScanStrategy(scanStrategy);
+        conf.setPropertyScanConfiguration(scanConf);
+        Mapper<Foo3> mapper = mappingManager.mapper(Foo3.class, conf);
+        assertThat(mapper.get(1).getV()).isEqualTo(1);
+    }
+
+    @Table(name = "foo")
+    public static class Goo3 {
+
+        private int v;
+
+        public int getV() {
+            return v;
+        }
+
+        public void setV(int v) {
+            this.v = v;
+        }
+
+    }
+
+    public static class Boo3 extends Goo3 {
+
+        @Column(name = "notAColumn")
+        private int notAColumn;
+
+    }
+
+    @Table(name = "foo")
+    public static class Foo3 extends Boo3 {
+
+        @PartitionKey
+        private int k;
+
+        public int getK() {
+            return k;
+        }
+
+        public void setK(int k) {
+            this.k = k;
+        }
+
+    }
+
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperConfigurationMappingStrategyTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperConfigurationMappingStrategyTest.java
@@ -28,7 +28,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Test for JAVA-1310 - validate ability configure property mapping strategy - whitelist vs. blacklist
  */
 public class MapperConfigurationMappingStrategyTest extends CCMTestsSupport {
-    private MappingManager mappingManager;
 
     @Override
     public void onTestContextInitialized() {
@@ -36,13 +35,9 @@ public class MapperConfigurationMappingStrategyTest extends CCMTestsSupport {
         execute("INSERT INTO foo (k, v) VALUES (1, 1)");
     }
 
-    @BeforeClass
-    public void setup() {
-        mappingManager = new MappingManager(session());
-    }
-
     @Test(groups = "short")
     public void should_map_only_non_transient() {
+        MappingManager mappingManager = new MappingManager(session());
         MapperConfiguration conf = new MapperConfiguration();
         MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
         scanConf.setPropertyMappingStrategy(MapperConfiguration.PropertyMappingStrategy.BLACK_LIST);
@@ -81,6 +76,7 @@ public class MapperConfigurationMappingStrategyTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_map_only_annotated() {
+        MappingManager mappingManager = new MappingManager(session());
         MapperConfiguration conf = new MapperConfiguration();
         MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
         scanConf.setPropertyMappingStrategy(MapperConfiguration.PropertyMappingStrategy.WHITE_LIST);

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperConfigurationMappingStrategyTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperConfigurationMappingStrategyTest.java
@@ -1,0 +1,115 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.core.CCMTestsSupport;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+import com.datastax.driver.mapping.annotations.Transient;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for JAVA-1310 - validate ability configure property mapping strategy - whitelist vs. blacklist
+ */
+public class MapperConfigurationMappingStrategyTest extends CCMTestsSupport {
+    private MappingManager mappingManager;
+
+    @Override
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE foo (k int primary key, v int)");
+        execute("INSERT INTO foo (k, v) VALUES (1, 1)");
+    }
+
+    @BeforeClass
+    public void setup() {
+        mappingManager = new MappingManager(session());
+    }
+
+    @Test(groups = "short")
+    public void should_map_only_non_transient() {
+        MapperConfiguration conf = new MapperConfiguration();
+        MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
+        scanConf.setPropertyMappingStrategy(MapperConfiguration.PropertyMappingStrategy.BLACK_LIST);
+        conf.setPropertyScanConfiguration(scanConf);
+        Mapper<Foo1> mapper = mappingManager.mapper(Foo1.class, conf);
+        assertThat(mapper.get(1).getV()).isEqualTo(1);
+    }
+
+    @Table(name = "foo")
+    public static class Foo1 {
+
+        @PartitionKey
+        private int k;
+
+        private int v;
+
+        @Transient
+        private int notAColumn;
+
+        public int getK() {
+            return k;
+        }
+
+        public void setK(int k) {
+            this.k = k;
+        }
+
+        public int getV() {
+            return v;
+        }
+
+        public void setV(int v) {
+            this.v = v;
+        }
+    }
+
+    @Test(groups = "short")
+    public void should_map_only_annotated() {
+        MapperConfiguration conf = new MapperConfiguration();
+        MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
+        scanConf.setPropertyMappingStrategy(MapperConfiguration.PropertyMappingStrategy.WHITE_LIST);
+        conf.setPropertyScanConfiguration(scanConf);
+        mappingManager.mapper(Foo2.class, conf);
+    }
+
+    @Table(name = "foo")
+    public static class Foo2 {
+        @PartitionKey
+        private int k;
+
+        private int notAColumn;
+
+        public int getK() {
+            return k;
+        }
+
+        public void setK(int k) {
+            this.k = k;
+        }
+
+        public int getNotAColumn() {
+            return notAColumn;
+        }
+
+        public void setNotAColumn(int notAColumn) {
+            this.notAColumn = notAColumn;
+        }
+    }
+
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperConfigurationScanScopeTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperConfigurationScanScopeTest.java
@@ -1,0 +1,139 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.core.CCMTestsSupport;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+import com.datastax.driver.mapping.annotations.Transient;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static javax.swing.UIManager.get;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for JAVA-1310 - validate ability configure property scope - getters vs. fields
+ */
+public class MapperConfigurationScanScopeTest extends CCMTestsSupport {
+    private MappingManager mappingManager;
+
+    @Override
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE foo (k int primary key, v int)");
+        execute("INSERT INTO foo (k, v) VALUES (1, 1)");
+    }
+
+    @BeforeClass
+    public void setup() {
+        mappingManager = new MappingManager(session());
+    }
+
+    @Test(groups = "short")
+    public void should_ignore_fields() {
+        MapperConfiguration conf = new MapperConfiguration();
+        MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
+        MapperConfiguration.PropertyScanScope scope = new MapperConfiguration.PropertyScanScope()
+                .setScanFields(false)
+                .setScanGetters(true);
+        scanConf.setPropertyScanScope(scope);
+        conf.setPropertyScanConfiguration(scanConf);
+        mappingManager.mapper(Foo1.class, conf);
+    }
+
+    @Table(name = "foo")
+    public static class Foo1 {
+        private int k;
+
+        private int notAColumn;
+
+        @PartitionKey
+        public int getK() {
+            return k;
+        }
+
+        public void setK(int k) {
+            this.k = k;
+        }
+    }
+
+    @Test(groups = "short")
+    public void should_ignore_getters() {
+        MapperConfiguration conf = new MapperConfiguration();
+        MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
+        MapperConfiguration.PropertyScanScope scope = new MapperConfiguration.PropertyScanScope()
+                .setScanFields(true)
+                .setScanGetters(false);
+        scanConf.setPropertyScanScope(scope);
+        conf.setPropertyScanConfiguration(scanConf);
+        mappingManager.mapper(Foo2.class, conf);
+    }
+
+    @Table(name = "foo")
+    public static class Foo2 {
+        @PartitionKey
+        private int k;
+
+        public int getNotAColumn() {
+            return 1;
+        }
+
+        public boolean isNotAColumn2() {
+            return true;
+        }
+
+    }
+
+    @Test(groups = "short")
+    public void should_map_fields_and_getters() {
+        MapperConfiguration conf = new MapperConfiguration();
+        MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
+        MapperConfiguration.PropertyScanScope scope = new MapperConfiguration.PropertyScanScope()
+                .setScanFields(true)
+                .setScanGetters(true);
+        scanConf.setPropertyScanScope(scope);
+        conf.setPropertyScanConfiguration(scanConf);
+        Mapper<Foo3> mapper = mappingManager.mapper(Foo3.class, conf);
+        Foo3 foo = mapper.get(1);
+        assertThat(foo.getV()).isEqualTo(1);
+    }
+
+    @Table(name = "foo")
+    public static class Foo3 {
+        @PartitionKey
+        private int k;
+
+        @Transient
+        private int storeVValueButNotMapped;
+
+        public int getK() {
+            return k;
+        }
+
+        public void setK(int k) {
+            this.k = k;
+        }
+
+        public int getV() {
+            return storeVValueButNotMapped;
+        }
+
+        public void setV(int v) {
+            this.storeVValueButNotMapped = v;
+        }
+    }
+
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperConfigurationScanScopeTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperConfigurationScanScopeTest.java
@@ -29,7 +29,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Test for JAVA-1310 - validate ability configure property scope - getters vs. fields
  */
 public class MapperConfigurationScanScopeTest extends CCMTestsSupport {
-    private MappingManager mappingManager;
 
     @Override
     public void onTestContextInitialized() {
@@ -37,13 +36,9 @@ public class MapperConfigurationScanScopeTest extends CCMTestsSupport {
         execute("INSERT INTO foo (k, v) VALUES (1, 1)");
     }
 
-    @BeforeClass
-    public void setup() {
-        mappingManager = new MappingManager(session());
-    }
-
     @Test(groups = "short")
     public void should_ignore_fields() {
+        MappingManager mappingManager = new MappingManager(session());
         MapperConfiguration conf = new MapperConfiguration();
         MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
         MapperConfiguration.PropertyScanScope scope = new MapperConfiguration.PropertyScanScope()
@@ -72,6 +67,7 @@ public class MapperConfigurationScanScopeTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_ignore_getters() {
+        MappingManager mappingManager = new MappingManager(session());
         MapperConfiguration conf = new MapperConfiguration();
         MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
         MapperConfiguration.PropertyScanScope scope = new MapperConfiguration.PropertyScanScope()
@@ -99,6 +95,7 @@ public class MapperConfigurationScanScopeTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_map_fields_and_getters() {
+        MappingManager mappingManager = new MappingManager(session());
         MapperConfiguration conf = new MapperConfiguration();
         MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
         MapperConfiguration.PropertyScanScope scope = new MapperConfiguration.PropertyScanScope()

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperConfigurationTransientTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperConfigurationTransientTest.java
@@ -1,0 +1,104 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.core.CCMTestsSupport;
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+import com.datastax.driver.mapping.annotations.Transient;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for JAVA-1310 - validate ability to transient properties at manager and mapper levels
+ */
+public class MapperConfigurationTransientTest extends CCMTestsSupport {
+    private MappingManager mappingManager;
+
+    @Override
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE foo (k int primary key, v int)");
+        execute("INSERT INTO foo (k, v) VALUES (1, 1)");
+    }
+
+    @BeforeClass
+    public void setup() {
+        mappingManager = new MappingManager(session());
+    }
+
+    @Test(groups = "short")
+    public void should_ignore_property_if_field_annotated_transient() {
+        mappingManager.mapper(Foo1.class);
+    }
+
+    @Table(name = "foo")
+    public static class Foo1 {
+        @PartitionKey
+        private int k;
+        @Transient
+        private int notAColumn;
+    }
+
+    @Test(groups = "short")
+    public void should_ignore_property_if_getter_annotated_transient() {
+        mappingManager.mapper(Foo2.class);
+    }
+
+    @Table(name = "foo")
+    public static class Foo2 {
+        @PartitionKey
+        private int k;
+        private int notAColumn;
+
+        @Transient
+        public int getNotAColumn() {
+            return notAColumn;
+        }
+    }
+
+    @Test(groups = "short")
+    public void should_ignore_property_if_declared_transient_in_class_annotation() {
+        mappingManager.mapper(Foo3.class);
+    }
+
+    @Table(name = "foo", transientProperties = {"class", "notAColumn"})
+    public static class Foo3 {
+        @PartitionKey
+        private int k;
+        private int notAColumn;
+    }
+
+    @Test(groups = "short")
+    public void should_ignore_property_if_declared_transient_in_mapper_configuration() {
+        MapperConfiguration configuration = new MapperConfiguration();
+        MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
+        scanConf.setExcludedProperties(ImmutableSet.of("notAColumn"));
+        configuration.setPropertyScanConfiguration(scanConf);
+        mappingManager.mapper(Foo3.class, configuration);
+    }
+
+    @Table(name = "foo")
+    public static class Foo4 {
+        @PartitionKey
+        private int k;
+        private int notAColumn;
+    }
+
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperConfigurationTransientTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperConfigurationTransientTest.java
@@ -30,7 +30,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Test for JAVA-1310 - validate ability to transient properties at manager and mapper levels
  */
 public class MapperConfigurationTransientTest extends CCMTestsSupport {
-    private MappingManager mappingManager;
 
     @Override
     public void onTestContextInitialized() {
@@ -38,13 +37,9 @@ public class MapperConfigurationTransientTest extends CCMTestsSupport {
         execute("INSERT INTO foo (k, v) VALUES (1, 1)");
     }
 
-    @BeforeClass
-    public void setup() {
-        mappingManager = new MappingManager(session());
-    }
-
     @Test(groups = "short")
     public void should_ignore_property_if_field_annotated_transient() {
+        MappingManager mappingManager = new MappingManager(session());
         mappingManager.mapper(Foo1.class);
     }
 
@@ -58,6 +53,7 @@ public class MapperConfigurationTransientTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_ignore_property_if_getter_annotated_transient() {
+        MappingManager mappingManager = new MappingManager(session());
         mappingManager.mapper(Foo2.class);
     }
 
@@ -75,6 +71,7 @@ public class MapperConfigurationTransientTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_ignore_property_if_declared_transient_in_class_annotation() {
+        MappingManager mappingManager = new MappingManager(session());
         mappingManager.mapper(Foo3.class);
     }
 
@@ -87,6 +84,7 @@ public class MapperConfigurationTransientTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_ignore_property_if_declared_transient_in_mapper_configuration() {
+        MappingManager mappingManager = new MappingManager(session());
         MapperConfiguration configuration = new MapperConfiguration();
         MapperConfiguration.PropertyScanConfiguration scanConf = new MapperConfiguration.PropertyScanConfiguration();
         scanConf.setExcludedProperties(ImmutableSet.of("notAColumn"));

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperInvalidAnnotationsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperInvalidAnnotationsTest.java
@@ -26,10 +26,12 @@ import static org.mockito.Mockito.*;
 public class MapperInvalidAnnotationsTest {
 
     MappingManager mappingManager;
+    MapperConfiguration mapperConfiguration;
 
     @BeforeClass(groups = "unit")
     public void setup() {
         mappingManager = mock(MappingManager.class);
+        mapperConfiguration = new MapperConfiguration();
         Session session = mock(Session.class);
         when(mappingManager.getSession()).thenReturn(session);
         Cluster cluster = mock(Cluster.class);
@@ -57,7 +59,7 @@ public class MapperInvalidAnnotationsTest {
                     "@Table annotation was not found on class " +
                             "com.datastax.driver.mapping.MapperInvalidAnnotationsTest\\$Invalid1")
     public void should_throw_IAE_when_Table_annotation_not_found_on_entity_class() throws Exception {
-        AnnotationParser.parseEntity(Invalid1.class, mappingManager);
+        AnnotationParser.parseEntity(Invalid1.class, mappingManager, mapperConfiguration);
     }
 
     @Test(groups = "unit", expectedExceptions = IllegalArgumentException.class,
@@ -65,7 +67,7 @@ public class MapperInvalidAnnotationsTest {
                     "@UDT annotation was not found on class " +
                             "com.datastax.driver.mapping.MapperInvalidAnnotationsTest\\$Invalid1")
     public void should_throw_IAE_when_UDT_annotation_not_found_on_udt_class() throws Exception {
-        AnnotationParser.parseUDT(Invalid1.class, mappingManager);
+        AnnotationParser.parseUDT(Invalid1.class, mappingManager, mapperConfiguration);
     }
 
     @Table(name = "foo")
@@ -78,7 +80,7 @@ public class MapperInvalidAnnotationsTest {
                     "Cannot have both @Table and @UDT on class " +
                             "com.datastax.driver.mapping.MapperInvalidAnnotationsTest\\$Invalid2")
     public void should_throw_IAE_when_UDT_annotation_found_on_entity_class() throws Exception {
-        AnnotationParser.parseEntity(Invalid2.class, mappingManager);
+        AnnotationParser.parseEntity(Invalid2.class, mappingManager, mapperConfiguration);
     }
 
     @Test(groups = "unit", expectedExceptions = IllegalArgumentException.class,
@@ -86,7 +88,7 @@ public class MapperInvalidAnnotationsTest {
                     "Cannot have both @UDT and @Table on class " +
                             "com.datastax.driver.mapping.MapperInvalidAnnotationsTest\\$Invalid2")
     public void should_throw_IAE_when_Table_annotation_found_on_udt_class() throws Exception {
-        AnnotationParser.parseUDT(Invalid2.class, mappingManager);
+        AnnotationParser.parseUDT(Invalid2.class, mappingManager, mapperConfiguration);
     }
 
     @Table(name = "foo")
@@ -99,7 +101,7 @@ public class MapperInvalidAnnotationsTest {
                     "Cannot have both @Table and @Accessor on class " +
                             "com.datastax.driver.mapping.MapperInvalidAnnotationsTest\\$Invalid3")
     public void should_throw_IAE_when_Accessor_annotation_found_on_entity_class() throws Exception {
-        AnnotationParser.parseEntity(Invalid3.class, mappingManager);
+        AnnotationParser.parseEntity(Invalid3.class, mappingManager, mapperConfiguration);
     }
 
     @UDT(name = "foo")
@@ -112,7 +114,7 @@ public class MapperInvalidAnnotationsTest {
                     "Cannot have both @UDT and @Accessor on class " +
                             "com.datastax.driver.mapping.MapperInvalidAnnotationsTest\\$Invalid4")
     public void should_throw_IAE_when_Accessor_annotation_found_on_udt_class() throws Exception {
-        AnnotationParser.parseUDT(Invalid4.class, mappingManager);
+        AnnotationParser.parseUDT(Invalid4.class, mappingManager, mapperConfiguration);
     }
 
     @Test(groups = "unit", expectedExceptions = IllegalArgumentException.class,
@@ -120,7 +122,7 @@ public class MapperInvalidAnnotationsTest {
                     "@Accessor annotation is only allowed on interfaces, got class " +
                             "com.datastax.driver.mapping.MapperInvalidAnnotationsTest\\$Invalid4")
     public void should_throw_IAE_when_Accessor_annotation_found_on_concrete_class() throws Exception {
-        AnnotationParser.parseAccessor(Invalid4.class, mappingManager);
+        AnnotationParser.parseAccessor(Invalid4.class, mappingManager, mapperConfiguration);
     }
 
     interface Invalid5 {
@@ -131,7 +133,7 @@ public class MapperInvalidAnnotationsTest {
                     "@Accessor annotation was not found on interface " +
                             "com.datastax.driver.mapping.MapperInvalidAnnotationsTest\\$Invalid5")
     public void should_throw_IAE_when_Accessor_annotation_not_found_on_accessor_class() throws Exception {
-        AnnotationParser.parseAccessor(Invalid5.class, mappingManager);
+        AnnotationParser.parseAccessor(Invalid5.class, mappingManager, mapperConfiguration);
     }
 
     @Table(name = "foo")
@@ -144,7 +146,7 @@ public class MapperInvalidAnnotationsTest {
                     "Cannot have both @Accessor and @Table on interface " +
                             "com.datastax.driver.mapping.MapperInvalidAnnotationsTest\\$Invalid6")
     public void should_throw_IAE_when_Table_annotation_found_on_accessor_class() throws Exception {
-        AnnotationParser.parseAccessor(Invalid6.class, mappingManager);
+        AnnotationParser.parseAccessor(Invalid6.class, mappingManager, mapperConfiguration);
     }
 
     @UDT(name = "foo")
@@ -157,7 +159,7 @@ public class MapperInvalidAnnotationsTest {
                     "Cannot have both @Accessor and @UDT on interface " +
                             "com.datastax.driver.mapping.MapperInvalidAnnotationsTest\\$Invalid7")
     public void should_throw_IAE_when_UDT_annotation_found_on_accessor_class() throws Exception {
-        AnnotationParser.parseAccessor(Invalid7.class, mappingManager);
+        AnnotationParser.parseAccessor(Invalid7.class, mappingManager, mapperConfiguration);
     }
 
     @Table(name = "foo", keyspace = "ks")
@@ -170,7 +172,7 @@ public class MapperInvalidAnnotationsTest {
             expectedExceptionsMessageRegExp =
                     "Annotation @Field is not allowed on property 'invalid'")
     public void should_throw_IAE_when_Field_annotation_found_on_entity_class_field() throws Exception {
-        AnnotationParser.parseEntity(Invalid8.class, mappingManager);
+        AnnotationParser.parseEntity(Invalid8.class, mappingManager, mapperConfiguration);
     }
 
     @UDT(name = "foo", keyspace = "ks")
@@ -188,7 +190,7 @@ public class MapperInvalidAnnotationsTest {
             expectedExceptionsMessageRegExp =
                     "Annotation @Column is not allowed on property 'invalid'")
     public void should_throw_IAE_when_Column_annotation_found_on_udt_class_field() throws Exception {
-        AnnotationParser.parseUDT(Invalid9.class, mappingManager);
+        AnnotationParser.parseUDT(Invalid9.class, mappingManager, mapperConfiguration);
     }
 
     @Table(name = "foo", keyspace = "ks")
@@ -204,7 +206,7 @@ public class MapperInvalidAnnotationsTest {
             expectedExceptionsMessageRegExp =
                     "Property 'invalid' cannot be annotated with both @PartitionKey and @ClusteringColumn")
     public void should_throw_IAE_when_PartitionKey_and_ClusteringColumn_on_same_property() throws Exception {
-        AnnotationParser.parseEntity(Invalid10.class, mappingManager);
+        AnnotationParser.parseEntity(Invalid10.class, mappingManager, mapperConfiguration);
     }
 
     @Table(name = "foo", keyspace = "ks")
@@ -220,7 +222,7 @@ public class MapperInvalidAnnotationsTest {
             expectedExceptionsMessageRegExp =
                     "Property 'invalid' cannot be annotated with both @Column and @Computed")
     public void should_throw_IAE_when_Computed_and_Column_on_same_property() throws Exception {
-        AnnotationParser.parseEntity(Invalid11.class, mappingManager);
+        AnnotationParser.parseEntity(Invalid11.class, mappingManager, mapperConfiguration);
     }
 
     @Table(name = "foo", keyspace = "ks")
@@ -235,7 +237,7 @@ public class MapperInvalidAnnotationsTest {
             expectedExceptionsMessageRegExp =
                     "Property 'invalid': attribute 'value' of annotation @Computed is mandatory for computed properties")
     public void should_throw_IAE_when_Computed_with_empty_value() throws Exception {
-        AnnotationParser.parseEntity(Invalid12.class, mappingManager);
+        AnnotationParser.parseEntity(Invalid12.class, mappingManager, mapperConfiguration);
     }
 
     @Table(name = "foo", keyspace = "ks")
@@ -250,7 +252,7 @@ public class MapperInvalidAnnotationsTest {
             expectedExceptionsMessageRegExp =
                     "Invalid ordering value -1 for annotation @PartitionKey of property 'invalid', was expecting 0")
     public void should_throw_IAE_when_PartitionKey_with_wrong_order() throws Exception {
-        AnnotationParser.parseEntity(Invalid13.class, mappingManager);
+        AnnotationParser.parseEntity(Invalid13.class, mappingManager, mapperConfiguration);
     }
 
     @Table(name = "foo", keyspace = "ks")
@@ -265,7 +267,7 @@ public class MapperInvalidAnnotationsTest {
             expectedExceptionsMessageRegExp =
                     "Property 'notReadable' is not readable")
     public void should_throw_IAE_when_unreadable_property() throws Exception {
-        AnnotationParser.parseEntity(Invalid14.class, mappingManager);
+        AnnotationParser.parseEntity(Invalid14.class, mappingManager, mapperConfiguration);
     }
 
     @Table(name = "foo", keyspace = "ks")
@@ -281,7 +283,7 @@ public class MapperInvalidAnnotationsTest {
             expectedExceptionsMessageRegExp =
                     "Property 'notWritable' is not writable")
     public void should_throw_IAE_when_unwritable_property() throws Exception {
-        AnnotationParser.parseEntity(Invalid15.class, mappingManager);
+        AnnotationParser.parseEntity(Invalid15.class, mappingManager, mapperConfiguration);
     }
 
 }

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperTransientTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperTransientTest.java
@@ -26,7 +26,6 @@ import org.testng.annotations.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MapperTransientTest extends CCMTestsSupport {
-    private MappingManager mappingManager;
 
     @Override
     public void onTestContextInitialized() {
@@ -34,13 +33,9 @@ public class MapperTransientTest extends CCMTestsSupport {
         execute("INSERT INTO foo (k, v) VALUES (1, 1)");
     }
 
-    @BeforeClass
-    public void setup() {
-        mappingManager = new MappingManager(session());
-    }
-
     @Test(groups = "short")
     public void should_ignore_property_if_field_annotated_transient() {
+        MappingManager mappingManager = new MappingManager(session());
         mappingManager.mapper(Foo1.class);
     }
 
@@ -54,6 +49,7 @@ public class MapperTransientTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_ignore_property_if_getter_annotated_transient() {
+        MappingManager mappingManager = new MappingManager(session());
         mappingManager.mapper(Foo2.class);
     }
 
@@ -71,6 +67,7 @@ public class MapperTransientTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_ignore_property_if_declared_transient_in_class_annotation() {
+        MappingManager mappingManager = new MappingManager(session());
         mappingManager.mapper(Foo3.class);
     }
 
@@ -83,6 +80,7 @@ public class MapperTransientTest extends CCMTestsSupport {
 
     @Test(groups = "short")
     public void should_not_ignore_property_if_ignored_at_class_level_but_annotated() {
+        MappingManager mappingManager = new MappingManager(session());
         Foo4 foo = mappingManager.mapper(Foo4.class).get(1);
         assertThat(foo.getV()).isEqualTo(1);
     }


### PR DESCRIPTION
Hi all!
As discussed with Alexandre on the [Jira ticket](https://datastax-oss.atlassian.net/browse/JAVA-1310), i took some effort to try and implement the mapper configuration the way i believe to be the most convenient.
So iv'e implemented the following abilities:

- Make the annotation parsing logic configurable at mapper level (only fields, only getters, or both)
- Make transient properties configurable at mapper level (should properties be transient by default or not)
- Make the class hierarchy scan configurable at mapper level (enable/disable scanning of hierarchy, scan all classes or just annotated classes and supplying of a maximal ancestor to scan for properties in class hierarchy).
- Make transient property names available to extend at mapper level (additionally to marking it at table and UDT annotations).

Take a look and let me have some feedback if you have any. I think once the general concept of MapperConfiguration is implemented, we can build more features on top of it (for example solving [JAVA-1316](https://datastax-oss.atlassian.net/browse/JAVA-1316)).

Note: I added two elements to clirr.xml that prevented me from compiling the source, let me know if i made a mistake.