### PR TITLE
JAVA-1357: Update documentation for getReplicas

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -5,6 +5,7 @@
 - [bug] JAVA-1371: Reintroduce connection pool timeout.
 - [bug] JAVA-1313: Copy SerialConsistencyLevel to PreparedStatement.
 - [documentation] JAVA-1334: Clarify documentation of method `addContactPoints`.
+- [improvement] JAVA-1357: Document that getReplicas only returns replicas of the last token in range.
 
 
 ### 3.0.6

--- a/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metadata.java
@@ -305,7 +305,12 @@ public class Metadata {
     /**
      * Returns the set of hosts that are replica for a given token range.
      * <p/>
-     * Note that this information is refreshed asynchronously by the control
+     * Note that it is assumed that the input range does not overlap across multiple host ranges.
+     * If the range extends over multiple hosts, it only returns the replicas for those hosts
+     * that are replicas for the last token of the range.  This behavior may change in a future
+     * release, see <a href="https://datastax-oss.atlassian.net/browse/JAVA-1355">JAVA-1355</a>.
+     * <p/>
+     * Also note that this information is refreshed asynchronously by the control
      * connection, when schema or ring topology changes. It might occasionally
      * be stale (or even empty).
      *


### PR DESCRIPTION
For [JAVA-1357](https://datastax-oss.atlassian.net/browse/JAVA-1357)

Motivation:

Metadata.getReplicas(String, TokenRange) currently assumes that the
TokenRange provided represents a TokenRange for a single host. Because
of this, it finds the replicas for the last Token on that range instead
of considering the entire range.  Document that this is the case.

Modifications:

Updated method javadoc.