### PR TITLE
Change SSLOptions API to take a remote address

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -1311,7 +1311,8 @@ class Connection {
             ChannelPipeline pipeline = channel.pipeline();
 
             if (sslOptions != null) {
-                pipeline.addLast("ssl", sslOptions.newSSLHandler(channel));
+                InetSocketAddress addr = new InetSocketAddress(connection.address.getAddress(), connection.address.getPort());
+                pipeline.addLast("ssl", sslOptions.newSSLHandler(channel, addr));
             }
 
 //            pipeline.addLast("debug", new LoggingHandler(LogLevel.INFO));

--- a/driver-core/src/main/java/com/datastax/driver/core/JdkSSLOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/JdkSSLOptions.java
@@ -20,6 +20,9 @@ import io.netty.handler.ssl.SslHandler;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.security.NoSuchAlgorithmException;
 
 /**
@@ -51,8 +54,8 @@ public class JdkSSLOptions implements SSLOptions {
     }
 
     @Override
-    public SslHandler newSSLHandler(SocketChannel channel) {
-        SSLEngine engine = newSSLEngine(channel);
+    public SslHandler newSSLHandler(SocketChannel channel, InetSocketAddress address) {
+        SSLEngine engine = newSSLEngine(channel, address);
         return new SslHandler(engine);
     }
 
@@ -64,10 +67,11 @@ public class JdkSSLOptions implements SSLOptions {
      * (for example enabling hostname verification).
      *
      * @param channel the Netty channel for that connection.
+     * @param address remote address for the connection
      * @return the engine.
      */
-    protected SSLEngine newSSLEngine(SocketChannel channel) {
-        SSLEngine engine = context.createSSLEngine();
+    protected SSLEngine newSSLEngine(SocketChannel channel, InetSocketAddress address) {
+        SSLEngine engine = context.createSSLEngine(address.getHostName(), address.getPort());
         engine.setUseClientMode(true);
         if (cipherSuites != null)
             engine.setEnabledCipherSuites(cipherSuites);

--- a/driver-core/src/main/java/com/datastax/driver/core/NettySSLOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/NettySSLOptions.java
@@ -15,6 +15,8 @@
  */
 package com.datastax.driver.core;
 
+import java.net.InetSocketAddress;
+
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
@@ -37,7 +39,7 @@ public class NettySSLOptions implements SSLOptions {
     }
 
     @Override
-    public SslHandler newSSLHandler(SocketChannel channel) {
-        return context.newHandler(channel.alloc());
+    public SslHandler newSSLHandler(SocketChannel channel, InetSocketAddress address) {
+        return context.newHandler(channel.alloc(), address.getHostName(), address.getPort());
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/SSLOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SSLOptions.java
@@ -15,6 +15,8 @@
  */
 package com.datastax.driver.core;
 
+import java.net.InetSocketAddress;
+
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.ssl.SslHandler;
 
@@ -38,5 +40,5 @@ public interface SSLOptions {
      * @param channel the channel.
      * @return the handler.
      */
-    SslHandler newSSLHandler(SocketChannel channel);
+    SslHandler newSSLHandler(SocketChannel channel, InetSocketAddress address);
 }


### PR DESCRIPTION
Enable creation of SSLHandler with remote address information. This is
needed to instantiate SSLEngine/SSLHandler with remote address
information set, which is needed to enable hostname verification. We
cannot take this information from SocketChannel at this time since it is
not connected yet at the time Connection.Initializer creates the
SSLHandler.