### PR TITLE
Add note to README about JDK 6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Other features are available only when using Apache Cassandra 2.0 or higher (e.g
 Trying to use these with a cluster running Cassandra 1.2 will result in 
 an [UnsupportedFeatureException](https://github.com/datastax/java-driver/blob/3.x/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnsupportedFeatureException.java) being thrown.
 
+The java driver supports Java JDK versions 6 and above.
+
 __Note__: DataStax products do not support big-endian systems.
 
 ## Upgrading from previous versions


### PR DESCRIPTION
Added a small note to README about JDK compatibility similar to how other drivers document runtime compatibility.