### PR TITLE
JAVA-1367: Make protocol negotiation more resilient

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -5,6 +5,7 @@
 - [new feature] JAVA-1347: Add support for duration type.
 - [new feature] JAVA-1248: Implement "beta" flag for native protocol v5.
 - [new feature] JAVA-1362: Send query options flags as [int] for Protocol V5+.
+- [improvement] JAVA-1367: Make protocol negotiation more resilient.
 
 
 ### 3.1.3

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -211,7 +211,7 @@ class ControlConnection implements Connection.Owner {
                 } catch (UnsupportedProtocolVersionException e) {
                     // If it's the very first node we've connected to, rethrow the exception and
                     // Cluster.init() will handle it. Otherwise, just mark this node in error.
-                    if (cluster.protocolVersion() == null)
+                    if (isInitialConnection)
                         throw e;
                     logger.debug("Ignoring host {}: {}", host, e.getMessage());
                     errors = logError(host, e, errors, iter);
@@ -225,8 +225,7 @@ class ControlConnection implements Connection.Owner {
             Thread.currentThread().interrupt();
 
             // Indicates that all remaining hosts are skipped due to the interruption
-            if (host != null)
-                errors = logError(host, new DriverException("Connection thread interrupted"), errors, iter);
+            errors = logError(host, new DriverException("Connection thread interrupted"), errors, iter);
             while (iter.hasNext())
                 errors = logError(iter.next(), new DriverException("Connection thread interrupted"), errors, iter);
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/Host.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Host.java
@@ -137,6 +137,11 @@ public class Host {
         this.dseGraphEnabled = dseGraphEnabled;
     }
 
+    boolean supports(ProtocolVersion version) {
+        return getCassandraVersion() == null
+                || version.minCassandraVersion().compareTo(getCassandraVersion().nextStable()) <= 0;
+    }
+
     /**
      * Returns the address that the driver will use to connect to the node.
      * <p/>

--- a/driver-core/src/main/java/com/datastax/driver/core/ProtocolVersion.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ProtocolVersion.java
@@ -26,38 +26,36 @@ import java.util.Map;
  */
 public enum ProtocolVersion {
 
-    V1("1.2.0", 1),
-    V2("2.0.0", 2),
-    V3("2.1.0", 3),
-    V4("2.2.0", 4),
-    V5("3.10.0", 5);
+    V1("1.2.0", 1, null),
+    V2("2.0.0", 2, V1),
+    V3("2.1.0", 3, V2),
+    V4("2.2.0", 4, V3),
+    V5("3.10.0", 5, V4);
 
     /**
      * The most recent protocol version supported by the driver.
      */
     public static final ProtocolVersion NEWEST_SUPPORTED = V4;
 
+    /**
+     * The most recent beta protocol version supported by the driver.
+     */
     public static final ProtocolVersion NEWEST_BETA = V5;
 
     private final VersionNumber minCassandraVersion;
+
     private final int asInt;
 
-    private ProtocolVersion(String minCassandraVersion, int asInt) {
+    private final ProtocolVersion lowerSupported;
+
+    private ProtocolVersion(String minCassandraVersion, int asInt, ProtocolVersion lowerSupported) {
         this.minCassandraVersion = VersionNumber.parse(minCassandraVersion);
         this.asInt = asInt;
-    }
-
-    boolean isSupportedBy(Host host) {
-        return host.getCassandraVersion() == null ||
-                isSupportedBy(host.getCassandraVersion());
+        this.lowerSupported = lowerSupported;
     }
 
     VersionNumber minCassandraVersion() {
         return minCassandraVersion;
-    }
-
-    private boolean isSupportedBy(VersionNumber cassandraVersion) {
-        return minCassandraVersion.compareTo(cassandraVersion.nextStable()) <= 0;
     }
 
     DriverInternalError unsupported() {
@@ -71,6 +69,16 @@ public enum ProtocolVersion {
      */
     public int toInt() {
         return asInt;
+    }
+
+    /**
+     * Returns the highest supported version that is lower than this version.
+     * Returns {@code null} if there isn't such a version.
+     *
+     * @return the highest supported version that is lower than this version.
+     */
+    public ProtocolVersion getLowerSupported() {
+        return lowerSupported;
     }
 
     private static final Map<Integer, ProtocolVersion> INT_TO_VERSION;

--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnsupportedProtocolVersionException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnsupportedProtocolVersionException.java
@@ -35,17 +35,23 @@ public class UnsupportedProtocolVersionException extends DriverException impleme
     private final ProtocolVersion serverVersion;
 
     public UnsupportedProtocolVersionException(InetSocketAddress address, ProtocolVersion unsupportedVersion, ProtocolVersion serverVersion) {
-        super(String.format("[%s] Host does not support protocol version %s but %s", address, unsupportedVersion, serverVersion));
+        super(makeErrorMessage(address, unsupportedVersion, serverVersion));
         this.address = address;
         this.unsupportedVersion = unsupportedVersion;
         this.serverVersion = serverVersion;
     }
 
     public UnsupportedProtocolVersionException(InetSocketAddress address, ProtocolVersion unsupportedVersion, ProtocolVersion serverVersion, Throwable cause) {
-        super(String.format("[%s] Host does not support protocol version %s but %s", address, unsupportedVersion, serverVersion), cause);
+        super(makeErrorMessage(address, unsupportedVersion, serverVersion), cause);
         this.address = address;
         this.unsupportedVersion = unsupportedVersion;
         this.serverVersion = serverVersion;
+    }
+
+    private static String makeErrorMessage(InetSocketAddress address, ProtocolVersion unsupportedVersion, ProtocolVersion serverVersion) {
+        return unsupportedVersion == serverVersion
+                ? String.format("[%s] Host does not support protocol version %s", address, unsupportedVersion)
+                : String.format("[%s] Host does not support protocol version %s but %s", address, unsupportedVersion, serverVersion);
     }
 
     @Override
@@ -58,10 +64,26 @@ public class UnsupportedProtocolVersionException extends DriverException impleme
         return address;
     }
 
+    /**
+     * The version with which the server replied.
+     * <p/>
+     * Note that this version is not necessarily a supported version.
+     * While this is usually the case, in rare situations,
+     * the server might respond with an unsupported version,
+     * to ensure that the client can decode its response properly.
+     * See CASSANDRA-11464 for more details.
+     *
+     * @return The version with which the server replied.
+     */
     public ProtocolVersion getServerVersion() {
         return serverVersion;
     }
 
+    /**
+     * The version with which the client sent its request.
+     *
+     * @return The version with which the client sent its request.
+     */
     public ProtocolVersion getUnsupportedVersion() {
         return unsupportedVersion;
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -903,13 +903,18 @@ public class CCMBridge implements CCMAccess {
             String clusterName = TestUtils.generateIdentifier("ccm_");
             boolean dse = isDSE == null ? isDSE() : isDSE;
 
-            Map<String, Object> cassandraConfiguration = randomizePorts(this.cassandraConfiguration);
             VersionNumber version = VersionNumber.parse(this.version);
+            Map<String, Object> cassandraConfiguration = randomizePorts(this.cassandraConfiguration);
             int storagePort = Integer.parseInt(cassandraConfiguration.get("storage_port").toString());
             int thriftPort = Integer.parseInt(cassandraConfiguration.get("rpc_port").toString());
             int binaryPort = Integer.parseInt(cassandraConfiguration.get("native_transport_port").toString());
+            if (version.compareTo(VersionNumber.parse("4.0")) >= 0) {
+                // remove thrift configuration
+                cassandraConfiguration.remove("start_rpc");
+                cassandraConfiguration.remove("rpc_port");
+                cassandraConfiguration.remove("thrift_prepared_statements_cache_size_mb");
+            }
             final CCMBridge ccm = new CCMBridge(clusterName, dse, version, storagePort, thriftPort, binaryPort, joinJvmArgs(), nodes);
-
             Runtime.getRuntime().addShutdownHook(new Thread() {
                 @Override
                 public void run() {

--- a/driver-core/src/test/java/com/datastax/driver/core/NettyOptionsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/NettyOptionsTest.java
@@ -77,9 +77,13 @@ public class NettyOptionsTest extends CCMTestsSupport {
 
         int expectedNumberOfCalls = TestUtils.numberOfLocalCoreConnections(cluster) * hosts + 1;
         // If the driver supports a more recent protocol version than C*, the negotiation at startup
-        // will open 1 extra connection.
-        if (!ProtocolVersion.NEWEST_SUPPORTED.isSupportedBy(TestUtils.findHost(cluster, 1)))
-            expectedNumberOfCalls += 1;
+        // will open an additional connection for each protocol version tried.
+        ProtocolVersion version = ProtocolVersion.NEWEST_SUPPORTED;
+        ProtocolVersion usedVersion = TestUtils.getDesiredProtocolVersion();
+        while (version != usedVersion && version != null) {
+            version = version.getLowerSupported();
+            expectedNumberOfCalls++;
+        }
 
         cluster.close();
         // then

--- a/driver-core/src/test/java/com/datastax/driver/core/ProtocolBetaVersionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ProtocolBetaVersionTest.java
@@ -102,12 +102,11 @@ public class ProtocolBetaVersionTest extends CCMTestsSupport {
     public void should_connect_with_beta_when_no_version_explicitly_required_and_flag_set() throws Exception {
         // Note: when the driver's ProtocolVersion.NEWEST_SUPPORTED will be incremented to V6 or higher
         // a renegotiation will start taking place here and will downgrade the version from V6 to V5,
-        // but the test should remain valid
+        // but the test should remain valid since it's executed against 3.10 exclusively
         Cluster cluster = Cluster.builder()
                 .addContactPoints(getContactPoints())
                 .withPort(ccm().getBinaryPort())
                 .allowBetaProtocolVersion()
-                // no version explicitly required -> renegotiation allowed
                 .build();
         cluster.connect();
         assertThat(cluster.getConfiguration().getProtocolOptions().getProtocolVersion()).isEqualTo(V5);
@@ -125,11 +124,10 @@ public class ProtocolBetaVersionTest extends CCMTestsSupport {
     public void should_connect_after_renegotiation_when_no_version_explicitly_required_and_flag_not_set() throws Exception {
         // Note: when the driver's ProtocolVersion.NEWEST_SUPPORTED will be incremented to V6 or higher
         // the renegotiation will start downgrading the version from V6 to V4 instead of V5 to V4,
-        // but the test should remain valid
+        // but the test should remain valid since it's executed against 3.10 exclusively
         Cluster cluster = Cluster.builder()
                 .addContactPoints(getContactPoints())
                 .withPort(ccm().getBinaryPort())
-                // no version explicitly required -> renegotiation allowed
                 .build();
         cluster.connect();
         assertThat(cluster.getConfiguration().getProtocolOptions().getProtocolVersion()).isEqualTo(V4);

--- a/driver-core/src/test/java/com/datastax/driver/core/ProtocolVersionRenegotiationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ProtocolVersionRenegotiationTest.java
@@ -1,0 +1,150 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.exceptions.UnsupportedProtocolVersionException;
+import org.testng.annotations.Test;
+
+import static com.datastax.driver.core.ProtocolVersion.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@CreateCCM(CreateCCM.TestMode.PER_METHOD)
+public class ProtocolVersionRenegotiationTest extends CCMTestsSupport {
+
+    /**
+     * @jira_ticket JAVA-1367
+     */
+    @Test(groups = "short")
+    @CCMConfig(version = "2.1.16", createCluster = false)
+    public void should_succeed_when_version_provided_and_matches() throws Exception {
+        Cluster cluster = connectWithVersion(V3);
+        assertThat(actualProtocolVersion(cluster)).isEqualTo(V3);
+    }
+
+    /**
+     * @jira_ticket JAVA-1367
+     */
+    @Test(groups = "short")
+    @CCMConfig(version = "3.6", createCluster = false)
+    public void should_fail_when_version_provided_and_too_low_3_6() throws Exception {
+        UnsupportedProtocolVersionException e = connectWithUnsupportedVersion(V1);
+        assertThat(e.getUnsupportedVersion()).isEqualTo(V1);
+        // pre-CASSANDRA-11464: server replies with its own version
+        assertThat(e.getServerVersion()).isEqualTo(V4);
+    }
+
+    /**
+     * @jira_ticket JAVA-1367
+     */
+    @Test(groups = "short")
+    @CCMConfig(version = "3.10", createCluster = false)
+    public void should_fail_when_version_provided_and_too_low_3_10() throws Exception {
+        UnsupportedProtocolVersionException e = connectWithUnsupportedVersion(V1);
+        assertThat(e.getUnsupportedVersion()).isEqualTo(V1);
+        // post-CASSANDRA-11464: server replies with client's version
+        assertThat(e.getServerVersion()).isEqualTo(V1);
+    }
+
+    /**
+     * @jira_ticket JAVA-1367
+     */
+    @Test(groups = "short")
+    @CCMConfig(version = "1.2.19", createCluster = false)
+    public void should_fail_when_version_provided_and_too_high() throws Exception {
+        UnsupportedProtocolVersionException e = connectWithUnsupportedVersion(V4);
+        assertThat(e.getUnsupportedVersion()).isEqualTo(V4);
+        // pre-CASSANDRA-11464: server replies with its own version
+        assertThat(e.getServerVersion()).isEqualTo(V1);
+    }
+
+    /**
+     * @jira_ticket JAVA-1367
+     */
+    @Test(groups = "short")
+    @CCMConfig(version = "2.1.16", createCluster = false)
+    public void should_fail_when_beta_allowed_and_too_high() throws Exception {
+        UnsupportedProtocolVersionException e = connectWithUnsupportedBetaVersion();
+        assertThat(e.getUnsupportedVersion()).isEqualTo(V5);
+        // pre-CASSANDRA-11464: server replies with its own version
+        assertThat(e.getServerVersion()).isEqualTo(V3);
+    }
+
+    /**
+     * @jira_ticket JAVA-1367
+     */
+    @Test(groups = "short")
+    @CCMConfig(version = "2.1.16", createCluster = false)
+    public void should_negotiate_when_no_version_provided() throws Exception {
+        Cluster cluster = connectWithoutVersion();
+        assertThat(actualProtocolVersion(cluster)).isEqualTo(V3);
+    }
+
+    private UnsupportedProtocolVersionException connectWithUnsupportedVersion(ProtocolVersion version) {
+        Cluster cluster = register(Cluster.builder()
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
+                .withProtocolVersion(version)
+                .build());
+        return initWithUnsupportedVersion(cluster);
+    }
+
+    private UnsupportedProtocolVersionException connectWithUnsupportedBetaVersion() {
+        Cluster cluster = register(Cluster.builder()
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
+                .allowBetaProtocolVersion()
+                .build());
+        return initWithUnsupportedVersion(cluster);
+    }
+
+    private UnsupportedProtocolVersionException initWithUnsupportedVersion(Cluster cluster) {
+        Throwable t = null;
+        try {
+            cluster.init();
+        } catch (Throwable t2) {
+            t = t2;
+        }
+        if (t instanceof UnsupportedProtocolVersionException) {
+            return (UnsupportedProtocolVersionException) t;
+        } else {
+            throw new AssertionError("Expected UnsupportedProtocolVersionException, got " + t);
+        }
+    }
+
+    private Cluster connectWithVersion(ProtocolVersion version) {
+        Cluster cluster = register(Cluster.builder()
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
+                .withProtocolVersion(version)
+                .build());
+        cluster.init();
+        return cluster;
+    }
+
+    private Cluster connectWithoutVersion() {
+        Cluster cluster = register(Cluster.builder()
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
+                .build());
+        cluster.init();
+        return cluster;
+    }
+
+    private ProtocolVersion actualProtocolVersion(Cluster cluster) {
+        return cluster.getConfiguration().getProtocolOptions().getProtocolVersion();
+    }
+
+}


### PR DESCRIPTION
Motivation:

CASSANDRA-11464 introduced in 3.0.8+, 3.8+ changed logic of protocol
error messages to be sent with the protocol version requested
by the client, instead of a version that the server supports,
to ensure that the client will be able to decode the response properly.

The driver currently uses the returned protocol version to determine
what protocol version to downgrade to and reattempt connection.
Because of this, the driver would retry the same protocol version and
fail again.

Modifications:

This commit changes the renegotiation algorithm to allow
more than one renegotiation attempt. It also makes no more distinction
between user-defined versions and inferred versions.
And finally, it now ignores the server response version
and always retries to connect using attempted version - 1.

Result:

Driver is compatible with Cassandra 3.0.8+, 3.8+.