### PR TITLE
Fixes for miscellaneous unreliable tests

### DIFF
--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperSaveNullFieldsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperSaveNullFieldsTest.java
@@ -17,6 +17,7 @@ package com.datastax.driver.mapping;
 
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.CCMTestsSupport;
+import com.datastax.driver.core.utils.CassandraVersion;
 import com.datastax.driver.mapping.Mapper.Option;
 import com.datastax.driver.mapping.annotations.PartitionKey;
 import com.datastax.driver.mapping.annotations.Table;
@@ -40,6 +41,7 @@ public class MapperSaveNullFieldsTest extends CCMTestsSupport {
         mapper = new MappingManager(session()).mapper(User.class);
     }
 
+    @CassandraVersion("2.1.0")
     @Test(groups = "short")
     void should_save_null_fields_if_requested() {
         should_save_null_fields(true, Option.saveNullFields(true));


### PR DESCRIPTION
If both the inserts occur in the same millisecond for the NullFieldsTest in C* <2.1.x the order of operations can be un predictable due to the use of server side timestamps.


We need to allow for the request have a connection allocated to it prior simulating the success response in the  Should_wait_on_connection_if_zero_core_connections() test.


The pool logic changed in such a way for  the should_adjust_connection_keyspace_on_dequeue_if_pool_state_is_different test needs to wait longer then the default pool timeout.
