### PR TITLE
JAVA-1542: Enable JaCoCo code coverage

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -16,4 +16,5 @@ build:
   - xunit:
     - "**/target/surefire-reports/TEST-*.xml"
     - "**/target/failsafe-reports/TEST-*.xml"
+  - jacoco: true
 disable_commit_status: true

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha2 (in progress)
 
+- [improvement] JAVA-1542: Enable JaCoCo code coverage
 - [improvement] JAVA-1295: Auto-detect best protocol version in mixed cluster
 - [bug] JAVA-1565: Mark node down when it loses its last connection and was already reconnecting
 - [bug] JAVA-1594: Don't create pool if node comes back up but is ignored

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,11 @@
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.7</version>
         </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.7.9</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -255,6 +260,24 @@ limitations under the License.]]>
             <phase>initialize</phase>
             <goals>
               <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>report</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Enables JaCoCo code coverage and enables the jacoco reporter plugin in the internal jenkins environment.   Does not appear to have a noticeable negative impact on runtime.

If we'd like, we could pursue using something like [coveralls](https://coveralls.io) to publish status checks to PRs, but I think for now it'd be good to get jacoco running.

Note that this does not aggregate results between modules (reports are in the target/site directory of each module).  Jenkins does aggregate results on the other hand.  We could aggregate reports using a separate module that runs after all the others, we could consider aggregating results once we have a binary distribution module.