### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,15 +51,15 @@
         <slf4j.version>1.7.25</slf4j.version>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
         <guava.version>19.0</guava.version>
-        <netty.version>4.0.47.Final</netty.version>
-        <metrics.version>3.2.2</metrics.version>
-        <snappy.version>1.1.2.6</snappy.version>
+        <netty.version>4.0.53.Final</netty.version>
+        <metrics.version>3.2.5</metrics.version>
+        <snappy.version>1.1.4</snappy.version>
         <lz4.version>1.3.0</lz4.version>
-        <hdr.version>2.1.9</hdr.version>
-        <jackson.version>2.8.8</jackson.version>
+        <hdr.version>2.1.10</hdr.version>
+        <jackson.version>2.9.0</jackson.version>
         <!-- jackson-databind 2.7.x is the last to support java 6 -->
         <jackson-databind.version>2.7.9.1</jackson-databind.version>
-        <joda.version>2.9.1</joda.version>
+        <joda.version>2.9.9</joda.version>
         <jsr353-api.version>1.0</jsr353-api.version>
         <jsr353-ri.version>1.0.4</jsr353-ri.version>
         <jnr-ffi.version>2.0.7</jnr-ffi.version>
@@ -78,7 +78,7 @@
         <commons-exec.version>1.3</commons-exec.version>
         <scassandra.version>1.1.2</scassandra.version>
         <logback.version>1.2.3</logback.version>
-        <byteman.version>3.0.8</byteman.version>
+        <byteman.version>3.0.10</byteman.version>
         <ipprefix>127.0.1.</ipprefix>
         <!-- defaults below are overridden by profiles and/or submodules -->
         <test.groups>unit</test.groups>
@@ -341,7 +341,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative</artifactId>
-                <version>2.0.1.Final</version>
+                <version>2.0.7.Final</version>
                 <classifier>${os.detected.classifier}</classifier>
             </dependency>
 


### PR DESCRIPTION
- netty 4.0.47 -> 4.0.53
- netty-tcnative 2.0.1 -> 2.0.7
- metrics 3.2.2 - > 3.2.5
- snappy 1.1.2.6 -> 1.1.4
- jackson 2.8.8 -> 2.9.0
- joda 2.9.1 -> 2.9.9
- byteman 3.0.8 -> 3.0.10