### PR TITLE
JAVA-1438: QueryBuilder check for empty orderings

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -6,6 +6,7 @@
 - [bug] JAVA-1599: exportAsString improvements (sort, format, clustering order)
 - [improvement] JAVA-1587: Deterministic ordering of columns used in Mapper#saveQuery
 - [improvement] JAVA-1500: Add a metric to report number of in-flight requests.
+- [bug] JAVA-1438: QueryBuilder check for empty orderings.
 
 
 ### 3.3.0

--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Select.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Select.java
@@ -154,6 +154,9 @@ public class Select extends BuiltStatement {
         if (this.orderings != null)
             throw new IllegalStateException("An ORDER BY clause has already been provided");
 
+        if (orderings.length == 0)
+            throw new IllegalArgumentException("Invalid ORDER BY argument, the orderings must not be empty.");
+
         this.orderings = Arrays.asList(orderings);
         for (Ordering ordering : orderings)
             checkForBindMarkers(ordering);

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -158,6 +158,10 @@ public class QueryBuilderTest {
         select = select().from("foo").where(like("e", "a%"));
         assertEquals(select.toString(), query);
 
+        query = "SELECT * FROM foo;";
+        select = select().from("foo").orderBy(new Ordering[0]);
+        assertEquals(select.toString(), query);
+
         try {
             select().countAll().from("foo").orderBy(asc("a"), desc("b")).orderBy(asc("a"), desc("b"));
             fail("Expected an IllegalStateException");

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderTest.java
@@ -158,15 +158,18 @@ public class QueryBuilderTest {
         select = select().from("foo").where(like("e", "a%"));
         assertEquals(select.toString(), query);
 
-        query = "SELECT * FROM foo;";
-        select = select().from("foo").orderBy(new Ordering[0]);
-        assertEquals(select.toString(), query);
-
         try {
             select().countAll().from("foo").orderBy(asc("a"), desc("b")).orderBy(asc("a"), desc("b"));
             fail("Expected an IllegalStateException");
         } catch (IllegalStateException e) {
             assertEquals(e.getMessage(), "An ORDER BY clause has already been provided");
+        }
+
+        try {
+            select().from("foo").orderBy();
+            fail("Expected an IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid ORDER BY argument, the orderings must not be empty.");
         }
 
         try {


### PR DESCRIPTION
Added orderings.isEmpty check before QueryBuilder adds ORDER BY clause