### PR TITLE
Skip all null field tests if C*< 2.1.0

### DIFF
--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperSaveNullFieldsTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperSaveNullFieldsTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("unused")
+@CassandraVersion("2.1.0")
 public class MapperSaveNullFieldsTest extends CCMTestsSupport {
 
     Mapper<User> mapper;
@@ -41,7 +42,6 @@ public class MapperSaveNullFieldsTest extends CCMTestsSupport {
         mapper = new MappingManager(session()).mapper(User.class);
     }
 
-    @CassandraVersion("2.1.0")
     @Test(groups = "short")
     void should_save_null_fields_if_requested() {
         should_save_null_fields(true, Option.saveNullFields(true));


### PR DESCRIPTION
This skip should have been scoped to all null field mapper tests.