### PR TITLE
Reorganize integration tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -10,7 +10,7 @@ cassandra:
 build:
   - type: maven
     version: 3.2.5
-    goals: verify -Plong
+    goals: verify
     properties: |
       ccm.cassandraVersion=$CCM_CASSANDRA_VERSION
   - xunit:

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/CompletionStageAssert.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/CompletionStageAssert.java
@@ -34,7 +34,7 @@ public class CompletionStageAssert<V>
 
   public CompletionStageAssert<V> isSuccess(Consumer<V> valueAssertions) {
     try {
-      V value = actual.toCompletableFuture().get(100, TimeUnit.MILLISECONDS);
+      V value = actual.toCompletableFuture().get(2, TimeUnit.SECONDS);
       valueAssertions.accept(value);
     } catch (TimeoutException e) {
       fail("Future did not complete within the timeout");
@@ -50,7 +50,7 @@ public class CompletionStageAssert<V>
 
   public CompletionStageAssert<V> isFailed(Consumer<Throwable> failureAssertions) {
     try {
-      actual.toCompletableFuture().get(100, TimeUnit.MILLISECONDS);
+      actual.toCompletableFuture().get(2, TimeUnit.SECONDS);
       fail("Expected completion stage to fail");
     } catch (TimeoutException e) {
       fail("Future did not complete within the timeout");

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -99,82 +99,52 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <executions>
           <execution>
-            <id>short-tests</id>
+            <id>parallelizable-tests</id>
             <goals>
               <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
             <configuration>
-              <!-- skip long & isolated tests by default -->
-              <excludedGroups>
-                com.datastax.oss.driver.categories.LongTests,com.datastax.oss.driver.categories.IsolatedTests
-              </excludedGroups>
-              <reportNameSuffix>short</reportNameSuffix>
+              <groups>com.datastax.oss.driver.categories.ParallelizableTests</groups>
               <parallel>classes</parallel>
               <threadCountClasses>8</threadCountClasses>
               <!-- set so test can exit with rc 0 (ci will mark test failures accordingly) -->
               <testFailureIgnore>true</testFailureIgnore>
+              <reportNameSuffix>parallelized</reportNameSuffix>
+            </configuration>
+          </execution>
+          <execution>
+            <id>serial-tests</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <excludedGroups>
+                com.datastax.oss.driver.categories.ParallelizableTests,
+                com.datastax.oss.driver.categories.IsolatedTests
+              </excludedGroups>
+              <testFailureIgnore>true</testFailureIgnore>
+              <reportNameSuffix>serial</reportNameSuffix>
+            </configuration>
+          </execution>
+          <execution>
+            <id>isolated-tests</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <groups>com.datastax.oss.driver.categories.IsolatedTests</groups>
+              <!-- run each test in its own jvm fork -->
+              <forkCount>1</forkCount>
+              <reuseForks>false</reuseForks>
+              <testFailureIgnore>true</testFailureIgnore>
+              <reportNameSuffix>isolated</reportNameSuffix>
             </configuration>
           </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>short</id>
-      <properties>
-        <!-- imply that integration tests are not skipped if using short -->
-        <skipITs>false</skipITs>
-      </properties>
-    </profile>
-    <profile>
-      <id>long</id>
-      <properties>
-        <!-- imply that integration tests are not skipped if using long -->
-        <skipITs>false</skipITs>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <executions>
-              <!-- add a special execution that only runs long tests -->
-              <execution>
-                <id>long-tests</id>
-                <goals>
-                  <goal>integration-test</goal>
-                  <goal>verify</goal>
-                </goals>
-                <configuration>
-                  <groups>com.datastax.oss.driver.categories.LongTests</groups>
-                  <reportNameSuffix>long</reportNameSuffix>
-                  <testFailureIgnore>true</testFailureIgnore>
-                </configuration>
-              </execution>
-              <!-- add a special execution that only runs isolated tests each in their own fork -->
-              <execution>
-                <id>isolated-tests</id>
-                <goals>
-                  <goal>integration-test</goal>
-                  <goal>verify</goal>
-                </goals>
-                <configuration>
-                  <groups>com.datastax.oss.driver.categories.IsolatedTests</groups>
-                  <reportNameSuffix>isolated</reportNameSuffix>
-                  <!-- run each test in it's own jvm fork -->
-                  <forkCount>1</forkCount>
-                  <reuseForks>false</reuseForks>
-                  <testFailureIgnore>true</testFailureIgnore>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
 </project>

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ConnectIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ConnectIT.java
@@ -18,11 +18,14 @@ package com.datastax.oss.driver.api.core;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category(ParallelizableTests.class)
 public class ConnectIT {
   @ClassRule public static CcmRule ccm = CcmRule.getInstance();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ProtocolVersionInitialNegotiationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ProtocolVersionInitialNegotiationIT.java
@@ -19,12 +19,15 @@ import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterUtils;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Covers protocol negotiation for the initial connection to the first contact point. */
+@Category(ParallelizableTests.class)
 public class ProtocolVersionInitialNegotiationIT {
 
   @Rule public CcmRule ccm = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ProtocolVersionMixedClusterIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ProtocolVersionMixedClusterIT.java
@@ -17,6 +17,7 @@ package com.datastax.oss.driver.api.core;
 
 import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.testinfra.cluster.TestConfigLoader;
 import com.datastax.oss.protocol.internal.request.Query;
@@ -30,6 +31,7 @@ import java.net.InetSocketAddress;
 import java.util.stream.Stream;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 import static com.datastax.oss.driver.assertions.Assertions.assertThat;
@@ -40,6 +42,7 @@ import static org.assertj.core.api.Assertions.fail;
  * first node list refresh, we find out that some nodes only support a lower version, reconnect the
  * control connection immediately.
  */
+@Category(ParallelizableTests.class)
 public class ProtocolVersionMixedClusterIT {
   @Rule public ExpectedException thrown = ExpectedException.none();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/auth/PlainTextAuthProviderIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/auth/PlainTextAuthProviderIT.java
@@ -21,15 +21,12 @@ import com.datastax.oss.driver.api.core.Cluster;
 import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterUtils;
-import com.datastax.oss.driver.categories.LongTests;
 import com.google.common.util.concurrent.Uninterruptibles;
 import java.util.concurrent.TimeUnit;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
-@Category(LongTests.class)
 public class PlainTextAuthProviderIT {
 
   @ClassRule

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/compression/DirectCompressionIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/compression/DirectCompressionIT.java
@@ -16,20 +16,23 @@
 package com.datastax.oss.driver.api.core.compression;
 
 import com.datastax.oss.driver.api.core.Cluster;
+import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
-import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterUtils;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
 
+@Category(ParallelizableTests.class)
 public class DirectCompressionIT {
 
   @ClassRule public static CcmRule ccmRule = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverConfigProfileIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverConfigProfileIT.java
@@ -30,12 +30,14 @@ import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterUtils;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
 import com.datastax.oss.simulacron.common.cluster.QueryLog;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.noRows;
@@ -44,6 +46,7 @@ import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.when;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
+@Category(ParallelizableTests.class)
 public class DriverConfigProfileIT {
 
   @Rule public SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(3));

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverConfigProfileReloadIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverConfigProfileReloadIT.java
@@ -17,10 +17,9 @@ package com.datastax.oss.driver.api.core.config;
 
 import com.datastax.oss.driver.api.core.Cluster;
 import com.datastax.oss.driver.api.core.DriverTimeoutException;
-import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.cql.CqlSession;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
-import com.datastax.oss.driver.categories.LongTests;
 import com.datastax.oss.driver.internal.core.config.ConfigChangeEvent;
 import com.datastax.oss.driver.internal.core.config.ForceReloadConfigEvent;
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader;
@@ -32,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 import static com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader.DEFAULT_CONFIG_SUPPLIER;
@@ -41,7 +39,6 @@ import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.when;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
-@Category(LongTests.class)
 public class DriverConfigProfileReloadIT {
 
   @Rule public SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(3));

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/connection/FrameLengthIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/connection/FrameLengthIT.java
@@ -25,6 +25,7 @@ import com.datastax.oss.driver.api.core.retry.RetryDecision;
 import com.datastax.oss.driver.api.core.session.Request;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
@@ -33,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.noRows;
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.rows;
@@ -40,6 +42,7 @@ import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.when;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
+@Category(ParallelizableTests.class)
 public class FrameLengthIT {
   public static @ClassRule SimulacronRule simulacron =
       new SimulacronRule(ClusterSpec.builder().withNodes(1));

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/AsyncResultSetIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/AsyncResultSetIT.java
@@ -17,6 +17,7 @@ package com.datastax.oss.driver.api.core.cql;
 
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -24,9 +25,11 @@ import java.util.function.Function;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category(ParallelizableTests.class)
 public class AsyncResultSetIT {
 
   private static final int PAGE_SIZE = 100;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BatchStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BatchStatementIT.java
@@ -19,14 +19,17 @@ import com.datastax.oss.driver.api.core.servererrors.InvalidQueryException;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import java.util.Iterator;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category(ParallelizableTests.class)
 public class BatchStatementIT {
 
   @Rule public CcmRule ccm = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BoundStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BoundStatementIT.java
@@ -22,14 +22,17 @@ import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterUtils;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category(ParallelizableTests.class)
 public class BoundStatementIT {
 
   @Rule public CcmRule ccm = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/SimpleStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/SimpleStatementIT.java
@@ -18,16 +18,19 @@ package com.datastax.oss.driver.api.core.cql;
 import com.datastax.oss.driver.api.core.servererrors.InvalidQueryException;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import java.util.concurrent.TimeUnit;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category(ParallelizableTests.class)
 public class SimpleStatementIT {
 
   @ClassRule public static CcmRule ccm = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/data/DataTypeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/data/DataTypeIT.java
@@ -36,6 +36,7 @@ import com.datastax.oss.driver.api.core.type.UserDefinedType;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.type.DefaultListType;
 import com.datastax.oss.driver.internal.core.type.DefaultMapType;
 import com.datastax.oss.driver.internal.core.type.DefaultSetType;
@@ -68,6 +69,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
@@ -76,6 +78,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 
+@Category(ParallelizableTests.class)
 @RunWith(DataProviderRunner.class)
 public class DataTypeIT {
   @ClassRule public static CcmRule ccm = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/heartbeat/HeartbeatDisabledIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/heartbeat/HeartbeatDisabledIT.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2017-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.heartbeat;
+
+import com.datastax.oss.driver.api.core.Cluster;
+import com.datastax.oss.driver.api.core.cql.CqlSession;
+import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
+import com.datastax.oss.driver.api.testinfra.cluster.ClusterUtils;
+import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+import com.datastax.oss.simulacron.server.BoundNode;
+import java.net.SocketAddress;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/** This test is separate from {@link HeartbeatIT} because it can't be parallelized. */
+public class HeartbeatDisabledIT {
+
+  @ClassRule
+  public static SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(2));
+
+  @Rule
+  public ClusterRule cluster =
+      ClusterRule.builder(simulacron)
+          .withDefaultSession(false)
+          .withOptions(
+              "connection.heartbeat.interval = 1 second",
+              "connection.heartbeat.timeout = 500 milliseconds",
+              "connection.init-query-timeout = 2 seconds",
+              "connection.reconnection-policy.max-delay = 1 second")
+          .build();
+
+  private SocketAddress controlConnection;
+
+  @Before
+  public void setUp() {
+    simulacron.cluster().clearLogs();
+    simulacron.cluster().clearPrimes(true);
+
+    Optional<BoundNode> controlNodeOption =
+        simulacron
+            .cluster()
+            .getNodes()
+            .stream()
+            .filter(n -> n.getActiveConnections() == 1)
+            .findFirst();
+
+    if (controlNodeOption.isPresent()) {
+      BoundNode controlNode = controlNodeOption.get();
+      controlConnection = controlNode.getConnections().getConnections().get(0);
+    } else {
+      fail("Control node not found");
+    }
+  }
+
+  @Test
+  public void should_not_send_heartbeat_when_disabled() throws InterruptedException {
+    // Disable heartbeats entirely, wait longer than the default timeout and make sure we didn't receive any
+    try (Cluster<CqlSession> cluster =
+        ClusterUtils.newCluster(simulacron, "connection.heartbeat.interval = 0 second")) {
+      cluster.connect();
+      AtomicInteger heartbeats = registerHeartbeatListener();
+      SECONDS.sleep(35);
+
+      assertThat(heartbeats.get()).isZero();
+    }
+  }
+
+  private AtomicInteger registerHeartbeatListener() {
+    AtomicInteger nonControlHeartbeats = new AtomicInteger();
+    simulacron
+        .cluster()
+        .registerQueryListener(
+            (n, l) -> nonControlHeartbeats.incrementAndGet(),
+            false,
+            (l) -> l.getQuery().equals("OPTIONS") && !l.getConnection().equals(controlConnection));
+    return nonControlHeartbeats;
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/heartbeat/HeartbeatIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/heartbeat/HeartbeatIT.java
@@ -15,14 +15,12 @@
  */
 package com.datastax.oss.driver.api.core.heartbeat;
 
-import com.datastax.oss.driver.api.core.Cluster;
+import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
-import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
-import com.datastax.oss.driver.api.testinfra.cluster.ClusterUtils;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
-import com.datastax.oss.driver.categories.LongTests;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
 import com.datastax.oss.simulacron.common.cluster.QueryLog;
 import com.datastax.oss.simulacron.common.request.Options;
@@ -50,10 +48,10 @@ import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.closeConnecti
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.noResult;
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.when;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
+@Category(ParallelizableTests.class)
 public class HeartbeatIT {
 
   @ClassRule
@@ -275,20 +273,6 @@ public class HeartbeatIT {
 
     checkThat(() -> heartbeats.get() >= 2).becomesTrue();
     assertThat(node.getState()).isEqualTo(NodeState.UP);
-  }
-
-  @Test
-  @Category(LongTests.class)
-  public void should_not_send_heartbeat_when_disabled() throws InterruptedException {
-    // Disable heartbeats entirely, wait longer than the default timeout and make sure we didn't receive any
-    try (Cluster<CqlSession> cluster =
-        ClusterUtils.newCluster(simulacron, "connection.heartbeat.interval = 0 second")) {
-      cluster.connect();
-      AtomicInteger heartbeats = registerHeartbeatListener();
-      SECONDS.sleep(35);
-
-      assertThat(heartbeats.get()).isZero();
-    }
   }
 
   /**

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/ByteOrderedTokenIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/ByteOrderedTokenIT.java
@@ -19,13 +19,10 @@ import com.datastax.oss.driver.api.core.Cluster;
 import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
-import com.datastax.oss.driver.categories.LongTests;
 import com.datastax.oss.driver.internal.core.metadata.token.ByteOrderedToken;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
 
-@Category(LongTests.class)
 public class ByteOrderedTokenIT extends TokenITBase {
 
   @ClassRule

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/ByteOrderedTokenVnodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/ByteOrderedTokenVnodesIT.java
@@ -19,13 +19,10 @@ import com.datastax.oss.driver.api.core.Cluster;
 import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
-import com.datastax.oss.driver.categories.LongTests;
 import com.datastax.oss.driver.internal.core.metadata.token.ByteOrderedToken;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
 
-@Category(LongTests.class)
 public class ByteOrderedTokenVnodesIT extends TokenITBase {
 
   @ClassRule

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/DescribeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/DescribeIT.java
@@ -18,11 +18,12 @@ package com.datastax.oss.driver.api.core.metadata;
 import com.datastax.oss.driver.api.core.CassandraVersion;
 import com.datastax.oss.driver.api.core.Cluster;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
-import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.cql.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterUtils;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closer;
 import java.io.ByteArrayOutputStream;
@@ -31,12 +32,14 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
+@Category(ParallelizableTests.class)
 public class DescribeIT {
 
   private static final Logger logger = LoggerFactory.getLogger(DescribeIT.class);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/Murmur3TokenIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/Murmur3TokenIT.java
@@ -19,13 +19,10 @@ import com.datastax.oss.driver.api.core.Cluster;
 import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
-import com.datastax.oss.driver.categories.LongTests;
 import com.datastax.oss.driver.internal.core.metadata.token.Murmur3Token;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
 
-@Category(LongTests.class)
 public class Murmur3TokenIT extends TokenITBase {
 
   @ClassRule public static CustomCcmRule ccmRule = CustomCcmRule.builder().withNodes(3).build();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/Murmur3TokenVnodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/Murmur3TokenVnodesIT.java
@@ -19,13 +19,10 @@ import com.datastax.oss.driver.api.core.Cluster;
 import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
-import com.datastax.oss.driver.categories.LongTests;
 import com.datastax.oss.driver.internal.core.metadata.token.Murmur3Token;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
 
-@Category(LongTests.class)
 public class Murmur3TokenVnodesIT extends TokenITBase {
 
   @ClassRule

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/NodeStateIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/NodeStateIT.java
@@ -16,12 +16,13 @@
 package com.datastax.oss.driver.api.core.metadata;
 
 import com.datastax.oss.driver.api.core.Cluster;
-import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
 import com.datastax.oss.driver.api.core.cql.CqlSession;
+import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterUtils;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
 import com.datastax.oss.driver.api.testinfra.utils.ConditionChecker;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
 import com.datastax.oss.driver.internal.core.metadata.NodeStateEvent;
@@ -45,6 +46,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
@@ -53,6 +55,7 @@ import static com.datastax.oss.driver.assertions.Assertions.fail;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 
+@Category(ParallelizableTests.class)
 public class NodeStateIT {
 
   public @Rule SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(2));

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/RandomTokenIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/RandomTokenIT.java
@@ -19,13 +19,10 @@ import com.datastax.oss.driver.api.core.Cluster;
 import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
-import com.datastax.oss.driver.categories.LongTests;
 import com.datastax.oss.driver.internal.core.metadata.token.RandomToken;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
 
-@Category(LongTests.class)
 public class RandomTokenIT extends TokenITBase {
 
   @ClassRule

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/RandomTokenVnodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/RandomTokenVnodesIT.java
@@ -19,13 +19,10 @@ import com.datastax.oss.driver.api.core.Cluster;
 import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
-import com.datastax.oss.driver.categories.LongTests;
 import com.datastax.oss.driver.internal.core.metadata.token.RandomToken;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
 
-@Category(LongTests.class)
 public class RandomTokenVnodesIT extends TokenITBase {
 
   @ClassRule

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaAgreementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaAgreementIT.java
@@ -16,23 +16,20 @@
 package com.datastax.oss.driver.api.core.metadata;
 
 import com.datastax.oss.driver.api.core.Cluster;
-import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.CqlSession;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterUtils;
-import com.datastax.oss.driver.categories.LongTests;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Category(LongTests.class)
 public class SchemaAgreementIT {
 
   private static CustomCcmRule ccm = CustomCcmRule.builder().withNodes(3).build();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaChangesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaChangesIT.java
@@ -26,6 +26,7 @@ import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterUtils;
 import com.datastax.oss.driver.api.testinfra.utils.ConditionChecker;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.function.BiConsumer;
@@ -35,10 +36,12 @@ import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category(ParallelizableTests.class)
 public class SchemaChangesIT {
 
   @Rule public CcmRule ccmRule = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaIT.java
@@ -18,19 +18,22 @@ package com.datastax.oss.driver.api.core.metadata;
 import com.datastax.oss.driver.api.core.Cluster;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
+import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
-import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterUtils;
 import com.datastax.oss.driver.api.testinfra.utils.ConditionChecker;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category(ParallelizableTests.class)
 public class SchemaIT {
 
   @Rule public CcmRule ccmRule = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/retry/DefaultRetryPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/retry/DefaultRetryPolicyIT.java
@@ -27,6 +27,7 @@ import com.datastax.oss.driver.api.core.servererrors.UnavailableException;
 import com.datastax.oss.driver.api.core.servererrors.WriteTimeoutException;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
 import com.datastax.oss.simulacron.common.stubbing.CloseType;
 import com.datastax.oss.simulacron.common.stubbing.DisconnectAction;
@@ -39,6 +40,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.datastax.oss.simulacron.common.codec.ConsistencyLevel.LOCAL_QUORUM;
@@ -52,6 +54,7 @@ import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.writeTimeout;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
+@Category(ParallelizableTests.class)
 @RunWith(DataProviderRunner.class)
 public class DefaultRetryPolicyIT {
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/session/RequestProcessorIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/session/RequestProcessorIT.java
@@ -21,6 +21,7 @@ import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
 import com.datastax.oss.driver.internal.testinfra.cluster.TestConfigLoader;
 import com.google.common.collect.Iterables;
@@ -30,6 +31,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,6 +53,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>{@link KeyRequestProcessor} is also registered for handling {@link KeyRequest}s which
  * simplifies a certain query down to 1 parameter.
  */
+@Category(ParallelizableTests.class)
 public class RequestProcessorIT {
 
   @ClassRule public static CcmRule ccm = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/specex/SpeculativeExecutionIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/specex/SpeculativeExecutionIT.java
@@ -17,23 +17,26 @@ package com.datastax.oss.driver.api.core.specex;
 
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.Cluster;
+import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
-import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterUtils;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
 import com.datastax.oss.simulacron.common.stubbing.PrimeDsl;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.isBootstrapping;
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.noRows;
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.when;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category(ParallelizableTests.class)
 public class SpeculativeExecutionIT {
 
   // Note: it looks like shorter delays cause precision issues with Netty timers

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistryIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistryIT.java
@@ -32,6 +32,7 @@ import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import com.datastax.oss.driver.api.core.type.reflect.GenericTypeParameter;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.cluster.ClusterRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.type.codec.IntCodec;
 import java.nio.ByteBuffer;
 import java.util.Collection;
@@ -44,11 +45,13 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TestName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category(ParallelizableTests.class)
 public class CodecRegistryIT {
 
   @ClassRule public static CcmRule ccm = CcmRule.getInstance();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/categories/IsolatedTests.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/categories/IsolatedTests.java
@@ -15,5 +15,9 @@
  */
 package com.datastax.oss.driver.categories;
 
-/** Defines a classification of tests that should be run in their own jvm fork. */
-public class IsolatedTests {}
+/**
+ * Defines a classification of tests that should be run in their own jvm fork.
+ *
+ * <p>This is generally because they need to set system properties.
+ */
+public interface IsolatedTests {}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/categories/ParallelizableTests.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/categories/ParallelizableTests.java
@@ -15,5 +15,11 @@
  */
 package com.datastax.oss.driver.categories;
 
-/** Defines a classification of tests that are slow. */
-public interface LongTests {}
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
+
+/**
+ * Defines a classification of tests that can be run in parallel, namely: tests that use {@link
+ * CcmRule} (not {@link CustomCcmRule}), and tests that use Simulacron.
+ */
+public interface ParallelizableTests {}

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,9 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.datastax.oss</groupId>
@@ -41,8 +43,6 @@
     <format.validateOnly>true</format.validateOnly>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <!-- skip integration tests by default -->
-    <skipITs>true</skipITs>
   </properties>
 
   <dependencyManagement>
@@ -375,6 +375,10 @@ limitations under the License.]]>
           </plugin>
         </plugins>
       </build>
+      <properties>
+        <!-- Our integration tests are too long to run during a release, we run them in CI -->
+        <skipITs>true</skipITs>
+      </properties>
     </profile>
   </profiles>
   <distributionManagement>


### PR DESCRIPTION
- use parallelizable/non-parallelizable terminology instead of
  short/long.
- make non-parallelizable the default.
- run all tests in the default profile.
- run tests by default in the build, only skip for release.