### PR TITLE
JAVA-1694: Upgrade to jackson-databind 2.7.9.2 to address CVE-2015-15095 

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,7 @@
 ### 3.4.0 (In progress)
 
 - [improvement] JAVA-1671: Remove unnecessary test on prepared statement metadata.
+- [bug] JAVA-1694: Upgrade to jackson-databind 2.7.9.2 to address CVE-2015-15095.
 
 Merged from 3.3.x:
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <hdr.version>2.1.9</hdr.version>
         <jackson.version>2.8.8</jackson.version>
         <!-- jackson-databind 2.7.x is the last to support java 6 -->
-        <jackson-databind.version>2.7.9.1</jackson-databind.version>
+        <jackson-databind.version>2.7.9.2</jackson-databind.version>
         <joda.version>2.9.1</joda.version>
         <jsr353-api.version>1.0</jsr353-api.version>
         <jsr353-ri.version>1.0.4</jsr353-ri.version>


### PR DESCRIPTION
For [JAVA-1694](https://datastax-oss.atlassian.net/browse/JAVA-1694).  This doesn't have much impact because jackson-databind is only used in extras and examples, but would be good to update anyways.