### PR TITLE
JAVA-1428: Upgrade logback and jackson dependencies

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@
 - [bug] JAVA-1455: Mapper support using unset for null values.
 - [bug] JAVA-1464: Allow custom codecs with non public constructors in @Param.
 - [bug] JAVA-1470: Querying multiple pages overrides WrappedStatement.
+- [improvement] JAVA-1428: Upgrade logback and jackson dependencies.
 
 
 ### 3.2.0

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -54,6 +54,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.jnr</groupId>
             <artifactId>jnr-ffi</artifactId>
             <version>${jnr-ffi.version}</version>

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -34,7 +34,6 @@
         <jax-rs.version>2.0.1</jax-rs.version>
         <jersey.version>2.23.1</jersey.version>
         <hk2.version>2.4.0-b34</hk2.version>
-        <logback.version>1.1.3</logback.version>
     </properties>
 
     <dependencies>
@@ -66,7 +65,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson-databind.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -119,13 +118,28 @@
             <optional>true</optional>
         </dependency>
 
-
         <!--CDI frameworks (HK2)-->
 
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-api</artifactId>
             <version>${hk2.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Standard annotations -->
+        
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.2</version>
             <optional>true</optional>
         </dependency>
 

--- a/driver-examples/src/main/java/com/datastax/driver/examples/paging/RandomPagingRestUi.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/paging/RandomPagingRestUi.java
@@ -16,7 +16,6 @@
 package com.datastax.driver.examples.paging;
 
 import com.datastax.driver.core.*;
-import com.google.common.collect.Lists;
 import com.sun.net.httpserver.HttpServer;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.jdkhttp.JdkHttpServerFactory;
@@ -31,6 +30,7 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -227,7 +227,7 @@ public class RandomPagingRestUi {
                 videos = Collections.emptyList();
             } else {
                 int remaining = ITEMS_PER_PAGE;
-                videos = Lists.newArrayListWithExpectedSize(remaining);
+                videos = new ArrayList<UserVideo>(remaining);
                 for (Row row : rs) {
                     UserVideo video = new UserVideo(
                             row.getInt("videoid"),

--- a/driver-extras/pom.xml
+++ b/driver-extras/pom.xml
@@ -51,8 +51,15 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>
+            <optional>true</optional>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson-databind.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -103,6 +110,13 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/driver-mapping/pom.xml
+++ b/driver-mapping/pom.xml
@@ -49,6 +49,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>${testng.version}</version>
@@ -78,22 +90,10 @@
 
         <dependency>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-all</artifactId>
+            <artifactId>asm</artifactId>
             <version>5.0.3</version>
             <scope>test</scope>
         </dependency>
-        <!--
-        <dependency>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm</artifactId>
-          <version>4.1</version>
-        </dependency>
-        <dependency>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm-util</artifactId>
-          <version>4.1</version>
-        </dependency>
-      -->
 
         <dependency>
             <groupId>log4j</groupId>

--- a/driver-tests/osgi/pom.xml
+++ b/driver-tests/osgi/pom.xml
@@ -35,8 +35,6 @@
         <!-- more recent version require JDK7+ -->
         <pax-exam.version>3.6.0</pax-exam.version>
         <url.version>2.4.0</url.version>
-        <logback.version>1.1.3</logback.version>
-        <slf4j.version>1.7.5</slf4j.version>
         <test.groups>none</test.groups>
         <!--
         Skip tests by default, short or long profile is required to run tests in this module
@@ -71,6 +69,12 @@
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
             <version>${felix.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
         </dependency>
 
         <dependency>
@@ -130,16 +134,16 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <version>1</version>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${testng.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -153,13 +157,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
             <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>

--- a/faq/osgi/README.md
+++ b/faq/osgi/README.md
@@ -113,13 +113,13 @@ dependencies:
     <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.12</version>
+        <version>1.7.25</version>
     </dependency>
 
     <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.1.2</version>
+        <version>1.2.3</version>
         <scope>runtime</scope>
     </dependency>
 

--- a/manual/logging/README.md
+++ b/manual/logging/README.md
@@ -19,7 +19,7 @@ For example, if you intend to use [Logback](http://logback.qos.ch), add the foll
 <dependency>
 	<groupId>ch.qos.logback</groupId>
 	<artifactId>logback-classic</artifactId>
-	<version>1.1.3</version>
+	<version>1.2.3</version>
 </dependency>
 ```
 
@@ -29,7 +29,7 @@ If you are using Log4J 1.2 instead, add the following dependency:
 <dependency>
   <groupId>org.slf4j</groupId>
   <artifactId>slf4j-log4j12</artifactId>
-  <version>1.7.12</version>
+  <version>1.7.25</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,8 @@
         <cassandra.version>3.10</cassandra.version>
         <java.version>1.6</java.version>
         <log4j.version>1.2.17</log4j.version>
-        <slf4j-log4j12.version>1.7.6</slf4j-log4j12.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
         <guava.version>19.0</guava.version>
         <netty.version>4.0.44.Final</netty.version>
         <metrics.version>3.2.2</metrics.version>
@@ -57,7 +58,9 @@
         <lz4.version>1.3.0</lz4.version>
         <hdr.version>2.1.9</hdr.version>
         <!-- driver-extras module -->
-        <jackson.version>2.6.3</jackson.version>
+        <jackson.version>2.8.8</jackson.version>
+        <!-- jackson-databind 2.7.x is the last to support java 6 -->
+        <jackson-databind.version>2.7.9.1</jackson-databind.version>
         <joda.version>2.9.1</joda.version>
         <jsr353-api.version>1.0</jsr353-api.version>
         <jsr353-ri.version>1.0.4</jsr353-ri.version>
@@ -69,6 +72,7 @@
         <mockito.version>1.10.8</mockito.version>
         <commons-exec.version>1.3</commons-exec.version>
         <scassandra.version>1.1.2</scassandra.version>
+        <logback.version>1.2.3</logback.version>
         <main.basedir>${project.basedir}</main.basedir>
         <ipprefix>127.0.1.</ipprefix>
         <test.groups>unit</test.groups>
@@ -140,11 +144,13 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.16</version>
                         <configuration>
-                            <property>
-                                <name>usedefaultlisteners</name>
-                                <value>false
-                                </value> <!-- disable default listeners as some of the html reports do a lot of File I/O -->
-                            </property>
+                            <properties>
+                                <property>
+                                    <name>usedefaultlisteners</name>
+                                    <value>false
+                                    </value> <!-- disable default listeners as some of the html reports do a lot of File I/O -->
+                                </property>
+                            </properties>
                             <skip>true</skip>
                             <forkCount>1</forkCount>
                             <reuseForks>false</reuseForks>
@@ -279,8 +285,8 @@
                         <link>http://netty.io/4.0/api/</link>
                         <!-- dependencies from driver-extras -->
                         <link>http://www.joda.org/joda-time/apidocs/</link>
-                        <link>http://fasterxml.github.io/jackson-core/javadoc/2.6/</link>
-                        <link>http://fasterxml.github.io/jackson-databind/javadoc/2.6/</link>
+                        <link>http://fasterxml.github.io/jackson-core/javadoc/2.8/</link>
+                        <link>http://fasterxml.github.io/jackson-databind/javadoc/2.7/</link>
                         <link>https://javaee-spec.java.net/nonav/javadocs/</link>
                     </links>
                     <!-- optional dependencies from other modules (must be explicitly declared here in order to be correctly resolved) -->
@@ -313,7 +319,7 @@
                         <additionalDependency>
                             <groupId>com.fasterxml.jackson.core</groupId>
                             <artifactId>jackson-databind</artifactId>
-                            <version>${jackson.version}</version>
+                            <version>${jackson-databind.version}</version>
                         </additionalDependency>
                         <additionalDependency>
                             <groupId>joda-time</groupId>


### PR DESCRIPTION
While not required dependencies, both logback and jackson have newer
versions that fix bugs and security vulnerabilities.