### PR TITLE
JAVA-1392: Reduce lock contention in RPTokenFactory

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -10,6 +10,7 @@
 - [improvement] JAVA-1308: CodecRegistry performance improvements.
 - [improvement] JAVA-1241: Upgrade Netty to 4.1.x.
 - [improvement] JAVA-1287: Add CDC to TableOptionsMetadata and Schema Builder.
+- [improvement] JAVA-1392: Reduce lock contention in RPTokenFactory.
 
 Merged from 3.1.x branch:
 

--- a/driver-core/src/test/java/com/datastax/driver/core/RPTokenFactoryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RPTokenFactoryTest.java
@@ -15,14 +15,26 @@
  */
 package com.datastax.driver.core;
 
+import com.datastax.driver.core.utils.Bytes;
 import org.testng.annotations.Test;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RPTokenFactoryTest {
     Token.Factory factory = Token.RPToken.FACTORY;
+
+    @Test(groups = "unit")
+    public void should_hash_consistently() {
+        ByteBuffer byteBuffer = Bytes.fromHexString("0xCAFEBABE");
+        Token tokenA = factory.hash(byteBuffer);
+        Token tokenB = factory.hash(byteBuffer);
+        assertThat(tokenA)
+                .isEqualTo(factory.fromString("59959303159920881837560881824507314222"))
+                .isEqualTo(tokenB);
+    }
 
     @Test(groups = "unit")
     public void should_split_range() {


### PR DESCRIPTION
Motivation:

RPTokenFactory.md5() is called for almost every query plan by TokenAwarePolicy.
This method in turn calls MessageDigest.getInstance(String),
which is known to create lock contentions (see https://bugs.openjdk.java.net/browse/JDK-7092821).

Modification:

Clone a prototype instance of MessageDigest instead of creating a new one from scratch.

Result:

RPTokenFactory.md5() has an improved performance as no more lock contentions arrive.