### PR TITLE
JAVA-1310: Make mapper's ignored properties configurable

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -19,6 +19,8 @@
 - [bug] JAVA-1418: Make Guava version detection more reliable.
 - [new feature] JAVA-1174: Add ifNotExists option to mapper.
 - [improvement] JAVA-1414: Optimize Metadata.escapeId and Metadata.handleId.
+- [improvement] JAVA-1310: Make mapper's ignored properties configurable.
+- [improvement] JAVA-1316: Add strategy for resolving properties into CQL names.
 
 Merged from 3.1.x branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/AggregateMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AggregateMetadata.java
@@ -195,21 +195,21 @@ public class AggregateMetadata {
     private String asCQLQuery(boolean formatted) {
 
         StringBuilder sb = new StringBuilder("CREATE AGGREGATE ")
-                .append(Metadata.escapeId(keyspace.getName()))
+                .append(Metadata.quoteIfNecessary(keyspace.getName()))
                 .append('.');
 
         appendSignature(sb);
 
         TableMetadata.spaceOrNewLine(sb, formatted)
                 .append("SFUNC ")
-                .append(Metadata.escapeId(stateFuncSimpleName))
+                .append(Metadata.quoteIfNecessary(stateFuncSimpleName))
                 .append(" STYPE ")
                 .append(stateType.asFunctionParameterString());
 
         if (finalFuncSimpleName != null)
             TableMetadata.spaceOrNewLine(sb, formatted)
                     .append("FINALFUNC ")
-                    .append(Metadata.escapeId(finalFuncSimpleName));
+                    .append(Metadata.quoteIfNecessary(finalFuncSimpleName));
 
         if (initCond != null)
             TableMetadata.spaceOrNewLine(sb, formatted)
@@ -234,7 +234,7 @@ public class AggregateMetadata {
 
     private void appendSignature(StringBuilder sb) {
         sb
-                .append(Metadata.escapeId(simpleName))
+                .append(Metadata.quoteIfNecessary(simpleName))
                 .append('(');
         boolean first = true;
         for (DataType type : argumentTypes) {

--- a/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ColumnMetadata.java
@@ -121,7 +121,7 @@ public class ColumnMetadata {
 
     @Override
     public String toString() {
-        String str = Metadata.escapeId(name) + ' ' + type;
+        String str = Metadata.quoteIfNecessary(name) + ' ' + type;
         return isStatic ? str + " static" : str;
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/FunctionMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/FunctionMetadata.java
@@ -163,9 +163,9 @@ public class FunctionMetadata {
         StringBuilder sb = new StringBuilder("CREATE FUNCTION ");
 
         sb
-                .append(Metadata.escapeId(keyspace.getName()))
+                .append(Metadata.quoteIfNecessary(keyspace.getName()))
                 .append('.')
-                .append(Metadata.escapeId(simpleName))
+                .append(Metadata.quoteIfNecessary(simpleName))
                 .append('(');
 
         boolean first = true;
@@ -179,7 +179,7 @@ public class FunctionMetadata {
             DataType type = entry.getValue();
             sb
                     .append(TableMetadata.spaces(4, formatted))
-                    .append(Metadata.escapeId(name))
+                    .append(Metadata.quoteIfNecessary(name))
                     .append(' ')
                     .append(type.asFunctionParameterString());
         }
@@ -226,7 +226,7 @@ public class FunctionMetadata {
     public String getSignature() {
         StringBuilder sb = new StringBuilder();
         sb
-                .append(Metadata.escapeId(simpleName))
+                .append(Metadata.quoteIfNecessary(simpleName))
                 .append('(');
         boolean first = true;
         for (DataType type : arguments.values()) {

--- a/driver-core/src/main/java/com/datastax/driver/core/IndexMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/IndexMetadata.java
@@ -113,7 +113,7 @@ public class IndexMetadata {
     }
 
     private static String targetFromLegacyOptions(ColumnMetadata column, Map<String, String> options) {
-        String columnName = Metadata.escapeId(column.getName());
+        String columnName = Metadata.quoteIfNecessary(column.getName());
         if (options.containsKey(INDEX_KEYS_OPTION_NAME))
             return String.format("keys(%s)", columnName);
         if (options.containsKey(INDEX_ENTRIES_OPTION_NAME))
@@ -202,9 +202,9 @@ public class IndexMetadata {
      * @return the 'CREATE INDEX' query corresponding to this index.
      */
     public String asCQLQuery() {
-        String keyspaceName = Metadata.escapeId(table.getKeyspace().getName());
-        String tableName = Metadata.escapeId(table.getName());
-        String indexName = Metadata.escapeId(this.name);
+        String keyspaceName = Metadata.quoteIfNecessary(table.getKeyspace().getName());
+        String tableName = Metadata.quoteIfNecessary(table.getName());
+        String indexName = Metadata.quoteIfNecessary(this.name);
         return isCustomIndex()
                 ? String.format("CREATE CUSTOM INDEX %s ON %s.%s (%s) USING '%s' %s;", indexName, keyspaceName, tableName, getTarget(), getIndexClassName(), getOptionsAsCql())
                 : String.format("CREATE INDEX %s ON %s.%s (%s);", indexName, keyspaceName, tableName, getTarget());

--- a/driver-core/src/main/java/com/datastax/driver/core/KeyspaceMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/KeyspaceMetadata.java
@@ -292,7 +292,7 @@ public class KeyspaceMetadata {
     public String asCQLQuery() {
         StringBuilder sb = new StringBuilder();
 
-        sb.append("CREATE KEYSPACE ").append(Metadata.escapeId(name)).append(" WITH ");
+        sb.append("CREATE KEYSPACE ").append(Metadata.quoteIfNecessary(name)).append(" WITH ");
         sb.append("REPLICATION = { 'class' : '").append(replication.get("class")).append('\'');
         for (Map.Entry<String, String> entry : replication.entrySet()) {
             if (entry.getKey().equals("class"))

--- a/driver-core/src/main/java/com/datastax/driver/core/MaterializedViewMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/MaterializedViewMetadata.java
@@ -155,9 +155,9 @@ public class MaterializedViewMetadata extends AbstractTableMetadata {
     @Override
     protected String asCQLQuery(boolean formatted) {
 
-        String keyspaceName = Metadata.escapeId(keyspace.getName());
-        String baseTableName = Metadata.escapeId(baseTable.getName());
-        String viewName = Metadata.escapeId(name);
+        String keyspaceName = Metadata.quoteIfNecessary(keyspace.getName());
+        String baseTableName = Metadata.quoteIfNecessary(baseTable.getName());
+        String viewName = Metadata.quoteIfNecessary(name);
 
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE MATERIALIZED VIEW ")
@@ -173,7 +173,7 @@ public class MaterializedViewMetadata extends AbstractTableMetadata {
             Iterator<ColumnMetadata> it = columns.values().iterator();
             while (it.hasNext()) {
                 ColumnMetadata column = it.next();
-                sb.append(spaces(4, formatted)).append(Metadata.escapeId(column.getName()));
+                sb.append(spaces(4, formatted)).append(Metadata.quoteIfNecessary(column.getName()));
                 if (it.hasNext()) sb.append(",");
                 sb.append(" ");
                 newLine(sb, formatted);
@@ -191,7 +191,7 @@ public class MaterializedViewMetadata extends AbstractTableMetadata {
         // PK
         sb.append("PRIMARY KEY (");
         if (partitionKey.size() == 1) {
-            sb.append(Metadata.escapeId(partitionKey.get(0).getName()));
+            sb.append(Metadata.quoteIfNecessary(partitionKey.get(0).getName()));
         } else {
             sb.append('(');
             boolean first = true;
@@ -200,12 +200,12 @@ public class MaterializedViewMetadata extends AbstractTableMetadata {
                     first = false;
                 else
                     sb.append(", ");
-                sb.append(Metadata.escapeId(cm.getName()));
+                sb.append(Metadata.quoteIfNecessary(cm.getName()));
             }
             sb.append(')');
         }
         for (ColumnMetadata cm : clusteringColumns)
-            sb.append(", ").append(Metadata.escapeId(cm.getName()));
+            sb.append(", ").append(Metadata.quoteIfNecessary(cm.getName()));
         sb.append(')');
 
         appendOptions(sb, formatted);

--- a/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
@@ -398,7 +398,7 @@ public class TableMetadata extends AbstractTableMetadata {
     @Override
     protected String asCQLQuery(boolean formatted) {
         StringBuilder sb = new StringBuilder();
-        sb.append("CREATE TABLE ").append(Metadata.escapeId(keyspace.getName())).append('.').append(Metadata.escapeId(name)).append(" (");
+        sb.append("CREATE TABLE ").append(Metadata.quoteIfNecessary(keyspace.getName())).append('.').append(Metadata.quoteIfNecessary(name)).append(" (");
         newLine(sb, formatted);
         for (ColumnMetadata cm : columns.values())
             newLine(sb.append(spaces(4, formatted)).append(cm).append(',').append(spaces(1, !formatted)), formatted);
@@ -406,7 +406,7 @@ public class TableMetadata extends AbstractTableMetadata {
         // PK
         sb.append(spaces(4, formatted)).append("PRIMARY KEY (");
         if (partitionKey.size() == 1) {
-            sb.append(Metadata.escapeId(partitionKey.get(0).getName()));
+            sb.append(Metadata.quoteIfNecessary(partitionKey.get(0).getName()));
         } else {
             sb.append('(');
             boolean first = true;
@@ -415,12 +415,12 @@ public class TableMetadata extends AbstractTableMetadata {
                     first = false;
                 else
                     sb.append(", ");
-                sb.append(Metadata.escapeId(cm.getName()));
+                sb.append(Metadata.quoteIfNecessary(cm.getName()));
             }
             sb.append(')');
         }
         for (ColumnMetadata cm : clusteringColumns)
-            sb.append(", ").append(Metadata.escapeId(cm.getName()));
+            sb.append(", ").append(Metadata.quoteIfNecessary(cm.getName()));
         sb.append(')');
         newLine(sb, formatted);
         // end PK

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
@@ -2132,7 +2132,7 @@ public abstract class TypeCodec<T> {
             ByteBuffer[] elements = new ByteBuffer[length];
             int i = 0;
             for (UserType.Field field : definition) {
-                elements[i] = serializeField(value, Metadata.escapeId(field.getName()), protocolVersion);
+                elements[i] = serializeField(value, Metadata.quoteIfNecessary(field.getName()), protocolVersion);
                 size += 4 + (elements[i] == null ? 0 : elements[i].remaining());
                 i++;
             }
@@ -2161,7 +2161,7 @@ public abstract class TypeCodec<T> {
                         break;
                     int n = input.getInt();
                     ByteBuffer element = n < 0 ? null : CodecUtils.readBytes(input, n);
-                    value = deserializeAndSetField(element, value, Metadata.escapeId(field.getName()), protocolVersion);
+                    value = deserializeAndSetField(element, value, Metadata.quoteIfNecessary(field.getName()), protocolVersion);
                 }
                 return value;
             } catch (BufferUnderflowException e) {
@@ -2178,9 +2178,9 @@ public abstract class TypeCodec<T> {
             for (UserType.Field field : definition) {
                 if (i > 0)
                     sb.append(",");
-                sb.append(Metadata.escapeId(field.getName()));
+                sb.append(Metadata.quoteIfNecessary(field.getName()));
                 sb.append(":");
-                sb.append(formatField(value, Metadata.escapeId(field.getName())));
+                sb.append(formatField(value, Metadata.quoteIfNecessary(field.getName())));
                 i += 1;
             }
             sb.append("}");

--- a/driver-core/src/main/java/com/datastax/driver/core/UserType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/UserType.java
@@ -277,7 +277,7 @@ public class UserType extends DataType implements Iterable<UserType.Field> {
     private String asCQLQuery(boolean formatted) {
         StringBuilder sb = new StringBuilder();
 
-        sb.append("CREATE TYPE ").append(Metadata.escapeId(keyspace)).append('.').append(Metadata.escapeId(typeName)).append(" (");
+        sb.append("CREATE TYPE ").append(Metadata.quoteIfNecessary(keyspace)).append('.').append(Metadata.quoteIfNecessary(typeName)).append(" (");
         TableMetadata.newLine(sb, formatted);
         for (int i = 0; i < byIdx.length; i++) {
             sb.append(TableMetadata.spaces(4, formatted)).append(byIdx[i]);
@@ -291,7 +291,7 @@ public class UserType extends DataType implements Iterable<UserType.Field> {
 
     @Override
     public String toString() {
-        String str = Metadata.escapeId(getKeyspace()) + "." + Metadata.escapeId(getTypeName());
+        String str = Metadata.quoteIfNecessary(getKeyspace()) + "." + Metadata.quoteIfNecessary(getTypeName());
         return isFrozen() ?
                 "frozen<" + str + ">" :
                 str;
@@ -299,7 +299,7 @@ public class UserType extends DataType implements Iterable<UserType.Field> {
 
     @Override
     public String asFunctionParameterString() {
-        return Metadata.escapeId(getTypeName());
+        return Metadata.quoteIfNecessary(getTypeName());
     }
 
     /**
@@ -349,7 +349,7 @@ public class UserType extends DataType implements Iterable<UserType.Field> {
 
         @Override
         public String toString() {
-            return Metadata.escapeId(name) + ' ' + type;
+            return Metadata.quoteIfNecessary(name) + ' ' + type;
         }
     }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/BuiltStatement.java
@@ -99,10 +99,12 @@ public abstract class BuiltStatement extends RegularStatement {
         this.keyspace = keyspace;
     }
 
-    // Same as Metadata.escapeId, but we don't have access to it here.
+    /**
+     * @deprecated preserved for backward compatibility, use {@link Metadata#quoteIfNecessary(String)} instead.
+     */
+    @Deprecated
     protected static String escapeId(String ident) {
-        // we don't need to escape if it's lowercase and match non-quoted CQL3 ids.
-        return lowercaseAlphanumeric.matcher(ident).matches() ? ident : Metadata.quote(ident);
+        return Metadata.quoteIfNecessary(ident);
     }
 
     @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Delete.java
@@ -17,6 +17,7 @@ package com.datastax.driver.core.querybuilder;
 
 import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.ColumnMetadata;
+import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.TableMetadata;
 
 import java.util.ArrayList;
@@ -40,8 +41,8 @@ public class Delete extends BuiltStatement {
     }
 
     Delete(TableMetadata table, List<Selector> columns) {
-        this(escapeId(table.getKeyspace().getName()),
-                escapeId(table.getName()),
+        this(Metadata.quoteIfNecessary(table.getKeyspace().getName()),
+                Metadata.quoteIfNecessary(table.getName()),
                 Arrays.asList(new Object[table.getPartitionKey().size()]),
                 table.getPartitionKey(),
                 columns);

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Insert.java
@@ -17,6 +17,7 @@ package com.datastax.driver.core.querybuilder;
 
 import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.ColumnMetadata;
+import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.TableMetadata;
 
 import java.util.ArrayList;
@@ -42,8 +43,8 @@ public class Insert extends BuiltStatement {
     }
 
     Insert(TableMetadata table) {
-        this(escapeId(table.getKeyspace().getName()),
-                escapeId(table.getName()),
+        this(Metadata.quoteIfNecessary(table.getKeyspace().getName()),
+                Metadata.quoteIfNecessary(table.getName()),
                 Arrays.asList(new Object[table.getPartitionKey().size()]),
                 table.getPartitionKey());
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Select.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Select.java
@@ -15,10 +15,7 @@
  */
 package com.datastax.driver.core.querybuilder;
 
-import com.datastax.driver.core.CodecRegistry;
-import com.datastax.driver.core.ColumnMetadata;
-import com.datastax.driver.core.DataType;
-import com.datastax.driver.core.TableMetadata;
+import com.datastax.driver.core.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,8 +44,8 @@ public class Select extends BuiltStatement {
     }
 
     Select(TableMetadata table, List<Object> columnNames, boolean isDistinct, boolean isJson) {
-        this(escapeId(table.getKeyspace().getName()),
-                escapeId(table.getName()),
+        this(Metadata.quoteIfNecessary(table.getKeyspace().getName()),
+                Metadata.quoteIfNecessary(table.getName()),
                 Arrays.asList(new Object[table.getPartitionKey().size()]),
                 table.getPartitionKey(),
                 columnNames,

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Truncate.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Truncate.java
@@ -17,6 +17,7 @@ package com.datastax.driver.core.querybuilder;
 
 import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.ColumnMetadata;
+import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.TableMetadata;
 
 import java.util.Arrays;
@@ -34,8 +35,8 @@ public class Truncate extends BuiltStatement {
     }
 
     Truncate(TableMetadata table) {
-        this(escapeId(table.getKeyspace().getName()),
-                escapeId(table.getName()),
+        this(Metadata.quoteIfNecessary(table.getKeyspace().getName()),
+                Metadata.quoteIfNecessary(table.getName()),
                 Arrays.asList(new Object[table.getPartitionKey().size()]),
                 table.getPartitionKey());
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Update.java
@@ -17,6 +17,7 @@ package com.datastax.driver.core.querybuilder;
 
 import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.ColumnMetadata;
+import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.TableMetadata;
 import com.datastax.driver.core.querybuilder.Assignment.CounterAssignment;
 
@@ -41,8 +42,8 @@ public class Update extends BuiltStatement {
     }
 
     Update(TableMetadata table) {
-        this(escapeId(table.getKeyspace().getName()),
-                escapeId(table.getName()),
+        this(Metadata.quoteIfNecessary(table.getKeyspace().getName()),
+                Metadata.quoteIfNecessary(table.getName()),
                 Arrays.asList(new Object[table.getPartitionKey().size()]),
                 table.getPartitionKey());
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
@@ -147,18 +147,18 @@ public class MetadataTest extends CCMTestsSupport {
     @Test(groups = "unit")
     public void escapeId_should_not_quote_lowercase_identifiers() {
         String id = "this_does_not_need_quoting_0123456789abcdefghijklmnopqrstuvwxyz";
-        assertThat(Metadata.escapeId(id)).isEqualTo(id);
+        assertThat(Metadata.quoteIfNecessary(id)).isEqualTo(id);
     }
 
     @Test(groups = "unit")
     public void escapeId_should_quote_non_lowercase_identifiers() {
-        assertThat(Metadata.escapeId("This_Needs_Quoting_1234")).isEqualTo("\"This_Needs_Quoting_1234\"");
-        assertThat(Metadata.escapeId("This Needs Quoting 1234!!")).isEqualTo("\"This Needs Quoting 1234!!\"");
+        assertThat(Metadata.quoteIfNecessary("This_Needs_Quoting_1234")).isEqualTo("\"This_Needs_Quoting_1234\"");
+        assertThat(Metadata.quoteIfNecessary("This Needs Quoting 1234!!")).isEqualTo("\"This Needs Quoting 1234!!\"");
     }
 
     @Test(groups = "unit")
     public void escapeId_should_quote_reserved_cql_keywords() {
-        assertThat(Metadata.escapeId("columnfamily")).isEqualTo("\"columnfamily\"");
+        assertThat(Metadata.quoteIfNecessary("columnfamily")).isEqualTo("\"columnfamily\"");
     }
 
 }

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/AliasedMappedProperty.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/AliasedMappedProperty.java
@@ -15,28 +15,13 @@
  */
 package com.datastax.driver.mapping;
 
-import java.util.Set;
+class AliasedMappedProperty<T> {
 
-/**
- * A pluggable component that maps
- * Java properties to a Cassandra objects.
- */
-public interface PropertyMapper {
+    final MappedProperty<T> mappedProperty;
+    final String alias;
 
-    /**
-     * Maps the given table class.
-     *
-     * @param tableClass the table class.
-     * @return a set of mapped properties for the given class.
-     */
-    Set<? extends MappedProperty<?>> mapTable(Class<?> tableClass);
-
-    /**
-     * Maps the given UDT class.
-     *
-     * @param udtClass the UDT class.
-     * @return a set of mapped properties for the given class.
-     */
-    Set<? extends MappedProperty<?>> mapUdt(Class<?> udtClass);
-
+    AliasedMappedProperty(MappedProperty<T> mappedProperty, String alias) {
+        this.mappedProperty = mappedProperty;
+        this.alias = alias;
+    }
 }

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/AnnotationParser.java
@@ -19,10 +19,8 @@ import com.datastax.driver.core.*;
 import com.datastax.driver.mapping.MethodMapper.ParamMapper;
 import com.datastax.driver.mapping.annotations.*;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.TypeToken;
 
-import java.beans.PropertyDescriptor;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -38,34 +36,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 class AnnotationParser {
 
-    /**
-     * Annotations allowed on a property that maps to a table column.
-     */
-    @SuppressWarnings("unchecked")
-    private static final Set<Class<? extends Annotation>> VALID_COLUMN_ANNOTATIONS = ImmutableSet.of(
-            Column.class,
-            Computed.class,
-            ClusteringColumn.class,
-            Frozen.class,
-            FrozenKey.class,
-            FrozenValue.class,
-            PartitionKey.class,
-            Transient.class);
-
-    /**
-     * Annotations allowed on a property that maps to a UDT field.
-     */
-    private static final Set<Class<? extends Annotation>> VALID_FIELD_ANNOTATIONS = ImmutableSet.of(
-            Field.class,
-            Frozen.class,
-            FrozenKey.class,
-            FrozenValue.class,
-            Transient.class);
-
-    private static final Comparator<PropertyMapper> POSITION_COMPARATOR = new Comparator<PropertyMapper>() {
+    private static final Comparator<AliasedMappedProperty<?>> POSITION_COMPARATOR = new Comparator<AliasedMappedProperty<?>>() {
         @Override
-        public int compare(PropertyMapper o1, PropertyMapper o2) {
-            return o1.position - o2.position;
+        public int compare(AliasedMappedProperty<?> o1, AliasedMappedProperty<?> o2) {
+            return o1.mappedProperty.getPosition() - o2.mappedProperty.getPosition();
         }
     };
 
@@ -104,45 +78,38 @@ class AnnotationParser {
 
         EntityMapper<T> mapper = new EntityMapper<T>(entityClass, ksName, tableName, writeConsistency, readConsistency);
 
-        List<PropertyMapper> pks = new ArrayList<PropertyMapper>();
-        List<PropertyMapper> ccs = new ArrayList<PropertyMapper>();
-        List<PropertyMapper> rgs = new ArrayList<PropertyMapper>();
+        List<AliasedMappedProperty<?>> pks = new ArrayList<AliasedMappedProperty<?>>();
+        List<AliasedMappedProperty<?>> ccs = new ArrayList<AliasedMappedProperty<?>>();
+        List<AliasedMappedProperty<?>> rgs = new ArrayList<AliasedMappedProperty<?>>();
 
-        Map<String, Object[]> fieldsAndProperties = ReflectionUtils.scanFieldsAndProperties(entityClass);
+        MappingConfiguration configuration = mappingManager.getConfiguration();
+        Set<? extends MappedProperty<?>> properties = configuration.getPropertyMapper().mapTable(entityClass);
         AtomicInteger columnCounter = mappingManager.isCassandraV1 ? null : new AtomicInteger(0);
 
-        for (Map.Entry<String, Object[]> entry : fieldsAndProperties.entrySet()) {
+        for (MappedProperty<?> mappedProperty : properties) {
 
-            String propertyName = entry.getKey();
-            java.lang.reflect.Field field = (java.lang.reflect.Field) entry.getValue()[0];
-            PropertyDescriptor property = (PropertyDescriptor) entry.getValue()[1];
             String alias = (columnCounter != null)
                     ? "col" + columnCounter.incrementAndGet()
                     : null;
 
-            PropertyMapper propertyMapper = new PropertyMapper(entityClass, propertyName, alias, field, property);
+            AliasedMappedProperty<?> aliasedMappedProperty = new AliasedMappedProperty(mappedProperty, alias);
 
-            if (mappingManager.isCassandraV1 && propertyMapper.isComputed())
+            if (mappingManager.isCassandraV1 && mappedProperty.isComputed())
                 throw new UnsupportedOperationException("Computed properties are not supported with native protocol v1");
 
-            AnnotationChecks.validateAnnotations(propertyMapper, VALID_COLUMN_ANNOTATIONS);
-
-            if (propertyMapper.isTransient())
-                continue;
-
-            if (!propertyMapper.isComputed() && tableMetadata.getColumn(propertyMapper.columnName) == null)
+            if (!mappedProperty.isComputed() && tableMetadata.getColumn(mappedProperty.getMappedName()) == null)
                 throw new IllegalArgumentException(String.format("Column %s does not exist in table %s.%s",
-                        propertyMapper.columnName, ksName, tableName));
+                        mappedProperty.getMappedName(), ksName, tableName));
 
-            if (propertyMapper.isPartitionKey())
-                pks.add(propertyMapper);
-            else if (propertyMapper.isClusteringColumn())
-                ccs.add(propertyMapper);
+            if (mappedProperty.isPartitionKey())
+                pks.add(aliasedMappedProperty);
+            else if (mappedProperty.isClusteringColumn())
+                ccs.add(aliasedMappedProperty);
             else
-                rgs.add(propertyMapper);
+                rgs.add(aliasedMappedProperty);
 
             // if the property is of a UDT type, parse it now
-            for (Class<?> udt : TypeMappings.findUDTs(propertyMapper.javaType.getType()))
+            for (Class<?> udt : TypeMappings.findUDTs(mappedProperty.getPropertyType().getType()))
                 mappingManager.getUDTCodec(udt);
         }
 
@@ -180,31 +147,23 @@ class AnnotationParser {
         if (userType == null)
             throw new IllegalArgumentException(String.format("User type %s does not exist in keyspace %s", udtName, ksName));
 
-        Map<String, PropertyMapper> propertyMappers = new HashMap<String, PropertyMapper>();
+        Map<String, AliasedMappedProperty<?>> propertyMappers = new HashMap<String, AliasedMappedProperty<?>>();
 
-        Map<String, Object[]> fieldsAndProperties = ReflectionUtils.scanFieldsAndProperties(udtClass);
+        MappingConfiguration configuration = mappingManager.getConfiguration();
+        Set<? extends MappedProperty<?>> properties = configuration.getPropertyMapper().mapUdt(udtClass);
 
-        for (Map.Entry<String, Object[]> entry : fieldsAndProperties.entrySet()) {
+        for (MappedProperty<?> mappedProperty : properties) {
 
-            String propertyName = entry.getKey();
-            java.lang.reflect.Field field = (java.lang.reflect.Field) entry.getValue()[0];
-            PropertyDescriptor property = (PropertyDescriptor) entry.getValue()[1];
+            AliasedMappedProperty<?> aliasedMappedProperty = new AliasedMappedProperty(mappedProperty, null);
 
-            PropertyMapper propertyMapper = new PropertyMapper(udtClass, propertyName, null, field, property);
-
-            AnnotationChecks.validateAnnotations(propertyMapper, VALID_FIELD_ANNOTATIONS);
-
-            if (propertyMapper.isTransient())
-                continue;
-
-            if (!userType.contains(propertyMapper.columnName))
+            if (!userType.contains(mappedProperty.getMappedName()))
                 throw new IllegalArgumentException(String.format("Field %s does not exist in type %s.%s",
-                        propertyMapper.columnName, ksName, userType.getTypeName()));
+                        mappedProperty.getMappedName(), ksName, userType.getTypeName()));
 
-            for (Class<?> fieldUdt : TypeMappings.findUDTs(propertyMapper.javaType.getType()))
+            for (Class<?> fieldUdt : TypeMappings.findUDTs(mappedProperty.getPropertyType().getType()))
                 mappingManager.getUDTCodec(fieldUdt);
 
-            propertyMappers.put(propertyMapper.columnName, propertyMapper);
+            propertyMappers.put(mappedProperty.getMappedName(), aliasedMappedProperty);
         }
 
         return new MappedUDTCodec<T>(userType, udtClass, propertyMappers, mappingManager);

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/DefaultHierarchyScanStrategy.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/DefaultHierarchyScanStrategy.java
@@ -1,0 +1,72 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * The default {@link HierarchyScanStrategy}.
+ * <p/>
+ * This strategy assumes that there exists a common ancestor
+ * for all mapped classes in the application, and allows all its
+ * descendants (optionally including itself) to be scanned for annotations.
+ */
+public class DefaultHierarchyScanStrategy implements HierarchyScanStrategy {
+
+    private final Class<?> highestAncestor;
+
+    private final boolean included;
+
+    /**
+     * Creates a new instance with defaults:
+     * the common ancestor is {@link Object} excluded, which implies
+     * that every ancestor of a mapped class, except {@code Object} itself,
+     * will be scanned for annotations.
+     */
+    public DefaultHierarchyScanStrategy() {
+        this(Object.class, false);
+    }
+
+    /**
+     * Creates a new instance with the given highest common ancestor.
+     *
+     * @param highestAncestor The highest ancestor class to consider; cannot be {@code null}.
+     * @param included        Whether or not to include the highest ancestor itself.
+     */
+    public DefaultHierarchyScanStrategy(Class<?> highestAncestor, boolean included) {
+        checkNotNull(highestAncestor);
+        this.highestAncestor = highestAncestor;
+        this.included = included;
+    }
+
+    @Override
+    public List<Class<?>> filterClassHierarchy(Class<?> mappedClass) {
+        List<Class<?>> classesToScan = new ArrayList<Class<?>>();
+        Class<?> highestAncestor = this.highestAncestor;
+        for (Class<?> clazz = mappedClass; clazz != null; clazz = clazz.getSuperclass()) {
+            if (!clazz.equals(highestAncestor) || included) {
+                classesToScan.add(clazz);
+            }
+            if (clazz.equals(highestAncestor)) {
+                break;
+            }
+        }
+        return classesToScan;
+    }
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/DefaultMappedProperty.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/DefaultMappedProperty.java
@@ -1,0 +1,184 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.mapping.annotations.*;
+import com.google.common.reflect.TypeToken;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Default implementation of {@link MappedProperty}.
+ */
+class DefaultMappedProperty<T> implements MappedProperty<T> {
+
+    static <T> DefaultMappedProperty<T> create(Class<?> mappedClass, String propertyName, String mappedName, Field field, Method getter, Method setter, Map<Class<? extends Annotation>, Annotation> annotations) {
+        @SuppressWarnings("unchecked")
+        TypeToken<T> propertyType = (TypeToken<T>) inferType(field, getter);
+        boolean partitionKey = annotations.containsKey(PartitionKey.class);
+        boolean clusteringColumn = annotations.containsKey(ClusteringColumn.class);
+        boolean computed = annotations.containsKey(Computed.class);
+        int position = inferPosition(annotations);
+        @SuppressWarnings("unchecked")
+        Class<? extends TypeCodec<T>> codecClass = (Class<? extends TypeCodec<T>>) getCustomCodecClass(annotations);
+        return new DefaultMappedProperty<T>(
+                mappedClass, propertyName, mappedName, propertyType,
+                partitionKey, clusteringColumn, computed, position, codecClass, field, getter, setter);
+
+    }
+
+    private final Class<?> mappedClass;
+    private final String propertyName;
+    private final TypeToken<T> propertyType;
+    private final String mappedName;
+    private final boolean partitionKey;
+    private final boolean clusteringColumn;
+    private final boolean computed;
+    private final int position;
+    private final TypeCodec<T> customCodec;
+    private final Field field;
+    private final Method getter;
+    private final Method setter;
+
+    private DefaultMappedProperty(
+            Class<?> mappedClass, String propertyName, String mappedName, TypeToken<T> propertyType,
+            boolean partitionKey, boolean clusteringColumn, boolean computed, int position,
+            Class<? extends TypeCodec<T>> codecClass, Field field, Method getter, Method setter) {
+        checkArgument(propertyName != null && !propertyName.isEmpty());
+        checkArgument(mappedName != null && !mappedName.isEmpty());
+        checkNotNull(propertyType);
+        this.mappedClass = mappedClass;
+        this.propertyName = propertyName;
+        this.mappedName = mappedName;
+        this.propertyType = propertyType;
+        this.partitionKey = partitionKey;
+        this.clusteringColumn = clusteringColumn;
+        this.computed = computed;
+        this.position = position;
+        this.customCodec = codecClass == null || codecClass.equals(Defaults.NoCodec.class) ? null : ReflectionUtils.newInstance(codecClass);
+        this.field = field;
+        this.getter = getter;
+        this.setter = setter;
+    }
+
+    @Override
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    @Override
+    public TypeToken<T> getPropertyType() {
+        return propertyType;
+    }
+
+    @Override
+    public String getMappedName() {
+        return mappedName;
+    }
+
+    @Override
+    public int getPosition() {
+        return position;
+    }
+
+    @Override
+    public TypeCodec<T> getCustomCodec() {
+        return customCodec;
+    }
+
+    @Override
+    public boolean isComputed() {
+        return computed;
+    }
+
+    @Override
+    public boolean isPartitionKey() {
+        return partitionKey;
+    }
+
+    @Override
+    public boolean isClusteringColumn() {
+        return clusteringColumn;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public T getValue(Object entity) {
+        try {
+            // try getter first, if available, otherwise direct field access
+            if (getter != null && getter.isAccessible())
+                return (T) getter.invoke(entity);
+            else
+                return (T) checkNotNull(field).get(entity);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to read property '" + getPropertyName() + "' in " + entity.getClass(), e);
+        }
+    }
+
+    @Override
+    public void setValue(Object entity, T value) {
+        try {
+            // try setter first, if available, otherwise direct field access
+            if (setter != null && setter.isAccessible())
+                setter.invoke(entity, value);
+            else
+                checkNotNull(field).set(entity, value);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to write property '" + getPropertyName() + "' in " + entity.getClass(), e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return mappedClass.getSimpleName() + "." + getPropertyName();
+    }
+
+    private static TypeToken<?> inferType(Field field, Method getter) {
+        if (getter != null)
+            return TypeToken.of(getter.getGenericReturnType());
+        else
+            return TypeToken.of(checkNotNull(field).getGenericType());
+    }
+
+    private static int inferPosition(Map<Class<? extends Annotation>, Annotation> annotations) {
+        if (annotations.containsKey(PartitionKey.class)) {
+            return ((PartitionKey) annotations.get(PartitionKey.class)).value();
+        }
+        if (annotations.containsKey(ClusteringColumn.class)) {
+            return ((ClusteringColumn) annotations.get(ClusteringColumn.class)).value();
+        }
+        return -1;
+    }
+
+    private static Class<? extends TypeCodec<?>> getCustomCodecClass(Map<Class<? extends Annotation>, Annotation> annotations) {
+        Column column = (Column) annotations.get(Column.class);
+        if (column != null)
+            return column.codec();
+        com.datastax.driver.mapping.annotations.Field udtField =
+                (com.datastax.driver.mapping.annotations.Field) annotations.get(com.datastax.driver.mapping.annotations.Field.class);
+        if (udtField != null)
+            return udtField.codec();
+        return null;
+    }
+
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/DefaultNamingStrategy.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/DefaultNamingStrategy.java
@@ -1,0 +1,72 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import java.util.List;
+
+/**
+ * A naming strategy that builds upon two naming conventions for the Java and Cassandra side.
+ * <p/>
+ * To infer a Cassandra name, the strategy will {@link NamingConvention#split(String) split}
+ * the Java name according to the Java convention, and then
+ * {@link NamingConvention#join(List) join} the resulting tokens according to the Cassandra
+ * convention. For example, a possible implementation might:
+ * <ul>
+ *     <li>trim a prefix and tokenize on camel case: split("mUserName") = "user, name"</li>
+ *     <li>join with a separator: join("user", "name") => "user_name"</li>
+ * </ul>
+ */
+public class DefaultNamingStrategy implements NamingStrategy {
+
+    private NamingConvention javaConvention;
+
+    private NamingConvention cassandraConvention;
+
+    /**
+     * Builds a new instance with the default conventions, namely
+     * {@link NamingConventions#LOWER_CAMEL_CASE lower camel case}
+     * for the Java convention, and
+     * {@link NamingConventions#LOWER_CASE lower case}
+     * for the Cassandra convention.
+     * <p/>
+     * For example, a "userName" Java property will be mapped to a "username" column.
+     */
+    public DefaultNamingStrategy() {
+        this(NamingConventions.LOWER_CAMEL_CASE, NamingConventions.LOWER_CASE);
+    }
+
+    /**
+     * Builds a new instance.
+     *
+     * @param javaConvention      the naming convention that will be used to tokenize the Java
+     *                            property names.
+     * @param cassandraConvention the naming convention that will be used to build the Cassandra
+     *                            names from the Java tokens.
+     */
+    public DefaultNamingStrategy(NamingConvention javaConvention, NamingConvention cassandraConvention) {
+        if (javaConvention == null || cassandraConvention == null) {
+            throw new IllegalArgumentException("input/output NamingConvention cannot be null");
+        }
+        this.javaConvention = javaConvention;
+        this.cassandraConvention = cassandraConvention;
+    }
+
+    @Override
+    public String toCassandraName(String javaPropertyName) {
+        return cassandraConvention.join(javaConvention.split(javaPropertyName));
+    }
+
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/DefaultPropertyMapper.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/DefaultPropertyMapper.java
@@ -1,0 +1,542 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.core.Metadata;
+import com.datastax.driver.mapping.annotations.*;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.beans.BeanInfo;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.*;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * The default {@link PropertyMapper} used by the mapper.
+ * <p/>
+ * This mapper can be configured to scan for fields, getters and setters, or both.
+ * The default is to scan for both.
+ * <p/>
+ * This mapper can also be configured to skip transient properties.
+ * By default, all properties will be mapped (non-transient),
+ * unless explicitly marked with {@link Transient @Transient}.
+ * <p/>
+ * This mapper recognizes standard getter and setter methods
+ * (as defined by the Java Beans specification),
+ * and also "relaxed" setter methods, i.e., setter methods
+ * whose return type are not {@code void}.
+ *
+ * @see DefaultMappedProperty
+ */
+public class DefaultPropertyMapper implements PropertyMapper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPropertyMapper.class);
+
+    private static final HashSet<String> DEFAULT_TRANSIENT_PROPERTY_NAMES = Sets.newHashSet(
+            "class",
+            // JAVA-1279: exclude Groovy's metaClass property
+            "metaClass"
+    );
+
+    private static final Set<Class<?>> NON_TRANSIENT_ANNOTATIONS = ImmutableSet.<Class<?>>of(
+            Column.class,
+            PartitionKey.class,
+            ClusteringColumn.class,
+            com.datastax.driver.mapping.annotations.Field.class,
+            Computed.class,
+            Frozen.class,
+            FrozenKey.class,
+            FrozenValue.class
+    );
+
+    /**
+     * Annotations allowed on a property that maps to a table column.
+     */
+    private static final Set<Class<? extends Annotation>> VALID_COLUMN_ANNOTATIONS = ImmutableSet.<Class<? extends Annotation>>builder()
+            .add(Column.class)
+            .add(Computed.class)
+            .add(ClusteringColumn.class)
+            .add(Frozen.class)
+            .add(FrozenKey.class)
+            .add(FrozenValue.class)
+            .add(PartitionKey.class)
+            .add(Transient.class)
+            .build();
+
+    /**
+     * Annotations allowed on a property that maps to a UDT field.
+     */
+    private static final Set<Class<? extends Annotation>> VALID_FIELD_ANNOTATIONS = ImmutableSet.of(
+            com.datastax.driver.mapping.annotations.Field.class,
+            Frozen.class,
+            FrozenKey.class,
+            FrozenValue.class,
+            Transient.class);
+
+    private PropertyAccessStrategy propertyAccessStrategy = PropertyAccessStrategy.BOTH;
+
+    private PropertyTransienceStrategy propertyTransienceStrategy = PropertyTransienceStrategy.OPT_OUT;
+
+    private HierarchyScanStrategy hierarchyScanStrategy = new DefaultHierarchyScanStrategy();
+
+    private NamingStrategy namingStrategy = new DefaultNamingStrategy();
+
+    private Set<String> transientPropertyNames = new HashSet<String>(DEFAULT_TRANSIENT_PROPERTY_NAMES);
+
+    /**
+     * Sets the {@link PropertyAccessStrategy property access strategy} to use.
+     * The default is {@link PropertyAccessStrategy#BOTH}.
+     *
+     * @param propertyAccessStrategy the {@link PropertyAccessStrategy property access strategy} to use; may not be {@code null}.
+     * @return this {@link DefaultPropertyMapper} instance (to allow for fluent builder pattern).
+     */
+    public DefaultPropertyMapper setPropertyAccessStrategy(PropertyAccessStrategy propertyAccessStrategy) {
+        this.propertyAccessStrategy = checkNotNull(propertyAccessStrategy);
+        return this;
+    }
+
+    /**
+     * Sets the {@link PropertyTransienceStrategy property transience strategy} to use.
+     * The default is {@link PropertyTransienceStrategy#OPT_OUT}.
+     *
+     * @param propertyTransienceStrategy the {@link PropertyTransienceStrategy property transience strategy} to use; may not be {@code null}.
+     * @return this {@link DefaultPropertyMapper} instance (to allow for fluent builder pattern).
+     */
+    public DefaultPropertyMapper setPropertyTransienceStrategy(PropertyTransienceStrategy propertyTransienceStrategy) {
+        this.propertyTransienceStrategy = checkNotNull(propertyTransienceStrategy);
+        return this;
+    }
+
+    /**
+     * Sets the {@link HierarchyScanStrategy hierarchy scan strategy} to use.
+     * The default is {@link DefaultHierarchyScanStrategy}.
+     *
+     * @param hierarchyScanStrategy the {@link HierarchyScanStrategy hierarchy scan strategy} to use; may not be {@code null}.
+     * @return this {@link DefaultPropertyMapper} instance (to allow for fluent builder pattern).
+     */
+    public DefaultPropertyMapper setHierarchyScanStrategy(HierarchyScanStrategy hierarchyScanStrategy) {
+        this.hierarchyScanStrategy = checkNotNull(hierarchyScanStrategy);
+        return this;
+    }
+
+    /**
+     * Sets the {@link NamingStrategy naming strategy} to use.
+     * The default is {@link DefaultNamingStrategy}.
+     *
+     * @param namingStrategy the {@link NamingStrategy naming strategy} to use; may not be {@code null}.
+     * @return this {@link DefaultPropertyMapper} instance (to allow for fluent builder pattern).
+     */
+    public DefaultPropertyMapper setNamingStrategy(NamingStrategy namingStrategy) {
+        this.namingStrategy = checkNotNull(namingStrategy);
+        return this;
+    }
+
+    /**
+     * Sets transient property names. This
+     * will completely replace any names already configured for this object.
+     * <p/>
+     * The default set comprises the following property names:
+     * {@code class} and {@code metaClass}.
+     * These properties pertain to the {@link Object} class –
+     * {@code metaClass} being specific to the Groovy language.
+     * <p/>
+     * Property names provided here will always be considered transient;
+     * if a more fine-grained tuning is required, it is also possible
+     * to use the {@link Transient @Transient} annotation
+     * on a specific property.
+     * <p/>
+     * Subclasses can also override {@link #isTransient(String, Field, Method, Method, Map)} to gain
+     * complete control over which properties should be considered transient.
+     *
+     * @param transientPropertyNames a set of property names to exclude from mapping; may not be {@code null}. This
+     *                               will completely replace any names already configured for this object.
+     */
+    public DefaultPropertyMapper setTransientPropertyNames(Set<String> transientPropertyNames) {
+        this.transientPropertyNames = checkNotNull(transientPropertyNames);
+        return this;
+    }
+
+    /**
+     * Adds new values to the existing set of transient property names.
+     * <p/>
+     * The default set comprises the following property names:
+     * {@code class} and {@code metaClass}.
+     * These properties pertain to the {@link Object} class –
+     * {@code metaClass} being specific to the Groovy language.
+     * <p/>
+     * Property names provided here will always be considered transient;
+     * if a more fine-grained tuning is required, it is also possible
+     * to use the {@link Transient @Transient} annotation
+     * on a specific property.
+     * <p/>
+     * Subclasses can also override {@link #isTransient(String, Field, Method, Method, Map)} to gain
+     * complete control over which properties should be considered transient.
+     *
+     * @param transientPropertyNames the values to add; may not be {@code null}.
+     */
+    public DefaultPropertyMapper addTransientPropertyNames(String... transientPropertyNames) {
+        return addTransientPropertyNames(Arrays.asList(checkNotNull(transientPropertyNames)));
+    }
+
+    /**
+     * Adds new values to the existing set of transient property names.
+     * <p/>
+     * The default set comprises the following property names:
+     * {@code class} and {@code metaClass}.
+     * These properties pertain to the {@link Object} class –
+     * {@code metaClass} being specific to the Groovy language.
+     * <p/>
+     * Property names provided here will always be considered transient;
+     * if a more fine-grained tuning is required, it is also possible
+     * to use the {@link Transient @Transient} annotation
+     * on a specific property.
+     * <p/>
+     * Subclasses can also override {@link #isTransient(String, Field, Method, Method, Map)} to gain
+     * complete control over which properties should be considered transient.
+     *
+     * @param transientPropertyNames the values to add; may not be {@code null}.
+     */
+    public DefaultPropertyMapper addTransientPropertyNames(Collection<String> transientPropertyNames) {
+        this.transientPropertyNames.addAll(checkNotNull(transientPropertyNames));
+        return this;
+    }
+
+    @Override
+    public Set<? extends MappedProperty<?>> mapTable(Class<?> tableClass) {
+        return mapTableOrUdt(tableClass, VALID_COLUMN_ANNOTATIONS);
+    }
+
+    @Override
+    public Set<? extends MappedProperty<?>> mapUdt(Class<?> udtClass) {
+        return mapTableOrUdt(udtClass, VALID_FIELD_ANNOTATIONS);
+    }
+
+    private Set<? extends MappedProperty<?>> mapTableOrUdt(Class<?> entityClass, Collection<? extends Class<? extends Annotation>> allowed) {
+        Map<String, Object[]> fieldsGettersAndSetters = new HashMap<String, Object[]>();
+        List<Class<?>> classHierarchy = hierarchyScanStrategy.filterClassHierarchy(entityClass);
+        if (propertyAccessStrategy.isFieldScanAllowed()) {
+            Map<String, Field> fields = scanFields(classHierarchy);
+            for (Map.Entry<String, Field> entry : fields.entrySet()) {
+                String propertyName = entry.getKey();
+                Field field = tryMakeAccessible(entry.getValue());
+                fieldsGettersAndSetters.put(propertyName, new Object[]{field, null, null});
+            }
+        }
+        if (propertyAccessStrategy.isGetterSetterScanAllowed()) {
+            Map<String, PropertyDescriptor> properties = scanProperties(classHierarchy);
+            for (Map.Entry<String, PropertyDescriptor> entry : properties.entrySet()) {
+                PropertyDescriptor property = entry.getValue();
+                Method getter = tryMakeAccessible(locateGetter(entityClass, property));
+                Method setter = tryMakeAccessible(locateSetter(entityClass, property));
+                Object[] value = fieldsGettersAndSetters.get(entry.getKey());
+                if (value != null) {
+                    value[1] = getter;
+                    value[2] = setter;
+                } else if (getter != null || setter != null) {
+                    fieldsGettersAndSetters.put(entry.getKey(), new Object[]{null, getter, setter});
+                }
+            }
+        }
+        Set<MappedProperty<?>> mappedProperties = new HashSet<MappedProperty<?>>(fieldsGettersAndSetters.size());
+        for (Map.Entry<String, Object[]> entry : fieldsGettersAndSetters.entrySet()) {
+            String propertyName = entry.getKey();
+            Field field = (Field) entry.getValue()[0];
+            Method getter = (Method) entry.getValue()[1];
+            Method setter = (Method) entry.getValue()[2];
+            Map<Class<? extends Annotation>, Annotation> annotations = scanPropertyAnnotations(field, getter);
+            AnnotationChecks.validateAnnotations(propertyName, annotations, allowed);
+            if (isTransient(propertyName, field, getter, setter, annotations)) {
+                LOGGER.debug(String.format("Property '%s' is transient and will not be mapped", propertyName));
+                continue;
+            }
+            if (!annotations.containsKey(Computed.class) && field == null && getter == null) {
+                throw new IllegalArgumentException(String.format("Property '%s' is not readable", propertyName));
+            }
+            if (field == null && setter == null) {
+                throw new IllegalArgumentException(String.format("Property '%s' is not writable", propertyName));
+            }
+            String mappedName = inferMappedName(entityClass, propertyName, annotations);
+            MappedProperty<?> property = createMappedProperty(entityClass, propertyName, mappedName, field, getter, setter, annotations);
+            mappedProperties.add(property);
+        }
+        return mappedProperties;
+    }
+
+    /**
+     * Returns {@code true} if the given property is transient,
+     * {@code false} otherwise.
+     * <p/>
+     * If this method returns {@code true} the given property will not be mapped.
+     * The implementation provided here relies on the
+     * {@link #setPropertyTransienceStrategy(PropertyTransienceStrategy) transience strategy}
+     * and the {@link #setTransientPropertyNames(Set) transient property names}
+     * configured on this mapper.
+     * <p/>
+     * Subclasses may override this method to take full control of which properties
+     * should be mapped and which should be considered transient.
+     *
+     * @param propertyName the property name; may not be {@code null}.
+     * @param field        the property field; may be {@code null}.
+     * @param getter       the getter method for this property; may be {@code null}.
+     * @param setter       the setter method for this property; may be {@code null}.
+     * @param annotations  the annotations found on this property; may be empty but never {@code null}.
+     * @return {@code true} if the given property is transient (i.e., non-mapped), {@code false} otherwise.
+     */
+    @SuppressWarnings("unused")
+    protected boolean isTransient(String propertyName, Field field, Method getter, Method setter, Map<Class<? extends Annotation>, Annotation> annotations) {
+        if (propertyTransienceStrategy == PropertyTransienceStrategy.OPT_OUT)
+            return annotations.containsKey(Transient.class)
+                    || (transientPropertyNames.contains(propertyName)
+                    && Collections.disjoint(annotations.keySet(), NON_TRANSIENT_ANNOTATIONS));
+        else
+            return Collections.disjoint(annotations.keySet(), NON_TRANSIENT_ANNOTATIONS);
+    }
+
+    /**
+     * Locates a getter method for the given mapped class and given property.
+     * <p/>
+     * Most users should rely on the implementation provided here.
+     * It is however possible to return any non-standard method, as long as it does
+     * not take parameters, and its return type is assignable to (and covariant with) the property's type.
+     * This might be particularly useful for boolean properties whose names are verbs, e.g. "{@code hasAccount}":
+     * one could then return the non-standard method {@code boolean hasAccount()} as its getter.
+     * <p/>
+     * This method is never called if {@link PropertyAccessStrategy#isGetterSetterScanAllowed()} returns {@code false}.
+     * Besides, implementors are free to return {@code null} if access to the property through reflection is not required
+     * (in which case, they will likely have to provide a custom implementation of {@link MappedProperty}).
+     *
+     * @param mappedClass The mapped class; this is necessarily a class annotated with
+     *                    either {@link Table @Table} or
+     *                    {@link UDT @UDT}.
+     * @param property    The property to locate a getter for; never {@code null}.
+     * @return The getter method for the given base class and given property, or {@code null} if no getter was found, or reflection is not required.
+     */
+    protected Method locateGetter(@SuppressWarnings("unused") Class<?> mappedClass, PropertyDescriptor property) {
+        return property.getReadMethod();
+    }
+
+    /**
+     * Locates a setter method for the given mapped class and given property.
+     * <p/>
+     * Most users should rely on the implementation provided here.
+     * It is however possible to return any non-standard method, as long as it accepts one single parameter type
+     * that is contravariant with the property's type.
+     * <p/>
+     * This method is never called if {@link PropertyAccessStrategy#isGetterSetterScanAllowed()} returns {@code false}.
+     * Besides, implementors are free to return {@code null} if access to the property through reflection is not required
+     * (in which case, they will likely have to provide a custom implementation of {@link MappedProperty}).
+     *
+     * @param mappedClass The mapped class; this is necessarily a class annotated with
+     *                    either {@link Table @Table} or
+     *                    {@link UDT @UDT}.
+     * @param property    The property to locate a setter for; never {@code null}.
+     * @return The setter method for the given base class and given property, or {@code null} if no setter was found, or reflection is not required.
+     */
+    protected Method locateSetter(Class<?> mappedClass, PropertyDescriptor property) {
+        Method setter = property.getWriteMethod();
+        if (setter == null) {
+            // JAVA-984: look for a "relaxed" setter, ie. a setter whose return type may be anything
+            String propertyName = property.getName();
+            String setterName = "set" + propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
+            try {
+                Method m = mappedClass.getMethod(setterName, property.getPropertyType());
+                if (!Modifier.isStatic(m.getModifiers()))
+                    setter = m;
+            } catch (NoSuchMethodException ignored) {
+            }
+        }
+        return setter;
+    }
+
+    /**
+     * Infers the Cassandra object name corresponding to given the property name.
+     * <p/>
+     * Most users should rely on the implementation provided here.
+     * It relies on annotation values and ultimately resorts to the
+     * {@link NamingStrategy} configured on this mapper.
+     * <p/>
+     * Subclasses may override this method if they need full control
+     * over generating Cassandra object names.
+     *
+     * @param mappedClass The mapped class; this is necessarily a class annotated with
+     *                    either {@link Table @Table} or
+     *                    {@link UDT @UDT}.
+     * @param propertyName The property name; may not be {@code null} nor empty.
+     * @param annotations  The property annotations (found on its field and getter method); may not be {@code null} but can be empty.
+     * @return The inferred Cassandra object name.
+     */
+    protected String inferMappedName(@SuppressWarnings("unused") Class<?> mappedClass, String propertyName, Map<Class<? extends Annotation>, Annotation> annotations) {
+        if (annotations.containsKey(Computed.class)) {
+            String expression = ((Computed) annotations.get(Computed.class)).value();
+            if (expression.isEmpty())
+                throw new IllegalArgumentException(String.format("Property '%s': attribute 'value' of annotation @Computed is mandatory for computed properties", propertyName));
+            return expression;
+        }
+
+        // If a name is explicitly provided with @Column or @Field, use it
+        boolean caseSensitive = false;
+        String mappedName = null;
+        if (annotations.containsKey(Column.class)) {
+            Column column = (Column) annotations.get(Column.class);
+            caseSensitive = column.caseSensitive();
+            if (!column.name().isEmpty())
+                mappedName = column.name();
+        } else if (annotations.containsKey(com.datastax.driver.mapping.annotations.Field.class)) {
+            com.datastax.driver.mapping.annotations.Field udtMappedField =
+                    (com.datastax.driver.mapping.annotations.Field) annotations.get(com.datastax.driver.mapping.annotations.Field.class);
+            caseSensitive = udtMappedField.caseSensitive();
+            if (!udtMappedField.name().isEmpty())
+                mappedName = udtMappedField.name();
+        }
+        if (mappedName != null) {
+            return caseSensitive ? Metadata.quote(mappedName) : mappedName.toLowerCase();
+        }
+
+        // Otherwise delegate to the naming strategy
+        mappedName = namingStrategy.toCassandraName(propertyName);
+        if (mappedName == null || mappedName.isEmpty())
+            throw new IllegalArgumentException(String.format("Property '%s': could not infer mapped name", propertyName));
+        return Metadata.quoteIfNecessary(mappedName);
+    }
+
+    /**
+     * Creates a {@link MappedProperty} instance.
+     * <p>
+     * Instances returned by the implementation below will use the Java reflection API to read and write values.
+     * Subclasses may override this method if they are capable of accessing
+     * properties without incurring the cost of reflection.
+     *
+     * @param mappedClass The mapped class; this is necessarily a class annotated with
+     *                    either {@link Table @Table} or
+     *                    {@link UDT @UDT}.
+     * @param propertyName The property name; may not be {@code null} nor empty.
+     * @param mappedName   The mapped name; may not be {@code null} nor empty.
+     * @param field        The property field; may be {@code null}.
+     * @param getter       The property getter method; may be {@code null}.
+     * @param setter       The property setter method; may  be {@code null}.
+     * @param annotations  The property annotations (found on its field and getter method); may not be {@code null} but can be empty.
+     * @return a newly-allocated {@link MappedProperty} instance.
+     */
+    protected MappedProperty<?> createMappedProperty(Class<?> mappedClass, String propertyName, String mappedName, Field field, Method getter, Method setter, Map<Class<? extends Annotation>, Annotation> annotations) {
+        return DefaultMappedProperty.create(mappedClass, propertyName, mappedName, field, getter, setter, annotations);
+    }
+
+    private static Map<String, Field> scanFields(List<Class<?>> classHierarchy) {
+        HashMap<String, Field> fields = new HashMap<String, Field>();
+        for (Class<?> clazz : classHierarchy) {
+            for (Field field : clazz.getDeclaredFields()) {
+                if (field.isSynthetic() || Modifier.isStatic(field.getModifiers()) || Modifier.isTransient(field.getModifiers()))
+                    continue;
+                // never override a more specific field masking another one declared in a superclass
+                if (!fields.containsKey(field.getName()))
+                    fields.put(field.getName(), field);
+            }
+        }
+        return fields;
+    }
+
+    private static Map<String, PropertyDescriptor> scanProperties(List<Class<?>> classHierarchy) {
+        Map<String, PropertyDescriptor> properties = new HashMap<String, PropertyDescriptor>();
+        for (Class<?> clazz : classHierarchy) {
+            // each time extract only current class properties
+            BeanInfo beanInfo;
+            try {
+                beanInfo = Introspector.getBeanInfo(clazz, clazz.getSuperclass());
+            } catch (IntrospectionException e) {
+                throw Throwables.propagate(e);
+            }
+            for (PropertyDescriptor property : beanInfo.getPropertyDescriptors()) {
+                if (!properties.containsKey(property.getName())) {
+                    properties.put(property.getName(), property);
+                }
+            }
+        }
+        return properties;
+    }
+
+    private static Map<Class<? extends Annotation>, Annotation> scanPropertyAnnotations(Field field, Method getter) {
+        Map<Class<? extends Annotation>, Annotation> annotations = new HashMap<Class<? extends Annotation>, Annotation>();
+        // annotations on getters should have precedence over annotations on fields
+        if (field != null)
+            scanFieldAnnotations(field, annotations);
+        if (getter != null)
+            scanMethodAnnotations(getter, annotations);
+        return annotations;
+    }
+
+    private static Map<Class<? extends Annotation>, Annotation> scanFieldAnnotations(Field field, Map<Class<? extends Annotation>, Annotation> annotations) {
+        for (Annotation annotation : field.getAnnotations()) {
+            annotations.put(annotation.annotationType(), annotation);
+        }
+        return annotations;
+    }
+
+    private static Map<Class<? extends Annotation>, Annotation> scanMethodAnnotations(Method method, Map<Class<? extends Annotation>, Annotation> annotations) {
+        // 1. direct method annotations
+        for (Annotation annotation : method.getAnnotations()) {
+            annotations.put(annotation.annotationType(), annotation);
+        }
+        // 2. Class hierarchy: check for annotations in overridden methods in superclasses
+        Class<?> getterClass = method.getDeclaringClass();
+        for (Class<?> clazz = getterClass.getSuperclass(); clazz != null && !clazz.equals(Object.class); clazz = clazz.getSuperclass()) {
+            maybeAddOverriddenMethodAnnotations(annotations, method, clazz);
+        }
+        // 3. Interfaces: check for annotations in implemented interfaces
+        for (Class<?> clazz = getterClass; !clazz.equals(Object.class); clazz = clazz.getSuperclass()) {
+            for (Class<?> itf : clazz.getInterfaces()) {
+                maybeAddOverriddenMethodAnnotations(annotations, method, itf);
+            }
+        }
+        return annotations;
+    }
+
+    private static void maybeAddOverriddenMethodAnnotations(Map<Class<? extends Annotation>, Annotation> annotations, Method getter, Class<?> clazz) {
+        try {
+            Method overriddenGetter = clazz.getDeclaredMethod(getter.getName(), (Class<?>[]) getter.getParameterTypes());
+            for (Annotation annotation : overriddenGetter.getAnnotations()) {
+                // do not override a more specific version of the annotation type being scanned
+                if (!annotations.containsKey(annotation.annotationType()))
+                    annotations.put(annotation.annotationType(), annotation);
+            }
+        } catch (NoSuchMethodException e) {
+            //ok
+        }
+    }
+
+    private static <T extends AccessibleObject> T tryMakeAccessible(T object) {
+        if (object != null && !object.isAccessible()) {
+            try {
+                object.setAccessible(true);
+            } catch (SecurityException e) {
+                // ok
+            }
+        }
+        return object;
+    }
+
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/EntityMapper.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/EntityMapper.java
@@ -29,10 +29,10 @@ class EntityMapper<T> {
     final ConsistencyLevel writeConsistency;
     final ConsistencyLevel readConsistency;
 
-    final List<PropertyMapper> partitionKeys = new ArrayList<PropertyMapper>();
-    final List<PropertyMapper> clusteringColumns = new ArrayList<PropertyMapper>();
+    final List<AliasedMappedProperty<?>> partitionKeys = new ArrayList<AliasedMappedProperty<?>>();
+    final List<AliasedMappedProperty<?>> clusteringColumns = new ArrayList<AliasedMappedProperty<?>>();
 
-    final List<PropertyMapper> allColumns = new ArrayList<PropertyMapper>();
+    final List<AliasedMappedProperty<?>> allColumns = new ArrayList<AliasedMappedProperty<?>>();
 
     EntityMapper(Class<T> entityClass, String keyspace, String table, ConsistencyLevel writeConsistency, ConsistencyLevel readConsistency) {
         this.entityClass = entityClass;
@@ -46,11 +46,11 @@ class EntityMapper<T> {
         return partitionKeys.size() + clusteringColumns.size();
     }
 
-    PropertyMapper getPrimaryKeyColumn(int i) {
+    AliasedMappedProperty<?> getPrimaryKeyColumn(int i) {
         return i < partitionKeys.size() ? partitionKeys.get(i) : clusteringColumns.get(i - partitionKeys.size());
     }
 
-    void addColumns(List<PropertyMapper> pks, List<PropertyMapper> ccs, List<PropertyMapper> rgs) {
+    void addColumns(List<AliasedMappedProperty<?>> pks, List<AliasedMappedProperty<?>> ccs, List<AliasedMappedProperty<?>> rgs) {
         partitionKeys.addAll(pks);
         clusteringColumns.addAll(ccs);
         allColumns.addAll(pks);

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/HierarchyScanStrategy.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/HierarchyScanStrategy.java
@@ -1,0 +1,42 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import java.util.List;
+
+/**
+ * A strategy to determine which ancestors of mapped classes should be scanned for mapped properties.
+ */
+public interface HierarchyScanStrategy {
+
+    /**
+     * Computes the ancestors of the given base class, optionally
+     * filtering out any ancestor that should not be scanned.
+     * <p/>
+     * Implementors should always include {@code mappedClass}
+     * in the returned list.
+     *
+     * @param mappedClass The mapped class; this is necessarily a class annotated with
+     *                  either {@link com.datastax.driver.mapping.annotations.Table @Table} or
+     *                  {@link com.datastax.driver.mapping.annotations.UDT @UDT}.
+     * @return the list of classes that should be scanned,
+     * including {@code mappedClass} itself and its ancestors,
+     * ordered from the lowest (closest to {@code mappedClass})
+     * to the highest (or farthest from {@code mappedClass}).
+     */
+    List<Class<?>> filterClassHierarchy(Class<?> mappedClass);
+
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/MappedClassesOnlyHierarchyScanStrategy.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/MappedClassesOnlyHierarchyScanStrategy.java
@@ -15,28 +15,21 @@
  */
 package com.datastax.driver.mapping;
 
-import java.util.Set;
+import java.util.Collections;
+import java.util.List;
 
 /**
- * A pluggable component that maps
- * Java properties to a Cassandra objects.
+ * A {@link HierarchyScanStrategy} that excludes all ancestors of mapped classes, thus
+ * restricting class scan to the mapped classes themselves.
+ * <p>
+ * This strategy can be used instead of {@link DefaultHierarchyScanStrategy} to
+ * achieve pre-<a href="https://datastax-oss.atlassian.net/browse/JAVA-541">JAVA-541</a>
+ * behavior.
  */
-public interface PropertyMapper {
+public class MappedClassesOnlyHierarchyScanStrategy implements HierarchyScanStrategy {
 
-    /**
-     * Maps the given table class.
-     *
-     * @param tableClass the table class.
-     * @return a set of mapped properties for the given class.
-     */
-    Set<? extends MappedProperty<?>> mapTable(Class<?> tableClass);
-
-    /**
-     * Maps the given UDT class.
-     *
-     * @param udtClass the UDT class.
-     * @return a set of mapped properties for the given class.
-     */
-    Set<? extends MappedProperty<?>> mapUdt(Class<?> udtClass);
-
+    @Override
+    public List<Class<?>> filterClassHierarchy(Class<?> mappedClass) {
+        return Collections.<Class<?>>singletonList(mappedClass);
+    }
 }

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/MappedProperty.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/MappedProperty.java
@@ -1,0 +1,158 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.core.TypeCodec;
+import com.google.common.reflect.TypeToken;
+
+/**
+ * A Java property that is mapped to either a table column,
+ * a user-defined type (UDT) field, or
+ * a CQL expression such as {@code "ttl(col1)"}.
+ */
+public interface MappedProperty<T> {
+
+    /**
+     * Returns this property's name.
+     *
+     * @return this property's name; may not be {@code null}.
+     */
+    String getPropertyName();
+
+    /**
+     * Returns the name of the table column or
+     * UDT field that this property maps to.
+     * <p/>
+     * Note that case-sensitive identifiers should
+     * be quoted with {@link com.datastax.driver.core.Metadata#quote}
+     * <p/>
+     * In case of a {@link #isComputed() computed} property,
+     * this method should return the CQL expression to compute
+     * the property value, e.g. {@code "ttl(col1)"}.
+     *
+     * @return the name of the table column or
+     * UDT field that this property maps to, or the CQL expression
+     * in case of computed properties; may not be {@code null}.
+     */
+    String getMappedName();
+
+    /**
+     * Returns this property's type.
+     *
+     * @return this property's type; may not be {@code null}.
+     */
+    TypeToken<T> getPropertyType();
+
+    /**
+     * Returns the {@link TypeCodec codec} to use
+     * to serialize and deserialize this property.
+     * <p/>
+     * If this method returns {@code null}, then a default codec
+     * for the property's {@link #getPropertyType() type}
+     * will be used.
+     *
+     * @return {@link TypeCodec codec} to use
+     * to serialize and deserialize this property.
+     */
+    TypeCodec<T> getCustomCodec();
+
+    /**
+     * Returns {@code true} if this property is
+     * part of the table's partition key,
+     * {@code false} otherwise.
+     * <p/>
+     * This method has no effect if this property
+     * is mapped to a UDT field or a CQL expression.
+     *
+     * @return {@code true} if this property is
+     * part of the table's partition key,
+     * {@code false} otherwise.
+     * @see com.datastax.driver.mapping.annotations.PartitionKey
+     */
+    boolean isPartitionKey();
+
+    /**
+     * Returns {@code true} if this property is
+     * a clustering column,
+     * {@code false} otherwise.
+     * <p/>
+     * This method has no effect if this property
+     * is mapped to a UDT field or a CQL expression.
+     *
+     * @return {@code true} if this property is
+     * a clustering column,
+     * {@code false} otherwise.
+     * @see com.datastax.driver.mapping.annotations.ClusteringColumn
+     */
+    boolean isClusteringColumn();
+
+    /**
+     * Returns this property's zero-based position
+     * among partition key columns or clustering columns.
+     * <p/>
+     * For example, assuming the following primary key definition:
+     * {@code PRIMARY KEY ((col1, col2), col3, col4)},
+     * {@code col1} has position 0 (i.e. first partition key column),
+     * {@code col2} has position 1 (i.e. second partition key column),
+     * {@code col3} has position 0 (i.e. first clustering key column),
+     * {@code col4} has position 1 (i.e. second clustering key column),
+     * <p/>
+     * This method has no effect if this property
+     * is not part of the primary key, or if it is
+     * mapped to a UDT field or a CQL expression.
+     * Implementors are encouraged to return {@code -1} in these
+     * situations.
+     *
+     * @return this property's zero-based position
+     * among partition key columns or clustering columns.
+     */
+    int getPosition();
+
+    /**
+     * Returns {@code true} if this property is computed,
+     * i.e. if it represents the result of a CQL expression
+     * such as {@code "ttl(col1)"},
+     * {@code false} otherwise.
+     * <p/>
+     * Computed properties are not allowed with protocol v1.
+     * <p/>
+     * Also note that computed properties are read-only.
+     *
+     * @return {@code true} if this property is computed,
+     * {@code false} otherwise.
+     * @see com.datastax.driver.mapping.annotations.Computed
+     */
+    boolean isComputed();
+
+    /**
+     * Reads the current value of this property in the given {@code entity}.
+     *
+     * @param entity The instance to read the property from; may not be {@code null}.
+     * @return The property value.
+     * @throws IllegalArgumentException if the property cannot be read.
+     */
+    T getValue(Object entity);
+
+    /**
+     * Writes the given value to this property in the given {@code entity}.
+     *
+     * @param entity The instance to write the property to; may not be {@code null}.
+     * @param value  The property value.
+     * @throws IllegalArgumentException if the property cannot be written.
+     */
+    void setValue(Object entity, T value);
+
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/MappingConfiguration.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/MappingConfiguration.java
@@ -1,0 +1,76 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+/**
+ * The configuration to use for the mappers.
+ */
+public class MappingConfiguration {
+
+    /**
+     * Returns a new {@link Builder} instance.
+     *
+     * @return a new {@link Builder} instance.
+     */
+    public static MappingConfiguration.Builder builder() {
+        return new MappingConfiguration.Builder();
+    }
+
+    /**
+     * Builder for {@link MappingConfiguration} instances.
+     */
+    public static class Builder {
+
+        private PropertyMapper propertyMapper = new DefaultPropertyMapper();
+
+        /**
+         * Sets the {@link PropertyMapper property access strategy} to use.
+         *
+         * @param propertyMapper the {@link PropertyMapper property access strategy} to use.
+         * @return this {@link Builder} instance (to allow for fluent builder pattern).
+         */
+        public Builder withPropertyMapper(PropertyMapper propertyMapper) {
+            this.propertyMapper = propertyMapper;
+            return this;
+        }
+
+        /**
+         * Builds a new instance of {@link MappingConfiguration} with this builder's
+         * settings.
+         *
+         * @return a new instance of {@link MappingConfiguration}
+         */
+        public MappingConfiguration build() {
+            return new MappingConfiguration(propertyMapper);
+        }
+    }
+
+    private final PropertyMapper propertyMapper;
+
+    private MappingConfiguration(PropertyMapper propertyMapper) {
+        this.propertyMapper = propertyMapper;
+    }
+
+    /**
+     * Returns the {@link PropertyMapper}.
+     *
+     * @return the {@link PropertyMapper}.
+     */
+    public PropertyMapper getPropertyMapper() {
+        return propertyMapper;
+    }
+
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/NamingConvention.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/NamingConvention.java
@@ -1,0 +1,81 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import java.util.List;
+
+/**
+ * Represent a naming convention (e.g. snake_case, camelCase, etc...) to be used when
+ * auto-translating java property names to cassandra column names and vice versa.
+ * <p>
+ * This interface may be implemented to define custom naming convention.
+ */
+public interface NamingConvention {
+
+    /**
+     * Receive a property name value and returns an ordered list of Word objects.
+     * Each word contains a String value and a boolean indicating whether or not
+     * the value is an abbreviation (In most cases could not be determined).
+     * Quick examples:
+     * <ul>
+     * <li>Let's consider lowerCamelCase convention and input = "myXMLParser",
+     * then the output should be:
+     * [
+     * word{value = "my", isAbbreviation = false},
+     * word{value = "xml", isAbbreviation = true},
+     * word{value = "parser", isAbbreviation = false}
+     * ]</li>
+     * <li>Let's consider lower_snake_case convention and input = "myXMLParser",
+     * then the output may be (since there's no trivial way to determine xml
+     * to an abbreviation):
+     * [
+     * word{value = "my", isAbbreviation = false},
+     * word{value = "xml", isAbbreviation = false},
+     * word{value = "parser", isAbbreviation = false}
+     * ]</li>
+     * </ul>
+     *
+     * @param input value to split
+     * @return an ordered list of split Word objects
+     */
+    List<Word> split(String input);
+
+    /**
+     * Receive an ordered list of Word objects and returns a result property name.
+     * Quick examples:
+     * <ul>
+     * <li>Let's consider lowerCamelCase convention with upperCaseAbbreviations set
+     * to false, and input = [
+     * word{value = "my", isAbbreviation = false},
+     * word{value = "xml", isAbbreviation = true},
+     * word{value = "parser", isAbbreviation = false}
+     * ]
+     * then the output should be "myXmlParser".</li>
+     * <li>Let's consider upperCamelCase convention with upperCaseAbbreviations set
+     * to true, and input = [
+     * word{value = "my", isAbbreviation = false},
+     * word{value = "xml", isAbbreviation = true},
+     * word{value = "parser", isAbbreviation = false}
+     * ]
+     * then the output should be "MyXMLParser".</li>
+     * </ul>
+     *
+     * @param input list to translate
+     * @return the result property name
+     */
+    String join(List<Word> input);
+
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/NamingConventions.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/NamingConventions.java
@@ -1,0 +1,328 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Implementations of industry common naming conventions.
+ */
+public class NamingConventions {
+
+    /**
+     * Represents a naming convention where all letters are lower cased,
+     * and words are not separated by any special character. E.g. "myxmlparser".
+     */
+    public static final NamingConvention LOWER_CASE = new SingleWordNamingConvention(false);
+
+    /**
+     * Represents a naming convention where all letters are upper cased,
+     * and words are not separated by any special character. E.g. "MYXMLPARSER".
+     */
+    public static final NamingConvention UPPER_CASE = new SingleWordNamingConvention(true);
+
+    /**
+     * Represents <a href="https://en.wikipedia.org/wiki/Snake_case">snake case</a> naming convention, meaning all letters are lower cased,
+     * and words are separated by an underscore ("_"). E.g. "my_xml_parser".
+     */
+    public static final NamingConvention LOWER_SNAKE_CASE = new CharDelimitedNamingConvention("_", false);
+
+    /**
+     * Represents <a href="https://en.wikipedia.org/wiki/Snake_case">snake case</a> naming convention, meaning all letters are upper cased,
+     * and words are separated by an underscore ("_"). E.g. "MY_XML_PARSER".
+     */
+    public static final NamingConvention UPPER_SNAKE_CASE = new CharDelimitedNamingConvention("_", true);
+
+    /**
+     * Represents <a href="https://en.wikipedia.org/wiki/Letter_case#Special_case_styles">Lisp case</a> naming convention,
+     * meaning all letters are lower cased,
+     * and words are separated by a dash sign ("-"). E.g. "my-xml-parser"
+     */
+    public static final NamingConvention LOWER_LISP_CASE = new CharDelimitedNamingConvention("-", false);
+
+    /**
+     * Represents <a href="https://en.wikipedia.org/wiki/Letter_case#Special_case_styles">Lisp case</a> naming convention,
+     * meaning all letters are upper cased,
+     * and words are separated by a dash sign ("-"). E.g. "MY-XML-PARSER".
+     */
+    public static final NamingConvention UPPER_LISP_CASE = new CharDelimitedNamingConvention("-", true);
+
+    /**
+     * Represents the default <a href="https://en.wikipedia.org/wiki/Camel_case">Camel case</a> naming convention,
+     * with a lower cased first letter.
+     *
+     * @see LowerCamelCase
+     */
+    public static final NamingConvention LOWER_CAMEL_CASE = new LowerCamelCase();
+
+    /**
+     * Represents the default <a href="https://en.wikipedia.org/wiki/Camel_case">Camel case</a> naming convention,
+     * with an upper cased first letter.
+     *
+     * @see UpperCamelCase
+     */
+    public static final NamingConvention UPPER_CAMEL_CASE = new UpperCamelCase();
+
+    /**
+     * Represents <a href="https://en.wikipedia.org/wiki/Camel_case">Camel case</a>
+     * naming convention with a lower cased first letter.
+     * <p/>
+     * E.g. "myXmlParser" and "myXMLParser". Note that both examples are valid
+     * lower camel case forms. The first one takes abbreviations as any other
+     * words where the first letter is upper case, and the rest are lower case
+     * (hence - "Xml"), while the latter upper cases all letters of an abbreviation
+     * (hence - "XML").
+     * <p/>
+     * Additionally, many different Java naming conventions introduce prefixes
+     * for field naming, some examples:
+     * <ul>
+     * <li><a href="http://source.android.com/source/code-style.html#follow-field-naming-conventions">Android</a></li>
+     * <li><a href="https://en.wikipedia.org/wiki/Hungarian_notation">Hungarian Notation</a></li>
+     * <li><a href="http://stackoverflow.com/questions/1899683/is-there-a-standard-in-java-for-underscore-in-front-of-variable-or-class-nam">Underscore</a></li>
+     * </ul>
+     * Those prefixes can be supported. For example, if this convention is
+     * configured with {@code ignorablePrefixes} set to "_" then a field
+     * named "_myXmlParser" will be split in 3 words only: "my", "Xml", "Parser".
+     */
+    public static class LowerCamelCase extends CamelCase {
+
+        private final boolean upperCaseAbbreviations;
+
+        /**
+         * @param upperCaseAbbreviations {@code true} to uppercase all abbreviations,
+         *                               {@code false} to treat abbreviations as any other word
+         * @param ignorablePrefixes      string prefixes to trim if constant field name prefixes are used
+         */
+        public LowerCamelCase(boolean upperCaseAbbreviations, String... ignorablePrefixes) {
+            super(ignorablePrefixes);
+            this.upperCaseAbbreviations = upperCaseAbbreviations;
+        }
+
+        /**
+         * @param ignorablePrefixes string prefixes to trim if constant field name prefixes are used
+         */
+        public LowerCamelCase(String... ignorablePrefixes) {
+            this(false, ignorablePrefixes);
+        }
+
+        /**
+         * @param upperCaseAbbreviations {@code true} to uppercase all abbreviations,
+         *                               {@code false} to treat abbreviations as any other word
+         */
+        public LowerCamelCase(boolean upperCaseAbbreviations) {
+            this(upperCaseAbbreviations, new String[0]);
+        }
+
+        @Override
+        public String join(List<Word> input) {
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < input.size(); i++) {
+                Word word = input.get(i);
+                String value;
+                if (i == 0) {
+                    value = word.getValue().toLowerCase();
+                } else if (upperCaseAbbreviations && word.isAbbreviation()) {
+                    value = word.getValue().toUpperCase();
+                } else {
+                    value = word.getValue().substring(0, 1).toUpperCase() + word.getValue().substring(1).toLowerCase();
+                }
+                builder.append(value);
+            }
+            return builder.toString();
+        }
+
+    }
+
+    /**
+     * Represents <a href="https://en.wikipedia.org/wiki/Camel_case">Camel case</a>
+     * naming convention with an upper cased first letter.
+     * <p/>
+     * E.g. "MyXmlParser" and "MyXMLParser". Note that both examples are valid
+     * upper camel case forms. The first one takes abbreviations as any other
+     * words where the first letter is upper case, and the rest are lower case
+     * (hence - "Xml"), while the latter upper cases all letters of an abbreviation
+     * (hence - "XML").
+     * <p/>
+     * Additionally, many different Java naming conventions introduce prefixes
+     * for field naming, some examples:
+     * <ul>
+     * <li><a href="http://source.android.com/source/code-style.html#follow-field-naming-conventions">Android</a></li>
+     * <li><a href="https://en.wikipedia.org/wiki/Hungarian_notation">Hungarian Notation</a></li>
+     * <li><a href="http://stackoverflow.com/questions/1899683/is-there-a-standard-in-java-for-underscore-in-front-of-variable-or-class-nam">Underscore</a></li>
+     * </ul>
+     * Those prefixes can be supported. For example, if this convention is
+     * configured with {@code ignorablePrefixes} set to "_" then a field
+     * named "_MyXmlParser" will be split in 3 words only: "My", "Xml", "Parser".
+     */
+    public static class UpperCamelCase extends CamelCase {
+
+        private final boolean upperCaseAbbreviations;
+
+        /**
+         * @param upperCaseAbbreviations {@code true} to uppercase all abbreviations,
+         *                               {@code false} to treat abbreviations as any other word
+         * @param ignorablePrefixes      string prefixes to trim if constant field name prefixes are used
+         */
+        public UpperCamelCase(boolean upperCaseAbbreviations, String... ignorablePrefixes) {
+            super(ignorablePrefixes);
+            this.upperCaseAbbreviations = upperCaseAbbreviations;
+        }
+
+        /**
+         * @param ignorablePrefixes string prefixes to trim if constant field name prefixes are used
+         */
+        public UpperCamelCase(String... ignorablePrefixes) {
+            this(false, ignorablePrefixes);
+        }
+
+        /**
+         * @param upperCaseAbbreviations {@code true} to uppercase all abbreviations,
+         *                               {@code false} to treat abbreviations as any other word
+         */
+        public UpperCamelCase(boolean upperCaseAbbreviations) {
+            this(upperCaseAbbreviations, new String[0]);
+        }
+
+        @Override
+        public String join(List<Word> input) {
+            StringBuilder builder = new StringBuilder();
+            for (Word word : input) {
+                String value;
+                if (upperCaseAbbreviations && word.isAbbreviation()) {
+                    value = word.getValue().toUpperCase();
+                } else {
+                    value = word.getValue().substring(0, 1).toUpperCase() + word.getValue().substring(1).toLowerCase();
+                }
+                builder.append(value);
+            }
+            return builder.toString();
+        }
+
+    }
+
+    public abstract static class CamelCase implements NamingConvention {
+
+        private static final Pattern SPLIT_PATTERN = Pattern.compile(String.format("%s|%s|%s",
+                "(?<=[A-Z])(?=[A-Z][a-z])",
+                "(?<=[^A-Z])(?=[A-Z])",
+                "(?<=[A-Za-z])(?=[^A-Za-z])"
+        ));
+
+        private static final Pattern ALL_UPPERCASE_PATTERN = Pattern.compile("([A-Z])*");
+
+        private static final Comparator<String> STRING_LENGTH_COMPARATOR = new Comparator<String>() {
+            @Override
+            public int compare(String o1, String o2) {
+                return o2.length() - o1.length();
+            }
+        };
+
+        private final Pattern ignorablePrefixPattern;
+
+        protected CamelCase(String... ignorablePrefixes) {
+            Arrays.sort(ignorablePrefixes, STRING_LENGTH_COMPARATOR);
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < ignorablePrefixes.length; i++) {
+                if (i > 0) {
+                    builder.append("|");
+                }
+                builder.append("^");
+                builder.append(ignorablePrefixes[i]);
+            }
+            ignorablePrefixPattern = Pattern.compile(builder.toString());
+        }
+
+        @Override
+        public List<Word> split(String input) {
+            List<Word> result = new LinkedList<Word>();
+            // slice all ignorable prefixes, then split
+            for (String value : SPLIT_PATTERN.split(ignorablePrefixPattern.matcher(input).replaceAll(""))) {
+                // if all uppercase, mark as abbreviation (e.g. MyXMLParser)
+                boolean isAbbreviation = ALL_UPPERCASE_PATTERN.matcher(value).matches();
+                Word word = new Word(value, isAbbreviation);
+                result.add(word);
+            }
+            return result;
+        }
+
+    }
+
+    public static class CharDelimitedNamingConvention implements NamingConvention {
+
+        private final String delimiter;
+
+        private final boolean isUpperCase;
+
+        protected CharDelimitedNamingConvention(String delimiter, boolean isUpperCase) {
+            this.delimiter = delimiter;
+            this.isUpperCase = isUpperCase;
+        }
+
+        @Override
+        public List<Word> split(String input) {
+            List<Word> result = new LinkedList<Word>();
+            for (String value : input.split(delimiter)) {
+                result.add(new Word(value));
+            }
+            return result;
+        }
+
+        @Override
+        public String join(List<Word> input) {
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < input.size(); i++) {
+                if (i > 0) {
+                    builder.append(delimiter);
+                }
+                builder.append(input.get(i).getValue());
+            }
+            String result = builder.toString();
+            return isUpperCase ? result.toUpperCase() : result.toLowerCase();
+        }
+
+    }
+
+    public static class SingleWordNamingConvention implements NamingConvention {
+
+        private final boolean isUpperCase;
+
+        protected SingleWordNamingConvention(boolean isUpperCase) {
+            this.isUpperCase = isUpperCase;
+        }
+
+        @Override
+        public List<Word> split(String input) {
+            List<Word> result = new LinkedList<Word>();
+            result.add(new Word(input));
+            return result;
+        }
+
+        @Override
+        public String join(List<Word> input) {
+            StringBuilder builder = new StringBuilder();
+            for (Word word : input) {
+                builder.append(word.getValue());
+            }
+            String result = builder.toString();
+            return isUpperCase ? result.toUpperCase() : result.toLowerCase();
+        }
+
+    }
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/NamingStrategy.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/NamingStrategy.java
@@ -1,0 +1,47 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.Field;
+
+/**
+ * Determines how Java property names are translated to Cassandra column/field names for a mapped
+ * class.
+ * <p/>
+ * This will be used for any property that doesn't have an explicit name provided (via a
+ * {@link Column} or {@link Field} annotation).
+ * <p/>
+ * If you need to implement your own strategy, the most straightforward approach is to build a
+ * {@link DefaultNamingStrategy#DefaultNamingStrategy(NamingConvention, NamingConvention)
+ * DefaultNamingStrategy with explicit naming conventions}.
+ */
+public interface NamingStrategy {
+
+    /**
+     * Infers a Cassandra column/field name from a Java property name.
+     *
+     * @param javaPropertyName the name of the Java property. Depending on the
+     *                         {@link DefaultPropertyMapper#setPropertyAccessStrategy(PropertyAccessStrategy)
+     *                         property access strategy}, this might the name of the Java field, or
+     *                         be inferred from a getter/setter based on the usual Java beans
+     *                         conventions.
+     * @return the name of the Cassandra column or field. If you want the mapping to be
+     * case-insensitive, this should be in lower case.
+     */
+    String toCassandraName(String javaPropertyName);
+
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/PropertyAccessStrategy.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/PropertyAccessStrategy.java
@@ -1,0 +1,61 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+/**
+ * A strategy to determine how mapped properties are discovered,
+ * and how to access them.
+ */
+public enum PropertyAccessStrategy {
+
+    /**
+     * Use getters and setters exclusively. These must be available for all mapped properties.
+     */
+    GETTERS_AND_SETTERS,
+
+    /**
+     * Use field access exclusively. Fields do not need to be declared public,
+     * the driver will attempt to make them accessible via reflection if required.
+     */
+    FIELDS,
+
+    /**
+     * Use getters and setters preferably, and if these are not available,
+     * use field access. Fields do not need to be declared public,
+     * the driver will attempt to make them accessible via reflection if required.
+     * This is the default access strategy.
+     */
+    BOTH;
+
+    /**
+     * Returns {@code true} if field scan is allowed, {@code false} otherwise.
+     *
+     * @return {@code true} if field access is allowed, {@code false} otherwise.
+     */
+    public boolean isFieldScanAllowed() {
+        return this == FIELDS || this == BOTH;
+    }
+
+    /**
+     * Returns {@code true} if getter and setter scan is allowed, {@code false} otherwise.
+     *
+     * @return {@code true} if getter and setter access is allowed, {@code false} otherwise.
+     */
+    public boolean isGetterSetterScanAllowed() {
+        return this == GETTERS_AND_SETTERS || this == BOTH;
+    }
+
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/PropertyTransienceStrategy.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/PropertyTransienceStrategy.java
@@ -1,0 +1,56 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import java.util.Set;
+
+/**
+ * A strategy to determine which properties are transient, and which aren't.
+ * <p/>
+ * Transient properties will be ignored, whereas non-transient
+ * ones will be mapped.
+ */
+public enum PropertyTransienceStrategy {
+
+    /**
+     * This strategy adopts a permissive, opt-out approach that
+     * will consider a property to be non-transient by default, unless:
+     * <ol>
+     * <li>The property is annotated with {@link com.datastax.driver.mapping.annotations.Transient @Transient};</li>
+     * <li>The corresponding field is non-null and is marked with the keyword {@code transient};</li>
+     * <li>The property name has been explicitly black-listed (see {@link DefaultPropertyMapper#setTransientPropertyNames(Set)}).</li>
+     * </ol>
+     */
+    OPT_OUT,
+
+    /**
+     * This strategy adopts a conservative, opt-in approach that
+     * only considers a property to be non-transient if it is explicitly annotated
+     * with one of the following annotations:
+     * <ol>
+     * <li>{@link com.datastax.driver.mapping.annotations.Column Column}</li>
+     * <li>{@link com.datastax.driver.mapping.annotations.Computed Computed}</li>
+     * <li>{@link com.datastax.driver.mapping.annotations.ClusteringColumn ClusteringColumn}</li>
+     * <li>{@link com.datastax.driver.mapping.annotations.Frozen Frozen}</li>
+     * <li>{@link com.datastax.driver.mapping.annotations.FrozenKey FrozenKey}</li>
+     * <li>{@link com.datastax.driver.mapping.annotations.FrozenValue FrozenValue}</li>
+     * <li>{@link com.datastax.driver.mapping.annotations.PartitionKey PartitionKey}</li>
+     * <li>{@link com.datastax.driver.mapping.annotations.Field Field}</li>
+     * </ol>
+     */
+    OPT_IN
+
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/ReflectionUtils.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/ReflectionUtils.java
@@ -15,29 +15,12 @@
  */
 package com.datastax.driver.mapping;
 
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableSet;
-
-import java.beans.BeanInfo;
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
-import java.beans.PropertyDescriptor;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.*;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.lang.reflect.Constructor;
 
 /**
  * Utility methods related to reflection.
  */
 class ReflectionUtils {
-
-    private static final Set<String> EXCLUDED_PROPERTIES = ImmutableSet.of(
-            "class",
-            // JAVA-1279: exclude Groovy's metaClass property
-            "metaClass"
-    );
 
     static <T> T newInstance(Class<T> clazz) {
         Constructor<T> publicConstructor;
@@ -57,148 +40,6 @@ class ReflectionUtils {
             return publicConstructor.newInstance();
         } catch (Exception e) {
             throw new IllegalArgumentException("Can't create an instance of " + clazz, e);
-        }
-    }
-
-    // for each key representing a property name,
-    // value[0] contains a Field object, value[1] contains a PropertyDescriptor object;
-    // they cannot be both null at the same time
-    static <T> Map<String, Object[]> scanFieldsAndProperties(Class<T> baseClass) {
-        Map<String, Object[]> fieldsAndProperties = new HashMap<String, Object[]>();
-        Map<String, Field> fields = scanFields(baseClass);
-        for (Map.Entry<String, Field> entry : fields.entrySet()) {
-            fieldsAndProperties.put(entry.getKey(), new Object[]{entry.getValue(), null});
-        }
-        Map<String, PropertyDescriptor> properties = scanProperties(baseClass);
-        for (Map.Entry<String, PropertyDescriptor> entry : properties.entrySet()) {
-            Object[] value = fieldsAndProperties.get(entry.getKey());
-            if (value == null)
-                fieldsAndProperties.put(entry.getKey(), new Object[]{null, entry.getValue()});
-            else value[1] = entry.getValue();
-        }
-        return fieldsAndProperties;
-    }
-
-    private static <T> Map<String, Field> scanFields(Class<T> baseClass) {
-        HashMap<String, Field> fields = new HashMap<String, Field>();
-        for (Class<?> clazz = baseClass; !clazz.equals(Object.class); clazz = clazz.getSuperclass()) {
-            for (Field field : clazz.getDeclaredFields()) {
-                if (field.isSynthetic() || Modifier.isStatic(field.getModifiers()) || isPropertyExcluded(field.getName()))
-                    continue;
-                // never override a more specific field masking another one declared in a superclass
-                if (!fields.containsKey(field.getName()))
-                    fields.put(field.getName(), field);
-            }
-        }
-        return fields;
-    }
-
-    private static <T> Map<String, PropertyDescriptor> scanProperties(Class<T> baseClass) {
-        BeanInfo beanInfo;
-        try {
-            beanInfo = Introspector.getBeanInfo(baseClass);
-        } catch (IntrospectionException e) {
-            throw Throwables.propagate(e);
-        }
-        Map<String, PropertyDescriptor> properties = new HashMap<String, PropertyDescriptor>();
-        for (PropertyDescriptor property : beanInfo.getPropertyDescriptors()) {
-            if (isPropertyExcluded(property.getName()))
-                continue;
-            properties.put(property.getName(), property);
-        }
-        return properties;
-    }
-
-    private static boolean isPropertyExcluded(String name) {
-        return EXCLUDED_PROPERTIES.contains(name);
-    }
-
-    static Map<Class<? extends Annotation>, Annotation> scanPropertyAnnotations(Field field, PropertyDescriptor property) {
-        Map<Class<? extends Annotation>, Annotation> annotations = new HashMap<Class<? extends Annotation>, Annotation>();
-        // annotations on getters should have precedence over annotations on fields
-        if (field != null)
-            scanFieldAnnotations(field, annotations);
-        Method getter = findGetter(property);
-        if (getter != null)
-            scanMethodAnnotations(getter, annotations);
-        return annotations;
-    }
-
-    private static Map<Class<? extends Annotation>, Annotation> scanFieldAnnotations(Field field, Map<Class<? extends Annotation>, Annotation> annotations) {
-        for (Annotation annotation : field.getAnnotations()) {
-            annotations.put(annotation.annotationType(), annotation);
-        }
-        return annotations;
-    }
-
-    private static Map<Class<? extends Annotation>, Annotation> scanMethodAnnotations(Method method, Map<Class<? extends Annotation>, Annotation> annotations) {
-        // 1. direct method annotations
-        for (Annotation annotation : method.getAnnotations()) {
-            annotations.put(annotation.annotationType(), annotation);
-        }
-        // 2. Class hierarchy: check for annotations in overridden methods in superclasses
-        Class<?> getterClass = method.getDeclaringClass();
-        for (Class<?> clazz = getterClass.getSuperclass(); !clazz.equals(Object.class); clazz = clazz.getSuperclass()) {
-            maybeAddOverriddenMethodAnnotations(annotations, method, clazz);
-        }
-        // 3. Interfaces: check for annotations in implemented interfaces
-        for (Class<?> clazz = getterClass; !clazz.equals(Object.class); clazz = clazz.getSuperclass()) {
-            for (Class<?> itf : clazz.getInterfaces()) {
-                maybeAddOverriddenMethodAnnotations(annotations, method, itf);
-            }
-        }
-        return annotations;
-    }
-
-    private static void maybeAddOverriddenMethodAnnotations(Map<Class<? extends Annotation>, Annotation> annotations, Method getter, Class<?> clazz) {
-        try {
-            Method overriddenGetter = clazz.getDeclaredMethod(getter.getName(), (Class[]) getter.getParameterTypes());
-            for (Annotation annotation : overriddenGetter.getAnnotations()) {
-                // do not override a more specific version of the annotation type being scanned
-                if (!annotations.containsKey(annotation.annotationType()))
-                    annotations.put(annotation.annotationType(), annotation);
-            }
-        } catch (NoSuchMethodException e) {
-            //ok
-        }
-    }
-
-    static Method findGetter(PropertyDescriptor property) {
-        if (property == null)
-            return null;
-        Method getter = property.getReadMethod();
-        if (getter == null)
-            return null;
-        return getter;
-    }
-
-    static Method findSetter(Class<?> baseClass, PropertyDescriptor property) {
-        if (property == null)
-            return null;
-        Method setter = property.getWriteMethod();
-        if (setter != null)
-            return setter;
-        String propertyName = property.getName();
-        String setterName = "set" + propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
-        // JAVA-984: look for a "relaxed" setter, ie. a setter whose return type may be anything
-        try {
-            setter = baseClass.getMethod(setterName, property.getPropertyType());
-            if (!Modifier.isStatic(setter.getModifiers())) {
-                return setter;
-            }
-        } catch (NoSuchMethodException e) {
-            // ok
-        }
-        return null;
-    }
-
-    static void tryMakeAccessible(AccessibleObject object) {
-        if (!object.isAccessible()) {
-            try {
-                object.setAccessible(true);
-            } catch (SecurityException e) {
-                // ok
-            }
         }
     }
 

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/Word.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/Word.java
@@ -1,0 +1,49 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+/**
+ * Represents a single-individual word in a property name. (e.g. "my", "xml" and "parser" in a
+ * property named "myXmlParser").
+ * Each word contains a String value and a boolean indicating whether or not
+ * the value is an abbreviation.
+ * In most cases there will be no trivial way to identify abbreviations
+ * (i.e. my_xml_parser in snake case), but for some naming conventions this may be helpful.
+ */
+public class Word {
+
+    private final String value;
+
+    private final boolean isAbbreviation;
+
+    public Word(String value, boolean isAbbreviation) {
+        this.value = value;
+        this.isAbbreviation = isAbbreviation;
+    }
+
+    public Word(String value) {
+        this(value, false);
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public boolean isAbbreviation() {
+        return isAbbreviation;
+    }
+
+}

--- a/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/Column.java
+++ b/driver-mapping/src/main/java/com/datastax/driver/mapping/annotations/Column.java
@@ -16,6 +16,8 @@
 package com.datastax.driver.mapping.annotations;
 
 import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.mapping.MappingConfiguration;
+import com.datastax.driver.mapping.NamingStrategy;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -37,18 +39,20 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Column {
     /**
-     * Name of the column being mapped in Cassandra. By default, the name of the
-     * field or Java bean property will be used.
+     * Name of the column being mapped in Cassandra. By default, the name returned
+     * by the {@link NamingStrategy} of the current
+     * {@link MappingConfiguration}.
      *
      * @return the name of the mapped column in Cassandra, or {@code ""} to use
-     * the field name.
+     * the naming strategy.
      */
     String name() default "";
 
     /**
-     * Whether the column name is a case sensitive one.
+     * Whether the value return by {@link #name()} is case-sensitive (this has no
+     * effect if no name is provided in the annotation).
      *
-     * @return whether the column name is a case sensitive one.
+     * @return whether the column name is case-sensitive.
      */
     boolean caseSensitive() default false;
 

--- a/driver-mapping/src/test/groovy/com/datastax/driver/mapping/MapperGroovyTest.groovy
+++ b/driver-mapping/src/test/groovy/com/datastax/driver/mapping/MapperGroovyTest.groovy
@@ -13,26 +13,26 @@ import static org.assertj.core.api.Assertions.assertThat
  *
  * @jira_ticket JAVA-1279
  */
-public class MapperGroovyTest extends CCMTestsSupport {
+class MapperGroovyTest extends CCMTestsSupport {
 
     @Table(name = "users")
     static class User {
 
         @PartitionKey
         @Column(name = "user_id")
-        def UUID userId
+        UUID userId
 
-        def String name
+        String name
 
     }
 
     @Override
-    public void onTestContextInitialized() {
+    void onTestContextInitialized() {
         execute("CREATE TABLE users (user_id uuid PRIMARY KEY, name text)")
     }
 
     @Test(groups = "short")
-    public void should_map_groovy_class() {
+    void should_map_groovy_class() {
         def mapper = new MappingManager(session()).mapper(User)
         def user1 = new User()
         user1.userId = UUID.randomUUID()

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperCaseSensitivityTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperCaseSensitivityTest.java
@@ -40,7 +40,7 @@ public class MapperCaseSensitivityTest extends CCMTestsSupport {
     static class User {
 
         @PartitionKey
-        @Column(caseSensitive = true)
+        @Column(name = "userId", caseSensitive = true)
         private String userId;
 
         @Column(name = "Address", caseSensitive = true)
@@ -91,7 +91,7 @@ public class MapperCaseSensitivityTest extends CCMTestsSupport {
         @Field(name = "Street", caseSensitive = true)
         private String street;
 
-        @Field(caseSensitive = true)
+        @Field(name = "zipCode", caseSensitive = true)
         private String zipCode;
 
         public Address() {
@@ -142,11 +142,6 @@ public class MapperCaseSensitivityTest extends CCMTestsSupport {
         public UserNoKeyspace(String id, Address address) {
             super(id, address);
         }
-
-    }
-
-    @UDT(name = TYPE, caseSensitiveKeyspace = true, caseSensitiveType = true)
-    static class AddressNoKeyspace extends Address {
 
     }
 

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperInvalidAnnotationsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperInvalidAnnotationsTest.java
@@ -26,12 +26,15 @@ import static org.mockito.Mockito.*;
 public class MapperInvalidAnnotationsTest {
 
     MappingManager mappingManager;
+    MappingConfiguration mappingConfiguration;
 
     @BeforeClass(groups = "unit")
     public void setup() {
         mappingManager = mock(MappingManager.class);
+        mappingConfiguration = MappingConfiguration.builder().build();
         Session session = mock(Session.class);
         when(mappingManager.getSession()).thenReturn(session);
+        when(mappingManager.getConfiguration()).thenReturn(mappingConfiguration);
         Cluster cluster = mock(Cluster.class);
         when(session.getCluster()).thenReturn(cluster);
         Metadata metadata = mock(Metadata.class);

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MappingConfigurationHierarchyScanStrategyTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MappingConfigurationHierarchyScanStrategyTest.java
@@ -1,0 +1,130 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.core.CCMTestsSupport;
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for JAVA-1310 - validate ability configure ancestor property scanning:
+ * - disable
+ * - configure max depth ancestor (included or not)
+ */
+public class MappingConfigurationHierarchyScanStrategyTest extends CCMTestsSupport {
+
+    @Override
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE foo (k int primary key, v int)");
+        execute("INSERT INTO foo (k, v) VALUES (1, 1)");
+    }
+
+    @Test(groups = "short")
+    public void should_not_inherit_annotations_when_hierarchy_scan_disabled() {
+        MappingConfiguration conf = MappingConfiguration.builder()
+                .withPropertyMapper(new DefaultPropertyMapper()
+                        .setHierarchyScanStrategy(new MappedClassesOnlyHierarchyScanStrategy()))
+                .build();
+        MappingManager mappingManager = new MappingManager(session(), conf);
+        mappingManager.mapper(Child1.class);
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public static class Parent1 {
+
+        @Column(name = "notAColumn")
+        private int notAColumn;
+    }
+
+    @Table(name = "foo")
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public static class Child1 extends Parent1 {
+
+        @PartitionKey
+        private int k;
+
+        public int getK() {
+            return k;
+        }
+
+        public void setK(int k) {
+            this.k = k;
+        }
+    }
+
+    @Test(groups = "short")
+    public void should_inherit_annotations_up_to_highest_ancestor_excluded() {
+        MappingConfiguration conf = MappingConfiguration.builder()
+                .withPropertyMapper(new DefaultPropertyMapper()
+                        .setHierarchyScanStrategy(new DefaultHierarchyScanStrategy(GrandParent2.class, false)))
+                .build();
+        MappingManager mappingManager = new MappingManager(session(), conf);
+        Mapper<Child2> mapper = mappingManager.mapper(Child2.class);
+        assertThat(mapper.get(1).getV()).isEqualTo(1);
+    }
+
+    @Test(groups = "short")
+    public void should_inherit_annotations_up_to_highest_ancestor_included() {
+        MappingConfiguration conf = MappingConfiguration.builder()
+                .withPropertyMapper(new DefaultPropertyMapper()
+                        .setHierarchyScanStrategy(new DefaultHierarchyScanStrategy(Parent2.class, true)))
+                .build();
+        MappingManager mappingManager = new MappingManager(session(), conf);
+        Mapper<Child2> mapper = mappingManager.mapper(Child2.class);
+        assertThat(mapper.get(1).getV()).isEqualTo(1);
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public static class GrandParent2 {
+
+        @Column(name = "notAColumn")
+        private int notAColumn;
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public static class Parent2 extends GrandParent2 {
+
+        private int v;
+
+        public int getV() {
+            return v;
+        }
+
+        public void setV(int v) {
+            this.v = v;
+        }
+    }
+
+    @Table(name = "foo")
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public static class Child2 extends Parent2 {
+
+        @PartitionKey
+        private int k;
+
+        public int getK() {
+            return k;
+        }
+
+        public void setK(int k) {
+            this.k = k;
+        }
+    }
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MappingConfigurationNamingStrategyTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MappingConfigurationNamingStrategyTest.java
@@ -1,0 +1,428 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.core.CCMTestsSupport;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.core.utils.CassandraVersion;
+import com.datastax.driver.mapping.annotations.*;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@CassandraVersion(value = "2.1.0")
+public class MappingConfigurationNamingStrategyTest extends CCMTestsSupport {
+
+    private static AtomicInteger counter = new AtomicInteger(0);
+
+    @Override
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE lowerlisp (\"primary-key\" int primary key, \"my-value\" int)",
+                "CREATE TABLE uppersnake (\"PRIMARY_KEY\" int primary key, \"MY_VALUE\" int)",
+                "CREATE TYPE \"ADDRESS\" (\"ZIP_CODE\" int, \"CITY_AND_STATE\" text)",
+                "CREATE TABLE user (\"NAME\" text primary key, \"ADDRESS\" frozen<\"ADDRESS\">)");
+    }
+
+    @Table(name = "lowerlisp")
+    static class UpperSnake {
+
+        @PartitionKey
+        int PRIMARY_KEY;
+
+        int MY_VALUE;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            UpperSnake that = (UpperSnake) o;
+
+            return PRIMARY_KEY == that.PRIMARY_KEY && MY_VALUE == that.MY_VALUE;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = PRIMARY_KEY;
+            result = 31 * result + MY_VALUE;
+            return result;
+        }
+    }
+
+    @Test(groups = "short")
+    public void should_use_naming_strategy_fields() {
+        // given a configuration with a java naming convention of upper snake case (i.e. HELLO_WORLD) and a
+        // cassandra naming convention of lower lisp case (i.e. hello-world) with and access strategy of fields
+        MappingConfiguration conf = MappingConfiguration.builder()
+                .withPropertyMapper(new DefaultPropertyMapper()
+                        .setNamingStrategy(new DefaultNamingStrategy(
+                                NamingConventions.UPPER_SNAKE_CASE,
+                                NamingConventions.LOWER_LISP_CASE))
+                        .setPropertyAccessStrategy(PropertyAccessStrategy.FIELDS))
+                .build();
+
+        MappingManager mappingManager = new MappingManager(session(), conf);
+        // when creating a mapper
+        // should succeed since fields match the upper snake case strategy and they are appropriately converted
+        // to lower lisp format (PRIMARY_KEY -> primary-key, MY_VALUE -> my-value)
+        Mapper<UpperSnake> mapper = mappingManager.mapper(UpperSnake.class);
+
+        // should be able to insert and retrieve data
+        UpperSnake in = new UpperSnake();
+        in.PRIMARY_KEY = counter.incrementAndGet();
+        in.MY_VALUE = counter.incrementAndGet();
+
+        mapper.save(in);
+
+        UpperSnake out = mapper.get(in.PRIMARY_KEY);
+        assertThat(out).isEqualTo(in);
+    }
+
+    @Table(name = "lowerlisp")
+    static class NamingStrategyOverrideField {
+
+        // Override what would be mapped to key to primary-key
+        @PartitionKey
+        @Column(name = "primary-key")
+        int key;
+
+        int MY_VALUE;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            NamingStrategyOverrideField that = (NamingStrategyOverrideField) o;
+
+            return key == that.key && MY_VALUE == that.MY_VALUE;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = key;
+            result = 31 * result + MY_VALUE;
+            return result;
+        }
+    }
+
+    @Test(groups = "short")
+    public void should_override_naming_strategy_with_column_annotation_name_fields() {
+        // given a configuration with a java naming convention of upper snake case (i.e. HELLO_WORLD) and a
+        // cassandra naming convention of lower lisp case (i.e. hello-world) with an access strategy of fields
+        MappingConfiguration conf = MappingConfiguration.builder()
+                .withPropertyMapper(new DefaultPropertyMapper()
+                        .setNamingStrategy(new DefaultNamingStrategy(
+                                NamingConventions.UPPER_SNAKE_CASE,
+                                NamingConventions.LOWER_LISP_CASE))
+                        .setPropertyAccessStrategy(PropertyAccessStrategy.FIELDS))
+                .build();
+
+        // when creating a mapper
+        // should succeed since fields match the upper snake case strategy and they are appropriately converted
+        // to lower lisp format (MY_VALUE -> my-value) and since there is a @Column-annotated name override (key field
+        // has override to 'primary-key'
+        MappingManager mappingManager = new MappingManager(session(), conf);
+        Mapper<NamingStrategyOverrideField> mapper = mappingManager.mapper(NamingStrategyOverrideField.class);
+
+        // should be able to insert and retrieve data
+        NamingStrategyOverrideField in = new NamingStrategyOverrideField();
+        in.key = counter.incrementAndGet();
+        in.MY_VALUE = counter.incrementAndGet();
+
+        mapper.save(in);
+
+        NamingStrategyOverrideField out = mapper.get(in.key);
+        assertThat(out).isEqualTo(in);
+    }
+
+    @Table(name = "uppersnake")
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    static class LowerSnake {
+
+        private int _primaryKey;
+        private int _myValue;
+
+        @PartitionKey
+        public int getprimary_key() {
+            return _primaryKey;
+        }
+
+        public void setprimary_key(int k) {
+            this._primaryKey = k;
+        }
+
+        public int getmy_value() {
+            return _myValue;
+        }
+
+        public void setmy_value(int v) {
+            this._myValue = v;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            LowerSnake that = (LowerSnake) o;
+
+            return _primaryKey == that._primaryKey && _myValue == that._myValue;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = _primaryKey;
+            result = 31 * result + _myValue;
+            return result;
+        }
+    }
+
+    @Test(groups = "short")
+    public void should_use_naming_strategy_getters_and_setters() {
+        // given a configuration with a java naming convention of lower snake case (i.e. hello_world) and a
+        // cassandra naming convention of upper snake case (i.e. HELLO_WORLD) with an access strategy of
+        // getters and setters
+        MappingConfiguration conf = MappingConfiguration.builder()
+                .withPropertyMapper(new DefaultPropertyMapper()
+                        .setNamingStrategy(new DefaultNamingStrategy(
+                                NamingConventions.LOWER_SNAKE_CASE,
+                                NamingConventions.UPPER_SNAKE_CASE))
+                        .setPropertyAccessStrategy(PropertyAccessStrategy.GETTERS_AND_SETTERS))
+                .build();
+
+        // when creating a mapper
+        // should succeed since getters match the lower snake case strategy and they are appropriately converted
+        // to upper snake case format (getprimary_key -> PRIMARY_KEY, getmy_value -> MY_VALUE)
+        MappingManager mappingManager = new MappingManager(session(), conf);
+        Mapper<LowerSnake> mapper = mappingManager.mapper(LowerSnake.class);
+
+        // should be able to insert and retrieve data
+        LowerSnake in = new LowerSnake();
+        in.setprimary_key(counter.incrementAndGet());
+        in.setmy_value(counter.incrementAndGet());
+
+        mapper.save(in);
+
+        LowerSnake out = mapper.get(in.getprimary_key());
+        assertThat(out).isEqualTo(in);
+    }
+
+    @Table(name = "uppersnake")
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    static class NamingStrategyOverrideGetter {
+
+        private int _primaryKey;
+        private int _myValue;
+
+        // Override column name from what would be mapped to KEY to PRIMARY_KEY
+        @PartitionKey
+        @Column(name = "PRIMARY_KEY", caseSensitive = true)
+        public int getKey() {
+            return _primaryKey;
+        }
+
+        public void setKey(int k) {
+            this._primaryKey = k;
+        }
+
+        public int getmy_value() {
+            return _myValue;
+        }
+
+        public void setmy_value(int v) {
+            this._myValue = v;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            NamingStrategyOverrideGetter that = (NamingStrategyOverrideGetter) o;
+
+            return _primaryKey == that._primaryKey && _myValue == that._myValue;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = _primaryKey;
+            result = 31 * result + _myValue;
+            return result;
+        }
+    }
+
+    @Test(groups = "short")
+    public void should_override_naming_strategy_with_column_annotation_name_getters() {
+        // given a configuration with a java naming convention of lower snake case (i.e. hello_world) and a
+        // cassandra naming convention of upper snake case (i.e. HELLO_WORLD) with an access strategy for
+        // getters and setters
+        MappingConfiguration conf = MappingConfiguration.builder()
+                .withPropertyMapper(new DefaultPropertyMapper()
+                        .setNamingStrategy(new DefaultNamingStrategy(
+                                NamingConventions.LOWER_SNAKE_CASE,
+                                NamingConventions.UPPER_SNAKE_CASE))
+                        .setPropertyAccessStrategy(PropertyAccessStrategy.GETTERS_AND_SETTERS))
+                .build();
+
+        // when creating a mapper
+        // should succeed since getters match the lower snake case strategy and they are appropriately converted
+        // to upper snake case format (getmy_value -> MY_VALUE) and @Column-annotated name override on getKey is
+        // PRIMARY_KEY.
+        MappingManager mappingManager = new MappingManager(session(), conf);
+        Mapper<NamingStrategyOverrideGetter> mapper = mappingManager.mapper(NamingStrategyOverrideGetter.class);
+
+        // should be able to insert and retrieve data
+        NamingStrategyOverrideGetter in = new NamingStrategyOverrideGetter();
+        in.setKey(counter.incrementAndGet());
+        in.setmy_value(counter.incrementAndGet());
+
+        mapper.save(in);
+
+        NamingStrategyOverrideGetter out = mapper.get(in.getKey());
+        assertThat(out).isEqualTo(in);
+    }
+
+    @Accessor
+    interface NamingStrategyAccessor {
+        @Query("SELECT * from uppersnake where \"PRIMARY_KEY\" = ?")
+        Result<NamingStrategyOverrideGetter> getValue(int key);
+    }
+
+    @Test(groups = "short")
+    public void should_apply_naming_strategy_when_mapping_from_accessor_result() {
+        // given a configuration with a java naming convention of lower snake case (i.e. hello_world) and a
+        // cassandra naming convention of upper snake case (i.e. HELLO_WORLD) with an access strategy for
+        // getters and setters
+        MappingConfiguration conf = MappingConfiguration.builder()
+                .withPropertyMapper(new DefaultPropertyMapper()
+                        .setNamingStrategy(new DefaultNamingStrategy(
+                                NamingConventions.LOWER_SNAKE_CASE,
+                                NamingConventions.UPPER_SNAKE_CASE))
+                        .setPropertyAccessStrategy(PropertyAccessStrategy.GETTERS_AND_SETTERS))
+                .build();
+
+        MappingManager mappingManager = new MappingManager(session(), conf);
+        Mapper<NamingStrategyOverrideGetter> mapper = mappingManager.mapper(NamingStrategyOverrideGetter.class);
+        NamingStrategyAccessor acc = mappingManager.createAccessor(NamingStrategyAccessor.class);
+
+        NamingStrategyOverrideGetter in = new NamingStrategyOverrideGetter();
+        in.setKey(counter.incrementAndGet());
+        in.setmy_value(counter.incrementAndGet());
+
+        mapper.save(in);
+
+        Result<NamingStrategyOverrideGetter> out = acc.getValue(in.getKey());
+
+        assertThat(out.one()).isEqualTo(in);
+    }
+
+    @UDT(name = "ADDRESS", caseSensitiveType = true)
+    static class Address {
+        int zip_code;
+
+        @Field(name = "CITY_AND_STATE", caseSensitive = true)
+        String cityAndState;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Address address = (Address) o;
+
+            return zip_code == address.zip_code && (cityAndState != null ? cityAndState.equals(address.cityAndState) : address.cityAndState == null);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = zip_code;
+            result = 31 * result + (cityAndState != null ? cityAndState.hashCode() : 0);
+            return result;
+        }
+    }
+
+    @Table(name = "user")
+    static class User {
+        @PartitionKey
+        String name;
+
+        Address address;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            User user = (User) o;
+
+            return (name != null ? name.equals(user.name) : user.name == null) && (address != null ? address.equals(user.address) : user.address == null);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = name != null ? name.hashCode() : 0;
+            result = 31 * result + (address != null ? address.hashCode() : 0);
+            return result;
+        }
+    }
+
+    @Test(groups = "short")
+    public void should_apply_naming_strategy_to_udts() {
+        // given a configuration with a java naming convention of lower snake case (i.e. hello_world) and a
+        // cassandra naming convention of upper snake case (i.e. HELLO_WORLD) with an access strategy for
+        // fields
+        MappingConfiguration conf = MappingConfiguration.builder()
+                .withPropertyMapper(new DefaultPropertyMapper()
+                        .setNamingStrategy(new DefaultNamingStrategy(
+                                NamingConventions.LOWER_SNAKE_CASE,
+                                NamingConventions.UPPER_SNAKE_CASE))
+                        .setPropertyAccessStrategy(PropertyAccessStrategy.FIELDS))
+                .build();
+
+        MappingManager mappingManager = new MappingManager(session(), conf);
+
+        // when creating a mapper
+        // should succeed since fields match the lower snake case strategy and they are appropriately converted for
+        // both the table (User) and the underlying UDT (Address)
+        Mapper<User> mapper = mappingManager.mapper(User.class);
+
+        // insert user w/ address
+        Address address = new Address();
+        address.zip_code = 90210;
+        address.cityAndState = "Beverly Hills, CA";
+
+        User user = new User();
+        user.name = "John Doe";
+        user.address = address;
+
+        mapper.save(user);
+
+        // retrieve user w/ address and ensure it matches the input.
+        User out = mapper.get(user.name);
+        assertThat(out).isEqualTo(user);
+
+        // should be able to use udtCodec to get a codec back that is capable of converting a retrieved
+        // udt column value into an Address object and it should match the input.
+        TypeCodec<Address> addressCodec = mappingManager.udtCodec(Address.class);
+        Row row = session().execute("select \"ADDRESS\" from user where \"NAME\" = 'John Doe'").one();
+        Address outAddress = row.get(0, addressCodec);
+        assertThat(outAddress).isEqualTo(address);
+    }
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MappingConfigurationPropertyAccessTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MappingConfigurationPropertyAccessTest.java
@@ -1,0 +1,139 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.core.CCMTestsSupport;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+import com.datastax.driver.mapping.annotations.Transient;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for JAVA-1310 - validate ability configure property scope - getters vs. fields
+ */
+public class MappingConfigurationPropertyAccessTest extends CCMTestsSupport {
+
+    @Override
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE foo (k int primary key, v int)");
+        execute("INSERT INTO foo (k, v) VALUES (1, 1)");
+    }
+
+    @Test(groups = "short")
+    public void should_ignore_fields() {
+        // given a configuration with an access strategy of getters and setters
+        MappingConfiguration conf = MappingConfiguration.builder()
+                .withPropertyMapper(new DefaultPropertyMapper()
+                        .setPropertyAccessStrategy(PropertyAccessStrategy.GETTERS_AND_SETTERS))
+                .build();
+        MappingManager mappingManager = new MappingManager(session(), conf);
+        // when creating a mapper
+        // should succeed since getters (getK) maps to a C* column (k) and fields are ignored
+        mappingManager.mapper(Foo1.class);
+    }
+
+    @Table(name = "foo")
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public static class Foo1 {
+        private int k;
+
+        private int notAColumn;
+
+        @PartitionKey
+        public int getK() {
+            return k;
+        }
+
+        public void setK(int k) {
+            this.k = k;
+        }
+    }
+
+    @Test(groups = "short")
+    public void should_ignore_getters() {
+        // given a configuration with an access strategy of fields
+        MappingConfiguration conf = MappingConfiguration.builder()
+                .withPropertyMapper(new DefaultPropertyMapper()
+                        .setPropertyAccessStrategy(PropertyAccessStrategy.FIELDS))
+                .build();
+        MappingManager mappingManager = new MappingManager(session(), conf);
+        // when creating a mapper
+        // should succeed since fields (k) maps to a C* column (k) and getters are ignored
+        mappingManager.mapper(Foo2.class);
+    }
+
+    @Table(name = "foo")
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public static class Foo2 {
+        @PartitionKey
+        private int k;
+
+        public int getNotAColumn() {
+            return 1;
+        }
+
+        public boolean isNotAColumn2() {
+            return true;
+        }
+    }
+
+    @Test(groups = "short")
+    public void should_map_fields_and_getters() {
+        // given a configuration with an access strategy of both
+        MappingConfiguration conf = MappingConfiguration.builder()
+                .withPropertyMapper(new DefaultPropertyMapper()
+                        .setPropertyAccessStrategy(PropertyAccessStrategy.BOTH))
+                .build();
+        MappingManager mappingManager = new MappingManager(session(), conf);
+        // when creating a mapper
+        // should succeed since fields and getters (k, getV) maps to a C* columns (k, v) and remaining field/getter
+        // has a @Transient annotation (storeVValueButNotMapped)
+        Mapper<Foo3> mapper = mappingManager.mapper(Foo3.class);
+        // should be able to retrieve data
+        Foo3 foo = mapper.get(1);
+        assertThat(foo.getV()).isEqualTo(1);
+        assertThat(foo.getK()).isEqualTo(1);
+    }
+
+    @Table(name = "foo")
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public static class Foo3 {
+        @PartitionKey
+        private int k;
+
+        @Transient
+        private int storeVValueButNotMapped;
+
+        @SuppressWarnings({"unused", "WeakerAccess"})
+        public int getK() {
+            return k;
+        }
+
+        public void setK(int k) {
+            this.k = k;
+        }
+
+        public int getV() {
+            return storeVValueButNotMapped;
+        }
+
+        public void setV(int v) {
+            this.storeVValueButNotMapped = v;
+        }
+    }
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MappingConfigurationTransienceStrategyTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MappingConfigurationTransienceStrategyTest.java
@@ -1,0 +1,122 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.core.CCMTestsSupport;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+import com.datastax.driver.mapping.annotations.Transient;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for JAVA-1310 - validate ability configure property mapping strategy - whitelist vs. blacklist
+ */
+public class MappingConfigurationTransienceStrategyTest extends CCMTestsSupport {
+
+    @Override
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE foo (k int primary key, v int)");
+        execute("INSERT INTO foo (k, v) VALUES (1, 1)");
+    }
+
+    @Test(groups = "short")
+    public void should_map_only_non_transient() {
+        // given an 'opt out' configuration
+        MappingConfiguration conf = MappingConfiguration.builder()
+                .withPropertyMapper(new DefaultPropertyMapper()
+                        .setPropertyTransienceStrategy(PropertyTransienceStrategy.OPT_OUT))
+                .build();
+        MappingManager mappingManager = new MappingManager(session(), conf);
+        // when creating a mapper
+        // then will succeed mapping since non-transient fields (k, v) exist in table and transient one (notAColumn)
+        // is not used
+        Mapper<Foo1> mapper = mappingManager.mapper(Foo1.class);
+        // k and v should have been mapped since they were non-transient
+        assertThat(mapper.get(1).getV()).isEqualTo(1);
+        assertThat(mapper.get(1).getK()).isEqualTo(1);
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    @Table(name = "foo")
+    public static class Foo1 {
+
+        @PartitionKey
+        private int k;
+
+        private int v;
+
+        @Transient
+        private int notAColumn;
+
+        public int getK() {
+            return k;
+        }
+
+        public void setK(int k) {
+            this.k = k;
+        }
+
+        public int getV() {
+            return v;
+        }
+
+        public void setV(int v) {
+            this.v = v;
+        }
+    }
+
+    @Test(groups = "short")
+    public void should_map_only_annotated() {
+        // given an 'opt in' configuration
+        MappingConfiguration conf = MappingConfiguration.builder()
+                .withPropertyMapper(new DefaultPropertyMapper()
+                        .setPropertyTransienceStrategy(PropertyTransienceStrategy.OPT_IN))
+                .build();
+        MappingManager mappingManager = new MappingManager(session(), conf);
+        // when creating a mapper
+        // then will succeed mapping since notAColumn is not annotated with @Column
+        Mapper<Foo2> mapper = mappingManager.mapper(Foo2.class);
+        // k should have been mapped since it is annotated with @PartitionKey
+        assertThat(mapper.get(1).getK()).isEqualTo(1);
+    }
+
+    @Table(name = "foo")
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public static class Foo2 {
+        @PartitionKey
+        private int k;
+
+        private int notAColumn;
+
+        public int getK() {
+            return k;
+        }
+
+        public void setK(int k) {
+            this.k = k;
+        }
+
+        public int getNotAColumn() {
+            return notAColumn;
+        }
+
+        public void setNotAColumn(int notAColumn) {
+            this.notAColumn = notAColumn;
+        }
+    }
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MappingConfigurationTransientTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MappingConfigurationTransientTest.java
@@ -1,0 +1,112 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import com.datastax.driver.core.CCMTestsSupport;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+import com.datastax.driver.mapping.annotations.Transient;
+import org.testng.annotations.Test;
+
+/**
+ * Test for JAVA-1310 - validate ability to transient properties at manager and mapper levels
+ */
+public class MappingConfigurationTransientTest extends CCMTestsSupport {
+
+    @Override
+    public void onTestContextInitialized() {
+        execute("CREATE TABLE foo (k int primary key, v int)");
+        execute("INSERT INTO foo (k, v) VALUES (1, 1)");
+    }
+
+    @Test(groups = "short")
+    public void should_ignore_property_if_field_annotated_transient() {
+        // given default configuration
+        MappingManager mappingManager = new MappingManager(session());
+        // when creating a mapper
+        // then mapping should succeed since non-existent column 'notAColumn' is annotated as Transient on its field
+        mappingManager.mapper(Foo1.class);
+    }
+
+    @Table(name = "foo")
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public static class Foo1 {
+        @PartitionKey
+        private int k;
+        @Transient
+        private int notAColumn;
+    }
+
+    @Test(groups = "short")
+    public void should_ignore_property_if_getter_annotated_transient() {
+        // given default configuration
+        MappingManager mappingManager = new MappingManager(session());
+        // when creating a mapper
+        // then mapping should succeed since non-existent column 'notAColumn' is annotated as @Transient on its getter
+        mappingManager.mapper(Foo2.class);
+    }
+
+    @Table(name = "foo")
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public static class Foo2 {
+        @PartitionKey
+        private int k;
+        private int notAColumn;
+
+        @Transient
+        public int getNotAColumn() {
+            return notAColumn;
+        }
+    }
+
+    @Table(name = "foo")
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public static class Foo3 {
+        @PartitionKey
+        private int k;
+        private int notAColumn;
+    }
+
+    @Test(groups = "short")
+    public void should_ignore_property_if_declared_transient_in_mapper_configuration() {
+        // given configuration that considers 'notAColumn' as transient
+        MappingConfiguration conf = MappingConfiguration.builder()
+                .withPropertyMapper(new DefaultPropertyMapper()
+                        .addTransientPropertyNames("notAColumn"))
+                .build();
+        // when creating a mapper
+        // then mapping should succeed since non-existent column 'notAColumn' is considered implicitly transient
+        MappingManager mappingManager = new MappingManager(session(), conf);
+        mappingManager.mapper(Foo3.class);
+    }
+
+    @Test(groups = "short")
+    public void should_ignore_property_if_field_has_transient_modifier() {
+        // given default configuration
+        MappingManager mappingManager = new MappingManager(session());
+        // when creating a mapper
+        // then mapping should succeed since non-existent column 'notAColumn' has transient modifier
+        mappingManager.mapper(Foo4.class);
+    }
+
+    @Table(name = "foo")
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public static class Foo4 {
+        @PartitionKey
+        private int k;
+        private transient int notAColumn;
+    }
+}

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/NamingConventionsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/NamingConventionsTest.java
@@ -1,0 +1,550 @@
+/*
+ *      Copyright (C) 2012-2015 DataStax Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.datastax.driver.mapping;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for JAVA-1316 - test combinations of different
+ * {@link NamingConventions} implementation.
+ */
+public class NamingConventionsTest {
+
+    // test lower camel case inputs
+
+    @Test(groups = "unit")
+    public void lower_camel_case_to_upper_camel_case() {
+        test(
+                NamingConventions.LOWER_CAMEL_CASE,
+                NamingConventions.UPPER_CAMEL_CASE,
+                "myXmlParser",
+                "MyXmlParser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_camel_case_to_lower_snake_case() {
+        test(
+                NamingConventions.LOWER_CAMEL_CASE,
+                NamingConventions.LOWER_SNAKE_CASE,
+                "myXmlParser",
+                "my_xml_parser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_camel_case_to_upper_snake_case() {
+        test(
+                NamingConventions.LOWER_CAMEL_CASE,
+                NamingConventions.UPPER_SNAKE_CASE,
+                "myXmlParser",
+                "MY_XML_PARSER"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_camel_case_to_lower_lisp_case() {
+        test(
+                NamingConventions.LOWER_CAMEL_CASE,
+                NamingConventions.LOWER_LISP_CASE,
+                "myXmlParser",
+                "my-xml-parser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_camel_case_to_upper_lisp_case() {
+        test(
+                NamingConventions.LOWER_CAMEL_CASE,
+                NamingConventions.UPPER_LISP_CASE,
+                "myXmlParser",
+                "MY-XML-PARSER"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_camel_case_to_lower_case() {
+        test(
+                NamingConventions.LOWER_CAMEL_CASE,
+                NamingConventions.LOWER_CASE,
+                "myXmlParser",
+                "myxmlparser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_camel_case_to_upper_case() {
+        test(
+                NamingConventions.LOWER_CAMEL_CASE,
+                NamingConventions.UPPER_CASE,
+                "myXmlParser",
+                "MYXMLPARSER"
+        );
+    }
+
+    // test upper camel case inputs
+
+    @Test(groups = "unit")
+    public void upper_camel_case_to_lower_camel_case() {
+        test(
+                NamingConventions.UPPER_CAMEL_CASE,
+                NamingConventions.LOWER_CAMEL_CASE,
+                "MyXmlParser",
+                "myXmlParser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_camel_case_to_lower_snake_case() {
+        test(
+                NamingConventions.UPPER_CAMEL_CASE,
+                NamingConventions.LOWER_SNAKE_CASE,
+                "MyXmlParser",
+                "my_xml_parser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_camel_case_to_upper_snake_case() {
+        test(
+                NamingConventions.UPPER_CAMEL_CASE,
+                NamingConventions.UPPER_SNAKE_CASE,
+                "MyXmlParser",
+                "MY_XML_PARSER"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_camel_case_to_lower_lisp_case() {
+        test(
+                NamingConventions.UPPER_CAMEL_CASE,
+                NamingConventions.LOWER_LISP_CASE,
+                "MyXmlParser",
+                "my-xml-parser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_camel_case_to_upper_lisp_case() {
+        test(
+                NamingConventions.UPPER_CAMEL_CASE,
+                NamingConventions.UPPER_LISP_CASE,
+                "MyXmlParser",
+                "MY-XML-PARSER"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_camel_case_to_lower_case() {
+        test(
+                NamingConventions.UPPER_CAMEL_CASE,
+                NamingConventions.LOWER_CASE,
+                "MyXmlParser",
+                "myxmlparser"
+        );
+    }
+
+    // test lower snake case inputs
+
+    @Test(groups = "unit")
+    public void lower_snake_case_to_lower_camel_case() {
+        test(
+                NamingConventions.LOWER_SNAKE_CASE,
+                NamingConventions.LOWER_CAMEL_CASE,
+                "my_xml_parser",
+                "myXmlParser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_snake_case_to_upper_camel_case() {
+        test(
+                NamingConventions.LOWER_SNAKE_CASE,
+                NamingConventions.UPPER_CAMEL_CASE,
+                "my_xml_parser",
+                "MyXmlParser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_snake_case_to_upper_snake_case() {
+        test(
+                NamingConventions.LOWER_SNAKE_CASE,
+                NamingConventions.UPPER_SNAKE_CASE,
+                "my_xml_parser",
+                "MY_XML_PARSER"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_snake_case_to_lower_lisp_case() {
+        test(
+                NamingConventions.LOWER_SNAKE_CASE,
+                NamingConventions.LOWER_LISP_CASE,
+                "my_xml_parser",
+                "my-xml-parser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_snake_case_to_upper_lisp_case() {
+        test(
+                NamingConventions.LOWER_SNAKE_CASE,
+                NamingConventions.UPPER_LISP_CASE,
+                "my_xml_parser",
+                "MY-XML-PARSER"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_snake_case_to_lower_case() {
+        test(
+                NamingConventions.LOWER_SNAKE_CASE,
+                NamingConventions.LOWER_CASE,
+                "my_xml_parser",
+                "myxmlparser"
+        );
+    }
+
+    // test upper snake case inputs
+
+    @Test(groups = "unit")
+    public void upper_snake_case_to_lower_camel_case() {
+        test(
+                NamingConventions.UPPER_SNAKE_CASE,
+                NamingConventions.LOWER_CAMEL_CASE,
+                "MY_XML_PARSER",
+                "myXmlParser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_snake_case_to_upper_camel_case() {
+        test(
+                NamingConventions.UPPER_SNAKE_CASE,
+                NamingConventions.UPPER_CAMEL_CASE,
+                "MY_XML_PARSER",
+                "MyXmlParser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_snake_case_to_lower_snake_case() {
+        test(
+                NamingConventions.UPPER_SNAKE_CASE,
+                NamingConventions.LOWER_SNAKE_CASE,
+                "MY_XML_PARSER",
+                "my_xml_parser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_snake_case_to_lower_lisp_case() {
+        test(
+                NamingConventions.UPPER_SNAKE_CASE,
+                NamingConventions.LOWER_LISP_CASE,
+                "MY_XML_PARSER",
+                "my-xml-parser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_snake_case_to_upper_lisp_case() {
+        test(
+                NamingConventions.UPPER_SNAKE_CASE,
+                NamingConventions.UPPER_LISP_CASE,
+                "MY_XML_PARSER",
+                "MY-XML-PARSER"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_snake_case_to_lower_case() {
+        test(
+                NamingConventions.UPPER_SNAKE_CASE,
+                NamingConventions.LOWER_CASE,
+                "MY_XML_PARSER",
+                "myxmlparser"
+        );
+    }
+
+    // test lower lisp case inputs
+
+    @Test(groups = "unit")
+    public void lower_lisp_case_to_lower_camel_case() {
+        test(
+                NamingConventions.LOWER_LISP_CASE,
+                NamingConventions.LOWER_CAMEL_CASE,
+                "my-xml-parser",
+                "myXmlParser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_lisp_case_to_upper_camel_case() {
+        test(
+                NamingConventions.LOWER_LISP_CASE,
+                NamingConventions.UPPER_CAMEL_CASE,
+                "my-xml-parser",
+                "MyXmlParser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_lisp_case_to_lower_snake_case() {
+        test(
+                NamingConventions.LOWER_LISP_CASE,
+                NamingConventions.LOWER_SNAKE_CASE,
+                "my-xml-parser",
+                "my_xml_parser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_lisp_case_to_upper_snake_case() {
+        test(
+                NamingConventions.LOWER_LISP_CASE,
+                NamingConventions.UPPER_SNAKE_CASE,
+                "my-xml-parser",
+                "MY_XML_PARSER"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_lisp_case_to_upper_lisp_case() {
+        test(
+                NamingConventions.LOWER_LISP_CASE,
+                NamingConventions.UPPER_LISP_CASE,
+                "my-xml-parser",
+                "MY-XML-PARSER"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_lisp_case_to_lower_case() {
+        test(
+                NamingConventions.LOWER_LISP_CASE,
+                NamingConventions.LOWER_CASE,
+                "my-xml-parser",
+                "myxmlparser"
+        );
+    }
+
+    // test upper lisp case inputs
+
+    @Test(groups = "unit")
+    public void upper_lisp_case_to_lower_camel_case() {
+        test(
+                NamingConventions.UPPER_LISP_CASE,
+                NamingConventions.LOWER_CAMEL_CASE,
+                "MY-XML-PARSER",
+                "myXmlParser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_lisp_case_to_upper_camel_case() {
+        test(
+                NamingConventions.UPPER_LISP_CASE,
+                NamingConventions.UPPER_CAMEL_CASE,
+                "MY-XML-PARSER",
+                "MyXmlParser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_lisp_case_to_lower_snake_case() {
+        test(
+                NamingConventions.UPPER_LISP_CASE,
+                NamingConventions.LOWER_SNAKE_CASE,
+                "MY-XML-PARSER",
+                "my_xml_parser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_lisp_case_to_upper_snake_case() {
+        test(
+                NamingConventions.UPPER_LISP_CASE,
+                NamingConventions.UPPER_SNAKE_CASE,
+                "MY-XML-PARSER",
+                "MY_XML_PARSER"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_lisp_case_to_lower_lisp_case() {
+        test(
+                NamingConventions.UPPER_LISP_CASE,
+                NamingConventions.LOWER_LISP_CASE,
+                "MY-XML-PARSER",
+                "my-xml-parser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_lisp_case_to_lower_case() {
+        test(
+                NamingConventions.UPPER_LISP_CASE,
+                NamingConventions.LOWER_CASE,
+                "MY-XML-PARSER",
+                "myxmlparser"
+        );
+    }
+
+    // test special camel case settings
+
+    @Test(groups = "unit")
+    public void lower_camel_case_with_prefix_to_upper_camel_case() {
+        test(
+                new NamingConventions.LowerCamelCase("_"),
+                NamingConventions.UPPER_CAMEL_CASE,
+                "_myXmlParser",
+                "MyXmlParser"
+        );
+        test(
+                new NamingConventions.LowerCamelCase("_"),
+                NamingConventions.UPPER_CAMEL_CASE,
+                "myXmlParser",
+                "MyXmlParser"
+        );
+        test(
+                new NamingConventions.LowerCamelCase("_", "m"),
+                NamingConventions.UPPER_CAMEL_CASE,
+                "mMyXmlParser",
+                "MyXmlParser"
+        );
+        test(
+                new NamingConventions.LowerCamelCase("_", "m"),
+                NamingConventions.UPPER_CAMEL_CASE,
+                "_MyXmlParser",
+                "MyXmlParser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_camel_case_with_prefix_to_lower_snake_case() {
+        test(
+                new NamingConventions.LowerCamelCase("_"),
+                NamingConventions.LOWER_SNAKE_CASE,
+                "_myXmlParser",
+                "my_xml_parser"
+        );
+        test(
+                new NamingConventions.LowerCamelCase("_"),
+                NamingConventions.LOWER_SNAKE_CASE,
+                "myXmlParser",
+                "my_xml_parser"
+        );
+        test(
+                new NamingConventions.LowerCamelCase("_", "m"),
+                NamingConventions.LOWER_SNAKE_CASE,
+                "mMyXmlParser",
+                "my_xml_parser"
+        );
+        test(
+                new NamingConventions.LowerCamelCase("_", "m"),
+                NamingConventions.LOWER_SNAKE_CASE,
+                "_MyXmlParser",
+                "my_xml_parser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_camel_case_with_prefix_to_upper_camel_case() {
+        test(
+                new NamingConventions.UpperCamelCase("_"),
+                NamingConventions.UPPER_CAMEL_CASE,
+                "_MyXmlParser",
+                "MyXmlParser"
+        );
+        test(
+                new NamingConventions.UpperCamelCase("_"),
+                NamingConventions.UPPER_CAMEL_CASE,
+                "MyXmlParser",
+                "MyXmlParser"
+        );
+        test(
+                new NamingConventions.UpperCamelCase("_", "m"),
+                NamingConventions.UPPER_CAMEL_CASE,
+                "mMyXmlParser",
+                "MyXmlParser"
+        );
+        test(
+                new NamingConventions.UpperCamelCase("_", "m"),
+                NamingConventions.UPPER_CAMEL_CASE,
+                "_MyXmlParser",
+                "MyXmlParser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_camel_case_with_prefix_to_upper_snake_case() {
+        test(
+                new NamingConventions.UpperCamelCase("_"),
+                NamingConventions.LOWER_SNAKE_CASE,
+                "_MyXmlParser",
+                "my_xml_parser"
+        );
+        test(
+                new NamingConventions.UpperCamelCase("_"),
+                NamingConventions.LOWER_SNAKE_CASE,
+                "MyXmlParser",
+                "my_xml_parser"
+        );
+        test(
+                new NamingConventions.UpperCamelCase("_", "m"),
+                NamingConventions.LOWER_SNAKE_CASE,
+                "mMyXmlParser",
+                "my_xml_parser"
+        );
+        test(
+                new NamingConventions.UpperCamelCase("_", "m"),
+                NamingConventions.LOWER_SNAKE_CASE,
+                "_MyXmlParser",
+                "my_xml_parser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void lower_camel_case_with_abbr_to_lower_camel_case_with_no_abbr() {
+        test(
+                new NamingConventions.LowerCamelCase(true),
+                new NamingConventions.LowerCamelCase(false),
+                "myXMLParser",
+                "myXmlParser"
+        );
+    }
+
+    @Test(groups = "unit")
+    public void upper_camel_case_with_abbr_to_lower_camel_case_with_abbr() {
+        test(
+                new NamingConventions.UpperCamelCase(true),
+                new NamingConventions.LowerCamelCase(true),
+                "MyXMLParser",
+                "myXMLParser"
+        );
+    }
+
+    private void test(NamingConvention inputConvention, NamingConvention outputConvention, String input, String output) {
+        DefaultNamingStrategy namingStrategy = new DefaultNamingStrategy(inputConvention, outputConvention);
+        String result = namingStrategy.toCassandraName(input);
+        assertThat(result).isEqualTo(output);
+    }
+
+}

--- a/manual/object_mapper/using/README.md
+++ b/manual/object_mapper/using/README.md
@@ -297,3 +297,49 @@ public ListenableFuture<Result<User>> getAllAsync();
 ```
 
 [@QueryParameters]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/annotations/QueryParameters.html
+
+
+### Mapping configuration
+
+[MappingConfiguration] lets you configure low-level aspects of the object mapper. It is configured
+when initializing the mapping manager:
+
+```java
+PropertyMapper propertyMapper = ... ; // see examples below
+MappingConfiguration configuration = 
+        MappingConfiguration.builder()
+                .withPropertyMapper(propertyMapper)
+                .build();
+MappingManager manager = new MappingManager(session, configuration);
+```
+
+The main component in the configuration is [PropertyMapper], which controls how annotated classes
+will relate to database objects. The best way to plug in specific behavior is to create an instance of
+[DefaultPropertyMapper] and customize it.
+
+For example, the mapper's default behavior is to try to map all the properties of your Java objects.
+You might want to take the opposite approach and only map the ones that are specifically annotated
+with `@Column` or `@Field`:
+
+```java
+PropertyMapper propertyMapper = new DefaultPropertyMapper()
+        .setPropertyTransienceStrategy(PropertyTransienceStrategy.OPT_IN);
+```
+
+Another common need is to customize the way Cassandra column names are inferred. Out of the box, Java
+property names are simply lowercased, so a `userName` property would be mapped to the `username` column.
+To map to `user_name` instead, use the following:
+
+```java
+PropertyMapper propertyMapper = new DefaultPropertyMapper()
+        .setNamingStrategy(new DefaultNamingStrategy(
+                NamingConventions.LOWER_CAMEL_CASE, 
+                NamingConventions.LOWER_SNAKE_CASE));
+```
+
+There is more to `DefaultPropertyMapper`; see the Javadocs and implementation for details.
+
+
+[MappingConfiguration]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/MappingConfiguration.html
+[PropertyMapper]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/PropertyMapper.html
+[DefaultPropertyMapper]: http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/mapping/DefaultPropertyMapper.html

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -17,6 +17,12 @@ In 3.1.0, the driver would log a warning the first time it would skip
 a retry for a non-idempotent request; this warning has now been 
 removed as users should now have adjusted their applications accordingly.
 
+The `caseSensitive` field on `@Column` and `@Field` annotation now only
+applies to the `name` field on the annotation and not the name of the
+variable / method itself.  If you were previously depending on the
+name of the field, you should add a `name` field to the annotation,
+i.e.:  `@Column(name="userName", caseSensitive=true)`.
+
 
 ### 3.1.0
 


### PR DESCRIPTION
Reboot of @avivcarmis original pull request:
- target 3.x branch
- rebase on top of current 3.x
- get rid of my initial implementation

Reminder of the remaining tasks:

1. `PropertyScanScope` class will be changed to an enum containing `{GETTERS_AND_SETTERS, FIELDS, BOTH}`.
2. `HierarchyScanStrategy` class will be migrated to a single field of type Class<?> indicating the deepest ancestor to scan.
    => I think it would also be useful to indicate if the bound is inclusive or not. In some cases you may have a common parent and you'll want to say "up to this parent included", but in others you may have multiple independent trees, and it will be "up to `Object` excluded".
3. ~~Add [this change](https://github.com/datastax/java-driver/pull/771#discussion-diff-101653251R175).~~
4. ~~Document the fact that `MappingManager` [getters](https://github.com/datastax/java-driver/blob/fbcd7d50e57845adfaf8bca7fb938943fb86c955/driver-mapping/src/main/java/com/datastax/driver/mapping/MappingManager.java#L236) will account for configuration object only for the first time, then they'll be ignored [as discussed here](https://github.com/datastax/java-driver/pull/771#discussion-diff-101658604R312).~~
5. Make configuration immutable (maybe switch to builders) and remove duplication on mapper creation [as discussed here](https://github.com/datastax/java-driver/pull/771#discussion-diff-101656586R46).
6. [Move class docs to getter methods](https://github.com/datastax/java-driver/pull/771#discussion-diff-101656317R36).
7. [Move nested classes to top level ones](https://github.com/datastax/java-driver/pull/771#discussion-diff-101656811R76).
8. ~~Rename transient config properties and document transient hierarchy (config transient props vs. class annotation transient properties vs. transient annotation) [as discussed here](https://github.com/datastax/java-driver/pull/771#discussion-diff-101765523R101).~~ => I've removed the annotation-level config property
9. ~~Rename `PropertyMappingStrategy` values to `{OPT_IN, OPT_OUT}` [as discussed here](https://github.com/datastax/java-driver/pull/771#discussion-diff-101766284R334).~~
10. ~~Reuse `AnnotationParser.VALID_COLUMN_ANNOTATIONS` [as discussed here](https://github.com/datastax/java-driver/pull/771#discussion-diff-101769396R44).~~
11. ~~Account for java `transient` modifier [as discussed here](https://github.com/datastax/java-driver/pull/771#discussion-diff-101766808R138) (i'm actually +1 on that, fell for it myself when i started using the mapper).~~
12. ~~Rename `MapperConfiguration` to `MappingConfiguration`.~~
13. ~~Last thing left open is whether we want to remove [`PropertyScanConfiguration`](https://github.com/datastax/java-driver/blob/fbcd7d50e57845adfaf8bca7fb938943fb86c955/driver-mapping/src/main/java/com/datastax/driver/mapping/MapperConfiguration.java#L46) field and move it's props to `MappingConfiguration` top level.~~ => no, let's keep it separate