### PR TITLE
JAVA-1671: Remove unnecessary test on prepared statement metadata

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,8 @@
 
 ### 3.4.0 (In progress)
 
+- [improvement] JAVA-1671: Remove unnecessary test on prepared statement metadata.
+
 Merged from 3.3.x:
 
 - [bug] JAVA-1555: Include VIEW and CDC in WriteType.

--- a/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedResultSet.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ArrayBackedResultSet.java
@@ -83,16 +83,7 @@ abstract class ArrayBackedResultSet implements ResultSet {
                     if (newMetadataId != null) {
                         BoundStatement bs = ((BoundStatement) actualStatement);
                         PreparedId preparedId = bs.preparedStatement().getPreparedId();
-                        // Extra test for CASSANDRA-13992: conditional updates yield a different result set depending on
-                        // whether the update was applied or not, so the prepared statement must never have result
-                        // metadata, and we should always execute with skip_metadata = false.
-                        // However the server sends a new_metadata_id in the response, so make sure we ignore it if the
-                        // prepared statement did not have metadata in the first place.
-                        // TODO remove the "if" (i.e. always assign resultSetMetadata) if CASSANDRA-13992 gets fixed before 4.0.0 GA
-                        if (preparedId.resultSetMetadata.variables != null) {
-                            preparedId.resultSetMetadata =
-                                    new PreparedId.PreparedMetadata(newMetadataId, columnDefs);
-                        }
+                        preparedId.resultSetMetadata = new PreparedId.PreparedMetadata(newMetadataId, columnDefs);
                     }
                 }
                 assert columnDefs != null;


### PR DESCRIPTION
For [JAVA-1671](https://datastax-oss.atlassian.net/browse/JAVA-1671)

As [CASSANDRA-13992](https://issues.apache.org/jira/browse/CASSANDRA-13992) is fixed this test is no longer needed.

Tested against C* trunk and metadata is `new_metadata_id` is indeed now missing for conditional updates.