### PR TITLE
Instant speculative retries for JAVA-1490

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -7,6 +7,7 @@
 - [improvement] JAVA-1587: Deterministic ordering of columns used in Mapper#saveQuery
 - [improvement] JAVA-1500: Add a metric to report number of in-flight requests.
 - [bug] JAVA-1438: QueryBuilder check for empty orderings.
+- [improvement] JAVA-1490: Allow zero delay for speculative executions.
 
 
 ### 3.3.0

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/ConstantSpeculativeExecutionPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/ConstantSpeculativeExecutionPolicy.java
@@ -32,13 +32,15 @@ public class ConstantSpeculativeExecutionPolicy implements SpeculativeExecutionP
     /**
      * Builds a new instance.
      *
-     * @param constantDelayMillis      the delay between each speculative execution. Must be strictly positive.
+     * @param constantDelayMillis      the delay between each speculative execution. Must be >= 0. A zero delay means
+     *                                 it should immediately send `maxSpeculativeExecutions` requests along with the
+     *                                 original request.
      * @param maxSpeculativeExecutions the number of speculative executions. Must be strictly positive.
      * @throws IllegalArgumentException if one of the arguments does not respect the preconditions above.
      */
     public ConstantSpeculativeExecutionPolicy(final long constantDelayMillis, final int maxSpeculativeExecutions) {
-        Preconditions.checkArgument(constantDelayMillis > 0,
-                "delay must be strictly positive (was %d)", constantDelayMillis);
+        Preconditions.checkArgument(constantDelayMillis >= 0,
+                "delay must be >= 0 (was %d)", constantDelayMillis);
         Preconditions.checkArgument(maxSpeculativeExecutions > 0,
                 "number of speculative executions must be strictly positive (was %d)", maxSpeculativeExecutions);
         this.constantDelayMillis = constantDelayMillis;

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/SpeculativeExecutionPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/SpeculativeExecutionPolicy.java
@@ -64,8 +64,8 @@ public interface SpeculativeExecutionPolicy {
          * Returns the time before the next speculative query.
          *
          * @param lastQueried the host that was just queried.
-         * @return the time (in milliseconds) before a speculative query is sent to the next host. If zero or negative,
-         * no speculative query will be sent.
+         * @return the time (in milliseconds) before a speculative query is sent to the next host. If negative,
+         * no speculative query will be sent. If zero it will immediately send the execution.
          */
         long nextExecution(Host lastQueried);
     }


### PR DESCRIPTION
Allow 0ms for the constant speculative execution policy and make it schedule it immediately.