### PR TITLE
Support Duration type in PrimitiveTypeSamples.

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
@@ -264,7 +264,9 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
             Object elementSample = entry.getValue();
 
             tables.add(new TestTable(DataType.list(elementType), Lists.newArrayList(elementSample, elementSample), "1.2.0"));
-            tables.add(new TestTable(DataType.set(elementType), Sets.newHashSet(elementSample), "1.2.0"));
+            // Duration not supported in Set
+            if (elementType != DataType.duration())
+                tables.add(new TestTable(DataType.set(elementType), Sets.newHashSet(elementSample), "1.2.0"));
         }
         return tables;
     }
@@ -272,7 +274,11 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
     private List<TestTable> tablesWithMapsOfPrimitives() {
         List<TestTable> tables = Lists.newArrayList();
         for (Map.Entry<DataType, Object> keyEntry : samples.entrySet()) {
+            // Duration not supported as Map key
             DataType keyType = keyEntry.getKey();
+            if (keyType == DataType.duration())
+                continue;
+
             Object keySample = keyEntry.getValue();
             for (Map.Entry<DataType, Object> valueEntry : samples.entrySet()) {
                 DataType valueType = valueEntry.getKey();
@@ -467,6 +473,8 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
                 return data.getMap(0,
                         codecRegistry.codecFor(dataType.getTypeArguments().get(0)).getJavaType(),
                         codecRegistry.codecFor(dataType.getTypeArguments().get(1)).getJavaType());
+            case DURATION:
+                return data.get(0, Duration.class);
             case CUSTOM:
             case COUNTER:
             default:

--- a/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataTypeIntegrationTest.java
@@ -217,7 +217,7 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
     private List<TestTable> tablesWithPrimitivesNull() {
         List<TestTable> tables = Lists.newArrayList();
         // Create a test table for each primitive type testing with null values.  If the
-        // type maps to a java primitive type it's value will by the default value instead of null.
+        // type maps to a java primitive type it's value will be the default one specified here instead of null.
         for (DataType dataType : TestUtils.allPrimitiveTypes(ccm().getProtocolVersion())) {
             Object expectedPrimitiveValue = null;
             switch (dataType.getName()) {
@@ -243,10 +243,8 @@ public class DataTypeIntegrationTest extends CCMTestsSupport {
                 case BOOLEAN:
                     expectedPrimitiveValue = false;
                     break;
-                case COUNTER:
-                case DURATION:
-                    // Duration is handled separately in DurationIntegrationTest, because it has specific restrictions (e.g.
-                    // not allowed in collections).
+                default:
+                    // not a Java primitive type
                     continue;
             }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/PrimitiveTypeSamples.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/PrimitiveTypeSamples.java
@@ -51,6 +51,7 @@ public class PrimitiveTypeSamples {
                     .put(DataType.tinyint(), Byte.MAX_VALUE)
                     .put(DataType.smallint(), Short.MAX_VALUE)
                     .put(DataType.cint(), Integer.MAX_VALUE)
+                    .put(DataType.duration(), Duration.from("PT30H20M"))
                     .put(DataType.text(), "text")
                     .put(DataType.timestamp(), new Date(872835240000L))
                     .put(DataType.date(), LocalDate.fromDaysSinceEpoch(16071))
@@ -74,9 +75,7 @@ public class PrimitiveTypeSamples {
             List<DataType> tmp = Lists.newArrayList(primitiveTypes);
             tmp.removeAll(result.keySet());
 
-            List<DataType> expectedFilteredTypes = protocolVersion.compareTo(ProtocolVersion.V5) >= 0 ?
-                    Lists.newArrayList(DataType.counter(), DataType.duration()) :
-                    Lists.newArrayList(DataType.counter());
+            List<DataType> expectedFilteredTypes = Lists.newArrayList(DataType.counter());
 
             assertThat(tmp)
                     .as("new datatype not covered in test")

--- a/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TupleTest.java
@@ -277,12 +277,16 @@ public class TupleTest extends CCMTestsSupport {
 
         // create set values
         for (DataType datatype : DATA_TYPE_PRIMITIVES) {
-            values.add(String.format("v_%s frozen<tuple<set<%s>>>", values.size(), datatype));
+            // Duration not supported in Set.
+            if (datatype != DataType.duration())
+                values.add(String.format("v_%s frozen<tuple<set<%s>>>", values.size(), datatype));
         }
 
         // create map values
         for (DataType datatype : DATA_TYPE_PRIMITIVES) {
-            values.add(String.format("v_%s frozen<tuple<map<%s, %s>>>", values.size(), datatype, datatype));
+            // Duration not supported as Map key.
+            if (datatype != DataType.duration())
+                values.add(String.format("v_%s frozen<tuple<map<%s, %s>>>", values.size(), datatype, datatype));
         }
 
         // create table
@@ -315,6 +319,9 @@ public class TupleTest extends CCMTestsSupport {
 
         // test tuple<set<datatype>>
         for (DataType datatype : DATA_TYPE_PRIMITIVES) {
+            if (datatype == DataType.duration())
+                continue;
+
             // create tuple
             ArrayList<DataType> dataTypes = new ArrayList<DataType>();
             ArrayList<Object> createdValues = new ArrayList<Object>();
@@ -338,6 +345,8 @@ public class TupleTest extends CCMTestsSupport {
 
         // test tuple<map<datatype, datatype>>
         for (DataType datatype : DATA_TYPE_PRIMITIVES) {
+            if (datatype == DataType.duration())
+                continue;
             // create tuple
             ArrayList<DataType> dataTypes = new ArrayList<DataType>();
             ArrayList<Object> createdValues = new ArrayList<Object>();

--- a/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/UserTypesTest.java
@@ -216,6 +216,7 @@ public class UserTypesTest extends CCMTestsSupport {
                     break;
                 case DURATION:
                     alldatatypes.set(index, Duration.from(sampleData.toString()), Duration.class);
+                    break;
                 case FLOAT:
                     alldatatypes.setFloat(index, (Float) sampleData);
                     break;


### PR DESCRIPTION
A number of tests use PrimitiveTypeSamples for getting sample values for
given DataTypes.  Duration was previously omitted from this because it
is not supported in Set or Map keys.  Special case tests that involve
using these samples for Map and Sets so we get better Duration coverage.

In addition, this fixes a bug in UserTypesTest where it attempts to
resolve a sample for Duration but one is not found.

Since `Duration` is part of protocol V5, this is not currently exercised in our main testing, but tried this out with V5 and it works.