### PR TITLE
JAVA-1415: Correctly report if a UDT column is frozen

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -15,6 +15,7 @@
 - [improvement] JAVA-1328: Provide compatibility with Guava 20.
 - [improvement] JAVA-1247: Disable idempotence warnings.
 - [improvement] JAVA-1286: Support setting and retrieving udt fields in QueryBuilder.
+- [bug] JAVA-1415: Correctly report if a UDT column is frozen.
 
 Merged from 3.1.x branch:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/ColumnDefinitions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ColumnDefinitions.java
@@ -145,6 +145,10 @@ public class ColumnDefinitions implements Iterable<ColumnDefinitions.Definition>
 
     /**
      * Returns the type of the {@code i}th column in this metadata.
+     * <p>
+     * Note that this method does not set the {@link DataType#isFrozen()} flag on the returned
+     * object, it will always default to {@code false}. Use {@link Cluster#getMetadata()} to
+     * determine if a column is frozen.
      *
      * @param i the index in this metadata.
      * @return the type of the {@code i}th column in this metadata.
@@ -156,6 +160,10 @@ public class ColumnDefinitions implements Iterable<ColumnDefinitions.Definition>
 
     /**
      * Returns the type of the first occurrence of {@code name} in this metadata.
+     * <p>
+     * Note that this method does not set the {@link DataType#isFrozen()} flag on the returned
+     * object, it will always default to {@code false}. Use {@link Cluster#getMetadata()} to
+     * determine if a column is frozen.
      *
      * @param name the name of the column.
      * @return the type of (the first occurrence of) {@code name} in this metadata.

--- a/driver-core/src/main/java/com/datastax/driver/core/DataType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataType.java
@@ -188,7 +188,7 @@ public abstract class DataType {
                     DataType fieldType = decode(buffer, protocolVersion, codecRegistry);
                     fields.add(new UserType.Field(fieldName, fieldType));
                 }
-                return new UserType(keyspace, type, fields, protocolVersion, codecRegistry);
+                return new UserType(keyspace, type, false, fields, protocolVersion, codecRegistry);
             case TUPLE:
                 nFields = buffer.readShort() & 0xffff;
                 List<DataType> types = new ArrayList<DataType>(nFields);

--- a/driver-core/src/main/java/com/datastax/driver/core/DataTypeClassNameParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataTypeClassNameParser.java
@@ -113,7 +113,8 @@ class DataTypeClassNameParser {
             List<UserType.Field> fields = new ArrayList<UserType.Field>(rawFields.size());
             for (Map.Entry<String, String> entry : rawFields.entrySet())
                 fields.add(new UserType.Field(entry.getKey(), parseOne(entry.getValue(), protocolVersion, codecRegistry)));
-            return new UserType(keyspace, typeName, fields, protocolVersion, codecRegistry);
+            // create a frozen UserType since C* 2.x UDTs are always frozen.
+            return new UserType(keyspace, typeName, true, fields, protocolVersion, codecRegistry);
         }
 
         if (isTupleType(next)) {

--- a/driver-core/src/main/java/com/datastax/driver/core/DataTypeCqlNameParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DataTypeCqlNameParser.java
@@ -137,7 +137,7 @@ class DataTypeCqlNameParser {
         // We need to remove escaped double quotes within the type name as it is stored unescaped.
         // Otherwise it's a UDT. If we only want a shallow definition build it, otherwise search known definitions.
         if (shallowUserTypes)
-            return new UserType.Shallow(currentKeyspaceName, Metadata.handleId(type));
+            return new UserType.Shallow(currentKeyspaceName, Metadata.handleId(type), frozen);
 
         UserType userType = null;
         if (currentUserTypes != null)
@@ -148,7 +148,7 @@ class DataTypeCqlNameParser {
         if (userType == null)
             throw new UnresolvedUserTypeException(currentKeyspaceName, type);
         else
-            return userType;
+            return userType.copy(frozen);
     }
 
     private static class Parser {

--- a/driver-core/src/test/java/com/datastax/driver/core/CodecRegistryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CodecRegistryTest.java
@@ -362,25 +362,25 @@ public class CodecRegistryTest {
     @Test(groups = "unit")
     public void should_create_udt_codec() {
         CodecRegistry registry = new CodecRegistry();
-        UserType udt = new UserType("ks", "test", Collections.<UserType.Field>emptyList(), V4, registry);
+        UserType udt = new UserType("ks", "test", false, Collections.<UserType.Field>emptyList(), V4, registry);
         assertThat(registry.codecFor(udt))
                 .isNotNull()
                 .accepts(udt)
                 .accepts(UDTValue.class);
         registry = new CodecRegistry();
-        udt = new UserType("ks", "test", Collections.<UserType.Field>emptyList(), V4, registry);
+        udt = new UserType("ks", "test", false, Collections.<UserType.Field>emptyList(), V4, registry);
         assertThat(registry.codecFor(udt, UDTValue.class))
                 .isNotNull()
                 .accepts(udt)
                 .accepts(UDTValue.class);
         registry = new CodecRegistry();
-        udt = new UserType("ks", "test", Collections.<UserType.Field>emptyList(), V4, registry);
+        udt = new UserType("ks", "test", false, Collections.<UserType.Field>emptyList(), V4, registry);
         assertThat(registry.codecFor(new UDTValue(udt)))
                 .isNotNull()
                 .accepts(udt)
                 .accepts(UDTValue.class);
         registry = new CodecRegistry();
-        udt = new UserType("ks", "test", Collections.<UserType.Field>emptyList(), V4, registry);
+        udt = new UserType("ks", "test", false, Collections.<UserType.Field>emptyList(), V4, registry);
         assertThat(registry.codecFor(udt, new UDTValue(udt)))
                 .isNotNull()
                 .accepts(udt)

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeTest.java
@@ -238,8 +238,8 @@ public class DataTypeTest {
     public void parseFormatUDTTest() {
         String toParse = "{t:'fo''o',i:3,\"L\":['a','b'],s:{3:{a:0x01}}}";
 
-        final UserType udt1 = new UserType("ks", "t", Arrays.asList(new UserType.Field("a", DataType.blob())), protocolVersion, codecRegistry);
-        UserType udt2 = new UserType("ks", "t", Arrays.asList(
+        final UserType udt1 = new UserType("ks", "t", false, Arrays.asList(new UserType.Field("a", DataType.blob())), protocolVersion, codecRegistry);
+        UserType udt2 = new UserType("ks", "t", false, Arrays.asList(
                 new UserType.Field("t", DataType.text()),
                 new UserType.Field("i", DataType.cint()),
                 new UserType.Field("L", DataType.list(DataType.text())),

--- a/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TypeCodecTest.java
@@ -148,10 +148,10 @@ public class TypeCodecTest {
                 .accepts(t2)
                 .accepts(t3)
                 .accepts(t4);
-        UserType u1 = new UserType("ks", "table", newArrayList(new Field("f1", varchar()), new Field("f2", varchar())), V3, new CodecRegistry());
-        UserType u2 = new UserType("ks", "table", newArrayList(new Field("f1", text()), new Field("f2", varchar())), V3, new CodecRegistry());
-        UserType u3 = new UserType("ks", "table", newArrayList(new Field("f1", varchar()), new Field("f2", text())), V3, new CodecRegistry());
-        UserType u4 = new UserType("ks", "table", newArrayList(new Field("f1", text()), new Field("f2", text())), V3, new CodecRegistry());
+        UserType u1 = new UserType("ks", "table", false, newArrayList(new Field("f1", varchar()), new Field("f2", varchar())), V3, new CodecRegistry());
+        UserType u2 = new UserType("ks", "table", false, newArrayList(new Field("f1", text()), new Field("f2", varchar())), V3, new CodecRegistry());
+        UserType u3 = new UserType("ks", "table", false, newArrayList(new Field("f1", varchar()), new Field("f2", text())), V3, new CodecRegistry());
+        UserType u4 = new UserType("ks", "table", false, newArrayList(new Field("f1", text()), new Field("f2", text())), V3, new CodecRegistry());
         assertThat(TypeCodec.userType(u1))
                 .accepts(u2)
                 .accepts(u3)
@@ -219,7 +219,7 @@ public class TypeCodecTest {
     @Test(groups = "unit")
     public void should_deserialize_empty_buffer_as_udt_with_null_values() {
         CodecRegistry codecRegistry = new CodecRegistry();
-        UserType udt = new UserType("ks", "t", Arrays.asList(
+        UserType udt = new UserType("ks", "t", false, Arrays.asList(
                 new UserType.Field("t", DataType.text()),
                 new UserType.Field("i", DataType.cint()),
                 new UserType.Field("l", DataType.list(DataType.text()))

--- a/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
@@ -30,11 +30,10 @@ import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.Callable;
 
+import static com.datastax.driver.core.Assertions.assertThat;
 import static com.datastax.driver.core.ConditionChecker.check;
 import static com.datastax.driver.core.Metadata.quote;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
 
 @CassandraVersion("2.1.0")
 public class UserTypesTest extends CCMTestsSupport {
@@ -66,13 +65,8 @@ public class UserTypesTest extends CCMTestsSupport {
         check().that(userTableExists).before(5, MINUTES).becomesTrue();
     }
 
-    /**
-     * Basic write read test to ensure UDTs are stored and retrieved correctly.
-     *
-     * @throws Exception
-     */
     @Test(groups = "short")
