### PR TITLE
JAVA-1266 & JAVA-1411: Stop using oss-parent and normalize versions across the build

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -9,9 +9,9 @@ platform: x64
 install:
   - ps: .\ci\appveyor.ps1
 build_script:
-  - "set \"JAVA_HOME=%JAVA_8_HOME%\" && mvn install -DskipTests=true -D\"maven.javadoc.skip\"=true -B -V"
+  - "set \"JAVA_HOME=%JAVA_8_HOME%\" && mvn install -DskipTests=true -B -V"
 test_script:
-  - "set \"JAVA_HOME=%JAVA_PLATFORM_HOME%\" && mvn -B -D\"ccm.java.home\"=\"%JAVA_8_HOME%\" -D\"ccm.maxNumberOfNodes\"=1 -D\"cassandra.version\"=%cassandra_version% test -P %test_profile%"
+  - "set \"JAVA_HOME=%JAVA_PLATFORM_HOME%\" && mvn -B -D\"ccm.java.home\"=\"%JAVA_8_HOME%\" -D\"ccm.maxNumberOfNodes\"=1 -D\"cassandra.version\"=%cassandra_version% verify -P %test_profile%"
 on_finish:
   - ps: .\ci\uploadtests.ps1
 cache:

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -16,55 +16,52 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.datastax.cassandra</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>cassandra-driver-core</artifactId>
-    <packaging>bundle</packaging>
     <name>DataStax Java Driver for Apache Cassandra - Core</name>
-    <description>A driver for Apache Cassandra 1.2+ that works exclusively with the Cassandra Query Language version 3
+    <description>
+        A driver for Apache Cassandra 1.2+ that works exclusively with the Cassandra Query Language version 3
         (CQL3) and Cassandra's binary protocol.
     </description>
-    <url>https://github.com/datastax/java-driver</url>
 
     <dependencies>
