### PR TITLE
JAVA-1595: Don't use system.local.rpc_address when refreshing node list

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha2 (in progress)
 
+- [bug] JAVA-1595: Don't use system.local.rpc_address when refreshing node list
 - [bug] JAVA-1568: Handle Reconnection#reconnectNow/stop while the current attempt is still in 
   progress
 - [improvement] JAVA-1585: Add GenericType#where


### PR DESCRIPTION
Turns out the fix was trivial to implement.