### PR TITLE
JAVA-1308: CodecRegistry performance improvements

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -7,6 +7,7 @@
 - [new feature] JAVA-1362: Send query options flags as [int] for Protocol V5+.
 - [improvement] JAVA-1367: Make protocol negotiation more resilient.
 - [bug] JAVA-1397: Handle duration as native datatype in protocol v5+.
+- [improvement] JAVA-1308: CodecRegistry performance improvements.
 
 Merged from 3.1.x branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
@@ -579,7 +579,7 @@ public abstract class TypeCodec<T> {
      * the given {@code javaType}, and {@code false} otherwise.
      * @throws NullPointerException if {@code javaType} is {@code null}.
      */
-    public boolean accepts(TypeToken javaType) {
+    public boolean accepts(TypeToken<?> javaType) {
         checkNotNull(javaType, "Parameter javaType cannot be null");
         return this.javaType.equals(javaType.wrap());
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/CodecRegistryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CodecRegistryTest.java
@@ -62,7 +62,8 @@ public class CodecRegistryTest {
                 {DataType.time(), TypeCodec.time()},
                 {DataType.uuid(), TypeCodec.uuid()},
                 {DataType.timeuuid(), TypeCodec.timeUUID()},
-                {DataType.inet(), TypeCodec.inet()}
+                {DataType.inet(), TypeCodec.inet()},
+                {DataType.duration(), TypeCodec.duration()}
         };
     }
 
@@ -87,7 +88,8 @@ public class CodecRegistryTest {
                 {DataType.time(), Long.class, TypeCodec.time()},
                 {DataType.uuid(), UUID.class, TypeCodec.uuid()},
                 {DataType.timeuuid(), UUID.class, TypeCodec.timeUUID()},
-                {DataType.inet(), InetAddress.class, TypeCodec.inet()}
+                {DataType.inet(), InetAddress.class, TypeCodec.inet()},
+                {DataType.duration(), Duration.class, TypeCodec.duration()}
         };
     }
 
@@ -108,7 +110,8 @@ public class CodecRegistryTest {
                 {new Date(42), TypeCodec.timestamp()},
                 {LocalDate.fromDaysSinceEpoch(42), TypeCodec.date()},
                 {UUID.randomUUID(), TypeCodec.uuid()},
-                {mock(InetAddress.class), TypeCodec.inet()}
+                {mock(InetAddress.class), TypeCodec.inet()},
+                {Duration.from("1mo2d3h"), TypeCodec.duration()}
         };
     }
 
@@ -133,7 +136,8 @@ public class CodecRegistryTest {
                 {DataType.time(), 42L, TypeCodec.time()},
                 {DataType.uuid(), UUID.randomUUID(), TypeCodec.uuid()},
                 {DataType.timeuuid(), UUID.randomUUID(), TypeCodec.timeUUID()},
-                {DataType.inet(), mock(InetAddress.class), TypeCodec.inet()}
+                {DataType.inet(), mock(InetAddress.class), TypeCodec.inet()},
+                {DataType.duration(), Duration.from("1mo2d3h"), TypeCodec.duration()}
         };
     }
 
