### PR TITLE
JAVA-1670 Added support for configuring and getting JmxPort per node

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 - [bug] JAVA-1666: Fix keyspace export when a UDT has case-sensitive field names.
 - [improvement] JAVA-1196: Include hash of result set metadata in prepared statement id.
+- [improvement] JAVA-1670: Support user-provided JMX ports for CCMBridge.
 
 
 ### 3.3.1

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMAccess.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMAccess.java
@@ -101,6 +101,16 @@ public interface CCMAccess extends Closeable {
      */
     InetSocketAddress addressOfNode(int n);
 
+    /**
+     * Returns the address that the @{code nth} host in the CCM cluster is listening on JMX on (counting from 1,
+     * i.e, {@code jmxAddressOfNode(1)} returns the jmx address of the first node.
+     * <p/>
+     * In multi-DC setups, nodes are numbered in ascending order of their datacenter number.
+     * E.g. with 2 DCs and 3 nodes in each DC, the first node in DC 2 is number 4.
+     *
+     * @return the address of the JMX listener of the {@code nth} host in the cluster
+     */
+    InetSocketAddress jmxAddressOfNode(int n);
 
     // Methods altering the whole cluster
 

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridgeTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2012-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.driver.core;
+
+import org.testng.annotations.Test;
+
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.net.InetSocketAddress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A simple test to validate jmx ports work
+ */
+@Test
+@CCMConfig(numberOfNodes = 3)
+public class CCMBridgeTest extends CCMTestsSupport {
+
+    @Test(groups = "short")
+    public void should_make_JMX_connection() throws Exception {
+        InetSocketAddress addr1 = ccm().jmxAddressOfNode(1);
+        InetSocketAddress addr2 = ccm().jmxAddressOfNode(2);
+        InetSocketAddress addr3 = ccm().jmxAddressOfNode(3);
+
+        assertThat(addr1.getPort()).isNotEqualTo(addr2.getPort());
+        assertThat(addr1.getPort()).isNotEqualTo(addr3.getPort());
+        assertThat(addr2.getPort()).isNotEqualTo(addr3.getPort());
+
+        JMXServiceURL url = new JMXServiceURL(
+                String.format(
+                        "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi",
+                        addr2.getAddress().getHostAddress(), addr2.getPort()
+                )
+        );
+        JMXConnector jmxc = JMXConnectorFactory.connect(url, null);
+        assertThat(jmxc.getConnectionId().isEmpty()).isFalse();
+    }
+
+    @Test(groups = "short")
+    public void should_configure_JMX_ports_through_builder() throws Exception {
+        CCMBridge.Builder ccmBuilder = CCMBridge.builder().withNodes(3).notStarted().withJmxPorts(12345);
+        CCMAccess ccm = ccmBuilder.build();
+        assertThat(ccm.jmxAddressOfNode(1).getPort()).isEqualTo(12345);
+
+        int port2 = ccm.jmxAddressOfNode(2).getPort();
+        int port3 = ccm.jmxAddressOfNode(3).getPort();
+        assertThat(port2).isBetween(0, 65535);
+        assertThat(port3).isBetween(0, 65535);
+    }
+}

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMCache.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMCache.java
@@ -104,6 +104,9 @@ public class CCMCache {
         }
 
         @Override
+        public InetSocketAddress jmxAddressOfNode(int n) { return ccm.jmxAddressOfNode(n); }
+
+        @Override
         public void start() {
             ccm.start();
         }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
@@ -93,6 +93,9 @@ public class CCMTestsSupport {
         }
 
         @Override
+        public InetSocketAddress jmxAddressOfNode(int n) { return delegate.jmxAddressOfNode(n); }
+
+        @Override
         public File getCcmDir() {
             return delegate.getCcmDir();
         }


### PR DESCRIPTION
This makes it possible to test multi node clusters and send the
jmx commands to specific nodes for testing purposes (e.g. compaction,
flushing, monitoring, repairs, etc ...)

Per the contributing guidelines I included changelog, tests, and code changes. Let me know if I missed something :-)

I also made CCMAccess's constructor protected so that subclasses can exist (that way folks can extend that class without copy pasting it).