### PR TITLE
JAVA-1196: Include hash of result set metadata in prepared statement id.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,7 @@
 ### 3.3.2 (in progress)
 
 - [bug] JAVA-1666: Fix keyspace export when a UDT has case-sensitive field names.
+- [improvement] JAVA-1196: Include hash of result set metadata in prepared statement id.
 
 
 ### 3.3.1

--- a/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedResultSet.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedResultSet.java
@@ -39,7 +39,7 @@ abstract class ArrayBackedResultSet implements ResultSet {
 
     private static final Queue<List<ByteBuffer>> EMPTY_QUEUE = new ArrayDeque<List<ByteBuffer>>(0);
 
-    protected final ColumnDefinitions metadata;
+    protected volatile ColumnDefinitions metadata;
     protected final Token.Factory tokenFactory;
     private final boolean wasApplied;
 
@@ -60,18 +60,42 @@ abstract class ArrayBackedResultSet implements ResultSet {
             case ROWS:
                 Responses.Result.Rows r = (Responses.Result.Rows) msg;
 
-                ColumnDefinitions columnDefs;
-                if (r.metadata.columns == null) {
-                    Statement actualStatement = statement;
-                    if (statement instanceof StatementWrapper) {
-                        actualStatement = ((StatementWrapper) statement).getWrappedStatement();
-                    }
-                    assert actualStatement instanceof BoundStatement;
-                    columnDefs = ((BoundStatement) actualStatement).statement.getPreparedId().resultSetMetadata;
-                    assert columnDefs != null;
-                } else {
-                    columnDefs = r.metadata.columns;
+                Statement actualStatement = statement;
+                if (statement instanceof StatementWrapper) {
+                    actualStatement = ((StatementWrapper) statement).getWrappedStatement();
                 }
+
+                ColumnDefinitions columnDefs = r.metadata.columns;
+                if (columnDefs == null) {
+                    // If result set metadata is not present, it means the request had SKIP_METADATA set, the driver
+                    // only ever does that for bound statements.
+                    BoundStatement bs = (BoundStatement) actualStatement;
+                    columnDefs = bs.preparedStatement().getPreparedId().resultSetMetadata.variables;
+                } else {
+                    // Otherwise, always use the response's metadata.
+                    // In addition, if a new id is present it means we're executing a bound statement with protocol v5,
+                    // the schema changed server-side, and we need to update the prepared statement (see
+                    // CASSANDRA-10786).
+                    MD5Digest newMetadataId = r.metadata.metadataId;
+                    assert !(actualStatement instanceof BoundStatement) ||
+                            ProtocolFeature.PREPARED_METADATA_CHANGES.isSupportedBy(protocolVersion) ||
+                            newMetadataId == null;
+                    if (newMetadataId != null) {
+                        BoundStatement bs = ((BoundStatement) actualStatement);
+                        PreparedId preparedId = bs.preparedStatement().getPreparedId();
+                        // Extra test for CASSANDRA-13992: conditional updates yield a different result set depending on
+                        // whether the update was applied or not, so the prepared statement must never have result
+                        // metadata, and we should always execute with skip_metadata = false.
+                        // However the server sends a new_metadata_id in the response, so make sure we ignore it if the
+                        // prepared statement did not have metadata in the first place.
+                        // TODO remove the "if" (i.e. always assign resultSetMetadata) if CASSANDRA-13992 gets fixed before 4.0.0 GA
+                        if (preparedId.resultSetMetadata.variables != null) {
+                            preparedId.resultSetMetadata =
+                                    new PreparedId.PreparedMetadata(newMetadataId, columnDefs);
+                        }
+                    }
+                }
+                assert columnDefs != null;
 
                 Token.Factory tokenFactory = (session == null) ? null
                         : session.getCluster().manager.metadata.tokenFactory();
@@ -224,7 +248,7 @@ abstract class ArrayBackedResultSet implements ResultSet {
     private static class MultiPage extends ArrayBackedResultSet {
 
         private Queue<List<ByteBuffer>> currentPage;
-        private final Queue<Queue<List<ByteBuffer>>> nextPages = new ConcurrentLinkedQueue<Queue<List<ByteBuffer>>>();
+        private final Queue<NextPage> nextPages = new ConcurrentLinkedQueue<NextPage>();
 
         private final Deque<ExecutionInfo> infos = new LinkedBlockingDeque<ExecutionInfo>();
 
@@ -280,8 +304,8 @@ abstract class ArrayBackedResultSet implements ResultSet {
         @Override
         public int getAvailableWithoutFetching() {
             int available = currentPage.size();
-            for (Queue<List<ByteBuffer>> page : nextPages)
-                available += page.size();
+            for (NextPage page : nextPages)
+                available += page.data.size();
             return available;
         }
 
@@ -297,9 +321,12 @@ abstract class ArrayBackedResultSet implements ResultSet {
                 // Grab the current state now to get a consistent view in this iteration.
                 FetchingState fetchingState = this.fetchState;
 
-                Queue<List<ByteBuffer>> nextPage = nextPages.poll();
+                NextPage nextPage = nextPages.poll();
                 if (nextPage != null) {
-                    currentPage = nextPage;
+                    if (nextPage.metadata != null) {
+                        this.metadata = nextPage.metadata;
+                    }
+                    currentPage = nextPage.data;
                     continue;
                 }
                 if (fetchingState == null)
@@ -363,7 +390,16 @@ abstract class ArrayBackedResultSet implements ResultSet {
                                 if (rm.kind == Responses.Result.Kind.ROWS) {
                                     Responses.Result.Rows rows = (Responses.Result.Rows) rm;
                                     info = update(info, rm, MultiPage.this.session, rows.metadata.pagingState, protocolVersion, codecRegistry, statement);
-                                    MultiPage.this.nextPages.offer(rows.data);
+                                    // If the query is a prepared 'SELECT *', the metadata can change between pages
+                                    ColumnDefinitions newMetadata = null;
+                                    if (rows.metadata.metadataId != null) {
+                                        newMetadata = rows.metadata.columns;
+                                        assert statement instanceof BoundStatement;
+                                        BoundStatement bs = (BoundStatement) statement;
+                                        bs.preparedStatement().getPreparedId().resultSetMetadata =
+                                                new PreparedId.PreparedMetadata(rows.metadata.metadataId, rows.metadata.columns);
+                                    }
+                                    MultiPage.this.nextPages.offer(new NextPage(newMetadata, rows.data));
                                     MultiPage.this.fetchState = rows.metadata.pagingState == null ? null : new FetchingState(rows.metadata.pagingState, null);
                                 } else if (rm.kind == Responses.Result.Kind.VOID) {
                                     // We shouldn't really get a VOID message here but well, no harm in handling it I suppose
@@ -441,6 +477,16 @@ abstract class ArrayBackedResultSet implements ResultSet {
                 assert (nextStart == null) != (inProgress == null);
                 this.nextStart = nextStart;
                 this.inProgress = inProgress;
+            }
+        }
+
+        private static class NextPage {
+            final ColumnDefinitions metadata;
+            final Queue<List<ByteBuffer>> data;
+
+            NextPage(ColumnDefinitions metadata, Queue<List<ByteBuffer>> data) {
+                this.metadata = metadata;
+                this.data = data;
             }
         }
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java
@@ -61,8 +61,6 @@ public class BatchStatement extends Statement {
         COUNTER
     }
 
-    ;
-
     final Type batchType;
     private final List<Statement> statements = new ArrayList<Statement>();
 
@@ -97,7 +95,7 @@ public class BatchStatement extends Statement {
                 // We handle BatchStatement in add() so ...
                 assert statement instanceof BoundStatement;
                 BoundStatement st = (BoundStatement) statement;
-                idAndVals.ids.add(st.statement.getPreparedId().id);
+                idAndVals.ids.add(st.statement.getPreparedId().boundValuesMetadata.id);
                 idAndVals.values.add(Arrays.asList(st.wrapper.values));
             }
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/BoundStatement.java
@@ -293,7 +293,10 @@ public class BoundStatement extends Statement implements SettableData<BoundState
      */
     @Override
     public String getKeyspace() {
-        return statement.getPreparedId().metadata.size() == 0 ? null : statement.getPreparedId().metadata.getKeyspace(0);
+        ColumnDefinitions defs = statement.getPreparedId().boundValuesMetadata.variables;
+        return defs.size() == 0
+                ? null
+                : defs.getKeyspace(0);
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/PreparedId.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PreparedId.java
@@ -19,21 +19,37 @@ package com.datastax.driver.core;
  * Identifies a PreparedStatement.
  */
 public class PreparedId {
-    // This class is mostly here to group PreparedStatement data that are need for
-    // execution but that we don't want to expose publicly (see JAVA-195)
-    final MD5Digest id;
 
-    final ColumnDefinitions metadata;
-    final ColumnDefinitions resultSetMetadata;
+    // This class is mostly here to group PreparedStatement data that are needed for
+    // execution but that we don't want to expose publicly (see JAVA-195)
 
     final int[] routingKeyIndexes;
+
     final ProtocolVersion protocolVersion;
 
-    PreparedId(MD5Digest id, ColumnDefinitions metadata, ColumnDefinitions resultSetMetadata, int[] routingKeyIndexes, ProtocolVersion protocolVersion) {
-        this.id = id;
-        this.metadata = metadata;
+    final PreparedMetadata boundValuesMetadata;
+
+    // can change over time, see JAVA-1196, JAVA-420
+    volatile PreparedMetadata resultSetMetadata;
+
+    PreparedId(PreparedMetadata boundValuesMetadata, PreparedMetadata resultSetMetadata, int[] routingKeyIndexes, ProtocolVersion protocolVersion) {
+        assert boundValuesMetadata != null;
+        assert resultSetMetadata != null;
+        this.boundValuesMetadata = boundValuesMetadata;
         this.resultSetMetadata = resultSetMetadata;
         this.routingKeyIndexes = routingKeyIndexes;
         this.protocolVersion = protocolVersion;
+    }
+
+
+    static class PreparedMetadata {
+
+        final MD5Digest id;
+        final ColumnDefinitions variables;
+
+        PreparedMetadata(MD5Digest id, ColumnDefinitions variables) {
+            this.id = id;
+            this.variables = variables;
+        }
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/ProtocolFeature.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ProtocolFeature.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2012-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.driver.core;
+
+/**
+ * A listing of features that may or not apply to a given {@link ProtocolVersion}.
+ */
+enum ProtocolFeature {
+
+    /**
+     * The capability of updating a prepared statement if the result's metadata changes at runtime (for example, if the
+     * query is a {@code SELECT *} and the table is altered).
+     */
+    PREPARED_METADATA_CHANGES,
+    //
+    ;
+
+    /**
+     * Determines whether or not the input version supports ths feature.
+     *
+     * @param version the version to test against.
+     * @return true if supported, false otherwise.
+     */
+    boolean isSupportedBy(ProtocolVersion version) {
+        switch (this) {
+            case PREPARED_METADATA_CHANGES:
+                return version == ProtocolVersion.V5;
+            default:
+                return false;
+        }
+    }
+
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SessionManager.java
@@ -574,16 +574,23 @@ class SessionManager extends AbstractSession {
             request = new Requests.Query(qString, options, statement.isTracing());
         } else if (statement instanceof BoundStatement) {
             BoundStatement bs = (BoundStatement) statement;
-            if (!cluster.manager.preparedQueries.containsKey(bs.statement.getPreparedId().id)) {
+            if (!cluster.manager.preparedQueries.containsKey(bs.statement.getPreparedId().boundValuesMetadata.id)) {
                 throw new InvalidQueryException(String.format("Tried to execute unknown prepared query : %s. "
-                        + "You may have used a PreparedStatement that was created with another Cluster instance.", bs.statement.getPreparedId().id));
+                        + "You may have used a PreparedStatement that was created with another Cluster instance.", bs.statement.getPreparedId().boundValuesMetadata.id));
             }
             if (protocolVersion.compareTo(ProtocolVersion.V4) < 0)
                 bs.ensureAllSet();
-            boolean skipMetadata = protocolVersion != ProtocolVersion.V1 && bs.statement.getPreparedId().resultSetMetadata != null;
-            Requests.QueryProtocolOptions options = new Requests.QueryProtocolOptions(Message.Request.Type.EXECUTE, consistency, Arrays.asList(bs.wrapper.values), Collections.<String, ByteBuffer>emptyMap(),
-                    skipMetadata, fetchSize, usedPagingState, serialConsistency, defaultTimestamp);
-            request = new Requests.Execute(bs.statement.getPreparedId().id, options, statement.isTracing());
+
+            // skip resultset metadata if version > 1 (otherwise this feature is not supported)
+            // and if we already have metadata for the prepared statement being executed.
+            boolean skipMetadata = protocolVersion != ProtocolVersion.V1 && bs.statement.getPreparedId().resultSetMetadata.variables != null;
+            Requests.QueryProtocolOptions options = new Requests.QueryProtocolOptions(Message.Request.Type.EXECUTE,
+                    consistency, Arrays.asList(bs.wrapper.values), Collections.<String, ByteBuffer>emptyMap(), skipMetadata,
+                    fetchSize, usedPagingState, serialConsistency, defaultTimestamp);
+            request = new Requests.Execute(
+                    bs.statement.getPreparedId().boundValuesMetadata.id,
+                    bs.statement.getPreparedId().resultSetMetadata.id,
+                    options, statement.isTracing());
         } else {
             assert statement instanceof BatchStatement : statement;
             assert pagingState == null;

--- a/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/Assertions.java
@@ -87,8 +87,12 @@ public class Assertions extends org.assertj.core.api.Assertions {
     public static VersionNumberAssert assertThat(VersionNumber actual) {
         return new VersionNumberAssert(actual);
     }
+
     public static ResultSetAssert assertThat(ResultSet rows) {
         return new ResultSetAssert(rows);
     }
 
+    public static ColumnDefinitionsAssert assertThat(ColumnDefinitions variables) {
+        return new ColumnDefinitionsAssert(variables);
+    }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
@@ -1015,6 +1015,21 @@ public class CCMTestsSupport {
         keyspace = null;
     }
 
+    protected void resetTestSession() throws Exception {
+        session.close();
+        Cluster.Builder builder = ccmTestConfig.clusterProvider(this);
+        // add contact points only if the provided builder didn't do so
+        if (builder.getContactPoints().isEmpty())
+            builder.addContactPoints(getContactPoints());
+        builder.withPort(ccm.getBinaryPort());
+        cluster = register(builder.build());
+        cluster.init();
+
+        session.close();
+        session = register(cluster.connect());
+        useKeyspace(session, keyspace);
+    }
+
     protected void closeCloseables() {
         if (closer != null)
             executeNoFail(new Callable<Void>() {

--- a/driver-core/src/test/java/com/datastax/driver/core/ColumnDefinitionsAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ColumnDefinitionsAssert.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2012-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import org.assertj.core.api.AbstractAssert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class ColumnDefinitionsAssert extends AbstractAssert<ColumnDefinitionsAssert, ColumnDefinitions> {
+
+    public ColumnDefinitionsAssert(ColumnDefinitions actual) {
+        super(actual, ColumnDefinitionsAssert.class);
+    }
+
+    public ColumnDefinitionsAssert hasSize(int expected) {
+        assertThat(actual.size()).isEqualTo(expected);
+        return this;
+    }
+
+    public ColumnDefinitionsAssert containsVariable(String name, DataType type) {
+        try {
+            assertThat(actual.getType(name)).isEqualTo(type);
+        } catch (Exception e) {
+            fail(String.format("Expected actual to contain variable %s of type %s, but it did not", name, type), e);
+        }
+        return this;
+    }
+
+    public ColumnDefinitionsAssert doesNotContainVariable(String name) {
+        assertThat(actual.getIndexOf(name)).isEqualTo(-1);
+        return this;
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementInvalidationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementInvalidationTest.java
@@ -1,0 +1,256 @@
+
+/*
+ * Copyright (C) 2012-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.driver.core;
+
+
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import com.datastax.driver.core.utils.CassandraVersion;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+import static junit.framework.TestCase.fail;
+
+/**
+ * Note: at the time of writing, this test exercises features of an unreleased Cassandra version. To
+ * test against a local build, run with
+ *
+ * <pre>
+ *   -Dcassandra.version=4.0.0 -Dcassandra.directory=/path/to/cassandra
+ * </pre>
+ */
+@CassandraVersion("4.0")
+public class PreparedStatementInvalidationTest extends CCMTestsSupport {
+
+    @Override
+    public Cluster.Builder createClusterBuilder() {
+        // TODO remove when protocol v5 is stable in C* 4
+        return super.createClusterBuilderNoDebouncing().allowBetaProtocolVersion();
+    }
+
+    @BeforeMethod(groups = "short", alwaysRun = true)
+    public void setup() throws Exception {
+        execute("CREATE TABLE prepared_statement_invalidation_test (a int PRIMARY KEY, b int, c int);");
+        execute("INSERT INTO prepared_statement_invalidation_test (a, b, c) VALUES (1, 1, 1);");
+        execute("INSERT INTO prepared_statement_invalidation_test (a, b, c) VALUES (2, 2, 2);");
+        execute("INSERT INTO prepared_statement_invalidation_test (a, b, c) VALUES (3, 3, 3);");
+        execute("INSERT INTO prepared_statement_invalidation_test (a, b, c) VALUES (4, 4, 4);");
+    }
+
+    @AfterMethod(groups = "short", alwaysRun = true)
+    public void teardown() throws Exception {
+        execute("DROP TABLE prepared_statement_invalidation_test");
+    }
+
+    @Test(groups = "short")
+    public void should_update_statement_id_when_metadata_changed_across_executions() {
+        // given
+        PreparedStatement ps = session().prepare("SELECT * FROM prepared_statement_invalidation_test WHERE a = ?");
+        MD5Digest idBefore = ps.getPreparedId().resultSetMetadata.id;
+        // when
+        session().execute("ALTER TABLE prepared_statement_invalidation_test ADD d int");
+        BoundStatement bs = ps.bind(1);
+        ResultSet rows = session().execute(bs);
+        // then
+        MD5Digest idAfter = ps.getPreparedId().resultSetMetadata.id;
+        assertThat(idBefore).isNotEqualTo(idAfter);
+        assertThat(ps.getPreparedId().resultSetMetadata.variables)
+                .hasSize(4)
+                .containsVariable("d", DataType.cint());
+        assertThat(bs.preparedStatement().getPreparedId().resultSetMetadata.variables)
+                .hasSize(4)
+                .containsVariable("d", DataType.cint());
+        assertThat(rows.getColumnDefinitions())
+                .hasSize(4)
+                .containsVariable("d", DataType.cint());
+    }
+
+    @Test(groups = "short")
+    public void should_update_statement_id_when_metadata_changed_across_pages() throws Exception {
+        // given
+        PreparedStatement ps = session().prepare("SELECT * FROM prepared_statement_invalidation_test");
+        ResultSet rows = session().execute(ps.bind().setFetchSize(2));
+        assertThat(rows.isFullyFetched()).isFalse();
+        MD5Digest idBefore = ps.getPreparedId().resultSetMetadata.id;
+        ColumnDefinitions definitionsBefore = rows.getColumnDefinitions();
+        assertThat(definitionsBefore)
+                .hasSize(3)
+                .doesNotContainVariable("d");
+        // consume the first page
+        int remaining = rows.getAvailableWithoutFetching();
+        while (remaining-- > 0) {
+            try {
+                rows.one().getInt("d");
+                fail("expected an error");
+            } catch (IllegalArgumentException e) { /*expected*/ }
+        }
+
+        // when
+        session().execute("ALTER TABLE prepared_statement_invalidation_test ADD d int");
+
+        // then
+        // this should trigger a background fetch of the second page, and therefore update the definitions
+        for (Row row : rows) {
+            assertThat(row.isNull("d")).isTrue();
+        }
+        MD5Digest idAfter = ps.getPreparedId().resultSetMetadata.id;
+        ColumnDefinitions definitionsAfter = rows.getColumnDefinitions();
+        assertThat(idBefore).isNotEqualTo(idAfter);
+        assertThat(definitionsAfter)
+                .hasSize(4)
+                .containsVariable("d", DataType.cint());
+    }
+
+    @Test(groups = "short")
+    public void should_update_statement_id_when_metadata_changed_across_sessions() {
+        Session session1 = cluster().connect();
+        useKeyspace(session1, keyspace);
+        Session session2 = cluster().connect();
+        useKeyspace(session2, keyspace);
+
+        PreparedStatement ps1 = session1.prepare("SELECT * FROM prepared_statement_invalidation_test WHERE a = ?");
+        PreparedStatement ps2 = session2.prepare("SELECT * FROM prepared_statement_invalidation_test WHERE a = ?");
+
+        MD5Digest id1a = ps1.getPreparedId().resultSetMetadata.id;
+        MD5Digest id2a = ps2.getPreparedId().resultSetMetadata.id;
+
+        ResultSet rows1 = session1.execute(ps1.bind(1));
+        ResultSet rows2 = session2.execute(ps2.bind(1));
+
+        assertThat(rows1.getColumnDefinitions())
+                .hasSize(3)
+                .containsVariable("a", DataType.cint())
+                .containsVariable("b", DataType.cint())
+                .containsVariable("c", DataType.cint());
+        assertThat(rows2.getColumnDefinitions())
+                .hasSize(3)
+                .containsVariable("a", DataType.cint())
+                .containsVariable("b", DataType.cint())
+                .containsVariable("c", DataType.cint());
+
+        session1.execute("ALTER TABLE prepared_statement_invalidation_test ADD d int");
+
+        rows1 = session1.execute(ps1.bind(1));
+        rows2 = session2.execute(ps2.bind(1));
+
+        MD5Digest id1b = ps1.getPreparedId().resultSetMetadata.id;
+        MD5Digest id2b = ps2.getPreparedId().resultSetMetadata.id;
+
+        assertThat(id1a).isNotEqualTo(id1b);
+        assertThat(id2a).isNotEqualTo(id2b);
+
+        assertThat(ps1.getPreparedId().resultSetMetadata.variables)
+                .hasSize(4)
+                .containsVariable("d", DataType.cint());
+        assertThat(ps2.getPreparedId().resultSetMetadata.variables)
+                .hasSize(4)
+                .containsVariable("d", DataType.cint());
+        assertThat(rows1.getColumnDefinitions())
+                .hasSize(4)
+                .containsVariable("d", DataType.cint());
+        assertThat(rows2.getColumnDefinitions())
+                .hasSize(4)
+                .containsVariable("d", DataType.cint());
+    }
+
+    @Test(groups = "short", expectedExceptions = NoHostAvailableException.class)
+    public void should_not_reprepare_invalid_statements() {
+        // given
+        session().execute("ALTER TABLE prepared_statement_invalidation_test ADD d int");
+        PreparedStatement ps = session().prepare("SELECT a, b, c, d FROM prepared_statement_invalidation_test WHERE a = ?");
+        session().execute("ALTER TABLE prepared_statement_invalidation_test DROP d");
+        // when
+        session().execute(ps.bind());
+    }
+
+    @Test(groups = "short")
+    public void should_never_update_statement_id_for_conditional_updates_in_modern_protocol() {
+        should_never_update_statement_id_for_conditional_updates(session());
+    }
+
+    private void should_never_update_statement_id_for_conditional_updates(Session session) {
+        // Given
+        PreparedStatement ps = session.prepare(
+                "INSERT INTO prepared_statement_invalidation_test (a, b, c) VALUES (?, ?, ?) IF NOT EXISTS");
+
+        // Never store metadata in the prepared statement for conditional updates, since the result set can change
+        // depending on the outcome.
+        assertThat(ps.getPreparedId().resultSetMetadata.variables).isNull();
+        MD5Digest idBefore = ps.getPreparedId().resultSetMetadata.id;
+
+        // When
+        ResultSet rs = session.execute(ps.bind(5, 5, 5));
+
+        // Then
+        // Successful conditional update => only contains the [applied] column
+        assertThat(rs.wasApplied()).isTrue();
+        assertThat(rs.getColumnDefinitions())
+                .hasSize(1)
+                .containsVariable("[applied]", DataType.cboolean());
+        // However the prepared statement shouldn't have changed
+        assertThat(ps.getPreparedId().resultSetMetadata.variables).isNull();
+        assertThat(ps.getPreparedId().resultSetMetadata.id).isEqualTo(idBefore);
+
+
+        // When
+        rs = session.execute(ps.bind(5, 5, 5));
+
+        // Then
+        // Failed conditional update => regular metadata
+        assertThat(rs.wasApplied()).isFalse();
+        assertThat(rs.getColumnDefinitions()).hasSize(4);
+        Row row = rs.one();
+        assertThat(row.getBool("[applied]")).isFalse();
+        assertThat(row.getInt("a")).isEqualTo(5);
+        assertThat(row.getInt("b")).isEqualTo(5);
+        assertThat(row.getInt("c")).isEqualTo(5);
+        // The prepared statement still shouldn't have changed
+        assertThat(ps.getPreparedId().resultSetMetadata.variables).isNull();
+        assertThat(ps.getPreparedId().resultSetMetadata.id).isEqualTo(idBefore);
+
+
+        // When
+        session.execute("ALTER TABLE prepared_statement_invalidation_test ADD d int");
+        rs = session.execute(ps.bind(5, 5, 5));
+
+        // Then
+        // Failed conditional update => regular metadata that should also contain the new column
+        assertThat(rs.wasApplied()).isFalse();
+        assertThat(rs.getColumnDefinitions()).hasSize(5);
+        row = rs.one();
+        assertThat(row.getBool("[applied]")).isFalse();
+        assertThat(row.getInt("a")).isEqualTo(5);
+        assertThat(row.getInt("b")).isEqualTo(5);
+        assertThat(row.getInt("c")).isEqualTo(5);
+        assertThat(row.isNull("d")).isTrue();
+        assertThat(ps.getPreparedId().resultSetMetadata.variables).isNull();
+        assertThat(ps.getPreparedId().resultSetMetadata.id).isEqualTo(idBefore);
+    }
+
+    @Test(groups = "short")
+    public void should_never_update_statement_for_conditional_updates_in_legacy_protocols() {
+        // Given
+        Cluster cluster = register(Cluster.builder()
+                .addContactPoints(getContactPoints())
+                .withPort(ccm().getBinaryPort())
+                .withProtocolVersion(ccm().getProtocolVersion(ProtocolVersion.V4))
+                .build());
+        Session session = cluster.connect(keyspace);
+        should_never_update_statement_id_for_conditional_updates(session);
+    }
+}


### PR DESCRIPTION
Created from [ifesdjeen/java-driver#10786-release](https://github.com/ifesdjeen/java-driver/tree/10786-release) and rebased on 3.x.    Used [tolbertam/cassandra#10786-queryflags](https://github.com/tolbertam/cassandra/tree/10786-queryflags) to test it.

Still needs review, but the tests are running good against that C* branch.