@@ -195,7 +199,7 @@ public class CodecRegistryTest {
     public void should_find_newly_registered_codec_by_cql_type() {
         // given
         CodecRegistry registry = new CodecRegistry();
-        TypeCodec expected = mockCodec(list(text()), listOf(String.class));
+        TypeCodec<?> expected = mockCodec(list(text()), listOf(String.class));
         registry.register(expected);
         // when
         TypeCodec<?> actual = registry.codecFor(list(text()));
@@ -209,7 +213,7 @@ public class CodecRegistryTest {
     public void should_find_default_codec_if_cql_type_already_registered() {
         // given
         CodecRegistry registry = new CodecRegistry();
-        TypeCodec newCodec = mockCodec(text(), of(StringBuilder.class));
+        TypeCodec<?> newCodec = mockCodec(text(), of(StringBuilder.class));
         registry.register(newCodec);
         // when
         TypeCodec<?> actual = registry.codecFor(text());
@@ -226,7 +230,7 @@ public class CodecRegistryTest {
     public void should_find_newly_registered_codec_by_cql_type_and_java_type() {
         // given
         CodecRegistry registry = new CodecRegistry();
-        TypeCodec expected = mockCodec(list(text()), listOf(String.class));
+        TypeCodec<?> expected = mockCodec(list(text()), listOf(String.class));
         registry.register(expected);
         // when
         TypeCodec<?> actual = registry.codecFor(list(text()), listOf(String.class));
@@ -443,7 +447,7 @@ public class CodecRegistryTest {
 
         CodecRegistry registry = new CodecRegistry();
 
-        TypeCodec newCodec = mockCodec(cint(), of(Integer.class));
+        TypeCodec<?> newCodec = mockCodec(cint(), of(Integer.class));
 
         registry.register(newCodec);
 
@@ -464,7 +468,7 @@ public class CodecRegistryTest {
         // Force generation of a list token from the default token
         registry.codecFor(list(cint()), listOf(Integer.class));
 
-        TypeCodec newCodec = mockCodec(list(cint()), listOf(Integer.class));
+        TypeCodec<?> newCodec = mockCodec(list(cint()), listOf(Integer.class));
 
         registry.register(newCodec);
 
@@ -490,8 +494,9 @@ public class CodecRegistryTest {
         registryLogger.removeAppender(logs);
     }
 
-    private TypeCodec<?> mockCodec(DataType cqlType, TypeToken<?> javaType) {
-        TypeCodec newCodec = mock(TypeCodec.class);
+    private <T> TypeCodec<T> mockCodec(DataType cqlType, TypeToken<T> javaType) {
+        @SuppressWarnings("unchecked")
+        TypeCodec<T> newCodec = mock(TypeCodec.class);
         when(newCodec.getCqlType()).thenReturn(cqlType);
         when(newCodec.getJavaType()).thenReturn(javaType);
         when(newCodec.accepts(cqlType)).thenReturn(true);


### PR DESCRIPTION
Opened this PR to explore another idea to improve `CodecRegistry` performance: use an `EnumMap` instead of Guava's `ImmutableMap`.

Here are my benchmark results:

```
EnumMap
Benchmark                                          Mode  Cnt       Score       Error   Units
CodecRegistryBenchmark.benchmarkCqlType           thrpt    5  295929.901 ± 15920.012  ops/ms
CodecRegistryBenchmark.benchmarkCqlTypeJavaType   thrpt    5  280676.140 ± 18111.264  ops/ms
CodecRegistryBenchmark.benchmarkCqlTypeJavaType2  thrpt    5  264239.794 ± 16157.046  ops/ms
CodecRegistryBenchmark.benchmarkCqlTypeValue      thrpt    5  231166.054 ± 20440.135  ops/ms
CodecRegistryBenchmark.benchmarkValue             thrpt    5  352292.682 ±  3457.407  ops/ms

ImmutableMap
Benchmark                                          Mode  Cnt       Score       Error   Units
CodecRegistryBenchmark.benchmarkCqlType           thrpt    5  236313.000 ± 12701.398  ops/ms
CodecRegistryBenchmark.benchmarkCqlTypeJavaType   thrpt    5  215917.116 ±  8664.283  ops/ms
CodecRegistryBenchmark.benchmarkCqlTypeJavaType2  thrpt    5  231635.771 ± 22187.916  ops/ms
CodecRegistryBenchmark.benchmarkCqlTypeValue      thrpt    5  120391.569 ± 10049.849  ops/ms
CodecRegistryBenchmark.benchmarkValue             thrpt    5  136206.073 ±  4016.883  ops/ms

pre-JAVA-1308
Benchmark                                          Mode  Cnt      Score      Error   Units
CodecRegistryBenchmark.benchmarkCqlType           thrpt    5   7568.787 ±  935.573  ops/ms
CodecRegistryBenchmark.benchmarkCqlTypeJavaType   thrpt    5   7537.136 ±  448.218  ops/ms
CodecRegistryBenchmark.benchmarkCqlTypeJavaType2  thrpt    5   7586.622 ± 1134.851  ops/ms
CodecRegistryBenchmark.benchmarkCqlTypeValue      thrpt    5  41315.849 ± 1726.394  ops/ms
CodecRegistryBenchmark.benchmarkValue             thrpt    5   2012.092 ±   47.753  ops/ms
```

Benchmark code [here](https://gist.github.com/adutra/04e83284ca5569eda1409779c1c93595).

Note: `benchmarkCqlTypeValue` and `benchmarkValue` are a bit biased in my implementation because they test the best-case scenario (the codec to find is the first in the array).