### PR TITLE
JAVA-1414: Optimize Metadata.escapeId and Metadata.handleId

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -18,6 +18,7 @@
 - [bug] JAVA-1415: Correctly report if a UDT column is frozen.
 - [bug] JAVA-1418: Make Guava version detection more reliable.
 - [new feature] JAVA-1174: Add ifNotExists option to mapper.
+- [improvement] JAVA-1414: Optimize Metadata.escapeId and Metadata.handleId.
 
 Merged from 3.1.x branch:
 

--- a/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
@@ -143,4 +143,22 @@ public class MetadataTest extends CCMTestsSupport {
     public void handleId_should_preserve_unquoted_non_alphanumeric_identifiers() {
         assertThat(Metadata.handleId("Foo Bar")).isEqualTo("Foo Bar");
     }
+
+    @Test(groups = "unit")
+    public void escapeId_should_not_quote_lowercase_identifiers() {
+        String id = "this_does_not_need_quoting_0123456789abcdefghijklmnopqrstuvwxyz";
+        assertThat(Metadata.escapeId(id)).isEqualTo(id);
+    }
+
+    @Test(groups = "unit")
+    public void escapeId_should_quote_non_lowercase_identifiers() {
+        assertThat(Metadata.escapeId("This_Needs_Quoting_1234")).isEqualTo("\"This_Needs_Quoting_1234\"");
+        assertThat(Metadata.escapeId("This Needs Quoting 1234!!")).isEqualTo("\"This Needs Quoting 1234!!\"");
+    }
+
+    @Test(groups = "unit")
+    public void escapeId_should_quote_reserved_cql_keywords() {
+        assertThat(Metadata.escapeId("columnfamily")).isEqualTo("\"columnfamily\"");
+    }
+
 }


### PR DESCRIPTION
Some benchmark results (benchmark code [here](https://gist.github.com/adutra/03ec7e8046c7db2b92646b8a929d1e54)):

```
1) No Optimization
Benchmark                               Mode  Cnt    Score     Error  Units
MetadataBenchmark.benchmarkSerialize    avgt   20  236.909 ±  20.722  ns/op
MetadataBenchmark.benchmarkDeserialize  avgt   20  150.895 ±   3.527  ns/op

2) Optimized handleId and escapeId
Benchmark                               Mode  Cnt    Score   Error  Units
MetadataBenchmark.benchmarkSerialize    avgt   20  166.681 ± 2.491  ns/op
MetadataBenchmark.benchmarkDeserialize  avgt   20  128.973 ± 1.439  ns/op

3) Optimized handleId and escapeId + Metadata.quote on deserialization
Benchmark                               Mode  Cnt    Score   Error  Units
MetadataBenchmark.benchmarkSerialize    avgt   20  165.921 ± 3.636  ns/op
MetadataBenchmark.benchmarkDeserialize  avgt   20  106.071 ± 1.998  ns/op
```

The current PR implements option 2 above. As you can see there would be an extra improvement by using `Metadata.quote()` instead of `Metadata.escapeId()` when deserializing, but that could break existing applications (although, this is rather unlikely imo).