### PR TITLE
Test fix for CASSANDRA-12443, add 3.10 to the build matrix

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -36,12 +36,12 @@ java:
 os:
   - ubuntu/trusty64
 cassandra:
-  - 1.2
-  - 2.0
-  - 2.1
-  - 2.2
-  - 3.0
-  - 3.9
+  - '1.2'
+  - '2.0'
+  - '2.1'
+  - '2.2'
+  - '3.0'
+  - '3.10'
 build:
   - type: maven
     version: 3.2.5

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesCCTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesCCTest.java
@@ -103,7 +103,7 @@ public class SchemaChangesCCTest extends CCMTestsSupport {
         session2.execute("drop keyspace ks2");
         session2.execute("drop table ks1.tbl2");
         session2.execute("alter keyspace ks1 with durable_writes=false");
-        session2.execute("alter table ks1.tbl1 alter v type blob");
+        session2.execute("alter table ks1.tbl1 add new_col varchar");
         session2.execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "ks3", 1));
         session2.execute("create table ks1.tbl3 (k text primary key, v text)");
 
@@ -165,14 +165,14 @@ public class SchemaChangesCCTest extends CCMTestsSupport {
         assertThat(originalTable.getValue())
                 .isInKeyspace("ks1")
                 .hasName("tbl1")
-                .hasColumn("v", DataType.text())
+                .doesNotHaveColumn("new_col")
                 .isEqualTo(prealteredTable);
 
         // New metadata should reflect that the column type changed.
         assertThat(alteredTable.getValue())
                 .isInKeyspace("ks1")
                 .hasName("tbl1")
-                .hasColumn("v", DataType.blob());
+                .hasColumn("new_col", DataType.varchar());
 
         // Ensure the add keyspace event shows up.
         ArgumentCaptor<KeyspaceMetadata> addedKeyspace = ArgumentCaptor.forClass(KeyspaceMetadata.class);

--- a/driver-core/src/test/java/com/datastax/driver/core/TableMetadataAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TableMetadataAssert.java
@@ -61,6 +61,12 @@ public class TableMetadataAssert extends AbstractAssert<TableMetadataAssert, Tab
         return this;
     }
 
+    public TableMetadataAssert doesNotHaveColumn(String columnName) {
+        ColumnMetadata column = actual.getColumn(columnName);
+        assertThat(column).isNull();
+        return this;
+    }
+
     public TableMetadataAssert isCompactStorage() {
         assertThat(actual.getOptions().isCompactStorage()).isTrue();
         return this;


### PR DESCRIPTION
Just a small adjustment for [CASSANDRA-12443](https://issues.apache.org/jira/browse/CASSANDRA-12443) which removes `alter type` support in 3.10/3.0.11.

Also add 3.10 to the build matrix.