### PR TITLE
Use java 1.8 for compiling in continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ jdk:
   - oraclejdk7
   - oraclejdk8
 sudo: false
+before_install: 
+    # Require JDK8 for compiling
+    - jdk_switcher use oraclejdk8
+before_script:
+    # Switch back to configured JDK for running tests
+    - jdk_switcher use $TRAVIS_JDK_VERSION
 cache:
   directories:
     - $HOME/.m2

--- a/build.yaml
+++ b/build.yaml
@@ -43,6 +43,15 @@ cassandra:
   - '3.0'
   - '3.10'
 build:
+  - script: |
+      . /usr/local/bin/jdk_switcher.sh
+      jdk_switcher use oraclejdk8
+      export MAVEN_HOME=/home/jenkins/.mvn/apache-maven-3.2.5
+      export PATH=$MAVEN_HOME/bin:$PATH
+      mvn -B -V install -DskipTests
+  - script: |
+      . /usr/local/bin/jdk_switcher.sh
+      jdk_switcher use $JAVA_VERSION
   - type: maven
     version: 3.2.5
     goals: verify --fail-never -P$TEST_GROUP

--- a/ci/appveyor.ps1
+++ b/ci/appveyor.ps1
@@ -19,6 +19,8 @@ If ($env:PLATFORM -eq "X64") {
 }
 
 $env:JAVA_HOME="C:\Program Files\Java\jdk$($env:java_version)"
+# The configured java version to test with.
+$env:JAVA_PLATFORM_HOME="$($env:JAVA_HOME)"
 $env:JAVA_8_HOME="C:\Program Files\Java\jdk1.8.0"
 $env:PATH="$($env:PYTHON);$($env:PYTHON)\Scripts;$($env:JAVA_HOME)\bin;$($env:OPENSSL_PATH)\bin;$($env:PATH)"
 $env:CCM_PATH="$($dep_dir)\ccm"

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -9,9 +9,13 @@ platform: x64
 install:
   - ps: .\ci\appveyor.ps1
 build_script:
-  - mvn -B install -DskipTests=true
+  - ps: |
+      $env:JAVA_HOME="$($env:JAVA_8_HOME)"
+      mvn install -DskipTests=true -D"maven.javadoc.skip"=true -B -V
 test_script:
-  - "mvn -B -Dccm.java.home=\"%JAVA_8_HOME%\" -Dccm.maxNumberOfNodes=1 -Dcassandra.version=%cassandra_version% verify -P%test_profile%"
+  - ps: |
+      $env:JAVA_HOME="$($env:JAVA_PLATFORM_HOME)"
+      mvn -B -D"ccm.java.home"="$($env:JAVA_8_HOME)" -D"ccm.maxNumberOfNodes"=1 -D"cassandra.version"=$($env:cassandra_version) test -P $($env:test_profile)
 on_finish:
   - ps: .\ci\uploadtests.ps1
 cache:


### PR DESCRIPTION
Since there is some java 1.8 specific code in driver-extras, use java
1.8 to compile the driver and then switch back to the matrix-configured
java version when running tests.