### PR TITLE
JAVA-1661: avoid toLowerCase if it is possible in Metadata

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -5,6 +5,7 @@
 - [bug] JAVA-1666: Fix keyspace export when a UDT has case-sensitive field names.
 - [improvement] JAVA-1196: Include hash of result set metadata in prepared statement id.
 - [improvement] JAVA-1670: Support user-provided JMX ports for CCMBridge.
+- [improvement] JAVA-1661: Avoid String.toLowerCase if possible in Metadata.
 
 
 ### 3.3.1

--- a/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MetadataTest.java
@@ -125,6 +125,7 @@ public class MetadataTest extends CCMTestsSupport {
     public void handleId_should_lowercase_unquoted_alphanumeric_identifiers() {
         assertThat(Metadata.handleId("FooBar1")).isEqualTo("foobar1");
         assertThat(Metadata.handleId("Foo_Bar_1")).isEqualTo("foo_bar_1");
+        assertThat(Metadata.handleId("foo_bar_1")).isEqualTo("foo_bar_1");
     }
 
     @Test(groups = "unit")
@@ -161,4 +162,21 @@ public class MetadataTest extends CCMTestsSupport {
         assertThat(Metadata.quoteIfNecessary("columnfamily")).isEqualTo("\"columnfamily\"");
     }
 
+    @Test(groups = "unit")
+    public void should_detect_reserved_keywords_in_upper_case() {
+        assertThat(Metadata.isReservedCqlKeyword("COLUMNFAMILY")).isTrue();
+        assertThat(Metadata.isReservedCqlKeyword("TEST_COLUMNFAMILY")).isFalse();
+    }
+
+    @Test(groups = "unit")
+    public void should_detect_reserved_keywords_in_lower_case() {
+        assertThat(Metadata.isReservedCqlKeyword("columnfamily")).isTrue();
+        assertThat(Metadata.isReservedCqlKeyword("test_columnfamily")).isFalse();
+    }
+
+    @Test(groups = "unit")
+    public void should_detect_reserved_keywords_in_mixed_case() {
+        assertThat(Metadata.isReservedCqlKeyword("ColumnFamily")).isTrue();
+        assertThat(Metadata.isReservedCqlKeyword("Test_ColumnFamily")).isFalse();
+    }
 }


### PR DESCRIPTION
Avoid toLowerCase invocation if it is possible to reduce CPU usage and GC overheads in Metadata class. The operation is quite simple but invokes very frequently.