### PR TITLE
JAVA-1707: Add test infrastructure for running DSE clusters with CCM

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -12,7 +12,7 @@ build:
     version: 3.2.5
     goals: verify
     properties: |
-      ccm.cassandraVersion=$CCM_CASSANDRA_VERSION
+      ccm.version=$CCM_CASSANDRA_VERSION
   - xunit:
     - "**/target/surefire-reports/TEST-*.xml"
     - "**/target/failsafe-reports/TEST-*.xml"

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha3 (in progress)
 
+- [improvement] JAVA-1707: Add test infrastructure for running DSE clusters with CCM
 - [bug] JAVA-1715: Propagate unchecked exceptions to CompletableFuture in SyncAuthenticator methods
 - [improvement] JAVA-1714: Make replication strategies pluggable
 - [new feature] JAVA-1647: Handle metadata_changed flag in protocol v5
@@ -19,6 +20,7 @@
 - [improvement] JAVA-1662: Raise default request timeout
 - [improvement] JAVA-1566: Enforce API rules automatically
 - [bug] JAVA-1584: Validate that no bound values are unset in protocol v3
+
 
 ### 4.0.0-alpha2
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -76,27 +76,16 @@
 
   <build>
     <plugins>
-      <!-- Don't install or deploy since it's just tests -->
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <configuration>
-          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-        </configuration>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>test-jar</id>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/PerRequestKeyspaceIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/PerRequestKeyspaceIT.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * test against a local build, run with
  *
  * <pre>
- *   -Dccm.cassandraVersion=4.0.0 -Dccm.cassandraDirectory=/path/to/cassandra -Ddatastax-java-driver.protocol.version=V5
+ *   -Dccm.version=4.0.0 -Dccm.directory=/path/to/cassandra -Ddatastax-java-driver.protocol.version=V5
  * </pre>
  */
 @Category(ParallelizableTests.class)

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/PreparedStatementInvalidationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/PreparedStatementInvalidationIT.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * version. To test against a local build, run with
  *
  * <pre>
- *   -Dccm.cassandraVersion=4.0.0 -Dccm.cassandraDirectory=/path/to/cassandra -Ddatastax-java-driver.protocol.version=V5
+ *   -Dccm.version=4.0.0 -Dccm.directory=/path/to/cassandra -Ddatastax-java-driver.protocol.version=V5
  * </pre>
  */
 @Category(ParallelizableTests.class)
