### PR TITLE
JAVA-1351: Include Custom Payload in Request.copy

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,7 @@
 ### 3.0.6 (in progress)
 
 - [bug] JAVA-1330: Add un/register for SchemaChangeListener in DelegatingCluster
+- [bug] JAVA-1351: Include Custom Payload in Request.copy.
 
 
 ### 3.0.5

--- a/driver-core/src/main/java/com/datastax/driver/core/Message.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Message.java
@@ -180,9 +180,21 @@ abstract class Message {
             }
         }
 
-        abstract Request copy();
+        Request copy() {
+            Request request = copyInternal();
+            request.setCustomPayload(this.getCustomPayload());
+            return request;
+        }
+
+        protected abstract Request copyInternal();
 
         Request copy(ConsistencyLevel newConsistencyLevel) {
+            Request request = copyInternal(newConsistencyLevel);
+            request.setCustomPayload(this.getCustomPayload());
+            return request;
+        }
+
+        protected Request copyInternal(ConsistencyLevel newConsistencyLevel) {
             throw new UnsupportedOperationException();
         }
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/Requests.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Requests.java
@@ -63,7 +63,7 @@ class Requests {
         }
 
         @Override
-        Request copy() {
+        protected Request copyInternal() {
             return new Startup(compression);
         }
 
@@ -99,7 +99,7 @@ class Requests {
         }
 
         @Override
-        Request copy() {
+        protected Request copyInternal() {
             return new Credentials(credentials);
         }
     }
@@ -122,7 +122,7 @@ class Requests {
         }
 
         @Override
-        Request copy() {
+        protected Request copyInternal() {
             return new Options();
         }
 
@@ -162,12 +162,12 @@ class Requests {
         }
 
         @Override
-        Request copy() {
+        protected Request copyInternal() {
             return new Query(this.query, options, isTracingRequested());
         }
 
         @Override
-        Request copy(ConsistencyLevel newConsistencyLevel) {
+        protected Request copyInternal(ConsistencyLevel newConsistencyLevel) {
             return new Query(this.query, options.copy(newConsistencyLevel), isTracingRequested());
         }
 
@@ -203,12 +203,12 @@ class Requests {
         }
 
         @Override
-        Request copy() {
+        protected Request copyInternal() {
             return new Execute(statementId, options, isTracingRequested());
         }
 
         @Override
-        Request copy(ConsistencyLevel newConsistencyLevel) {
+        protected Request copyInternal(ConsistencyLevel newConsistencyLevel) {
             return new Execute(statementId, options.copy(newConsistencyLevel), isTracingRequested());
         }
 
@@ -460,12 +460,12 @@ class Requests {
         }
 
         @Override
-        Request copy() {
+        protected Request copyInternal() {
             return new Batch(type, queryOrIdList, values, options, isTracingRequested());
         }
 
         @Override
-        Request copy(ConsistencyLevel newConsistencyLevel) {
+        protected Request copyInternal(ConsistencyLevel newConsistencyLevel) {
             return new Batch(type, queryOrIdList, values, options.copy(newConsistencyLevel), isTracingRequested());
         }
 
@@ -571,7 +571,7 @@ class Requests {
         }
 
         @Override
-        Request copy() {
+        protected Request copyInternal() {
             return new Prepare(query);
         }
 
@@ -608,7 +608,7 @@ class Requests {
         }
 
         @Override
-        Request copy() {
+        protected Request copyInternal() {
             return new Register(eventTypes);
         }
 
@@ -641,7 +641,7 @@ class Requests {
         }
 
         @Override
-        Request copy() {
+        protected Request copyInternal() {
             return new AuthResponse(token);
         }
     }


### PR DESCRIPTION
For [JAVA-1351](https://datastax-oss.atlassian.net/browse/JAVA-1351)

Motivation:

When a request is retried or speculatively executed, a new Request
instance is created from the existing one using Request.copy.  This has
a side effect of not carrying over custom payload from the previous
request.  This change ensures Request.copy carries over custom payload
from the previous Request if present.

Modifications:

Renamed existing copy implementations to copyInternal and introduced new
copy methods that call copyInternal and then setCustomPayload to carry
over custom payload from previous Request.

Result:

Custom payload is now carried over on retries and speculative
executions.