### PR TITLE
JAVA-1397: Handle duration as native datatype in protocol v5+

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -36,12 +36,12 @@ java:
 os:
   - ubuntu/trusty64
 cassandra:
-  - 1.2
-  - 2.0
-  - 2.1
-  - 2.2
-  - 3.0
-  - 3.9
+  - '1.2'
+  - '2.0'
+  - '2.1'
+  - '2.2'
+  - '3.0'
+  - '3.10'
 build:
   - type: maven
     version: 3.2.5

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -6,6 +6,7 @@
 - [new feature] JAVA-1248: Implement "beta" flag for native protocol v5.
 - [new feature] JAVA-1362: Send query options flags as [int] for Protocol V5+.
 - [improvement] JAVA-1367: Make protocol negotiation more resilient.
+- [bug] JAVA-1397: Handle duration as native datatype in protocol v5+.
 
 Merged from 3.1.x branch:
 

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
@@ -212,7 +212,7 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
         List<TestTable> tables = Lists.newArrayList();
         // Create a test table for each primitive type testing with null values.  If the
         // type maps to a java primitive type it's value will by the default value instead of null.
-        for (DataType dataType : DataType.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion())) {
+        for (DataType dataType : TestUtils.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion())) {
             Object expectedPrimitiveValue = null;
             switch (dataType.getName()) {
                 case BIGINT:
@@ -237,11 +237,14 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
                 case BOOLEAN:
                     expectedPrimitiveValue = false;
                     break;
+                case COUNTER:
+                case DURATION:
+                    // Duration is handled separately in DurationIntegrationTest, because it has specific restrictions (e.g.
+                    // not allowed in collections).
+                    continue;
             }
 
-            if (!dataType.getName().equals(DataType.Name.COUNTER)) {
-                tables.add(new TestTable(dataType, null, null, expectedPrimitiveValue, "1.2.0"));
-            }
+            tables.add(new TestTable(dataType, null, null, expectedPrimitiveValue, "1.2.0"));
         }
         return tables;
 

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
@@ -40,7 +40,7 @@ public class DataTypeTest {
     ProtocolVersion protocolVersion = TestUtils.getDesiredProtocolVersion();
 
     static boolean exclude(DataType t) {
-        return t.getName() == DataType.Name.COUNTER;
+        return t.getName() == DataType.Name.COUNTER || t.getName() == DataType.Name.DURATION;
     }
 
     /**
@@ -316,23 +316,5 @@ public class DataTypeTest {
             codec.serialize(l, version);
             fail("This should not have worked");
         } catch (InvalidTypeException e) { /* That's what we want */ }
-    }
-
-    @Test(groups = "unit")
-    public void should_not_return_v4_types_in_all_primitive_types_with_v3() {
-        Set<DataType> dataTypes = DataType.allPrimitiveTypes(ProtocolVersion.V3);
-
-        // Ensure it does not contain specific newer types tinyint and smallint.
-        assertThat(dataTypes).doesNotContainAnyElementsOf(newArrayList(DataType.tinyint(), DataType.smallint()));
-
-        // Ensure all values are <= V3.
-        for (DataType dataType : dataTypes) {
-            assertThat(dataType.getName().minProtocolVersion).isLessThanOrEqualTo(ProtocolVersion.V3);
-        }
-    }
-
-    @Test(groups = "unit")
-    public void should_return_same_elements_with_all_primitive_types_using_latest_protocol_version() {
-        assertThat(DataType.allPrimitiveTypes(ProtocolVersion.NEWEST_SUPPORTED)).isEqualTo(DataType.allPrimitiveTypes());
     }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
@@ -48,10 +48,11 @@ public class PreparedStatementTest extends CCMTestsSupport {
     private static final String SIMPLE_TABLE = "test";
     private static final String SIMPLE_TABLE2 = "test2";
 
-    private final Collection<DataType> primitiveTypes = DataType.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion());
+    private final Collection<DataType> primitiveTypes = allPrimitiveTypes(TestUtils.getDesiredProtocolVersion());
 
     private boolean exclude(DataType t) {
-        return t.getName() == DataType.Name.COUNTER;
+        // duration is not supported in collections
+        return t.getName() == DataType.Name.COUNTER || t.getName() == DataType.Name.DURATION;
     }
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/PrimitiveTypeSamples.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PrimitiveTypeSamples.java
@@ -40,7 +40,7 @@ public class PrimitiveTypeSamples {
 
     private static Map<DataType, Object> generateAll() {
         try {
-            final Collection<DataType> primitiveTypes = DataType.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion());
+            final Collection<DataType> primitiveTypes = TestUtils.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion());
             ImmutableMap<DataType, Object> data = ImmutableMap.<DataType, Object>builder()
                     .put(DataType.ascii(), "ascii")
                     .put(DataType.bigint(), Long.MAX_VALUE)

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.mock;
 public class QueryLoggerTest extends CCMTestsSupport {
 
     private static final List<DataType> dataTypes = new ArrayList<DataType>(
-            Sets.filter(DataType.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion()), new Predicate<DataType>() {
+            Sets.filter(TestUtils.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion()), new Predicate<DataType>() {
                 @Override
                 public boolean apply(DataType type) {
                     return type != DataType.counter();

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -19,6 +19,7 @@ import com.datastax.driver.core.policies.RoundRobinPolicy;
 import com.datastax.driver.core.policies.WhiteListPolicy;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.sun.management.OperatingSystemMXBean;
@@ -461,6 +462,26 @@ public abstract class TestUtils {
             throw new RuntimeException(e);
         }
         throw new RuntimeException("Missing handling of " + type);
+    }
+
+    /**
+     * Returns a set of all primitive types supported by the given protocolVersion.
+     * <p>
+     * Primitive types are defined as the types that don't have type arguments
+     * (that is excluding lists, sets, and maps, tuples and udts).
+     * </p>
+     *
+     * @param protocolVersion protocol version to get types for.
+     * @return returns a set of all the primitive types for the given protocolVersion.
+     */
+    static Set<DataType> allPrimitiveTypes(final ProtocolVersion protocolVersion) {
+        return Sets.filter(DataType.allPrimitiveTypes(), new Predicate<DataType>() {
+
+            @Override
+            public boolean apply(DataType dataType) {
+                return protocolVersion.compareTo(dataType.getName().minProtocolVersion) >= 0;
+            }
+        });
     }
 
     // Wait for a node to be up and running

--- a/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
@@ -39,7 +39,7 @@ import static org.testng.Assert.assertNotEquals;
 @CassandraVersion("2.1.0")
 public class UserTypesTest extends CCMTestsSupport {
 
-    private final static List<DataType> DATA_TYPE_PRIMITIVES = new ArrayList<DataType>(DataType.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion()));
+    private final static List<DataType> DATA_TYPE_PRIMITIVES = new ArrayList<DataType>(TestUtils.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion()));
 
     static {
         DATA_TYPE_PRIMITIVES.remove(DataType.counter());

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cassandra.version>3.8</cassandra.version>
+        <cassandra.version>3.10</cassandra.version>
         <java.version>1.6</java.version>
         <log4j.version>1.2.17</log4j.version>
         <slf4j-log4j12.version>1.7.6</slf4j-log4j12.version>


### PR DESCRIPTION
Protocol v5 is still beta, I temporarily added this (not committed) in DurationIntegrationTest to test:
```java
    @Override
    public Cluster.Builder createClusterBuilder() {
        return super.createClusterBuilder().allowBetaProtocolVersion();
    }
```