### PR TITLE
JAVA-1500: Add a metric to report number of in-flight requests

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -5,6 +5,7 @@
 - [bug] JAVA-1555: Include VIEW and CDC in WriteType.
 - [bug] JAVA-1599: exportAsString improvements (sort, format, clustering order)
 - [improvement] JAVA-1587: Deterministic ordering of columns used in Mapper#saveQuery
+- [improvement] JAVA-1500: Add a metric to report number of in-flight requests.
 
 
 ### 3.3.0

--- a/driver-core/src/main/java/com/datastax/driver/core/Metrics.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metrics.java
@@ -79,6 +79,16 @@ public class Metrics {
             return value;
         }
     });
+    private final Gauge<Integer> inFlightRequests = registry.register("inflight-requests", new Gauge<Integer>() {
+        @Override
+        public Integer getValue() {
+            int value = 0;
+            for (SessionManager session : manager.sessions)
+                for (HostConnectionPool pool : session.pools.values())
+                    value += pool.totalInFlight.get();
+            return value;
+        }
+    });
 
     private final Gauge<Integer> executorQueueDepth;
     private final Gauge<Integer> blockingExecutorQueueDepth;
@@ -216,6 +226,15 @@ public class Metrics {
      */
     public Gauge<Integer> getTrashedConnections() {
         return trashedConnections;
+    }
+
+    /**
+     * Returns the total number of in flight requests to Cassandra hosts.
+     *
+     * @return The total number of in flight requests to Cassandra hosts.
+     */
+    public Gauge<Integer> getInFlightRequests() {
+        return inFlightRequests;
     }
 
     /**

--- a/driver-core/src/test/java/com/datastax/driver/core/MetricsInFlightTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MetricsInFlightTest.java
@@ -1,0 +1,97 @@
+package com.datastax.driver.core;
+
+import org.scassandra.Scassandra;
+import org.scassandra.http.client.PrimingRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static com.datastax.driver.core.TestUtils.nonQuietClusterCloseOptions;
+import static org.scassandra.http.client.PrimingRequest.then;
+
+public class MetricsInFlightTest {
+    private ScassandraCluster sCluster;
+
+    @BeforeMethod(groups = "short")
+    public void setUp() {
+        sCluster = ScassandraCluster.builder().withNodes(1).build();
+        sCluster.init();
+    }
+
+    @AfterMethod(groups = "short")
+    public void tearDown() {
+        clearActivityLog();
+        sCluster.stop();
+    }
+
+    public void clearActivityLog() {
+        for (Scassandra node : sCluster.nodes()) {
+            node.activityClient().clearAllRecordedActivity();
+        }
+    }
+
+    public Cluster.Builder builder() {
+        //Note: nonQuietClusterCloseOptions is used to speed up tests
+        return Cluster.builder()
+                .addContactPoints(sCluster.address(1).getAddress())
+                .withPort(sCluster.getBinaryPort()).withNettyOptions(nonQuietClusterCloseOptions);
+    }
+
+    @Test(groups = "short")
+    public void should_count_inflight_requests_metrics() {
+        sCluster.node(1).primingClient().prime(PrimingRequest.queryBuilder()
+                .withQuery("mock query")
+                .withThen(then().withFixedDelay(100000L))
+                .build()
+        );
+
+        Cluster cluster = null;
+        try {
+            cluster = builder().build();
+            Session session = cluster.connect();
+
+            assertThat(cluster.getMetrics().getInFlightRequests().getValue()).isEqualTo(0);
+            session.executeAsync("mock query");
+            session.executeAsync("mock query");
+            assertThat(cluster.getMetrics().getInFlightRequests().getValue()).isEqualTo(2);
+
+        } finally {
+            if (cluster != null) {
+                cluster.close();
+            }
+        }
+    }
+
+
+    @Test(groups = "short")
+    public void should_countdown_inflight_requests_metrics() {
+        sCluster.node(1).primingClient().prime(PrimingRequest.queryBuilder()
+                .withQuery("mock query")
+                .withThen(then())
+                .build()
+        );
+
+        Cluster cluster = null;
+        try {
+            cluster = builder().build();
+            Session session = cluster.connect();
+
+            assertThat(cluster.getMetrics().getInFlightRequests().getValue()).isEqualTo(0);
+            session.executeAsync("mock query").getUninterruptibly();
+            session.executeAsync("mock query").getUninterruptibly();
+            assertThat(cluster.getMetrics().getInFlightRequests().getValue()).isEqualTo(0);
+
+        } finally {
+            if (cluster != null) {
+                cluster.close();
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Exposes a new Gauge backed by the sum of all totalInFlight counts of all HostConnectionPools.