### PR TITLE
Fix number of executions parameter to match documented behavior.

### DIFF
--- a/manual/speculative_execution/README.md
+++ b/manual/speculative_execution/README.md
@@ -87,7 +87,7 @@ Cluster cluster = Cluster.builder()
     .withSpeculativeExecutionPolicy(
         new ConstantSpeculativeExecutionPolicy(
             500, // delay before a new execution is launched
-            2    // maximum number of executions
+            3    // maximum number of executions
         ))
     .build();
 ```


### PR DESCRIPTION
The documentation shows the behavior for 3 executions, but only 2 were configured.