@@ -49,8 +49,8 @@ public class PreparedStatementInvalidationIT {
   @Rule public CcmRule ccmRule = CcmRule.getInstance();
 
   @Rule
-  public ClusterRule clusterRule =
-      new ClusterRule(ccmRule, "request.page-size = 2", "request.timeout = 30 seconds");
+  public ClusterRule<CqlSession> clusterRule =
+      new ClusterRule<>(ccmRule, "request.page-size = 2", "request.timeout = 30 seconds");
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/heartbeat/HeartbeatIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/heartbeat/HeartbeatIT.java
@@ -55,8 +55,9 @@ public class HeartbeatIT {
 
   @Rule public SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(2));
 
+  @SuppressWarnings("unchecked")
   @Rule
-  public ClusterRule cluster =
+  public ClusterRule<CqlSession> cluster =
       ClusterRule.builder(simulacron)
           .withDefaultSession(false)
           .withOptions(

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,10 @@
           <version>3.0.0-M1</version>
         </plugin>
         <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>
           <version>1.6.8</version>

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/DseRequirement.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/DseRequirement.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.testinfra;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotation for a Class or Method that defines a DSE Version requirement. If the DSE version in
+ * use does not meet the version requirement or DSE isn't used at all, the test is skipped.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DseRequirement {
+
+  /** @return The minimum version required to execute this test, i.e. "5.0.13" */
+  String min() default "";
+
+  /**
+   * @return the maximum exclusive version allowed to execute this test, i.e. "2.2" means only tests
+   *     < "2.2" may execute this test.
+   */
+  String max() default "";
+
+  /** @return The description returned if this version requirement is not met. */
+  String description() default "Does not meet version requirement.";
+}

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
@@ -20,20 +20,19 @@ import com.datastax.oss.driver.api.core.CoreProtocolVersion;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
 import com.datastax.oss.driver.api.testinfra.CassandraResourceRule;
-import com.datastax.oss.driver.api.testinfra.ccm.CcmBridge;
+import com.datastax.oss.driver.api.testinfra.DseRequirement;
 import org.junit.AssumptionViolatedException;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
+import java.util.Optional;
 
 public abstract class BaseCcmRule extends CassandraResourceRule {
 
   protected final CcmBridge ccmBridge;
 
-  private final CassandraVersion cassandraVersion;
-
-  public BaseCcmRule(CcmBridge ccmBridge) {
+  BaseCcmRule(CcmBridge ccmBridge) {
     this.ccmBridge = ccmBridge;
-    this.cassandraVersion = ccmBridge.getCassandraVersion();
     Runtime.getRuntime()
         .addShutdownHook(
             new Thread(
@@ -57,8 +56,28 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
     ccmBridge.remove();
   }
 
+  private Statement buildErrorStatement(
+      CassandraVersion requirement, String description, boolean lessThan, boolean dse) {
+    return new Statement() {
+
+      @Override
+      public void evaluate() {
+        throw new AssumptionViolatedException(
+            String.format(
+                "Test requires %s %s %s but %s is configured.  Description: %s",
+                lessThan ? "less than" : "at least",
+                dse ? "DSE" : "C*",
+                requirement,
+                dse ? ccmBridge.getDseVersion().orElse(null) : ccmBridge.getCassandraVersion(),
+                description));
+      }
+    };
+  }
+
   @Override
   public Statement apply(Statement base, Description description) {
+    // If test is annotated with CassandraRequirement or DseRequirement, ensure configured CCM
+    // cluster meets those requirements.
     CassandraRequirement cassandraRequirement =
         description.getAnnotation(CassandraRequirement.class);
 
@@ -66,21 +85,8 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
       // if the configured cassandra cassandraRequirement exceeds the one being used skip this test.
       if (!cassandraRequirement.min().isEmpty()) {
         CassandraVersion minVersion = CassandraVersion.parse(cassandraRequirement.min());
-        if (minVersion.compareTo(cassandraVersion) > 0) {
-          // Create a statement which simply indicates that the configured cassandra cassandraRequirement is too old for this test.
-          return new Statement() {
-
-            @Override
-            public void evaluate() throws Throwable {
-              throw new AssumptionViolatedException(
-                  "Test requires C* "
-                      + minVersion
-                      + " but "
-                      + cassandraVersion
-                      + " is configured.  Description: "
-                      + cassandraRequirement.description());
-            }
-          };
+        if (minVersion.compareTo(ccmBridge.getCassandraVersion()) > 0) {
+          return buildErrorStatement(minVersion, cassandraRequirement.description(), false, false);
         }
       }
 
@@ -88,20 +94,38 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
         // if the test version exceeds the maximum configured one, fail out.
         CassandraVersion maxVersion = CassandraVersion.parse(cassandraRequirement.max());
 
-        if (maxVersion.compareTo(cassandraVersion) <= 0) {
-          return new Statement() {
+        if (maxVersion.compareTo(ccmBridge.getCassandraVersion()) <= 0) {
+          return buildErrorStatement(maxVersion, cassandraRequirement.description(), true, false);
+        }
+      }
+    }
 
-            @Override
-            public void evaluate() throws Throwable {
-              throw new AssumptionViolatedException(
-                  "Test requires C* less than "
-                      + maxVersion
-                      + " but "
-                      + cassandraVersion
-                      + " is configured.  Description: "
-                      + cassandraRequirement.description());
-            }
-          };
+    DseRequirement dseRequirement = description.getAnnotation(DseRequirement.class);
+    if (dseRequirement != null) {
+      Optional<CassandraVersion> dseVersionOption = ccmBridge.getDseVersion();
+      if (!dseVersionOption.isPresent()) {
+        return new Statement() {
+
+          @Override
+          public void evaluate() {
+            throw new AssumptionViolatedException("Test Requires DSE but C* is configured.");
+          }
+        };
+      } else {
+        CassandraVersion dseVersion = dseVersionOption.get();
+        if (!dseRequirement.min().isEmpty()) {
+          CassandraVersion minVersion = CassandraVersion.parse(dseRequirement.min());
+          if (minVersion.compareTo(dseVersion) > 0) {
+            return buildErrorStatement(dseVersion, dseRequirement.description(), false, true);
+          }
+        }
+
+        if (!dseRequirement.max().isEmpty()) {
+          CassandraVersion maxVersion = CassandraVersion.parse(dseRequirement.max());
+
+          if (maxVersion.compareTo(ccmBridge.getCassandraVersion()) <= 0) {
+            return buildErrorStatement(dseVersion, dseRequirement.description(), true, true);
+          }
         }
       }
     }
@@ -109,12 +133,16 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
   }
 
   public CassandraVersion getCassandraVersion() {
-    return cassandraVersion;
+    return ccmBridge.getCassandraVersion();
+  }
+
+  public Optional<CassandraVersion> getDseVersion() {
+    return ccmBridge.getDseVersion();
   }
 
   @Override
   public ProtocolVersion getHighestProtocolVersion() {
-    if (cassandraVersion.compareTo(CassandraVersion.V2_2_0) >= 0) {
+    if (ccmBridge.getCassandraVersion().compareTo(CassandraVersion.V2_2_0) >= 0) {
       return CoreProtocolVersion.V4;
     } else {
       return CoreProtocolVersion.V3;

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.oss.driver.api.testinfra.ccm;
 
-import com.datastax.oss.driver.api.core.CassandraVersion;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -73,13 +72,18 @@ public class CustomCcmRule extends BaseCcmRule {
       return this;
     }
 
-    public Builder withJvmArgs(String... jvmArgs) {
-      bridgeBuilder.withJvmArgs(jvmArgs);
+    public Builder withDseConfiguration(String key, Object value) {
+      bridgeBuilder.withDseConfiguration(key, value);
       return this;
     }
 
-    public Builder withCassandraVersion(CassandraVersion cassandraVersion) {
-      bridgeBuilder.withCassandraVersion(cassandraVersion);
+    public Builder withDseWorkloads(String... workloads) {
+      bridgeBuilder.withDseWorkloads(workloads);
+      return this;
+    }
+
+    public Builder withJvmArgs(String... jvmArgs) {
+      bridgeBuilder.withJvmArgs(jvmArgs);
       return this;
     }
 

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/cluster/ClusterRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/cluster/ClusterRule.java
@@ -18,8 +18,8 @@ package com.datastax.oss.driver.api.testinfra.cluster;
 import com.datastax.oss.driver.api.core.Cluster;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
-import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
 import com.datastax.oss.driver.api.core.cql.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
 import com.datastax.oss.driver.api.testinfra.CassandraResourceRule;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
 import org.junit.rules.ExternalResource;
@@ -49,7 +49,7 @@ import org.junit.rules.ExternalResource;
  * <p>If you would rather create a new keyspace manually in each test, see the utility methods in
  * {@link ClusterUtils}.
  */
-public class ClusterRule extends ExternalResource {
+public class ClusterRule<T extends CqlSession> extends ExternalResource {
 
   // the CCM or Simulacron rule to depend on
   private final CassandraResourceRule cassandraResource;
@@ -59,10 +59,10 @@ public class ClusterRule extends ExternalResource {
   private final String[] defaultClusterOptions;
 
   // the default cluster that is auto created for this rule.
-  private Cluster<CqlSession> cluster;
+  private Cluster<T> cluster;
 
   // the default session that is auto created for this rule and is tied to the given keyspace.
-  private CqlSession defaultSession;
+  private T defaultSession;
 
   private DriverConfigProfile slowProfile;
 
@@ -71,8 +71,9 @@ public class ClusterRule extends ExternalResource {
    *
    * @param cassandraResource resource to create clusters for.
    */
-  public static ClusterRuleBuilder builder(CassandraResourceRule cassandraResource) {
-    return new ClusterRuleBuilder(cassandraResource);
+  public static <T extends CqlSession> ClusterRuleBuilder<ClusterRuleBuilder, T> builder(
+      CassandraResourceRule cassandraResource) {
+    return new ClusterRuleBuilder<>(cassandraResource);
   }
 
   /** @see #builder(CassandraResourceRule) */
@@ -122,7 +123,7 @@ public class ClusterRule extends ExternalResource {
   }
 
   /** @return the cluster created with this rule. */
-  public Cluster<CqlSession> cluster() {
+  public Cluster<T> cluster() {
     return cluster;
   }
 
@@ -130,7 +131,7 @@ public class ClusterRule extends ExternalResource {
    * @return the default session created with this rule, or {@code null} if no default session was
    *     created.
    */
-  public CqlSession session() {
+  public T session() {
     return defaultSession;
   }
 

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/cluster/ClusterRuleBuilder.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/cluster/ClusterRuleBuilder.java
@@ -15,18 +15,22 @@
  */
 package com.datastax.oss.driver.api.testinfra.cluster;
 
+import com.datastax.oss.driver.api.core.cql.CqlSession;
 import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
 import com.datastax.oss.driver.api.testinfra.CassandraResourceRule;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
 
-public class ClusterRuleBuilder {
+public class ClusterRuleBuilder<SelfT extends ClusterRuleBuilder, SessionT extends CqlSession> {
 
   private final CassandraResourceRule cassandraResource;
   private boolean createDefaultSession = true;
   private boolean createKeyspace = true;
   private String[] options = new String[] {};
   private NodeStateListener[] nodeStateListeners = new NodeStateListener[] {};
+
+  @SuppressWarnings("unchecked")
+  protected final SelfT self = (SelfT) this;
 
   public ClusterRuleBuilder(CassandraResourceRule cassandraResource) {
     this.cassandraResource = cassandraResource;
@@ -46,9 +50,9 @@ public class ClusterRuleBuilder {
    * {@link SimulacronRule}, this option is ignored, no keyspace gets created, and {@link
    * ClusterRule#keyspace()} returns {@code null}.
    */
-  public ClusterRuleBuilder withKeyspace(boolean createKeyspace) {
+  public SelfT withKeyspace(boolean createKeyspace) {
     this.createKeyspace = createKeyspace;
-    return this;
+    return self;
   }
 
   /**
@@ -60,24 +64,24 @@ public class ClusterRuleBuilder {
    *
    * <p>If this method is not called, the default value is {@code true}.
    */
-  public ClusterRuleBuilder withDefaultSession(boolean createDefaultSession) {
+  public SelfT withDefaultSession(boolean createDefaultSession) {
     this.createDefaultSession = createDefaultSession;
-    return this;
+    return self;
   }
 
   /** A set of options to override in the cluster configuration. */
-  public ClusterRuleBuilder withOptions(String... options) {
+  public SelfT withOptions(String... options) {
     this.options = options;
-    return this;
+    return self;
   }
 
-  public ClusterRuleBuilder withNodeStateListeners(NodeStateListener... listeners) {
+  public SelfT withNodeStateListeners(NodeStateListener... listeners) {
     this.nodeStateListeners = listeners;
-    return this;
+    return self;
   }
 
-  public ClusterRule build() {
-    return new ClusterRule(
+  public ClusterRule<SessionT> build() {
+    return new ClusterRule<>(
         cassandraResource, createKeyspace, createDefaultSession, nodeStateListeners, options);
   }
 }

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/cluster/DefaultClusterBuilderInstantiator.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/cluster/DefaultClusterBuilderInstantiator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.testinfra.cluster;
+
+import com.datastax.oss.driver.api.core.Cluster;
+import com.datastax.oss.driver.api.core.ClusterBuilder;
+
+public class DefaultClusterBuilderInstantiator {
+  public static ClusterBuilder builder() {
+    return Cluster.builder();
+  }
+
+  public static String configPath() {
+    return "datastax-java-driver";
+  }
+}

--- a/test-infra/src/main/java/com/datastax/oss/driver/internal/testinfra/cluster/TestConfigLoader.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/internal/testinfra/cluster/TestConfigLoader.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.testinfra.cluster;
 
 import com.datastax.oss.driver.api.core.config.CoreDriverOption;
+import com.datastax.oss.driver.api.testinfra.cluster.ClusterUtils;
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -35,7 +36,11 @@ public class TestConfigLoader extends DefaultDriverConfigLoader {
             customConfig,
             "netty.io-group.shutdown.quiet-period = 0",
             "netty.admin-group.shutdown.quiet-period = 0");
-    return ConfigFactory.parseString(additionalCustomConfig)
-        .withFallback(DEFAULT_CONFIG_SUPPLIER.get());
+    return ConfigFactory.parseString(additionalCustomConfig).withFallback(getConfig());
+  }
+
+  public static Config getConfig() {
+    ConfigFactory.invalidateCaches();
+    return ConfigFactory.load().getConfig(ClusterUtils.getConfigPath());
   }
 }


### PR DESCRIPTION
Includes the following changes:

* Updates `CcmBridge` so it supports running DSE clusters.
* Add `@DseRequirement` for checing against DSE versions for test requirements.
* Rename ccm.cassandraVersion and ccm.cassandraDirectory to ccm.version and ccm.directory respecitvely.
* Adds ccm.dse, if set assumes DSE cluster.
* Adds support for EverywhereStrategy ([JAVA-1707](https://datastax-oss.atlassian.net/browse/JAVA-1708)), which is currently only supported by DSE, but thought it was simple enough to include.
* Changes integration-tests pom to deploy the tests jar so it may be used in other projects.
* Use generic version of `Cluster<CqlSession>` in tests and introduce system property `cluster.builder` for specifying what class to use to create initial cluster builder instances.   See `DefaultClusterBuilderInstantiator` for base implementation.  Will be useful for running all tests against custom Cluster/Session implementations.