### PR TITLE
[JAVA-1659] Propagate fix from CASSANDRA-13651 to reduce CPU usage by eventLoop.schedule

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -6,6 +6,7 @@
 - [improvement] JAVA-1196: Include hash of result set metadata in prepared statement id.
 - [improvement] JAVA-1670: Support user-provided JMX ports for CCMBridge.
 - [improvement] JAVA-1661: Avoid String.toLowerCase if possible in Metadata.
+- [improvement] JAVA-1659: Expose low-level flusher tuning options.
 
 
 ### 3.3.1


### PR DESCRIPTION
Introduce new tuning options:
com.datastax.driver.FLUSHER_SCHEDULE_PERIOD_NS
com.datastax.driver.FLUSHER_RUN_WITHOUT_WORK_TIMES
Old behavior is used as default