+
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>${netty.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>${metrics.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.jnr</groupId>
             <artifactId>jnr-ffi</artifactId>
-            <version>${jnr-ffi.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.jnr</groupId>
             <artifactId>jnr-posix</artifactId>
-            <version>${jnr-posix.version}</version>
         </dependency>
 
         <!-- Compression libraries for the protocol. -->
@@ -73,14 +70,12 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>${snappy.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>net.jpountz.lz4</groupId>
             <artifactId>lz4</artifactId>
-            <version>${lz4.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -89,62 +84,48 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <version>${netty.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.hdrhistogram</groupId>
             <artifactId>HdrHistogram</artifactId>
-            <version>${hdr.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>${testng.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scassandra</groupId>
             <artifactId>java-client</artifactId>
-            <version>${scassandra.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
-            <version>${commons-exec.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative</artifactId>
-            <version>2.0.1.Final</version>
             <classifier>${os.detected.classifier}</classifier>
             <scope>test</scope>
         </dependency>
@@ -152,191 +133,166 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
             <scope>test</scope>
         </dependency>
 
     </dependencies>
 
     <build>
+
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
             </resource>
         </resources>
+
         <plugins>
+
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.2</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
                 <executions>
                     <execution>
+                        <id>test-jar</id>
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
-                        <phase>test-compile</phase>
                     </execution>
                 </executions>
             </plugin>
+
+            <!--
+            We avoid packaging bundle because it does not play nicely with the shade plugin, see
+            https://stackoverflow.com/questions/31262032/maven-shade-plugin-and-custom-packaging-type
+            -->
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <version>2.4.0</version>
-                <!--
-                  Default configuration, used by the `bundle` goal that is implicitly bound to the `package` phase
-                  (because the project uses the `bundle` packaging)
-                -->
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>com.datastax.driver.core</Bundle-SymbolicName>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                        <_include>-osgi.bnd</_include>
-                        <Import-Package>
-                            <!-- JNR does not provide OSGi bundles, so exclude it; the driver can live without it -->
-                            <![CDATA[com.google.common.*;version="[16.0.1,22)",!jnr.*,*]]></Import-Package>
                     </instructions>
-                    <supportedProjectTypes>
-                        <supportedProjectType>jar</supportedProjectType>
-                        <supportedProjectType>bundle</supportedProjectType>
-                        <supportedProjectType>pom</supportedProjectType>
-                    </supportedProjectTypes>
+                    <!--
+                    Prevent customized manifest entries from the project's maven-jar-plugin configuration from being read, see
+                    http://apache-felix.18485.x6.nabble.com/how-lt-manifestLocation-gt-is-used-in-maven-bundle-plugin-td4835566.html
+                    -->
+                    <archive>
+                        <forced>true</forced>
+                    </archive>
                 </configuration>
                 <executions>
+                    <!-- Default execution -->
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <configuration>
+                            <manifestLocation>${project.build.outputDirectory}/META-INF</manifestLocation>
+                            <instructions>
+                                <!-- JNR does not provide OSGi bundles, so exclude it; the driver can live without it -->
+                                <Import-Package><![CDATA[com.google.common.*;version="[16.0.1,22)",!jnr.*,*]]></Import-Package>
+                            </instructions>
+                        </configuration>
+                    </execution>
                     <!-- Alternate execution to generate the shaded JAR's manifest -->
                     <execution>
                         <id>bundle-manifest-shaded</id>
-                        <phase>prepare-package</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>manifest</goal>
                         </goals>
                         <configuration>
                             <manifestLocation>${project.build.directory}/META-INF-shaded</manifestLocation>
                             <instructions>
-                                <Import-Package>
-                                    <!--
-                                    JNR does not provide OSGi bundles, so exclude it; the driver can live without it
-                                    Explicitly import javax.security.cert because it's required by Netty, but Netty has been explicitly excluded
-                                    -->
-                                    <![CDATA[com.google.common.*;version="[16.0.1,22)",!jnr.*,!io.netty.*,javax.security.cert,*]]></Import-Package>
+                                <!--
+                                JNR does not provide OSGi bundles, so exclude it; the driver can live without it
+                                Explicitly import javax.security.cert because it's required by Netty, but Netty has been explicitly excluded
+                                -->
+                                <Import-Package><![CDATA[com.google.common.*;version="[16.0.1,22)",!jnr.*,!io.netty.*,javax.security.cert,*]]></Import-Package>
                                 <Private-Package>com.datastax.shaded.*</Private-Package>
                             </instructions>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
+                <configuration>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <artifactSet>
+                        <includes>
+                            <include>io.netty:*</include>
+                        </includes>
+                        <excludes>
+                            <exclude>io.netty:netty-transport-native-epoll</exclude>
+                        </excludes>
+                    </artifactSet>
+                    <relocations>
+                        <relocation>
+                            <pattern>io.netty</pattern>
+                            <shadedPattern>com.datastax.shaded.netty</shadedPattern>
+                        </relocation>
+                    </relocations>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                            <resources>
+                                <resource>META-INF/MANIFEST.MF</resource>
+                                <resource>META-INF/io.netty.versions.properties</resource>
+                                <resource>META-INF/maven/io.netty/netty-buffer/pom.properties</resource>
+                                <resource>META-INF/maven/io.netty/netty-buffer/pom.xml</resource>
+                                <resource>META-INF/maven/io.netty/netty-codec/pom.properties</resource>
+                                <resource>META-INF/maven/io.netty/netty-codec/pom.xml</resource>
+                                <resource>META-INF/maven/io.netty/netty-common/pom.properties</resource>
+                                <resource>META-INF/maven/io.netty/netty-common/pom.xml</resource>
+                                <resource>META-INF/maven/io.netty/netty-handler/pom.properties</resource>
+                                <resource>META-INF/maven/io.netty/netty-handler/pom.xml</resource>
+                                <resource>META-INF/maven/io.netty/netty-transport/pom.properties</resource>
+                                <resource>META-INF/maven/io.netty/netty-transport/pom.xml</resource>
+                            </resources>
+                        </transformer>
+                        <!-- Pick up the alternate manifest that was generated by the alternate execution of the bundle plugin -->
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                            <resource>META-INF/MANIFEST.MF</resource>
+                            <file>${project.build.directory}/META-INF-shaded/MANIFEST.MF</file>
+                        </transformer>
+                    </transformers>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
-                        <configuration>
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <artifactSet>
-                                <includes>
-                                    <include>io.netty:*</include>
-                                </includes>
-                                <excludes>
-                                    <exclude>io.netty:netty-transport-native-epoll</exclude>
-                                </excludes>
-                            </artifactSet>
-                            <relocations>
-                                <relocation>
-                                    <pattern>io.netty</pattern>
-                                    <shadedPattern>com.datastax.shaded.netty</shadedPattern>
-                                </relocation>
-                            </relocations>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
-                                    <resources>
-                                        <resource>META-INF/MANIFEST.MF</resource>
-                                        <resource>META-INF/io.netty.versions.properties</resource>
-                                        <resource>META-INF/maven/io.netty/netty-buffer/pom.properties</resource>
-                                        <resource>META-INF/maven/io.netty/netty-buffer/pom.xml</resource>
-                                        <resource>META-INF/maven/io.netty/netty-codec/pom.properties</resource>
-                                        <resource>META-INF/maven/io.netty/netty-codec/pom.xml</resource>
-                                        <resource>META-INF/maven/io.netty/netty-common/pom.properties</resource>
-                                        <resource>META-INF/maven/io.netty/netty-common/pom.xml</resource>
-                                        <resource>META-INF/maven/io.netty/netty-handler/pom.properties</resource>
-                                        <resource>META-INF/maven/io.netty/netty-handler/pom.xml</resource>
-                                        <resource>META-INF/maven/io.netty/netty-transport/pom.properties</resource>
-                                        <resource>META-INF/maven/io.netty/netty-transport/pom.xml</resource>
-                                    </resources>
-                                </transformer>
-                                <!-- Pick up the alternate manifest that was generated by the alternate execution of the bundle plugin -->
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
-                                    <resource>META-INF/MANIFEST.MF</resource>
-                                    <file>${project.build.directory}/META-INF-shaded/MANIFEST.MF</file>
-                                </transformer>
-                            </transformers>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
+
         </plugins>
 
-        <pluginManagement>
-            <plugins>
-                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-                <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
-                    <configuration>
-                        <lifecycleMappingMetadata>
-                            <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-jar-plugin</artifactId>
-                                        <versionRange>[2.2,)</versionRange>
-                                        <goals>
-                                            <goal>test-jar</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore />
-                                    </action>
-                                </pluginExecution>
-                            </pluginExecutions>
-                        </lifecycleMappingMetadata>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
-            </extension>
-        </extensions>
     </build>
 
     <profiles>
+
         <profile>
             <id>isolated</id>
-            <properties>
-                <env>default</env>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.16</version>
                         <configuration>
                             <skip>false</skip>
                             <includes>
@@ -352,30 +308,8 @@
                 </plugins>
             </build>
         </profile>
+
     </profiles>
-
-    <licenses>
-        <license>
-            <name>Apache 2</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>Apache License Version 2.0</comments>
-        </license>
-    </licenses>
-
-    <scm>
-        <connection>scm:git:git@github.com:datastax/java-driver.git</connection>
-        <developerConnection>scm:git:git@github.com:datastax/java-driver.git</developerConnection>
-        <url>https://github.com/datastax/java-driver</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <developers>
-        <developer>
-            <name>Various</name>
-            <organization>DataStax</organization>
-        </developer>
-    </developers>
 
 </project>
 

--- a/driver-dist/pom.xml
+++ b/driver-dist/pom.xml
@@ -16,83 +16,48 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.datastax.cassandra</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
     </parent>
-    <artifactId>cassandra-driver-dist</artifactId>
 
+    <artifactId>cassandra-driver-dist</artifactId>
     <!-- Should be pom but Javadoc generation requires a "classpath-capable" package -->
     <packaging>jar</packaging>
-
     <name>DataStax Java Driver for Apache Cassandra - Binary distribution</name>
 
-    <!-- These dependencies are only here to ensure proper build order -->
+    <!-- These dependencies are only here to ensure proper build order and proper inclusion of binaries in the final tarball -->
     <dependencies>
+
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-mapping</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-extras</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
     </dependencies>
 
     <build>
+
         <finalName>cassandra-java-driver-${project.version}</finalName>
+
         <plugins>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
-                <executions>
-                    <execution>
-                        <id>dependencies-javadoc</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <includeDependencySources>true</includeDependencySources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.0.0</version>
-                <executions>
-                    <execution>
-                        <id>assemble-binary-tarball</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <appendAssemblyId>false</appendAssemblyId>
-                    <descriptors>
-                        <descriptor>src/assembly/binary-tarball.xml</descriptor>
-                    </descriptors>
-                    <tarLongFileMode>posix</tarLongFileMode>
-                </configuration>
-            </plugin>
+
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
                 <!-- http://stackoverflow.com/questions/13218313/unable-to-disable-generation-of-empty-jar-maven-jar-plugin -->
                 <executions>
                     <execution>
@@ -101,24 +66,84 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <skipSource>true</skipSource>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
+
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
+
         </plugins>
+
     </build>
+
+    <profiles>
+
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>dependencies-javadoc</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <includeDependencySources>true</includeDependencySources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>assemble-binary-tarball</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <descriptors>
+                                <descriptor>src/assembly/binary-tarball.xml</descriptor>
+                            </descriptors>
+                            <tarLongFileMode>posix</tarLongFileMode>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <configuration>
+                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
 
 </project>
 

--- a/driver-dist/src/assembly/binary-tarball.xml
+++ b/driver-dist/src/assembly/binary-tarball.xml
@@ -67,6 +67,9 @@
                             <exclude>com.datastax.cassandra:cassandra-driver-core</exclude>
                             <exclude>com.datastax.cassandra:cassandra-driver-mapping</exclude>
                             <exclude>com.datastax.cassandra:cassandra-driver-extras</exclude>
+                            <!-- already included in lib/core -->
+                            <exclude>com.google.guava:guava</exclude>
+                            <exclude>org.slf4j:slf4j-api</exclude>
                         </excludes>
                         <useTransitiveFiltering>true</useTransitiveFiltering>
                     </dependencySet>
@@ -74,7 +77,7 @@
             </binaries>
         </moduleSet>
 
-        <!-- dependencies of module cassandra:cassandra-driver-extras -->
+        <!-- dependencies of module cassandra-driver-extras -->
         <moduleSet>
             <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
@@ -92,6 +95,7 @@
                             <exclude>com.datastax.cassandra:cassandra-driver-extras</exclude>
                             <!-- already included in lib/core -->
                             <exclude>com.google.guava:guava</exclude>
+                            <exclude>org.slf4j:slf4j-api</exclude>
                         </excludes>
                         <useTransitiveFiltering>true</useTransitiveFiltering>
                     </dependencySet>

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -15,25 +15,19 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>cassandra-driver-parent</artifactId>
-        <groupId>com.datastax.cassandra</groupId>
-        <version>3.2.1-SNAPSHOT</version>
-    </parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>cassandra-driver-examples</artifactId>
+    <parent>
+        <groupId>com.datastax.cassandra</groupId>
+        <artifactId>cassandra-driver-parent</artifactId>
+        <version>3.3.0-SNAPSHOT</version>
+    </parent>
 
+    <artifactId>cassandra-driver-examples</artifactId>
     <name>DataStax Java Driver for Apache Cassandra - Examples</name>
     <description>A collection of examples to demonstrate DataStax Java Driver for Apache Cassandra.</description>
-    <url>https://github.com/datastax/java-driver</url>
-
-    <properties>
-        <jax-rs.version>2.0.1</jax-rs.version>
-        <jersey.version>2.23.1</jersey.version>
-        <hk2.version>2.4.0-b34</hk2.version>
-    </properties>
 
     <dependencies>
 
@@ -42,13 +36,11 @@
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-extras</artifactId>
-            <version>${project.parent.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -57,14 +49,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -73,14 +63,12 @@
         <dependency>
             <groupId>javax.json</groupId>
             <artifactId>javax.json-api</artifactId>
-            <version>${jsr353-api.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
-            <version>${jsr353-ri.version}</version>
             <optional>true</optional>
             <scope>runtime</scope>
         </dependency>
@@ -90,7 +78,6 @@
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>${jax-rs.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -99,21 +86,18 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>${jersey.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>${jersey.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-jdk-http</artifactId>
-            <version>${jersey.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -122,7 +106,6 @@
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-api</artifactId>
-            <version>${hk2.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -131,14 +114,12 @@
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
-            <version>1</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-            <version>1.2</version>
             <optional>true</optional>
         </dependency>
 
@@ -147,7 +128,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
         </dependency>
 
     </dependencies>
@@ -159,7 +139,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.15</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -168,25 +147,34 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>clirr-maven-plugin</artifactId>
-                <version>2.7</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -196,27 +184,23 @@
 
     </build>
 
-    <licenses>
-        <license>
-            <name>Apache 2</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>Apache License Version 2.0</comments>
-        </license>
-    </licenses>
+    <profiles>
 
-    <scm>
-        <connection>scm:git:git@github.com:datastax/java-driver.git</connection>
-        <developerConnection>scm:git:git@github.com:datastax/java-driver.git</developerConnection>
-        <url>https://github.com/datastax/java-driver</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <developers>
-        <developer>
-            <name>Various</name>
-            <organization>DataStax</organization>
-        </developer>
-    </developers>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <configuration>
+                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        
+    </profiles>
 
 </project>

--- a/driver-extras/pom.xml
+++ b/driver-extras/pom.xml
@@ -15,71 +15,60 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>cassandra-driver-parent</artifactId>
-        <groupId>com.datastax.cassandra</groupId>
-        <version>3.2.1-SNAPSHOT</version>
-    </parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.datastax.cassandra</groupId>
+        <artifactId>cassandra-driver-parent</artifactId>
+        <version>3.3.0-SNAPSHOT</version>
+    </parent>
 
     <artifactId>cassandra-driver-extras</artifactId>
     <packaging>bundle</packaging>
     <name>DataStax Java Driver for Apache Cassandra - Extras</name>
     <description>Extended functionality for the Java driver.</description>
-    <url>https://github.com/datastax/java-driver</url>
-
-    <properties>
-        <test.groups>unit</test.groups>
-        <jdk8.excludes>none</jdk8.excludes>
-    </properties>
 
     <dependencies>
 
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
             <optional>true</optional>
         </dependency>
         
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>${joda.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>javax.json</groupId>
             <artifactId>javax.json-api</artifactId>
-            <version>${jsr353-api.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>${project.parent.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -87,63 +76,48 @@
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-mapping</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>${testng.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-exec</artifactId>
-            <version>${commons-exec.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
-            <version>${jsr353-ri.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-exec</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -154,162 +128,18 @@
         <plugins>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>${jdk8.excludes}</exclude>
-                    </excludes>
-                    <testExcludes>
-                        <exclude>${jdk8.excludes}</exclude>
-                    </testExcludes>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>check</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <signature>
-                                <groupId>org.codehaus.mojo.signature</groupId>
-                                <artifactId>java16</artifactId>
-                                <version>1.0</version>
-                            </signature>
-                            <annotations>
-                                <annotation>com.datastax.driver.extras.codecs.jdk8.IgnoreJDK6Requirement</annotation>
-                            </annotations>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>check-jdk8</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <signature>
-                                <groupId>org.codehaus.mojo.signature</groupId>
-                                <artifactId>java18</artifactId>
-                                <version>1.0</version>
-                            </signature>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
-                <configuration>
-                    <groups>${test.groups}</groups>
-                    <useFile>false</useFile>
-                    <systemPropertyVariables>
-                        <cassandra.version>${cassandra.version}</cassandra.version>
-                        <ipprefix>${ipprefix}</ipprefix>
-                    </systemPropertyVariables>
-                    <classpathDependencyExcludes>
-                        <classpathDependencyExcludes>io.netty:netty-transport-native-epoll</classpathDependencyExcludes>
-                    </classpathDependencyExcludes>
-                    <excludes>
-                        <exclude>${jdk8.excludes}</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <version>2.4.0</version>
-                <executions>
-                    <execution>
-                        <id>bundle-manifest</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>com.datastax.driver.extras</Bundle-SymbolicName>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                        <_include>-osgi.bnd</_include>
                         <Import-Package><![CDATA[com.google.common.*;version="[16.0.1,22)",*]]></Import-Package>
                     </instructions>
-                    <supportedProjectTypes>
-                        <supportedProjectType>jar</supportedProjectType>
-                        <supportedProjectType>bundle</supportedProjectType>
-                        <supportedProjectType>pom</supportedProjectType>
-                    </supportedProjectTypes>
                 </configuration>
             </plugin>
 
         </plugins>
 
     </build>
-
-    <profiles>
-
-        <profile>
-            <id>short</id>
-            <properties>
-                <test.groups>unit,short</test.groups>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>long</id>
-            <properties>
-                <test.groups>unit,short,long</test.groups>
-            </properties>
-        </profile>
-
-        <!--
-        This profile excludes all JDK 8 dependent classes from
-        compilation. Use this when running tests with a legacy JDK (6 or 7)
-        -->
-        <profile>
-            <id>legacy-jdks</id>
-            <activation>
-                <jdk>[,1.8)</jdk>
-            </activation>
-            <properties>
-                <jdk8.excludes>**/jdk8/*.java</jdk8.excludes>
-            </properties>
-        </profile>
-
-    </profiles>
-
-    <licenses>
-        <license>
-            <name>Apache 2</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>Apache License Version 2.0</comments>
-        </license>
-    </licenses>
-
-    <scm>
-        <connection>scm:git:git@github.com:datastax/java-driver.git</connection>
-        <developerConnection>scm:git:git@github.com:datastax/java-driver.git</developerConnection>
-        <url>https://github.com/datastax/java-driver</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <developers>
-        <developer>
-            <name>Various</name>
-            <organization>DataStax</organization>
-        </developer>
-    </developers>
 
 </project>

--- a/driver-mapping/pom.xml
+++ b/driver-mapping/pom.xml
@@ -16,113 +16,101 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.datastax.cassandra</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>cassandra-driver-mapping</artifactId>
     <packaging>bundle</packaging>
     <name>DataStax Java Driver for Apache Cassandra - Object Mapping</name>
     <description>Object mapper for the DataStax CQL Java Driver.</description>
-    <url>https://github.com/datastax/java-driver</url>
-
-    <properties>
-        <groovy.version>2.4.7</groovy.version>
-    </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.datastax.cassandra</groupId>
-            <artifactId>cassandra-driver-core</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>${project.parent.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>${testng.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
-            <version>${commons-exec.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
-            <version>5.0.3</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>${groovy.version}</version>
             <scope>test</scope>
         </dependency>
 
     </dependencies>
 
     <build>
+
         <plugins>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.12</version>
                 <executions>
                     <execution>
                         <id>add-source</id>
@@ -138,88 +126,26 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <version>2.4.0</version>
-                <executions>
-                    <execution>
-                        <id>bundle-manifest</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>com.datastax.driver.mapping</Bundle-SymbolicName>
-                        <Bundle-Version>${project.version}</Bundle-Version>
-                        <_include>-osgi.bnd</_include>
                         <Import-Package><![CDATA[com.google.common.*;version="[16.0.1,22)",*]]></Import-Package>
                     </instructions>
-                    <supportedProjectTypes>
-                        <supportedProjectType>jar</supportedProjectType>
-                        <supportedProjectType>bundle</supportedProjectType>
-                        <supportedProjectType>pom</supportedProjectType>
-                    </supportedProjectTypes>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>gmaven-plugin</artifactId>
-                <version>1.5</version>
-                <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <fileset>
-                                    <directory>${pom.basedir}/src/test/groovy</directory>
-                                    <includes>
-                                        <include>**/*.groovy</include>
-                                    </includes>
-                                </fileset>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.codehaus.groovy</groupId>
-                        <artifactId>groovy-all</artifactId>
-                        <version>${groovy.version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
+
         </plugins>
+
     </build>
 
-    <licenses>
-        <license>
-            <name>Apache 2</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>Apache License Version 2.0</comments>
-        </license>
-    </licenses>
-
-    <scm>
-        <connection>scm:git:git@github.com:datastax/java-driver.git</connection>
-        <developerConnection>scm:git:git@github.com:datastax/java-driver.git</developerConnection>
-        <url>https://github.com/datastax/java-driver</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <developers>
-        <developer>
-            <name>Various</name>
-            <organization>DataStax</organization>
-        </developer>
-    </developers>
 </project>
 

--- a/driver-tests/osgi/pom.xml
+++ b/driver-tests/osgi/pom.xml
@@ -16,76 +16,69 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.datastax.cassandra</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-osgi</artifactId>
-    <packaging>jar</packaging>
     <name>DataStax Java Driver for Apache Cassandra Tests - OSGi</name>
     <description>A test for the DataStax Java Driver in an OSGi container.</description>
-    <url>https://github.com/datastax/java-driver</url>
-
-    <properties>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <felix.version>4.4.1</felix.version>
-        <!-- more recent version require JDK7+ -->
-        <pax-exam.version>3.6.0</pax-exam.version>
-        <url.version>2.4.0</url.version>
-        <test.groups>none</test.groups>
-        <!--
-        Skip tests by default, short or long profile is required to run tests in this module
-        since pax-exam will throw exception if it encounters a
-        test with no matching methods.
-        -->
-        <test.skip>true</test.skip>
-    </properties>
 
     <dependencies>
 
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>${project.parent.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.jnr</groupId>
+                    <artifactId>jnr-ffi</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.jnr</groupId>
+                    <artifactId>jnr-posix</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-mapping</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-extras</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
-            <version>${felix.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
         </dependency>
 
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>${project.parent.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -93,71 +86,60 @@
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam</artifactId>
-            <version>${pax-exam.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-testng</artifactId>
-            <version>${pax-exam.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-container-forked</artifactId>
-            <version>${pax-exam.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
             <artifactId>pax-exam-link-mvn</artifactId>
-            <version>${pax-exam.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.ops4j.pax.url</groupId>
             <artifactId>pax-url-reference</artifactId>
-            <version>${url.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>javax.transaction</groupId>
             <artifactId>jta</artifactId>
-            <version>1.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
-            <version>1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>${testng.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
-            <version>1.3</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
-            <scope>test</scope>
         </dependency>
 
     </dependencies>
@@ -172,25 +154,16 @@
             get automatically passed to tests run with IntelliJ
             -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
                 <configuration>
                     <skip>true</skip>
-                    <systemPropertyVariables>
-                        <cassandra.version>${cassandra.version}</cassandra.version>
-                        <ipprefix>${ipprefix}</ipprefix>
-                    </systemPropertyVariables>
                 </configuration>
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.18.1</version>
                 <configuration>
-                    <skip>${test.skip}</skip>
-                    <groups>${test.groups}</groups>
+                    <skip>${test.osgi.skip}</skip>
                     <systemPropertyVariables>
                         <cassandra.version>${cassandra.version}</cassandra.version>
                         <!-- pull in declared version properties, this ensures we test with the same versions used by the driver -->
@@ -203,29 +176,18 @@
                         <logback.version>${logback.version}</logback.version>
                         <metrics.version>${metrics.version}</metrics.version>
                         <testng.version>${testng.version}</testng.version>
+                        <jsr353-api.version>${jsr353-api.version}</jsr353-api.version>
                         <ipprefix>${ipprefix}</ipprefix>
                     </systemPropertyVariables>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <version>2.4.0</version>
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>com.datastax.driver.osgi</Bundle-SymbolicName>
-                        <Bundle-Version>${project.version}</Bundle-Version>
                         <Export-Package>com.datastax.driver.osgi.api,!com.datastax.driver.osgi.impl</Export-Package>
                         <Bundle-Activator>com.datastax.driver.osgi.impl.Activator</Bundle-Activator>
                         <_include>-osgi.bnd</_include>
@@ -234,7 +196,7 @@
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>
-                        <phase>compile</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>manifest</goal>
                         </goals>
@@ -242,73 +204,9 @@
                 </executions>
             </plugin>
 
-            <!--
-            To launch Pax Runner and check that all driver bundles are correctly provisioned,
-            do the following:
-            mvn pax:run
-            Note: you MUST run 'mvn install' on the entire project before!
-             -->
-            <plugin>
-                <groupId>org.ops4j</groupId>
-                <artifactId>maven-pax-plugin</artifactId>
-                <version>1.6.0</version>
-                <configuration>
-                    <framework>felix</framework>
-                    <showWarnings>true</showWarnings>
-                    <provision>
-                        <param>--platform=felix</param>
-                        <param>--version=${felix.version}</param>
-                        <param>--log=debug</param>
-                        <param>--systemPackages=sun.misc</param>
-                    </provision>
-                </configuration>
-            </plugin>
-
         </plugins>
 
     </build>
 
-    <profiles>
-
-        <profile>
-            <id>short</id>
-            <properties>
-                <test.groups>unit,short</test.groups>
-                <test.skip>false</test.skip>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>long</id>
-            <properties>
-                <test.groups>unit,short,long</test.groups>
-                <test.skip>false</test.skip>
-            </properties>
-        </profile>
-
-    </profiles>
-
-    <licenses>
-        <license>
-            <name>Apache 2</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>Apache License Version 2.0</comments>
-        </license>
-    </licenses>
-
-    <scm>
-        <connection>scm:git:git@github.com:datastax/java-driver.git</connection>
-        <developerConnection>scm:git:git@github.com:datastax/java-driver.git</developerConnection>
-        <url>https://github.com/datastax/java-driver</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <developers>
-        <developer>
-            <name>Various</name>
-            <organization>DataStax</organization>
-        </developer>
-    </developers>
 </project>
 

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
@@ -20,16 +20,32 @@ import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ProtocolOptions;
 import com.datastax.driver.core.TestUtils;
 import com.google.common.collect.Lists;
+import java.util.List;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.options.CompositeOption;
 import org.ops4j.pax.exam.options.MavenArtifactProvisionOption;
 import org.ops4j.pax.exam.options.UrlProvisionOption;
 import org.ops4j.pax.exam.util.PathUtils;
 
-import java.util.List;
+import static org.ops4j.pax.exam.CoreOptions.bootDelegationPackage;
+import static org.ops4j.pax.exam.CoreOptions.bundle;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+import static org.ops4j.pax.exam.CoreOptions.systemPackages;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
 
-import static org.ops4j.pax.exam.CoreOptions.*;
-
+/**
+ * To check that all driver bundles are correctly provisioned, or to debug provisioning problems,
+ * run the Maven Pax Runner plugin:
+ * <pre>
+ * mvn pax:run
+ * </pre>
+ * The plugin will start a Felix Gogo interactive shell and attempt to provision the driver bundles.
+ * <p/>
+ * Note: you MUST run 'mvn install' on the entire project before!
+ *
+ * @see <a href="http://felix.apache.org/documentation/subprojects/apache-felix-gogo.html">Apache Felix Gogo Documentation</a>
+ */
 public class BundleOptions {
 
     public static UrlProvisionOption driverBundle() {

--- a/driver-tests/pom.xml
+++ b/driver-tests/pom.xml
@@ -16,45 +16,24 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.datastax.cassandra</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>cassandra-driver-tests-parent</artifactId>
     <packaging>pom</packaging>
     <name>DataStax Java Driver for Apache Cassandra Tests</name>
     <description>Tests for the DataStax Java Driver for Apache Cassandra.</description>
-    <url>https://github.com/datastax/java-driver</url>
 
     <modules>
         <module>stress</module>
         <module>osgi</module>
     </modules>
-
-    <licenses>
-        <license>
-            <name>Apache 2</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>Apache License Version 2.0</comments>
-        </license>
-    </licenses>
-
-    <scm>
-        <connection>scm:git:git@github.com:datastax/java-driver.git</connection>
-        <developerConnection>scm:git:git@github.com:datastax/java-driver.git</developerConnection>
-        <url>https://github.com/datastax/java-driver</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <developers>
-        <developer>
-            <name>Various</name>
-            <organization>DataStax</organization>
-        </developer>
-    </developers>
 
     <build>
 
@@ -63,25 +42,41 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>clirr-maven-plugin</artifactId>
-                <version>2.7</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <skipSource>true</skipSource>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -90,5 +85,24 @@
         </plugins>
 
     </build>
+
+    <profiles>
+
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <configuration>
+                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
 
 </project>

--- a/driver-tests/stress/pom.xml
+++ b/driver-tests/stress/pom.xml
@@ -16,23 +16,29 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.datastax.cassandra</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>cassandra-driver-tests-stress</artifactId>
-    <packaging>jar</packaging>
     <name>DataStax Java Driver for Apache Cassandra Tests - Stress</name>
     <description>A stress test example for DataStax Java Driver for Apache Cassandra.</description>
-    <url>https://github.com/datastax/java-driver</url>
 
     <dependencies>
+
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>3.2.1-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
         </dependency>
 
         <dependency>
@@ -50,21 +56,21 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.5</version>
         </dependency>
+
     </dependencies>
 
     <build>
+
         <plugins>
+
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -76,30 +82,10 @@
                     </descriptorRefs>
                 </configuration>
             </plugin>
+
         </plugins>
+
     </build>
 
-    <licenses>
-        <license>
-            <name>Apache 2</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>Apache License Version 2.0</comments>
-        </license>
-    </licenses>
-
-    <scm>
-        <connection>scm:git:git@github.com:datastax/java-driver.git</connection>
-        <developerConnection>scm:git:git@github.com:datastax/java-driver.git</developerConnection>
-        <url>https://github.com/datastax/java-driver</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <developers>
-        <developer>
-            <name>Various</name>
-            <organization>DataStax</organization>
-        </developer>
-    </developers>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,23 +16,21 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-        <relativePath />
-    </parent>
 
     <groupId>com.datastax.cassandra</groupId>
     <artifactId>cassandra-driver-parent</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>DataStax Java Driver for Apache Cassandra</name>
-    <description>A driver for Apache Cassandra 1.2+ that works exclusively with the Cassandra Query Language version 3
+    <description>
+        A driver for Apache Cassandra 1.2+ that works exclusively with the Cassandra Query Language version 3
         (CQL3) and Cassandra's binary protocol.
     </description>
+
     <url>https://github.com/datastax/java-driver</url>
+
     <inceptionYear>2012</inceptionYear>
 
     <modules>
@@ -46,6 +44,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <cassandra.version>3.10</cassandra.version>
         <java.version>1.6</java.version>
         <log4j.version>1.2.17</log4j.version>
@@ -57,7 +56,6 @@
         <snappy.version>1.1.2.6</snappy.version>
         <lz4.version>1.3.0</lz4.version>
         <hdr.version>2.1.9</hdr.version>
-        <!-- driver-extras module -->
         <jackson.version>2.8.8</jackson.version>
         <!-- jackson-databind 2.7.x is the last to support java 6 -->
         <jackson-databind.version>2.7.9.1</jackson-databind.version>
@@ -66,7 +64,14 @@
         <jsr353-ri.version>1.0.4</jsr353-ri.version>
         <jnr-ffi.version>2.0.7</jnr-ffi.version>
         <jnr-posix.version>3.0.27</jnr-posix.version>
-        <!-- test dependency versions -->
+        <groovy.version>2.4.7</groovy.version>
+        <jax-rs.version>2.0.1</jax-rs.version>
+        <jersey.version>2.23.1</jersey.version>
+        <hk2.version>2.4.0-b34</hk2.version>
+        <felix.version>4.4.1</felix.version>
+        <!-- more recent versions of pax-exam require JDK7+ -->
+        <pax-exam.version>3.6.0</pax-exam.version>
+        <url.version>2.4.0</url.version>
         <testng.version>6.8.8</testng.version>
         <assertj.version>1.7.0</assertj.version>
         <mockito.version>1.10.8</mockito.version>
@@ -74,319 +79,577 @@
         <scassandra.version>1.1.2</scassandra.version>
         <logback.version>1.2.3</logback.version>
         <ipprefix>127.0.1.</ipprefix>
+        <!-- defaults below are overridden by profiles and/or submodules -->
         <test.groups>unit</test.groups>
-        <!-- Set default javadoc.opts, overriden by profiles -->
+        <test.osgi.skip>true</test.osgi.skip>
         <javadoc.opts />
     </properties>
 
-    <profiles>
-        <profile>
-            <id>default</id>
-            <properties>
-                <env>default</env>
-                <test.groups>unit</test.groups>
-            </properties>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-        </profile>
+    <dependencyManagement>
 
-        <profile>
-            <id>doclint-java8-disable</id>
-            <activation>
-                <jdk>[1.8,)</jdk>
-            </activation>
-            <properties>
-                <javadoc.opts>-Xdoclint:none</javadoc.opts>
-            </properties>
-        </profile>
+        <dependencies>
 
-        <profile>
-            <id>short</id>
-            <properties>
-                <env>default</env>
-                <test.groups>unit,short</test.groups>
-            </properties>
-        </profile>
-        <profile>
-            <id>long</id>
-            <properties>
-                <env>default</env>
-                <test.groups>unit,short,long</test.groups>
-            </properties>
-        </profile>
-        <profile>
-            <id>duration</id>
-            <properties>
-                <env>default</env>
-                <test.groups>unit,short,long,duration</test.groups>
-            </properties>
-        </profile>
-        <profile>
-            <id>doc</id>
-            <properties>
-                <env>default</env>
-                <test.groups>unit,doc</test.groups>
-            </properties>
-        </profile>
-        <profile>
-            <!-- default profile settings for 'isolated' test group, will skip tests unless overridden in child module. -->
-            <id>isolated</id>
-            <properties>
-                <env>default</env>
-                <test.groups>isolated</test.groups>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.16</version>
-                        <configuration>
-                            <properties>
-                                <property>
-                                    <name>usedefaultlisteners</name>
-                                    <value>false
-                                    </value> <!-- disable default listeners as some of the html reports do a lot of File I/O -->
-                                </property>
-                            </properties>
-                            <skip>true</skip>
-                            <forkCount>1</forkCount>
-                            <reuseForks>false</reuseForks>
-                            <reportNameSuffix>isolated</reportNameSuffix>
-                            <!-- This requires includes to be explicitly specified by implementing classes.
-                                 This is needed to prevent creating a JVM fork for each test, even those that don't
-                                 have the isolated group. -->
-                            <includes />
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+            <dependency>
+                <groupId>com.datastax.cassandra</groupId>
+                <artifactId>cassandra-driver-core</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
 
-        <profile>
-            <id>enforce-java8</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <version>1.4.1</version>
-                        <executions>
-                            <execution>
-                                <id>enforce-java8</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <configuration>
-                                    <rules>
-                                        <requireJavaVersion>
-                                            <version>1.8</version>
-                                        </requireJavaVersion>
-                                    </rules>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+            <dependency>
+                <groupId>com.datastax.cassandra</groupId>
+                <artifactId>cassandra-driver-core</artifactId>
+                <version>${project.parent.version}</version>
+                <type>test-jar</type>
+            </dependency>
 
-        <!--
-        This profile excludes all JDK 8 dependent tests from being
-        run with legacy JDKs (6 or 7).
-        It is automatically activated when a legacy JDK is in use.
-        Note that running tests with a legacy JDK require
-        that you provide a non-legacy JDK for CCM through the
-        system property ccm.java.home.
-        -->
-        <profile>
-            <id>legacy-jdks</id>
-            <activation>
-                <jdk>[,1.8)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <!-- exclude Jdk8* test classes from being compiled -->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <testExcludes>
-                                <exclude>**/Jdk8*.java</exclude>
-                            </testExcludes>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <!-- exclude Jdk* test classes from being run
-                        This is needed in event that code was built with JDK8
-                        and tests are ran with JDK6 or 7. -->
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.16</version>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/Jdk8*.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+            <dependency>
+                <groupId>com.datastax.cassandra</groupId>
+                <artifactId>cassandra-driver-mapping</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
 
-    </profiles>
+            <dependency>
+                <groupId>com.datastax.cassandra</groupId>
+                <artifactId>cassandra-driver-extras</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-core</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.jnr</groupId>
+                <artifactId>jnr-ffi</artifactId>
+                <version>${jnr-ffi.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.jnr</groupId>
+                <artifactId>jnr-posix</artifactId>
+                <version>${jnr-posix.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>${snappy.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>net.jpountz.lz4</groupId>
+                <artifactId>lz4</artifactId>
+                <version>${lz4.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hdrhistogram</groupId>
+                <artifactId>HdrHistogram</artifactId>
+                <version>${hdr.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-databind.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>javax.json</artifactId>
+                <version>${jsr353-ri.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.json</groupId>
+                <artifactId>javax.json-api</artifactId>
+                <version>${jsr353-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.ws.rs</groupId>
+                <artifactId>javax.ws.rs-api</artifactId>
+                <version>${jax-rs.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-server</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-json-jackson</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.jersey.containers</groupId>
+                <artifactId>jersey-container-jdk-http</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-api</artifactId>
+                <version>${hk2.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+                <version>1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.transaction</groupId>
+                <artifactId>jta</artifactId>
+                <version>1.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>${joda.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.framework</artifactId>
+                <version>${felix.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ops4j.pax.exam</groupId>
+                <artifactId>pax-exam</artifactId>
+                <version>${pax-exam.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ops4j.pax.exam</groupId>
+                <artifactId>pax-exam-testng</artifactId>
+                <version>${pax-exam.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ops4j.pax.exam</groupId>
+                <artifactId>pax-exam-container-forked</artifactId>
+                <version>${pax-exam.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ops4j.pax.exam</groupId>
+                <artifactId>pax-exam-link-mvn</artifactId>
+                <version>${pax-exam.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ops4j.pax.url</groupId>
+                <artifactId>pax-url-reference</artifactId>
+                <version>${url.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>${testng.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>${mockito.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.scassandra</groupId>
+                <artifactId>java-client</artifactId>
+                <version>${scassandra.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-exec</artifactId>
+                <version>${commons-exec.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-tcnative</artifactId>
+                <version>2.0.1.Final</version>
+                <classifier>${os.detected.classifier}</classifier>
+            </dependency>
+
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>${slf4j-log4j12.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>5.0.3</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>${groovy.version}</version>
+            </dependency>
+
+        </dependencies>
+
+    </dependencyManagement>
 
     <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                    <optimize>true</optimize>
-                    <showDeprecation>true</showDeprecation>
-                    <showWarnings>true</showWarnings>
+
+        <extensions>
+
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.4.1.Final</version>
+            </extension>
+
+        </extensions>
+
+        <!--
+        Run the following command to check if plugin updates are available:
+        mvn versions:display-plugin-updates
+        -->
+        <pluginManagement>
+
+            <plugins>
+
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.6</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <!-- last version compatible with Java 6 -->
+                    <version>1.9.1</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>1.4.1</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.6.1</version>
+                    <configuration>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
+                        <optimize>true</optimize>
+                        <showDeprecation>true</showDeprecation>
+                        <showWarnings>true</showWarnings>
+                        <!--
+                        Avoids warnings when cross-compiling to older source levels, see
+                        https://blogs.oracle.com/darcy/entry/bootclasspath_older_source
+                        -->
+                        <compilerArgument>-Xlint:-options</compilerArgument>
+                        <!-- this actually means: use incremental compilation -->
+                        <useIncrementalCompilation>false</useIncrementalCompilation>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.gmaven</groupId>
+                    <artifactId>gmaven-plugin</artifactId>
+                    <version>1.5</version>
+                    <extensions>true</extensions>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>testCompile</goal>
+                            </goals>
+                            <configuration>
+                                <sources>
+                                    <fileset>
+                                        <directory>${pom.basedir}/src/test/groovy</directory>
+                                        <includes>
+                                            <include>**/*.groovy</include>
+                                        </includes>
+                                    </fileset>
+                                </sources>
+                            </configuration>
+                        </execution>
+                    </executions>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.groovy</groupId>
+                            <artifactId>groovy-all</artifactId>
+                            <version>${groovy.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.0.1</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>jar-no-fork</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.10.4</version>
+                    <inherited>true</inherited>
+                    <configuration>
+                        <quiet>true</quiet>
+                        <verbose>false</verbose>
+                        <additionalparam>${javadoc.opts}</additionalparam>
+                        <links>
+                            <link>https://docs.oracle.com/javase/8/docs/api/</link>
+                            <link>https://google.github.io/guava/releases/19.0/api/docs/</link>
+                            <link>http://netty.io/4.0/api/</link>
+                            <link>http://www.joda.org/joda-time/apidocs/</link>
+                            <link>http://fasterxml.github.io/jackson-core/javadoc/2.8/</link>
+                            <link>http://fasterxml.github.io/jackson-databind/javadoc/2.7/</link>
+                            <link>https://javaee-spec.java.net/nonav/javadocs/</link>
+                        </links>
+                        <!-- optional dependencies from other modules (must be explicitly declared here in order to be correctly resolved) -->
+                        <additionalDependencies>
+                            <additionalDependency>
+                                <groupId>org.xerial.snappy</groupId>
+                                <artifactId>snappy-java</artifactId>
+                                <version>${snappy.version}</version>
+                            </additionalDependency>
+                            <additionalDependency>
+                                <groupId>net.jpountz.lz4</groupId>
+                                <artifactId>lz4</artifactId>
+                                <version>${lz4.version}</version>
+                            </additionalDependency>
+                            <additionalDependency>
+                                <groupId>org.hdrhistogram</groupId>
+                                <artifactId>HdrHistogram</artifactId>
+                                <version>${hdr.version}</version>
+                            </additionalDependency>
+                            <additionalDependency>
+                                <groupId>com.fasterxml.jackson.core</groupId>
+                                <artifactId>jackson-core</artifactId>
+                                <version>${jackson.version}</version>
+                            </additionalDependency>
+                            <additionalDependency>
+                                <groupId>com.fasterxml.jackson.core</groupId>
+                                <artifactId>jackson-annotations</artifactId>
+                                <version>${jackson.version}</version>
+                            </additionalDependency>
+                            <additionalDependency>
+                                <groupId>com.fasterxml.jackson.core</groupId>
+                                <artifactId>jackson-databind</artifactId>
+                                <version>${jackson-databind.version}</version>
+                            </additionalDependency>
+                            <additionalDependency>
+                                <groupId>joda-time</groupId>
+                                <artifactId>joda-time</artifactId>
+                                <version>${joda.version}</version>
+                            </additionalDependency>
+                            <additionalDependency>
+                                <groupId>javax.json</groupId>
+                                <artifactId>javax.json-api</artifactId>
+                                <version>${jsr353-api.version}</version>
+                            </additionalDependency>
+                        </additionalDependencies>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <extensions>true</extensions>
+                    <!-- last version compatible with Java 6 -->
+                    <version>2.5.4</version>
+                    <configuration>
+                        <instructions>
+                            <Bundle-Version>${project.version}</Bundle-Version>
+                            <_include>-osgi.bnd</_include>
+                        </instructions>
+                        <supportedProjectTypes>
+                            <supportedProjectType>jar</supportedProjectType>
+                            <supportedProjectType>bundle</supportedProjectType>
+                            <supportedProjectType>pom</supportedProjectType>
+                        </supportedProjectTypes>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.5.3</version>
+                    <configuration>
+                        <tagNameFormat>@{project.version}</tagNameFormat>
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <useReleaseProfile>false</useReleaseProfile>
+                        <releaseProfiles>release</releaseProfiles>
+                        <goals>deploy</goals>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>clirr-maven-plugin</artifactId>
+                    <!-- Last version compatible with Java 6 -->
+                    <version>2.7</version>
+                    <executions>
+                        <execution>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <comparisonVersion>3.2.0</comparisonVersion>
+                        <ignoredDifferencesFile>../clirr-ignores.xml</ignoredDifferencesFile>
+                        <excludes>
+                            <exclude>com/datastax/shaded/**</exclude>
+                        </excludes>
+                    </configuration>
                     <!--
-                    Avoids warnings when cross-compiling to older source levels, see
-                    https://blogs.oracle.com/darcy/entry/bootclasspath_older_source
+                    Workaround to make clirr plugin work with Java 8.
+                    The bug is actually in the BCEL library,
+                    see https://issues.apache.org/jira/browse/BCEL-173.
+                    See also https://github.com/RichardWarburton/lambda-behave/issues/31#issuecomment-86052095
                     -->
-                    <compilerArgument>-Xlint:-options</compilerArgument>
-                    <!-- this actually means: use incremental compilation -->
-                    <useIncrementalCompilation>false</useIncrementalCompilation>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
-                <inherited>true</inherited>
-                <configuration>
-                    <quiet>true</quiet>
-                    <verbose>false</verbose>
-                    <additionalparam>${javadoc.opts}</additionalparam>
-                    <links>
-                        <link>https://docs.oracle.com/javase/8/docs/api/</link>
-                        <link>https://google.github.io/guava/releases/19.0/api/docs/</link>
-                        <link>http://netty.io/4.0/api/</link>
-                        <!-- dependencies from driver-extras -->
-                        <link>http://www.joda.org/joda-time/apidocs/</link>
-                        <link>http://fasterxml.github.io/jackson-core/javadoc/2.8/</link>
-                        <link>http://fasterxml.github.io/jackson-databind/javadoc/2.7/</link>
-                        <link>https://javaee-spec.java.net/nonav/javadocs/</link>
-                    </links>
-                    <!-- optional dependencies from other modules (must be explicitly declared here in order to be correctly resolved) -->
-                    <additionalDependencies>
-                        <additionalDependency>
-                            <groupId>org.xerial.snappy</groupId>
-                            <artifactId>snappy-java</artifactId>
-                            <version>${snappy.version}</version>
-                        </additionalDependency>
-                        <additionalDependency>
-                            <groupId>net.jpountz.lz4</groupId>
-                            <artifactId>lz4</artifactId>
-                            <version>${lz4.version}</version>
-                        </additionalDependency>
-                        <additionalDependency>
-                            <groupId>org.hdrhistogram</groupId>
-                            <artifactId>HdrHistogram</artifactId>
-                            <version>${hdr.version}</version>
-                        </additionalDependency>
-                        <additionalDependency>
-                            <groupId>com.fasterxml.jackson.core</groupId>
-                            <artifactId>jackson-core</artifactId>
-                            <version>${jackson.version}</version>
-                        </additionalDependency>
-                        <additionalDependency>
-                            <groupId>com.fasterxml.jackson.core</groupId>
-                            <artifactId>jackson-annotations</artifactId>
-                            <version>${jackson.version}</version>
-                        </additionalDependency>
-                        <additionalDependency>
-                            <groupId>com.fasterxml.jackson.core</groupId>
-                            <artifactId>jackson-databind</artifactId>
-                            <version>${jackson-databind.version}</version>
-                        </additionalDependency>
-                        <additionalDependency>
-                            <groupId>joda-time</groupId>
-                            <artifactId>joda-time</artifactId>
-                            <version>${joda.version}</version>
-                        </additionalDependency>
-                        <additionalDependency>
-                            <groupId>javax.json</groupId>
-                            <artifactId>javax.json-api</artifactId>
-                            <version>${jsr353-api.version}</version>
-                        </additionalDependency>
-                    </additionalDependencies>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5</version>
-                <configuration>
-                    <tagNameFormat>@{project.version}</tagNameFormat>
-                    <preparationGoals>clean verify -Penforce-java8</preparationGoals>
-                    <!-- do NOT specify arguments tag here as it would override the arguments tag in this plugin's definition in the parent POM -->
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>clirr-maven-plugin</artifactId>
-                <version>2.7</version>
-                <executions>
-                    <execution>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <comparisonVersion>3.1.4</comparisonVersion>
-                    <ignoredDifferencesFile>../clirr-ignores.xml</ignoredDifferencesFile>
-                </configuration>
-                <!--
-                Workaround to make clirr plugin work with Java 8.
-                The bug is actually in the BCEL library,
-                see https://issues.apache.org/jira/browse/BCEL-173.
-                See also https://github.com/RichardWarburton/lambda-behave/issues/31#issuecomment-86052095
-                -->
-                <dependencies>
-                    <dependency>
-                        <groupId>com.google.code.findbugs</groupId>
-                        <artifactId>bcel-findbugs</artifactId>
-                        <version>6.0</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>3.0</version>
-                <configuration>
-                    <inlineHeader><![CDATA[
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.google.code.findbugs</groupId>
+                            <artifactId>bcel-findbugs</artifactId>
+                            <version>6.0</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+
+                <plugin>
+                    <groupId>com.mycila</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>3.0</version>
+                    <configuration>
+                        <inlineHeader><![CDATA[
 
 Copyright (C) 2012-2017 DataStax Inc.
 
@@ -403,105 +666,389 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ]]>
-                    </inlineHeader>
-                    <includes>
-                        <include>src/**/*.java</include>
-                        <include>src/**/*.xml</include>
-                        <include>src/**/*.properties</include>
-                        <include>**/pom.xml</include>
-                    </includes>
-                    <mapping>
-                        <java>SLASHSTAR_STYLE</java>
-                        <properties>SCRIPT_STYLE</properties>
-                    </mapping>
-                    <strictCheck>true</strictCheck>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>check-license</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+                        </inlineHeader>
+                        <includes>
+                            <include>src/**/*.java</include>
+                            <include>src/**/*.xml</include>
+                            <include>src/**/*.properties</include>
+                            <include>**/pom.xml</include>
+                        </includes>
+                        <mapping>
+                            <java>SLASHSTAR_STYLE</java>
+                            <properties>SCRIPT_STYLE</properties>
+                        </mapping>
+                        <strictCheck>true</strictCheck>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>check-license</id>
+                            <phase>initialize</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>1.15</version>
+                    <executions>
+                        <execution>
+                            <id>check-jdk6</id>
+                            <phase>process-classes</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <configuration>
+                                <signature>
+                                    <groupId>org.codehaus.mojo.signature</groupId>
+                                    <artifactId>java16</artifactId>
+                                    <version>1.0</version>
+                                </signature>
+                                <annotations>
+                                    <annotation>com.datastax.driver.extras.codecs.jdk8.IgnoreJDK6Requirement
+                                    </annotation>
+                                </annotations>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>check-jdk8</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <configuration>
+                                <signature>
+                                    <groupId>org.codehaus.mojo.signature</groupId>
+                                    <artifactId>java18</artifactId>
+                                    <version>1.0</version>
+                                </signature>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <!-- do not upgrade until https://issues.apache.org/jira/browse/SUREFIRE-1302 is fixed -->
+                    <version>2.18</version>
+                    <configuration>
+                        <groups>${test.groups}</groups>
+                        <useFile>false</useFile>
+                        <systemPropertyVariables>
+                            <cassandra.version>${cassandra.version}</cassandra.version>
+                            <ipprefix>${ipprefix}</ipprefix>
+                            <com.datastax.driver.NEW_NODE_DELAY_SECONDS>60</com.datastax.driver.NEW_NODE_DELAY_SECONDS>
+                        </systemPropertyVariables>
+                        <classpathDependencyExcludes>
+                            <classpathDependencyExcludes>io.netty:netty-transport-native-epoll</classpathDependencyExcludes>
+                        </classpathDependencyExcludes>
+                        <properties>
+                            <property>
+                                <name>usedefaultlisteners</name>
+                                <value>false
+                                </value> <!-- disable default listeners as some of the html reports do a lot of File I/O -->
+                            </property>
+                            <property>
+                                <!-- Don't skip tests after a @Before method throws a SkipException -->
+                                <name>configfailurepolicy</name>
+                                <value>continue</value>
+                            </property>
+                        </properties>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <!-- do not upgrade until https://issues.apache.org/jira/browse/SUREFIRE-1302 is fixed -->
+                    <version>2.18</version>
+                    <configuration>
+                        <groups>${test.groups}</groups>
+                        <useFile>false</useFile>
+                        <systemPropertyVariables>
+                            <cassandra.version>${cassandra.version}</cassandra.version>
+                            <ipprefix>${ipprefix}</ipprefix>
+                            <com.datastax.driver.NEW_NODE_DELAY_SECONDS>60</com.datastax.driver.NEW_NODE_DELAY_SECONDS>
+                        </systemPropertyVariables>
+                        <classpathDependencyExcludes>
+                            <classpathDependencyExcludes>io.netty:netty-transport-native-epoll</classpathDependencyExcludes>
+                        </classpathDependencyExcludes>
+                        <properties>
+                            <property>
+                                <name>usedefaultlisteners</name>
+                                <value>false
+                                </value> <!-- disable default listeners as some of the html reports do a lot of File I/O -->
+                            </property>
+                            <property>
+                                <!-- Don't skip tests after a @Before method throws a SkipException -->
+                                <name>configfailurepolicy</name>
+                                <value>continue</value>
+                            </property>
+                        </properties>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.5</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.8</version>
+                    <extensions>true</extensions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.ops4j</groupId>
+                    <artifactId>maven-pax-plugin</artifactId>
+                    <version>1.6.0</version>
+                    <configuration>
+                        <framework>felix</framework>
+                        <showWarnings>true</showWarnings>
+                        <provision>
+                            <param>--platform=felix</param>
+                            <param>--version=${felix.version}</param>
+                            <param>--log=debug</param>
+                            <param>--systemPackages=sun.misc</param>
+                        </provision>
+                    </configuration>
+                </plugin>
+
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <artifactId>maven-jar-plugin</artifactId>
+                                        <versionRange>[2.2,)</versionRange>
+                                        <goals>
+                                            <goal>test-jar</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore/>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+
+            </plugins>
+
+        </pluginManagement>
+
+        <plugins>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.15</version>
-                <configuration>
-                    <signature>
-                        <groupId>org.codehaus.mojo.signature</groupId>
-                        <artifactId>java16</artifactId>
-                        <version>1.0</version>
-                    </signature>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>check</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
+
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
-                <configuration>
-                    <groups>${test.groups}</groups>
-                    <useFile>false</useFile>
-                    <systemPropertyVariables>
-                        <cassandra.version>${cassandra.version}</cassandra.version>
-                        <ipprefix>${ipprefix}</ipprefix>
-                        <com.datastax.driver.NEW_NODE_DELAY_SECONDS>60</com.datastax.driver.NEW_NODE_DELAY_SECONDS>
-                    </systemPropertyVariables>
-                    <classpathDependencyExcludes>
-                        <classpathDependencyExcludes>io.netty:netty-transport-native-epoll</classpathDependencyExcludes>
-                    </classpathDependencyExcludes>
-                    <properties>
-                        <property>
-                            <name>usedefaultlisteners</name>
-                            <value>false
-                            </value> <!-- disable default listeners as some of the html reports do a lot of File I/O -->
-                        </property>
-                        <property>
-                            <!-- Don't skip tests after a @Before method throws a SkipException -->
-                            <name>configfailurepolicy</name>
-                            <value>continue</value>
-                        </property>
-                    </properties>
-                </configuration>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>clirr-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.16</version>
-                <configuration>
-                    <groups>${test.groups}</groups>
-                    <useFile>false</useFile>
-                    <systemPropertyVariables>
-                        <cassandra.version>${cassandra.version}</cassandra.version>
-                        <ipprefix>${ipprefix}</ipprefix>
-                        <com.datastax.driver.NEW_NODE_DELAY_SECONDS>60</com.datastax.driver.NEW_NODE_DELAY_SECONDS>
-                    </systemPropertyVariables>
-                    <classpathDependencyExcludes>
-                        <classpathDependencyExcludes>io.netty:netty-transport-native-epoll</classpathDependencyExcludes>
-                    </classpathDependencyExcludes>
-                    <properties>
-                        <property>
-                            <!-- Don't skip tests after a @Before method throws a SkipException -->
-                            <name>configfailurepolicy</name>
-                            <value>continue</value>
-                        </property>
-                    </properties>
-                </configuration>
-            </plugin>
+
         </plugins>
+
     </build>
+
+    <profiles>
+
+        <profile>
+            <id>short</id>
+            <properties>
+                <test.groups>unit,short</test.groups>
+                <test.osgi.skip>false</test.osgi.skip>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>long</id>
+            <properties>
+                <test.groups>unit,short,long</test.groups>
+                <test.osgi.skip>false</test.osgi.skip>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>duration</id>
+            <properties>
+                <test.groups>unit,short,long,duration</test.groups>
+                <test.osgi.skip>false</test.osgi.skip>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>doc</id>
+            <properties>
+                <test.groups>unit,doc</test.groups>
+            </properties>
+        </profile>
+
+        <!-- default profile settings for 'isolated' test group, will skip tests unless overridden in child module. -->
+        <profile>
+            <id>isolated</id>
+            <properties>
+                <test.groups>isolated</test.groups>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                            <forkCount>1</forkCount>
+                            <reuseForks>false</reuseForks>
+                            <reportNameSuffix>isolated</reportNameSuffix>
+                            <!-- This requires includes to be explicitly specified by implementing classes.
+                                 This is needed to prevent creating a JVM fork for each test, even those that don't
+                                 have the isolated group. -->
+                            <includes/>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!--
+        Profile activated when releasing. See:
+        http://central.sonatype.org/pages/apache-maven.html
+        -->
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-java8</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireJavaVersion>
+                                            <version>1.8</version>
+                                        </requireJavaVersion>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <skipLocalStaging>true</skipLocalStaging>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>modern-jdks</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.opts>-Xdoclint:none</javadoc.opts>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>legacy-jdks</id>
+            <activation>
+                <jdk>[,1.8)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <!--
+                        Exclude Jdk* test classes from being run
+                        This is needed in event that code was built with JDK8
+                        and tests are ran with JDK6 or 7.
+                        Note that running CCM tests with a legacy JDK require
+                        setting two system properties: ccm.java.home and ccm.path;
+                        both should point to a valid JDK8+ installation.
+                        -->
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/jdk8/*.java</exclude>
+                                <exclude>**/Jdk8*.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
+
+    <distributionManagement>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
     <licenses>
         <license>
@@ -525,4 +1072,5 @@ limitations under the License.
             <organization>DataStax</organization>
         </developer>
     </developers>
+
 </project>


### PR DESCRIPTION
Summary of changes:

[JAVA-1266](https://datastax-oss.atlassian.net/browse/JAVA-1266):
- Removed reference to deprecated OSS Sonatype parent poms
- Adjusted release process to use the recommended method,
  as described in http://central.sonatype.org/pages/apache-maven.html
- Created new 'release' profile to contain release-specific plugins

[JAVA-1411](https://datastax-oss.atlassian.net/browse/JAVA-1411):
- Introduced dependencyManagement and pluginManagement sections in the parent pom
- Declared versions for all dependencies and plugins at parent pom
- Concentrated common plugin configuration items into the parent pom
- Revisited bundle and shade plugin configurations
- Updated &lt;url> tags
- Removed unused 'env' system property
- Profile declaration cleanup