### PR TITLE
JAVA-1682: Provide a way to record latencies for cancelled speculative executions

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -11,6 +11,7 @@
 - [new feature] JAVA-1651: Add NO_COMPACT startup option.
 - [improvement] JAVA-1683: Add metrics to track writes to nodes.
 - [new feature] JAVA-1229: Allow specifying the keyspace for individual queries.
+- [improvement] JAVA-1682: Provide a way to record latencies for cancelled speculative executions.
 
 Merged from 3.3.x:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/CancelledSpeculativeExecutionException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CancelledSpeculativeExecutionException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2012-2017 DataStax Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.driver.core;
+
+/**
+ * Special exception that gets emitted to {@link LatencyTracker}s with the latencies of cancelled speculative
+ * executions. This allows those trackers to choose whether to ignore those latencies or not.
+ */
+class CancelledSpeculativeExecutionException extends Exception {
+
+    static CancelledSpeculativeExecutionException INSTANCE = new CancelledSpeculativeExecutionException();
+
+    private CancelledSpeculativeExecutionException() {
+        super();
+    }
+}

--- a/driver-core/src/main/java/com/datastax/driver/core/PercentileTracker.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/PercentileTracker.java
@@ -255,7 +255,8 @@ public abstract class PercentileTracker implements LatencyTracker {
             OverloadedException.class,
             BootstrappingException.class,
             UnpreparedException.class,
-            QueryValidationException.class // query validation also happens at early stages in the coordinator
+            QueryValidationException.class, // query validation also happens at early stages in the coordinator
+            CancelledSpeculativeExecutionException.class
     );
 
     /**


### PR DESCRIPTION
Those latencies are emitted with a
CancelledSpeculativeExecutionException, which allows LatencyTracker
implementations to choose whether to include them or not. For example, a
tracker that wants to detect "slowness" of a node might want to record
them (otherwise a node that always hits the speculative execution
threshold would appear to have no measurement), whereas a tracker that
monitors latencies of successful executions should ignore them.