### PR TITLE
JAVA-1631 Publish a sources jar for driver-core-tests

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -185,6 +185,18 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-test-sources</id>
+                        <goals>
+                            <goal>test-jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>


### PR DESCRIPTION
Over the past years, a lot of investment has been made in sophisticated testing API for the driver internals to make it easy to use CCM and Scassandra. These tools are available as a test-jar extra artifact of driver-core. This can be very convenient for users that need to implement some extensions to the DataStax Driver. Unfortunately the sources for this test-jar aren't published.