### PR TITLE
Various test fixes for 3.2.0

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/AggregateMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AggregateMetadataTest.java
@@ -24,7 +24,7 @@ import static com.datastax.driver.core.DataType.cint;
 import static com.datastax.driver.core.DataType.text;
 import static com.datastax.driver.core.TestUtils.serializeForDynamicCompositeType;
 
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 @CCMConfig(config = "enable_user_defined_functions:true")
 public class AggregateMetadataTest extends CCMTestsSupport {
 
@@ -183,7 +183,7 @@ public class AggregateMetadataTest extends CCMTestsSupport {
      * @since 3.0.1
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_parse_and_format_aggregate_with_composite_type_literal_initcond() {
         VersionNumber ver = VersionNumber.parse(CCMBridge.getCassandraVersion());
         if (ver.getMajor() == 3) {
@@ -204,7 +204,7 @@ public class AggregateMetadataTest extends CCMTestsSupport {
      * @since 3.0.1
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 3.0, minor = 4)
+    @CassandraVersion("3.4")
     public void should_parse_and_format_aggregate_with_composite_type_hex_initcond() {
         VersionNumber ver = VersionNumber.parse(CCMBridge.getCassandraVersion());
         if ((ver.getMinor() >= 1 && ver.getMinor() < 4)) {

--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
@@ -166,7 +166,7 @@ public class AsyncQueryTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0, description = "Paging is not supported until 2.0")
+    @CassandraVersion(value = "2.0.0", description = "Paging is not supported until 2.0")
     public void should_fail_when_auto_paging_on_io_thread() throws Exception {
         for (int i = 0; i < 1000; i++) {
             Statement statement = new SimpleStatement("select v from asyncquerytest.foo where k = 1");

--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncResultSetTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncResultSetTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.0, description = "uses paging")
+@CassandraVersion(value = "2.0.0", description = "uses paging")
 public class AsyncResultSetTest extends CCMTestsSupport {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/BatchStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/BatchStatementTest.java
@@ -71,7 +71,7 @@ public class BatchStatementTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0, minor = 9, description = "This will only work with C* 2.0.9 (CASSANDRA-7337)")
+    @CassandraVersion(value = "2.0.9", description = "This will only work with C* 2.0.9 (CASSANDRA-7337)")
     public void casBatchTest() {
         PreparedStatement st = session().prepare("INSERT INTO test (k, v) VALUES (?, ?) IF NOT EXISTS");
 

--- a/driver-core/src/test/java/com/datastax/driver/core/ConditionalUpdateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ConditionalUpdateTest.java
@@ -24,7 +24,7 @@ import static org.testng.Assert.assertTrue;
 /**
  * Test {@link ResultSet#wasApplied()} for conditional updates.
  */
-@CassandraVersion(major = 2.0, description = "Conditional Updates requires 2.0+.")
+@CassandraVersion(value = "2.0.0", description = "Conditional Updates requires 2.0+.")
 public class ConditionalUpdateTest extends CCMTestsSupport {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
@@ -94,7 +94,7 @@ public class ControlConnectionTest extends CCMTestsSupport {
      * Therefore we use two different driver instances in this test.
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_parse_UDT_definitions_when_using_default_protocol_version() {
         // First driver instance: create UDT
         Cluster cluster = register(Cluster.builder()

--- a/driver-core/src/test/java/com/datastax/driver/core/CustomPayloadTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CustomPayloadTest.java
@@ -33,7 +33,7 @@ import static org.apache.log4j.Level.TRACE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 @CCMConfig(jvmArgs = "-Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler")
 public class CustomPayloadTest extends CCMTestsSupport {
 
@@ -85,8 +85,6 @@ public class CustomPayloadTest extends CCMTestsSupport {
 
     /**
      * Ensures that an incoming payload is propagated from prepared to bound statements.
-     *
-     * @throws Exception
      */
     @Test(groups = "short")
     public void should_propagate_incoming_payload_to_bound_statement() throws Exception {
@@ -113,8 +111,6 @@ public class CustomPayloadTest extends CCMTestsSupport {
     /**
      * Ensures that an incoming payload is overridden by an explicitly set outgoing payload
      * when propagated to bound statements.
-     *
-     * @throws Exception
      */
     @Test(groups = "short")
     public void should_override_incoming_payload_when_outgoing_payload_explicitly_set_on_preparing_statement() throws Exception {
@@ -141,8 +137,6 @@ public class CustomPayloadTest extends CCMTestsSupport {
     /**
      * Ensures that payloads can still be set individually on bound statements
      * if the prepared statement does not have a default payload.
-     *
-     * @throws Exception
      */
     @Test(groups = "short")
     public void should_not_set_any_payload_on_bound_statement() throws Exception {
@@ -171,8 +165,6 @@ public class CustomPayloadTest extends CCMTestsSupport {
 
     /**
      * Ensures that a custom payload is propagated throughout pages.
-     *
-     * @throws Exception
      */
     @Test(groups = "short")
     public void should_echo_custom_payload_when_paginating() throws Exception {
@@ -253,8 +245,6 @@ public class CustomPayloadTest extends CCMTestsSupport {
 
     /**
      * Ensures that when debugging custom payloads, the driver will print appropriate log messages.
-     *
-     * @throws Exception
      */
     @Test(groups = "short")
     public void should_print_log_message_when_level_trace() throws Exception {

--- a/driver-core/src/test/java/com/datastax/driver/core/CustomTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CustomTypeTest.java
@@ -19,7 +19,6 @@ import com.datastax.driver.core.utils.CassandraVersion;
 import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -153,7 +152,7 @@ public class CustomTypeTest extends CCMTestsSupport {
      * @test_category metadata
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_handle_udt_with_custom_type() {
         // Given: a UDT with custom types, and a table using it.
         session().execute("CREATE TYPE custom_udt (regular int, c1 'DynamicCompositeType(s => UTF8Type, i => Int32Type)', c2 'LongType')");

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeCqlNameParserTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeCqlNameParserTest.java
@@ -23,7 +23,7 @@ import static com.datastax.driver.core.DataType.*;
 import static com.datastax.driver.core.DataTypeCqlNameParser.parse;
 import static com.datastax.driver.core.Metadata.quote;
 
-@CassandraVersion(major = 3.0)
+@CassandraVersion("3.0")
 public class DataTypeCqlNameParserTest extends CCMTestsSupport {
 
     @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
@@ -36,7 +36,6 @@ import static org.assertj.core.api.Assertions.fail;
  * (protocol > v2 only) and a prepared statement.
  * This is repeated with a large number of datatypes.
  */
-@CCMConfig(clusterProvider = "createClusterBuilderNoDebouncing")
 public class DataTypeIntegrationTest extends CCMTestsSupport {
     private static final Logger logger = LoggerFactory.getLogger(DataTypeIntegrationTest.class);
 
@@ -71,7 +70,7 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
     }
 
     @Test(groups = "long")
-    @CassandraVersion(major = 2.0, description = "Uses parameterized simple statements, which are only available with protocol v2")
+    @CassandraVersion(value = "2.0", description = "Uses parameterized simple statements, which are only available with protocol v2")
     public void should_insert_and_retrieve_data_with_parameterized_simple_statements() {
         should_insert_and_retrieve_data(StatementType.SIMPLE_WITH_PARAM);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/DirectCompressionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DirectCompressionTest.java
@@ -40,7 +40,7 @@ public class DirectCompressionTest extends CompressionTest {
      * @expected_result session established and queries made successfully using it.
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_function_with_lz4_compression() throws Exception {
         compressionTest(ProtocolOptions.Compression.LZ4);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/DurationIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DurationIntegrationTest.java
@@ -23,7 +23,7 @@ import java.util.UUID;
 
 import static com.datastax.driver.core.Assertions.assertThat;
 
-@CassandraVersion(major = 3.10)
+@CassandraVersion("3.10")
 public class DurationIntegrationTest extends CCMTestsSupport {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/FunctionMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/FunctionMetadataTest.java
@@ -19,10 +19,11 @@ import com.datastax.driver.core.utils.CassandraVersion;
 import org.testng.annotations.Test;
 
 import static com.datastax.driver.core.Assertions.assertThat;
-import static com.datastax.driver.core.DataType.*;
+import static com.datastax.driver.core.DataType.cint;
+import static com.datastax.driver.core.DataType.map;
 import static org.assertj.core.api.Assertions.entry;
 
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 @CCMConfig(config = "enable_user_defined_functions:true")
 public class FunctionMetadataTest extends CCMTestsSupport {
 

--- a/driver-core/src/test/java/com/datastax/driver/core/HeapCompressionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HeapCompressionTest.java
@@ -47,7 +47,7 @@ public class HeapCompressionTest extends CompressionTest {
      * @expected_result session established and queries made successfully using it.
      */
     @Test(groups = "isolated")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_function_with_lz4_compression() throws Exception {
         compressionTest(ProtocolOptions.Compression.LZ4);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/HostMetadataIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostMetadataIntegrationTest.java
@@ -42,7 +42,7 @@ public class HostMetadataIntegrationTest {
      * @see HostMetadataIntegrationTest#should_parse_dse_workload_and_version_if_available()
      */
     @Test(groups = "long")
-    @DseVersion(major = 5.0)
+    @DseVersion("5.0.0")
     public void test_mixed_dse_workload() {
         CCMBridge.Builder builder = CCMBridge.builder()
                 .withNodes(3)

--- a/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
@@ -32,7 +32,7 @@ import static com.datastax.driver.core.ColumnMetadata.*;
 import static com.datastax.driver.core.DataType.*;
 import static com.datastax.driver.core.IndexMetadata.Kind.*;
 
-@CassandraVersion(major = 1.2)
+@CassandraVersion("1.2.0")
 public class IndexMetadataTest extends CCMTestsSupport {
 
     /**
@@ -103,7 +103,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1, description = "index names with quoted identifiers and collection indexes not supported until 2.1")
+    @CassandraVersion(value = "2.1", description = "index names with quoted identifiers and collection indexes not supported until 2.1")
     public void should_create_metadata_for_values_index_on_mixed_case_column() {
         // 3.0 assumes the 'values' keyword if index on a collection
         String createValuesIndex = ccm().getVersion().getMajor() > 2 ?
@@ -123,7 +123,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_create_metadata_for_index_on_map_values() {
         // 3.0 assumes the 'values' keyword if index on a collection
         String createValuesIndex = ccm().getVersion().getMajor() > 2 ?
@@ -143,7 +143,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_create_metadata_for_index_on_map_keys() {
         String createKeysIndex = String.format("CREATE INDEX map_keys_index ON %s.indexing (keys(map_keys));", keyspace);
         session().execute(createKeysIndex);
@@ -160,7 +160,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1, minor = 3)
+    @CassandraVersion("2.1.3")
     public void should_create_metadata_for_full_index_on_map() {
         String createFullIndex = String.format("CREATE INDEX map_full_index ON %s.indexing (full(map_full));", keyspace);
         session().execute(createFullIndex);
@@ -177,7 +177,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1, minor = 3)
+    @CassandraVersion("2.1.3")
     public void should_create_metadata_for_full_index_on_set() {
         String createFullIndex = String.format("CREATE INDEX set_full_index ON %s.indexing (full(set_full));", keyspace);
         session().execute(createFullIndex);
@@ -194,7 +194,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1, minor = 3)
+    @CassandraVersion("2.1.3")
     public void should_create_metadata_for_full_index_on_list() {
         String createFullIndex = String.format("CREATE INDEX list_full_index ON %s.indexing (full(list_full));", keyspace);
         session().execute(createFullIndex);
@@ -211,7 +211,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_create_metadata_for_index_on_map_entries() {
         String createEntriesIndex = String.format("CREATE INDEX map_entries_index ON %s.indexing (entries(map_entries));", keyspace);
         session().execute(createEntriesIndex);
@@ -228,7 +228,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 3.0)
+    @CassandraVersion("3.0")
     public void should_allow_multiple_indexes_on_map_column() {
         String createEntriesIndex = String.format("CREATE INDEX map_all_entries_index ON %s.indexing (entries(map_all));", keyspace);
         session().execute(createEntriesIndex);

--- a/driver-core/src/test/java/com/datastax/driver/core/LargeDataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LargeDataTest.java
@@ -180,11 +180,9 @@ public class LargeDataTest extends CCMTestsSupport {
 
     /**
      * Test a wide row of size 1,000,000
-     *
-     * @throws Throwable
      */
     @Test(groups = "stress")
-    @CassandraVersion(major = 2.0, minor = 0, description = "< 2.0 is skipped as 1.2 does not handle reading wide rows well.")
+    @CassandraVersion(value = "2.0.0", description = "< 2.0 is skipped as 1.2 does not handle reading wide rows well.")
     public void wideRows() throws Throwable {
         session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "large_data", 1));
         session().execute("USE large_data");
@@ -194,11 +192,9 @@ public class LargeDataTest extends CCMTestsSupport {
 
     /**
      * Test a batch that writes a row of size 4,000 (just below the error threshold for 2.2).
-     *
-     * @throws Throwable
      */
     @Test(groups = "stress")
-    @CassandraVersion(major = 2.0, minor = 0, description = "< 2.0 is skipped as 1.2 does not handle large batches well.")
+    @CassandraVersion(value = "2.0.0", description = "< 2.0 is skipped as 1.2 does not handle large batches well.")
     public void wideBatchRows() throws Throwable {
         session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "large_data", 1));
         session().execute("USE large_data");
@@ -208,8 +204,6 @@ public class LargeDataTest extends CCMTestsSupport {
 
     /**
      * Test a wide row of size 1,000,000 consisting of a ByteBuffer
-     *
-     * @throws Throwable
      */
     @Test(groups = "stress")
     public void wideByteRows() throws Throwable {
@@ -221,8 +215,6 @@ public class LargeDataTest extends CCMTestsSupport {
 
     /**
      * Test a row with a single extra large text value
-     *
-     * @throws Throwable
      */
     @Test(groups = "stress")
     public void largeText() throws Throwable {
@@ -234,8 +226,6 @@ public class LargeDataTest extends CCMTestsSupport {
 
     /**
      * Creates a table with 330 columns
-     *
-     * @throws Throwable
      */
     @Test(groups = "stress")
     public void wideTable() throws Throwable {
@@ -255,8 +245,6 @@ public class LargeDataTest extends CCMTestsSupport {
 
     /**
      * Tests 10 random tests consisting of the other methods in this class
-     *
-     * @throws Throwable
      */
     @Test(groups = "duration")
     @CCMConfig(numberOfNodes = 3)

--- a/driver-core/src/test/java/com/datastax/driver/core/MaterializedViewMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MaterializedViewMetadataTest.java
@@ -22,7 +22,7 @@ import static com.datastax.driver.core.Assertions.assertThat;
 import static com.datastax.driver.core.ClusteringOrder.DESC;
 import static com.datastax.driver.core.DataType.cint;
 
-@CassandraVersion(major = 3)
+@CassandraVersion("3.0")
 public class MaterializedViewMetadataTest extends CCMTestsSupport {
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/PagingStateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PagingStateTest.java
@@ -25,7 +25,7 @@ import java.util.Iterator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.0)
+@CassandraVersion("2.0.0")
 public class PagingStateTest extends CCMTestsSupport {
 
     private static final Logger logger = LoggerFactory.getLogger(PagingStateTest.class);
@@ -141,7 +141,7 @@ public class PagingStateTest extends CCMTestsSupport {
      * from the first query.
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_be_able_to_use_state_with_bound_statement() {
         PreparedStatement prepared = session().prepare("SELECT v from test where k=?");
         BoundStatement bs = prepared.bind(KEY);
@@ -164,7 +164,7 @@ public class PagingStateTest extends CCMTestsSupport {
      * @expected_result A failure is thrown when setting paging state on a different {@link BoundStatement}.
      */
     @Test(groups = "short", expectedExceptions = {PagingStateException.class})
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_not_be_able_to_use_state_with_different_bound_statement() {
         PreparedStatement prepared = session().prepare("SELECT v from test where k=?");
         BoundStatement bs0 = prepared.bind(KEY);

--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
@@ -464,7 +464,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
      * @since 2.2.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_not_allow_unbound_value_on_batch_statement_when_protocol_lesser_than_v4() {
         Cluster cluster = register(Cluster.builder()
                 .addContactPoints(getContactPoints())
@@ -494,7 +494,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
      * @since 2.2.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_not_create_tombstone_when_unbound_value_on_bound_statement_and_protocol_v4() {
         PreparedStatement prepared = session().prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (?, ?)");
         BoundStatement st1 = prepared.bind();
@@ -524,7 +524,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
      * @since 2.2.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_unset_value_by_index() {
         PreparedStatement prepared = session().prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (?, ?)");
         BoundStatement bound = prepared.bind();
@@ -555,7 +555,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
      * @since 2.2.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_unset_value_by_name() {
         PreparedStatement prepared = session().prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (:k, :i)");
         BoundStatement bound = prepared.bind();
@@ -587,7 +587,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
      * @since 2.2.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_not_create_tombstone_when_unbound_value_on_batch_statement_and_protocol_v4() {
         PreparedStatement prepared = session().prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (?, ?)");
         BoundStatement st1 = prepared.bind();
@@ -640,7 +640,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
      * @since 2.2.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_create_tombstone_when_null_value_on_batch_statement() {
         PreparedStatement prepared = session().prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (?, ?)");
         BoundStatement st1 = prepared.bind();

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
@@ -171,7 +171,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_batch_statements() throws Exception {
         // given
         normal.setLevel(DEBUG);
@@ -202,7 +202,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_unlogged_batch_statements() throws Exception {
         // given
         normal.setLevel(DEBUG);
@@ -233,7 +233,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_counter_batch_statements() throws Exception {
         // Create a special table for testing with counters.
         session().execute(
@@ -376,7 +376,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     // Tests with query parameters (log level TRACE)
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_non_null_named_parameter_bound_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -426,7 +426,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_non_null_positional_parameter_simple_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -470,7 +470,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_null_parameter_simple_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -491,7 +491,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 3.0)
+    @CassandraVersion("3.0")
     public void should_log_unset_parameter() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -514,7 +514,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_bound_statement_parameters_inside_batch_statement() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -541,7 +541,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_simple_statement_parameters_inside_batch_statement() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -596,7 +596,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_all_parameter_types_simple_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -648,7 +648,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
                 .doesNotContain(query);
     }
 
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     @Test(groups = "short")
     public void should_show_total_statements_for_batches_even_if_query_truncated() throws Exception {
         // given
@@ -695,7 +695,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
                 .doesNotContain(TRUNCATED_OUTPUT);
     }
 
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     @Test(groups = "short")
     public void should_truncate_parameter_when_max_length_exceeded_bound_statements() throws Exception {
         // given
@@ -720,7 +720,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
                 .doesNotContain("123456");
     }
 
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     @Test(groups = "short")
     public void should_truncate_parameter_when_max_length_exceeded_simple_statements() throws Exception {
         // given
@@ -767,7 +767,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_truncate_blob_parameter_when_max_length_exceeded_simple_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -813,7 +813,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_not_truncate_parameter_when_max_length_unlimited_simple_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -860,7 +860,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_not_log_exceeding_number_of_parameters_simple_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -883,7 +883,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_not_log_exceeding_number_of_parameters_simple_statements_with_named_values() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -909,7 +909,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_not_log_exceeding_number_of_parameters_in_batch_statement_bound_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -939,7 +939,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_not_log_exceeding_number_of_parameters_in_batch_statement_simple_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -991,7 +991,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_all_parameters_when_max_unlimited_simple_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -1013,7 +1013,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_log_all_parameters_when_max_unlimited_simple_statements_with_named_values() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -1037,7 +1037,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
                 .contains("42");
     }
 
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     @Test(groups = "short")
     public void should_log_wrapped_bound_statement() throws Exception {
         // given

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryTimestampTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryTimestampTest.java
@@ -27,7 +27,7 @@ import static org.testng.Assert.assertTrue;
 /**
  * Tests the behavior of client-provided timestamps with protocol v3.
  */
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class QueryTimestampTest extends CCMTestsSupport {
 
     private volatile long timestampFromGenerator;

--- a/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
@@ -145,7 +145,7 @@ public class RecommissionedNodeTest {
     }
 
     @Test(groups = "long")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_ignore_node_that_does_not_support_protocol_version_on_session_init() throws Exception {
         // Simulate the bug before starting the cluster
         mainCcmBuilder = CCMBridge.builder().withNodes(2);

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
@@ -209,7 +209,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
 
     @SuppressWarnings("RedundantCast")
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_notify_of_udt_creation(String keyspace) {
         session1.execute(String.format("CREATE TYPE %s.type1(i int)", keyspace));
         for (SchemaChangeListener listener : listeners) {
@@ -223,7 +223,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_notify_of_udt_update(String keyspace) {
         session1.execute(String.format("CREATE TYPE %s.type1(i int)", keyspace));
         session1.execute(String.format("ALTER TYPE %s.type1 ADD j int", keyspace));
@@ -240,7 +240,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
 
     @SuppressWarnings("RedundantCast")
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_notify_of_udt_drop(String keyspace) {
         session1.execute(String.format("CREATE TYPE %s.type1(i int)", keyspace));
         session1.execute(String.format("DROP TYPE %s.type1", keyspace));
@@ -254,7 +254,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_notify_of_function_creation(String keyspace) {
         session1.execute(String.format("CREATE FUNCTION %s.\"ID\"(i int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return i;'", keyspace));
         for (SchemaChangeListener listener : listeners) {
@@ -270,7 +270,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_notify_of_function_update(String keyspace) {
         session1.execute(String.format("CREATE FUNCTION %s.\"ID\"(i int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return i;'", keyspace));
         for (SchemaChangeListener listener : listeners) {
@@ -297,7 +297,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_notify_of_function_drop(String keyspace) {
         session1.execute(String.format("CREATE FUNCTION %s.\"ID\"(i int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return i;'", keyspace));
         session1.execute(String.format("DROP FUNCTION %s.\"ID\"", keyspace));
@@ -314,7 +314,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_notify_of_aggregate_creation(String keyspace) {
         session1.execute(String.format("CREATE FUNCTION %s.\"PLUS\"(s int, v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java"
                 + " AS 'return s+v;'", keyspace));
@@ -332,7 +332,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_notify_of_aggregate_update(String keyspace) {
         session1.execute(String.format("CREATE FUNCTION %s.\"PLUS\"(s int, v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java"
                 + " AS 'return s+v;'", keyspace));
@@ -361,7 +361,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_notify_of_aggregate_drop(String keyspace) {
         session1.execute(String.format("CREATE FUNCTION %s.\"PLUS\"(s int, v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java"
                 + " AS 'return s+v;'", keyspace));
@@ -380,7 +380,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 3.0)
+    @CassandraVersion("3.0")
     public void should_notify_of_view_creation(String keyspace) {
         session1.execute(String.format("CREATE TABLE %s.table1 (pk int PRIMARY KEY, c int)", keyspace));
         session1.execute(String.format("CREATE MATERIALIZED VIEW %s.mv1 AS SELECT c FROM %s.table1 WHERE c IS NOT NULL PRIMARY KEY (pk, c)", keyspace, keyspace));
@@ -395,7 +395,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 3.0)
+    @CassandraVersion("3.0")
     public void should_notify_of_view_update(String keyspace) {
         session1.execute(String.format("CREATE TABLE %s.table1 (pk int PRIMARY KEY, c int)", keyspace));
         session1.execute(String.format("CREATE MATERIALIZED VIEW %s.mv1 AS SELECT c FROM %s.table1 WHERE c IS NOT NULL PRIMARY KEY (pk, c) WITH compaction = { 'class' : 'SizeTieredCompactionStrategy' }", keyspace, keyspace));
@@ -424,7 +424,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 3.0)
+    @CassandraVersion("3.0")
     public void should_notify_of_view_drop(String keyspace) {
         session1.execute(String.format("CREATE TABLE %s.table1 (pk int PRIMARY KEY, c int)", keyspace));
         session1.execute(String.format("CREATE MATERIALIZED VIEW %s.mv1 AS SELECT c FROM %s.table1 WHERE c IS NOT NULL PRIMARY KEY (pk, c)", keyspace, keyspace));

--- a/driver-core/src/test/java/com/datastax/driver/core/SimpleStatementIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SimpleStatementIntegrationTest.java
@@ -35,7 +35,7 @@ public class SimpleStatementIntegrationTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_execute_query_with_named_values() {
         // Given
         SimpleStatement statement = new SimpleStatement("SELECT * FROM users WHERE id = :id and id2 = :id2",
@@ -50,7 +50,7 @@ public class SimpleStatementIntegrationTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", expectedExceptions = InvalidQueryException.class)
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_fail_if_query_with_named_values_but_missing_parameter() {
         // Given a Statement missing named parameters.
         SimpleStatement statement = new SimpleStatement("SELECT * FROM users WHERE id = :id and id2 = :id2",
@@ -64,7 +64,7 @@ public class SimpleStatementIntegrationTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", expectedExceptions = InvalidQueryException.class)
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_fail_if_query_with_named_values_but_using_wrong_type() {
         // Given a Statement using a named parameter with the wrong value for the type (id is of type int, using double)
         SimpleStatement statement = new SimpleStatement("SELECT * FROM users WHERE id = :id and id2 = :id2",
@@ -98,7 +98,7 @@ public class SimpleStatementIntegrationTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", expectedExceptions = UnsupportedFeatureException.class)
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_fail_if_query_with_named_values_if_protocol_is_V2() {
         if (ccm().getVersion().getMajor() >= 3) {
             throw new SkipException("Skipping since Cassandra 3.0+ does not support protocol v2");
@@ -107,7 +107,7 @@ public class SimpleStatementIntegrationTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", expectedExceptions = UnsupportedFeatureException.class)
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_fail_if_query_with_named_values_if_protocol_is_V1() {
         if (ccm().getVersion().getMajor() >= 3) {
             throw new SkipException("Skipping since Cassandra 3.0+ does not support protocol v1");

--- a/driver-core/src/test/java/com/datastax/driver/core/SingleConnectionPoolTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SingleConnectionPoolTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.testng.Assert.fail;
 
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class SingleConnectionPoolTest extends CCMTestsSupport {
 
     @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/SpeculativeExecutionIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SpeculativeExecutionIntegrationTest.java
@@ -53,7 +53,7 @@ public class SpeculativeExecutionIntegrationTest extends CCMTestsSupport {
      * @expected_result timestamp generator invoked only once for a query that caused two executions.
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_use_same_default_timestamp_for_all_executions() {
         Metrics.Errors errors = cluster().getMetrics().getErrorMetrics();
 

--- a/driver-core/src/test/java/com/datastax/driver/core/StatementWrapperTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StatementWrapperTest.java
@@ -87,7 +87,7 @@ public class StatementWrapperTest extends CCMTestsSupport {
         assertThat(retryPolicy.customStatementsHandled.get()).isEqualTo(1);
     }
 
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     @Test(groups = "short")
     public void should_execute_wrapped_simple_statement() {
         session().execute(new CustomStatement(new SimpleStatement(INSERT_QUERY, "key_simple", 1)));
@@ -106,7 +106,7 @@ public class StatementWrapperTest extends CCMTestsSupport {
         assertThat(rs.one().getInt("v")).isEqualTo(1);
     }
 
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     @Test(groups = "short")
     public void should_execute_wrapped_batch_statement() {
         BatchStatement batchStatement = new BatchStatement();
@@ -118,7 +118,7 @@ public class StatementWrapperTest extends CCMTestsSupport {
         assertThat(rs.one().getInt("v")).isEqualTo(1);
     }
 
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     @Test(groups = "short")
     public void should_add_wrapped_batch_statement_to_batch_statement() {
         BatchStatement batchStatementForWrapping = new BatchStatement();

--- a/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
@@ -407,7 +407,7 @@ public class TableMetadataTest extends CCMTestsSupport {
      * @jira_ticket CASSANDRA-9424
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 3.0)
+    @CassandraVersion("3.0")
     public void should_parse_new_compression_options() {
         // given
         String cql = String.format("CREATE TABLE %s.new_compression_options (\n"
@@ -475,7 +475,7 @@ public class TableMetadataTest extends CCMTestsSupport {
      * @test_category metadata
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 3.0)
+    @CassandraVersion("3.0")
     public void should_parse_extensions_from_table_options() throws Exception {
         // given
         // create a simple table and retrieve it's metadata from system_schema.tables.

--- a/driver-core/src/test/java/com/datastax/driver/core/TestListener.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestListener.java
@@ -20,6 +20,7 @@ import com.datastax.driver.core.utils.DseVersion;
 import org.testng.*;
 import org.testng.internal.ConstructorOrMethod;
 
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 
@@ -87,27 +88,29 @@ public class TestListener extends TestListenerAdapter implements IInvokedMethodL
 
         Class<?> clazz = testNgMethod.getInstance().getClass();
         if (clazz != null) {
-            if (clazz.isAnnotationPresent(CassandraVersion.class)) {
-                CassandraVersion cassandraVersion = clazz.getAnnotation(CassandraVersion.class);
-                cassandraVersionCheck(cassandraVersion);
-            }
-            if (clazz.isAnnotationPresent(DseVersion.class)) {
-                DseVersion dseVersion = clazz.getAnnotation(DseVersion.class);
-                dseVersionCheck(dseVersion);
-            }
+            do {
+                if (scanAnnotatedElement(clazz))
+                    break;
+            } while (!(clazz = clazz.getSuperclass()).equals(Object.class));
         }
-
         Method method = constructorOrMethod.getMethod();
         if (method != null) {
-            if (method.isAnnotationPresent(CassandraVersion.class)) {
-                CassandraVersion cassandraVersion = method.getAnnotation(CassandraVersion.class);
-                cassandraVersionCheck(cassandraVersion);
-            }
-            if (method.isAnnotationPresent(DseVersion.class)) {
-                DseVersion dseVersion = method.getAnnotation(DseVersion.class);
-                dseVersionCheck(dseVersion);
-            }
+            scanAnnotatedElement(method);
         }
+    }
+
+    private boolean scanAnnotatedElement(AnnotatedElement element) {
+        if (element.isAnnotationPresent(CassandraVersion.class)) {
+            CassandraVersion cassandraVersion = element.getAnnotation(CassandraVersion.class);
+            cassandraVersionCheck(cassandraVersion);
+            return true;
+        }
+        if (element.isAnnotationPresent(DseVersion.class)) {
+            DseVersion dseVersion = element.getAnnotation(DseVersion.class);
+            dseVersionCheck(dseVersion);
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -116,29 +119,25 @@ public class TestListener extends TestListenerAdapter implements IInvokedMethodL
     }
 
     private static void cassandraVersionCheck(CassandraVersion version) {
-        versionCheck(CCMBridge.getCassandraVersion(), version.major(), version.minor(), version.description());
+        versionCheck(CCMBridge.getCassandraVersionNumber(), VersionNumber.parse(version.value()), version.description());
     }
 
     private static void dseVersionCheck(DseVersion version) {
         if (CCMBridge.isDSE()) {
-            versionCheck(CCMBridge.getDSEVersion(), version.major(), version.minor(), version.description());
+            versionCheck(CCMBridge.getDSEVersionNumber(), VersionNumber.parse(version.value()), version.description());
         } else {
             throw new SkipException("Skipping test because not configured for DataStax Enterprise cluster.");
         }
     }
 
-    private static void versionCheck(String version, double majorCheck, int minorCheck, String skipString) {
-        if (version == null) {
+    private static void versionCheck(VersionNumber current, VersionNumber required, String skipString) {
+        if (current == null) {
             throw new SkipException("Skipping test because provided version is null");
         } else {
-            String[] versionArray = version.split("\\.|-");
-            double major = Double.parseDouble(versionArray[0] + "." + versionArray[1]);
-            // If there is no minor version, assume latest version of whatever was provided.
-            int minor = versionArray.length >= 3 ? Integer.parseInt(versionArray[2]) : Integer.MAX_VALUE;
-
-            if (major < majorCheck || (major == majorCheck && minor < minorCheck)) {
-                throw new SkipException("Version >= " + majorCheck + "." + minorCheck + " required.  " +
-                        "Description: " + skipString);
+            if (current.compareTo(required) < 0) {
+                throw new SkipException(
+                        String.format("Version >= %s required, but found %s. Justification: %s",
+                                required, current, skipString));
             }
         }
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
@@ -191,7 +191,7 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
      * </ol>
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2)
+    @CassandraVersion("2.0")
     public void should_get_token_from_row_and_set_token_in_query_with_binding_and_aliasing() {
         Row row = session().execute("SELECT token(i) AS t FROM foo WHERE i = 1").one();
         Token token = row.getToken("t");

--- a/driver-core/src/test/java/com/datastax/driver/core/TracingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TracingTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.0)
+@CassandraVersion("2.0.0")
 public class TracingTest extends CCMTestsSupport {
 
     private static final String KEY = "tracing_test";

--- a/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class TupleTest extends CCMTestsSupport {
 
     ProtocolVersion protocolVersion = TestUtils.getDesiredProtocolVersion();

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecCollectionsIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecCollectionsIntegrationTest.java
@@ -33,7 +33,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.0)
+@CassandraVersion("2.0.0")
 public class TypeCodecCollectionsIntegrationTest extends CCMTestsSupport {
 
     private final String insertQuery = "INSERT INTO \"myTable2\" (c_int, l_int, l_bigint, s_float, s_double, m_varint, m_decimal) VALUES (?, ?, ?, ?, ?, ?, ?)";

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecEncapsulationIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecEncapsulationIntegrationTest.java
@@ -102,7 +102,7 @@ public class TypeCodecEncapsulationIntegrationTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_use_custom_codecs_with_simple_statements() {
         session().execute(insertQuery,
                 n_int,

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNestedCollectionsIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNestedCollectionsIntegrationTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Validates that nested collections are properly encoded,
  * even if some inner type requires a custom codec.
  */
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class TypeCodecNestedCollectionsIntegrationTest extends CCMTestsSupport {
 
     private final String insertQuery = "INSERT INTO \"myTable\" (pk, v) VALUES (?, ?)";

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNestedUDTAndTupleIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNestedUDTAndTupleIntegrationTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @jira_ticket JAVA-847
  */
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class TypeCodecNestedUDTAndTupleIntegrationTest extends CCMTestsSupport {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNumbersIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNumbersIntegrationTest.java
@@ -52,7 +52,7 @@ public class TypeCodecNumbersIntegrationTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_use_defaut_codecs_with_simple_statements() {
         session().execute(insertQuery, n_int, n_bigint, n_float, n_double, n_varint, n_decimal);
         ResultSet rows = session().execute(selectQuery, n_int, n_bigint);

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTupleIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTupleIntegrationTest.java
@@ -23,7 +23,7 @@ import java.util.UUID;
 import static com.datastax.driver.core.DataType.cfloat;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class TypeCodecTupleIntegrationTest extends CCMTestsSupport {
 
     private final String insertQuery = "INSERT INTO users (id, name, location) VALUES (?, ?, ?)";

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecUDTIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecUDTIntegrationTest.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class TypeCodecUDTIntegrationTest extends CCMTestsSupport {
 
     private final String insertQuery = "INSERT INTO users (id, name, address) VALUES (?, ?, ?)";

--- a/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ExecutionException;
 import static com.datastax.driver.core.Assertions.assertThat;
 import static com.datastax.driver.core.DataType.*;
 
-@CassandraVersion(major = 3.0)
+@CassandraVersion("3.0")
 public class UnresolvedUserTypeTest extends CCMTestsSupport {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
@@ -36,7 +36,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class UserTypesTest extends CCMTestsSupport {
 
     private final static List<DataType> DATA_TYPE_PRIMITIVES = new ArrayList<DataType>(DataType.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion()));

--- a/driver-core/src/test/java/com/datastax/driver/core/WarningsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/WarningsTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @CCMConfig(config = {"batch_size_warn_threshold_in_kb:5"})
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 public class WarningsTest extends CCMTestsSupport {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/exceptions/FunctionExecutionExceptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/exceptions/FunctionExecutionExceptionTest.java
@@ -20,7 +20,7 @@ import com.datastax.driver.core.CCMTestsSupport;
 import com.datastax.driver.core.utils.CassandraVersion;
 import org.testng.annotations.Test;
 
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 @CCMConfig(config = "enable_user_defined_functions:true")
 public class FunctionExecutionExceptionTest extends CCMTestsSupport {
 

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilder21ExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilder21ExecutionTest.java
@@ -25,7 +25,7 @@ import org.testng.annotations.Test;
 import static com.datastax.driver.core.Assertions.assertThat;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class QueryBuilder21ExecutionTest extends CCMTestsSupport {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
@@ -213,7 +213,7 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
      * @since 3.0.1
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 3.2)
+    @CassandraVersion("3.2")
     public void should_support_cast_function_on_column() {
         //when
         ResultSet r = session().execute(select().cast("f", DataType.cint()).as("fint").column("i").from(TABLE2).where(eq("k", "cast_t")));
@@ -256,7 +256,7 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
      * @since 3.0.1
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 3.2)
+    @CassandraVersion("3.2")
     public void should_support_fcall_on_cast_column() {
         //when
         ResultSet ar = session().execute(select().fcall("avg", cast(column("i"), DataType.cfloat())).as("iavg").from(TABLE2).where(eq("k", "cast_t")));
@@ -281,7 +281,7 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
      * @since 3.0.1
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 3.6)
+    @CassandraVersion("3.6")
     public void should_retrieve_using_like_operator_on_table_with_sasi_index() {
         //given
         String table = "s_table";
@@ -320,7 +320,7 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
      * @jira_ticket JAVA-1153
      * @since 3.1.0
      */
-    @CassandraVersion(major = 3.6, description = "Support for PER PARTITION LIMIT was added to C* 3.6 (CASSANDRA-7017)")
+    @CassandraVersion(value = "3.6", description = "Support for PER PARTITION LIMIT was added to C* 3.6 (CASSANDRA-7017)")
     @Test(groups = "short")
     public void should_support_per_partition_limit() throws Exception {
         assertThat(session().execute(select().all().from("test_ppl").perPartitionLimit(2)))

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
@@ -72,7 +72,7 @@ public class QueryBuilderITest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0, minor = 7, description = "DELETE..IF EXISTS only supported in 2.0.7+ (CASSANDRA-5708)")
+    @CassandraVersion(value = "2.0.7", description = "DELETE..IF EXISTS only supported in 2.0.7+ (CASSANDRA-5708)")
     public void conditionalDeletesTest() throws Exception {
         session().execute(String.format("INSERT INTO %s.test_int (k, a, b) VALUES (1, 1, 1)", keyspace));
 
@@ -98,7 +98,7 @@ public class QueryBuilderITest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0, minor = 13, description = "Allow IF EXISTS for UPDATE statements (CASSANDRA-8610)")
+    @CassandraVersion(value = "2.0.13", description = "Allow IF EXISTS for UPDATE statements (CASSANDRA-8610)")
     public void conditionalUpdatesTest() throws Exception {
         session().execute(String.format("INSERT INTO %s.test_int (k, a, b) VALUES (1, 1, 1)", keyspace));
 

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTupleExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTupleExecutionTest.java
@@ -29,7 +29,7 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
-@CassandraVersion(major = 2.1, minor = 3)
+@CassandraVersion("2.1.3")
 public class QueryBuilderTupleExecutionTest extends CCMTestsSupport {
 
     @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderUDTExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderUDTExecutionTest.java
@@ -29,7 +29,7 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
-@CassandraVersion(major = 2.1, minor = 3)
+@CassandraVersion("2.1.3")
 public class QueryBuilderUDTExecutionTest extends CCMTestsSupport {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/SchemaBuilderIT.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/SchemaBuilderIT.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.fail;
 public class SchemaBuilderIT extends CCMTestsSupport {
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1, minor = 2)
+    @CassandraVersion("2.1.2")
     public void should_modify_table_metadata() {
         // Create a table
         session().execute(SchemaBuilder.createTable("ks", "TableMetadata")
@@ -128,7 +128,7 @@ public class SchemaBuilderIT extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_create_a_table_and_a_udt() {
         // Create a UDT and a table
         session().execute(SchemaBuilder.createType("MyUDT")

--- a/driver-core/src/test/java/com/datastax/driver/core/utils/CassandraVersion.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/utils/CassandraVersion.java
@@ -22,19 +22,15 @@ import java.lang.annotation.RetentionPolicy;
  * <p>Annotation for a Class or Method that defines a Cassandra Version requirement.  If the cassandra version in use
  * does not meet the version requirement, the test is skipped.</p>
  *
- * @see {@link com.datastax.driver.core.TestListener#beforeInvocation(org.testng.IInvokedMethod, org.testng.ITestResult)} for usage.
+ * @see com.datastax.driver.core.TestListener#beforeInvocation(org.testng.IInvokedMethod, org.testng.ITestResult)
  */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CassandraVersion {
-    /**
-     * @return The major version required to execute this test, i.e. "2.0"
-     */
-    double major();
 
     /**
-     * @return The minor version required to execute this test, i.e. "0"
+     * @return The minimum version required to execute this test, i.e. "2.0.13"
      */
-    int minor() default 0;
+    String value();
 
     /**
      * @return The description returned if this version requirement is not met.

--- a/driver-core/src/test/java/com/datastax/driver/core/utils/DseVersion.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/utils/DseVersion.java
@@ -22,19 +22,15 @@ import java.lang.annotation.RetentionPolicy;
  * <p>Annotation for a Class or Method that defines a DataStax Enterprise Version requirement.
  * If the version in use does not meet the version requirement or DSE is not used, the test is skipped.</p>
  *
- * @see {@link com.datastax.driver.core.TestListener#beforeInvocation(org.testng.IInvokedMethod, org.testng.ITestResult)} for usage.
+ * @see com.datastax.driver.core.TestListener#beforeInvocation(org.testng.IInvokedMethod, org.testng.ITestResult)
  */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DseVersion {
-    /**
-     * @return The major version required to execute this test, i.e. "4.8"
-     */
-    double major() default 0.0;
 
     /**
-     * @return The minor version required to execute this test, i.e. "3"
+     * @return The minimum version required to execute this test, i.e. "2.0.13"
      */
-    int minor() default 0;
+    String value();
 
     /**
      * @return The description returned if this version requirement is not met.

--- a/driver-core/src/test/resources/log4j.properties
+++ b/driver-core/src/test/resources/log4j.properties
@@ -20,6 +20,7 @@ log4j.rootLogger=INFO, A1
 # Adjust Scassandra's log level
 # (it seems some messages are conditioned by log4j.properties and others by reference.conf, so we need both)
 log4j.logger.org.scassandra=ERROR
+log4j.logger.spray.can=ERROR
 # Useful loggers when debugging Scassandra tests
 #log4j.logger.org.scassandra.cql=ERROR
 #log4j.logger.org.scassandra.server.cqlmessages=ERROR

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/date/SimpleDateCodecsTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/date/SimpleDateCodecsTest.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 public class SimpleDateCodecsTest extends CCMTestsSupport {
 
     @Override

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/enums/EnumCodecsTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/enums/EnumCodecsTest.java
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * and ints (with EnumOrdinalCodec).
  * It also validates that both codecs may coexist in the same CodecRegistry.
  */
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class EnumCodecsTest extends CCMTestsSupport {
 
     private final String insertQuery = "INSERT INTO t1 (pk, foo, foos, bar, bars, foobars, tup, udt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/guava/OptionalCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/guava/OptionalCodecTest.java
@@ -69,7 +69,7 @@ public class OptionalCodecTest extends CCMTestsSupport {
      * @since 2.2.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_map_unset_value_to_absent() {
         PreparedStatement insertPrep = session().prepare(this.insertStmt);
         PreparedStatement selectPrep = session().prepare(this.selectStmt);

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/jdk8/Jdk8TimeCodecsTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/jdk8/Jdk8TimeCodecsTest.java
@@ -41,7 +41,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 public class Jdk8TimeCodecsTest extends CCMTestsSupport {
 
     @Override

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/jdk8/OptionalCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/jdk8/OptionalCodecTest.java
@@ -69,7 +69,7 @@ public class OptionalCodecTest extends CCMTestsSupport {
      * @since 2.2.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_map_unset_value_to_empty() {
         PreparedStatement insertPrep = session().prepare(this.insertStmt);
         PreparedStatement selectPrep = session().prepare(this.selectStmt);

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/joda/JodaTimeCodecsTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/joda/JodaTimeCodecsTest.java
@@ -42,7 +42,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 public class JodaTimeCodecsTest extends CCMTestsSupport {
 
     @Override

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/JacksonJsonCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/JacksonJsonCodecTest.java
@@ -81,7 +81,7 @@ public class JacksonJsonCodecTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_use_custom_codec_with_simple_statements() {
         session().execute(insertQuery, notAJsonString, alice, bobAndCharlie);
         ResultSet rows = session().execute(selectQuery, notAJsonString, alice);

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/Jsr353JsonCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/Jsr353JsonCodecTest.java
@@ -99,7 +99,7 @@ public class Jsr353JsonCodecTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "Jsr353JsonCodecTest")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_use_custom_codec_with_simple_statements(JsonStructure object) throws IOException {
         session().execute(insertQuery, notAJsonString, object);
         ResultSet rows = session().execute(selectQuery, notAJsonString, object);
@@ -184,7 +184,7 @@ public class Jsr353JsonCodecTest extends CCMTestsSupport {
      * @since 3.1.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_support_select_json_output() throws Exception {
         // when
         ResultSet r = session().execute(select().json().from(TABLE1).where(eq("k", "key0")));
@@ -234,7 +234,7 @@ public class Jsr353JsonCodecTest extends CCMTestsSupport {
      * @since 3.1.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_support_insert_json() throws Exception {
         // when
         String key = "should_support_insert_json_with_codec_format";
@@ -262,7 +262,7 @@ public class Jsr353JsonCodecTest extends CCMTestsSupport {
      * @since 3.1.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_support_fromJson_and_toJson() throws Exception {
         String key = "should_support_fromJson_and_toJson";
         JsonObject inputAddr = Json.createObjectBuilder()

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorParamsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorParamsTest.java
@@ -41,7 +41,7 @@ public class MapperAccessorParamsTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0, description = "Uses named parameters")
+    @CassandraVersion(value = "2.0", description = "Uses named parameters")
     public void should_allow_less_parameters_than_bind_markers_if_there_are_repeated_names() {
         UserPhoneAccessor accessor = new MappingManager(session())
                 .createAccessor(UserPhoneAccessor.class);

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorTest.java
@@ -52,7 +52,7 @@ public class MapperAccessorTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_allow_null_argument_in_accessor_when_set_by_name() {
         FooAccessor accessor = new MappingManager(session())
                 .createAccessor(FooAccessor.class);

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAsyncResultTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAsyncResultTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @jira_ticket JAVA-1157
  */
 @SuppressWarnings("unused")
-@CassandraVersion(major = 2.0, description = "uses paging")
+@CassandraVersion(value = "2.0", description = "uses paging")
 public class MapperAsyncResultTest extends CCMTestsSupport {
 
     @Override

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperCaseSensitivityTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperCaseSensitivityTest.java
@@ -27,7 +27,7 @@ import static com.datastax.driver.core.Metadata.quote;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @CCMConfig(createKeyspace = false)
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class MapperCaseSensitivityTest extends CCMTestsSupport {
 
     static final String KS = "ks_MapperCaseSensitivityTest";

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperComputedFieldsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperComputedFieldsTest.java
@@ -61,7 +61,7 @@ public class MapperComputedFieldsTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_save_and_get_entity_with_computed_fields() {
         long writeTime = System.currentTimeMillis() * 1000;
         User newUser = new User("testlogin2", "blah");
@@ -87,7 +87,7 @@ public class MapperComputedFieldsTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_add_aliases_for_fields_in_select_queries() {
         BoundStatement bs = (BoundStatement) userMapper.getQuery("test");
         assertThat(bs.preparedStatement().getQueryString())
@@ -95,7 +95,7 @@ public class MapperComputedFieldsTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_map_aliased_resultset_to_objects() {
         Statement getQuery = userMapper.getQuery("testlogin");
         getQuery.setConsistencyLevel(ConsistencyLevel.QUORUM);
@@ -108,7 +108,7 @@ public class MapperComputedFieldsTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_map_unaliased_resultset_to_objects() {
         UserAccessor userAccessor = mappingManager.createAccessor(UserAccessor.class);
         ResultSet rs = userAccessor.all();
@@ -120,7 +120,7 @@ public class MapperComputedFieldsTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", expectedExceptions = CodecNotFoundException.class)
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_fail_if_computed_field_is_not_right_type() {
         Mapper<User_WrongComputedType> mapper = mappingManager.mapper(User_WrongComputedType.class);
 
@@ -128,7 +128,7 @@ public class MapperComputedFieldsTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", expectedExceptions = IllegalArgumentException.class)
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_fail_if_computed_field_marked_with_column_annotation() {
         mappingManager.mapper(User_WrongAnnotationForComputed.class);
     }

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperCustomCodecTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperCustomCodecTest.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 @SuppressWarnings("unused")
 public class MapperCustomCodecTest extends CCMTestsSupport {
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperDefaultKeyspaceTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperDefaultKeyspaceTest.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.assertNull;
 /**
  * Tests usage of mapping annotations without specifying a keyspace.
  */
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 @SuppressWarnings("unused")
 public class MapperDefaultKeyspaceTest extends CCMTestsSupport {
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperMaterializedViewTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperMaterializedViewTest.java
@@ -26,7 +26,7 @@ import java.util.Iterator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("unused")
-@CassandraVersion(major = 3.0)
+@CassandraVersion("3.0")
 public class MapperMaterializedViewTest extends CCMTestsSupport {
 
     @Override

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperNestedCollectionsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperNestedCollectionsTest.java
@@ -31,7 +31,7 @@ import java.util.Set;
 
 import static com.datastax.driver.core.Assertions.assertThat;
 
-@CassandraVersion(major = 2.1, minor = 3)
+@CassandraVersion("2.1.3")
 @SuppressWarnings("unused")
 public class MapperNestedCollectionsTest extends CCMTestsSupport {
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperNestedUDTTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperNestedUDTTest.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings({"unused"})
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class MapperNestedUDTTest extends CCMTestsSupport {
 
     @Override

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperOptionTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperOptionTest.java
@@ -51,7 +51,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_save_options() throws Exception {
         Long tsValue = futureTimestamp();
         mapper.save(new User(42, "helloworld"), Option.timestamp(tsValue), Option.tracing(true));
@@ -61,7 +61,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_delete_options() {
         User todelete = new User(45, "todelete");
         mapper.save(todelete);
@@ -72,7 +72,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", expectedExceptions = {IllegalArgumentException.class})
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_get_options() {
         User user = new User(45, "toget");
         mapper.save(user);
@@ -90,7 +90,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_options_only_once() {
         Long tsValue = futureTimestamp();
         mapper.save(new User(43, "helloworld"), Option.timestamp(tsValue));
@@ -101,7 +101,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_default_options() {
         mapper.setDefaultSaveOptions(Option.timestamp(644746L), Option.ttl(76324));
         BoundStatement bs = (BoundStatement) mapper.saveQuery(new User(46, "rjhrgce"));
@@ -134,7 +134,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_prioritize_option_over_model_consistency() {
         // Generate Write Query and ensure User model writeConsistency is used.
         User user = new User(1859, "Steve");
@@ -155,7 +155,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_explicit_options_over_default_options() {
         long defaultTimestamp = futureTimestamp();
         long explicitTimestamp = futureTimestamp();
@@ -171,7 +171,7 @@ public class MapperOptionTest extends CCMTestsSupport {
      * Cover all versions of save() to check that methods that call each other properly propagate the options
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_save_options_for_all_variants() throws ExecutionException, InterruptedException {
         Long timestamp = futureTimestamp();
         User user = new User(42, "helloworld");
@@ -210,7 +210,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_get_options_for_all_variants() throws InterruptedException {
         try {
             mapper.get(42, Option.consistencyLevel(TWO));
@@ -251,7 +251,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_delete_options_for_all_variants() throws InterruptedException {
         User user = new User(42, "helloworld");
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperPolymorphismTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperPolymorphismTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * JAVA-636 Allow @Column annotations on getters/setters as well as fields
  */
 @SuppressWarnings({"unused", "WeakerAccess"})
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class MapperPolymorphismTest extends CCMTestsSupport {
 
     Circle circle = new Circle(new Point2D(11, 22), 12.34);

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperPrimitiveTypes22Test.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperPrimitiveTypes22Test.java
@@ -27,7 +27,7 @@ import java.nio.ByteBuffer;
 
 import static org.testng.Assert.assertEquals;
 
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 public class MapperPrimitiveTypes22Test extends CCMTestsSupport {
 
     @Override

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperTest.java
@@ -310,7 +310,7 @@ public class MapperTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void testDynamicEntity() throws Exception {
         MappingManager manager = new MappingManager(session());
 
@@ -439,7 +439,7 @@ public class MapperTest extends CCMTestsSupport {
      * @test_category object_mapper
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_flag_statement_as_idempotent() {
         MappingManager manager = new MappingManager(session());
         PostAccessor post = manager.createAccessor(PostAccessor.class);
@@ -456,7 +456,7 @@ public class MapperTest extends CCMTestsSupport {
      * @test_category object_mapper
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_flag_statement_as_non_idempotent() {
         MappingManager manager = new MappingManager(session());
         PostAccessor post = manager.createAccessor(PostAccessor.class);
@@ -473,7 +473,7 @@ public class MapperTest extends CCMTestsSupport {
      * @test_category object_mapper
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_flag_statement_with_null_idempotence() {
         MappingManager manager = new MappingManager(session());
         PostAccessor post = manager.createAccessor(PostAccessor.class);
@@ -489,7 +489,7 @@ public class MapperTest extends CCMTestsSupport {
      * @test_category object_mapper
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_flag_all_mapper_generated_statements_as_idempotent() {
         MappingManager manager = new MappingManager(session());
         Mapper<User> mapper = manager.mapper(User.class);

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTCollectionsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTCollectionsTest.java
@@ -34,7 +34,7 @@ import static org.testng.Assert.assertEquals;
  * Tests mapping of collections of UDTs.
  */
 @SuppressWarnings("unused")
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class MapperUDTCollectionsTest extends CCMTestsSupport {
 
     @Override

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.testng.Assert.*;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 @CreateCCM(PER_METHOD)
 public class MapperUDTTest extends CCMTestsSupport {
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/UDTFieldMapperTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/UDTFieldMapperTest.java
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 @CCMConfig(createCluster = false)
 @SuppressWarnings("unused")
 public class UDTFieldMapperTest extends CCMTestsSupport {

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cassandra.version>3.6</cassandra.version>
+        <cassandra.version>3.8</cassandra.version>
         <java.version>1.6</java.version>
         <log4j.version>1.2.17</log4j.version>
         <slf4j-log4j12.version>1.7.6</slf4j-log4j12.version>


### PR DESCRIPTION
Motivation:

Many tests are failing when using recent versions of C* or DSE.

Modifications:

1) Bump the default C* version to 3.8
2) Redesign @CassandraVersion and @DseVersion to be able to fully accept
tick-tock releases and correctly compare them.
3) Reduce log verbosity for Scassandra tests
4) Prevent thrift from being enabled for C* >= 4.0
5) Fix decommission tests with C* >= 3.12

This commit contains contributions by Andrew Tolbert (@tolbertam).

Result:

All tests should pass.