### PR TITLE
JAVA-1632: Add a withIpPrefix(String) method to CCMBridge.Builder

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.datastax.driver.core.TestUtils.*;
+import static com.datastax.driver.core.TestUtils.executeNoFail;
 
 public class CCMBridge implements CCMAccess {
 
@@ -270,6 +270,8 @@ public class CCMBridge implements CCMAccess {
 
     private final int binaryPort;
 
+    private final String ipPrefix;
+
     private final File ccmDir;
 
     private final boolean isDSE;
@@ -284,11 +286,12 @@ public class CCMBridge implements CCMAccess {
 
     private final int[] nodes;
 
-    private CCMBridge(String clusterName, VersionNumber cassandraVersion, VersionNumber dseVersion,
+    private CCMBridge(String clusterName, VersionNumber cassandraVersion, VersionNumber dseVersion, String ipPrefix,
                       int storagePort, int thriftPort, int binaryPort, String jvmArgs, int[] nodes) {
         this.clusterName = clusterName;
         this.cassandraVersion = cassandraVersion;
         this.dseVersion = dseVersion;
+        this.ipPrefix = ipPrefix;
         this.storagePort = storagePort;
         this.thriftPort = thriftPort;
         this.binaryPort = binaryPort;
@@ -307,9 +310,13 @@ public class CCMBridge implements CCMAccess {
         return clusterName;
     }
 
+    protected String ipOfNode(int n) {
+        return ipPrefix + n;
+    }
+
     @Override
     public InetSocketAddress addressOfNode(int n) {
-        return new InetSocketAddress(TestUtils.ipOfNode(n), binaryPort);
+        return new InetSocketAddress(ipOfNode(n), binaryPort);
     }
 
     @Override
@@ -426,7 +433,7 @@ public class CCMBridge implements CCMAccess {
             for (int dc = 1; dc <= nodes.length; dc++) {
                 int nodesInDc = nodes[dc - 1];
                 for (int i = 0; i < nodesInDc; i++) {
-                    InetSocketAddress addr = new InetSocketAddress(ipOfNode(n), binaryPort);
+                    InetSocketAddress addr = addressOfNode(n);
                     logger.debug("Waiting for binary protocol to show up for {}", addr);
                     TestUtils.waitUntilPortIsUp(addr);
                     n++;
@@ -487,7 +494,7 @@ public class CCMBridge implements CCMAccess {
 
     @Override
     public void start(int n) {
-        logger.debug(String.format("Starting: node %s (%s%s:%s) in %s", n, TestUtils.IP_PREFIX, n, binaryPort, this));
+        logger.debug(String.format("Starting: node %s (%s%s:%s) in %s", n, ipPrefix, n, binaryPort, this));
         try {
             String cmd = CCM_COMMAND + " node%d start " + jvmArgs + getStartWaitArguments();
             if (isWindows() && this.cassandraVersion.compareTo(VersionNumber.parse("2.2.4")) >= 0) {
@@ -511,31 +518,31 @@ public class CCMBridge implements CCMAccess {
 
     @Override
     public void stop(int n) {
-        logger.debug(String.format("Stopping: node %s (%s%s:%s) in %s", n, TestUtils.IP_PREFIX, n, binaryPort, this));
+        logger.debug(String.format("Stopping: node %s (%s%s:%s) in %s", n, ipPrefix, n, binaryPort, this));
         execute(CCM_COMMAND + " node%d stop", n);
     }
 
     @Override
     public void forceStop(int n) {
-        logger.debug(String.format("Force stopping: node %s (%s%s:%s) in %s", n, TestUtils.IP_PREFIX, n, binaryPort, this));
+        logger.debug(String.format("Force stopping: node %s (%s%s:%s) in %s", n, ipPrefix, n, binaryPort, this));
         execute(CCM_COMMAND + " node%d stop --not-gently", n);
     }
 
     @Override
     public void pause(int n) {
-        logger.debug(String.format("Pausing: node %s (%s%s:%s) in %s", n, TestUtils.IP_PREFIX, n, binaryPort, this));
+        logger.debug(String.format("Pausing: node %s (%s%s:%s) in %s", n, ipPrefix, n, binaryPort, this));
         execute(CCM_COMMAND + " node%d pause", n);
     }
 
     @Override
     public void resume(int n) {
-        logger.debug(String.format("Resuming: node %s (%s%s:%s) in %s", n, TestUtils.IP_PREFIX, n, binaryPort, this));
+        logger.debug(String.format("Resuming: node %s (%s%s:%s) in %s", n, ipPrefix, n, binaryPort, this));
         execute(CCM_COMMAND + " node%d resume", n);
     }
 
     @Override
     public void remove(int n) {
-        logger.debug(String.format("Removing: node %s (%s%s:%s) from %s", n, TestUtils.IP_PREFIX, n, binaryPort, this));
+        logger.debug(String.format("Removing: node %s (%s%s:%s) from %s", n, ipPrefix, n, binaryPort, this));
         execute(CCM_COMMAND + " node%d remove", n);
     }
 
@@ -546,18 +553,18 @@ public class CCMBridge implements CCMAccess {
 
     @Override
     public void add(int dc, int n) {
-        logger.debug(String.format("Adding: node %s (%s%s:%s) to %s", n, TestUtils.IP_PREFIX, n, binaryPort, this));
-        String thriftItf = TestUtils.ipOfNode(n) + ":" + thriftPort;
-        String storageItf = TestUtils.ipOfNode(n) + ":" + storagePort;
-        String binaryItf = TestUtils.ipOfNode(n) + ":" + binaryPort;
-        String remoteLogItf = TestUtils.ipOfNode(n) + ":" + TestUtils.findAvailablePort();
+        logger.debug(String.format("Adding: node %s (%s%s:%s) to %s", n, ipPrefix, n, binaryPort, this));
+        String thriftItf = ipOfNode(n) + ":" + thriftPort;
+        String storageItf = ipOfNode(n) + ":" + storagePort;
+        String binaryItf = ipOfNode(n) + ":" + binaryPort;
+        String remoteLogItf = ipOfNode(n) + ":" + TestUtils.findAvailablePort();
         execute(CCM_COMMAND + " add node%d -d dc%s -i %s%d -t %s -l %s --binary-itf %s -j %d -r %s -s -b" + (isDSE ? " --dse" : ""),
-                n, dc, TestUtils.IP_PREFIX, n, thriftItf, storageItf, binaryItf, TestUtils.findAvailablePort(), remoteLogItf);
+                n, dc, ipPrefix, n, thriftItf, storageItf, binaryItf, TestUtils.findAvailablePort(), remoteLogItf);
     }
 
     @Override
     public void decommission(int n) {
-        logger.debug(String.format("Decommissioning: node %s (%s%s:%s) from %s", n, TestUtils.IP_PREFIX, n, binaryPort, this));
+        logger.debug(String.format("Decommissioning: node %s (%s%s:%s) from %s", n, ipPrefix, n, binaryPort, this));
         // Special case for C* 3.12+, DSE 5.1+, force decommission (see CASSANDRA-12510)
         String cmd = CCM_COMMAND + " node%d decommission";
         if (this.cassandraVersion.compareTo(VersionNumber.parse("3.12")) >= 0) {
@@ -780,6 +787,7 @@ public class CCMBridge implements CCMAccess {
         public static final String RANDOM_PORT = "__RANDOM_PORT__";
         private static final Pattern RANDOM_PORT_PATTERN = Pattern.compile(RANDOM_PORT);
 
+        private String ipPrefix = TestUtils.IP_PREFIX;
         int[] nodes = {1};
         private boolean start = true;
         private boolean dse = false;
@@ -795,6 +803,14 @@ public class CCMBridge implements CCMAccess {
             cassandraConfiguration.put("storage_port", RANDOM_PORT);
             cassandraConfiguration.put("rpc_port", RANDOM_PORT);
             cassandraConfiguration.put("native_transport_port", RANDOM_PORT);
+        }
+
+        /**
+         * IP Prefix to use for the address of each node. Its format has to be like {@code "127.1.1."}.
+         */
+        public Builder withIpPrefix(String ipPrefix) {
+            this.ipPrefix = ipPrefix;
+            return this;
         }
 
         /**
@@ -949,7 +965,7 @@ public class CCMBridge implements CCMAccess {
                 cassandraConfiguration.remove("rpc_port");
                 cassandraConfiguration.remove("thrift_prepared_statements_cache_size_mb");
             }
-            final CCMBridge ccm = new CCMBridge(clusterName, cassandraVersion, dseVersion, storagePort, thriftPort, binaryPort, joinJvmArgs(), nodes);
+            final CCMBridge ccm = new CCMBridge(clusterName, cassandraVersion, dseVersion, ipPrefix, storagePort, thriftPort, binaryPort, joinJvmArgs(), nodes);
 
             Runtime.getRuntime().addShutdownHook(new Thread() {
                 @Override
@@ -1010,7 +1026,7 @@ public class CCMBridge implements CCMAccess {
                 cassandraVersion, VersionNumber dseVersion) {
             StringBuilder result = new StringBuilder(CCM_COMMAND + " create");
             result.append(" ").append(clusterName);
-            result.append(" -i ").append(TestUtils.IP_PREFIX);
+            result.append(" -i ").append(ipPrefix);
             result.append(" ");
             if (nodes.length > 0) {
                 result.append(" -n ");
@@ -1052,8 +1068,8 @@ public class CCMBridge implements CCMAccess {
                 for (int dc = 1; dc <= nodes.length; dc++) {
                     int nodesInDc = nodes[dc - 1];
                     for (int i = 0; i < nodesInDc; i++) {
-                        int jmxPort = findAvailablePort();
-                        int debugPort = findAvailablePort();
+                        int jmxPort = TestUtils.findAvailablePort();
+                        int debugPort = TestUtils.findAvailablePort();
                         logger.trace("Node {} in cluster {} using JMX port {} and debug port {}", n, ccm.getClusterName(), jmxPort, debugPort);
                         File nodeConf = new File(ccm.getNodeDir(n), "node.conf");
                         File nodeConf2 = new File(ccm.getNodeDir(n), "node.conf.tmp");
@@ -1068,7 +1084,7 @@ public class CCMBridge implements CCMAccess {
                             if (line.startsWith("jmx_port")) {
                                 line = String.format("jmx_port: '%s'", jmxPort);
                             } else if (line.startsWith("remote_debug_port")) {
-                                line = String.format("remote_debug_port: %s:%s", TestUtils.ipOfNode(n), debugPort);
+                                line = String.format("remote_debug_port: %s:%s", ipPrefix + n, debugPort);
                             }
                             pw.println(line);
                         }
@@ -1128,6 +1144,7 @@ public class CCMBridge implements CCMAccess {
 
             Builder builder = (Builder) o;
 
+            if (ipPrefix != builder.ipPrefix) return false;
             if (dse != builder.dse) return false;
             if (!Arrays.equals(nodes, builder.nodes)) return false;
             if (version != null ? !version.equals(builder.version) : builder.version != null) return false;
@@ -1143,6 +1160,7 @@ public class CCMBridge implements CCMAccess {
             // do not include start as it is not relevant to the settings of the cluster.
             int result = Arrays.hashCode(nodes);
             result = 31 * result + (dse ? 1 : 0);
+            result = 31 * result + ipPrefix.hashCode();
             result = 31 * result + (version != null ? version.hashCode() : 0);
             result = 31 * result + createOptions.hashCode();
             result = 31 * result + jvmArgs.hashCode();


### PR DESCRIPTION
Currently, the IP prefix of the CCM cluster is obtained through TestUtils.IP_PREFIX which can be configured with a system property. This doesn't make it possible to create multiple CCM clusters at the same time as they would each need a different prefix. This is something we've needed in order to test a dual writes feature, for which we currently have to fork the class on our side.
Not of any immediate use for the driver itself, but note that ScassandraClusterBuilder does currently offer a withIpPrefix method anyway.