### PR TITLE
JAVA-1725: Add a getNodeCount method to CCMAccess for easier automation

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -12,6 +12,7 @@
 - [documentation] JAVA-1380: Add FAQ entry for errors arising from incompatibilities.
 - [improvement] JAVA-1748: Support IS NOT NULL and != in query builder.
 - [documentation] JAVA-1740: Mention C*2.2/3.0 incompatibilities in paging state manual.
+- [improvement] JAVA-1725: Add a getNodeCount method to CCMAccess for easier automation.
 
 
 ### 3.4.0

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMAccess.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMAccess.java
@@ -91,6 +91,14 @@ public interface CCMAccess extends Closeable {
     void setKeepLogs(boolean keepLogs);
 
     /**
+     * @return the node count for each datacenter, mapped in the corresponding cell of the returned int array. This is
+     * the count that was passed at initialization (that is, the argument to {@link CCMBridge.Builder#withNodes(int...)}
+     * or {@link CCMConfig#numberOfNodes()}). Note that it will <b>NOT</b> be updated dynamically if nodes are added or
+     * removed at runtime.
+     */
+    int[] getNodeCount();
+
+    /**
      * Returns the address of the {@code nth} host in the CCM cluster (counting from 1, i.e.,
      * {@code addressOfNode(1)} returns the address of the first node.
      * <p/>

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -315,6 +315,11 @@ public class CCMBridge implements CCMAccess {
         return clusterName;
     }
 
+    @Override
+    public int[] getNodeCount() {
+        return Arrays.copyOf(nodes, nodes.length);
+    }
+
     protected String ipOfNode(int n) {
         return ipPrefix + n;
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMCache.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMCache.java
@@ -99,6 +99,11 @@ public class CCMCache {
         }
 
         @Override
+        public int[] getNodeCount() {
+            return ccm.getNodeCount();
+        }
+
+        @Override
         public InetSocketAddress addressOfNode(int n) {
             return ccm.addressOfNode(n);
         }


### PR DESCRIPTION
The int[] with the node count isn't accessible easily, whereas it can be useful when manipulating CCMAccess objects in a generic way.