### PR TITLE
JAVA-1582, JAVA-1457, JAVA-1599 Consistent order in exportAsString and other fixes

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -42,7 +42,7 @@ cassandra:
   - '2.1'
   - '2.2'
   - '3.0'
-  - '3.10'
+  - '3.11'
 build:
   - script: |
       . /usr/local/bin/jdk_switcher.sh

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,8 @@
 ### 3.4.0 (In progress)
 
 - [bug] JAVA-1555: Include VIEW and CDC in WriteType.
+- [bug] JAVA-1599: exportAsString improvements (sort, format, clustering order)
+
 
 ### 3.3.0
 

--- a/driver-core/src/main/java/com/datastax/driver/core/AggregateMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AggregateMetadata.java
@@ -202,8 +202,9 @@ public class AggregateMetadata {
 
         TableMetadata.spaceOrNewLine(sb, formatted)
                 .append("SFUNC ")
-                .append(Metadata.quoteIfNecessary(stateFuncSimpleName))
-                .append(" STYPE ")
+                .append(Metadata.quoteIfNecessary(stateFuncSimpleName));
+        TableMetadata.spaceOrNewLine(sb, formatted)
+                .append("STYPE ")
                 .append(stateType.asFunctionParameterString());
 
         if (finalFuncSimpleName != null)

--- a/driver-core/src/main/java/com/datastax/driver/core/DirectedGraph.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DirectedGraph.java
@@ -33,8 +33,10 @@ class DirectedGraph<V> {
     final Map<V, Integer> vertices;
     final Multimap<V, V> adjacencyList;
     boolean wasSorted;
+    final Comparator<V> comparator;
 
-    DirectedGraph(List<V> vertices) {
+    DirectedGraph(Comparator<V> comparator, List<V> vertices) {
+        this.comparator = comparator;
         this.vertices = Maps.newHashMapWithExpectedSize(vertices.size());
         this.adjacencyList = HashMultimap.create();
 
@@ -43,8 +45,8 @@ class DirectedGraph<V> {
         }
     }
 
-    DirectedGraph(V... vertices) {
-        this(Arrays.asList(vertices));
+    DirectedGraph(Comparator<V> comparator, V... vertices) {
+        this(comparator, Arrays.asList(vertices));
     }
 
     /**
@@ -65,16 +67,21 @@ class DirectedGraph<V> {
 
         Queue<V> queue = new LinkedList<V>();
 
-        for (Map.Entry<V, Integer> entry : vertices.entrySet()) {
-            if (entry.getValue() == 0)
-                queue.add(entry.getKey());
+        // Sort vertices so order of evaluation is always the same (instead of depending on undefined map order behavior)
+        List<V> orderedVertices = new ArrayList<V>(vertices.keySet());
+        Collections.sort(orderedVertices, comparator);
+        for (V v : orderedVertices) {
+            if (vertices.get(v) == 0)
+                queue.add(v);
         }
 
         List<V> result = Lists.newArrayList();
         while (!queue.isEmpty()) {
             V vertex = queue.remove();
             result.add(vertex);
-            for (V successor : adjacencyList.get(vertex)) {
+            List<V> adjacentVertices = new ArrayList<V>(adjacencyList.get(vertex));
+            Collections.sort(adjacentVertices, comparator);
+            for (V successor : adjacentVertices) {
                 if (decrementAndGetCount(successor) == 0)
                     queue.add(successor);
             }

--- a/driver-core/src/main/java/com/datastax/driver/core/FunctionMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/FunctionMetadata.java
@@ -174,11 +174,9 @@ public class FunctionMetadata {
                 first = false;
             else
                 sb.append(',');
-            TableMetadata.newLine(sb, formatted);
             String name = entry.getKey();
             DataType type = entry.getValue();
             sb
-                    .append(TableMetadata.spaces(4, formatted))
                     .append(Metadata.quoteIfNecessary(name))
                     .append(' ')
                     .append(type.asFunctionParameterString());
@@ -190,7 +188,7 @@ public class FunctionMetadata {
 
         TableMetadata.spaceOrNewLine(sb, formatted)
                 .append("RETURNS ")
-                .append(returnType);
+                .append(returnType.asFunctionParameterString());
 
         TableMetadata.spaceOrNewLine(sb, formatted)
                 .append("LANGUAGE ")

--- a/driver-core/src/main/java/com/datastax/driver/core/MaterializedViewMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/MaterializedViewMetadata.java
@@ -162,34 +162,32 @@ public class MaterializedViewMetadata extends AbstractTableMetadata {
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE MATERIALIZED VIEW ")
                 .append(keyspaceName).append('.').append(viewName)
-                .append(" AS ");
-        newLine(sb, formatted);
+                .append(" AS");
 
         // SELECT
-        sb.append("SELECT ");
+        spaceOrNewLine(sb, formatted).append("SELECT ");
         if (includeAllColumns) {
-            sb.append(" * ");
+            sb.append("*");
         } else {
             Iterator<ColumnMetadata> it = columns.values().iterator();
             while (it.hasNext()) {
                 ColumnMetadata column = it.next();
-                sb.append(spaces(4, formatted)).append(Metadata.quoteIfNecessary(column.getName()));
-                if (it.hasNext()) sb.append(",");
-                sb.append(" ");
-                newLine(sb, formatted);
+                sb.append(Metadata.quoteIfNecessary(column.getName()));
+                if (it.hasNext()) sb.append(", ");
             }
         }
 
         // FROM
-        newLine(sb.append("FROM ").append(keyspaceName).append('.').append(baseTableName).append(" "), formatted);
+        spaceOrNewLine(sb, formatted).append("FROM ").append(keyspaceName).append('.').append(baseTableName);
 
         // WHERE
         // the CQL grammar allows missing WHERE clauses, although C* currently disallows it
-        if (whereClause != null && !whereClause.isEmpty())
-            newLine(sb.append("WHERE ").append(whereClause).append(' '), formatted);
+        if (whereClause != null && !whereClause.isEmpty()) {
+            spaceOrNewLine(sb, formatted).append("WHERE ").append(whereClause);
+        }
 
         // PK
-        sb.append("PRIMARY KEY (");
+        spaceOrNewLine(sb, formatted).append("PRIMARY KEY (");
         if (partitionKey.size() == 1) {
             sb.append(Metadata.quoteIfNecessary(partitionKey.get(0).getName()));
         } else {
@@ -208,6 +206,8 @@ public class MaterializedViewMetadata extends AbstractTableMetadata {
             sb.append(", ").append(Metadata.quoteIfNecessary(cm.getName()));
         sb.append(')');
 
+        // append 3 extra spaces if formatted to align WITH.
+        spaceOrNewLine(sb, formatted);
         appendOptions(sb, formatted);
         return sb.toString();
 

--- a/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
@@ -663,6 +663,24 @@ abstract class SchemaParser {
             return whereClause;
         }
 
+        // Used by maybeSortUdts to sort at each dependency group alphabetically.
+        private static final Comparator<Row> sortByTypeName = new Comparator<Row>() {
+            @Override
+            public int compare(Row o1, Row o2) {
+                String type1 = o1.getString(UserType.TYPE_NAME);
+                String type2 = o2.getString(UserType.TYPE_NAME);
+
+                if (type1 == null && type2 == null) {
+                    return 0;
+                } else if (type2 == null) {
+                    return 1;
+                } else if (type1 == null) {
+                    return -1;
+                } else {
+                    return type1.compareTo(type2);
+                }
+            }
+        };
 
         @Override
         protected List<Row> maybeSortUdts(List<Row> udtRows, Cluster cluster, String keyspace) {
@@ -671,7 +689,7 @@ abstract class SchemaParser {
 
             // For C* 3+, user-defined type resolution must be done in proper order
             // to guarantee that nested UDTs get resolved
-            DirectedGraph<Row> graph = new DirectedGraph<Row>(udtRows);
+            DirectedGraph<Row> graph = new DirectedGraph<Row>(sortByTypeName, udtRows);
             for (Row from : udtRows) {
                 for (Row to : udtRows) {
                     if (from != to && dependsOn(to, from, cluster, keyspace))

--- a/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableMetadata.java
@@ -16,6 +16,7 @@
 package com.datastax.driver.core;
 
 import com.datastax.driver.core.utils.MoreObjects;
+import com.google.common.collect.ImmutableSortedSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -384,12 +385,30 @@ public class TableMetadata extends AbstractTableMetadata {
 
         sb.append(super.exportAsString());
 
-        for (IndexMetadata index : indexes.values()) {
-            sb.append('\n').append(index.asCQLQuery());
+        if (!indexes.isEmpty()) {
+            sb.append('\n');
+
+            Iterator<IndexMetadata> indexIt = indexes.values().iterator();
+            while (indexIt.hasNext()) {
+                IndexMetadata index = indexIt.next();
+                sb.append('\n').append(index.asCQLQuery());
+                if (indexIt.hasNext()) {
+                    sb.append('\n');
+                }
+            }
         }
 
-        for (MaterializedViewMetadata view : views.values()) {
-            sb.append('\n').append(view.asCQLQuery());
+        if (!views.isEmpty()) {
+            sb.append('\n');
+
+            Iterator<AbstractTableMetadata> viewsIt = ImmutableSortedSet.orderedBy(AbstractTableMetadata.byNameComparator).addAll(views.values()).build().iterator();
+            while (viewsIt.hasNext()) {
+                AbstractTableMetadata view = viewsIt.next();
+                sb.append('\n').append(view.exportAsString());
+                if (viewsIt.hasNext()) {
+                    sb.append('\n');
+                }
+            }
         }
 
         return sb.toString();
@@ -399,12 +418,16 @@ public class TableMetadata extends AbstractTableMetadata {
     protected String asCQLQuery(boolean formatted) {
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE TABLE ").append(Metadata.quoteIfNecessary(keyspace.getName())).append('.').append(Metadata.quoteIfNecessary(name)).append(" (");
-        newLine(sb, formatted);
-        for (ColumnMetadata cm : columns.values())
-            newLine(sb.append(spaces(4, formatted)).append(cm).append(',').append(spaces(1, !formatted)), formatted);
+        if (formatted) {
+            spaceOrNewLine(sb, true);
+        }
+        for (ColumnMetadata cm : columns.values()) {
+            sb.append(cm).append(',');
+            spaceOrNewLine(sb, formatted);
+        }
 
         // PK
-        sb.append(spaces(4, formatted)).append("PRIMARY KEY (");
+        sb.append("PRIMARY KEY (");
         if (partitionKey.size() == 1) {
             sb.append(Metadata.quoteIfNecessary(partitionKey.get(0).getName()));
         } else {
@@ -425,7 +448,7 @@ public class TableMetadata extends AbstractTableMetadata {
         newLine(sb, formatted);
         // end PK
 
-        sb.append(")");
+        sb.append(") ");
         appendOptions(sb, formatted);
         return sb.toString();
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/UserType.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/UserType.java
@@ -278,12 +278,17 @@ public class UserType extends DataType implements Iterable<UserType.Field> {
         StringBuilder sb = new StringBuilder();
 
         sb.append("CREATE TYPE ").append(Metadata.quoteIfNecessary(keyspace)).append('.').append(Metadata.quoteIfNecessary(typeName)).append(" (");
-        TableMetadata.newLine(sb, formatted);
+        if (formatted) {
+            TableMetadata.spaceOrNewLine(sb, true);
+        }
         for (int i = 0; i < byIdx.length; i++) {
-            sb.append(TableMetadata.spaces(4, formatted)).append(byIdx[i]);
-            if (i < byIdx.length - 1)
+            sb.append(byIdx[i]);
+            if (i < byIdx.length - 1) {
                 sb.append(',');
-            TableMetadata.newLine(sb, formatted);
+                TableMetadata.spaceOrNewLine(sb, formatted);
+            } else {
+                TableMetadata.newLine(sb, formatted);
+            }
         }
 
         return sb.append(");").toString();

--- a/driver-core/src/test/java/com/datastax/driver/core/AggregateMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/AggregateMetadataTest.java
@@ -51,8 +51,9 @@ public class AggregateMetadataTest extends CCMTestsSupport {
         assertThat(aggregate.getStateType()).isEqualTo(text());
         assertThat(aggregate.toString()).isEqualTo(cqlAggregate);
         assertThat(aggregate.exportAsString()).isEqualTo(String.format("CREATE AGGREGATE %s.cat_tos(int)\n"
-                + "SFUNC cat STYPE text\n"
-                + "INITCOND '0';", this.keyspace));
+                + "    SFUNC cat\n"
+                + "    STYPE text\n"
+                + "    INITCOND '0';", this.keyspace));
     }
 
     @Test(groups = "short")
@@ -78,8 +79,9 @@ public class AggregateMetadataTest extends CCMTestsSupport {
         assertThat(aggregate.getStateType()).isEqualTo(cint());
         assertThat(aggregate.toString()).isEqualTo(cqlAggregate);
         assertThat(aggregate.exportAsString()).isEqualTo(String.format("CREATE AGGREGATE %s.mycount()\n"
-                + "SFUNC inc STYPE int\n"
-                + "INITCOND 0;", this.keyspace));
+                + "    SFUNC inc\n"
+                + "    STYPE int\n"
+                + "    INITCOND 0;", this.keyspace));
     }
 
     @Test(groups = "short")
@@ -108,9 +110,10 @@ public class AggregateMetadataTest extends CCMTestsSupport {
         assertThat(aggregate.getStateType()).isEqualTo(cint());
         assertThat(aggregate.toString()).isEqualTo(cqlAggregate);
         assertThat(aggregate.exportAsString()).isEqualTo(String.format("CREATE AGGREGATE %s.prettysum(int)\n"
-                + "SFUNC plus STYPE int\n"
-                + "FINALFUNC announce\n"
-                + "INITCOND 0;", this.keyspace));
+                + "    SFUNC plus\n"
+                + "    STYPE int\n"
+                + "    FINALFUNC announce\n"
+                + "    INITCOND 0;", this.keyspace));
     }
 
     @Test(groups = "short")
@@ -136,7 +139,8 @@ public class AggregateMetadataTest extends CCMTestsSupport {
         assertThat(aggregate.getStateType()).isEqualTo(cint());
         assertThat(aggregate.toString()).isEqualTo(cqlAggregate);
         assertThat(aggregate.exportAsString()).isEqualTo(String.format("CREATE AGGREGATE %s.sum(int)\n"
-                + "SFUNC plus2 STYPE int;", this.keyspace));
+                + "    SFUNC plus2\n"
+                + "    STYPE int;", this.keyspace));
     }
 
     @Test(groups = "short")

--- a/driver-core/src/test/java/com/datastax/driver/core/DirectedGraphTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DirectedGraphTest.java
@@ -16,22 +16,31 @@
 package com.datastax.driver.core;
 
 import com.datastax.driver.core.exceptions.DriverInternalError;
-import org.testng.annotations.Test;
-
+import java.util.Comparator;
 import java.util.List;
+import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DirectedGraphTest {
+
+    private Comparator<String> alphaComparator = new Comparator<String>() {
+
+        @Override
+        public int compare(String o1, String o2) {
+            return o1.compareTo(o2);
+        }
+    };
+
     @Test(groups = "unit")
     public void should_sort_empty_graph() {
-        DirectedGraph<String> g = new DirectedGraph<String>();
+        DirectedGraph<String> g = new DirectedGraph<String>(alphaComparator);
         assertThat(g.topologicalSort()).isEmpty();
     }
 
     @Test(groups = "unit")
     public void should_sort_graph_with_one_node() {
-        DirectedGraph<String> g = new DirectedGraph<String>("A");
+        DirectedGraph<String> g = new DirectedGraph<String>(alphaComparator, "A");
         assertThat(g.topologicalSort())
                 .containsExactly("A");
     }
@@ -47,7 +56,7 @@ public class DirectedGraphTest {
         //        B  C
         //        |
         //        A
-        DirectedGraph<String> g = new DirectedGraph<String>("A", "B", "C", "D", "E", "F", "G", "H");
+        DirectedGraph<String> g = new DirectedGraph<String>(alphaComparator, "A", "B", "C", "D", "E", "F", "G", "H");
         g.addEdge("H", "F");
         g.addEdge("G", "E");
         g.addEdge("H", "D");
@@ -58,24 +67,54 @@ public class DirectedGraphTest {
         g.addEdge("D", "B");
         g.addEdge("B", "A");
 
-        // Topological sort order should be : GH,FE,D,CB,A
-        // There's no guarantee on the order within the same level, so we use sublists:
+        // Topological sort order should be : GH,E,F,D,BC,A
         List<String> sorted = g.topologicalSort();
-        assertThat(sorted.subList(0, 2))
-                .contains("G", "H");
-        assertThat(sorted.subList(2, 4))
-                .contains("F", "E");
-        assertThat(sorted.subList(4, 5))
-                .contains("D");
-        assertThat(sorted.subList(5, 7))
-                .contains("C", "B");
-        assertThat(sorted.subList(7, 8))
-                .contains("A");
+        assertThat(sorted).containsExactly("G", "H", "E", "F", "D", "B", "C", "A");
+    }
+
+    @Test(groups = "unit")
+    public void should_sort_complex_custom_comparator() {
+        // Version of should_sort_complex_graph using a custom comparator based on ordering largest values first.
+        // This is counter to how hashmaps should usually behave, so this should help ensure that the comparator is
+        // being used.
+        Comparator<Integer> highFirst = new Comparator<Integer>() {
+            @Override
+            public int compare(Integer o1, Integer o2) {
+                return o2 - o1;
+            }
+        };
+
+        // sort graph and use a alphaComparator that favors larger values ordered first.
+        //         7   6
+        //        / \ /\
+        //       5   | 10
+        //        \ /  /
+        //         9  /
+        //        / \/
+        //        1  2
+        //        |
+        //        0
+        DirectedGraph<Integer> g = new DirectedGraph<Integer>(highFirst, 0, 1, 2, 9, 10, 5, 6, 7);
+        g.addEdge(7, 5);
+        g.addEdge(6, 10);
+        g.addEdge(7, 9);
+        g.addEdge(5, 9);
+        g.addEdge(6, 9);
+        g.addEdge(9, 2);
+        g.addEdge(10, 2);
+        g.addEdge(9, 1);
+        g.addEdge(1, 0);
+
+        // Topological sort order should be : [7,6],[5],[10],[9],[2,1],[0]
+        // 5 comes before 10 even though they appear at the same depth.  This happens because 5's (7) dependency
+        // is evaluated before 10's (6), so it is placed first.
+        List<Integer> sorted = g.topologicalSort();
+        assertThat(sorted).containsExactly(7, 6, 5, 10, 9, 2, 1, 0);
     }
 
     @Test(groups = "unit", expectedExceptions = DriverInternalError.class)
     public void should_fail_to_sort_if_graph_has_a_cycle() {
-        DirectedGraph<String> g = new DirectedGraph<String>("A", "B", "C");
+        DirectedGraph<String> g = new DirectedGraph<String>(alphaComparator, "A", "B", "C");
         g.addEdge("A", "B");
         g.addEdge("B", "C");
         g.addEdge("C", "B");
@@ -85,7 +124,7 @@ public class DirectedGraphTest {
 
     @Test(groups = "unit", expectedExceptions = DriverInternalError.class)
     public void should_fail_to_sort_if_graph_is_a_cycle() {
-        DirectedGraph<String> g = new DirectedGraph<String>("A", "B", "C");
+        DirectedGraph<String> g = new DirectedGraph<String>(alphaComparator, "A", "B", "C");
         g.addEdge("A", "B");
         g.addEdge("B", "C");
         g.addEdge("C", "A");

--- a/driver-core/src/test/java/com/datastax/driver/core/ExportAsStringTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ExportAsStringTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2012-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import com.datastax.driver.core.schemabuilder.SchemaBuilder;
+import com.datastax.driver.core.utils.CassandraVersion;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.ByteStreams;
+import com.google.common.io.Closer;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+@CassandraVersion("2.0")
+@CCMConfig(config = "enable_user_defined_functions:true")
+public class ExportAsStringTest extends CCMTestsSupport {
+
+    private static final Logger logger = LoggerFactory.getLogger(ExportAsStringTest.class);
+
+    /**
+     * Creates a keyspace using a variety of features and ensures {@link KeyspaceMetadata#exportAsString()}
+     * contains the expected data in the expected order.  This is not exhaustive, but covers quite a bit of different
+     * scenarios (materialized views, aggregates, functions, nested UDTs, etc.).
+     * <p>
+     * The test also verifies that the generated schema is the same whether the keyspace and its schema was created
+     * during the lifecycle of the cluster or before connecting.
+     * <p>
+     * Note that this test might be fragile in the future if default option values change in cassandra.  In order to
+     * deal with new features, we create a schema for each tested C* version, and if one is not present the test
+     * is failed.
+     */
+    @Test(groups = "short")
+    public void create_schema_and_ensure_exported_cql_is_as_expected() {
+        String keyspace = "complex_ks";
+        Map<String, Object> replicationOptions = ImmutableMap.<String, Object>of("class", "SimpleStrategy", "replication_factor", 1);
+
+        // create keyspace
+        session().execute(SchemaBuilder.createKeyspace(keyspace).with().replication(replicationOptions));
+
+        // create session from this keyspace.
+        Session session = cluster().connect(keyspace);
+
+        KeyspaceMetadata ks;
+
+        // udts require 2.1+
+        if (ccm().getCassandraVersion().compareTo(VersionNumber.parse("2.1")) >= 0) {
+            // Usertype 'ztype' with two columns.  Given name to ensure that even though it has an alphabetically
+            // later name, it shows up before other user types ('ctype') that depend on it.
+            session.execute(SchemaBuilder.createType("ztype")
+                    .addColumn("c", DataType.text()).addColumn("a", DataType.cint()));
+
+            // Usertype 'xtype' with two columns.  At same level as 'ztype' since both are depended on by ctype, should
+            // show up before 'ztype' because it's alphabetically before, even though it was created after.
+            session.execute(SchemaBuilder.createType("xtype")
+                    .addColumn("d", DataType.text()));
+
+            ks = cluster().getMetadata().getKeyspace(keyspace);
+
+            // Usertype 'ctype' which depends on both ztype and xtype, therefore ztype and xtype should show up earlier.
+            session.execute(SchemaBuilder.createType("ctype")
+                    .addColumn("z", ks.getUserType("ztype").copy(true))
+                    .addColumn("x", ks.getUserType("xtype").copy(true)));
+
+            // Usertype 'btype' which has no dependencies, should show up before 'xtype' and 'ztype' since it's
+            // alphabetically before.
+            session.execute(SchemaBuilder.createType("btype").addColumn("a", DataType.text()));
+
+            // Refetch keyspace for < 3.0 schema this is required as a new keyspace metadata reference may be created.
+            ks = cluster().getMetadata().getKeyspace(keyspace);
+
+            // Usertype 'atype' which depends on 'ctype', so should show up after 'ctype', 'xtype' and 'ztype'.
+            session.execute(SchemaBuilder.createType("atype")
+                    .addColumn("c", ks.getUserType("ctype").copy(true)));
+
+            // A simple table with a udt column and LCS compaction strategy.
+            session.execute(SchemaBuilder.createTable("ztable")
+                    .addPartitionKey("zkey", DataType.text())
+                    .addColumn("a", ks.getUserType("atype").copy(true))
+                    .withOptions().compactionOptions(SchemaBuilder.leveledStrategy().ssTableSizeInMB(95)));
+        } else {
+            // A simple table with LCS compaction strategy.
+            session.execute(SchemaBuilder.createTable("ztable")
+                    .addPartitionKey("zkey", DataType.text())
+                    .addColumn("a", DataType.cint())
+                    .withOptions().compactionOptions(SchemaBuilder.leveledStrategy().ssTableSizeInMB(95)));
+        }
+
+        // date type requries 2.2+
+        if (ccm().getCassandraVersion().compareTo(VersionNumber.parse("2.2")) >= 0) {
+            // A table that will have materialized views (copied from mv docs)
+            session.execute(SchemaBuilder.createTable("cyclist_mv").addPartitionKey("cid", DataType.uuid())
+                    .addColumn("name", DataType.text())
+                    .addColumn("age", DataType.cint())
+                    .addColumn("birthday", DataType.date())
+                    .addColumn("country", DataType.text()));
+
+            // index on table with view, index should be printed first.
+            session.execute(SchemaBuilder.createIndex("cyclist_by_country")
+                    .onTable("cyclist_mv")
+                    .andColumn("country"));
+
+            // materialized views require 3.0+
+            if (ccm().getCassandraVersion().compareTo(VersionNumber.parse("3.0")) >= 0) {
+                // A materialized view for cyclist_mv, reverse clustering.  created first to ensure creation order does not
+                // matter, alphabetical does.
+                session.execute("CREATE MATERIALIZED VIEW cyclist_by_r_age " +
+                        "AS SELECT age, birthday, name, country " +
+                        "FROM cyclist_mv " +
+                        "WHERE age IS NOT NULL AND cid IS NOT NULL " +
+                        "PRIMARY KEY (age, cid) " +
+                        "WITH CLUSTERING ORDER BY (cid DESC)"
+                );
+
+                // A materialized view for cyclist_mv, select *
+                session.execute("CREATE MATERIALIZED VIEW cyclist_by_a_age " +
+                        "AS SELECT * " +
+                        "FROM cyclist_mv " +
+                        "WHERE age IS NOT NULL AND cid IS NOT NULL " +
+                        "PRIMARY KEY (age, cid)");
+
+                // A materialized view for cyclist_mv, select columns
+                session.execute("CREATE MATERIALIZED VIEW cyclist_by_age " +
+                        "AS SELECT age, birthday, name, country " +
+                        "FROM cyclist_mv " +
+                        "WHERE age IS NOT NULL AND cid IS NOT NULL " +
+                        "PRIMARY KEY (age, cid) WITH comment = 'simple view'");
+            }
+        }
+
+        // A table with a secondary index, taken from documentation on secondary index.
+        session.execute(SchemaBuilder.createTable("rank_by_year_and_name")
+                .addPartitionKey("race_year", DataType.cint())
+                .addPartitionKey("race_name", DataType.text())
+                .addClusteringColumn("rank", DataType.cint())
+                .addColumn("cyclist_name", DataType.text()));
+
+        session.execute(SchemaBuilder.createIndex("ryear")
+                .onTable("rank_by_year_and_name")
+                .andColumn("race_year"));
+
+        session.execute(SchemaBuilder.createIndex("rrank")
+                .onTable("rank_by_year_and_name")
+                .andColumn("rank"));
+
+        // udfs and udas require 2.22+
+        if (ccm().getCassandraVersion().compareTo(VersionNumber.parse("2.2")) >= 0) {
+            // UDFs
+            session.execute("CREATE OR REPLACE FUNCTION avgState ( state tuple<int,bigint>, val int ) CALLED ON NULL INPUT RETURNS tuple<int,bigint> LANGUAGE java AS \n" +
+                    "  'if (val !=null) { state.setInt(0, state.getInt(0)+1); state.setLong(1, state.getLong(1)+val.intValue()); } return state;';");
+            session.execute("CREATE OR REPLACE FUNCTION avgFinal ( state tuple<int,bigint> ) CALLED ON NULL INPUT RETURNS double LANGUAGE java AS \n" +
+                    "  'double r = 0; if (state.getInt(0) == 0) return null; r = state.getLong(1); r /= state.getInt(0); return Double.valueOf(r);';");
+
+            // UDAs
+            session.execute("CREATE AGGREGATE IF NOT EXISTS mean ( int ) \n" +
+                    "SFUNC avgState STYPE tuple<int,bigint> FINALFUNC avgFinal INITCOND (0,0);");
+            session.execute("CREATE AGGREGATE IF NOT EXISTS average ( int ) \n" +
+                    "SFUNC avgState STYPE tuple<int,bigint> FINALFUNC avgFinal INITCOND (0,0);");
+        }
+
+        ks = cluster().getMetadata().getKeyspace(keyspace);
+
+        // validate that the exported schema matches what was expected exactly.
+        assertThat(ks.exportAsString().trim()).isEqualTo(getExpectedCqlString());
+
+        // Also validate that when you create a Cluster with schema already created that the exported string
+        // is the same.
+        Cluster newCluster = this.createClusterBuilderNoDebouncing()
+                .addContactPointsWithPorts(this.getContactPointsWithPorts())
+                .build();
+        try {
+            newCluster.init();
+            ks = newCluster.getMetadata().getKeyspace(keyspace);
+            assertThat(ks.exportAsString().trim()).isEqualTo(getExpectedCqlString());
+        } finally {
+            newCluster.close();
+        }
+    }
+
+    private String getExpectedCqlString() {
+        String majorMinor = ccm().getCassandraVersion().getMajor() + "." + ccm().getCassandraVersion().getMinor();
+        String resourceName = "/export_as_string_test_" + majorMinor + ".cql";
+
+        Closer closer = Closer.create();
+        try {
+            InputStream is = ExportAsStringTest.class.getResourceAsStream(resourceName);
+            closer.register(is);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(baos);
+            ByteStreams.copy(is, ps);
+            return baos.toString().trim();
+        } catch (IOException e) {
+            logger.warn("Failure to read {}", resourceName, e);
+            fail("Unable to read " + resourceName + " is it defined?");
+        } finally {
+            try {
+                closer.close();
+            } catch (IOException e) { // no op
+                logger.warn("Failure closing streams", e);
+            }
+        }
+        return "";
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/FunctionMetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/FunctionMetadataTest.java
@@ -50,13 +50,11 @@ public class FunctionMetadataTest extends CCMTestsSupport {
         assertThat(function.toString())
                 .isEqualTo(cql);
         assertThat(function.exportAsString())
-                .isEqualTo(String.format("CREATE FUNCTION %s.plus(\n"
-                        + "    s int,\n"
-                        + "    v int)\n"
-                        + "RETURNS NULL ON NULL INPUT\n"
-                        + "RETURNS int\n"
-                        + "LANGUAGE java\n"
-                        + "AS 'return s+v;';", this.keyspace));
+                .isEqualTo(String.format("CREATE FUNCTION %s.plus(s int,v int)\n"
+                        + "    RETURNS NULL ON NULL INPUT\n"
+                        + "    RETURNS int\n"
+                        + "    LANGUAGE java\n"
+                        + "    AS 'return s+v;';", this.keyspace));
     }
 
     @Test(groups = "short")
@@ -81,10 +79,10 @@ public class FunctionMetadataTest extends CCMTestsSupport {
                 .isEqualTo(cql);
         assertThat(function.exportAsString())
                 .isEqualTo(String.format("CREATE FUNCTION %s.pi()\n"
-                        + "CALLED ON NULL INPUT\n"
-                        + "RETURNS double\n"
-                        + "LANGUAGE java\n"
-                        + "AS 'return Math.PI;';", this.keyspace));
+                        + "    CALLED ON NULL INPUT\n"
+                        + "    RETURNS double\n"
+                        + "    LANGUAGE java\n"
+                        + "    AS 'return Math.PI;';", this.keyspace));
     }
 
     @Test(groups = "short")
@@ -154,12 +152,11 @@ public class FunctionMetadataTest extends CCMTestsSupport {
         assertThat(function.toString())
                 .isEqualTo(cql);
         assertThat(function.exportAsString())
-                .isEqualTo(String.format("CREATE FUNCTION %s.complex(\n"
-                        + "    x tuple<tuple<int>, map<int, int>>)\n"
-                        + "RETURNS NULL ON NULL INPUT\n"
-                        + "RETURNS int\n"
-                        + "LANGUAGE java\n"
-                        + "AS 'return 42;';", this.keyspace));
+                .isEqualTo(String.format("CREATE FUNCTION %s.complex(x tuple<tuple<int>, map<int, int>>)\n"
+                        + "    RETURNS NULL ON NULL INPUT\n"
+                        + "    RETURNS int\n"
+                        + "    LANGUAGE java\n"
+                        + "    AS 'return 42;';", this.keyspace));
     }
 
     @Override

--- a/driver-core/src/test/resources/export_as_string_test_2.0.cql
+++ b/driver-core/src/test/resources/export_as_string_test_2.0.cql
@@ -1,0 +1,42 @@
+CREATE KEYSPACE complex_ks WITH REPLICATION = { 'class' : 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1' } AND DURABLE_WRITES = true;
+
+CREATE TABLE complex_ks.rank_by_year_and_name (
+    race_year int,
+    race_name text,
+    rank int,
+    cyclist_name text,
+    PRIMARY KEY ((race_year, race_name), rank)
+) WITH CLUSTERING ORDER BY (rank ASC)
+    AND read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND replicate_on_write = true
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = 'KEYS_ONLY'
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy' }
+    AND compression = { 'sstable_compression' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99.0PERCENTILE'
+    AND index_interval = 128;
+
+CREATE INDEX rrank ON complex_ks.rank_by_year_and_name (rank);
+
+CREATE INDEX ryear ON complex_ks.rank_by_year_and_name (race_year);
+
+CREATE TABLE complex_ks.ztable (
+    zkey text,
+    a int,
+    PRIMARY KEY (zkey)
+) WITH read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND replicate_on_write = true
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.1
+    AND caching = 'KEYS_ONLY'
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'sstable_size_in_mb' : 95 }
+    AND compression = { 'sstable_compression' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99.0PERCENTILE'
+    AND index_interval = 128;

--- a/driver-core/src/test/resources/export_as_string_test_2.1.cql
+++ b/driver-core/src/test/resources/export_as_string_test_2.1.cql
@@ -1,0 +1,64 @@
+CREATE KEYSPACE complex_ks WITH REPLICATION = { 'class' : 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1' } AND DURABLE_WRITES = true;
+
+CREATE TYPE complex_ks.btype (
+    a text
+);
+
+CREATE TYPE complex_ks.xtype (
+    d text
+);
+
+CREATE TYPE complex_ks.ztype (
+    c text,
+    a int
+);
+
+CREATE TYPE complex_ks.ctype (
+    z frozen<complex_ks.ztype>,
+    x frozen<complex_ks.xtype>
+);
+
+CREATE TYPE complex_ks.atype (
+    c frozen<complex_ks.ctype>
+);
+
+CREATE TABLE complex_ks.rank_by_year_and_name (
+    race_year int,
+    race_name text,
+    rank int,
+    cyclist_name text,
+    PRIMARY KEY ((race_year, race_name), rank)
+) WITH CLUSTERING ORDER BY (rank ASC)
+    AND read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy' }
+    AND compression = { 'sstable_compression' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99.0PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048;
+
+CREATE INDEX rrank ON complex_ks.rank_by_year_and_name (rank);
+
+CREATE INDEX ryear ON complex_ks.rank_by_year_and_name (race_year);
+
+CREATE TABLE complex_ks.ztable (
+    zkey text,
+    a frozen<complex_ks.atype>,
+    PRIMARY KEY (zkey)
+) WITH read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.1
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'sstable_size_in_mb' : 95 }
+    AND compression = { 'sstable_compression' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99.0PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048;

--- a/driver-core/src/test/resources/export_as_string_test_2.2.cql
+++ b/driver-core/src/test/resources/export_as_string_test_2.2.cql
@@ -1,0 +1,110 @@
+CREATE KEYSPACE complex_ks WITH REPLICATION = { 'class' : 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1' } AND DURABLE_WRITES = true;
+
+CREATE TYPE complex_ks.btype (
+    a text
+);
+
+CREATE TYPE complex_ks.xtype (
+    d text
+);
+
+CREATE TYPE complex_ks.ztype (
+    c text,
+    a int
+);
+
+CREATE TYPE complex_ks.ctype (
+    z frozen<complex_ks.ztype>,
+    x frozen<complex_ks.xtype>
+);
+
+CREATE TYPE complex_ks.atype (
+    c frozen<complex_ks.ctype>
+);
+
+CREATE TABLE complex_ks.cyclist_mv (
+    cid uuid,
+    age int,
+    birthday date,
+    country text,
+    name text,
+    PRIMARY KEY (cid)
+) WITH read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy' }
+    AND compression = { 'sstable_compression' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99.0PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048;
+
+CREATE INDEX cyclist_by_country ON complex_ks.cyclist_mv (country);
+
+CREATE TABLE complex_ks.rank_by_year_and_name (
+    race_year int,
+    race_name text,
+    rank int,
+    cyclist_name text,
+    PRIMARY KEY ((race_year, race_name), rank)
+) WITH CLUSTERING ORDER BY (rank ASC)
+    AND read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy' }
+    AND compression = { 'sstable_compression' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99.0PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048;
+
+CREATE INDEX rrank ON complex_ks.rank_by_year_and_name (rank);
+
+CREATE INDEX ryear ON complex_ks.rank_by_year_and_name (race_year);
+
+CREATE TABLE complex_ks.ztable (
+    zkey text,
+    a frozen<complex_ks.atype>,
+    PRIMARY KEY (zkey)
+) WITH read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.1
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'sstable_size_in_mb' : 95 }
+    AND compression = { 'sstable_compression' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99.0PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048;
+
+CREATE FUNCTION complex_ks.avgfinal(state tuple<int, bigint>)
+    CALLED ON NULL INPUT
+    RETURNS double
+    LANGUAGE java
+    AS 'double r = 0; if (state.getInt(0) == 0) return null; r = state.getLong(1); r /= state.getInt(0); return Double.valueOf(r);';
+
+CREATE FUNCTION complex_ks.avgstate(state tuple<int, bigint>,val int)
+    CALLED ON NULL INPUT
+    RETURNS tuple<int, bigint>
+    LANGUAGE java
+    AS 'if (val !=null) { state.setInt(0, state.getInt(0)+1); state.setLong(1, state.getLong(1)+val.intValue()); } return state;';
+
+CREATE AGGREGATE complex_ks.average(int)
+    SFUNC avgstate
+    STYPE tuple<int, bigint>
+    FINALFUNC avgfinal
+    INITCOND (0,0);
+
+CREATE AGGREGATE complex_ks.mean(int)
+    SFUNC avgstate
+    STYPE tuple<int, bigint>
+    FINALFUNC avgfinal
+    INITCOND (0,0);

--- a/driver-core/src/test/resources/export_as_string_test_3.0.cql
+++ b/driver-core/src/test/resources/export_as_string_test_3.0.cql
@@ -1,0 +1,173 @@
+CREATE KEYSPACE complex_ks WITH REPLICATION = { 'class' : 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1' } AND DURABLE_WRITES = true;
+
+CREATE TYPE complex_ks.btype (
+    a text
+);
+
+CREATE TYPE complex_ks.xtype (
+    d text
+);
+
+CREATE TYPE complex_ks.ztype (
+    c text,
+    a int
+);
+
+CREATE TYPE complex_ks.ctype (
+    z frozen<complex_ks.ztype>,
+    x frozen<complex_ks.xtype>
+);
+
+CREATE TYPE complex_ks.atype (
+    c frozen<complex_ks.ctype>
+);
+
+CREATE TABLE complex_ks.cyclist_mv (
+    cid uuid,
+    age int,
+    birthday date,
+    country text,
+    name text,
+    PRIMARY KEY (cid)
+) WITH read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold' : 32, 'min_threshold' : 4 }
+    AND compression = { 'chunk_length_in_kb' : 64, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0;
+
+CREATE INDEX cyclist_by_country ON complex_ks.cyclist_mv (country);
+
+CREATE MATERIALIZED VIEW complex_ks.cyclist_by_a_age AS
+    SELECT *
+    FROM complex_ks.cyclist_mv
+    WHERE age IS NOT NULL AND cid IS NOT NULL
+    PRIMARY KEY (age, cid)
+    WITH CLUSTERING ORDER BY (cid ASC)
+    AND read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold' : 32, 'min_threshold' : 4 }
+    AND compression = { 'chunk_length_in_kb' : 64, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0;
+
+CREATE MATERIALIZED VIEW complex_ks.cyclist_by_age AS
+    SELECT age, cid, birthday, country, name
+    FROM complex_ks.cyclist_mv
+    WHERE age IS NOT NULL AND cid IS NOT NULL
+    PRIMARY KEY (age, cid)
+    WITH CLUSTERING ORDER BY (cid ASC)
+    AND read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = 'simple view'
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold' : 32, 'min_threshold' : 4 }
+    AND compression = { 'chunk_length_in_kb' : 64, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0;
+
+CREATE MATERIALIZED VIEW complex_ks.cyclist_by_r_age AS
+    SELECT age, cid, birthday, country, name
+    FROM complex_ks.cyclist_mv
+    WHERE age IS NOT NULL AND cid IS NOT NULL
+    PRIMARY KEY (age, cid)
+    WITH CLUSTERING ORDER BY (cid DESC)
+    AND read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold' : 32, 'min_threshold' : 4 }
+    AND compression = { 'chunk_length_in_kb' : 64, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0;
+
+CREATE TABLE complex_ks.rank_by_year_and_name (
+    race_year int,
+    race_name text,
+    rank int,
+    cyclist_name text,
+    PRIMARY KEY ((race_year, race_name), rank)
+) WITH CLUSTERING ORDER BY (rank ASC)
+    AND read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold' : 32, 'min_threshold' : 4 }
+    AND compression = { 'chunk_length_in_kb' : 64, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0;
+
+CREATE INDEX rrank ON complex_ks.rank_by_year_and_name (rank);
+
+CREATE INDEX ryear ON complex_ks.rank_by_year_and_name (race_year);
+
+CREATE TABLE complex_ks.ztable (
+    zkey text,
+    a frozen<complex_ks.atype>,
+    PRIMARY KEY (zkey)
+) WITH read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.1
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'sstable_size_in_mb' : 95 }
+    AND compression = { 'chunk_length_in_kb' : 64, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0;
+
+CREATE FUNCTION complex_ks.avgfinal(state tuple<int, bigint>)
+    CALLED ON NULL INPUT
+    RETURNS double
+    LANGUAGE java
+    AS 'double r = 0; if (state.getInt(0) == 0) return null; r = state.getLong(1); r /= state.getInt(0); return Double.valueOf(r);';
+
+CREATE FUNCTION complex_ks.avgstate(state tuple<int, bigint>,val int)
+    CALLED ON NULL INPUT
+    RETURNS tuple<int, bigint>
+    LANGUAGE java
+    AS 'if (val !=null) { state.setInt(0, state.getInt(0)+1); state.setLong(1, state.getLong(1)+val.intValue()); } return state;';
+
+CREATE AGGREGATE complex_ks.average(int)
+    SFUNC avgstate
+    STYPE tuple<int, bigint>
+    FINALFUNC avgfinal
+    INITCOND (0,0);
+
+CREATE AGGREGATE complex_ks.mean(int)
+    SFUNC avgstate
+    STYPE tuple<int, bigint>
+    FINALFUNC avgfinal
+    INITCOND (0,0);

--- a/driver-core/src/test/resources/export_as_string_test_3.11.cql
+++ b/driver-core/src/test/resources/export_as_string_test_3.11.cql
@@ -1,0 +1,179 @@
+CREATE KEYSPACE complex_ks WITH REPLICATION = { 'class' : 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1' } AND DURABLE_WRITES = true;
+
+CREATE TYPE complex_ks.btype (
+    a text
+);
+
+CREATE TYPE complex_ks.xtype (
+    d text
+);
+
+CREATE TYPE complex_ks.ztype (
+    c text,
+    a int
+);
+
+CREATE TYPE complex_ks.ctype (
+    z frozen<complex_ks.ztype>,
+    x frozen<complex_ks.xtype>
+);
+
+CREATE TYPE complex_ks.atype (
+    c frozen<complex_ks.ctype>
+);
+
+CREATE TABLE complex_ks.cyclist_mv (
+    cid uuid,
+    age int,
+    birthday date,
+    country text,
+    name text,
+    PRIMARY KEY (cid)
+) WITH read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold' : 32, 'min_threshold' : 4 }
+    AND compression = { 'chunk_length_in_kb' : 64, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0
+    AND cdc = false;
+
+CREATE INDEX cyclist_by_country ON complex_ks.cyclist_mv (country);
+
+CREATE MATERIALIZED VIEW complex_ks.cyclist_by_a_age AS
+    SELECT *
+    FROM complex_ks.cyclist_mv
+    WHERE age IS NOT NULL AND cid IS NOT NULL
+    PRIMARY KEY (age, cid)
+    WITH CLUSTERING ORDER BY (cid ASC)
+    AND read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold' : 32, 'min_threshold' : 4 }
+    AND compression = { 'chunk_length_in_kb' : 64, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0
+    AND cdc = false;
+
+CREATE MATERIALIZED VIEW complex_ks.cyclist_by_age AS
+    SELECT age, cid, birthday, country, name
+    FROM complex_ks.cyclist_mv
+    WHERE age IS NOT NULL AND cid IS NOT NULL
+    PRIMARY KEY (age, cid)
+    WITH CLUSTERING ORDER BY (cid ASC)
+    AND read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = 'simple view'
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold' : 32, 'min_threshold' : 4 }
+    AND compression = { 'chunk_length_in_kb' : 64, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0
+    AND cdc = false;
+
+CREATE MATERIALIZED VIEW complex_ks.cyclist_by_r_age AS
+    SELECT age, cid, birthday, country, name
+    FROM complex_ks.cyclist_mv
+    WHERE age IS NOT NULL AND cid IS NOT NULL
+    PRIMARY KEY (age, cid)
+    WITH CLUSTERING ORDER BY (cid DESC)
+    AND read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold' : 32, 'min_threshold' : 4 }
+    AND compression = { 'chunk_length_in_kb' : 64, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0
+    AND cdc = false;
+
+CREATE TABLE complex_ks.rank_by_year_and_name (
+    race_year int,
+    race_name text,
+    rank int,
+    cyclist_name text,
+    PRIMARY KEY ((race_year, race_name), rank)
+) WITH CLUSTERING ORDER BY (rank ASC)
+    AND read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold' : 32, 'min_threshold' : 4 }
+    AND compression = { 'chunk_length_in_kb' : 64, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0
+    AND cdc = false;
+
+CREATE INDEX rrank ON complex_ks.rank_by_year_and_name (rank);
+
+CREATE INDEX ryear ON complex_ks.rank_by_year_and_name (race_year);
+
+CREATE TABLE complex_ks.ztable (
+    zkey text,
+    a frozen<complex_ks.atype>,
+    PRIMARY KEY (zkey)
+) WITH read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.1
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.1
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'sstable_size_in_mb' : 95 }
+    AND compression = { 'chunk_length_in_kb' : 64, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99PERCENTILE'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0
+    AND cdc = false;
+
+CREATE FUNCTION complex_ks.avgfinal(state tuple<int, bigint>)
+    CALLED ON NULL INPUT
+    RETURNS double
+    LANGUAGE java
+    AS 'double r = 0; if (state.getInt(0) == 0) return null; r = state.getLong(1); r /= state.getInt(0); return Double.valueOf(r);';
+
+CREATE FUNCTION complex_ks.avgstate(state tuple<int, bigint>,val int)
+    CALLED ON NULL INPUT
+    RETURNS tuple<int, bigint>
+    LANGUAGE java
+    AS 'if (val !=null) { state.setInt(0, state.getInt(0)+1); state.setLong(1, state.getLong(1)+val.intValue()); } return state;';
+
+CREATE AGGREGATE complex_ks.average(int)
+    SFUNC avgstate
+    STYPE tuple<int, bigint>
+    FINALFUNC avgfinal
+    INITCOND (0,0);
+
+CREATE AGGREGATE complex_ks.mean(int)
+    SFUNC avgstate
+    STYPE tuple<int, bigint>
+    FINALFUNC avgfinal
+    INITCOND (0,0);


### PR DESCRIPTION
For [JAVA-1582](https://datastax-oss.atlassian.net/browse/JAVA-1582).  This could use an integration test, so I will add one.

-------

JAVA-1407 improved exportAsString to ensure that user types were
described in topological order.  However a side effect of this change is
that User Types are not always consistently ordered as it depended on
undefined Map ordering behavior which may vary based on JDK
implementation.

While this is not a functional issue, it would be preferable that the
same order were always returned.  This implementation ensures this by
ordering the adjacency list of a vertex by alphabetical name of the user
type.  If there are no dependencies between user types, the result of
this change is that user types are ordered alphabetically.