### PR TITLE
Use Cassandra 3.7 instead of 3.6 in ProtocolVersionRenegotiationTest

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/ProtocolVersionRenegotiationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ProtocolVersionRenegotiationTest.java
@@ -38,8 +38,8 @@ public class ProtocolVersionRenegotiationTest extends CCMTestsSupport {
      * @jira_ticket JAVA-1367
      */
     @Test(groups = "short")
-    @CCMConfig(version = "3.6", createCluster = false)
-    public void should_fail_when_version_provided_and_too_low_3_6() throws Exception {
+    @CCMConfig(version = "3.7", createCluster = false)
+    public void should_fail_when_version_provided_and_too_low_3_7() throws Exception {
         UnsupportedProtocolVersionException e = connectWithUnsupportedVersion(V1);
         assertThat(e.getUnsupportedVersion()).isEqualTo(V1);
         // pre-CASSANDRA-11464: server replies with its own version


### PR DESCRIPTION
Cassandra 3.6 does not work with > JDK 1.8u100 because of [CASSANDRA-11661](https://issues.apache.org/jira/browse/CASSANDRA-11661), use 3.7 instead.

This was causing this test to repeatedly fail in appveyor.  It does not fail in our jenkins environment because we are using an older JDK update, but I will fix that.