### PR TITLE
JAVA-1355: Update getReplicas to handle range covering multiple hosts

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 - [bug] JAVA-1330: Add un/register for SchemaChangeListener in DelegatingCluster
 - [bug] JAVA-1351: Include Custom Payload in Request.copy.
+- [bug] JAVA-1355: Update getReplicas to handle range covering multiple hosts
 
 
 ### 3.0.5


### PR DESCRIPTION
For [JAVA-1355](https://datastax-oss.atlassian.net/browse/JAVA-1355):

Motivation:

Metadata.getReplicas(String, TokenRange) currently assumes that the
TokenRange provided represents a TokenRange for a single host.  Because
of this, it finds the replicas for the last Token on that range instead
of considering the entire range.

Arbitrary TokenRanges may be provided that span multiple hosts.  In
this case, this method should include each host spanning this range
and their replicas.

Modifications:

Updated method to evaluate which Host's TokenRanges intersect with the
input TokenRange and include those range's replicas.

Result:

Metadata.getReplicas(String TokenRange) now includes replicas for all
hosts covering a range, not just the replicas for the last token in the
range.

Targeted this against 3.0.x & 3.0.6, but wasn't sure if that was appropriate.  It could also be debated as to whether this is a bug fix or a functionality change, which could effect what target release could be.  If we decide to leave as is, I think it would be good to update the javadoc to make it clear that the method assumes the range only covers 1 host.