### PR TITLE
Updates for testing with DSE Cluster, commit CI config change

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4,7 +4,12 @@ schedules:
     schedule: per_commit
     matrix:
       exclude:
-        - java: [openjdk6, oraclejdk7]
+        # Exclude all java 7 builds
+        - java: oraclejdk7
+        # Exclude java6 with all versions except latest
+        - java: openjdk6
+          cassandra: ['1.2', '2.0', '2.1', '2.2', '3.0']
+        # Exclude 2.2 and 3.0 always since 3.X provides latest protocol version
         - cassandra: ['2.2', '3.0']
     env_vars: |
       TEST_GROUP="short"
@@ -39,6 +44,7 @@ build:
       cassandra.version=$CCM_CASSANDRA_VERSION
       ccm.java.home=$CCM_JAVA_HOME
       ccm.path=$CCM_JAVA_HOME/bin
+      ccm.maxNumberOfNodes=3
       failIfNoTests=false
       maven.test.failure.ignore=true
       maven.javadoc.skip=true
@@ -51,6 +57,7 @@ build:
       cassandra.version=$CCM_CASSANDRA_VERSION
       ccm.java.home=$CCM_JAVA_HOME
       ccm.path=$CCM_JAVA_HOME/bin
+      ccm.maxNumberOfNodes=3
       failIfNoTests=false
       maven.test.failure.ignore=true
       maven.javadoc.skip=true

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
@@ -919,12 +919,6 @@ public class CCMTestsSupport {
             }
             LOGGER.debug("Using {}", ccm);
         }
-
-        // Check to ensure binary protocol is listening before proceeding.
-        for (InetSocketAddress node : getContactPointsWithPorts()) {
-            LOGGER.debug("Waiting for binary protocol to show up for {}", node);
-            TestUtils.waitUntilPortIsUp(node);
-        }
     }
 
     protected void initTestCluster(Object testInstance) throws Exception {

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
@@ -271,12 +271,12 @@ public class CCMTestsSupport {
         }
 
         @SuppressWarnings("SimplifiableIfStatement")
-        private boolean dse() {
+        private Boolean dse() {
             for (CCMConfig ann : annotations) {
                 if (ann != null && ann.dse().length > 0)
                     return ann.dse()[0];
             }
-            return false;
+            return null;
         }
 
         @SuppressWarnings("SimplifiableIfStatement")
@@ -430,8 +430,14 @@ public class CCMTestsSupport {
                 }
                 if (version() != null)
                     ccmBuilder.withVersion(version());
-                if (dse())
-                    ccmBuilder.withDSE();
+                Boolean dse = dse();
+                if (dse != null) {
+                    if (dse) {
+                        ccmBuilder.withDSE();
+                    } else {
+                        ccmBuilder.withoutDSE();
+                    }
+                }
                 if (ssl())
                     ccmBuilder.withSSL();
                 if (auth())
@@ -912,6 +918,12 @@ public class CCMTestsSupport {
                 fail(e.getMessage());
             }
             LOGGER.debug("Using {}", ccm);
+        }
+
+        // Check to ensure binary protocol is listening before proceeding.
+        for (InetSocketAddress node : getContactPointsWithPorts()) {
+            LOGGER.debug("Waiting for binary protocol to show up for {}", node);
+            TestUtils.waitUntilPortIsUp(node);
         }
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/HostMetadataIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostMetadataIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.driver.core;
 
+import com.datastax.driver.core.utils.DseVersion;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.testng.annotations.Test;
@@ -35,24 +36,22 @@ public class HostMetadataIntegrationTest {
      * This test is disabled as running DSE with workloads is intensive and has unreliable results
      * when running CCM with multiple workloads.
      * <p/>
-     * FIXME: this test is currently disabled because nodes with specific workload
-     * do not seem to come up within the allocated time.
      *
      * @test_category host:metadata
-     * @jira_ticket JAVA1042
+     * @jira_ticket JAVA-1042
      * @see HostMetadataIntegrationTest#should_parse_dse_workload_and_version_if_available()
      */
-    @Test(groups = "long", enabled = false)
+    @Test(groups = "long")
+    @DseVersion(major = 5.0)
     public void test_mixed_dse_workload() {
         CCMBridge.Builder builder = CCMBridge.builder()
                 .withNodes(3)
                 .withDSE()
-                .withVersion("4.8.3")
                 .withWorkload(2, solr)
                 .withWorkload(3, spark);
         CCMAccess ccm = CCMCache.get(builder);
 
-        VersionNumber version = VersionNumber.parse("4.8.3");
+        VersionNumber version = VersionNumber.parse(CCMBridge.getDSEVersion());
 
         Cluster cluster = Cluster.builder()
                 .addContactPoints(ccm.addressOfNode(1).getAddress())

--- a/driver-core/src/test/java/com/datastax/driver/core/ProtocolV1Test.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ProtocolV1Test.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests targeting protocol v1 specifically.
  */
-@CCMConfig(version = "1.2.19")
+@CCMConfig(version = "1.2.19", dse = false)
 public class ProtocolV1Test extends CCMTestsSupport {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
@@ -157,6 +157,7 @@ public class RecommissionedNodeTest {
                 .withStoragePort(mainCcm.getStoragePort())
                 .withThriftPort(mainCcm.getThriftPort())
                 .withBinaryPort(mainCcm.getBinaryPort())
+                .withoutDSE()
                 .withVersion("1.2.19");
         otherCcm = CCMCache.get(otherCcmBuilder);
         otherCcm.waitForUp(1);

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -739,7 +739,7 @@ public abstract class TestUtils {
      * @return The desired target protocol version based on the 'cassandra.version' System property.
      */
     public static ProtocolVersion getDesiredProtocolVersion() {
-        String version = System.getProperty("cassandra.version");
+        String version = CCMBridge.getCassandraVersion();
         String[] versionArray = version.split("\\.|-");
         double major = Double.parseDouble(versionArray[0] + "." + versionArray[1]);
         if (major < 2.0) {

--- a/driver-core/src/test/java/com/datastax/driver/core/WarningsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/WarningsTest.java
@@ -23,6 +23,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@CCMConfig(config = {"batch_size_warn_threshold_in_kb:5"})
+@CassandraVersion(major = 2.2)
 public class WarningsTest extends CCMTestsSupport {
 
     @Override
@@ -30,7 +32,6 @@ public class WarningsTest extends CCMTestsSupport {
         execute("CREATE TABLE foo(k int primary key, v text)");
     }
 
-    @CassandraVersion(major = 2.2)
     @Test(groups = "short")
     public void should_expose_warnings_on_execution_info() {
         // the default batch size warn threshold is 5 * 1024 bytes, but after CASSANDRA-10876 there must be


### PR DESCRIPTION
* Pulls some DSE-specific logic we had in java-driver-dse tests here to enable testing with DSE clusters (port config selection).
* Adjusts behavior for waiting on binary interface.  Now waits on port instead of depending on CCM to check for us (which has some faulty issues around C* 1.2 and 2.1).
* For our 'on commit' CI builds in jenkins, addiitonall build with latest version of C* and java 6.