### PR TITLE
PrimitiveTypeSamples Duration fix

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -347,6 +347,8 @@ public abstract class TestUtils {
                     return true;
                 case COUNTER:
                     throw new UnsupportedOperationException("Cannot 'getSomeValue' for counters");
+                case DURATION:
+                    return Duration.from("1h20m3s");
                 case DECIMAL:
                     return new BigDecimal("3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679");
                 case DOUBLE:

--- a/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
@@ -253,6 +253,8 @@ public class UserTypesTest extends CCMTestsSupport {
                 case DOUBLE:
                     alldatatypes.setDouble(index, ((Double) sampleData).doubleValue());
                     break;
+                case DURATION:
+                    alldatatypes.set(index, Duration.from(sampleData.toString()), Duration.class);
                 case FLOAT:
                     alldatatypes.setFloat(index, ((Float) sampleData).floatValue());
                     break;
@@ -322,8 +324,9 @@ public class UserTypesTest extends CCMTestsSupport {
                 "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
         session().execute("USE test_nonprimitive_datatypes");
 
-        // counters are not allowed inside collections
+        // counters and durations are not allowed inside collections
         DATA_TYPE_PRIMITIVES.remove(DataType.counter());
+        DATA_TYPE_PRIMITIVES.remove(DataType.duration());
 
         // create UDT
         List<String> alpha_type_list = new ArrayList<String>();


### PR DESCRIPTION
Duration is excluded because it can't be used in collections and udts.  It is tested separately in DurationIntegrationTest.

This doesn't actually impact testing yet so Protocol V5 is currently marked as beta, but eventually it'll tear down the test framework if running against a Cassandra version that supports it.