### PR TITLE
JAVA-1247: Disable idempotence warnings

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -13,6 +13,7 @@
 - [improvement] JAVA-1287: Add CDC to TableOptionsMetadata and Schema Builder.
 - [improvement] JAVA-1392: Reduce lock contention in RPTokenFactory.
 - [improvement] JAVA-1328: Provide compatibility with Guava 20.
+- [improvement] JAVA-1247: Disable idempotence warnings.
 
 Merged from 3.1.x branch:
 

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -13,6 +13,10 @@ are now deprecated in favor of `RemoteEndpointAwareJdkSSLOptions`
 and `RemoteEndpointAwareNettySSLOptions` respectively (see 
 [JAVA-1364](https://datastax-oss.atlassian.net/browse/JAVA-1364)).
 
+In 3.1.0, the driver would log a warning the first time it would skip 
+a retry for a non-idempotent request; this warning has now been 
+removed as users should now have adjusted their applications accordingly.
+
 
 ### 3.1.0
 


### PR DESCRIPTION
In 3.1.0, we added a warning when the first non-idempotent statement
is not retried (see JAVA-1225), as a way to ease the transition to
the new behavior.

By 3.2.0 users should be more familiar with this, so this commit
removes the warning.