### PR TITLE
JAVA-1362: Send query options flags as [int] for Protocol V5+

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 - [new feature] JAVA-1347: Add support for duration type.
 - [new feature] JAVA-1248: Implement "beta" flag for native protocol v5.
+- [new feature] JAVA-1362: Send query options flags as [int] for Protocol V5+.
 
 
 ### 3.1.3


### PR DESCRIPTION
For [JAVA-1362](https://datastax-oss.atlassian.net/browse/JAVA-1362):

Motivation:

[CASSANDRA-12838](https://issues.apache.org/jira/browse/CASSANDRA-12838) changes the flags field on the QUERY, EXECUTE and BATCH
messages from [byte] to [int].  This change accounts for that change in
width in Protocol V5.

Modifications:

Write flags as int for Protocol V5+, byte otherwise.

Result:

QUERY, EXECUTE, and BATCH messages are now compatible with Protocol V5.