### PR TITLE
JAVA-1651: Add NO_COMPACT startup option

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -8,6 +8,7 @@
 - [improvement] JAVA-1679: Improve error message on batch log write timeout.
 - [improvement] JAVA-1672: Remove schema agreement check when repreparing on up.
 - [improvement] JAVA-1677: Warn if auth is configured on the client but not the server.
+- [new feature] JAVA-1651: Add NO_COMPACT startup option.
 
 Merged from 3.3.x:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -687,6 +687,7 @@ public class Cluster implements Closeable {
         private boolean metricsEnabled = true;
         private boolean jmxEnabled = true;
         private boolean allowBetaProtocolVersion = false;
+        private boolean noCompact = false;
 
         private Collection<Host.StateListener> listeners;
 
@@ -1296,6 +1297,24 @@ public class Cluster implements Closeable {
         }
 
         /**
+         * Enables the <code>NO_COMPACT</code> startup option.
+         * <p>
+         * When this option is supplied, <code>SELECT</code>, <code>UPDATE</code>, <code>DELETE</code> and
+         * <code>BATCH</code> statements on <code>COMPACT STORAGE</code> tables function in "compatibility" mode which
+         * allows seeing these tables as if they were "regular" CQL tables.
+         * <p>
+         * This option only effects interactions with tables using <code>COMPACT STORAGE<code> and is only supported by
+         * C* 4.0+ and DSE 6.0+.
+         *
+         * @return this builder.
+         * @see <a href="https://issues.apache.org/jira/browse/CASSANDRA-10857">CASSANDRA-10857</a>
+         */
+        public Builder withNoCompact() {
+            this.noCompact = true;
+            return this;
+        }
+
+        /**
          * The configuration that will be used for the new cluster.
          * <p/>
          * You <b>should not</b> modify this object directly because changes made
@@ -1306,7 +1325,7 @@ public class Cluster implements Closeable {
          */
         @Override
         public Configuration getConfiguration() {
-            ProtocolOptions protocolOptions = new ProtocolOptions(port, protocolVersion, maxSchemaAgreementWaitSeconds, sslOptions, authProvider)
+            ProtocolOptions protocolOptions = new ProtocolOptions(port, protocolVersion, maxSchemaAgreementWaitSeconds, sslOptions, authProvider, noCompact)
                     .setCompression(compression);
 
             MetricsOptions metricsOptions = new MetricsOptions(metricsEnabled, jmxEnabled);

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -232,8 +232,8 @@ class Connection {
         return new AsyncFunction<Void, Void>() {
             @Override
             public ListenableFuture<Void> apply(Void input) throws Exception {
-                ProtocolOptions.Compression compression = factory.configuration.getProtocolOptions().getCompression();
-                Future startupResponseFuture = write(new Requests.Startup(compression));
+                ProtocolOptions protocolOptions = factory.configuration.getProtocolOptions();
+                Future startupResponseFuture = write(new Requests.Startup(protocolOptions.getCompression(), protocolOptions.isNoCompact()));
                 return GuavaCompatibility.INSTANCE.transformAsync(startupResponseFuture,
                         onStartupResponse(protocolVersion, initExecutor), initExecutor);
             }

--- a/driver-core/src/main/java/com/datastax/driver/core/ProtocolOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ProtocolOptions.java
@@ -99,6 +99,8 @@ public class ProtocolOptions {
     private final SSLOptions sslOptions; // null if no SSL
     private final AuthProvider authProvider;
 
+    private final boolean noCompact;
+
     private volatile Compression compression = Compression.NONE;
 
     /**
@@ -118,7 +120,7 @@ public class ProtocolOptions {
      * @param port the port to use for the binary protocol.
      */
     public ProtocolOptions(int port) {
-        this(port, null, DEFAULT_MAX_SCHEMA_AGREEMENT_WAIT_SECONDS, null, AuthProvider.NONE);
+        this(port, null, DEFAULT_MAX_SCHEMA_AGREEMENT_WAIT_SECONDS, null, AuthProvider.NONE, false);
     }
 
     /**
@@ -135,11 +137,30 @@ public class ProtocolOptions {
      *                        the Cassandra nodes.
      */
     public ProtocolOptions(int port, ProtocolVersion protocolVersion, int maxSchemaAgreementWaitSeconds, SSLOptions sslOptions, AuthProvider authProvider) {
+        this(port, protocolVersion, maxSchemaAgreementWaitSeconds, sslOptions, authProvider, false);
+    }
+
+    /**
+     * Creates a new {@code ProtocolOptions} instance using the provided port
+     * and SSL context.
+     *
+     * @param port            the port to use for the binary protocol.
+     * @param protocolVersion the protocol version to use. This can be {@code null}, in which case the
+     *                        version used will be the biggest version supported by the <em>first</em> node the driver connects to.
+     *                        See {@link Cluster.Builder#withProtocolVersion} for more details.
+     * @param sslOptions      the SSL options to use. Use {@code null} if SSL is not
+     *                        to be used.
+     * @param authProvider    the {@code AuthProvider} to use for authentication against
+     *                        the Cassandra nodes.
+     * @param noCompact       whether or not to include the NO_COMPACT startup option.
+     */
+    public ProtocolOptions(int port, ProtocolVersion protocolVersion, int maxSchemaAgreementWaitSeconds, SSLOptions sslOptions, AuthProvider authProvider, boolean noCompact) {
         this.port = port;
         this.initialProtocolVersion = protocolVersion;
         this.maxSchemaAgreementWaitSeconds = maxSchemaAgreementWaitSeconds;
         this.sslOptions = sslOptions;
         this.authProvider = authProvider;
+        this.noCompact = noCompact;
     }
 
     void register(Cluster.Manager manager) {
@@ -231,4 +252,10 @@ public class ProtocolOptions {
         return authProvider;
     }
 
+    /**
+     * @return Whether or not to include the NO_COMPACT startup option.
+     */
+    public boolean isNoCompact() {
+        return noCompact;
+    }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/Requests.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Requests.java
@@ -35,6 +35,7 @@ class Requests {
         private static final String CQL_VERSION = "3.0.0";
 
         static final String COMPRESSION_OPTION = "COMPRESSION";
+        static final String NO_COMPACT_OPTION = "NO_COMPACT";
 
         static final Message.Coder<Startup> coder = new Message.Coder<Startup>() {
             @Override
@@ -50,21 +51,25 @@ class Requests {
 
         private final Map<String, String> options;
         private final ProtocolOptions.Compression compression;
+        private final boolean noCompact;
 
-        Startup(ProtocolOptions.Compression compression) {
+        Startup(ProtocolOptions.Compression compression, boolean noCompact) {
             super(Message.Request.Type.STARTUP);
             this.compression = compression;
+            this.noCompact = noCompact;
 
             ImmutableMap.Builder<String, String> map = new ImmutableMap.Builder<String, String>();
             map.put(CQL_VERSION_OPTION, CQL_VERSION);
             if (compression != ProtocolOptions.Compression.NONE)
                 map.put(COMPRESSION_OPTION, compression.toString());
+            if (noCompact)
+                map.put(NO_COMPACT_OPTION, "true");
             this.options = map.build();
         }
 
         @Override
         protected Request copyInternal() {
-            return new Startup(compression);
+            return new Startup(compression, noCompact);
         }
 
         @Override


### PR DESCRIPTION
For [JAVA-1651](https://datastax-oss.atlassian.net/browse/JAVA-1651) in support of [CASSANDRA-10857](https://issues.apache.org/jira/browse/CASSANDRA-10857).

Since this requires creating a table with the thrift API, i've excluded tests, but I did test it manually in the following manner:

1. Create a cluster running 2.1:

    ```bash
    ccm create -n 1 -v 2.1.17 10857_test -s

2. Define the schema and insert some data using cassandra-cli:

    ```bash
    create keyspace simple;
    use simple;
    create column family foo 
        with comparator = UTF8Type
        and default_validation_class = UTF8Type
        and column_metadata = [
            {column_name: bar, validation_class: Int32Type, index_type: KEYS},
            {column_name: baz, validation_class: UUIDType, index_type: KEYS}
        ];
    set foo['c0']['bar'] = 10;
    set foo['c0']['baz'] = 33cb65d4-6721-4ca8-854f-1f020c5353cb;
    set foo['c0']['yak'] = cafedead;
    ```

    Both `bar` and `baz` are part of column metadata and will show up as static columns in cql tables,  `yak` should not unless `NO_COMPACT` is provided on startup.

3.  upgrade to 2.2:

    ```bash
    ccm stop
    ccm node1 setdir -v 2.2.11
    ccm node1 updateconf start_rpc:true
    ccm start --wait-for-binary-proto
    ccm node1 nodetool upgradesstables
    ```

4. Upgrade to 3.0 (local install dir of cassandra-3.0):

    ```bash
    ccm stop
    ccm node1 setdir --install-dir=/Users/atolbert/Documents/Projects/cassandra-3.0
    ccm start --wait-for-binary-proto
    ccm node1 nodetool upgradesstables
    ```

5. To test with cqlsh first, try without `--no_compact` to observe `yak` is missing:

    ```bash
    ccm node1 cqlsh
    cqlsh> select * from simple.foo where key=0xc0;

     key  | bar | baz
    ------+-----+--------------------------------------
     0xc0 |  10 | 33cb65d4-6721-4ca8-854f-1f020c5353cb
    ```

6.  Try again with `--no_compact` and observe the precense of `yak`:

    ```bash
    ccm node1 cqlsh --no_compact
    cqlsh> select * from simple.foo where key=0xc0;

     key  | column1 | bar | baz                                  | value
    ------+---------+-----+--------------------------------------+----------
     0xc0 |     yak |  10 | 33cb65d4-6721-4ca8-854f-1f020c5353cb | cafedead
    ```

7. Verify the same behavior with java driver:

    ```java
    Cluster cluster = Cluster.builder().withNoCompact(true).addContactPoint("127.0.0.1").build();
    try {
        Session session = cluster.connect();
        Row row = session.execute("select * from simple.foo where key=0xc0").one();
        System.out.println(row);
    } finally {
        cluster.close();
    }
    ```

    Should print with `withNoCompact()`:

    > Row[java.nio.HeapByteBuffer[pos=0 lim=1 cap=1], yak, 10, 33cb65d4-6721-4ca8-854f-1f020c5353cb, cafedead]

    Should print without `withNoCompact()`:

    > Row[java.nio.HeapByteBuffer[pos=0 lim=1 cap=1], 10, 33cb65d4-6721-4ca8-854f-1f020c5353cb]
  