### PR TITLE
Upgrade to simulacron 0.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
       <dependency>
         <groupId>com.datastax.oss.simulacron</groupId>
         <artifactId>simulacron-native-server</artifactId>
-        <version>0.5.5</version>
+        <version>0.6.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Includes update to jackson-databind 2.9.2 which has a fix for [CVE-2017-15095](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15095).  Since jackson is only used by our test code this is not really a concern.