-    public void simpleWriteReadTest() throws Exception {
+    public void should_store_and_retrieve_with_prepared_statements() throws Exception {
         int userId = 0;
         PreparedStatement ins = session().prepare("INSERT INTO user(id, addr) VALUES (?, ?)");
         PreparedStatement sel = session().prepare("SELECT * FROM user WHERE id=?");
@@ -89,19 +83,12 @@ public class UserTypesTest extends CCMTestsSupport {
 
         Row r = session().execute(sel.bind(userId)).one();
 
-        assertEquals(r.getInt("id"), 0);
-        assertEquals(r.getUDTValue("addr"), addr);
+        assertThat(r.getInt("id")).isEqualTo(0);
     }
 
-    /**
-     * Run simpleWriteReadTest with unprepared requests.
-     *
-     * @throws Exception
-     */
     @Test(groups = "short")
-    public void simpleUnpreparedWriteReadTest() throws Exception {
+    public void should_store_and_retrieve_with_simple_statements() throws Exception {
         int userId = 1;
-        session().execute("USE " + keyspace);
         UserType addrDef = cluster().getMetadata().getKeyspace(keyspace).getUserType(quote("\"User Address\""));
         UserType phoneDef = cluster().getMetadata().getKeyspace(keyspace).getUserType("phone");
 
@@ -114,59 +101,41 @@ public class UserTypesTest extends CCMTestsSupport {
 
         Row r = session().execute("SELECT * FROM user WHERE id=?", userId).one();
 
-        assertEquals(r.getInt("id"), 1);
-        assertEquals(r.getUDTValue("addr"), addr);
+        assertThat(r.getInt("id")).isEqualTo(userId);
+        assertThat(r.getUDTValue("addr")).isEqualTo(addr);
     }
 
-    /**
-     * Test for ensuring udts are defined in a particular keyspace.
-     *
-     * @throws Exception
-     */
     @Test(groups = "short")
-    public void nonExistingTypesTest() throws Exception {
-        UserType addrDef = cluster().getMetadata().getKeyspace(keyspace).getUserType("address1");
-        UserType phoneDef = cluster().getMetadata().getKeyspace(keyspace).getUserType("phone1");
-        assertEquals(addrDef, null);
-        assertEquals(phoneDef, null);
+    public void should_store_type_definitions_in_their_keyspace() throws Exception {
+        KeyspaceMetadata thisKeyspace = cluster().getMetadata().getKeyspace(this.keyspace);
 
-        addrDef = cluster().getMetadata().getKeyspace(keyspace).getUserType(quote("\"User Address\""));
-        phoneDef = cluster().getMetadata().getKeyspace(keyspace).getUserType("phone");
-        assertNotEquals(addrDef, null);
-        assertNotEquals(phoneDef, null);
+        // Types that don't exist don't have definitions
+        assertThat(thisKeyspace.getUserType("address1"))
+                .isNull();
+        assertThat(thisKeyspace.getUserType("phone1"))
+                .isNull();
 
-        // create keyspace
-        String nonExistingKeyspace = keyspace + "_nonEx";
-        session().execute("CREATE KEYSPACE " + nonExistingKeyspace + " " +
+        // Types created by this test have definitions
+        assertThat(thisKeyspace.getUserType(quote("\"User Address\"")))
+                .isNotNull();
+        assertThat(thisKeyspace.getUserType("phone"))
+                .isNotNull();
+
+        // If we create another keyspace, it doesn't have the definitions of this keyspace
+        String otherKeyspaceName = this.keyspace + "_nonEx";
+        session().execute("CREATE KEYSPACE " + otherKeyspaceName + " " +
                 "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
-        session().execute("USE " + nonExistingKeyspace);
 
-        addrDef = cluster().getMetadata().getKeyspace(nonExistingKeyspace).getUserType(quote("\"User Address\""));
-        phoneDef = cluster().getMetadata().getKeyspace(nonExistingKeyspace).getUserType("phone");
-        assertEquals(addrDef, null);
-        assertEquals(phoneDef, null);
-
-        session().execute("USE " + keyspace);
-
-        addrDef = cluster().getMetadata().getKeyspace(keyspace).getUserType(quote("\"User Address\""));
-        phoneDef = cluster().getMetadata().getKeyspace(keyspace).getUserType("phone");
-        assertNotEquals(addrDef, null);
-        assertNotEquals(phoneDef, null);
+        KeyspaceMetadata otherKeyspace = cluster().getMetadata().getKeyspace(otherKeyspaceName);
+        assertThat(otherKeyspace.getUserType(quote("\"User Address\"")))
+                .isNull();
+        assertThat(otherKeyspace.getUserType("phone"))
+                .isNull();
     }
 
-    /**
-     * Test for ensuring extra-lengthy udts are handled correctly.
-     * Original code found in python-driver:integration.standard.test_udts.py:test_udt_sizes
-     *
-     * @throws Exception
-     */
     @Test(groups = "short")
-    public void udtSizesTest() throws Exception {
+    public void should_handle_UDT_with_many_fields() throws Exception {
         int MAX_TEST_LENGTH = 1024;
-        // create keyspace
-        session().execute("CREATE KEYSPACE test_udt_sizes " +
-                "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
-        session().execute("USE test_udt_sizes");
 
         // create the seed udt
         StringBuilder sb = new StringBuilder();
@@ -179,10 +148,10 @@ public class UserTypesTest extends CCMTestsSupport {
         session().execute(String.format("CREATE TYPE lengthy_udt (%s)", sb.toString()));
 
         // create a table with multiple sizes of udts
-        session().execute("CREATE TABLE mytable (k int PRIMARY KEY, v frozen<lengthy_udt>)");
+        session().execute("CREATE TABLE lengthy_udt_table (k int PRIMARY KEY, v frozen<lengthy_udt>)");
 
         // hold onto the UserType for future use
-        UserType udtDef = cluster().getMetadata().getKeyspace("test_udt_sizes").getUserType("lengthy_udt");
+        UserType udtDef = cluster().getMetadata().getKeyspace(keyspace).getUserType("lengthy_udt");
 
         // verify inserts and reads
         for (int i : Arrays.asList(0, 1, 2, 3, MAX_TEST_LENGTH)) {
@@ -193,28 +162,17 @@ public class UserTypesTest extends CCMTestsSupport {
             }
 
             // write udt
-            session().execute("INSERT INTO mytable (k, v) VALUES (0, ?)", createdUDT);
+            session().execute("INSERT INTO lengthy_udt_table (k, v) VALUES (0, ?)", createdUDT);
 
             // verify udt was written and read correctly
-            UDTValue r = session().execute("SELECT v FROM mytable WHERE k=0")
+            UDTValue r = session().execute("SELECT v FROM lengthy_udt_table WHERE k=0")
                     .one().getUDTValue("v");
-            assertEquals(r.toString(), createdUDT.toString());
+            assertThat(r.toString()).isEqualTo(createdUDT.toString());
         }
     }
 
-    /**
-     * Test for inserting various types of DATA_TYPE_PRIMITIVES into UDT's.
-     * Original code found in python-driver:integration.standard.test_udts.py:test_primitive_datatypes
-     *
-     * @throws Exception
-     */
     @Test(groups = "short")
-    public void testPrimitiveDatatypes() throws Exception {
-        // create keyspace
-        session().execute("CREATE KEYSPACE testPrimitiveDatatypes " +
-                "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
-        session().execute("USE testPrimitiveDatatypes");
-
+    public void should_store_and_retrieve_UDT_containing_any_primitive_type() throws Exception {
         // create UDT
         List<String> alpha_type_list = new ArrayList<String>();
         int startIndex = (int) 'a';
@@ -224,10 +182,10 @@ public class UserTypesTest extends CCMTestsSupport {
         }
 
         session().execute(String.format("CREATE TYPE alldatatypes (%s)", Joiner.on(',').join(alpha_type_list)));
-        session().execute("CREATE TABLE mytable (a int PRIMARY KEY, b frozen<alldatatypes>)");
+        session().execute("CREATE TABLE alldatatypes_table (a int PRIMARY KEY, b frozen<alldatatypes>)");
 
         // insert UDT data
-        UserType alldatatypesDef = cluster().getMetadata().getKeyspace("testPrimitiveDatatypes").getUserType("alldatatypes");
+        UserType alldatatypesDef = cluster().getMetadata().getKeyspace(keyspace).getUserType("alldatatypes");
         UDTValue alldatatypes = alldatatypesDef.newValue();
 
 
@@ -241,24 +199,24 @@ public class UserTypesTest extends CCMTestsSupport {
                     alldatatypes.setString(index, (String) sampleData);
                     break;
                 case BIGINT:
-                    alldatatypes.setLong(index, ((Long) sampleData).longValue());
+                    alldatatypes.setLong(index, (Long) sampleData);
                     break;
                 case BLOB:
                     alldatatypes.setBytes(index, (ByteBuffer) sampleData);
                     break;
                 case BOOLEAN:
-                    alldatatypes.setBool(index, ((Boolean) sampleData).booleanValue());
+                    alldatatypes.setBool(index, (Boolean) sampleData);
                     break;
                 case DECIMAL:
                     alldatatypes.setDecimal(index, (BigDecimal) sampleData);
                     break;
                 case DOUBLE:
-                    alldatatypes.setDouble(index, ((Double) sampleData).doubleValue());
+                    alldatatypes.setDouble(index, (Double) sampleData);
                     break;
                 case DURATION:
                     alldatatypes.set(index, Duration.from(sampleData.toString()), Duration.class);
                 case FLOAT:
-                    alldatatypes.setFloat(index, ((Float) sampleData).floatValue());
+                    alldatatypes.setFloat(index, (Float) sampleData);
                     break;
                 case INET:
                     alldatatypes.setInet(index, (InetAddress) sampleData);
@@ -270,7 +228,7 @@ public class UserTypesTest extends CCMTestsSupport {
                     alldatatypes.setShort(index, (Short) sampleData);
                     break;
                 case INT:
-                    alldatatypes.setInt(index, ((Integer) sampleData).intValue());
+                    alldatatypes.setInt(index, (Integer) sampleData);
                     break;
                 case TEXT:
                     alldatatypes.setString(index, (String) sampleData);
@@ -299,33 +257,22 @@ public class UserTypesTest extends CCMTestsSupport {
             }
         }
 
-        PreparedStatement ins = session().prepare("INSERT INTO mytable (a, b) VALUES (?, ?)");
+        PreparedStatement ins = session().prepare("INSERT INTO alldatatypes_table (a, b) VALUES (?, ?)");
         session().execute(ins.bind(0, alldatatypes));
 
         // retrieve and verify data
-        ResultSet rs = session().execute("SELECT * FROM mytable");
+        ResultSet rs = session().execute("SELECT * FROM alldatatypes_table");
         List<Row> rows = rs.all();
-        assertEquals(1, rows.size());
+        assertThat(rows.size()).isEqualTo(1);
 
         Row row = rows.get(0);
 
-        assertEquals(row.getInt("a"), 0);
-        assertEquals(row.getUDTValue("b"), alldatatypes);
+        assertThat(row.getInt("a")).isEqualTo(0);
+        assertThat(row.getUDTValue("b")).isEqualTo(alldatatypes);
     }
 
-    /**
-     * Test for inserting various types of DATA_TYPE_NON_PRIMITIVE into UDT's
-     * Original code found in python-driver:integration.standard.test_udts.py:test_nonprimitive_datatypes
-     *
-     * @throws Exception
-     */
     @Test(groups = "short")
-    public void testNonPrimitiveDatatypes() throws Exception {
-        // create keyspace
-        session().execute("CREATE KEYSPACE test_nonprimitive_datatypes " +
-                "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
-        session().execute("USE test_nonprimitive_datatypes");
-
+    public void should_store_and_retrieve_UDT_containing_collections_and_tuples() throws Exception {
         // counters and durations are not allowed inside collections
         DATA_TYPE_PRIMITIVES.remove(DataType.counter());
         DATA_TYPE_PRIMITIVES.remove(DataType.duration());
@@ -352,12 +299,12 @@ public class UserTypesTest extends CCMTestsSupport {
                 alpha_type_list.add(typeString);
             }
 
-        session().execute(String.format("CREATE TYPE alldatatypes (%s)", Joiner.on(',').join(alpha_type_list)));
-        session().execute("CREATE TABLE mytable (a int PRIMARY KEY, b frozen<alldatatypes>)");
+        session().execute(String.format("CREATE TYPE allcollectiontypes (%s)", Joiner.on(',').join(alpha_type_list)));
+        session().execute("CREATE TABLE allcollectiontypes_table (a int PRIMARY KEY, b frozen<allcollectiontypes>)");
 
         // insert UDT data
-        UserType alldatatypesDef = cluster().getMetadata().getKeyspace("test_nonprimitive_datatypes").getUserType("alldatatypes");
-        UDTValue alldatatypes = alldatatypesDef.newValue();
+        UserType allcollectiontypesDef = cluster().getMetadata().getKeyspace(keyspace).getUserType("allcollectiontypes");
+        UDTValue allcollectiontypes = allcollectiontypesDef.newValue();
 
         for (int i = 0; i < DATA_TYPE_NON_PRIMITIVE_NAMES.size(); i++)
             for (int j = 0; j < DATA_TYPE_PRIMITIVES.size(); j++) {
@@ -368,46 +315,36 @@ public class UserTypesTest extends CCMTestsSupport {
                 Object sampleElement = samples.get(dataType);
                 switch (name) {
                     case LIST:
-                        alldatatypes.setList(index, Lists.newArrayList(sampleElement));
+                        allcollectiontypes.setList(index, Lists.newArrayList(sampleElement));
                         break;
                     case SET:
-                        alldatatypes.setSet(index, Sets.newHashSet(sampleElement));
+                        allcollectiontypes.setSet(index, Sets.newHashSet(sampleElement));
                         break;
                     case MAP:
-                        alldatatypes.setMap(index, ImmutableMap.of(sampleElement, sampleElement));
+                        allcollectiontypes.setMap(index, ImmutableMap.of(sampleElement, sampleElement));
                         break;
                     case TUPLE:
-                        alldatatypes.setTupleValue(index, cluster().getMetadata().newTupleType(dataType).newValue(sampleElement));
+                        allcollectiontypes.setTupleValue(index, cluster().getMetadata().newTupleType(dataType).newValue(sampleElement));
                 }
             }
 
-        PreparedStatement ins = session().prepare("INSERT INTO mytable (a, b) VALUES (?, ?)");
-        session().execute(ins.bind(0, alldatatypes));
+        PreparedStatement ins = session().prepare("INSERT INTO allcollectiontypes_table (a, b) VALUES (?, ?)");
+        session().execute(ins.bind(0, allcollectiontypes));
 
         // retrieve and verify data
-        ResultSet rs = session().execute("SELECT * FROM mytable");
+        ResultSet rs = session().execute("SELECT * FROM allcollectiontypes_table");
         List<Row> rows = rs.all();
-        assertEquals(1, rows.size());
+        assertThat(rows.size()).isEqualTo(1);
 
         Row row = rows.get(0);
 
-        assertEquals(row.getInt("a"), 0);
-        assertEquals(row.getUDTValue("b"), alldatatypes);
+        assertThat(row.getInt("a")).isEqualTo(0);
+        assertThat(row.getUDTValue("b")).isEqualTo(allcollectiontypes);
     }
 
-    /**
-     * Test for ensuring nested UDT's are handled correctly.
-     * Original code found in python-driver:integration.standard.test_udts.py:test_nested_registered_udts
-     *
-     * @throws Exception
-     */
     @Test(groups = "short")
-    public void udtNestedTest() throws Exception {
+    public void should_save_and_retrieve_nested_UDTs() throws Exception {
         final int MAX_NESTING_DEPTH = 4;
-        // create keyspace
-        session().execute("CREATE KEYSPACE udtNestedTest " +
-                "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
-        session().execute("USE udtNestedTest");
 
         // create UDT
         session().execute("CREATE TYPE depth_0 (age int, name text)");
@@ -416,139 +353,119 @@ public class UserTypesTest extends CCMTestsSupport {
             session().execute(String.format("CREATE TYPE depth_%s (value frozen<depth_%s>)", String.valueOf(i), String.valueOf(i - 1)));
         }
 
-        session().execute(String.format("CREATE TABLE mytable (a int PRIMARY KEY, b frozen<depth_0>, c frozen<depth_1>, d frozen<depth_2>, e frozen<depth_3>," +
+        session().execute(String.format("CREATE TABLE nested_udt_table (a int PRIMARY KEY, b frozen<depth_0>, c frozen<depth_1>, d frozen<depth_2>, e frozen<depth_3>," +
                 "f frozen<depth_%s>)", MAX_NESTING_DEPTH));
 
         // insert UDT data
-        UserType depthZeroDef = cluster().getMetadata().getKeyspace("udtNestedTest").getUserType("depth_0");
+        KeyspaceMetadata keyspaceMetadata = cluster().getMetadata().getKeyspace(keyspace);
+        UserType depthZeroDef = keyspaceMetadata.getUserType("depth_0");
         UDTValue depthZero = depthZeroDef.newValue().setInt("age", 42).setString("name", "Bob");
 
-        UserType depthOneDef = cluster().getMetadata().getKeyspace("udtNestedTest").getUserType("depth_1");
+        UserType depthOneDef = keyspaceMetadata.getUserType("depth_1");
         UDTValue depthOne = depthOneDef.newValue().setUDTValue("value", depthZero);
 
-        UserType depthTwoDef = cluster().getMetadata().getKeyspace("udtNestedTest").getUserType("depth_2");
+        UserType depthTwoDef = keyspaceMetadata.getUserType("depth_2");
         UDTValue depthTwo = depthTwoDef.newValue().setUDTValue("value", depthOne);
 
-        UserType depthThreeDef = cluster().getMetadata().getKeyspace("udtNestedTest").getUserType("depth_3");
+        UserType depthThreeDef = keyspaceMetadata.getUserType("depth_3");
         UDTValue depthThree = depthThreeDef.newValue().setUDTValue("value", depthTwo);
 
-        UserType depthFourDef = cluster().getMetadata().getKeyspace("udtNestedTest").getUserType("depth_4");
+        UserType depthFourDef = keyspaceMetadata.getUserType("depth_4");
         UDTValue depthFour = depthFourDef.newValue().setUDTValue("value", depthThree);
 
-        PreparedStatement ins = session().prepare("INSERT INTO mytable (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)");
+        PreparedStatement ins = session().prepare("INSERT INTO nested_udt_table (a, b, c, d, e, f) VALUES (?, ?, ?, ?, ?, ?)");
         session().execute(ins.bind(0, depthZero, depthOne, depthTwo, depthThree, depthFour));
 
         // retrieve and verify data
-        ResultSet rs = session().execute("SELECT * FROM mytable");
+        ResultSet rs = session().execute("SELECT * FROM nested_udt_table");
         List<Row> rows = rs.all();
-        assertEquals(1, rows.size());
+        assertThat(rows.size()).isEqualTo(1);
 
         Row row = rows.get(0);
 
-        assertEquals(row.getInt("a"), 0);
-        assertEquals(row.getUDTValue("b"), depthZero);
-        assertEquals(row.getUDTValue("c"), depthOne);
-        assertEquals(row.getUDTValue("d"), depthTwo);
-        assertEquals(row.getUDTValue("e"), depthThree);
-        assertEquals(row.getUDTValue("f"), depthFour);
+        assertThat(row.getInt("a")).isEqualTo(0);
+        assertThat(row.getUDTValue("b")).isEqualTo(depthZero);
+        assertThat(row.getUDTValue("c")).isEqualTo(depthOne);
+        assertThat(row.getUDTValue("d")).isEqualTo(depthTwo);
+        assertThat(row.getUDTValue("e")).isEqualTo(depthThree);
+        assertThat(row.getUDTValue("f")).isEqualTo(depthFour);
     }
 
-    /**
-     * Test for inserting null values into UDT's
-     * Original code found in python-driver:integration.standard.test_udts.py:test_udts_with_nulls
-     *
-     * @throws Exception
-     */
     @Test(groups = "short")
-    public void testUdtsWithNulls() throws Exception {
-        // create keyspace
-        session().execute("CREATE KEYSPACE testUdtsWithNulls " +
-                "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
-        session().execute("USE testUdtsWithNulls");
-
+    public void should_save_and_retrieve_UDTs_with_null_values() throws Exception {
         // create UDT
-        session().execute("CREATE TYPE user (a text, b int, c uuid, d blob)");
-        session().execute("CREATE TABLE mytable (a int PRIMARY KEY, b frozen<user>)");
+        session().execute("CREATE TYPE user_null_values (a text, b int, c uuid, d blob)");
+        session().execute("CREATE TABLE null_values_table (a int PRIMARY KEY, b frozen<user_null_values>)");
 
         // insert UDT data
-        UserType userTypeDef = cluster().getMetadata().getKeyspace("testUdtsWithNulls").getUserType("user");
+        UserType userTypeDef = cluster().getMetadata().getKeyspace(keyspace).getUserType("user_null_values");
         UDTValue userType = userTypeDef.newValue().setString("a", null).setInt("b", 0).setUUID("c", null).setBytes("d", null);
 
-        PreparedStatement ins = session().prepare("INSERT INTO mytable (a, b) VALUES (?, ?)");
+        PreparedStatement ins = session().prepare("INSERT INTO null_values_table (a, b) VALUES (?, ?)");
         session().execute(ins.bind(0, userType));
 
         // retrieve and verify data
-        ResultSet rs = session().execute("SELECT * FROM mytable");
+        ResultSet rs = session().execute("SELECT * FROM null_values_table");
         List<Row> rows = rs.all();
-        assertEquals(1, rows.size());
+        assertThat(rows.size()).isEqualTo(1);
 
         Row row = rows.get(0);
 
-        assertEquals(row.getInt("a"), 0);
-        assertEquals(row.getUDTValue("b"), userType);
+        assertThat(row.getInt("a")).isEqualTo(0);
+        assertThat(row.getUDTValue("b")).isEqualTo(userType);
 
         // test empty strings
         userType = userTypeDef.newValue().setString("a", "").setInt("b", 0).setUUID("c", null).setBytes("d", ByteBuffer.allocate(0));
         session().execute(ins.bind(0, userType));
 
         // retrieve and verify data
-        rs = session().execute("SELECT * FROM mytable");
+        rs = session().execute("SELECT * FROM null_values_table");
         rows = rs.all();
-        assertEquals(1, rows.size());
+        assertThat(rows.size()).isEqualTo(1);
 
         row = rows.get(0);
 
-        assertEquals(row.getInt("a"), 0);
-        assertEquals(row.getUDTValue("b"), userType);
+        assertThat(row.getInt("a")).isEqualTo(0);
+        assertThat(row.getUDTValue("b")).isEqualTo(userType);
     }
 
-    /**
-     * Test for inserting null values into collections of UDT's
-     *
-     * @throws Exception
-     */
     @Test(groups = "short")
-    public void testUdtsWithCollectionNulls() throws Exception {
-        // create keyspace
-        session().execute("CREATE KEYSPACE testUdtsWithCollectionNulls " +
-                "WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}");
-        session().execute("USE testUdtsWithCollectionNulls");
-
+    public void should_save_and_retrieve_UDTs_with_null_collections() throws Exception {
         // create UDT
-        session().execute("CREATE TYPE user (a List<text>, b Set<text>, c Map<text, text>, d frozen<Tuple<text>>)");
-        session().execute("CREATE TABLE mytable (a int PRIMARY KEY, b frozen<user>)");
+        session().execute("CREATE TYPE user_null_collections (a List<text>, b Set<text>, c Map<text, text>, d frozen<Tuple<text>>)");
+        session().execute("CREATE TABLE null_collections_table (a int PRIMARY KEY, b frozen<user_null_collections>)");
 
         // insert null UDT data
-        PreparedStatement ins = session().prepare("INSERT INTO mytable (a, b) " +
+        PreparedStatement ins = session().prepare("INSERT INTO null_collections_table (a, b) " +
                 "VALUES (0, { a: ?, b: ?, c: ?, d: ? })");
         session().execute(ins.bind().setList(0, null).setSet(1, null).setMap(2, null).setTupleValue(3, null));
 
         // retrieve and verify data
-        ResultSet rs = session().execute("SELECT * FROM mytable");
+        ResultSet rs = session().execute("SELECT * FROM null_collections_table");
         List<Row> rows = rs.all();
-        assertEquals(1, rows.size());
+        assertThat(rows.size()).isEqualTo(1);
 
         Row row = rows.get(0);
-        assertEquals(row.getInt("a"), 0);
+        assertThat(row.getInt("a")).isEqualTo(0);
 
-        UserType userTypeDef = cluster().getMetadata().getKeyspace("testUdtsWithCollectionNulls").getUserType("user");
+        UserType userTypeDef = cluster().getMetadata().getKeyspace(keyspace).getUserType("user_null_collections");
         UDTValue userType = userTypeDef.newValue().setList("a", null).setSet("b", null).setMap("c", null).setTupleValue("d", null);
-        assertEquals(row.getUDTValue("b"), userType);
+        assertThat(row.getUDTValue("b")).isEqualTo(userType);
 
         // test missing UDT args
-        ins = session().prepare("INSERT INTO mytable (a, b) " +
+        ins = session().prepare("INSERT INTO null_collections_table (a, b) " +
                 "VALUES (1, { a: ? })");
         session().execute(ins.bind().setList(0, new ArrayList<Object>()));
 
         // retrieve and verify data
-        rs = session().execute("SELECT * FROM mytable");
+        rs = session().execute("SELECT * FROM null_collections_table");
         rows = rs.all();
-        assertEquals(2, rows.size());
+        assertThat(rows.size()).isEqualTo(2);
 
         row = rows.get(0);
-        assertEquals(row.getInt("a"), 1);
+        assertThat(row.getInt("a")).isEqualTo(1);
 
         userType = userTypeDef.newValue().setList(0, new ArrayList<Object>());
-        assertEquals(row.getUDTValue("b"), userType);
+        assertThat(row.getUDTValue("b")).isEqualTo(userType);
     }
 }


### PR DESCRIPTION
Notes:
* `isFrozen()` used to be hard-coded to true, but the default is now false. I think it makes more sense in a context where frozenness does not apply, for example when retrieving the UDT definition directly from the cluster metadata.
* I've not updated `equals` and `hashCode`. Whether a UDT is frozen or not, it's still the same type, I can't think of a situation where it would make sense to differentiate (the opposite seems more likely, e.g. you retrieve the type of a frozen column, it should be equal to the metadata one).