### PR TITLE
JAVA-1364: Enable creation of SslHandler with remote address information

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -5,6 +5,7 @@
 - [new feature] JAVA-1347: Add support for duration type.
 - [new feature] JAVA-1248: Implement "beta" flag for native protocol v5.
 - [new feature] JAVA-1362: Send query options flags as [int] for Protocol V5+.
+- [new feature] JAVA-1364: Enable creation of SSLHandler with remote address information.
 - [improvement] JAVA-1367: Make protocol negotiation more resilient.
 - [bug] JAVA-1397: Handle duration as native datatype in protocol v5+.
 - [improvement] JAVA-1308: CodecRegistry performance improvements.

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1173,7 +1173,7 @@ public class Cluster implements Closeable {
          * Enables the use of SSL for the created {@code Cluster}.
          * <p/>
          * Calling this method will use the JDK-based implementation with the default options
-         * (see {@link JdkSSLOptions.Builder}).
+         * (see {@link RemoteEndpointAwareJdkSSLOptions.Builder}).
          * This is thus a shortcut for {@code withSSL(JdkSSLOptions.builder().build())}.
          * <p/>
          * Note that if SSL is enabled, the driver will not connect to any
@@ -1184,7 +1184,7 @@ public class Cluster implements Closeable {
          * @return this builder.
          */
         public Builder withSSL() {
-            this.sslOptions = JdkSSLOptions.builder().build();
+            this.sslOptions = RemoteEndpointAwareJdkSSLOptions.builder().build();
             return this;
         }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -1425,7 +1425,11 @@ class Connection {
             ChannelPipeline pipeline = channel.pipeline();
 
             if (sslOptions != null) {
-                pipeline.addLast("ssl", sslOptions.newSSLHandler(channel));
+                if (sslOptions instanceof RemoteEndpointAwareSSLOptions)
+                    pipeline.addLast("ssl", ((RemoteEndpointAwareSSLOptions) sslOptions).newSSLHandler(channel, connection.address));
+                else
+                    //noinspection deprecation
+                    pipeline.addLast("ssl", sslOptions.newSSLHandler(channel));
             }
 
             //            pipeline.addLast("debug", new LoggingHandler(LogLevel.INFO));

--- a/driver-core/src/main/java/com/datastax/driver/core/JdkSSLOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/JdkSSLOptions.java
@@ -24,7 +24,11 @@ import java.security.NoSuchAlgorithmException;
 
 /**
  * {@link SSLOptions} implementation based on built-in JDK classes.
+ *
+ * @deprecated Use {@link RemoteEndpointAwareJdkSSLOptions} instead.
  */
+@SuppressWarnings("DeprecatedIsStillUsed")
+@Deprecated
 public class JdkSSLOptions implements SSLOptions {
 
     /**
@@ -36,8 +40,8 @@ public class JdkSSLOptions implements SSLOptions {
         return new Builder();
     }
 
-    private final SSLContext context;
-    private final String[] cipherSuites;
+    protected final SSLContext context;
+    protected final String[] cipherSuites;
 
     /**
      * Creates a new instance.
@@ -66,7 +70,7 @@ public class JdkSSLOptions implements SSLOptions {
      * @param channel the Netty channel for that connection.
      * @return the engine.
      */
-    protected SSLEngine newSSLEngine(SocketChannel channel) {
+    protected SSLEngine newSSLEngine(@SuppressWarnings("unused") SocketChannel channel) {
         SSLEngine engine = context.createSSLEngine();
         engine.setUseClientMode(true);
         if (cipherSuites != null)
@@ -86,8 +90,8 @@ public class JdkSSLOptions implements SSLOptions {
      * Helper class to build JDK-based SSL options.
      */
     public static class Builder {
-        private SSLContext context;
-        private String[] cipherSuites;
+        protected SSLContext context;
+        protected String[] cipherSuites;
 
         /**
          * Set the SSL context to use.
@@ -124,6 +128,7 @@ public class JdkSSLOptions implements SSLOptions {
          *
          * @return the new instance.
          */
+        @SuppressWarnings("deprecation")
         public JdkSSLOptions build() {
             return new JdkSSLOptions(context, cipherSuites);
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/RemoteEndpointAwareJdkSSLOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RemoteEndpointAwareJdkSSLOptions.java
@@ -1,0 +1,100 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.ssl.SslHandler;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import java.net.InetSocketAddress;
+
+/**
+ * {@link RemoteEndpointAwareSSLOptions} implementation based on built-in JDK classes.
+ *
+ * @see <a href="https://datastax-oss.atlassian.net/browse/JAVA-1364">JAVA-1364</a>
+ * @since 3.2.0
+ */
+@SuppressWarnings("deprecation")
+public class RemoteEndpointAwareJdkSSLOptions extends JdkSSLOptions implements RemoteEndpointAwareSSLOptions {
+
+    /**
+     * Creates a builder to create a new instance.
+     *
+     * @return the builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param context      the SSL context.
+     * @param cipherSuites the cipher suites to use.
+     */
+    protected RemoteEndpointAwareJdkSSLOptions(SSLContext context, String[] cipherSuites) {
+        super(context, cipherSuites);
+    }
+
+    @Override
+    public SslHandler newSSLHandler(SocketChannel channel) {
+        throw new AssertionError("This class implements RemoteEndpointAwareSSLOptions, this method should not be called");
+    }
+
+    @Override
+    public SslHandler newSSLHandler(SocketChannel channel, InetSocketAddress remoteEndpoint) {
+        SSLEngine engine = newSSLEngine(channel, remoteEndpoint);
+        return new SslHandler(engine);
+    }
+
+    /**
+     * Creates an SSL engine each time a connection is established.
+     * <p/>
+     * You might want to override this if you need to fine-tune the engine's configuration
+     * (for example enabling hostname verification).
+     *
+     * @param channel        the Netty channel for that connection.
+     * @param remoteEndpoint the remote endpoint we are connecting to.
+     * @return the engine.
+     * @since 3.2.0
+     */
+    protected SSLEngine newSSLEngine(@SuppressWarnings("unused") SocketChannel channel, InetSocketAddress remoteEndpoint) {
+        SSLEngine engine = remoteEndpoint == null
+                ? context.createSSLEngine()
+                : context.createSSLEngine(remoteEndpoint.getHostName(), remoteEndpoint.getPort());
+        engine.setUseClientMode(true);
+        if (cipherSuites != null)
+            engine.setEnabledCipherSuites(cipherSuites);
+        return engine;
+    }
+
+    /**
+     * Helper class to build JDK-based SSL options.
+     */
+    public static class Builder extends JdkSSLOptions.Builder {
+
+        /**
+         * Builds a new instance based on the parameters provided to this builder.
+         *
+         * @return the new instance.
+         */
+        @Override
+        public RemoteEndpointAwareJdkSSLOptions build() {
+            return new RemoteEndpointAwareJdkSSLOptions(context, cipherSuites);
+        }
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/RemoteEndpointAwareNettySSLOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RemoteEndpointAwareNettySSLOptions.java
@@ -19,29 +19,35 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 
+import java.net.InetSocketAddress;
+
 /**
- * {@link SSLOptions} implementation based on Netty's SSL context.
+ * {@link RemoteEndpointAwareSSLOptions} implementation based on Netty's SSL context.
  * <p/>
  * Netty has the ability to use OpenSSL if available, instead of the JDK's built-in engine. This yields better performance.
  *
- * @deprecated Use {@link RemoteEndpointAwareNettySSLOptions} instead.
+ * @see <a href="https://datastax-oss.atlassian.net/browse/JAVA-1364">JAVA-1364</a>
+ * @since 3.2.0
  */
-@SuppressWarnings("DeprecatedIsStillUsed")
-@Deprecated
-public class NettySSLOptions implements SSLOptions {
-    protected final SslContext context;
+@SuppressWarnings("deprecation")
+public class RemoteEndpointAwareNettySSLOptions extends NettySSLOptions implements RemoteEndpointAwareSSLOptions {
 
     /**
      * Create a new instance from a given context.
      *
      * @param context the Netty context. {@code SslContextBuilder.forClient()} provides a fluent API to build it.
      */
-    public NettySSLOptions(SslContext context) {
-        this.context = context;
+    public RemoteEndpointAwareNettySSLOptions(SslContext context) {
+        super(context);
     }
 
     @Override
     public SslHandler newSSLHandler(SocketChannel channel) {
-        return context.newHandler(channel.alloc());
+        throw new AssertionError("This class implements RemoteEndpointAwareSSLOptions, this method should not be called");
+    }
+
+    @Override
+    public SslHandler newSSLHandler(SocketChannel channel, InetSocketAddress remoteEndpoint) {
+        return context.newHandler(channel.alloc(), remoteEndpoint.getHostName(), remoteEndpoint.getPort());
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/RemoteEndpointAwareSSLOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RemoteEndpointAwareSSLOptions.java
@@ -1,0 +1,53 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.ssl.SslHandler;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Child interface to {@link SSLOptions} with the possibility to pass remote endpoint data
+ * when instantiating {@link SslHandler}s.
+ * <p/>
+ * This is needed when e.g. hostname verification is required.
+ * See <a href="https://datastax-oss.atlassian.net/browse/JAVA-1364">JAVA-1364</a> for details.
+ * <p/>
+ * The reason this is a child interface is to keep {@link SSLOptions} backwards-compatible.
+ * This interface may be be merged into {@link SSLOptions} in a later major release.
+ *
+ * @see <a href="https://datastax-oss.atlassian.net/browse/JAVA-1364">JAVA-1364</a>
+ * @since 3.2.0
+ */
+public interface RemoteEndpointAwareSSLOptions extends SSLOptions {
+
+    /**
+     * Creates a new SSL handler for the given Netty channel and the given remote endpoint.
+     * <p/>
+     * This gets called each time the driver opens a new connection to a Cassandra host. The newly created handler will be added
+     * to the channel's pipeline to provide SSL support for the connection.
+     * <p/>
+     * You don't necessarily need to implement this method directly; see the provided implementations:
+     * {@link RemoteEndpointAwareJdkSSLOptions} and {@link RemoteEndpointAwareNettySSLOptions}.
+     *
+     * @param channel        the channel.
+     * @param remoteEndpoint the remote endpoint address.
+     * @return a newly-created {@link SslHandler}.
+     */
+    SslHandler newSSLHandler(SocketChannel channel, InetSocketAddress remoteEndpoint);
+
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/SSLOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SSLOptions.java
@@ -18,12 +18,19 @@ package com.datastax.driver.core;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.ssl.SslHandler;
 
+import java.net.InetSocketAddress;
+
 /**
  * Defines how the driver configures SSL connections.
+ * <p/>
+ * Note: since version 3.2.0, users are encouraged to implement
+ * {@link RemoteEndpointAwareSSLOptions} instead.
  *
+ * @see RemoteEndpointAwareSSLOptions
  * @see JdkSSLOptions
  * @see NettySSLOptions
  */
+@SuppressWarnings("deprecation")
 public interface SSLOptions {
 
     /**
@@ -37,6 +44,10 @@ public interface SSLOptions {
      *
      * @param channel the channel.
      * @return the handler.
+     * @deprecated use {@link RemoteEndpointAwareSSLOptions#newSSLHandler(SocketChannel, InetSocketAddress)} instead.
+     *
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    @Deprecated
     SslHandler newSSLHandler(SocketChannel channel);
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/Jdk8SSLEncryptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/Jdk8SSLEncryptionTest.java
@@ -1,0 +1,170 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import io.netty.handler.ssl.SslContextBuilder;
+import org.testng.annotations.Test;
+
+import javax.net.ssl.*;
+import java.net.Socket;
+import java.security.*;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import static com.datastax.driver.core.CreateCCM.TestMode.PER_METHOD;
+import static io.netty.handler.ssl.SslProvider.OPENSSL;
+
+@CreateCCM(PER_METHOD)
+@CCMConfig(auth = false)
+public class Jdk8SSLEncryptionTest extends SSLTestBase {
+
+    /**
+     * Validates that {@link RemoteEndpointAwareSSLOptions} implementations properly pass remote endpoint information
+     * to the underlying {@link SSLEngine} that is created.  This is done by creating a custom {@link TrustManagerFactory}
+     * that inspects the peer information on the {@link SSLEngine} in
+     * {@link X509ExtendedTrustManager#checkServerTrusted(X509Certificate[], String, SSLEngine)} and throws a
+     * {@link CertificateException} if the peer host or port do not match.
+     * <p>
+     * This test is prefixed with 'Jdk8' so it only runs against JDK 8+ runtimes.  This is required because
+     * X509ExtendedTrustManager was added in JDK 7.  Technically this would also run against JDK 7, but for simplicity
+     * we only run it against 8+.
+     *
+     * @test_category connection:ssl
+     * @jira_ticket JAVA-1364
+     * @since 3.2.0
+     */
+    @Test(groups = "short", dataProvider = "sslImplementation", dataProviderClass = SSLTestBase.class)
+    public void should_pass_peer_address_to_engine(SslImplementation sslImplementation) throws Exception {
+        String expectedPeerHost = TestUtils.IP_PREFIX + "1";
+        int expectedPeerPort = ccm().getBinaryPort();
+
+        EngineInspectingTrustManagerFactory tmf = new EngineInspectingTrustManagerFactory(expectedPeerHost, expectedPeerPort);
+        SSLOptions options = null;
+        switch (sslImplementation) {
+            case JDK:
+                SSLContext sslContext = SSLContext.getInstance("TLS");
+                sslContext.init(null, tmf.getTrustManagers(), new SecureRandom());
+                SSLParameters parameters = sslContext.getDefaultSSLParameters();
+                parameters.setEndpointIdentificationAlgorithm("HTTPS");
+                options = RemoteEndpointAwareJdkSSLOptions.builder().withSSLContext(sslContext).build();
+                break;
+            case NETTY_OPENSSL:
+                SslContextBuilder builder = SslContextBuilder
+                        .forClient()
+                        .sslProvider(OPENSSL)
+                        .trustManager(tmf);
+
+                options = new RemoteEndpointAwareNettySSLOptions(builder.build());
+        }
+
+        connectWithSSLOptions(options);
+    }
+
+    static class EngineInspectingTrustManagerFactory extends TrustManagerFactory {
+
+        private static final Provider provider = new Provider("", 0.0, "") {
+
+        };
+
+        final EngineInspectingTrustManagerFactorySpi spi;
+
+        EngineInspectingTrustManagerFactory(String expectedPeerHost, int expectedPeerPort) {
+            this(new EngineInspectingTrustManagerFactorySpi(expectedPeerHost, expectedPeerPort));
+        }
+
+        private EngineInspectingTrustManagerFactory(EngineInspectingTrustManagerFactorySpi spi) {
+            super(spi, provider, "EngineInspectingTrustManagerFactory");
+            this.spi = spi;
+        }
+    }
+
+    static class EngineInspectingTrustManagerFactorySpi extends TrustManagerFactorySpi {
+
+        String expectedPeerHost;
+        int expectedPeerPort;
+
+        private final TrustManager tm = new X509ExtendedTrustManager() {
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] certs, String authType, SSLEngine sslEngine) throws CertificateException {
+                // Capture peer address information and compare it to expectation.
+                String peerHost = sslEngine.getPeerHost();
+                int peerPort = sslEngine.getPeerPort();
+                if (peerHost == null || !peerHost.equals(expectedPeerHost)) {
+                    throw new CertificateException(String.format("Expected SSLEngine.getPeerHost() (%s) to equal (%s)", peerHost, expectedPeerHost));
+                }
+                if (peerPort != expectedPeerPort) {
+                    throw new CertificateException(String.format("Expected SSLEngine.getPeerPort() (%d) to equal (%d)", peerPort, expectedPeerPort));
+                }
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] certs, String authType, Socket socket) throws CertificateException {
+                // no op
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] certs, String authType) throws CertificateException {
+                // no op
+            }
+
+            @Override
+            public void checkClientTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) throws CertificateException {
+                // Since we are doing server trust only, this is a no op.
+                throw new UnsupportedOperationException("TrustManger is for establishing server trust only.");
+
+            }
+
+            @Override
+            public void checkClientTrusted(X509Certificate[] certs, String authType, Socket socket) throws CertificateException {
+                // Since we are doing server trust only, this is a no op.
+                throw new UnsupportedOperationException("TrustManger is for establishing server trust only.");
+            }
+
+            @Override
+            public void checkClientTrusted(X509Certificate[] certs, String authType) throws CertificateException {
+                // Since we are doing server trust only, this is a no op.
+                throw new UnsupportedOperationException("TrustManger is for establishing server trust only.");
+            }
+
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+        };
+
+        EngineInspectingTrustManagerFactorySpi(String expectedPeerHost, int expectedPeerPort) {
+            this.expectedPeerHost = expectedPeerHost;
+            this.expectedPeerPort = expectedPeerPort;
+        }
+
+        @Override
+        protected void engineInit(KeyStore keyStore) throws KeyStoreException {
+            // no op
+        }
+
+        @Override
+        protected void engineInit(ManagerFactoryParameters managerFactoryParameters) throws InvalidAlgorithmParameterException {
+            // no op
+        }
+
+        @Override
+        protected TrustManager[] engineGetTrustManagers() {
+            return new TrustManager[]{tm};
+        }
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/SSLEncryptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLEncryptionTest.java
@@ -129,4 +129,5 @@ public class SSLEncryptionTest extends SSLTestBase {
             }
         }
     }
+
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/SSLTestBase.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SSLTestBase.java
@@ -119,7 +119,7 @@ public abstract class SSLTestBase extends CCMTestsSupport {
                 SSLContext sslContext = SSLContext.getInstance("TLS");
                 sslContext.init(kmf != null ? kmf.getKeyManagers() : null, tmf != null ? tmf.getTrustManagers() : null, new SecureRandom());
 
-                return JdkSSLOptions.builder().withSSLContext(sslContext).build();
+                return RemoteEndpointAwareJdkSSLOptions.builder().withSSLContext(sslContext).build();
 
             case NETTY_OPENSSL:
                 SslContextBuilder builder = SslContextBuilder
@@ -131,7 +131,7 @@ public abstract class SSLTestBase extends CCMTestsSupport {
                     builder.keyManager(CCMBridge.DEFAULT_CLIENT_CERT_CHAIN_FILE, CCMBridge.DEFAULT_CLIENT_PRIVATE_KEY_FILE);
                 }
 
-                return new NettySSLOptions(builder.build());
+                return new RemoteEndpointAwareNettySSLOptions(builder.build());
             default:
                 fail("Unsupported SSL implementation: " + sslImplementation);
                 return null;

--- a/manual/ssl/README.md
+++ b/manual/ssl/README.md
@@ -71,7 +71,7 @@ if you've followed the steps for inter-node encryption).
 
 ### Driver configuration
 
-The base class to configure SSL is [SSLOptions]. It's very generic, but
+The base class to configure SSL is [RemoteEndpointAwareSSLOptions]. It's very generic, but
 you don't necessarily need to deal with it directly: the default
 instance, or the provided subclasses, might be enough for your needs.
 
@@ -101,12 +101,12 @@ for specific details, like keystore locations and passwords:
 #### JSSE, programmatic
 
 If you need more control than what system properties allow, you can
-configure SSL programmatically with [JdkSSLOptions]:
+configure SSL programmatically with [RemoteEndpointAwareJdkSSLOptions]:
 
 ```java
 SSLContext sslContext = ... // create and configure SSL context
 
-JdkSSLOptions sslOptions = JdkSSLOptions.builder()
+RemoteEndpointAwareJdkSSLOptions sslOptions = RemoteEndpointAwareJdkSSLOptions.builder()
   .withSSLContext(context)
   .build();
 
@@ -117,14 +117,13 @@ Cluster cluster = Cluster.builder()
 ```
 
 Note that you can also extend the class and override
-[newSSLEngine(SocketChannel)][newSSLEngine] if you need specific
+[newSSLEngine(SocketChannel,InetSocketAddress)][newSSLEngine] if you need specific
 configuration on the `SSLEngine` (for example hostname verification).
 
-[newSSLEngine]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/JdkSSLOptions.html#newSSLEngine-io.netty.channel.socket.SocketChannel-
 
 #### Netty
 
-[NettySSLOptions] allows you to use Netty's `SslContext` instead of
+[RemoteEndpointAwareNettySSLOptions] allows you to use Netty's `SslContext` instead of
 the JDK directly. The advantage is that Netty can use OpenSSL directly,
 which provides better performance and generates less garbage.  A disadvantage of
 using the OpenSSL provider is that it requires platform-specific dependencies,
@@ -178,7 +177,7 @@ SslContextBuilder builder = SslContextBuilder
   // only if you use client authentication
   .keyManager(new File("client.crt"), new File("client.key"));
 
-SSLOptions sslOptions = new NettySSLOptions(builder.build());
+SSLOptions sslOptions = new RemoteEndpointAwareNettySSLOptions(builder.build());
 
 Cluster cluster = Cluster.builder()
   .addContactPoint("127.0.0.1")
@@ -186,7 +185,8 @@ Cluster cluster = Cluster.builder()
   .build();
 ```
 
-[SSLOptions]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/SSLOptions.html
-[JdkSSLOptions]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/JdkSSLOptions.html
-[NettySSLOptions]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/NettySSLOptions.html
-[NettyOptions]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/NettyOptions.html
+[RemoteEndpointAwareSSLOptions]:      http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/RemoteEndpointAwareSSLOptions.html
+[RemoteEndpointAwareJdkSSLOptions]:   http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/RemoteEndpointAwareJdkSSLOptions.html
+[newSSLEngine]:                       http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/RemoteEndpointAwareJdkSSLOptions.html#newSSLEngine-io.netty.channel.socket.SocketChannel-java.net.InetSocketAddress-
+[RemoteEndpointAwareNettySSLOptions]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/RemoteEndpointAwareNettySSLOptions.html
+[NettyOptions]:                       http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/NettyOptions.html

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,47 @@
             </build>
         </profile>
 
+        <!--
+        This profile excludes all JDK 8 dependent tests from being
+        run with legacy JDKs (6 or 7).
+        It is automatically activated when a legacy JDK is in use.
+        Note that running tests with a legacy JDK require
+        that you provide a non-legacy JDK for CCM through the
+        system property ccm.java.home.
+        -->
+        <profile>
+            <id>legacy-jdks</id>
+            <activation>
+                <jdk>[,1.8)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <!-- exclude Jdk8* test classes from being compiled -->
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <testExcludes>
+                                <exclude>**/Jdk8*.java</exclude>
+                            </testExcludes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <!-- exclude Jdk* test classes from being run
+                        This is needed in event that code was built with JDK8
+                        and tests are ran with JDK6 or 7. -->
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.16</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/Jdk8*.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 
     <build>

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -3,6 +3,17 @@
 The purpose of this guide is to detail changes made by successive
 versions of the Java driver.
 
+### 3.2.0
+
+The `SSLOptions` interface is now deprecated in favor of
+`RemoteEndpointAwareSSLOptions`. 
+Similarly, the two existing implementations of that interface, 
+`JdkSSLOptions` and `NettySSLOptions`, 
+are now deprecated in favor of `RemoteEndpointAwareJdkSSLOptions` 
+and `RemoteEndpointAwareNettySSLOptions` respectively (see 
+[JAVA-1364](https://datastax-oss.atlassian.net/browse/JAVA-1364)).
+
+
 ### 3.1.0
 
 This version introduces an important change in the default retry behavior: statements that are not idempotent are not


### PR DESCRIPTION
Motivation:

SSLOptions do not currently allow to create SslHandler instances with remote address information.
This is needed to instantiate SSLEngine/SslHandler with remote address information set,
which enables doing hostname verification (for example through a custom TrustManager).
We cannot take this information from SocketChannel since it is not connected yet
at the time Connection.Initializer creates the SslHandler.

Modifications:

Create a child interface to SSLOptions, EndpointAwareSSLOptions, that exposes a new
method to create SslHandler instances with remote address information.
Modify Connection class so that it detects instances of EndpointAwareSSLOptions
and calls the new method instead of the old one.
Modify current implementations of SSLOptions, JdkSSLOptions and NettySSLOptions
to implement the new interface; delegate old methods to new ones.

Result:

Remote endpoint information is now available to implementors of EndpointAwareSSLOptions,
and to the driver built-in implementations JdkSSLOptions and NettySSLOptions.

This commit has substantial contributions from Tim Lamballais Tessensohn (@wimtie).