### PR TITLE
Backport #791 and remove ambiguity in Cassandra and DSE versions in tests

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/AggregateMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AggregateMetadataTest.java
@@ -24,7 +24,7 @@ import static com.datastax.driver.core.DataType.cint;
 import static com.datastax.driver.core.DataType.text;
 import static com.datastax.driver.core.TestUtils.serializeForDynamicCompositeType;
 
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 @CCMConfig(config = "enable_user_defined_functions:true")
 public class AggregateMetadataTest extends CCMTestsSupport {
 
@@ -183,7 +183,7 @@ public class AggregateMetadataTest extends CCMTestsSupport {
      * @since 3.0.1
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_parse_and_format_aggregate_with_composite_type_literal_initcond() {
         VersionNumber ver = VersionNumber.parse(CCMBridge.getCassandraVersion());
         if (ver.getMajor() == 3) {
@@ -204,7 +204,7 @@ public class AggregateMetadataTest extends CCMTestsSupport {
      * @since 3.0.1
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 3.0, minor = 4)
+    @CassandraVersion("3.4")
     public void should_parse_and_format_aggregate_with_composite_type_hex_initcond() {
         VersionNumber ver = VersionNumber.parse(CCMBridge.getCassandraVersion());
         if ((ver.getMinor() >= 1 && ver.getMinor() < 4)) {

--- a/driver-core/src/test/java/com/datastax/driver/core/AggregateMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AggregateMetadataTest.java
@@ -185,7 +185,7 @@ public class AggregateMetadataTest extends CCMTestsSupport {
     @Test(groups = "short")
     @CassandraVersion("2.2.0")
     public void should_parse_and_format_aggregate_with_composite_type_literal_initcond() {
-        VersionNumber ver = VersionNumber.parse(CCMBridge.getCassandraVersion());
+        VersionNumber ver = ccm().getCassandraVersion();
         if (ver.getMajor() == 3) {
             if ((ver.getMinor() >= 1 && ver.getMinor() < 4) || (ver.getMinor() == 0 && ver.getPatch() < 4)) {
                 throw new SkipException("Requires C* 2.2.X, 3.0.4+ or 3.4.X+");
@@ -206,7 +206,7 @@ public class AggregateMetadataTest extends CCMTestsSupport {
     @Test(groups = "short")
     @CassandraVersion("3.4")
     public void should_parse_and_format_aggregate_with_composite_type_hex_initcond() {
-        VersionNumber ver = VersionNumber.parse(CCMBridge.getCassandraVersion());
+        VersionNumber ver = ccm().getCassandraVersion();
         if ((ver.getMinor() >= 1 && ver.getMinor() < 4)) {
             throw new SkipException("Requires 3.0.4+ or 3.4.X+");
         }

--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncQueryTest.java
@@ -166,7 +166,7 @@ public class AsyncQueryTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0, description = "Paging is not supported until 2.0")
+    @CassandraVersion(value = "2.0.0", description = "Paging is not supported until 2.0")
     public void should_fail_when_auto_paging_on_io_thread() throws Exception {
         for (int i = 0; i < 1000; i++) {
             Statement statement = new SimpleStatement("select v from asyncquerytest.foo where k = 1");

--- a/driver-core/src/test/java/com/datastax/driver/core/AsyncResultSetTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AsyncResultSetTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.0, description = "uses paging")
+@CassandraVersion(value = "2.0.0", description = "uses paging")
 public class AsyncResultSetTest extends CCMTestsSupport {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/AuthenticationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AuthenticationTest.java
@@ -41,7 +41,7 @@ public class AuthenticationTest extends CCMTestsSupport {
     public void sleepIf12() {
         // For C* 1.2, sleep before attempting to connect as there is a small delay between
         // user being created.
-        if (ccm().getVersion().getMajor() < 2) {
+        if (ccm().getCassandraVersion().getMajor() < 2) {
             Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
         }
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/BatchStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/BatchStatementTest.java
@@ -71,7 +71,7 @@ public class BatchStatementTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0, minor = 9, description = "This will only work with C* 2.0.9 (CASSANDRA-7337)")
+    @CassandraVersion(value = "2.0.9", description = "This will only work with C* 2.0.9 (CASSANDRA-7337)")
     public void casBatchTest() {
         PreparedStatement st = session().prepare("INSERT INTO test (k, v) VALUES (?, ?) IF NOT EXISTS");
 

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMAccess.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMAccess.java
@@ -32,13 +32,21 @@ public interface CCMAccess extends Closeable {
     String getClusterName();
 
     /**
-     * Returns the Cassandra version of this CCM cluster.
+     * Returns the Cassandra version of this CCM cluster.  If {@link #getDSEVersion()} is non-null it is assumed
+     * that this value is only used for representing the compatible Cassandra version for that DSE version.
      * <p/>
-     * By default the version is equal to {@link CCMBridge#getCassandraVersion()}.
      *
      * @return The version of this CCM cluster.
      */
-    VersionNumber getVersion();
+    VersionNumber getCassandraVersion();
+
+    /**
+     * Returns the DSE version of this CCM cluster if this is a DSE cluster, otherwise null.
+     * <p/>
+     *
+     * @return The version of this CCM cluster.
+     */
+    VersionNumber getDSEVersion();
 
     /**
      * @return The config directory for this CCM cluster.
@@ -236,4 +244,19 @@ public interface CCMAccess extends Closeable {
      */
     void waitForDown(int node);
 
+    /**
+     * @return The target protocolVersion to use when connecting to this CCM cluster.
+     * <p/>
+     * This should be based on the highest protocol version that both the cluster and driver support.
+     * <p/>
+     * For example, C* 2.0.17 should return {@link ProtocolVersion#V2} since C* supports up to V2 and the driver
+     * supports that version.
+     */
+    ProtocolVersion getProtocolVersion();
+
+    /**
+     * @param maximumAllowed The maximum protocol version to use.
+     * @return The target protocolVersion or maximumAllowed if {@link #getProtocolVersion} is greater.
+     */
+    ProtocolVersion getProtocolVersion(ProtocolVersion maximumAllowed);
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -282,6 +282,21 @@ public class CCMBridge implements CCMAccess {
     }
 
     /**
+     * @return {@link VersionNumber} representation of {@link CCMBridge#getCassandraVersion()}
+     */
+    public static VersionNumber getCassandraVersionNumber() {
+        return VersionNumber.parse(getCassandraVersion());
+    }
+
+    /**
+     * @param compareVersion The given version to compare with.
+     * @return Whether or not the configured cassandra version is greater than or equal to the given version.
+     */
+    public static boolean isCassandraVersionAtLeast(String compareVersion) {
+        return getCassandraVersionNumber().compareTo(VersionNumber.parse(compareVersion)) >= 0;
+    }
+
+    /**
      * @return The configured DSE version if '-Ddse=true' specified, otherwise null.
      */
     public static String getDSEVersion() {
@@ -290,6 +305,22 @@ public class CCMBridge implements CCMAccess {
         } else {
             return null;
         }
+    }
+
+    /**
+     * @return {@link VersionNumber} representation of {@link CCMBridge#getDSEVersion()}
+     */
+    public static VersionNumber getDSEVersionNumber() {
+        return VersionNumber.parse(getDSEVersion());
+    }
+
+    /**
+     * @param compareVersion The given version to compare with.
+     * @return Whether or not the configured dse version is greater than or equal to the given version.
+     */
+    public static boolean isDSEVersionAtLeast(String compareVersion) {
+        VersionNumber dseVersion = getDSEVersionNumber();
+        return dseVersion != null && dseVersion.compareTo(VersionNumber.parse(compareVersion)) >= 0;
     }
 
     /**
@@ -549,7 +580,12 @@ public class CCMBridge implements CCMAccess {
     @Override
     public void decommission(int n) {
         logger.debug(String.format("Decommissioning: node %s (%s%s:%s) from %s", n, TestUtils.IP_PREFIX, n, binaryPort, this));
-        execute(CCM_COMMAND + " node%d decommission", n);
+        // Special case for C* 3.12+, DSE 5.1+, force decommission (see CASSANDRA-12510)
+        String cmd = CCM_COMMAND + " node%d decommission";
+        if ((!isDSE() && isCassandraVersionAtLeast("3.12")) || (isDSE() && isDSEVersionAtLeast("5.1"))) {
+            cmd += " --force";
+        }
+        execute(cmd, n);
     }
 
     @Override
@@ -908,6 +944,12 @@ public class CCMBridge implements CCMAccess {
             int storagePort = Integer.parseInt(cassandraConfiguration.get("storage_port").toString());
             int thriftPort = Integer.parseInt(cassandraConfiguration.get("rpc_port").toString());
             int binaryPort = Integer.parseInt(cassandraConfiguration.get("native_transport_port").toString());
+            if (!isThriftSupported(dse, version)) {
+                // remove thrift configuration
+                cassandraConfiguration.remove("start_rpc");
+                cassandraConfiguration.remove("rpc_port");
+                cassandraConfiguration.remove("thrift_prepared_statements_cache_size_mb");
+            }
             final CCMBridge ccm = new CCMBridge(clusterName, dse, version, storagePort, thriftPort, binaryPort, joinJvmArgs(), nodes);
 
             Runtime.getRuntime().addShutdownHook(new Thread() {
@@ -921,10 +963,7 @@ public class CCMBridge implements CCMAccess {
             ccm.updateConfig(cassandraConfiguration);
             if (dse) {
                 Map<String, Object> dseConfiguration = Maps.newLinkedHashMap(this.dseConfiguration);
-                /* TODO: Use version passed in if present, there is currently a conflation of C* and DSE versions
-                 * when it comes to this that don't want to disturb.  No tests are currently using withVersion with
-                 * dse, so its not an issue at the moment. */
-                if (VersionNumber.parse(CCMBridge.getDSEVersion()).getMajor() >= 5) {
+                if (dse && version.getMajor() >= 5) {
                     // randomize DSE specific ports if dse present and greater than 5.0
                     dseConfiguration.put("lease_netty_server_port", RANDOM_PORT);
                     dseConfiguration.put("internode_messaging_options.port", RANDOM_PORT);
@@ -939,6 +978,10 @@ public class CCMBridge implements CCMAccess {
             if (start)
                 ccm.start();
             return ccm;
+        }
+
+        private static boolean isThriftSupported(boolean dse, VersionNumber version) {
+            return dse || version.compareTo(VersionNumber.parse("4.0")) < 0;
         }
 
         public int weight() {

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -40,11 +40,11 @@ public class CCMBridge implements CCMAccess {
 
     private static final Logger logger = LoggerFactory.getLogger(CCMBridge.class);
 
-    private static final String CASSANDRA_VERSION;
+    private static final VersionNumber GLOBAL_CASSANDRA_VERSION_NUMBER;
+
+    private static final VersionNumber GLOBAL_DSE_VERSION_NUMBER;
 
     private static final Set<String> CASSANDRA_INSTALL_ARGS;
-
-    private static final boolean IS_DSE;
 
     public static final String DEFAULT_CLIENT_TRUSTSTORE_PASSWORD = "cassandra1sfun";
     public static final String DEFAULT_CLIENT_TRUSTSTORE_PATH = "/client.truststore";
@@ -81,8 +81,8 @@ public class CCMBridge implements CCMAccess {
     private static final Map<String, String> ENVIRONMENT_MAP;
 
     /**
-     * A mapping of full DSE versions to their C* counterpart.  This is not meant to be comprehensive.  Used by
-     * {@link #getCassandraVersion()}.  If C* version cannot be derived, the method makes a 'best guess'.
+     * A mapping of full DSE versions to their C* counterpart.  This is not meant to be comprehensive.
+     * If C* version cannot be derived, the method makes a 'best guess'.
      */
     private static final Map<String, String> dseToCassandraVersions = ImmutableMap.<String, String>builder()
             .put("5.0.4", "3.0.10")
@@ -144,14 +144,14 @@ public class CCMBridge implements CCMAccess {
     private static final String CCM_COMMAND;
 
     static {
-        CASSANDRA_VERSION = System.getProperty("cassandra.version");
+        String inputCassandraVersion = System.getProperty("cassandra.version");
         String installDirectory = System.getProperty("cassandra.directory");
         String branch = System.getProperty("cassandra.branch");
 
         String dseProperty = System.getProperty("dse");
         // If -Ddse, if the value is empty interpret it as enabled,
         // otherwise if there is a value, parse as boolean.
-        IS_DSE = dseProperty != null && (dseProperty.isEmpty() || Boolean.parseBoolean(dseProperty));
+        boolean isDse = dseProperty != null && (dseProperty.isEmpty() || Boolean.parseBoolean(dseProperty));
 
         ImmutableSet.Builder<String> installArgs = ImmutableSet.builder();
         if (installDirectory != null && !installDirectory.trim().isEmpty()) {
@@ -159,10 +159,10 @@ public class CCMBridge implements CCMAccess {
         } else if (branch != null && !branch.trim().isEmpty()) {
             installArgs.add("-v git:" + branch.trim().replaceAll("\"", ""));
         } else {
-            installArgs.add("-v " + CASSANDRA_VERSION);
+            installArgs.add("-v " + inputCassandraVersion);
         }
 
-        if (IS_DSE) {
+        if (isDse) {
             installArgs.add("--dse");
         }
 
@@ -193,12 +193,57 @@ public class CCMBridge implements CCMAccess {
         }
         ENVIRONMENT_MAP = ImmutableMap.copyOf(envMap);
 
-        if (CCMBridge.isDSE()) {
+        if (isDse) {
+            GLOBAL_DSE_VERSION_NUMBER = VersionNumber.parse(inputCassandraVersion);
+            GLOBAL_CASSANDRA_VERSION_NUMBER = CCMBridge.getCassandraVersion(GLOBAL_DSE_VERSION_NUMBER);
             logger.info("Tests requiring CCM will by default use DSE version {} (C* {}, install arguments: {})",
-                    CCMBridge.getDSEVersion(), CCMBridge.getCassandraVersion(), CCMBridge.getInstallArguments());
+                    GLOBAL_DSE_VERSION_NUMBER, GLOBAL_CASSANDRA_VERSION_NUMBER, CASSANDRA_INSTALL_ARGS);
         } else {
+            GLOBAL_CASSANDRA_VERSION_NUMBER = VersionNumber.parse(inputCassandraVersion);
+            GLOBAL_DSE_VERSION_NUMBER = null;
             logger.info("Tests requiring CCM will by default use Cassandra version {} (install arguments: {})",
-                    CCMBridge.getCassandraVersion(), CCMBridge.getInstallArguments());
+                    GLOBAL_CASSANDRA_VERSION_NUMBER, CASSANDRA_INSTALL_ARGS);
+        }
+    }
+
+    /**
+     * @return {@link VersionNumber} configured for Cassandra based on system properties.
+     */
+    public static VersionNumber getGlobalCassandraVersion() {
+        return GLOBAL_CASSANDRA_VERSION_NUMBER;
+    }
+
+    /**
+     * @return {@link VersionNumber} configured for DSE based on system properties.
+     */
+    public static VersionNumber getGlobalDSEVersion() {
+        return GLOBAL_DSE_VERSION_NUMBER;
+    }
+
+    /**
+     * @return The mapped cassandra version to the given dseVersion.
+     * If the DSE version can't be derived the following logic is used:
+     * <ol>
+     * <li>If <= 3.X, use C* 1.2</li>
+     * <li>If 4.X, use 2.1 for >= 4.7, 2.0 otherwise.</li>
+     * <li>Otherwise 3.0</li>
+     * </ol>
+     */
+    public static VersionNumber getCassandraVersion(VersionNumber dseVersion) {
+        String cassandraVersion = dseToCassandraVersions.get(dseVersion.toString());
+        if (cassandraVersion != null) {
+            return VersionNumber.parse(cassandraVersion);
+        } else if (dseVersion.getMajor() <= 3) {
+            return VersionNumber.parse("1.2");
+        } else if (dseVersion.getMajor() == 4) {
+            if (dseVersion.getMinor() >= 7) {
+                return VersionNumber.parse("2.1");
+            } else {
+                return VersionNumber.parse("2.0");
+            }
+        } else {
+            // Fallback on 3.0 by default.
+            return VersionNumber.parse("3.0");
         }
     }
 
@@ -215,7 +260,9 @@ public class CCMBridge implements CCMAccess {
 
     private final String clusterName;
 
-    private final VersionNumber version;
+    private final VersionNumber cassandraVersion;
+
+    private final VersionNumber dseVersion;
 
     private final int storagePort;
 
@@ -237,104 +284,18 @@ public class CCMBridge implements CCMAccess {
 
     private final int[] nodes;
 
-    private CCMBridge(String clusterName, boolean isDSE, VersionNumber version, int storagePort, int thriftPort, int binaryPort, String jvmArgs, int[] nodes) {
+    private CCMBridge(String clusterName, VersionNumber cassandraVersion, VersionNumber dseVersion,
+                      int storagePort, int thriftPort, int binaryPort, String jvmArgs, int[] nodes) {
         this.clusterName = clusterName;
-        this.version = version;
+        this.cassandraVersion = cassandraVersion;
+        this.dseVersion = dseVersion;
         this.storagePort = storagePort;
         this.thriftPort = thriftPort;
         this.binaryPort = binaryPort;
-        this.isDSE = isDSE;
+        this.isDSE = dseVersion != null;
         this.jvmArgs = jvmArgs;
         this.nodes = nodes;
         this.ccmDir = Files.createTempDir();
-    }
-
-    /**
-     * @return The configured cassandra version.  If -Ddse=true was used, this value is derived from the
-     * DSE version provided.  If the DSE version can't be derived the following logic is used:
-     * <ol>
-     * <li>If <= 3.X, use C* 1.2</li>
-     * <li>If 4.X, use 2.1 for >= 4.7, 2.0 otherwise.</li>
-     * <li>Otherwise 3.0</li>
-     * </ol>
-     */
-    public static String getCassandraVersion() {
-        if (isDSE()) {
-            String cassandraVersion = dseToCassandraVersions.get(CASSANDRA_VERSION);
-            if (cassandraVersion != null) {
-                return cassandraVersion;
-            } else if (CASSANDRA_VERSION.startsWith("3.") || CASSANDRA_VERSION.compareTo("3") <= 0) {
-                return "1.2";
-            } else if (CASSANDRA_VERSION.startsWith("4.")) {
-                if (CASSANDRA_VERSION.compareTo("4.7") >= 0) {
-                    return "2.1";
-                } else {
-                    return "2.0";
-                }
-            } else {
-                // Fallback on 3.0 by default.
-                return "3.0";
-            }
-
-        } else {
-            return CASSANDRA_VERSION;
-        }
-    }
-
-    /**
-     * @return {@link VersionNumber} representation of {@link CCMBridge#getCassandraVersion()}
-     */
-    public static VersionNumber getCassandraVersionNumber() {
-        return VersionNumber.parse(getCassandraVersion());
-    }
-
-    /**
-     * @param compareVersion The given version to compare with.
-     * @return Whether or not the configured cassandra version is greater than or equal to the given version.
-     */
-    public static boolean isCassandraVersionAtLeast(String compareVersion) {
-        return getCassandraVersionNumber().compareTo(VersionNumber.parse(compareVersion)) >= 0;
-    }
-
-    /**
-     * @return The configured DSE version if '-Ddse=true' specified, otherwise null.
-     */
-    public static String getDSEVersion() {
-        if (isDSE()) {
-            return CASSANDRA_VERSION;
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * @return {@link VersionNumber} representation of {@link CCMBridge#getDSEVersion()}
-     */
-    public static VersionNumber getDSEVersionNumber() {
-        return VersionNumber.parse(getDSEVersion());
-    }
-
-    /**
-     * @param compareVersion The given version to compare with.
-     * @return Whether or not the configured dse version is greater than or equal to the given version.
-     */
-    public static boolean isDSEVersionAtLeast(String compareVersion) {
-        VersionNumber dseVersion = getDSEVersionNumber();
-        return dseVersion != null && dseVersion.compareTo(VersionNumber.parse(compareVersion)) >= 0;
-    }
-
-    /**
-     * @return Whether or not DSE was configured via '-Ddse=true'.
-     */
-    public static boolean isDSE() {
-        return IS_DSE;
-    }
-
-    /**
-     * @return The install arguments to pass to CCM when creating the cluster.
-     */
-    public static Set<String> getInstallArguments() {
-        return CASSANDRA_INSTALL_ARGS;
     }
 
     public static Builder builder() {
@@ -352,8 +313,13 @@ public class CCMBridge implements CCMAccess {
     }
 
     @Override
-    public VersionNumber getVersion() {
-        return version;
+    public VersionNumber getCassandraVersion() {
+        return cassandraVersion;
+    }
+
+    @Override
+    public VersionNumber getDSEVersion() {
+        return dseVersion;
     }
 
     @Override
@@ -435,7 +401,7 @@ public class CCMBridge implements CCMAccess {
     private String getStartWaitArguments() {
         // make a small exception for C* 1.2 as it has a bug where it starts listening on the binary
         // interface slightly before it joins the cluster.
-        if (getCassandraVersion().startsWith("1.")) {
+        if (this.cassandraVersion.getMajor() == 1) {
             return " --wait-other-notice";
         } else {
             return " --no-wait";
@@ -450,7 +416,7 @@ public class CCMBridge implements CCMAccess {
             logger.debug("Starting: {} - free memory: {} MB", this, TestUtils.getFreeMemoryMB());
         try {
             String cmd = CCM_COMMAND + " start " + jvmArgs + getStartWaitArguments();
-            if (isWindows() && this.version.compareTo(VersionNumber.parse("2.2.4")) >= 0) {
+            if (isWindows() && this.cassandraVersion.compareTo(VersionNumber.parse("2.2.4")) >= 0) {
                 cmd += " --quiet-windows";
             }
             execute(cmd);
@@ -524,7 +490,7 @@ public class CCMBridge implements CCMAccess {
         logger.debug(String.format("Starting: node %s (%s%s:%s) in %s", n, TestUtils.IP_PREFIX, n, binaryPort, this));
         try {
             String cmd = CCM_COMMAND + " node%d start " + jvmArgs + getStartWaitArguments();
-            if (isWindows() && this.version.compareTo(VersionNumber.parse("2.2.4")) >= 0) {
+            if (isWindows() && this.cassandraVersion.compareTo(VersionNumber.parse("2.2.4")) >= 0) {
                 cmd += " --quiet-windows";
             }
             execute(cmd, n);
@@ -582,7 +548,7 @@ public class CCMBridge implements CCMAccess {
         logger.debug(String.format("Decommissioning: node %s (%s%s:%s) from %s", n, TestUtils.IP_PREFIX, n, binaryPort, this));
         // Special case for C* 3.12+, DSE 5.1+, force decommission (see CASSANDRA-12510)
         String cmd = CCM_COMMAND + " node%d decommission";
-        if ((!isDSE() && isCassandraVersionAtLeast("3.12")) || (isDSE() && isDSEVersionAtLeast("5.1"))) {
+        if (this.cassandraVersion.compareTo(VersionNumber.parse("3.12")) >= 0) {
             cmd += " --force";
         }
         execute(cmd, n);
@@ -724,6 +690,26 @@ public class CCMBridge implements CCMAccess {
         TestUtils.waitUntilPortIsDown(addressOfNode(node));
     }
 
+    @Override
+    public ProtocolVersion getProtocolVersion() {
+        VersionNumber version = getCassandraVersion();
+        if (version.compareTo(VersionNumber.parse("2.0")) < 0) {
+            return ProtocolVersion.V1;
+        } else if (version.compareTo(VersionNumber.parse("2.1")) < 0) {
+            return ProtocolVersion.V2;
+        } else if (version.compareTo(VersionNumber.parse("2.2")) < 0) {
+            return ProtocolVersion.V3;
+        } else {
+            return ProtocolVersion.V4;
+        }
+    }
+
+    @Override
+    public ProtocolVersion getProtocolVersion(ProtocolVersion maximumAllowed) {
+        ProtocolVersion versionToUse = getProtocolVersion();
+        return versionToUse.compareTo(maximumAllowed) > 0 ? maximumAllowed : versionToUse;
+    }
+
     /**
      * <p>
      * Extracts a keystore from the classpath into a temporary file.
@@ -782,9 +768,9 @@ public class CCMBridge implements CCMAccess {
 
         int[] nodes = {1};
         private boolean start = true;
-        private Boolean isDSE = null;
-        private String version = getCassandraVersion();
-        private Set<String> createOptions = new LinkedHashSet<String>(getInstallArguments());
+        private boolean dse = false;
+        private VersionNumber version = null;
+        private Set<String> createOptions = new LinkedHashSet<String>();
         private Set<String> jvmArgs = new LinkedHashSet<String>();
         private final Map<String, Object> cassandraConfiguration = Maps.newLinkedHashMap();
         private final Map<String, Object> dseConfiguration = Maps.newLinkedHashMap();
@@ -840,41 +826,24 @@ public class CCMBridge implements CCMAccess {
         }
 
         /**
-         * Sets this cluster to be a DSE cluster (defaults to {@link #isDSE()} if this is never called).
+         * The Cassandra or DSE version to use.  If not specified the globally configured version is used instead.
          */
-        public Builder withDSE() {
-            this.isDSE = true;
-            return this;
-        }
-
-        /**
-         * Sets this cluster to be a non-DSE cluster (defaults to {@link #isDSE()} if this is never called).
-         */
-        public Builder withoutDSE() {
-            this.isDSE = false;
-            return this;
-        }
-
-        /**
-         * The Cassandra or DSE version to use (defaults to {@link #getCassandraVersion()} if this is never called).
-         */
-        public Builder withVersion(String version) {
-            Iterator<String> it = createOptions.iterator();
-            while (it.hasNext()) {
-                String option = it.next();
-                // remove any version previously set and
-                // install-dir, which is incompatible
-                if (option.startsWith("-v ") || option.startsWith("--install-dir"))
-                    it.remove();
-            }
-            this.createOptions.add("-v " + version);
+        public Builder withVersion(VersionNumber version) {
             this.version = version;
             return this;
         }
 
         /**
+         * Indicates whether or not this cluster is meant to be a DSE cluster.
+         */
+        public Builder withDSE(boolean dse) {
+            this.dse = dse;
+            return this;
+        }
+
+        /**
          * Free-form options that will be added at the end of the {@code ccm create} command
-         * (defaults to {@link #getInstallArguments()} if this is never called).
+         * (defaults to {@link #CASSANDRA_INSTALL_ARGS} if this is never called).
          */
         public Builder withCreateOptions(String... createOptions) {
             Collections.addAll(this.createOptions, createOptions);
@@ -937,20 +906,36 @@ public class CCMBridge implements CCMAccess {
         public CCMBridge build() {
             // be careful NOT to alter internal state (hashCode/equals) during build!
             String clusterName = TestUtils.generateIdentifier("ccm_");
-            boolean dse = isDSE == null ? isDSE() : isDSE;
+
+
+            VersionNumber dseVersion;
+            VersionNumber cassandraVersion;
+            boolean versionConfigured = this.version != null;
+            // No version was explicitly provided, fallback on global config.
+            if (!versionConfigured) {
+                dseVersion = GLOBAL_DSE_VERSION_NUMBER;
+                cassandraVersion = GLOBAL_CASSANDRA_VERSION_NUMBER;
+            } else if (dse) {
+                // given version is the DSE version, base cassandra version on DSE version.
+                dseVersion = this.version;
+                cassandraVersion = getCassandraVersion(dseVersion);
+            } else {
+                // given version is cassandra version.
+                dseVersion = null;
+                cassandraVersion = this.version;
+            }
 
             Map<String, Object> cassandraConfiguration = randomizePorts(this.cassandraConfiguration);
-            VersionNumber version = VersionNumber.parse(this.version);
             int storagePort = Integer.parseInt(cassandraConfiguration.get("storage_port").toString());
             int thriftPort = Integer.parseInt(cassandraConfiguration.get("rpc_port").toString());
             int binaryPort = Integer.parseInt(cassandraConfiguration.get("native_transport_port").toString());
-            if (!isThriftSupported(dse, version)) {
+            if (!isThriftSupported(cassandraVersion)) {
                 // remove thrift configuration
                 cassandraConfiguration.remove("start_rpc");
                 cassandraConfiguration.remove("rpc_port");
                 cassandraConfiguration.remove("thrift_prepared_statements_cache_size_mb");
             }
-            final CCMBridge ccm = new CCMBridge(clusterName, dse, version, storagePort, thriftPort, binaryPort, joinJvmArgs(), nodes);
+            final CCMBridge ccm = new CCMBridge(clusterName, cassandraVersion, dseVersion, storagePort, thriftPort, binaryPort, joinJvmArgs(), nodes);
 
             Runtime.getRuntime().addShutdownHook(new Thread() {
                 @Override
@@ -958,12 +943,12 @@ public class CCMBridge implements CCMAccess {
                     ccm.close();
                 }
             });
-            ccm.execute(buildCreateCommand(clusterName, dse));
+            ccm.execute(buildCreateCommand(clusterName, versionConfigured, cassandraVersion, dseVersion));
             updateNodeConf(ccm);
             ccm.updateConfig(cassandraConfiguration);
-            if (dse) {
+            if (dseVersion != null) {
                 Map<String, Object> dseConfiguration = Maps.newLinkedHashMap(this.dseConfiguration);
-                if (dse && version.getMajor() >= 5) {
+                if (dseVersion.getMajor() >= 5) {
                     // randomize DSE specific ports if dse present and greater than 5.0
                     dseConfiguration.put("lease_netty_server_port", RANDOM_PORT);
                     dseConfiguration.put("internode_messaging_options.port", RANDOM_PORT);
@@ -980,8 +965,8 @@ public class CCMBridge implements CCMAccess {
             return ccm;
         }
 
-        private static boolean isThriftSupported(boolean dse, VersionNumber version) {
-            return dse || version.compareTo(VersionNumber.parse("4.0")) < 0;
+        private static boolean isThriftSupported(VersionNumber cassandraVersion) {
+            return cassandraVersion.compareTo(VersionNumber.parse("4.0")) < 0;
         }
 
         public int weight() {
@@ -1007,7 +992,7 @@ public class CCMBridge implements CCMAccess {
             return allJvmArgs.toString();
         }
 
-        private String buildCreateCommand(String clusterName, boolean dse) {
+        private String buildCreateCommand(String clusterName, boolean versionConfigured, VersionNumber cassandraVersion, VersionNumber dseVersion) {
             StringBuilder result = new StringBuilder(CCM_COMMAND + " create");
             result.append(" ").append(clusterName);
             result.append(" -i ").append(TestUtils.IP_PREFIX);
@@ -1022,16 +1007,18 @@ public class CCMBridge implements CCMAccess {
                 }
             }
 
-            // If not DSE, remove --dse if in createOptions.
             Set<String> lCreateOptions = new LinkedHashSet<String>(createOptions);
-            if (!dse) {
-                Iterator<String> it = lCreateOptions.iterator();
-                while (it.hasNext()) {
-                    String option = it.next();
-                    // remove any version previously set and
-                    // install-dir, which is incompatible
-                    if (option.equals("--dse"))
-                        it.remove();
+            if (!versionConfigured) {
+                // If no version was provided, use the default install ags.
+                lCreateOptions.addAll(CASSANDRA_INSTALL_ARGS);
+            } else {
+                if (dseVersion != null) {
+                    lCreateOptions.add("--dse");
+                    lCreateOptions.add("-v");
+                    lCreateOptions.add(dseVersion.toString());
+                } else {
+                    lCreateOptions.add("-v");
+                    lCreateOptions.add(cassandraVersion.toString());
                 }
             }
             result.append(" ").append(Joiner.on(" ").join(randomizePorts(lCreateOptions)));
@@ -1120,14 +1107,15 @@ public class CCMBridge implements CCMAccess {
         @Override
         @SuppressWarnings("SimplifiableIfStatement")
         public boolean equals(Object o) {
-            // do not include cluster name and start, only
-            // properties relevant to the settings of the cluster
+            // do not include start as it is not relevant to the settings of the cluster.
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
+
             Builder builder = (Builder) o;
+
+            if (dse != builder.dse) return false;
             if (!Arrays.equals(nodes, builder.nodes)) return false;
-            if (isDSE != null ? !isDSE.equals(builder.isDSE) : builder.isDSE != null) return false;
-            if (!version.equals(builder.version)) return false;
+            if (version != null ? !version.equals(builder.version) : builder.version != null) return false;
             if (!createOptions.equals(builder.createOptions)) return false;
             if (!jvmArgs.equals(builder.jvmArgs)) return false;
             if (!cassandraConfiguration.equals(builder.cassandraConfiguration)) return false;
@@ -1137,19 +1125,17 @@ public class CCMBridge implements CCMAccess {
 
         @Override
         public int hashCode() {
-            // do not include cluster name and start, only
-            // properties relevant to the settings of the cluster
+            // do not include start as it is not relevant to the settings of the cluster.
             int result = Arrays.hashCode(nodes);
-            result = 31 * result + (isDSE != null ? isDSE.hashCode() : 0);
+            result = 31 * result + (dse ? 1 : 0);
+            result = 31 * result + (version != null ? version.hashCode() : 0);
             result = 31 * result + createOptions.hashCode();
             result = 31 * result + jvmArgs.hashCode();
             result = 31 * result + cassandraConfiguration.hashCode();
             result = 31 * result + dseConfiguration.hashCode();
             result = 31 * result + workloads.hashCode();
-            result = 31 * result + version.hashCode();
             return result;
         }
-
     }
 
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMCache.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMCache.java
@@ -49,8 +49,13 @@ public class CCMCache {
         }
 
         @Override
-        public VersionNumber getVersion() {
-            return ccm.getVersion();
+        public VersionNumber getCassandraVersion() {
+            return ccm.getCassandraVersion();
+        }
+
+        @Override
+        public VersionNumber getDSEVersion() {
+            return ccm.getDSEVersion();
         }
 
         @Override
@@ -213,6 +218,16 @@ public class CCMCache {
         @Override
         public void waitForDown(int node) {
             ccm.waitForDown(node);
+        }
+
+        @Override
+        public ProtocolVersion getProtocolVersion() {
+            return ccm.getProtocolVersion();
+        }
+
+        @Override
+        public ProtocolVersion getProtocolVersion(ProtocolVersion maximumAllowed) {
+            return ccm.getProtocolVersion(maximumAllowed);
         }
 
         @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/ConditionalUpdateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ConditionalUpdateTest.java
@@ -24,7 +24,7 @@ import static org.testng.Assert.assertTrue;
 /**
  * Test {@link ResultSet#wasApplied()} for conditional updates.
  */
-@CassandraVersion(major = 2.0, description = "Conditional Updates requires 2.0+.")
+@CassandraVersion(value = "2.0.0", description = "Conditional Updates requires 2.0+.")
 public class ConditionalUpdateTest extends CCMTestsSupport {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
@@ -86,7 +86,7 @@ public class ControlConnectionTest extends CCMTestsSupport {
      * Therefore we use two different driver instances in this test.
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_parse_UDT_definitions_when_using_default_protocol_version() {
         // First driver instance: create UDT
         Cluster cluster = register(Cluster.builder()

--- a/driver-core/src/test/java/com/datastax/driver/core/CustomPayloadTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CustomPayloadTest.java
@@ -33,7 +33,7 @@ import static org.apache.log4j.Level.TRACE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 @CCMConfig(jvmArgs = "-Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler")
 public class CustomPayloadTest extends CCMTestsSupport {
 
@@ -85,8 +85,6 @@ public class CustomPayloadTest extends CCMTestsSupport {
 
     /**
      * Ensures that an incoming payload is propagated from prepared to bound statements.
-     *
-     * @throws Exception
      */
     @Test(groups = "short")
     public void should_propagate_incoming_payload_to_bound_statement() throws Exception {
@@ -113,8 +111,6 @@ public class CustomPayloadTest extends CCMTestsSupport {
     /**
      * Ensures that an incoming payload is overridden by an explicitly set outgoing payload
      * when propagated to bound statements.
-     *
-     * @throws Exception
      */
     @Test(groups = "short")
     public void should_override_incoming_payload_when_outgoing_payload_explicitly_set_on_preparing_statement() throws Exception {
@@ -141,8 +137,6 @@ public class CustomPayloadTest extends CCMTestsSupport {
     /**
      * Ensures that payloads can still be set individually on bound statements
      * if the prepared statement does not have a default payload.
-     *
-     * @throws Exception
      */
     @Test(groups = "short")
     public void should_not_set_any_payload_on_bound_statement() throws Exception {
@@ -171,8 +165,6 @@ public class CustomPayloadTest extends CCMTestsSupport {
 
     /**
      * Ensures that a custom payload is propagated throughout pages.
-     *
-     * @throws Exception
      */
     @Test(groups = "short")
     public void should_echo_custom_payload_when_paginating() throws Exception {
@@ -253,8 +245,6 @@ public class CustomPayloadTest extends CCMTestsSupport {
 
     /**
      * Ensures that when debugging custom payloads, the driver will print appropriate log messages.
-     *
-     * @throws Exception
      */
     @Test(groups = "short")
     public void should_print_log_message_when_level_trace() throws Exception {

--- a/driver-core/src/test/java/com/datastax/driver/core/CustomTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CustomTypeTest.java
@@ -19,7 +19,6 @@ import com.datastax.driver.core.utils.CassandraVersion;
 import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -153,7 +152,7 @@ public class CustomTypeTest extends CCMTestsSupport {
      * @test_category metadata
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_handle_udt_with_custom_type() {
         // Given: a UDT with custom types, and a table using it.
         session().execute("CREATE TYPE custom_udt (regular int, c1 'DynamicCompositeType(s => UTF8Type, i => Int32Type)', c2 'LongType')");

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeClassNameParserTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeClassNameParserTest.java
@@ -25,7 +25,7 @@ import static org.testng.Assert.*;
 
 public class DataTypeClassNameParserTest {
 
-    private ProtocolVersion protocolVersion = TestUtils.getDesiredProtocolVersion();
+    private ProtocolVersion protocolVersion = ProtocolVersion.NEWEST_SUPPORTED;
     private CodecRegistry codecRegistry = new CodecRegistry();
 
     @Test(groups = "unit")

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeCqlNameParserTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeCqlNameParserTest.java
@@ -23,7 +23,7 @@ import static com.datastax.driver.core.DataType.*;
 import static com.datastax.driver.core.DataTypeCqlNameParser.parse;
 import static com.datastax.driver.core.Metadata.quote;
 
-@CassandraVersion(major = 3.0)
+@CassandraVersion("3.0")
 public class DataTypeCqlNameParserTest extends CCMTestsSupport {
 
     @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
@@ -36,7 +36,6 @@ import static org.assertj.core.api.Assertions.fail;
  * (protocol > v2 only) and a prepared statement.
  * This is repeated with a large number of datatypes.
  */
-@CCMConfig(clusterProvider = "createClusterBuilderNoDebouncing")
 public class DataTypeIntegrationTest extends CCMTestsSupport {
     private static final Logger logger = LoggerFactory.getLogger(DataTypeIntegrationTest.class);
 
@@ -71,7 +70,7 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
     }
 
     @Test(groups = "long")
-    @CassandraVersion(major = 2.0, description = "Uses parameterized simple statements, which are only available with protocol v2")
+    @CassandraVersion(value = "2.0", description = "Uses parameterized simple statements, which are only available with protocol v2")
     public void should_insert_and_retrieve_data_with_parameterized_simple_statements() {
         should_insert_and_retrieve_data(StatementType.SIMPLE_WITH_PARAM);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
@@ -39,13 +39,19 @@ import static org.assertj.core.api.Assertions.fail;
 public class DataTypeIntegrationTest extends CCMTestsSupport {
     private static final Logger logger = LoggerFactory.getLogger(DataTypeIntegrationTest.class);
 
-    List<TestTable> tables = allTables();
-    VersionNumber cassandraVersion;
+    private Map<DataType, Object> samples;
+
+    private List<TestTable> tables;
+
+    private VersionNumber cassandraVersion;
 
     enum StatementType {RAW_STRING, SIMPLE_WITH_PARAM, PREPARED}
 
     @Override
     public void onTestContextInitialized() {
+        ProtocolVersion protocolVersion = ccm().getProtocolVersion();
+        samples = PrimitiveTypeSamples.samples(protocolVersion);
+        tables = allTables();
         Host host = cluster().getMetadata().getAllHosts().iterator().next();
         cassandraVersion = host.getCassandraVersion().nextStable();
         List<String> statements = Lists.newArrayList();
@@ -188,7 +194,7 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
         }
     }
 
-    private static List<TestTable> allTables() {
+    private List<TestTable> allTables() {
         List<TestTable> tables = Lists.newArrayList();
 
         tables.addAll(tablesWithPrimitives());
@@ -201,18 +207,18 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
         return ImmutableList.copyOf(tables);
     }
 
-    private static List<TestTable> tablesWithPrimitives() {
+    private List<TestTable> tablesWithPrimitives() {
         List<TestTable> tables = Lists.newArrayList();
-        for (Map.Entry<DataType, Object> entry : PrimitiveTypeSamples.ALL.entrySet())
+        for (Map.Entry<DataType, Object> entry : samples.entrySet())
             tables.add(new TestTable(entry.getKey(), entry.getValue(), "1.2.0"));
         return tables;
     }
 
-    private static List<TestTable> tablesWithPrimitivesNull() {
+    private List<TestTable> tablesWithPrimitivesNull() {
         List<TestTable> tables = Lists.newArrayList();
         // Create a test table for each primitive type testing with null values.  If the
         // type maps to a java primitive type it's value will by the default value instead of null.
-        for (DataType dataType : DataType.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion())) {
+        for (DataType dataType : DataType.allPrimitiveTypes(ccm().getProtocolVersion())) {
             Object expectedPrimitiveValue = null;
             switch (dataType.getName()) {
                 case BIGINT:
@@ -247,9 +253,9 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
 
     }
 
-    private static List<TestTable> tablesWithCollectionsOfPrimitives() {
+    private List<TestTable> tablesWithCollectionsOfPrimitives() {
         List<TestTable> tables = Lists.newArrayList();
-        for (Map.Entry<DataType, Object> entry : PrimitiveTypeSamples.ALL.entrySet()) {
+        for (Map.Entry<DataType, Object> entry : samples.entrySet()) {
 
             DataType elementType = entry.getKey();
             Object elementSample = entry.getValue();
@@ -260,12 +266,12 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
         return tables;
     }
 
-    private static List<TestTable> tablesWithMapsOfPrimitives() {
+    private List<TestTable> tablesWithMapsOfPrimitives() {
         List<TestTable> tables = Lists.newArrayList();
-        for (Map.Entry<DataType, Object> keyEntry : PrimitiveTypeSamples.ALL.entrySet()) {
+        for (Map.Entry<DataType, Object> keyEntry : samples.entrySet()) {
             DataType keyType = keyEntry.getKey();
             Object keySample = keyEntry.getValue();
-            for (Map.Entry<DataType, Object> valueEntry : PrimitiveTypeSamples.ALL.entrySet()) {
+            for (Map.Entry<DataType, Object> valueEntry : samples.entrySet()) {
                 DataType valueType = valueEntry.getKey();
                 Object valueSample = valueEntry.getValue();
 
@@ -277,7 +283,7 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
         return tables;
     }
 
-    private static Collection<? extends TestTable> tablesWithNestedCollections() {
+    private Collection<? extends TestTable> tablesWithNestedCollections() {
         List<TestTable> tables = Lists.newArrayList();
 
         // To avoid combinatorial explosion, only use int as the primitive type, and two levels of nesting.
@@ -308,7 +314,7 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
         return tables;
     }
 
-    private static Collection<? extends TestTable> tablesWithRandomlyGeneratedNestedCollections() {
+    private Collection<? extends TestTable> tablesWithRandomlyGeneratedNestedCollections() {
         List<TestTable> tables = Lists.newArrayList();
 
         DataType nestedListType = buildNestedType(DataType.Name.LIST, 5);
@@ -324,7 +330,7 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
     /**
      * Populate a nested collection based on the given type and it's arguments.
      */
-    public static Object nestedObject(DataType type) {
+    public Object nestedObject(DataType type) {
 
         int typeIdx = type.getTypeArguments().size() > 1 ? 1 : 0;
         DataType argument = type.getTypeArguments().get(typeIdx);
@@ -374,7 +380,7 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
      * @return a DataType that is a nested collection with the given baseType with the
      * given depth.
      */
-    public static DataType buildNestedType(DataType.Name baseType, int depth) {
+    public DataType buildNestedType(DataType.Name baseType, int depth) {
         Random r = new Random();
         DataType t = null;
 

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
@@ -37,7 +37,7 @@ public class DataTypeTest {
 
     CodecRegistry codecRegistry = new CodecRegistry();
 
-    ProtocolVersion protocolVersion = TestUtils.getDesiredProtocolVersion();
+    ProtocolVersion protocolVersion = ProtocolVersion.NEWEST_SUPPORTED;
 
     static boolean exclude(DataType t) {
         return t.getName() == DataType.Name.COUNTER;

--- a/driver-core/src/test/java/com/datastax/driver/core/DirectCompressionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DirectCompressionTest.java
@@ -40,7 +40,7 @@ public class DirectCompressionTest extends CompressionTest {
      * @expected_result session established and queries made successfully using it.
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_function_with_lz4_compression() throws Exception {
         compressionTest(ProtocolOptions.Compression.LZ4);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/FunctionMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/FunctionMetadataTest.java
@@ -19,10 +19,11 @@ import com.datastax.driver.core.utils.CassandraVersion;
 import org.testng.annotations.Test;
 
 import static com.datastax.driver.core.Assertions.assertThat;
-import static com.datastax.driver.core.DataType.*;
+import static com.datastax.driver.core.DataType.cint;
+import static com.datastax.driver.core.DataType.map;
 import static org.assertj.core.api.Assertions.entry;
 
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 @CCMConfig(config = "enable_user_defined_functions:true")
 public class FunctionMetadataTest extends CCMTestsSupport {
 

--- a/driver-core/src/test/java/com/datastax/driver/core/GettableDataIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/GettableDataIntegrationTest.java
@@ -45,7 +45,7 @@ public class GettableDataIntegrationTest extends CCMTestsSupport {
 
     @Override
     public void onTestContextInitialized() {
-        is21 = ccm().getVersion().compareTo(VersionNumber.parse("2.1.3")) > 0;
+        is21 = ccm().getCassandraVersion().compareTo(VersionNumber.parse("2.1.3")) > 0;
         // only add tuples / nested collections at > 2.1.3.
         execute("CREATE TABLE codec_mapping (k int PRIMARY KEY, "
                 + "v int, l list<int>, m map<int,int>" +

--- a/driver-core/src/test/java/com/datastax/driver/core/HeapCompressionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HeapCompressionTest.java
@@ -47,7 +47,7 @@ public class HeapCompressionTest extends CompressionTest {
      * @expected_result session established and queries made successfully using it.
      */
     @Test(groups = "isolated")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_function_with_lz4_compression() throws Exception {
         compressionTest(ProtocolOptions.Compression.LZ4);
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/HostMetadataIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostMetadataIntegrationTest.java
@@ -42,7 +42,7 @@ public class HostMetadataIntegrationTest {
      * @see HostMetadataIntegrationTest#should_parse_dse_workload_and_version_if_available()
      */
     @Test(groups = "long")
-    @DseVersion(major = 5.0)
+    @DseVersion("5.0.0")
     public void test_mixed_dse_workload() {
         CCMBridge.Builder builder = CCMBridge.builder()
                 .withNodes(3)

--- a/driver-core/src/test/java/com/datastax/driver/core/HostMetadataIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostMetadataIntegrationTest.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.driver.core;
 
-import com.datastax.driver.core.utils.DseVersion;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.testng.annotations.Test;
@@ -23,51 +22,9 @@ import org.testng.annotations.Test;
 import java.net.InetAddress;
 
 import static com.datastax.driver.core.Assertions.assertThat;
-import static com.datastax.driver.core.CCMAccess.Workload.solr;
-import static com.datastax.driver.core.CCMAccess.Workload.spark;
 import static com.datastax.driver.core.TestUtils.nonQuietClusterCloseOptions;
 
 public class HostMetadataIntegrationTest {
-
-    /**
-     * Validates that when given a DSE cluster that the workload and dse versions are properly
-     * parsed and set on the respective {@link Host} instances.
-     * <p/>
-     * This test is disabled as running DSE with workloads is intensive and has unreliable results
-     * when running CCM with multiple workloads.
-     * <p/>
-     *
-     * @test_category host:metadata
-     * @jira_ticket JAVA-1042
-     * @see HostMetadataIntegrationTest#should_parse_dse_workload_and_version_if_available()
-     */
-    @Test(groups = "long")
-    @DseVersion("5.0.0")
-    public void test_mixed_dse_workload() {
-        CCMBridge.Builder builder = CCMBridge.builder()
-                .withNodes(3)
-                .withDSE()
-                .withWorkload(2, solr)
-                .withWorkload(3, spark);
-        CCMAccess ccm = CCMCache.get(builder);
-
-        VersionNumber version = VersionNumber.parse(CCMBridge.getDSEVersion());
-
-        Cluster cluster = Cluster.builder()
-                .addContactPoints(ccm.addressOfNode(1).getAddress())
-                .withPort(ccm.getBinaryPort())
-                .build();
-        try {
-            cluster.connect();
-
-            assertThat(cluster).host(1).hasWorkload("Cassandra").hasDseVersion(version);
-            assertThat(cluster).host(2).hasWorkload("Search").hasDseVersion(version);
-            assertThat(cluster).host(3).hasWorkload("Analytics").hasDseVersion(version);
-        } finally {
-            cluster.close();
-            ccm.close();
-        }
-    }
 
     /**
      * Validates that {@link Host#getDseVersion()} and {@link Host#getDseWorkload()} return values defined in

--- a/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
@@ -75,7 +75,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
                 + "\"MixedCaseColumn\" list<text>,"
                 +
                 // Frozen collections was introduced only in C* 2.1.3
-                (ccm().getVersion().compareTo(VersionNumber.parse("2.1.3")) >= 0
+                (ccm().getCassandraVersion().compareTo(VersionNumber.parse("2.1.3")) >= 0
                         ?
                         ", map_full frozen<map<text, int>>,"
                                 + "set_full frozen<set<text>>,"
@@ -106,7 +106,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     @CassandraVersion(value = "2.1", description = "index names with quoted identifiers and collection indexes not supported until 2.1")
     public void should_create_metadata_for_values_index_on_mixed_case_column() {
         // 3.0 assumes the 'values' keyword if index on a collection
-        String createValuesIndex = ccm().getVersion().getMajor() > 2 ?
+        String createValuesIndex = ccm().getCassandraVersion().getMajor() > 2 ?
                 String.format("CREATE INDEX \"MixedCaseIndex\" ON %s.indexing (values(\"MixedCaseColumn\"));", keyspace) :
                 String.format("CREATE INDEX \"MixedCaseIndex\" ON %s.indexing (\"MixedCaseColumn\");", keyspace);
         session().execute(createValuesIndex);
@@ -116,7 +116,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
                 .hasName("MixedCaseIndex")
                 .hasParent((TableMetadata) column.getParent())
                 .isNotCustomIndex()
-                .hasTarget(ccm().getVersion().getMajor() > 2 ? "values(\"MixedCaseColumn\")" : "\"MixedCaseColumn\"")
+                .hasTarget(ccm().getCassandraVersion().getMajor() > 2 ? "values(\"MixedCaseColumn\")" : "\"MixedCaseColumn\"")
                 .hasKind(COMPOSITES)
                 .asCqlQuery(createValuesIndex);
         assertThat((TableMetadata) column.getParent()).hasIndex(index);
@@ -126,7 +126,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     @CassandraVersion("2.1.0")
     public void should_create_metadata_for_index_on_map_values() {
         // 3.0 assumes the 'values' keyword if index on a collection
-        String createValuesIndex = ccm().getVersion().getMajor() > 2 ?
+        String createValuesIndex = ccm().getCassandraVersion().getMajor() > 2 ?
                 String.format("CREATE INDEX map_values_index ON %s.indexing (values(map_values));", keyspace) :
                 String.format("CREATE INDEX map_values_index ON %s.indexing (map_values);", keyspace);
         session().execute(createValuesIndex);
@@ -136,7 +136,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
                 .hasName("map_values_index")
                 .hasParent((TableMetadata) column.getParent())
                 .isNotCustomIndex()
-                .hasTarget(ccm().getVersion().getMajor() > 2 ? "values(map_values)" : "map_values")
+                .hasTarget(ccm().getCassandraVersion().getMajor() > 2 ? "values(map_values)" : "map_values")
                 .hasKind(COMPOSITES)
                 .asCqlQuery(createValuesIndex);
         assertThat((TableMetadata) column.getParent()).hasIndex(index);

--- a/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/IndexMetadataTest.java
@@ -32,7 +32,7 @@ import static com.datastax.driver.core.ColumnMetadata.*;
 import static com.datastax.driver.core.DataType.*;
 import static com.datastax.driver.core.IndexMetadata.Kind.*;
 
-@CassandraVersion(major = 1.2)
+@CassandraVersion("1.2.0")
 public class IndexMetadataTest extends CCMTestsSupport {
 
     /**
@@ -103,7 +103,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1, description = "index names with quoted identifiers and collection indexes not supported until 2.1")
+    @CassandraVersion(value = "2.1", description = "index names with quoted identifiers and collection indexes not supported until 2.1")
     public void should_create_metadata_for_values_index_on_mixed_case_column() {
         // 3.0 assumes the 'values' keyword if index on a collection
         String createValuesIndex = ccm().getVersion().getMajor() > 2 ?
@@ -123,7 +123,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_create_metadata_for_index_on_map_values() {
         // 3.0 assumes the 'values' keyword if index on a collection
         String createValuesIndex = ccm().getVersion().getMajor() > 2 ?
@@ -143,7 +143,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_create_metadata_for_index_on_map_keys() {
         String createKeysIndex = String.format("CREATE INDEX map_keys_index ON %s.indexing (keys(map_keys));", keyspace);
         session().execute(createKeysIndex);
@@ -160,7 +160,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1, minor = 3)
+    @CassandraVersion("2.1.3")
     public void should_create_metadata_for_full_index_on_map() {
         String createFullIndex = String.format("CREATE INDEX map_full_index ON %s.indexing (full(map_full));", keyspace);
         session().execute(createFullIndex);
@@ -177,7 +177,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1, minor = 3)
+    @CassandraVersion("2.1.3")
     public void should_create_metadata_for_full_index_on_set() {
         String createFullIndex = String.format("CREATE INDEX set_full_index ON %s.indexing (full(set_full));", keyspace);
         session().execute(createFullIndex);
@@ -194,7 +194,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1, minor = 3)
+    @CassandraVersion("2.1.3")
     public void should_create_metadata_for_full_index_on_list() {
         String createFullIndex = String.format("CREATE INDEX list_full_index ON %s.indexing (full(list_full));", keyspace);
         session().execute(createFullIndex);
@@ -211,7 +211,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_create_metadata_for_index_on_map_entries() {
         String createEntriesIndex = String.format("CREATE INDEX map_entries_index ON %s.indexing (entries(map_entries));", keyspace);
         session().execute(createEntriesIndex);
@@ -228,7 +228,7 @@ public class IndexMetadataTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 3.0)
+    @CassandraVersion("3.0")
     public void should_allow_multiple_indexes_on_map_column() {
         String createEntriesIndex = String.format("CREATE INDEX map_all_entries_index ON %s.indexing (entries(map_all));", keyspace);
         session().execute(createEntriesIndex);

--- a/driver-core/src/test/java/com/datastax/driver/core/LargeDataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LargeDataTest.java
@@ -180,11 +180,9 @@ public class LargeDataTest extends CCMTestsSupport {
 
     /**
      * Test a wide row of size 1,000,000
-     *
-     * @throws Throwable
      */
     @Test(groups = "stress")
-    @CassandraVersion(major = 2.0, minor = 0, description = "< 2.0 is skipped as 1.2 does not handle reading wide rows well.")
+    @CassandraVersion(value = "2.0.0", description = "< 2.0 is skipped as 1.2 does not handle reading wide rows well.")
     public void wideRows() throws Throwable {
         session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "large_data", 1));
         session().execute("USE large_data");
@@ -194,11 +192,9 @@ public class LargeDataTest extends CCMTestsSupport {
 
     /**
      * Test a batch that writes a row of size 4,000 (just below the error threshold for 2.2).
-     *
-     * @throws Throwable
      */
     @Test(groups = "stress")
-    @CassandraVersion(major = 2.0, minor = 0, description = "< 2.0 is skipped as 1.2 does not handle large batches well.")
+    @CassandraVersion(value = "2.0.0", description = "< 2.0 is skipped as 1.2 does not handle large batches well.")
     public void wideBatchRows() throws Throwable {
         session().execute(String.format(CREATE_KEYSPACE_SIMPLE_FORMAT, "large_data", 1));
         session().execute("USE large_data");
@@ -208,8 +204,6 @@ public class LargeDataTest extends CCMTestsSupport {
 
     /**
      * Test a wide row of size 1,000,000 consisting of a ByteBuffer
-     *
-     * @throws Throwable
      */
     @Test(groups = "stress")
     public void wideByteRows() throws Throwable {
@@ -221,8 +215,6 @@ public class LargeDataTest extends CCMTestsSupport {
 
     /**
      * Test a row with a single extra large text value
-     *
-     * @throws Throwable
      */
     @Test(groups = "stress")
     public void largeText() throws Throwable {
@@ -234,8 +226,6 @@ public class LargeDataTest extends CCMTestsSupport {
 
     /**
      * Creates a table with 330 columns
-     *
-     * @throws Throwable
      */
     @Test(groups = "stress")
     public void wideTable() throws Throwable {
@@ -255,8 +245,6 @@ public class LargeDataTest extends CCMTestsSupport {
 
     /**
      * Tests 10 random tests consisting of the other methods in this class
-     *
-     * @throws Throwable
      */
     @Test(groups = "duration")
     @CCMConfig(numberOfNodes = 3)

--- a/driver-core/src/test/java/com/datastax/driver/core/MaterializedViewMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MaterializedViewMetadataTest.java
@@ -22,7 +22,7 @@ import static com.datastax.driver.core.Assertions.assertThat;
 import static com.datastax.driver.core.ClusteringOrder.DESC;
 import static com.datastax.driver.core.DataType.cint;
 
-@CassandraVersion(major = 3)
+@CassandraVersion("3.0")
 public class MaterializedViewMetadataTest extends CCMTestsSupport {
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/PagingStateTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PagingStateTest.java
@@ -25,7 +25,7 @@ import java.util.Iterator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.0)
+@CassandraVersion("2.0.0")
 public class PagingStateTest extends CCMTestsSupport {
 
     private static final Logger logger = LoggerFactory.getLogger(PagingStateTest.class);
@@ -141,7 +141,7 @@ public class PagingStateTest extends CCMTestsSupport {
      * from the first query.
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_be_able_to_use_state_with_bound_statement() {
         PreparedStatement prepared = session().prepare("SELECT v from test where k=?");
         BoundStatement bs = prepared.bind(KEY);
@@ -164,7 +164,7 @@ public class PagingStateTest extends CCMTestsSupport {
      * @expected_result A failure is thrown when setting paging state on a different {@link BoundStatement}.
      */
     @Test(groups = "short", expectedExceptions = {PagingStateException.class})
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_not_be_able_to_use_state_with_different_bound_statement() {
         PreparedStatement prepared = session().prepare("SELECT v from test where k=?");
         BoundStatement bs0 = prepared.bind(KEY);

--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
@@ -48,7 +48,8 @@ public class PreparedStatementTest extends CCMTestsSupport {
     private static final String SIMPLE_TABLE = "test";
     private static final String SIMPLE_TABLE2 = "test2";
 
-    private final Collection<DataType> primitiveTypes = DataType.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion());
+    private ProtocolVersion protocolVersion;
+    private Collection<DataType> primitiveTypes;
 
     private boolean exclude(DataType t) {
         return t.getName() == DataType.Name.COUNTER;
@@ -56,6 +57,8 @@ public class PreparedStatementTest extends CCMTestsSupport {
 
     @Override
     public void onTestContextInitialized() {
+        protocolVersion = ccm().getProtocolVersion();
+        primitiveTypes = DataType.allPrimitiveTypes(protocolVersion);
         execute(createTestFixtures());
     }
 
@@ -340,7 +343,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
         toPrepare.setConsistencyLevel(ConsistencyLevel.QUORUM);
         toPrepare.setSerialConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL);
         toPrepare.setRetryPolicy(FallthroughRetryPolicy.INSTANCE);
-        if (TestUtils.getDesiredProtocolVersion().compareTo(V4) >= 0)
+        if (protocolVersion.compareTo(V4) >= 0)
             toPrepare.setOutgoingPayload(ImmutableMap.of("foo", Bytes.fromHexString("0xcafebabe")));
         toPrepare.setIdempotent(true);
         toPrepare.enableTracing();
@@ -349,7 +352,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
         assertThat(prepared.getConsistencyLevel()).isEqualTo(ConsistencyLevel.QUORUM);
         assertThat(prepared.getSerialConsistencyLevel()).isEqualTo(ConsistencyLevel.LOCAL_SERIAL);
         assertThat(prepared.getRetryPolicy()).isEqualTo(FallthroughRetryPolicy.INSTANCE);
-        if (TestUtils.getDesiredProtocolVersion().compareTo(V4) >= 0)
+        if (protocolVersion.compareTo(V4) >= 0)
             assertThat(prepared.getOutgoingPayload()).isEqualTo(ImmutableMap.of("foo", Bytes.fromHexString("0xcafebabe")));
         assertThat(prepared.isIdempotent()).isTrue();
         assertThat(prepared.isTracing()).isTrue();
@@ -358,7 +361,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
         assertThat(bs.getConsistencyLevel()).isEqualTo(ConsistencyLevel.QUORUM);
         assertThat(bs.getSerialConsistencyLevel()).isEqualTo(ConsistencyLevel.LOCAL_SERIAL);
         assertThat(bs.getRetryPolicy()).isEqualTo(FallthroughRetryPolicy.INSTANCE);
-        if (TestUtils.getDesiredProtocolVersion().compareTo(V4) >= 0)
+        if (protocolVersion.compareTo(V4) >= 0)
             assertThat(bs.getOutgoingPayload()).isEqualTo(ImmutableMap.of("foo", Bytes.fromHexString("0xcafebabe")));
         assertThat(bs.isIdempotent()).isTrue();
         assertThat(bs.isTracing()).isTrue();
@@ -460,7 +463,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
         Cluster cluster = register(Cluster.builder()
                 .addContactPoints(getContactPoints())
                 .withPort(ccm().getBinaryPort())
-                .withProtocolVersion(TestUtils.getDesiredProtocolVersion(ProtocolVersion.V3))
+                .withProtocolVersion(ccm().getProtocolVersion(ProtocolVersion.V3))
                 .build());
         Session session = cluster.connect();
         try {
@@ -490,7 +493,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
         Cluster cluster = register(Cluster.builder()
                 .addContactPoints(getContactPoints())
                 .withPort(ccm().getBinaryPort())
-                .withProtocolVersion(TestUtils.getDesiredProtocolVersion(ProtocolVersion.V3))
+                .withProtocolVersion(ccm().getProtocolVersion(ProtocolVersion.V3))
                 .build());
         Session session = cluster.connect();
         try {

--- a/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PreparedStatementTest.java
@@ -485,7 +485,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
      * @since 2.2.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_not_allow_unbound_value_on_batch_statement_when_protocol_lesser_than_v4() {
         Cluster cluster = register(Cluster.builder()
                 .addContactPoints(getContactPoints())
@@ -515,7 +515,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
      * @since 2.2.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_not_create_tombstone_when_unbound_value_on_bound_statement_and_protocol_v4() {
         PreparedStatement prepared = session().prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (?, ?)");
         BoundStatement st1 = prepared.bind();
@@ -545,7 +545,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
      * @since 2.2.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_unset_value_by_index() {
         PreparedStatement prepared = session().prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (?, ?)");
         BoundStatement bound = prepared.bind();
@@ -576,7 +576,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
      * @since 2.2.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_unset_value_by_name() {
         PreparedStatement prepared = session().prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (:k, :i)");
         BoundStatement bound = prepared.bind();
@@ -608,7 +608,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
      * @since 2.2.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_not_create_tombstone_when_unbound_value_on_batch_statement_and_protocol_v4() {
         PreparedStatement prepared = session().prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (?, ?)");
         BoundStatement st1 = prepared.bind();
@@ -661,7 +661,7 @@ public class PreparedStatementTest extends CCMTestsSupport {
      * @since 2.2.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_create_tombstone_when_null_value_on_batch_statement() {
         PreparedStatement prepared = session().prepare("INSERT INTO " + SIMPLE_TABLE + " (k, i) VALUES (?, ?)");
         BoundStatement st1 = prepared.bind();

--- a/driver-core/src/test/java/com/datastax/driver/core/PrimitiveTypeSamples.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PrimitiveTypeSamples.java
@@ -36,11 +36,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class PrimitiveTypeSamples {
 
-    public static final Map<DataType, Object> ALL = generateAll();
-
-    private static Map<DataType, Object> generateAll() {
+    static Map<DataType, Object> samples(ProtocolVersion protocolVersion) {
         try {
-            final Collection<DataType> primitiveTypes = DataType.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion());
+            final Collection<DataType> primitiveTypes = DataType.allPrimitiveTypes(protocolVersion);
             ImmutableMap<DataType, Object> data = ImmutableMap.<DataType, Object>builder()
                     .put(DataType.ascii(), "ascii")
                     .put(DataType.bigint(), Long.MAX_VALUE)

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryLoggerTest.java
@@ -171,7 +171,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_batch_statements() throws Exception {
         // given
         normal.setLevel(DEBUG);
@@ -202,7 +202,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_unlogged_batch_statements() throws Exception {
         // given
         normal.setLevel(DEBUG);
@@ -233,7 +233,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_counter_batch_statements() throws Exception {
         // Create a special table for testing with counters.
         session().execute(
@@ -376,7 +376,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     // Tests with query parameters (log level TRACE)
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_non_null_named_parameter_bound_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -426,7 +426,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_non_null_positional_parameter_simple_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -470,7 +470,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_null_parameter_simple_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -491,7 +491,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 3.0)
+    @CassandraVersion("3.0")
     public void should_log_unset_parameter() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -514,7 +514,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_bound_statement_parameters_inside_batch_statement() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -541,7 +541,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_simple_statement_parameters_inside_batch_statement() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -596,7 +596,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_all_parameter_types_simple_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -648,7 +648,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
                 .doesNotContain(query);
     }
 
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     @Test(groups = "short")
     public void should_show_total_statements_for_batches_even_if_query_truncated() throws Exception {
         // given
@@ -695,7 +695,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
                 .doesNotContain(TRUNCATED_OUTPUT);
     }
 
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     @Test(groups = "short")
     public void should_truncate_parameter_when_max_length_exceeded_bound_statements() throws Exception {
         // given
@@ -720,7 +720,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
                 .doesNotContain("123456");
     }
 
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     @Test(groups = "short")
     public void should_truncate_parameter_when_max_length_exceeded_simple_statements() throws Exception {
         // given
@@ -767,7 +767,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_truncate_blob_parameter_when_max_length_exceeded_simple_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -813,7 +813,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_not_truncate_parameter_when_max_length_unlimited_simple_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -860,7 +860,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_not_log_exceeding_number_of_parameters_simple_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -883,7 +883,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_not_log_exceeding_number_of_parameters_simple_statements_with_named_values() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -909,7 +909,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_not_log_exceeding_number_of_parameters_in_batch_statement_bound_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -939,7 +939,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_not_log_exceeding_number_of_parameters_in_batch_statement_simple_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -991,7 +991,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_log_all_parameters_when_max_unlimited_simple_statements() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -1013,7 +1013,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_log_all_parameters_when_max_unlimited_simple_statements_with_named_values() throws Exception {
         // given
         normal.setLevel(TRACE);
@@ -1037,7 +1037,7 @@ public class QueryLoggerTest extends CCMTestsSupport {
                 .contains("42");
     }
 
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     @Test(groups = "short")
     public void should_log_wrapped_bound_statement() throws Exception {
         // given

--- a/driver-core/src/test/java/com/datastax/driver/core/QueryTimestampTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/QueryTimestampTest.java
@@ -27,7 +27,7 @@ import static org.testng.Assert.assertTrue;
 /**
  * Tests the behavior of client-provided timestamps with protocol v3.
  */
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class QueryTimestampTest extends CCMTestsSupport {
 
     private volatile long timestampFromGenerator;

--- a/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
@@ -157,8 +157,7 @@ public class RecommissionedNodeTest {
                 .withStoragePort(mainCcm.getStoragePort())
                 .withThriftPort(mainCcm.getThriftPort())
                 .withBinaryPort(mainCcm.getBinaryPort())
-                .withoutDSE()
-                .withVersion("1.2.19");
+                .withVersion(VersionNumber.parse("1.2.19"));
         otherCcm = CCMCache.get(otherCcmBuilder);
         otherCcm.waitForUp(1);
 

--- a/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
@@ -145,7 +145,7 @@ public class RecommissionedNodeTest {
     }
 
     @Test(groups = "long")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_ignore_node_that_does_not_support_protocol_version_on_session_init() throws Exception {
         // Simulate the bug before starting the cluster
         mainCcmBuilder = CCMBridge.builder().withNodes(2);

--- a/driver-core/src/test/java/com/datastax/driver/core/ReconnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ReconnectionTest.java
@@ -83,7 +83,7 @@ public class ReconnectionTest extends CCMTestsSupport {
     public void should_keep_reconnecting_on_authentication_error() throws InterruptedException {
         // For C* 1.2, sleep before attempting to connect as there is a small delay between
         // user being created.
-        if (ccm().getVersion().getMajor() < 2) {
+        if (ccm().getCassandraVersion().getMajor() < 2) {
             Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
         }
         CountingReconnectionPolicy reconnectionPolicy = new CountingReconnectionPolicy(new ConstantReconnectionPolicy(reconnectionDelayMillis));
@@ -223,7 +223,7 @@ public class ReconnectionTest extends CCMTestsSupport {
                 .withReconnectionPolicy(new ConstantReconnectionPolicy(5000))
                 .withLoadBalancingPolicy(loadBalancingPolicy)
                 .withSocketOptions(socketOptions)
-                .withProtocolVersion(TestUtils.getDesiredProtocolVersion())
+                .withProtocolVersion(ccm().getProtocolVersion())
                 .build());
         // Create two sessions to have multiple pools
         cluster.connect();

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
@@ -209,7 +209,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
 
     @SuppressWarnings("RedundantCast")
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_notify_of_udt_creation(String keyspace) {
         session1.execute(String.format("CREATE TYPE %s.type1(i int)", keyspace));
         for (SchemaChangeListener listener : listeners) {
@@ -223,7 +223,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_notify_of_udt_update(String keyspace) {
         session1.execute(String.format("CREATE TYPE %s.type1(i int)", keyspace));
         session1.execute(String.format("ALTER TYPE %s.type1 ADD j int", keyspace));
@@ -240,7 +240,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
 
     @SuppressWarnings("RedundantCast")
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_notify_of_udt_drop(String keyspace) {
         session1.execute(String.format("CREATE TYPE %s.type1(i int)", keyspace));
         session1.execute(String.format("DROP TYPE %s.type1", keyspace));
@@ -254,7 +254,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_notify_of_function_creation(String keyspace) {
         session1.execute(String.format("CREATE FUNCTION %s.\"ID\"(i int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return i;'", keyspace));
         for (SchemaChangeListener listener : listeners) {
@@ -270,7 +270,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_notify_of_function_update(String keyspace) {
         session1.execute(String.format("CREATE FUNCTION %s.\"ID\"(i int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return i;'", keyspace));
         for (SchemaChangeListener listener : listeners) {
@@ -297,7 +297,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_notify_of_function_drop(String keyspace) {
         session1.execute(String.format("CREATE FUNCTION %s.\"ID\"(i int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return i;'", keyspace));
         session1.execute(String.format("DROP FUNCTION %s.\"ID\"", keyspace));
@@ -314,7 +314,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_notify_of_aggregate_creation(String keyspace) {
         session1.execute(String.format("CREATE FUNCTION %s.\"PLUS\"(s int, v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java"
                 + " AS 'return s+v;'", keyspace));
@@ -332,7 +332,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_notify_of_aggregate_update(String keyspace) {
         session1.execute(String.format("CREATE FUNCTION %s.\"PLUS\"(s int, v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java"
                 + " AS 'return s+v;'", keyspace));
@@ -361,7 +361,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_notify_of_aggregate_drop(String keyspace) {
         session1.execute(String.format("CREATE FUNCTION %s.\"PLUS\"(s int, v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java"
                 + " AS 'return s+v;'", keyspace));
@@ -380,7 +380,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 3.0)
+    @CassandraVersion("3.0")
     public void should_notify_of_view_creation(String keyspace) {
         session1.execute(String.format("CREATE TABLE %s.table1 (pk int PRIMARY KEY, c int)", keyspace));
         session1.execute(String.format("CREATE MATERIALIZED VIEW %s.mv1 AS SELECT c FROM %s.table1 WHERE c IS NOT NULL PRIMARY KEY (pk, c)", keyspace, keyspace));
@@ -395,7 +395,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 3.0)
+    @CassandraVersion("3.0")
     public void should_notify_of_view_update(String keyspace) {
         session1.execute(String.format("CREATE TABLE %s.table1 (pk int PRIMARY KEY, c int)", keyspace));
         session1.execute(String.format("CREATE MATERIALIZED VIEW %s.mv1 AS SELECT c FROM %s.table1 WHERE c IS NOT NULL PRIMARY KEY (pk, c) WITH compaction = { 'class' : 'SizeTieredCompactionStrategy' }", keyspace, keyspace));
@@ -424,7 +424,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "existingKeyspaceName")
-    @CassandraVersion(major = 3.0)
+    @CassandraVersion("3.0")
     public void should_notify_of_view_drop(String keyspace) {
         session1.execute(String.format("CREATE TABLE %s.table1 (pk int PRIMARY KEY, c int)", keyspace));
         session1.execute(String.format("CREATE MATERIALIZED VIEW %s.mv1 AS SELECT c FROM %s.table1 WHERE c IS NOT NULL PRIMARY KEY (pk, c)", keyspace, keyspace));

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaRefreshDebouncerTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaRefreshDebouncerTest.java
@@ -189,7 +189,7 @@ public class SchemaRefreshDebouncerTest extends CCMTestsSupport {
      */
     @Test(groups = "short")
     public void should_debounce_and_coalesce_multiple_alter_events_on_same_table_into_refresh_table() throws Exception {
-        if (ccm().getVersion().getMajor() > 2 || ccm().getVersion().getMajor() == 2 && ccm().getVersion().getMinor() > 1)
+        if (ccm().getCassandraVersion().compareTo(VersionNumber.parse("2.2")) >= 0)
             throw new SkipException("Disabled in Cassandra 2.2+ because of CASSANDRA-9996");
 
         String keyspace = TestUtils.generateIdentifier("ks_");

--- a/driver-core/src/test/java/com/datastax/driver/core/SimpleStatementIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SimpleStatementIntegrationTest.java
@@ -35,7 +35,7 @@ public class SimpleStatementIntegrationTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_execute_query_with_named_values() {
         // Given
         SimpleStatement statement = new SimpleStatement("SELECT * FROM users WHERE id = :id and id2 = :id2",
@@ -50,7 +50,7 @@ public class SimpleStatementIntegrationTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", expectedExceptions = InvalidQueryException.class)
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_fail_if_query_with_named_values_but_missing_parameter() {
         // Given a Statement missing named parameters.
         SimpleStatement statement = new SimpleStatement("SELECT * FROM users WHERE id = :id and id2 = :id2",
@@ -64,7 +64,7 @@ public class SimpleStatementIntegrationTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", expectedExceptions = InvalidQueryException.class)
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_fail_if_query_with_named_values_but_using_wrong_type() {
         // Given a Statement using a named parameter with the wrong value for the type (id is of type int, using double)
         SimpleStatement statement = new SimpleStatement("SELECT * FROM users WHERE id = :id and id2 = :id2",
@@ -98,7 +98,7 @@ public class SimpleStatementIntegrationTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", expectedExceptions = UnsupportedFeatureException.class)
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_fail_if_query_with_named_values_if_protocol_is_V2() {
         if (ccm().getVersion().getMajor() >= 3) {
             throw new SkipException("Skipping since Cassandra 3.0+ does not support protocol v2");
@@ -107,7 +107,7 @@ public class SimpleStatementIntegrationTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", expectedExceptions = UnsupportedFeatureException.class)
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_fail_if_query_with_named_values_if_protocol_is_V1() {
         if (ccm().getVersion().getMajor() >= 3) {
             throw new SkipException("Skipping since Cassandra 3.0+ does not support protocol v1");

--- a/driver-core/src/test/java/com/datastax/driver/core/SimpleStatementIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SimpleStatementIntegrationTest.java
@@ -100,7 +100,7 @@ public class SimpleStatementIntegrationTest extends CCMTestsSupport {
     @Test(groups = "short", expectedExceptions = UnsupportedFeatureException.class)
     @CassandraVersion("2.0.0")
     public void should_fail_if_query_with_named_values_if_protocol_is_V2() {
-        if (ccm().getVersion().getMajor() >= 3) {
+        if (ccm().getCassandraVersion().getMajor() >= 3) {
             throw new SkipException("Skipping since Cassandra 3.0+ does not support protocol v2");
         }
         useNamedValuesWithProtocol(ProtocolVersion.V2);
@@ -109,7 +109,7 @@ public class SimpleStatementIntegrationTest extends CCMTestsSupport {
     @Test(groups = "short", expectedExceptions = UnsupportedFeatureException.class)
     @CassandraVersion("2.0.0")
     public void should_fail_if_query_with_named_values_if_protocol_is_V1() {
-        if (ccm().getVersion().getMajor() >= 3) {
+        if (ccm().getCassandraVersion().getMajor() >= 3) {
             throw new SkipException("Skipping since Cassandra 3.0+ does not support protocol v1");
         }
         useNamedValuesWithProtocol(ProtocolVersion.V1);

--- a/driver-core/src/test/java/com/datastax/driver/core/SingleConnectionPoolTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SingleConnectionPoolTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.testng.Assert.fail;
 
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class SingleConnectionPoolTest extends CCMTestsSupport {
 
     @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/StatementIdempotenceTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StatementIdempotenceTest.java
@@ -41,7 +41,7 @@ public class StatementIdempotenceTest {
         when(cluster.getConfiguration()).thenReturn(configuration);
         when(configuration.getCodecRegistry()).thenReturn(codecRegistry);
         when(configuration.getProtocolOptions()).thenReturn(protocolOptions);
-        when(protocolOptions.getProtocolVersion()).thenReturn(TestUtils.getDesiredProtocolVersion());
+        when(protocolOptions.getProtocolVersion()).thenReturn(ProtocolVersion.NEWEST_SUPPORTED);
     }
 
     @Test(groups = "unit")

--- a/driver-core/src/test/java/com/datastax/driver/core/StatementWrapperTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/StatementWrapperTest.java
@@ -87,7 +87,7 @@ public class StatementWrapperTest extends CCMTestsSupport {
         assertThat(retryPolicy.customStatementsHandled.get()).isEqualTo(1);
     }
 
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     @Test(groups = "short")
     public void should_execute_wrapped_simple_statement() {
         session().execute(new CustomStatement(new SimpleStatement(INSERT_QUERY, "key_simple", 1)));
@@ -106,7 +106,7 @@ public class StatementWrapperTest extends CCMTestsSupport {
         assertThat(rs.one().getInt("v")).isEqualTo(1);
     }
 
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     @Test(groups = "short")
     public void should_execute_wrapped_batch_statement() {
         BatchStatement batchStatement = new BatchStatement();
@@ -118,7 +118,7 @@ public class StatementWrapperTest extends CCMTestsSupport {
         assertThat(rs.one().getInt("v")).isEqualTo(1);
     }
 
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     @Test(groups = "short")
     public void should_add_wrapped_batch_statement_to_batch_statement() {
         BatchStatement batchStatementForWrapping = new BatchStatement();

--- a/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TableMetadataTest.java
@@ -407,7 +407,7 @@ public class TableMetadataTest extends CCMTestsSupport {
      * @jira_ticket CASSANDRA-9424
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 3.0)
+    @CassandraVersion("3.0")
     public void should_parse_new_compression_options() {
         // given
         String cql = String.format("CREATE TABLE %s.new_compression_options (\n"
@@ -475,7 +475,7 @@ public class TableMetadataTest extends CCMTestsSupport {
      * @test_category metadata
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 3.0)
+    @CassandraVersion("3.0")
     public void should_parse_extensions_from_table_options() throws Exception {
         // given
         // create a simple table and retrieve it's metadata from system_schema.tables.

--- a/driver-core/src/test/java/com/datastax/driver/core/TestListener.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestListener.java
@@ -119,12 +119,13 @@ public class TestListener extends TestListenerAdapter implements IInvokedMethodL
     }
 
     private static void cassandraVersionCheck(CassandraVersion version) {
-        versionCheck(CCMBridge.getCassandraVersionNumber(), VersionNumber.parse(version.value()), version.description());
+        versionCheck(CCMBridge.getGlobalCassandraVersion(), VersionNumber.parse(version.value()), version.description());
     }
 
     private static void dseVersionCheck(DseVersion version) {
-        if (CCMBridge.isDSE()) {
-            versionCheck(CCMBridge.getDSEVersionNumber(), VersionNumber.parse(version.value()), version.description());
+        VersionNumber dseVersion = CCMBridge.getGlobalDSEVersion();
+        if (dseVersion != null) {
+            versionCheck(CCMBridge.getGlobalDSEVersion(), VersionNumber.parse(version.value()), version.description());
         } else {
             throw new SkipException("Skipping test because not configured for DataStax Enterprise cluster.");
         }

--- a/driver-core/src/test/java/com/datastax/driver/core/TestListener.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestListener.java
@@ -20,6 +20,7 @@ import com.datastax.driver.core.utils.DseVersion;
 import org.testng.*;
 import org.testng.internal.ConstructorOrMethod;
 
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 
@@ -87,27 +88,29 @@ public class TestListener extends TestListenerAdapter implements IInvokedMethodL
 
         Class<?> clazz = testNgMethod.getInstance().getClass();
         if (clazz != null) {
-            if (clazz.isAnnotationPresent(CassandraVersion.class)) {
-                CassandraVersion cassandraVersion = clazz.getAnnotation(CassandraVersion.class);
-                cassandraVersionCheck(cassandraVersion);
-            }
-            if (clazz.isAnnotationPresent(DseVersion.class)) {
-                DseVersion dseVersion = clazz.getAnnotation(DseVersion.class);
-                dseVersionCheck(dseVersion);
-            }
+            do {
+                if (scanAnnotatedElement(clazz))
+                    break;
+            } while (!(clazz = clazz.getSuperclass()).equals(Object.class));
         }
-
         Method method = constructorOrMethod.getMethod();
         if (method != null) {
-            if (method.isAnnotationPresent(CassandraVersion.class)) {
-                CassandraVersion cassandraVersion = method.getAnnotation(CassandraVersion.class);
-                cassandraVersionCheck(cassandraVersion);
-            }
-            if (method.isAnnotationPresent(DseVersion.class)) {
-                DseVersion dseVersion = method.getAnnotation(DseVersion.class);
-                dseVersionCheck(dseVersion);
-            }
+            scanAnnotatedElement(method);
         }
+    }
+
+    private boolean scanAnnotatedElement(AnnotatedElement element) {
+        if (element.isAnnotationPresent(CassandraVersion.class)) {
+            CassandraVersion cassandraVersion = element.getAnnotation(CassandraVersion.class);
+            cassandraVersionCheck(cassandraVersion);
+            return true;
+        }
+        if (element.isAnnotationPresent(DseVersion.class)) {
+            DseVersion dseVersion = element.getAnnotation(DseVersion.class);
+            dseVersionCheck(dseVersion);
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -116,29 +119,25 @@ public class TestListener extends TestListenerAdapter implements IInvokedMethodL
     }
 
     private static void cassandraVersionCheck(CassandraVersion version) {
-        versionCheck(CCMBridge.getCassandraVersion(), version.major(), version.minor(), version.description());
+        versionCheck(CCMBridge.getCassandraVersionNumber(), VersionNumber.parse(version.value()), version.description());
     }
 
     private static void dseVersionCheck(DseVersion version) {
         if (CCMBridge.isDSE()) {
-            versionCheck(CCMBridge.getDSEVersion(), version.major(), version.minor(), version.description());
+            versionCheck(CCMBridge.getDSEVersionNumber(), VersionNumber.parse(version.value()), version.description());
         } else {
             throw new SkipException("Skipping test because not configured for DataStax Enterprise cluster.");
         }
     }
 
-    private static void versionCheck(String version, double majorCheck, int minorCheck, String skipString) {
-        if (version == null) {
+    private static void versionCheck(VersionNumber current, VersionNumber required, String skipString) {
+        if (current == null) {
             throw new SkipException("Skipping test because provided version is null");
         } else {
-            String[] versionArray = version.split("\\.|-");
-            double major = Double.parseDouble(versionArray[0] + "." + versionArray[1]);
-            // If there is no minor version, assume latest version of whatever was provided.
-            int minor = versionArray.length >= 3 ? Integer.parseInt(versionArray[2]) : Integer.MAX_VALUE;
-
-            if (major < majorCheck || (major == majorCheck && minor < minorCheck)) {
-                throw new SkipException("Version >= " + majorCheck + "." + minorCheck + " required.  " +
-                        "Description: " + skipString);
+            if (current.compareTo(required) < 0) {
+                throw new SkipException(
+                        String.format("Version >= %s required, but found %s. Justification: %s",
+                                required, current, skipString));
             }
         }
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -736,33 +736,6 @@ public abstract class TestUtils {
     }
 
     /**
-     * @return The desired target protocol version based on the 'cassandra.version' System property.
-     */
-    public static ProtocolVersion getDesiredProtocolVersion() {
-        String version = CCMBridge.getCassandraVersion();
-        String[] versionArray = version.split("\\.|-");
-        double major = Double.parseDouble(versionArray[0] + "." + versionArray[1]);
-        if (major < 2.0) {
-            return ProtocolVersion.V1;
-        } else if (major < 2.1) {
-            return ProtocolVersion.V2;
-        } else if (major < 2.2) {
-            return ProtocolVersion.V3;
-        } else {
-            return ProtocolVersion.V4;
-        }
-    }
-
-    /**
-     * @param maximumAllowed The maximum protocol version to use.
-     * @return The desired protocolVersion or maximumAllowed if {@link #getDesiredProtocolVersion} is greater.
-     */
-    public static ProtocolVersion getDesiredProtocolVersion(ProtocolVersion maximumAllowed) {
-        ProtocolVersion versionToUse = getDesiredProtocolVersion();
-        return versionToUse.compareTo(maximumAllowed) > 0 ? maximumAllowed : versionToUse;
-    }
-
-    /**
      * @return a {@link Cluster} instance that connects only to the control host of the given cluster.
      */
     public static Cluster buildControlCluster(Cluster cluster, CCMAccess ccm) {
@@ -838,7 +811,7 @@ public abstract class TestUtils {
 
     /**
      * Helper for generating a DynamicCompositeType {@link ByteBuffer} from the given parameters.
-     *
+     * <p/>
      * Any of params given as an Integer will be considered with a field name of 'i', any as String will
      * be considered with a field name of 's'.
      *
@@ -881,7 +854,7 @@ public abstract class TestUtils {
 
     /**
      * Helper for generating a Composite {@link ByteBuffer} from the given parameters.
-     *
+     * <p/>
      * Expects Integer and String types for parameters.
      *
      * @param params params to serialize.

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
@@ -191,7 +191,7 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
      * </ol>
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2)
+    @CassandraVersion("2.0")
     public void should_get_token_from_row_and_set_token_in_query_with_binding_and_aliasing() {
         Row row = session().execute("SELECT token(i) AS t FROM foo WHERE i = 1").one();
         Token token = row.getToken("t");

--- a/driver-core/src/test/java/com/datastax/driver/core/TracingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TracingTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.0)
+@CassandraVersion("2.0.0")
 public class TracingTest extends CCMTestsSupport {
 
     private static final String KEY = "tracing_test";

--- a/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
@@ -30,10 +30,13 @@ import static org.testng.Assert.fail;
 @CassandraVersion("2.1.0")
 public class TupleTest extends CCMTestsSupport {
 
-    ProtocolVersion protocolVersion = TestUtils.getDesiredProtocolVersion();
+    private ProtocolVersion protocolVersion;
+    private Map<DataType, Object> samples;
 
     @Override
     public void onTestContextInitialized() {
+        protocolVersion = ccm().getProtocolVersion();
+        samples = PrimitiveTypeSamples.samples(protocolVersion);
         execute("CREATE TABLE t (k int PRIMARY KEY, v frozen<tuple<int, text, float>>)");
     }
 
@@ -202,8 +205,7 @@ public class TupleTest extends CCMTestsSupport {
      */
     @Test(groups = "short")
     public void tupleSubtypesTest() throws Exception {
-
-        List<DataType> DATA_TYPE_PRIMITIVES = Lists.newArrayList(PrimitiveTypeSamples.ALL.keySet());
+        List<DataType> DATA_TYPE_PRIMITIVES = Lists.newArrayList(samples.keySet());
         session().execute("CREATE KEYSPACE test_tuple_subtypes " +
                 "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
         session().execute("USE test_tuple_subtypes");
@@ -226,8 +228,8 @@ public class TupleTest extends CCMTestsSupport {
             for (int j = 0; j < i; ++j) {
                 dataTypes.add(DATA_TYPE_PRIMITIVES.get(j));
                 completeDataTypes.add(DATA_TYPE_PRIMITIVES.get(j));
-                createdValues.add(PrimitiveTypeSamples.ALL.get(DATA_TYPE_PRIMITIVES.get(j)));
-                completeValues.add(PrimitiveTypeSamples.ALL.get(DATA_TYPE_PRIMITIVES.get(j)));
+                createdValues.add(samples.get(DATA_TYPE_PRIMITIVES.get(j)));
+                completeValues.add(samples.get(DATA_TYPE_PRIMITIVES.get(j)));
             }
 
             // complete portion of the arrays needed for trailing nulls
@@ -261,8 +263,7 @@ public class TupleTest extends CCMTestsSupport {
      */
     @Test(groups = "short")
     public void tupleNonPrimitiveSubTypesTest() throws Exception {
-
-        List<DataType> DATA_TYPE_PRIMITIVES = Lists.newArrayList(PrimitiveTypeSamples.ALL.keySet());
+        List<DataType> DATA_TYPE_PRIMITIVES = Lists.newArrayList(samples.keySet());
         session().execute("CREATE KEYSPACE test_tuple_non_primitive_subtypes " +
                 "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
         session().execute("USE test_tuple_non_primitive_subtypes");
@@ -296,7 +297,7 @@ public class TupleTest extends CCMTestsSupport {
             ArrayList<Object> createdValues = new ArrayList<Object>();
 
             dataTypes.add(DataType.list(datatype));
-            createdValues.add(Collections.singletonList(PrimitiveTypeSamples.ALL.get(datatype)));
+            createdValues.add(Collections.singletonList(samples.get(datatype)));
 
             TupleType t = new TupleType(dataTypes, protocolVersion, cluster().getConfiguration().getCodecRegistry());
             TupleValue createdTuple = t.newValue(createdValues.toArray());
@@ -319,7 +320,7 @@ public class TupleTest extends CCMTestsSupport {
             ArrayList<Object> createdValues = new ArrayList<Object>();
 
             dataTypes.add(DataType.set(datatype));
-            createdValues.add(new HashSet<Object>(Collections.singletonList(PrimitiveTypeSamples.ALL.get(datatype))));
+            createdValues.add(new HashSet<Object>(Collections.singletonList(samples.get(datatype))));
 
             TupleType t = new TupleType(dataTypes, protocolVersion, cluster().getConfiguration().getCodecRegistry());
             TupleValue createdTuple = t.newValue(createdValues.toArray());
@@ -342,7 +343,7 @@ public class TupleTest extends CCMTestsSupport {
             ArrayList<Object> createdValues = new ArrayList<Object>();
 
             HashMap<Object, Object> hm = new HashMap<Object, Object>();
-            hm.put(PrimitiveTypeSamples.ALL.get(datatype), PrimitiveTypeSamples.ALL.get(datatype));
+            hm.put(samples.get(datatype), samples.get(datatype));
 
             dataTypes.add(DataType.map(datatype, datatype));
             createdValues.add(hm);
@@ -370,7 +371,7 @@ public class TupleTest extends CCMTestsSupport {
      */
     @Test(groups = "short")
     public void detachedTupleTypeTest() {
-        TupleType detachedType = TupleType.of(TestUtils.getDesiredProtocolVersion(), CodecRegistry.DEFAULT_INSTANCE,
+        TupleType detachedType = TupleType.of(protocolVersion, CodecRegistry.DEFAULT_INSTANCE,
                 DataType.cint(), DataType.text(), DataType.cfloat());
         TupleValue detachedValue = detachedType.newValue(1, "hello", 2.0f);
 

--- a/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class TupleTest extends CCMTestsSupport {
 
     ProtocolVersion protocolVersion = TestUtils.getDesiredProtocolVersion();

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecAssert.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Fail.fail;
 @SuppressWarnings("unused")
 public class TypeCodecAssert<T> extends AbstractAssert<TypeCodecAssert<T>, TypeCodec<T>> {
 
-    private ProtocolVersion version = TestUtils.getDesiredProtocolVersion();
+    private ProtocolVersion version = ProtocolVersion.NEWEST_SUPPORTED;
 
     protected TypeCodecAssert(TypeCodec<T> actual) {
         super(actual, TypeCodecAssert.class);

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecCollectionsIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecCollectionsIntegrationTest.java
@@ -33,7 +33,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.0)
+@CassandraVersion("2.0.0")
 public class TypeCodecCollectionsIntegrationTest extends CCMTestsSupport {
 
     private final String insertQuery = "INSERT INTO \"myTable2\" (c_int, l_int, l_bigint, s_float, s_double, m_varint, m_decimal) VALUES (?, ?, ?, ?, ?, ?, ?)";

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecEncapsulationIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecEncapsulationIntegrationTest.java
@@ -102,7 +102,7 @@ public class TypeCodecEncapsulationIntegrationTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_use_custom_codecs_with_simple_statements() {
         session().execute(insertQuery,
                 n_int,

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNestedCollectionsIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNestedCollectionsIntegrationTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Validates that nested collections are properly encoded,
  * even if some inner type requires a custom codec.
  */
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class TypeCodecNestedCollectionsIntegrationTest extends CCMTestsSupport {
 
     private final String insertQuery = "INSERT INTO \"myTable\" (pk, v) VALUES (?, ?)";

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNestedUDTAndTupleIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNestedUDTAndTupleIntegrationTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @jira_ticket JAVA-847
  */
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class TypeCodecNestedUDTAndTupleIntegrationTest extends CCMTestsSupport {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNumbersIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecNumbersIntegrationTest.java
@@ -52,7 +52,7 @@ public class TypeCodecNumbersIntegrationTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_use_defaut_codecs_with_simple_statements() {
         session().execute(insertQuery, n_int, n_bigint, n_float, n_double, n_varint, n_decimal);
         ResultSet rows = session().execute(selectQuery, n_int, n_bigint);

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTupleIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTupleIntegrationTest.java
@@ -23,7 +23,7 @@ import java.util.UUID;
 import static com.datastax.driver.core.DataType.cfloat;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class TypeCodecTupleIntegrationTest extends CCMTestsSupport {
 
     private final String insertQuery = "INSERT INTO users (id, name, location) VALUES (?, ?, ?)";

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecUDTIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecUDTIntegrationTest.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class TypeCodecUDTIntegrationTest extends CCMTestsSupport {
 
     private final String insertQuery = "INSERT INTO users (id, name, address) VALUES (?, ?, ?)";

--- a/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/UnresolvedUserTypeTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ExecutionException;
 import static com.datastax.driver.core.Assertions.assertThat;
 import static com.datastax.driver.core.DataType.*;
 
-@CassandraVersion(major = 3.0)
+@CassandraVersion("3.0")
 public class UnresolvedUserTypeTest extends CCMTestsSupport {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
@@ -36,7 +36,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class UserTypesTest extends CCMTestsSupport {
 
     private final static List<DataType> DATA_TYPE_PRIMITIVES = new ArrayList<DataType>(DataType.allPrimitiveTypes(TestUtils.getDesiredProtocolVersion()));

--- a/driver-core/src/test/java/com/datastax/driver/core/WarningsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/WarningsTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @CCMConfig(config = {"batch_size_warn_threshold_in_kb:5"})
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 public class WarningsTest extends CCMTestsSupport {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/exceptions/FunctionExecutionExceptionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/exceptions/FunctionExecutionExceptionTest.java
@@ -20,7 +20,7 @@ import com.datastax.driver.core.CCMTestsSupport;
 import com.datastax.driver.core.utils.CassandraVersion;
 import org.testng.annotations.Test;
 
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 @CCMConfig(config = "enable_user_defined_functions:true")
 public class FunctionExecutionExceptionTest extends CCMTestsSupport {
 

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilder21ExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilder21ExecutionTest.java
@@ -25,7 +25,7 @@ import org.testng.annotations.Test;
 import static com.datastax.driver.core.Assertions.assertThat;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class QueryBuilder21ExecutionTest extends CCMTestsSupport {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
@@ -205,7 +205,7 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
      * @since 3.0.1
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 3.2)
+    @CassandraVersion("3.2")
     public void should_support_cast_function_on_column() {
         //when
         ResultSet r = session().execute(select().cast("f", DataType.cint()).as("fint").column("i").from(TABLE2).where(eq("k", "cast_t")));
@@ -248,7 +248,7 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
      * @since 3.0.1
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 3.2)
+    @CassandraVersion("3.2")
     public void should_support_fcall_on_cast_column() {
         //when
         ResultSet ar = session().execute(select().fcall("avg", cast(column("i"), DataType.cfloat())).as("iavg").from(TABLE2).where(eq("k", "cast_t")));
@@ -273,7 +273,7 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
      * @since 3.0.1
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 3.6)
+    @CassandraVersion("3.6")
     public void should_retrieve_using_like_operator_on_table_with_sasi_index() {
         //given
         String table = "s_table";

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderITest.java
@@ -208,7 +208,7 @@ public class QueryBuilderITest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0, minor = 7, description = "DELETE..IF EXISTS only supported in 2.0.7+ (CASSANDRA-5708)")
+    @CassandraVersion(value = "2.0.7", description = "DELETE..IF EXISTS only supported in 2.0.7+ (CASSANDRA-5708)")
     public void conditionalDeletesTest() throws Exception {
         session().execute(String.format("INSERT INTO %s.test_int (k, a, b) VALUES (1, 1, 1)", keyspace));
 
@@ -234,7 +234,7 @@ public class QueryBuilderITest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0, minor = 13, description = "Allow IF EXISTS for UPDATE statements (CASSANDRA-8610)")
+    @CassandraVersion(value = "2.0.13", description = "Allow IF EXISTS for UPDATE statements (CASSANDRA-8610)")
     public void conditionalUpdatesTest() throws Exception {
         session().execute(String.format("INSERT INTO %s.test_int (k, a, b) VALUES (1, 1, 1)", keyspace));
 

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -20,7 +20,6 @@ import com.datastax.driver.core.exceptions.CodecNotFoundException;
 import com.datastax.driver.core.exceptions.InvalidQueryException;
 import com.datastax.driver.core.exceptions.InvalidTypeException;
 import com.datastax.driver.core.utils.Bytes;
-import com.datastax.driver.core.utils.CassandraVersion;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -861,7 +860,6 @@ public class QueryBuilderTest {
     }
 
     @Test(groups = "unit")
-    @CassandraVersion(major = 2.1, minor = 3)
     public void should_handle_nested_collections() {
         String query;
         Statement statement;

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTupleExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTupleExecutionTest.java
@@ -29,7 +29,7 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
-@CassandraVersion(major = 2.1, minor = 3)
+@CassandraVersion("2.1.3")
 public class QueryBuilderTupleExecutionTest extends CCMTestsSupport {
 
     @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderUDTExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderUDTExecutionTest.java
@@ -29,7 +29,7 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
-@CassandraVersion(major = 2.1, minor = 3)
+@CassandraVersion("2.1.3")
 public class QueryBuilderUDTExecutionTest extends CCMTestsSupport {
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/SchemaBuilderIT.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/schemabuilder/SchemaBuilderIT.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.fail;
 public class SchemaBuilderIT extends CCMTestsSupport {
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1, minor = 2)
+    @CassandraVersion("2.1.2")
     public void should_modify_table_metadata() {
         // Create a table
         session().execute(SchemaBuilder.createTable("ks", "TableMetadata")
@@ -128,7 +128,7 @@ public class SchemaBuilderIT extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.1)
+    @CassandraVersion("2.1.0")
     public void should_create_a_table_and_a_udt() {
         // Create a UDT and a table
         session().execute(SchemaBuilder.createType("MyUDT")

--- a/driver-core/src/test/java/com/datastax/driver/core/utils/CassandraVersion.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/utils/CassandraVersion.java
@@ -22,19 +22,15 @@ import java.lang.annotation.RetentionPolicy;
  * <p>Annotation for a Class or Method that defines a Cassandra Version requirement.  If the cassandra version in use
  * does not meet the version requirement, the test is skipped.</p>
  *
- * @see {@link com.datastax.driver.core.TestListener#beforeInvocation(org.testng.IInvokedMethod, org.testng.ITestResult)} for usage.
+ * @see com.datastax.driver.core.TestListener#beforeInvocation(org.testng.IInvokedMethod, org.testng.ITestResult)
  */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CassandraVersion {
-    /**
-     * @return The major version required to execute this test, i.e. "2.0"
-     */
-    double major();
 
     /**
-     * @return The minor version required to execute this test, i.e. "0"
+     * @return The minimum version required to execute this test, i.e. "2.0.13"
      */
-    int minor() default 0;
+    String value();
 
     /**
      * @return The description returned if this version requirement is not met.

--- a/driver-core/src/test/java/com/datastax/driver/core/utils/DseVersion.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/utils/DseVersion.java
@@ -22,19 +22,15 @@ import java.lang.annotation.RetentionPolicy;
  * <p>Annotation for a Class or Method that defines a DataStax Enterprise Version requirement.
  * If the version in use does not meet the version requirement or DSE is not used, the test is skipped.</p>
  *
- * @see {@link com.datastax.driver.core.TestListener#beforeInvocation(org.testng.IInvokedMethod, org.testng.ITestResult)} for usage.
+ * @see com.datastax.driver.core.TestListener#beforeInvocation(org.testng.IInvokedMethod, org.testng.ITestResult)
  */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DseVersion {
-    /**
-     * @return The major version required to execute this test, i.e. "4.8"
-     */
-    double major() default 0.0;
 
     /**
-     * @return The minor version required to execute this test, i.e. "3"
+     * @return The minimum version required to execute this test, i.e. "2.0.13"
      */
-    int minor() default 0;
+    String value();
 
     /**
      * @return The description returned if this version requirement is not met.

--- a/driver-core/src/test/resources/log4j.properties
+++ b/driver-core/src/test/resources/log4j.properties
@@ -20,6 +20,7 @@ log4j.rootLogger=INFO, A1
 # Adjust Scassandra's log level
 # (it seems some messages are conditioned by log4j.properties and others by reference.conf, so we need both)
 log4j.logger.org.scassandra=ERROR
+log4j.logger.spray.can=ERROR
 # Useful loggers when debugging Scassandra tests
 #log4j.logger.org.scassandra.cql=ERROR
 #log4j.logger.org.scassandra.server.cqlmessages=ERROR

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/date/SimpleDateCodecsTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/date/SimpleDateCodecsTest.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 public class SimpleDateCodecsTest extends CCMTestsSupport {
 
     @Override

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/enums/EnumCodecsTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/enums/EnumCodecsTest.java
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * and ints (with EnumOrdinalCodec).
  * It also validates that both codecs may coexist in the same CodecRegistry.
  */
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class EnumCodecsTest extends CCMTestsSupport {
 
     private final String insertQuery = "INSERT INTO t1 (pk, foo, foos, bar, bars, foobars, tup, udt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/guava/OptionalCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/guava/OptionalCodecTest.java
@@ -69,7 +69,7 @@ public class OptionalCodecTest extends CCMTestsSupport {
      * @since 2.2.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_map_unset_value_to_absent() {
         PreparedStatement insertPrep = session().prepare(this.insertStmt);
         PreparedStatement selectPrep = session().prepare(this.selectStmt);

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/jdk8/Jdk8TimeCodecsTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/jdk8/Jdk8TimeCodecsTest.java
@@ -41,7 +41,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 public class Jdk8TimeCodecsTest extends CCMTestsSupport {
 
     @Override

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/jdk8/OptionalCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/jdk8/OptionalCodecTest.java
@@ -69,7 +69,7 @@ public class OptionalCodecTest extends CCMTestsSupport {
      * @since 2.2.0
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.2)
+    @CassandraVersion("2.2.0")
     public void should_map_unset_value_to_empty() {
         PreparedStatement insertPrep = session().prepare(this.insertStmt);
         PreparedStatement selectPrep = session().prepare(this.selectStmt);

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/joda/JodaTimeCodecsTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/joda/JodaTimeCodecsTest.java
@@ -42,7 +42,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 public class JodaTimeCodecsTest extends CCMTestsSupport {
 
     @Override

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/JacksonJsonCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/JacksonJsonCodecTest.java
@@ -81,7 +81,7 @@ public class JacksonJsonCodecTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_use_custom_codec_with_simple_statements() {
         session().execute(insertQuery, notAJsonString, alice, bobAndCharlie);
         ResultSet rows = session().execute(selectQuery, notAJsonString, alice);

--- a/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/Jsr353JsonCodecTest.java
+++ b/driver-extras/src/test/java/com/datastax/driver/extras/codecs/json/Jsr353JsonCodecTest.java
@@ -82,7 +82,7 @@ public class Jsr353JsonCodecTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", dataProvider = "Jsr353JsonCodecTest")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_use_custom_codec_with_simple_statements(JsonStructure object) throws IOException {
         session().execute(insertQuery, notAJsonString, object);
         ResultSet rows = session().execute(selectQuery, notAJsonString, object);
@@ -133,13 +133,13 @@ public class Jsr353JsonCodecTest extends CCMTestsSupport {
     @Test(groups = "short", dataProvider = "Jsr353JsonCodecTest")
     public void should_use_custom_codec_with_prepared_statements_2(JsonStructure object) throws IOException {
         session().execute(session().prepare(insertQuery).bind()
-                        .setString(0, notAJsonString)
-                        .set(1, object, JsonStructure.class)
+                .setString(0, notAJsonString)
+                .set(1, object, JsonStructure.class)
         );
         PreparedStatement ps = session().prepare(selectQuery);
         ResultSet rows = session().execute(ps.bind()
-                        .setString(0, notAJsonString)
-                        .set(1, object, JsonStructure.class)
+                .setString(0, notAJsonString)
+                .set(1, object, JsonStructure.class)
         );
         Row row = rows.one();
         assertRow(row, object);

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorParamsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorParamsTest.java
@@ -41,7 +41,7 @@ public class MapperAccessorParamsTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0, description = "Uses named parameters")
+    @CassandraVersion(value = "2.0", description = "Uses named parameters")
     public void should_allow_less_parameters_than_bind_markers_if_there_are_repeated_names() {
         UserPhoneAccessor accessor = new MappingManager(session())
                 .createAccessor(UserPhoneAccessor.class);

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperAccessorTest.java
@@ -52,7 +52,7 @@ public class MapperAccessorTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_allow_null_argument_in_accessor_when_set_by_name() {
         FooAccessor accessor = new MappingManager(session())
                 .createAccessor(FooAccessor.class);

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperComputedFieldsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperComputedFieldsTest.java
@@ -61,7 +61,7 @@ public class MapperComputedFieldsTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_save_and_get_entity_with_computed_fields() {
         long writeTime = System.currentTimeMillis() * 1000;
         User newUser = new User("testlogin2", "blah");
@@ -87,7 +87,7 @@ public class MapperComputedFieldsTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_add_aliases_for_fields_in_select_queries() {
         BoundStatement bs = (BoundStatement) userMapper.getQuery("test");
         assertThat(bs.preparedStatement().getQueryString())
@@ -95,7 +95,7 @@ public class MapperComputedFieldsTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_map_aliased_resultset_to_objects() {
         Statement getQuery = userMapper.getQuery("testlogin");
         getQuery.setConsistencyLevel(ConsistencyLevel.QUORUM);
@@ -108,7 +108,7 @@ public class MapperComputedFieldsTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_map_unaliased_resultset_to_objects() {
         UserAccessor userAccessor = mappingManager.createAccessor(UserAccessor.class);
         ResultSet rs = userAccessor.all();
@@ -120,7 +120,7 @@ public class MapperComputedFieldsTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", expectedExceptions = CodecNotFoundException.class)
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_fail_if_computed_field_is_not_right_type() {
         Mapper<User_WrongComputedType> mapper = mappingManager.mapper(User_WrongComputedType.class);
 
@@ -128,7 +128,7 @@ public class MapperComputedFieldsTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", expectedExceptions = IllegalArgumentException.class)
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_fail_if_computed_field_marked_with_column_annotation() {
         mappingManager.mapper(User_WrongAnnotationForComputed.class);
     }

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperCustomCodecTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperCustomCodecTest.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 @SuppressWarnings("unused")
 public class MapperCustomCodecTest extends CCMTestsSupport {
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperDefaultKeyspaceTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperDefaultKeyspaceTest.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.assertNull;
 /**
  * Tests usage of mapping annotations without specifying a keyspace.
  */
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 @SuppressWarnings("unused")
 public class MapperDefaultKeyspaceTest extends CCMTestsSupport {
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperMaterializedViewTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperMaterializedViewTest.java
@@ -26,7 +26,7 @@ import java.util.Iterator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("unused")
-@CassandraVersion(major = 3.0)
+@CassandraVersion("3.0")
 public class MapperMaterializedViewTest extends CCMTestsSupport {
 
     @Override

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperNestedCollectionsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperNestedCollectionsTest.java
@@ -31,7 +31,7 @@ import java.util.Set;
 
 import static com.datastax.driver.core.Assertions.assertThat;
 
-@CassandraVersion(major = 2.1, minor = 3)
+@CassandraVersion("2.1.3")
 @SuppressWarnings("unused")
 public class MapperNestedCollectionsTest extends CCMTestsSupport {
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperOptionTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperOptionTest.java
@@ -51,7 +51,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_save_options() throws Exception {
         Long tsValue = futureTimestamp();
         mapper.save(new User(42, "helloworld"), Option.timestamp(tsValue), Option.tracing(true));
@@ -61,7 +61,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_delete_options() {
         User todelete = new User(45, "todelete");
         mapper.save(todelete);
@@ -72,7 +72,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short", expectedExceptions = {IllegalArgumentException.class})
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_get_options() {
         User user = new User(45, "toget");
         mapper.save(user);
@@ -90,7 +90,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_options_only_once() {
         Long tsValue = futureTimestamp();
         mapper.save(new User(43, "helloworld"), Option.timestamp(tsValue));
@@ -101,7 +101,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_default_options() {
         mapper.setDefaultSaveOptions(Option.timestamp(644746L), Option.ttl(76324));
         BoundStatement bs = (BoundStatement) mapper.saveQuery(new User(46, "rjhrgce"));
@@ -134,7 +134,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_prioritize_option_over_model_consistency() {
         // Generate Write Query and ensure User model writeConsistency is used.
         User user = new User(1859, "Steve");
@@ -155,7 +155,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_explicit_options_over_default_options() {
         long defaultTimestamp = futureTimestamp();
         long explicitTimestamp = futureTimestamp();
@@ -171,7 +171,7 @@ public class MapperOptionTest extends CCMTestsSupport {
      * Cover all versions of save() to check that methods that call each other properly propagate the options
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_save_options_for_all_variants() throws ExecutionException, InterruptedException {
         Long timestamp = futureTimestamp();
         User user = new User(42, "helloworld");
@@ -210,7 +210,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_get_options_for_all_variants() throws InterruptedException {
         try {
             mapper.get(42, Option.consistencyLevel(TWO));
@@ -251,7 +251,7 @@ public class MapperOptionTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     void should_use_delete_options_for_all_variants() throws InterruptedException {
         User user = new User(42, "helloworld");
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperPrimitiveTypes22Test.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperPrimitiveTypes22Test.java
@@ -27,7 +27,7 @@ import java.nio.ByteBuffer;
 
 import static org.testng.Assert.assertEquals;
 
-@CassandraVersion(major = 2.2)
+@CassandraVersion("2.2.0")
 public class MapperPrimitiveTypes22Test extends CCMTestsSupport {
 
     @Override

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperTest.java
@@ -311,7 +311,7 @@ public class MapperTest extends CCMTestsSupport {
     }
 
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void testDynamicEntity() throws Exception {
         MappingManager manager = new MappingManager(session());
 
@@ -440,7 +440,7 @@ public class MapperTest extends CCMTestsSupport {
      * @test_category object_mapper
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_flag_statement_as_idempotent() {
         MappingManager manager = new MappingManager(session());
         PostAccessor post = manager.createAccessor(PostAccessor.class);
@@ -457,7 +457,7 @@ public class MapperTest extends CCMTestsSupport {
      * @test_category object_mapper
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_flag_statement_as_non_idempotent() {
         MappingManager manager = new MappingManager(session());
         PostAccessor post = manager.createAccessor(PostAccessor.class);
@@ -474,7 +474,7 @@ public class MapperTest extends CCMTestsSupport {
      * @test_category object_mapper
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_flag_statement_with_null_idempotence() {
         MappingManager manager = new MappingManager(session());
         PostAccessor post = manager.createAccessor(PostAccessor.class);
@@ -490,7 +490,7 @@ public class MapperTest extends CCMTestsSupport {
      * @test_category object_mapper
      */
     @Test(groups = "short")
-    @CassandraVersion(major = 2.0)
+    @CassandraVersion("2.0.0")
     public void should_flag_all_mapper_generated_statements_as_idempotent() {
         MappingManager manager = new MappingManager(session());
         Mapper<User> mapper = manager.mapper(User.class);

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTCollectionsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTCollectionsTest.java
@@ -34,7 +34,7 @@ import static org.testng.Assert.assertEquals;
  * Tests mapping of collections of UDTs.
  */
 @SuppressWarnings("unused")
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 public class MapperUDTCollectionsTest extends CCMTestsSupport {
 
     @Override

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperUDTTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.testng.Assert.*;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 @CreateCCM(PER_METHOD)
 public class MapperUDTTest extends CCMTestsSupport {
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/UDTFieldMapperTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/UDTFieldMapperTest.java
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-@CassandraVersion(major = 2.1)
+@CassandraVersion("2.1.0")
 @CCMConfig(createCluster = false)
 @SuppressWarnings("unused")
 public class UDTFieldMapperTest extends CCMTestsSupport {

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
@@ -93,7 +93,7 @@ public class BundleOptions {
                         // Delegate javax.security.cert to the parent classloader.  javax.security.cert.X509Certificate is used in
                         // io.netty.util.internal.EmptyArrays, but not directly by the driver.
                         bootDelegationPackage("javax.security.cert"),
-                        systemProperty("cassandra.version").value(CCMBridge.getCassandraVersion()),
+                        systemProperty("cassandra.version").value(CCMBridge.getGlobalCassandraVersion().toString()),
                         systemProperty("cassandra.contactpoints").value(TestUtils.IP_PREFIX + 1),
                         systemProperty("logback.configurationFile").value("file:" + PathUtils.getBaseDir() + "/src/test/resources/logback.xml"),
                         mavenBundle("org.slf4j", "slf4j-api", "1.7.5"),

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cassandra.version>3.8</cassandra.version>
+        <cassandra.version>3.10</cassandra.version>
         <java.version>1.6</java.version>
         <log4j.version>1.2.17</log4j.version>
         <slf4j-log4j12.version>1.7.6</slf4j-log4j12.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cassandra.version>3.2.1</cassandra.version>
+        <cassandra.version>3.8</cassandra.version>
         <java.version>1.6</java.version>
         <log4j.version>1.2.17</log4j.version>
         <slf4j-log4j12.version>1.7.6</slf4j-log4j12.version>


### PR DESCRIPTION
Backports test changes from #791 and also removes ambiguity in Cassandra and DSE versions in tests (see b2e51ab for details).

If accepted, will need to make changes on each upstream branch as we go upwards.  I've tested this change on all upstream branches and made the individual fixes, so I should be able to do that quickly when the time comes.