### PR TITLE
JAVA-1395-allow to disable request's timer metric for some statements

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -85,7 +85,7 @@ class RequestHandler {
                 && statement.isIdempotentWithDefault(manager.configuration().getQueryOptions());
         this.statement = statement;
 
-        this.timerContext = metricsEnabled() && statement.isMetricing()
+        this.timerContext = metricsEnabled()
                 ? metrics().getRequestsTimer().time()
                 : null;
         this.startTime = System.nanoTime();
@@ -212,7 +212,7 @@ class RequestHandler {
     }
 
     private boolean metricsEnabled() {
-        return manager.configuration().getMetricsOptions().isEnabled();
+        return manager.configuration().getMetricsOptions().isEnabled() && statement.isMetricing();
     }
 
     private Metrics metrics() {

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -85,7 +85,7 @@ class RequestHandler {
                 && statement.isIdempotentWithDefault(manager.configuration().getQueryOptions());
         this.statement = statement;
 
-        this.timerContext = metricsEnabled()
+        this.timerContext = metricsEnabled() && statement.isMetricing()
                 ? metrics().getRequestsTimer().time()
                 : null;
         this.startTime = System.nanoTime();

--- a/driver-core/src/main/java/com/datastax/driver/core/Statement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Statement.java
@@ -63,7 +63,7 @@ public abstract class Statement {
     private volatile ConsistencyLevel consistency;
     private volatile ConsistencyLevel serialConsistency;
     private volatile boolean traceQuery;
-    private volatile boolean recordMetric;
+    private volatile boolean recordMetric = true;
     private volatile int fetchSize;
     private volatile long defaultTimestamp = Long.MIN_VALUE;
     private volatile int readTimeoutMillis = Integer.MIN_VALUE;

--- a/driver-core/src/main/java/com/datastax/driver/core/Statement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Statement.java
@@ -63,6 +63,7 @@ public abstract class Statement {
     private volatile ConsistencyLevel consistency;
     private volatile ConsistencyLevel serialConsistency;
     private volatile boolean traceQuery;
+    private volatile boolean recordMetric;
     private volatile int fetchSize;
     private volatile long defaultTimestamp = Long.MIN_VALUE;
     private volatile int readTimeoutMillis = Integer.MIN_VALUE;
@@ -174,6 +175,25 @@ public abstract class Statement {
      */
     public boolean isTracing() {
         return traceQuery;
+    }
+    
+    /**
+     * Disables metricing for this query.
+     *
+     * @return this {@code Statement} object.
+     */
+    public Statement disableMetricing() {
+        this.traceQuery = false;
+        return this;
+    }        
+    /**
+     * Returns whether metricing is enabled for this query or not.
+     *
+     * @return {@code true} if this query has metricing enabled, {@code false}
+     * otherwise.
+     */
+    public boolean isMetricing() {
+        return recordMetric;
     }
 
     /**

--- a/driver-core/src/main/java/com/datastax/driver/core/Statement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Statement.java
@@ -183,7 +183,7 @@ public abstract class Statement {
      * @return this {@code Statement} object.
      */
     public Statement disableMetricing() {
-        this.traceQuery = false;
+        this.recordMetric = false;
         return this;
     }        
     /**


### PR DESCRIPTION
refer to :

https://datastax-oss.atlassian.net/browse/JAVA-1395?filter=-2

I hadn't clean up the code such as adding test code and squashing the commit due to I am n't sure if it is one improvement or requirement you also think it is need. So just write code demo for the issue-1395 to show the code change scope.

Thanks in advanced. if agree with this requirement, I will clean up this PR. 