### PR TITLE
JAVA-1241: Upgrade Netty to 4.1.x

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@
 - [improvement] JAVA-1367: Make protocol negotiation more resilient.
 - [bug] JAVA-1397: Handle duration as native datatype in protocol v5+.
 - [improvement] JAVA-1308: CodecRegistry performance improvements.
+- [improvement] JAVA-1241: Upgrade Netty to 4.1.x.
 
 Merged from 3.1.x branch:
 

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative</artifactId>
-            <version>1.1.33.Fork18</version>
+            <version>1.1.33.Fork26</version>
             <classifier>${os.detected.classifier}</classifier>
             <scope>test</scope>
         </dependency>
@@ -269,6 +269,8 @@
                                         <resource>META-INF/maven/io.netty/netty-common/pom.xml</resource>
                                         <resource>META-INF/maven/io.netty/netty-handler/pom.properties</resource>
                                         <resource>META-INF/maven/io.netty/netty-handler/pom.xml</resource>
+                                        <resource>META-INF/maven/io.netty/netty-resolver/pom.properties</resource>
+                                        <resource>META-INF/maven/io.netty/netty-resolver/pom.xml</resource>
                                         <resource>META-INF/maven/io.netty/netty-transport/pom.properties</resource>
                                         <resource>META-INF/maven/io.netty/netty-transport/pom.xml</resource>
                                     </resources>

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
@@ -93,7 +93,7 @@ public class BundleOptions {
     }
 
     public static CompositeOption nettyBundles() {
-        final String nettyVersion = "4.0.33.Final";
+        final String nettyVersion = "4.1.8.Final";
         return new CompositeOption() {
 
             @Override
@@ -103,7 +103,8 @@ public class BundleOptions {
                         mavenBundle("io.netty", "netty-codec", nettyVersion),
                         mavenBundle("io.netty", "netty-common", nettyVersion),
                         mavenBundle("io.netty", "netty-handler", nettyVersion),
-                        mavenBundle("io.netty", "netty-transport", nettyVersion)
+                        mavenBundle("io.netty", "netty-transport", nettyVersion),
+                        mavenBundle("io.netty", "netty-resolver", nettyVersion)
                 );
             }
         };

--- a/manual/ssl/README.md
+++ b/manual/ssl/README.md
@@ -154,7 +154,7 @@ add it to your dependencies.
 
 There are known runtime incompatibilities between newer versions of
 netty-tcnative and the version of netty that the driver uses.  For best
-results, use version 1.1.33.Fork18.
+results, use version 1.1.33.Fork26.
 
 Using netty-tcnative requires JDK 1.7 or above and requires the presence of
 OpenSSL on the system.  It will not fall back to the JDK implementation.

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <log4j.version>1.2.17</log4j.version>
         <slf4j-log4j12.version>1.7.6</slf4j-log4j12.version>
         <guava.version>16.0.1</guava.version>
-        <netty.version>4.0.37.Final</netty.version>
+        <netty.version>4.1.8.Final</netty.version>
         <metrics.version>3.1.2</metrics.version>
         <snappy.version>1.1.2.6</snappy.version>
         <lz4.version>1.3.0</lz4.version>


### PR DESCRIPTION
This commit also updates netty-tcnative to Fork26, and
accounts for netty-transport depending on new netty-resolver module in 4.1.