### PR TITLE
Remove use of MathJax from javadocs, update guava javadoc link

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/policies/LatencyAwarePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/LatencyAwarePolicy.java
@@ -589,18 +589,16 @@ public class LatencyAwarePolicy implements ChainableLoadBalancingPolicy {
          * Sets the scale to use for the resulting latency aware policy.
          * <p/>
          * The {@code scale} provides control on how the weight given to older latencies
-         * decreases over time. For a given host, if a new latency \(l\) is received at
-         * time \(t\), and the previously calculated average is \(prev\) calculated at
-         * time \(t'\), then the newly calculated average \(avg\) for that host is calculated
+         * decreases over time. For a given host, if a new latency {@code l} is received at
+         * time {@code t}, and the previously calculated average is {@code prev} calculated at
+         * time {@code t'}, then the newly calculated average {@code avg} for that host is calculated
          * thusly:
-         * \[
-         * d = \frac{t - t'}{scale} \\
-         * \alpha = 1 - \left(\frac{\ln(d+1)}{d}\right) \\
-         * avg = \alpha * l + (1-\alpha) * prev
-         * \]
+         * <pre>{@code d = (t - t') / scale
+         * alpha = 1 - (ln(d+1) / d)
+         * avg = alpha * l + (1 - alpha * prev)}</pre>
          * Typically, with a {@code scale} of 100 milliseconds (the default), if a new
-         * latency is measured and the previous measure is 10 millisecond old (so \(d=0.1\)),
-         * then \(\alpha\) will be around \(0.05\). In other words, the new latency will
+         * latency is measured and the previous measure is 10 millisecond old (so {@code d=0.1}),
+         * then {@code alpha} will be around {@code 0.05}. In other words, the new latency will
          * weight 5% of the updated average. A bigger scale will get less weight to new
          * measurements (compared to previous ones), a smaller one will give them more weight.
          * <p/>
@@ -612,7 +610,7 @@ public class LatencyAwarePolicy implements ChainableLoadBalancingPolicy {
          * @param scale the scale to use.
          * @param unit  the unit of {@code scale}.
          * @return this builder.
-         * @throws IllegalArgumentException if {@code scale &lte; 0}.
+         * @throws IllegalArgumentException if {@code scale <= 0}.
          */
         public Builder withScale(long scale, TimeUnit unit) {
             if (scale <= 0)

--- a/pom.xml
+++ b/pom.xml
@@ -228,23 +228,9 @@
                 <configuration>
                     <verbose>false</verbose>
                     <additionalparam>${javadoc.opts}</additionalparam>
-                    <!-- I can haz math in my javadoc (see http://zverovich.net/2012/01/14/beautiful-math-in-javadoc.html) -->
-                    <header>
-                        &lt;script type="text/javascript"
-                        src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"&gt;&lt;/script&gt;
-                    </header>
-                    <!-- open external links in a separate window -->
-                    <bottom>
-                        &lt;script type="text/javascript"&gt;
-                        for(var i in document.links) {
-                        var link = document.links[i];
-                        if (link.href.indexOf('is-external=true') != -1) link.target = '_blank';
-                        }
-                        &lt;/script&gt;
-                    </bottom>
                     <links>
                         <link>https://docs.oracle.com/javase/8/docs/api/</link>
-                        <link>http://docs.guava-libraries.googlecode.com/git-history/v16.0.1/javadoc/</link>
+                        <link>http://google.github.io/guava/releases/16.0.1/api/docs/</link>
                         <link>http://netty.io/4.0/api/</link>
                         <!-- dependencies from driver-extras -->
                         <link>http://www.joda.org/joda-time/apidocs/</link>


### PR DESCRIPTION
Motivation:

In Java 8 update 121 javadoc is now more strict about including script
tags in comments, headers, etc.  A new option --allow-script-in-comments
was added to allow this, but it does not support older versions of JDK
8.  Limitations in maven make it difficult to selectively inject options
based on JDK update versions.  Since we only use script tags for MathJax
in one method (LatencyAwarePolicy.Builder.withScale) we opted to remove
our use of MathJax and use `{@code}` instead.

Modifications:

Remove MathJax from javadoc header.

Remove javascript that changed link target based on URL.

Update LatencyAwarePolicy.Builder.withScale to use `{@code}` instead of
LateX.

Update guava javadoc link.

Result:

Build now works with Java 8 Update 121+.