### PR TITLE
JAVA-1313: Copy SerialConsistencyLevel to PreparedStatement

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,7 @@
 ### 3.0.7 (in progress)
 
 - [bug] JAVA-1371: Reintroduce connection pool timeout.
+- [bug] JAVA-1313: Copy SerialConsistencyLevel to PreparedStatement.
 
 
 ### 3.0.6

--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractSession.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractSession.java
@@ -144,7 +144,10 @@ public abstract class AbstractSession implements Session {
                 ByteBuffer routingKey = statement.getRoutingKey(protocolVersion, codecRegistry);
                 if (routingKey != null)
                     prepared.setRoutingKey(routingKey);
-                prepared.setConsistencyLevel(statement.getConsistencyLevel());
+                if (statement.getConsistencyLevel() != null)
+                    prepared.setConsistencyLevel(statement.getConsistencyLevel());
+                if (statement.getSerialConsistencyLevel() != null)
+                    prepared.setSerialConsistencyLevel(statement.getSerialConsistencyLevel());
                 if (statement.isTracing())
                     prepared.enableTracing();
                 prepared.setRetryPolicy(statement.getRetryPolicy());


### PR DESCRIPTION
Motivation:

A serial consistency level set on a statement that is going
to be prepared is not being propagated to the prepared statement.

Modifications:

Modify AbstractSession.prepareAsync(RegularStatement) and propagate
the serial consistency level to prepared statements, just as for
other inherited properties.

Result:

Serial consistency level is now being propagated to prepared
statements.