### PR TITLE
JAVA-1518: Expose metrics

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha3 (in progress)
 
+- [new feature] JAVA-1518: Expose metrics
 - [improvement] JAVA-1739: Add host_id and schema_version to node metadata
 - [improvement] JAVA-1738: Convert enums to allow extensibility
 - [bug] JAVA-1727: Override DefaultUdtValue.equals

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,9 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -74,6 +76,14 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hdrhistogram</groupId>
+      <artifactId>HdrHistogram</artifactId>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/CoreDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/CoreDriverOption.java
@@ -37,6 +37,7 @@ public enum CoreDriverOption implements DriverOption {
   CONNECTION_HEARTBEAT_INTERVAL("connection.heartbeat.interval", true),
   CONNECTION_HEARTBEAT_TIMEOUT("connection.heartbeat.timeout", true),
   CONNECTION_MAX_ORPHAN_REQUESTS("connection.max-orphan-requests", true),
+  CONNECTION_WARN_INIT_ERROR("connection.warn-on-init-error", true),
   CONNECTION_POOL_LOCAL_SIZE("connection.pool.local.size", true),
   CONNECTION_POOL_REMOTE_SIZE("connection.pool.remote.size", true),
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/CoreDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/CoreDriverOption.java
@@ -109,6 +109,15 @@ public enum CoreDriverOption implements DriverOption {
   TIMESTAMP_GENERATOR_DRIFT_WARNING_INTERVAL(
       "request.timestamp-generator.drift-warning.interval", false),
 
+  METRICS_SESSION_ENABLED("metrics.session.enabled", false),
+  METRICS_NODE_ENABLED("metrics.node.enabled", false),
+  METRICS_SESSION_CQL_REQUESTS_HIGHEST("metrics.session.cql-requests.highest-latency", false),
+  METRICS_SESSION_CQL_REQUESTS_DIGITS("metrics.session.cql-requests.significant-digits", false),
+  METRICS_SESSION_CQL_REQUESTS_INTERVAL("metrics.session.cql-requests.refresh-interval", false),
+  METRICS_NODE_CQL_MESSAGES_HIGHEST("metrics.node.cql-messages.highest-latency", false),
+  METRICS_NODE_CQL_MESSAGES_DIGITS("metrics.node.cql-messages.significant-digits", false),
+  METRICS_NODE_CQL_MESSAGES_INTERVAL("metrics.node.cql-messages.refresh-interval", false),
+
   NETTY_IO_SIZE("netty.io-group.size", false),
   NETTY_IO_SHUTDOWN_QUIET_PERIOD("netty.io-group.shutdown.quiet-period", false),
   NETTY_IO_SHUTDOWN_TIMEOUT("netty.io-group.shutdown.timeout", false),

--- a/core/src/main/java/com/datastax/oss/driver/api/core/context/DriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/context/DriverContext.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.driver.api.core.context;
 
+import com.codahale.metrics.MetricRegistry;
 import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
 import com.datastax.oss.driver.api.core.auth.AuthProvider;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
@@ -56,4 +57,6 @@ public interface DriverContext extends AttachmentPoint {
   Optional<SslEngineFactory> sslEngineFactory();
 
   TimestampGenerator timestampGenerator();
+
+  MetricRegistry metricRegistry();
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metrics/CoreNodeMetric.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metrics/CoreNodeMetric.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.metrics;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+
+/** See {@code reference.conf} for a description of each metric. */
+public enum CoreNodeMetric implements NodeMetric {
+  OPEN_CONNECTIONS("pool.open-connections"),
+  AVAILABLE_STREAMS("pool.available-streams"),
+  IN_FLIGHT("pool.in-flight"),
+  ORPHANED_STREAMS("pool.orphaned-streams"),
+  CQL_MESSAGES("cql-messages"),
+  UNSENT_REQUESTS("errors.request.unsent"),
+  ABORTED_REQUESTS("errors.request.aborted"),
+  WRITE_TIMEOUTS("errors.request.write-timeouts"),
+  READ_TIMEOUTS("errors.request.read-timeouts"),
+  UNAVAILABLES("errors.request.unavailables"),
+  OTHER_ERRORS("errors.request.others"),
+  RETRIES("retries.total"),
+  RETRIES_ON_ABORTED("retries.aborted"),
+  RETRIES_ON_READ_TIMEOUT("retries.read-timeout"),
+  RETRIES_ON_WRITE_TIMEOUT("retries.write-timeout"),
+  RETRIES_ON_UNAVAILABLE("retries.unavailable"),
+  RETRIES_ON_OTHER_ERROR("retries.other"),
+  IGNORES("ignores.total"),
+  IGNORES_ON_ABORTED("ignores.aborted"),
+  IGNORES_ON_READ_TIMEOUT("ignores.read-timeout"),
+  IGNORES_ON_WRITE_TIMEOUT("ignores.write-timeout"),
+  IGNORES_ON_UNAVAILABLE("ignores.unavailable"),
+  IGNORES_ON_OTHER_ERROR("ignores.other"),
+  SPECULATIVE_EXECUTIONS("speculative-executions"),
+  CONNECTION_INIT_ERRORS("errors.connection.init"),
+  AUTHENTICATION_ERRORS("errors.connection.auth"),
+  ;
+
+  private static final Map<String, CoreNodeMetric> BY_PATH = sortByPath();
+
+  private final String path;
+
+  CoreNodeMetric(String path) {
+    this.path = path;
+  }
+
+  @Override
+  public String getPath() {
+    return path;
+  }
+
+  public static CoreNodeMetric fromPath(String path) {
+    CoreNodeMetric metric = BY_PATH.get(path);
+    if (metric == null) {
+      throw new IllegalArgumentException("Unknown node metric path " + path);
+    }
+    return metric;
+  }
+
+  private static Map<String, CoreNodeMetric> sortByPath() {
+    ImmutableMap.Builder<String, CoreNodeMetric> result = ImmutableMap.builder();
+    for (CoreNodeMetric value : values()) {
+      result.put(value.getPath(), value);
+    }
+    return result.build();
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metrics/CoreSessionMetric.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metrics/CoreSessionMetric.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.metrics;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+
+/** See {@code reference.conf} for a description of each metric. */
+public enum CoreSessionMetric implements SessionMetric {
+  CONNECTED_NODES("connected-nodes"),
+  CQL_REQUESTS("cql-requests"),
+  CQL_CLIENT_TIMEOUTS("cql-client-timeouts"),
+  ;
+
+  private static final Map<String, CoreSessionMetric> BY_PATH = sortByPath();
+
+  private final String path;
+
+  CoreSessionMetric(String path) {
+    this.path = path;
+  }
+
+  @Override
+  public String getPath() {
+    return path;
+  }
+
+  public static CoreSessionMetric fromPath(String path) {
+    CoreSessionMetric metric = BY_PATH.get(path);
+    if (metric == null) {
+      throw new IllegalArgumentException("Unknown session metric path " + path);
+    }
+    return metric;
+  }
+
+  private static Map<String, CoreSessionMetric> sortByPath() {
+    ImmutableMap.Builder<String, CoreSessionMetric> result = ImmutableMap.builder();
+    for (CoreSessionMetric value : values()) {
+      result.put(value.getPath(), value);
+    }
+    return result.build();
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metrics/NodeMetric.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metrics/NodeMetric.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.metrics;
+
+import com.datastax.oss.driver.api.core.session.Session;
+import java.net.InetAddress;
+
+/**
+ * A node-level metric exposed through {@link Session#getMetricRegistry()}.
+ *
+ * <p>Note that the actual key in the registry is composed of the {@link Session#getName() name of
+ * the session}, followed by "nodes", followed by a textual representation of the address of the
+ * node, followed by the path of the metric. IPv4 addresses are represented as the decimal
+ * components followed by the port, separated with underscores; IPv6 addresses are represented as
+ * the result of {@link InetAddress#getHostAddress()}, followed by an underscore, followed by the
+ * port. For example:
+ *
+ * <pre>
+ * // Retrieve the `retries.total` metric for node 127.0.0.1:9042 in session `s0`:
+ * Meter retriesMeter = session.getMetricRegistry().meter("s0.nodes.127_0_0_1_9042.retries.total");
+ *
+ * // Retrieve the `retries.total` metric for node ::1:9042 in session `s0`:
+ * Meter retriesMeter = session.getMetricRegistry().meter("s0.nodes.0:0:0:0:0:0:0:1_9042.retries.total");
+ * </pre>
+ *
+ * <p>All metrics exposed out of the box by the driver are instances of {@link CoreNodeMetric} (this
+ * interface only exists to allow custom metrics in driver extensions).
+ *
+ * @see SessionMetric
+ */
+public interface NodeMetric {
+  String getPath();
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metrics/SessionMetric.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metrics/SessionMetric.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.metrics;
+
+import com.datastax.oss.driver.api.core.session.Session;
+
+/**
+ * A session-level metric exposed through {@link Session#getMetricRegistry()}.
+ *
+ * <p>Note that the actual key in the registry is composed of the {@link Session#getName() name of
+ * the session} followed by the path of the metric, for example:
+ *
+ * <pre>
+ * // Retrieve the `cql_requests` metric for session `s0`:
+ * Timer requestsTimer = session.getMetricRegistry().timer("s0.cql_requests");
+ * </pre>
+ *
+ * <p>All metrics exposed out of the box by the driver are instances of {@link CoreSessionMetric}
+ * (this interface only exists to allow custom metrics in driver extensions).
+ *
+ * @see NodeMetric
+ */
+public interface SessionMetric {
+  String getPath();
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/Session.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/Session.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.driver.api.core.session;
 
+import com.codahale.metrics.MetricRegistry;
 import com.datastax.oss.driver.api.core.AsyncAutoCloseable;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -177,6 +178,17 @@ public interface Session extends AsyncAutoCloseable {
    * cqlsh-style program where requests are never concurrent).
    */
   CqlIdentifier getKeyspace();
+
+  /**
+   * The registry of driver metrics.
+   *
+   * <p>The driver is instrumented with DropWizard metrics, use this object to register metric
+   * reporters.
+   *
+   * @see <a href="http://metrics.dropwizard.io/4.0.0/manual/core.html#reporters">Reporters
+   *     (DropWizard Metrics manual)</a>
+   */
+  MetricRegistry getMetricRegistry();
 
   /**
    * Executes an arbitrary request.

--- a/core/src/main/java/com/datastax/oss/driver/api/core/specex/ConstantSpeculativeExecutionPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/specex/ConstantSpeculativeExecutionPolicy.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.config.CoreDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
 import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.session.Request;
 
 /**
@@ -47,7 +48,11 @@ public class ConstantSpeculativeExecutionPolicy implements SpeculativeExecutionP
   }
 
   @Override
-  public long nextExecution(CqlIdentifier keyspace, Request request, int runningExecutions) {
+  public long nextExecution(
+      @SuppressWarnings("unused") Node node,
+      @SuppressWarnings("unused") CqlIdentifier keyspace,
+      @SuppressWarnings("unused") Request request,
+      int runningExecutions) {
     assert runningExecutions >= 1;
     return (runningExecutions < maxExecutions) ? constantDelayMillis : -1;
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/specex/NoSpeculativeExecutionPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/specex/NoSpeculativeExecutionPolicy.java
@@ -17,6 +17,7 @@ package com.datastax.oss.driver.api.core.specex;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.session.Request;
 
 /** A policy that never triggers speculative executions. */
@@ -27,7 +28,9 @@ public class NoSpeculativeExecutionPolicy implements SpeculativeExecutionPolicy 
   }
 
   @Override
-  public long nextExecution(CqlIdentifier keyspace, Request request, int runningExecutions) {
+  @SuppressWarnings("unused")
+  public long nextExecution(
+      Node node, CqlIdentifier keyspace, Request request, int runningExecutions) {
     // never start speculative executions
     return -1;
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/specex/SpeculativeExecutionPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/specex/SpeculativeExecutionPolicy.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.api.core.specex;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.session.Request;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
 
@@ -26,6 +27,8 @@ import com.datastax.oss.driver.api.core.session.SessionBuilder;
 public interface SpeculativeExecutionPolicy extends AutoCloseable {
 
   /**
+   * @param node the node that caused the speculative execution (that is, the node that was queried
+   *     previously but was too slow to answer)
    * @param keyspace the CQL keyspace currently associated to the session. This is set either
    *     through the configuration, by calling {@link SessionBuilder#withKeyspace(CqlIdentifier)},
    *     or by manually executing a {@code USE} CQL statement. It can be {@code null} if the session
@@ -38,7 +41,7 @@ public interface SpeculativeExecutionPolicy extends AutoCloseable {
    * @return the time (in milliseconds) until a speculative request is sent to the next node, or 0
    *     to send it immediately, or a negative value to stop sending requests.
    */
-  long nextExecution(CqlIdentifier keyspace, Request request, int runningExecutions);
+  long nextExecution(Node node, CqlIdentifier keyspace, Request request, int runningExecutions);
 
   /** Called when the cluster that this policy is associated with closes. */
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
@@ -129,6 +129,23 @@ public class DriverChannel {
     return inFlightHandler.getAvailableIds();
   }
 
+  /**
+   * @return the number of requests currently executing on this channel (including {@link
+   *     #getOrphanedIds() orphaned ids}).
+   */
+  public int getInFlight() {
+    return inFlightHandler.getInFlight();
+  }
+
+  /**
+   * @return the number of stream ids for requests that have either timed out or been cancelled, but
+   *     for which we can't release the stream id because a request might still come from the
+   *     server.
+   */
+  public int getOrphanedIds() {
+    return inFlightHandler.getOrphanIds();
+  }
+
   public EventLoop eventLoop() {
     return channel.eventLoop();
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.driver.internal.core.context;
 
+import com.codahale.metrics.MetricRegistry;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
 import com.datastax.oss.driver.api.core.auth.AuthProvider;
@@ -50,6 +51,8 @@ import com.datastax.oss.driver.internal.core.metadata.token.DefaultReplicationSt
 import com.datastax.oss.driver.internal.core.metadata.token.DefaultTokenFactoryRegistry;
 import com.datastax.oss.driver.internal.core.metadata.token.ReplicationStrategyFactory;
 import com.datastax.oss.driver.internal.core.metadata.token.TokenFactoryRegistry;
+import com.datastax.oss.driver.internal.core.metrics.DefaultMetricUpdaterFactory;
+import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
 import com.datastax.oss.driver.internal.core.pool.ChannelPoolFactory;
 import com.datastax.oss.driver.internal.core.protocol.ByteBufPrimitiveCodec;
 import com.datastax.oss.driver.internal.core.servererrors.DefaultWriteTypeRegistry;
@@ -156,6 +159,10 @@ public class DefaultDriverContext implements InternalDriverContext {
           "replicationStrategyFactory", this::buildReplicationStrategyFactory, cycleDetector);
   private final LazyReference<PoolManager> poolManagerRef =
       new LazyReference<>("poolManager", this::buildPoolManager, cycleDetector);
+  private final LazyReference<MetricRegistry> metricRegistryRef =
+      new LazyReference<>("metricRegistry", this::buildMetricRegistry, cycleDetector);
+  private final LazyReference<MetricUpdaterFactory> metricUpdaterFactoryRef =
+      new LazyReference<>("metricUpdaterFactory", this::buildMetricUpdaterFactory, cycleDetector);
 
   private final DriverConfig config;
   private final DriverConfigLoader configLoader;
@@ -352,6 +359,14 @@ public class DefaultDriverContext implements InternalDriverContext {
     return new PoolManager(this);
   }
 
+  protected MetricRegistry buildMetricRegistry() {
+    return new MetricRegistry();
+  }
+
+  protected MetricUpdaterFactory buildMetricUpdaterFactory() {
+    return new DefaultMetricUpdaterFactory(this);
+  }
+
   @Override
   public String sessionName() {
     return sessionName;
@@ -510,6 +525,16 @@ public class DefaultDriverContext implements InternalDriverContext {
   @Override
   public PoolManager poolManager() {
     return poolManagerRef.get();
+  }
+
+  @Override
+  public MetricRegistry metricRegistry() {
+    return metricRegistryRef.get();
+  }
+
+  @Override
+  public MetricUpdaterFactory metricUpdaterFactory() {
+    return metricUpdaterFactoryRef.get();
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/InternalDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/InternalDriverContext.java
@@ -29,6 +29,7 @@ import com.datastax.oss.driver.internal.core.metadata.schema.parsing.SchemaParse
 import com.datastax.oss.driver.internal.core.metadata.schema.queries.SchemaQueriesFactory;
 import com.datastax.oss.driver.internal.core.metadata.token.ReplicationStrategyFactory;
 import com.datastax.oss.driver.internal.core.metadata.token.TokenFactoryRegistry;
+import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
 import com.datastax.oss.driver.internal.core.pool.ChannelPoolFactory;
 import com.datastax.oss.driver.internal.core.servererrors.WriteTypeRegistry;
 import com.datastax.oss.driver.internal.core.session.PoolManager;
@@ -85,4 +86,6 @@ public interface InternalDriverContext extends DriverContext {
   ReplicationStrategyFactory replicationStrategyFactory();
 
   PoolManager poolManager();
+
+  MetricUpdaterFactory metricUpdaterFactory();
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/AddNodeRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/AddNodeRefresh.java
@@ -38,7 +38,7 @@ public class AddNodeRefresh extends NodesRefresh {
     if (oldNodes.containsKey(newNodeInfo.getConnectAddress())) {
       return new Result(oldMetadata);
     } else {
-      DefaultNode newNode = new DefaultNode(newNodeInfo.getConnectAddress());
+      DefaultNode newNode = new DefaultNode(newNodeInfo.getConnectAddress(), context);
       copyInfos(newNodeInfo, newNode, null, context.sessionName());
       Map<InetSocketAddress, Node> newNodes =
           ImmutableMap.<InetSocketAddress, Node>builder()

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/FullNodeListRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/FullNodeListRefresh.java
@@ -67,7 +67,7 @@ class FullNodeListRefresh extends NodesRefresh {
       seen.add(address);
       DefaultNode node = (DefaultNode) oldNodes.get(address);
       if (node == null) {
-        node = new DefaultNode(address);
+        node = new DefaultNode(address, context);
         LOG.debug("[{}] Adding new node {}", logPrefix, node);
         added.put(address, node);
       }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/InitContactPointsRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/InitContactPointsRefresh.java
@@ -43,7 +43,7 @@ class InitContactPointsRefresh implements MetadataRefresh {
 
     ImmutableMap.Builder<InetSocketAddress, Node> newNodes = ImmutableMap.builder();
     for (InetSocketAddress address : contactPoints) {
-      newNodes.put(address, new DefaultNode(address));
+      newNodes.put(address, new DefaultNode(address, context));
     }
     return new Result(new DefaultMetadata(newNodes.build()));
     // No token map refresh, because we don't have enough information yet

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DefaultMetricUpdaterFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DefaultMetricUpdaterFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metrics;
+
+import com.datastax.oss.driver.api.core.config.CoreDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metrics.CoreNodeMetric;
+import com.datastax.oss.driver.api.core.metrics.CoreSessionMetric;
+import com.datastax.oss.driver.api.core.metrics.NodeMetric;
+import com.datastax.oss.driver.api.core.metrics.SessionMetric;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultMetricUpdaterFactory implements MetricUpdaterFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultMetricUpdaterFactory.class);
+
+  private final String logPrefix;
+  private final InternalDriverContext context;
+  private final Set<SessionMetric> enabledSessionMetrics;
+  private final Set<NodeMetric> enabledNodeMetrics;
+
+  public DefaultMetricUpdaterFactory(InternalDriverContext context) {
+    this.logPrefix = context.sessionName();
+    this.context = context;
+    DriverConfigProfile config = context.config().getDefaultProfile();
+    this.enabledSessionMetrics =
+        parseSessionMetricPaths(config.getStringList(CoreDriverOption.METRICS_SESSION_ENABLED));
+    this.enabledNodeMetrics =
+        parseNodeMetricPaths(config.getStringList(CoreDriverOption.METRICS_NODE_ENABLED));
+  }
+
+  @Override
+  public SessionMetricUpdater newSessionUpdater() {
+    return new DefaultSessionMetricUpdater(enabledSessionMetrics, context);
+  }
+
+  @Override
+  public NodeMetricUpdater newNodeUpdater(Node node) {
+    return new DefaultNodeMetricUpdater(node, enabledNodeMetrics, context);
+  }
+
+  private Set<SessionMetric> parseSessionMetricPaths(List<String> paths) {
+    EnumSet<CoreSessionMetric> result = EnumSet.noneOf(CoreSessionMetric.class);
+    for (String path : paths) {
+      try {
+        result.add(CoreSessionMetric.fromPath(path));
+      } catch (IllegalArgumentException e) {
+        LOG.warn("[{}] Unknown session metric {}, skipping", logPrefix, path);
+      }
+    }
+    return Collections.unmodifiableSet(result);
+  }
+
+  private Set<NodeMetric> parseNodeMetricPaths(List<String> paths) {
+    EnumSet<CoreNodeMetric> result = EnumSet.noneOf(CoreNodeMetric.class);
+    for (String path : paths) {
+      try {
+        result.add(CoreNodeMetric.fromPath(path));
+      } catch (IllegalArgumentException e) {
+        LOG.warn("[{}] Unknown node metric {}, skipping", logPrefix, path);
+      }
+    }
+    return Collections.unmodifiableSet(result);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DefaultNodeMetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DefaultNodeMetricUpdater.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metrics;
+
+import com.codahale.metrics.Gauge;
+import com.datastax.oss.driver.api.core.config.CoreDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metrics.CoreNodeMetric;
+import com.datastax.oss.driver.api.core.metrics.NodeMetric;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.pool.ChannelPool;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Set;
+import java.util.function.Function;
+
+public class DefaultNodeMetricUpdater extends MetricUpdaterBase<NodeMetric>
+    implements NodeMetricUpdater {
+
+  private final String metricNamePrefix;
+
+  public DefaultNodeMetricUpdater(
+      Node node, Set<NodeMetric> enabledMetrics, InternalDriverContext context) {
+    super(enabledMetrics, context.metricRegistry());
+    this.metricNamePrefix = buildPrefix(context.sessionName(), node.getConnectAddress());
+
+    DriverConfigProfile config = context.config().getDefaultProfile();
+
+    if (enabledMetrics.contains(CoreNodeMetric.OPEN_CONNECTIONS)) {
+      metricRegistry.register(
+          buildFullName(CoreNodeMetric.OPEN_CONNECTIONS),
+          (Gauge<Integer>) node::getOpenConnections);
+    }
+    initializePoolGauge(
+        CoreNodeMetric.AVAILABLE_STREAMS, node, ChannelPool::getAvailableIds, context);
+    initializePoolGauge(CoreNodeMetric.IN_FLIGHT, node, ChannelPool::getInFlight, context);
+    initializePoolGauge(
+        CoreNodeMetric.ORPHANED_STREAMS, node, ChannelPool::getOrphanedIds, context);
+    initializeHdrTimer(
+        CoreNodeMetric.CQL_MESSAGES,
+        config,
+        CoreDriverOption.METRICS_NODE_CQL_MESSAGES_HIGHEST,
+        CoreDriverOption.METRICS_NODE_CQL_MESSAGES_DIGITS,
+        CoreDriverOption.METRICS_NODE_CQL_MESSAGES_INTERVAL);
+    initializeDefaultCounter(CoreNodeMetric.UNSENT_REQUESTS);
+    initializeDefaultCounter(CoreNodeMetric.ABORTED_REQUESTS);
+    initializeDefaultCounter(CoreNodeMetric.WRITE_TIMEOUTS);
+    initializeDefaultCounter(CoreNodeMetric.READ_TIMEOUTS);
+    initializeDefaultCounter(CoreNodeMetric.UNAVAILABLES);
+    initializeDefaultCounter(CoreNodeMetric.OTHER_ERRORS);
+    initializeDefaultCounter(CoreNodeMetric.RETRIES);
+    initializeDefaultCounter(CoreNodeMetric.RETRIES_ON_ABORTED);
+    initializeDefaultCounter(CoreNodeMetric.RETRIES_ON_READ_TIMEOUT);
+    initializeDefaultCounter(CoreNodeMetric.RETRIES_ON_WRITE_TIMEOUT);
+    initializeDefaultCounter(CoreNodeMetric.RETRIES_ON_UNAVAILABLE);
+    initializeDefaultCounter(CoreNodeMetric.RETRIES_ON_OTHER_ERROR);
+    initializeDefaultCounter(CoreNodeMetric.IGNORES);
+    initializeDefaultCounter(CoreNodeMetric.IGNORES_ON_ABORTED);
+    initializeDefaultCounter(CoreNodeMetric.IGNORES_ON_READ_TIMEOUT);
+    initializeDefaultCounter(CoreNodeMetric.IGNORES_ON_WRITE_TIMEOUT);
+    initializeDefaultCounter(CoreNodeMetric.IGNORES_ON_UNAVAILABLE);
+    initializeDefaultCounter(CoreNodeMetric.IGNORES_ON_OTHER_ERROR);
+    initializeDefaultCounter(CoreNodeMetric.SPECULATIVE_EXECUTIONS);
+    initializeDefaultCounter(CoreNodeMetric.CONNECTION_INIT_ERRORS);
+    initializeDefaultCounter(CoreNodeMetric.AUTHENTICATION_ERRORS);
+  }
+
+  @Override
+  protected String buildFullName(NodeMetric metric) {
+    return metricNamePrefix + metric.getPath();
+  }
+
+  private String buildPrefix(String sessionName, InetSocketAddress addressAndPort) {
+    StringBuilder prefix = new StringBuilder(sessionName).append(".nodes.");
+    InetAddress address = addressAndPort.getAddress();
+    int port = addressAndPort.getPort();
+    if (address instanceof Inet4Address) {
+      // Metrics use '.' as a delimiter, replace so that the IP is a single path component
+      // (127.0.0.1 => 127_0_0_1)
+      prefix.append(address.getHostAddress().replace('.', '_'));
+    } else {
+      assert address instanceof Inet6Address;
+      // IPv6 only uses '%' and ':' as separators, so no replacement needed
+      prefix.append(address.getHostAddress());
+    }
+    // Append the port in anticipation of when C* will support nodes on different ports
+    return prefix.append('_').append(port).append('.').toString();
+  }
+
+  private void initializePoolGauge(
+      NodeMetric metric,
+      Node node,
+      Function<ChannelPool, Integer> reading,
+      InternalDriverContext context) {
+    if (enabledMetrics.contains(metric)) {
+      metricRegistry.register(
+          buildFullName(metric),
+          (Gauge<Integer>)
+              () -> {
+                ChannelPool pool = context.poolManager().getPools().get(node);
+                return (pool == null) ? 0 : reading.apply(pool);
+              });
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DefaultSessionMetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DefaultSessionMetricUpdater.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metrics;
+
+import com.codahale.metrics.Gauge;
+import com.datastax.oss.driver.api.core.config.CoreDriverOption;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metrics.CoreSessionMetric;
+import com.datastax.oss.driver.api.core.metrics.SessionMetric;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import java.util.Set;
+
+public class DefaultSessionMetricUpdater extends MetricUpdaterBase<SessionMetric>
+    implements SessionMetricUpdater {
+
+  private final String metricNamePrefix;
+
+  public DefaultSessionMetricUpdater(
+      Set<SessionMetric> enabledMetrics, InternalDriverContext context) {
+    super(enabledMetrics, context.metricRegistry());
+    this.metricNamePrefix = context.sessionName() + ".";
+
+    if (enabledMetrics.contains(CoreSessionMetric.CONNECTED_NODES)) {
+      metricRegistry.register(
+          buildFullName(CoreSessionMetric.CONNECTED_NODES),
+          (Gauge<Integer>)
+              () -> {
+                int count = 0;
+                for (Node node : context.metadataManager().getMetadata().getNodes().values()) {
+                  if (node.getOpenConnections() > 0) {
+                    count += 1;
+                  }
+                }
+                return count;
+              });
+    }
+    initializeHdrTimer(
+        CoreSessionMetric.CQL_REQUESTS,
+        context.config().getDefaultProfile(),
+        CoreDriverOption.METRICS_SESSION_CQL_REQUESTS_HIGHEST,
+        CoreDriverOption.METRICS_SESSION_CQL_REQUESTS_DIGITS,
+        CoreDriverOption.METRICS_SESSION_CQL_REQUESTS_INTERVAL);
+    initializeDefaultCounter(CoreSessionMetric.CQL_CLIENT_TIMEOUTS);
+  }
+
+  @Override
+  protected String buildFullName(SessionMetric metric) {
+    return metricNamePrefix + metric.getPath();
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/HdrReservoir.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/HdrReservoir.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metrics;
+
+import com.codahale.metrics.Reservoir;
+import com.codahale.metrics.Snapshot;
+import java.io.OutputStream;
+import java.time.Duration;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.Recorder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A reservoir implementation backed by the HdrHistogram library.
+ *
+ * <p>It uses a {@link Recorder} to capture snapshots at a configurable interval: calls to {@link
+ * #update(long)} are recorded in a "live" histogram, while {@link #getSnapshot()} is based on a
+ * "cached", read-only histogram. Each time the cached histogram becomes older than the interval,
+ * the two histograms are switched (therefore statistics won't be available during the first
+ * interval after initialization, since we don't have a cached histogram yet).
+ *
+ * <p>Note that this class does not implement {@link #size()}.
+ *
+ * @see <a href="http://hdrhistogram.github.io/HdrHistogram/">HdrHistogram</a>
+ */
+public class HdrReservoir implements Reservoir {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HdrReservoir.class);
+
+  private final String logPrefix;
+  private final Recorder recorder;
+  private final long refreshIntervalNanos;
+
+  // The lock only orchestrates `getSnapshot()` calls; `update()` is fed directly to the recorder,
+  // which is lock-free. `getSnapshot()` calls are comparatively rare, so locking is not a
+  // bottleneck.
+  private final ReadWriteLock cacheLock = new ReentrantReadWriteLock();
+  private Histogram cachedHistogram; // Guarded by cacheLock
+  private long cachedHistogramTimestampNanos; // Guarded by cacheLock
+  private Snapshot cachedSnapshot; // Guarded by cacheLock
+
+  public HdrReservoir(
+      Duration highestTrackableLatency,
+      int numberOfSignificantValueDigits,
+      Duration refreshInterval,
+      String logPrefix) {
+    this.logPrefix = logPrefix;
+    // The Reservoir interface is supposed to be agnostic to the unit. However, the Metrics library
+    // heavily leans towards nanoseconds (for example, Timer feeds nanoseconds to update(); JmxTimer
+    // assumes that the snapshot results are in nanoseconds).
+    // In our case, microseconds are precise enough for request metrics, and we don't want to waste
+    // space unnecessarily. So we simply use microseconds for our internal storage, and do the
+    // conversion when needed.
+    this.recorder =
+        new Recorder(highestTrackableLatency.toNanos() / 1000, numberOfSignificantValueDigits);
+    this.refreshIntervalNanos = refreshInterval.toNanos();
+    this.cachedHistogramTimestampNanos = System.nanoTime();
+    this.cachedSnapshot = EMPTY_SNAPSHOT;
+  }
+
+  @Override
+  public void update(long value) {
+    try {
+      recorder.recordValue(value / 1000);
+    } catch (ArrayIndexOutOfBoundsException e) {
+      LOG.warn("[{}] Recorded value ({}) is out of bounds, discarding", logPrefix, value);
+    }
+  }
+
+  /**
+   * <em>Not implemented</em>: this reservoir implementation is intended for use with a {@link
+   * com.codahale.metrics.Histogram}, which doesn't use this method.
+   *
+   * <p>(original description: {@inheritDoc})
+   */
+  @Override
+  public int size() {
+    throw new UnsupportedOperationException("HdrReservoir does not implement size()");
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Note that the snapshots returned from this method do not implement {@link
+   * Snapshot#getValues()} nor {@link Snapshot#dump(OutputStream)}. In addition, due to the way that
+   * internal data structures are recycled, you should not hold onto a snapshot for more than the
+   * refresh interval; one way to ensure this is to never cache the result of this method.
+   */
+  @Override
+  public Snapshot getSnapshot() {
+    long now = System.nanoTime();
+
+    cacheLock.readLock().lock();
+    try {
+      if (now - cachedHistogramTimestampNanos < refreshIntervalNanos) {
+        return cachedSnapshot;
+      }
+    } finally {
+      cacheLock.readLock().unlock();
+    }
+
+    cacheLock.writeLock().lock();
+    try {
+      // Might have raced with another writer => re-check the timestamp
+      if (now - cachedHistogramTimestampNanos >= refreshIntervalNanos) {
+        LOG.debug("Cached snapshot is too old, refreshing");
+        cachedHistogram = recorder.getIntervalHistogram(cachedHistogram);
+        cachedSnapshot = new HdrSnapshot(cachedHistogram);
+        cachedHistogramTimestampNanos = now;
+      }
+      return cachedSnapshot;
+    } finally {
+      cacheLock.writeLock().unlock();
+    }
+  }
+
+  private class HdrSnapshot extends Snapshot {
+
+    private final Histogram histogram;
+    private final double meanNanos;
+    private final double stdDevNanos;
+
+    private HdrSnapshot(Histogram histogram) {
+      this.histogram = histogram;
+
+      // Cache those values because they rely on HdrHistogram's internal iterators, which are not
+      // safe if the snapshot is accessed by concurrent reporters.
+      // In contrast, getMin(), getMax() and getValue() are safe.
+      this.meanNanos = histogram.getMean() * 1000;
+      this.stdDevNanos = histogram.getStdDeviation() * 1000;
+    }
+
+    @Override
+    public double getValue(double quantile) {
+      return histogram.getValueAtPercentile(quantile * 100) * 1000;
+    }
+
+    /**
+     * <em>Not implemented</em>: this reservoir implementation is intended for use with a {@link
+     * com.codahale.metrics.Histogram}, which doesn't use this method.
+     *
+     * <p>(original description: {@inheritDoc})
+     */
+    @Override
+    public long[] getValues() {
+      // This can be implemented, but we ran into issues when accessed by concurrent reporters
+      // because HdrHistogram uses an unsafe shared iterator.
+      // So throwing instead since this method should be seldom used anyway.
+      throw new UnsupportedOperationException(
+          "HdrReservoir's snapshots do not implement getValues()");
+    }
+
+    @Override
+    public int size() {
+      long longSize = histogram.getTotalCount();
+      // The Metrics API requires an int. It's very unlikely that we get an overflow here, unless
+      // the refresh interval is ridiculously high (at 10k requests/s, it would have to be more than
+      // 59 hours). However handle gracefully just in case.
+      int size;
+      if (longSize > Integer.MAX_VALUE) {
+        LOG.warn("[{}] Too many recorded values, truncating", logPrefix);
+        size = Integer.MAX_VALUE;
+      } else {
+        size = (int) longSize;
+      }
+      return size;
+    }
+
+    @Override
+    public long getMax() {
+      return histogram.getMaxValue() * 1000;
+    }
+
+    @Override
+    public double getMean() {
+      return meanNanos;
+    }
+
+    @Override
+    public long getMin() {
+      return histogram.getMinValue() * 1000;
+    }
+
+    @Override
+    public double getStdDev() {
+      return stdDevNanos;
+    }
+
+    /**
+     * <em>Not implemented</em>: this reservoir implementation is intended for use with a {@link
+     * com.codahale.metrics.Histogram}, which doesn't use this method.
+     *
+     * <p>(original description: {@inheritDoc})
+     */
+    @Override
+    public void dump(OutputStream output) {
+      throw new UnsupportedOperationException("HdrReservoir's snapshots do not implement dump()");
+    }
+  }
+
+  private static final Snapshot EMPTY_SNAPSHOT =
+      new Snapshot() {
+        @Override
+        public double getValue(double quantile) {
+          return 0;
+        }
+
+        @Override
+        public long[] getValues() {
+          return new long[0];
+        }
+
+        @Override
+        public int size() {
+          return 0;
+        }
+
+        @Override
+        public long getMax() {
+          return 0;
+        }
+
+        @Override
+        public double getMean() {
+          return 0;
+        }
+
+        @Override
+        public long getMin() {
+          return 0;
+        }
+
+        @Override
+        public double getStdDev() {
+          return 0;
+        }
+
+        @Override
+        public void dump(OutputStream output) {
+          // nothing to do
+        }
+      };
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/MetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/MetricUpdater.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+public interface MetricUpdater<MetricT> {
+
+  void incrementCounter(MetricT metric, long amount);
+
+  default void incrementCounter(MetricT metric) {
+    incrementCounter(metric, 1);
+  }
+
+  void updateHistogram(MetricT metric, long value);
+
+  void markMeter(MetricT metric, long amount);
+
+  default void markMeter(MetricT metric) {
+    markMeter(metric, 1);
+  }
+
+  void updateTimer(MetricT metric, long duration, TimeUnit unit);
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/MetricUpdaterBase.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/MetricUpdaterBase.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.datastax.oss.driver.api.core.config.CoreDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class MetricUpdaterBase<MetricT> implements MetricUpdater<MetricT> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MetricUpdaterBase.class);
+
+  protected final Set<MetricT> enabledMetrics;
+  protected final MetricRegistry metricRegistry;
+
+  protected MetricUpdaterBase(Set<MetricT> enabledMetrics, MetricRegistry metricRegistry) {
+    this.enabledMetrics = enabledMetrics;
+    this.metricRegistry = metricRegistry;
+  }
+
+  protected abstract String buildFullName(MetricT metric);
+
+  @Override
+  public void incrementCounter(MetricT metric, long amount) {
+    if (enabledMetrics.contains(metric)) {
+      metricRegistry.counter(buildFullName(metric)).inc(amount);
+    }
+  }
+
+  @Override
+  public void updateHistogram(MetricT metric, long value) {
+    if (enabledMetrics.contains(metric)) {
+      metricRegistry.histogram(buildFullName(metric)).update(value);
+    }
+  }
+
+  @Override
+  public void markMeter(MetricT metric, long amount) {
+    if (enabledMetrics.contains(metric)) {
+      metricRegistry.meter(buildFullName(metric)).mark(amount);
+    }
+  }
+
+  @Override
+  public void updateTimer(MetricT metric, long duration, TimeUnit unit) {
+    if (enabledMetrics.contains(metric)) {
+      metricRegistry.timer(buildFullName(metric)).update(duration, unit);
+    }
+  }
+
+  protected void initializeDefaultCounter(MetricT metric) {
+    if (enabledMetrics.contains(metric)) {
+      // Just initialize eagerly so that the metric appears even when it has no data yet
+      metricRegistry.counter(buildFullName(metric));
+    }
+  }
+
+  protected void initializeHdrTimer(
+      MetricT metric,
+      DriverConfigProfile config,
+      CoreDriverOption highestLatencyOption,
+      CoreDriverOption significantDigitsOption,
+      CoreDriverOption intervalOption) {
+    if (enabledMetrics.contains(metric)) {
+      String fullName = buildFullName(metric);
+
+      Duration highestLatency = config.getDuration(highestLatencyOption);
+      final int significantDigits;
+      int d = config.getInt(significantDigitsOption);
+      if (d >= 0 && d <= 5) {
+        significantDigits = d;
+      } else {
+        LOG.warn(
+            "[{}] Configuration option {} is out of range (expected between 0 and 5, found {}); "
+                + "using 3 instead.",
+            fullName,
+            significantDigitsOption,
+            d);
+        significantDigits = 3;
+      }
+      Duration refreshInterval = config.getDuration(intervalOption);
+
+      // Initialize eagerly to use the custom implementation
+      metricRegistry.timer(
+          fullName,
+          () ->
+              new Timer(
+                  new HdrReservoir(highestLatency, significantDigits, refreshInterval, fullName)));
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/MetricUpdaterFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/MetricUpdaterFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metrics;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+
+public interface MetricUpdaterFactory {
+
+  SessionMetricUpdater newSessionUpdater();
+
+  NodeMetricUpdater newNodeUpdater(Node node);
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/NodeMetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/NodeMetricUpdater.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metrics;
+
+import com.datastax.oss.driver.api.core.metrics.NodeMetric;
+
+public interface NodeMetricUpdater extends MetricUpdater<NodeMetric> {}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/SessionMetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/SessionMetricUpdater.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metrics;
+
+import com.datastax.oss.driver.api.core.metrics.SessionMetric;
+
+public interface SessionMetricUpdater extends MetricUpdater<SessionMetric> {}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java
@@ -24,6 +24,7 @@ import com.datastax.oss.driver.api.core.config.CoreDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
 import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metrics.CoreNodeMetric;
 import com.datastax.oss.driver.internal.core.channel.ChannelEvent;
 import com.datastax.oss.driver.internal.core.channel.ChannelFactory;
 import com.datastax.oss.driver.internal.core.channel.ClusterNameMismatchException;
@@ -32,6 +33,7 @@ import com.datastax.oss.driver.internal.core.channel.DriverChannelOptions;
 import com.datastax.oss.driver.internal.core.config.ConfigChangeEvent;
 import com.datastax.oss.driver.internal.core.context.EventBus;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
 import com.datastax.oss.driver.internal.core.metadata.TopologyEvent;
 import com.datastax.oss.driver.internal.core.util.Loggers;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
@@ -143,8 +145,21 @@ public class ChannelPool implements AsyncAutoCloseable {
     return channels.next();
   }
 
+  /** @return the number of active channels in the pool. */
+  public int size() {
+    return channels.size();
+  }
+
   public int getAvailableIds() {
     return channels.getAvailableIds();
+  }
+
+  public int getInFlight() {
+    return channels.getInFlight();
+  }
+
+  public int getOrphanedIds() {
+    return channels.getOrphanedIds();
   }
 
   public void resize(NodeDistance newDistance) {
@@ -274,6 +289,12 @@ public class ChannelPool implements AsyncAutoCloseable {
         assert future.isDone();
         if (future.isCompletedExceptionally()) {
           Throwable error = CompletableFutures.getFailed(future);
+          ((DefaultNode) node)
+              .getMetricUpdater()
+              .incrementCounter(
+                  error instanceof AuthenticationException
+                      ? CoreNodeMetric.AUTHENTICATION_ERRORS
+                      : CoreNodeMetric.CONNECTION_INIT_ERRORS);
           if (error instanceof ClusterNameMismatchException
               || error instanceof UnsupportedProtocolVersionException) {
             // This will likely be thrown by all channels, but finish the loop cleanly

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelSet.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelSet.java
@@ -104,6 +104,24 @@ class ChannelSet implements Iterable<DriverChannel> {
     return availableIds;
   }
 
+  int getInFlight() {
+    int inFlight = 0;
+    DriverChannel[] snapshot = this.channels;
+    for (DriverChannel channel : snapshot) {
+      inFlight += channel.getInFlight();
+    }
+    return inFlight;
+  }
+
+  int getOrphanedIds() {
+    int orphanedIds = 0;
+    DriverChannel[] snapshot = this.channels;
+    for (DriverChannel channel : snapshot) {
+      orphanedIds += channel.getOrphanedIds();
+    }
+    return orphanedIds;
+  }
+
   int size() {
     return this.channels.length;
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/SessionWrapper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/SessionWrapper.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.driver.internal.core.session;
 
+import com.codahale.metrics.MetricRegistry;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.context.DriverContext;
 import com.datastax.oss.driver.api.core.metadata.Metadata;
@@ -88,6 +89,11 @@ public class SessionWrapper implements Session {
   @Override
   public CqlIdentifier getKeyspace() {
     return delegate.getKeyspace();
+  }
+
+  @Override
+  public MetricRegistry getMetricRegistry() {
+    return delegate.getMetricRegistry();
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/Loggers.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/Loggers.java
@@ -29,7 +29,8 @@ public class Loggers {
     } else {
       Object last = arguments[arguments.length - 1];
       if (last instanceof Throwable) {
-        arguments[arguments.length - 1] = ((Throwable) last).getMessage();
+        Throwable t = (Throwable) last;
+        arguments[arguments.length - 1] = t.getClass().getSimpleName() + ": " + t.getMessage();
         logger.warn(format + " ({})", arguments);
       } else {
         // Should only be called with an exception as last argument, but handle gracefully anyway

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -190,6 +190,22 @@ datastax-java-driver {
     # after the change.
     max-orphan-requests = 24576
 
+    # Whether to log non-fatal errors when the driver tries to open a new connection.
+    #
+    # This error as recoverable, as the driver will try to reconnect according to the reconnection
+    # policy. Therefore some users see them as unnecessary clutter in the logs. On the other hand,
+    # those logs can be handy to debug a misbehaving node.
+    #
+    # This option can be changed at runtime, the new value will be used for new connections created
+    # after the change.
+    #
+    # Note that some type of errors are always logged, regardless of this option:
+    # - protocol version mismatches (the node gets forced down)
+    # - when the cluster name in system.local doesn't match the other nodes (the node gets forced
+    #   down)
+    # - authentication errors (will be retried)
+    warn-on-init-error = true
+
     heartbeat {
       # The heartbeat interval. If a connection stays idle for that duration (no reads), the driver
       # sends a dummy message on it to make sure it's still alive. If not, the connection is

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -566,6 +566,198 @@ datastax-java-driver {
     token-map.enabled = true
   }
 
+  metrics {
+    # The session-level metrics (all disabled by default).
+    session {
+      enabled = [
+        # The number of nodes to which the driver has at least one active connection (exposed as a
+        # Gauge<Integer>).
+        // connected-nodes,
+
+        # The throughput and latency percentiles of CQL requests (exposed as a Timer).
+        #
+        # This corresponds to the overall duration of the session.execute() call, including any
+        # retry.
+        // cql-requests,
+
+        # The number of CQL requests that timed out -- that is, the session.execute() call failed
+        # with a DriverTimeoutException (exposed as a Counter).
+        // cql-client-timeouts,
+      ]
+
+      # Extra configuration (for the metrics that need it)
+      cql-requests {
+        # The largest latency that we expect to record.
+        #
+        # This should be slightly higher than request.timeout (in theory, readings can't be higher
+        # than the timeout, but there might be a small overhead due to internal scheduling).
+        #
+        # This is used to scale internal data structures. If a higher recording is encountered at
+        # runtime, it is discarded and a warning is logged.
+        highest-latency = 3 seconds
+
+        # The number of significant decimal digits to which internal structures will maintain value
+        # resolution and separation (for example, 3 means that recordings up to 1 second will be
+        # recorded with a resolution of 1 millisecond or better).
+        #
+        # This must be between 0 and 5. If the value is out of range, it defaults to 3 and a warning
+        # is logged.
+        significant-digits = 3
+
+        # The interval at which percentile data is refreshed.
+        #
+        # The driver records latency data in a "live" histogram, and serves results from a cached
+        # snapshot. Each time the snapshot gets older than the interval, the two are switched. Note
+        # that this switch happens upon fetching the metrics, so if you never fetch the recording
+        # interval might grow higher (that shouldn't be an issue in a production environment because
+        # you would typically have a metrics reporter that exports to a monitoring tool at a regular
+        # interval).
+        #
+        # In practice, this means that if you set this to 5 minutes, you're looking at data from a
+        # 5-minute interval in the past, that is at most 5 minutes old. If you fetch the metrics at
+        # a faster pace, you will observe the same data for 5 minutes until the interval expires.
+        #
+        # Note that this does not apply to the total count and rates (those are updated in real
+        # time).
+        refresh-interval = 5 minutes
+      }
+    }
+    # The node-level metrics (all disabled by default).
+    node {
+      enabled = [
+        # The number of connections open to this node for regular requests (exposed as a
+        # Gauge<Integer>).
+        #
+        # This includes the control connection (which uses at most one extra connection to a random
+        # node in the cluster).
+        // pool.open-connections,
+
+        # The number of stream ids available on the connections to this node (exposed as a
+        # Gauge<Integer>).
+        #
+        # Stream ids are used to multiplex requests on each connection, so this is an indication of
+        # how many more requests the node could handle concurrently before becoming saturated (note
+        # that this is a driver-side only consideration, there might be other limitations on the
+        # server that prevent reaching that theoretical limit).
+        // pool.available-streams,
+
+        # The number of requests currently executing on the connections to this node (exposed as a
+        # Gauge<Integer>). This includes orphaned streams.
+        // pool.in-flight,
+
+        # The number of "orphaned" stream ids on the connections to this node (exposed as a
+        # Gauge<Integer>).
+        #
+        # See the description of the connection.max-orphan-requests option for more details.
+        // pool.orphaned-streams,
+
+        # The throughput and latency percentiles of individual CQL messages sent to this node as
+        # part of an overall request (exposed as a Timer).
+        #
+        # Note that this does not necessarily correspond to the overall duration of the
+        # session.execute() call, since the driver might query multiple nodes because of retries and
+        # speculative executions. Therefore a single "request" (as seen from a client of the driver)
+        # can be composed of more than one of the "messages" measured by this metric.
+        #
+        # Therefore this metric is intended as an insight into the performance of this particular
+        # node. For statistics on overall request completion, use the session-level cql-requests.
+        // cql-messages,
+
+        # The number of times the driver failed to send a request to this node (exposed as a
+        # Counter).
+        #
+        # In those case we know the request didn't even reach the coordinator, so they are retried
+        # on the next node automatically (without going through the retry policy).
+        // errors.request.unsent,
+
+        # The number of times a request was aborted before the driver even received a response from
+        # this node (exposed as a Counter).
+        #
+        # This can happen in two cases: if the connection was closed due to an external event (such
+        # as a network error or heartbeat failure); or if there was an unexpected error while
+        # decoding the response (this can only be a driver bug).
+        // errors.request.aborted,
+
+        # The number of times this node replied with a WRITE_TIMEOUT error (exposed as a Counter).
+        #
+        # Whether this error is rethrown directly to the client, rethrown or ignored is determined
+        # by the RetryPolicy.
+        // errors.request.write-timeouts,
+
+        # The number of times this node replied with a READ_TIMEOUT error (exposed as a Counter).
+        #
+        # Whether this error is rethrown directly to the client, rethrown or ignored is determined
+        # by the RetryPolicy.
+        // errors.request.read-timeouts,
+
+        # The number of times this node replied with an UNAVAILABLE error (exposed as a Counter).
+        #
+        # Whether this error is rethrown directly to the client, rethrown or ignored is determined
+        # by the RetryPolicy.
+        // errors.request.unavailables,
+
+        # The number of times this node replied with an error that doesn't fall under other errors.*
+        # metrics (exposed as a Counter).
+        // errors.request.others,
+
+        # The total number of errors on this node that caused the RetryPolicy to trigger a retry
+        # (exposed as a Counter).
+        #
+        # This is a sum of all the other retries.* metrics.
+        // retries.total,
+
+        # The number of errors on this node that caused the RetryPolicy to trigger a retry, broken
+        # down by error type (exposed as Counters).
+        // retries.aborted,
+        // retries.read-timeout,
+        // retries.write-timeout,
+        // retries.unavailable,
+        // retries.other,
+
+        # The total number of errors on this node that were ignored by the RetryPolicy (exposed as a
+        # Counter).
+        #
+        # This is a sum of all the other ignores.* metrics.
+        // ignores.total,
+
+        # The number of errors on this node that were ignored by the RetryPolicy, broken down by
+        # error type (exposed as Counters).
+        // ignores.aborted,
+        // ignores.read-timeout,
+        // ignores.write-timeout,
+        // ignores.unavailable,
+        // ignores.other,
+
+        # The number of speculative executions triggered by a slow response from this node (exposed
+        # as a Counter).
+        // speculative-executions,
+
+        # The number of errors encountered while trying to establish a connection to this node
+        # (exposed as a Counter).
+        #
+        # Connection errors are not a fatal issue for the driver, failed connections will be retried
+        # periodically according to the reconnection policy. You can choose whether or not to log
+        # those errors at WARN level with the connection.warn-on-init-error option.
+        #
+        # Authentication errors are not included in this counter, they are tracked separately in
+        # errors.connection.auth.
+        // errors.connection.init,
+
+        # The number of authentication errors encountered while trying to establish a connection to
+        # this node (exposed as a Counter).
+        # Authentication errors are also logged at WARN level.
+        // errors.connection.auth,
+      ]
+
+      // See cql-requests in the `session` section
+      cql-messages {
+        highest-latency = 3 seconds
+        significant-digits = 3
+        refresh-interval = 5 minutes
+      }
+    }
+  }
+
   # The address translator to use to convert the addresses sent by Cassandra nodes into ones that
   # the driver uses to connect.
   # This is only needed if the nodes are not directly reachable from the driver (for example, the

--- a/core/src/test/java/com/datastax/oss/driver/api/core/specex/ConstantSpeculativeExecutionPolicyTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/specex/ConstantSpeculativeExecutionPolicyTest.java
@@ -68,10 +68,10 @@ public class ConstantSpeculativeExecutionPolicyTest {
     SpeculativeExecutionPolicy policy = new ConstantSpeculativeExecutionPolicy(context);
 
     // Initial execution starts, schedule first speculative execution
-    assertThat(policy.nextExecution(null, request, 1)).isEqualTo(10);
+    assertThat(policy.nextExecution(null, null, request, 1)).isEqualTo(10);
     // First speculative execution starts, schedule second one
-    assertThat(policy.nextExecution(null, request, 2)).isEqualTo(10);
+    assertThat(policy.nextExecution(null, null, request, 2)).isEqualTo(10);
     // Second speculative execution starts, we're at 3 => stop
-    assertThat(policy.nextExecution(null, request, 3)).isNegative();
+    assertThat(policy.nextExecution(null, null, request, 3)).isNegative();
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
@@ -31,6 +31,7 @@ import com.datastax.oss.driver.internal.core.context.NettyOptions;
 import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
 import com.datastax.oss.driver.internal.core.metadata.LoadBalancingPolicyWrapper;
 import com.datastax.oss.driver.internal.core.metadata.MetadataManager;
+import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.DefaultEventLoopGroup;
@@ -54,8 +55,6 @@ import org.mockito.MockitoAnnotations;
 abstract class ControlConnectionTestBase {
   protected static final InetSocketAddress ADDRESS1 = new InetSocketAddress("127.0.0.1", 9042);
   protected static final InetSocketAddress ADDRESS2 = new InetSocketAddress("127.0.0.2", 9042);
-  protected static final DefaultNode NODE1 = new DefaultNode(ADDRESS1);
-  protected static final DefaultNode NODE2 = new DefaultNode(ADDRESS2);
 
   @Mock protected InternalDriverContext context;
   @Mock protected ReconnectionPolicy reconnectionPolicy;
@@ -67,7 +66,11 @@ abstract class ControlConnectionTestBase {
   protected Exchanger<CompletableFuture<DriverChannel>> channelFactoryFuture;
   @Mock protected LoadBalancingPolicyWrapper loadBalancingPolicyWrapper;
   @Mock protected MetadataManager metadataManager;
+  @Mock protected MetricUpdaterFactory metricUpdaterFactory;
+
   protected AddressTranslator addressTranslator;
+  protected DefaultNode node1;
+  protected DefaultNode node2;
 
   protected ControlConnection controlConnection;
 
@@ -99,7 +102,11 @@ abstract class ControlConnectionTestBase {
     Mockito.when(reconnectionSchedule.nextDelay()).thenReturn(Duration.ofDays(1));
 
     Mockito.when(context.loadBalancingPolicyWrapper()).thenReturn(loadBalancingPolicyWrapper);
-    mockQueryPlan(NODE1, NODE2);
+
+    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+    node1 = new DefaultNode(ADDRESS1, context);
+    node2 = new DefaultNode(ADDRESS2, context);
+    mockQueryPlan(node1, node2);
 
     Mockito.when(metadataManager.refreshNodes())
         .thenReturn(CompletableFuture.completedFuture(null));

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTestBase.java
@@ -18,7 +18,8 @@ package com.datastax.oss.driver.internal.core.cql;
 import com.datastax.oss.driver.TestDataProviders;
 import com.datastax.oss.driver.api.core.CoreProtocolVersion;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
-import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
+import com.datastax.oss.driver.internal.core.metrics.NodeMetricUpdater;
 import com.datastax.oss.protocol.internal.Frame;
 import com.datastax.oss.protocol.internal.Message;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
@@ -30,6 +31,7 @@ import com.datastax.oss.protocol.internal.util.Bytes;
 import com.google.common.collect.ImmutableList;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Collections;
@@ -38,6 +40,7 @@ import java.util.Queue;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 @RunWith(DataProviderRunner.class)
@@ -49,14 +52,24 @@ public abstract class CqlRequestHandlerTestBase {
       SimpleStatement.builder("mock query").withIdempotence(true).build();
   protected static final SimpleStatement NON_IDEMPOTENT_STATEMENT =
       SimpleStatement.builder("mock query").withIdempotence(false).build();
+  protected static final InetSocketAddress ADDRESS1 = new InetSocketAddress("127.0.0.1", 9042);
+  protected static final InetSocketAddress ADDRESS2 = new InetSocketAddress("127.0.0.2", 9042);
+  protected static final InetSocketAddress ADDRESS3 = new InetSocketAddress("127.0.0.3", 9042);
 
-  @Mock protected Node node1;
-  @Mock protected Node node2;
-  @Mock protected Node node3;
+  @Mock protected DefaultNode node1;
+  @Mock protected DefaultNode node2;
+  @Mock protected DefaultNode node3;
+  @Mock protected NodeMetricUpdater nodeMetricUpdater1;
+  @Mock protected NodeMetricUpdater nodeMetricUpdater2;
+  @Mock protected NodeMetricUpdater nodeMetricUpdater3;
 
   @Before
   public void setup() {
     MockitoAnnotations.initMocks(this);
+
+    Mockito.when(node1.getMetricUpdater()).thenReturn(nodeMetricUpdater1);
+    Mockito.when(node2.getMetricUpdater()).thenReturn(nodeMetricUpdater2);
+    Mockito.when(node3.getMetricUpdater()).thenReturn(nodeMetricUpdater3);
   }
 
   protected static Frame defaultFrameOf(Message responseMessage) {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/RequestHandlerTestHarness.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/RequestHandlerTestHarness.java
@@ -116,7 +116,7 @@ public class RequestHandlerTestHarness implements AutoCloseable {
     // Disable speculative executions by default
     Mockito.when(
             speculativeExecutionPolicy.nextExecution(
-                any(CqlIdentifier.class), any(Request.class), anyInt()))
+                any(Node.class), any(CqlIdentifier.class), any(Request.class), anyInt()))
         .thenReturn(-1L);
     Mockito.when(context.speculativeExecutionPolicy()).thenReturn(speculativeExecutionPolicy);
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/AddNodeRefreshTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/AddNodeRefreshTest.java
@@ -20,13 +20,16 @@ import static com.datastax.oss.driver.Assertions.assertThat;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.uuid.Uuids;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
 import com.google.common.collect.ImmutableMap;
 import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.UUID;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -34,9 +37,16 @@ public class AddNodeRefreshTest {
   private static final InetSocketAddress ADDRESS1 = new InetSocketAddress("127.0.0.1", 9042);
   private static final InetSocketAddress ADDRESS2 = new InetSocketAddress("127.0.0.2", 9042);
 
-  private static final DefaultNode node1 = new DefaultNode(ADDRESS1);
-
   @Mock private InternalDriverContext context;
+  @Mock protected MetricUpdaterFactory metricUpdaterFactory;
+
+  private DefaultNode node1;
+
+  @Before
+  public void setup() {
+    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+    node1 = new DefaultNode(ADDRESS1, context);
+  }
 
   @Test
   public void should_add_new_node() {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
@@ -30,6 +30,7 @@ import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.control.ControlConnection;
+import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
@@ -62,6 +63,8 @@ public class DefaultTopologyMonitorTest {
   @Mock private DriverConfigProfile defaultConfig;
   @Mock private ControlConnection controlConnection;
   @Mock private DriverChannel channel;
+  @Mock protected MetricUpdaterFactory metricUpdaterFactory;
+
   private AddressTranslator addressTranslator;
   private DefaultNode node1;
   private DefaultNode node2;
@@ -84,8 +87,10 @@ public class DefaultTopologyMonitorTest {
     Mockito.when(controlConnection.channel()).thenReturn(channel);
     Mockito.when(context.controlConnection()).thenReturn(controlConnection);
 
-    node1 = new DefaultNode(ADDRESS1);
-    node2 = new DefaultNode(ADDRESS2);
+    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+
+    node1 = new DefaultNode(ADDRESS1, context);
+    node2 = new DefaultNode(ADDRESS2, context);
 
     topologyMonitor = new TestTopologyMonitor(context);
   }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/FullNodeListRefreshTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/FullNodeListRefreshTest.java
@@ -19,13 +19,16 @@ import static com.datastax.oss.driver.Assertions.assertThat;
 
 import com.datastax.oss.driver.api.core.uuid.Uuids;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.net.InetSocketAddress;
 import java.util.UUID;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -35,11 +38,21 @@ public class FullNodeListRefreshTest {
   private static final InetSocketAddress ADDRESS2 = new InetSocketAddress("127.0.0.2", 9042);
   private static final InetSocketAddress ADDRESS3 = new InetSocketAddress("127.0.0.3", 9042);
 
-  private static final DefaultNode node1 = new DefaultNode(ADDRESS1);
-  private static final DefaultNode node2 = new DefaultNode(ADDRESS2);
-  private static final DefaultNode node3 = new DefaultNode(ADDRESS3);
-
   @Mock private InternalDriverContext context;
+  @Mock protected MetricUpdaterFactory metricUpdaterFactory;
+
+  private DefaultNode node1;
+  private DefaultNode node2;
+  private DefaultNode node3;
+
+  @Before
+  public void setup() {
+    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+
+    node1 = new DefaultNode(ADDRESS1, context);
+    node2 = new DefaultNode(ADDRESS2, context);
+    node3 = new DefaultNode(ADDRESS3, context);
+  }
 
   @Test
   public void should_add_and_remove_nodes() {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/InitContactPointsRefreshTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/InitContactPointsRefreshTest.java
@@ -18,11 +18,14 @@ package com.datastax.oss.driver.internal.core.metadata;
 import static com.datastax.oss.driver.Assertions.assertThat;
 
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
 import com.google.common.collect.ImmutableSet;
 import java.net.InetSocketAddress;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -32,6 +35,12 @@ public class InitContactPointsRefreshTest {
   private static final InetSocketAddress ADDRESS2 = new InetSocketAddress("127.0.0.2", 9042);
 
   @Mock private InternalDriverContext context;
+  @Mock private MetricUpdaterFactory metricUpdaterFactory;
+
+  @Before
+  public void setup() {
+    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+  }
 
   @Test
   public void should_create_nodes() {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapperTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapperTest.java
@@ -29,6 +29,7 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.datastax.oss.driver.internal.core.context.EventBus;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -59,6 +60,7 @@ public class LoadBalancingPolicyWrapperTest {
   private EventBus eventBus;
   @Mock private MetadataManager metadataManager;
   @Mock private Metadata metadata;
+  @Mock protected MetricUpdaterFactory metricUpdaterFactory;
 
   private LoadBalancingPolicyWrapper wrapper;
 
@@ -66,9 +68,11 @@ public class LoadBalancingPolicyWrapperTest {
   public void setup() {
     MockitoAnnotations.initMocks(this);
 
-    node1 = new DefaultNode(new InetSocketAddress("127.0.0.1", 9042));
-    node2 = new DefaultNode(new InetSocketAddress("127.0.0.2", 9042));
-    node3 = new DefaultNode(new InetSocketAddress("127.0.0.3", 9042));
+    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+
+    node1 = new DefaultNode(new InetSocketAddress("127.0.0.1", 9042), context);
+    node2 = new DefaultNode(new InetSocketAddress("127.0.0.2", 9042), context);
+    node3 = new DefaultNode(new InetSocketAddress("127.0.0.3", 9042), context);
 
     contactPointsMap =
         ImmutableMap.<InetSocketAddress, Node>builder()

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
@@ -28,6 +28,7 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.context.NettyOptions;
 import com.datastax.oss.driver.internal.core.metadata.schema.parsing.SchemaParserFactory;
 import com.datastax.oss.driver.internal.core.metadata.schema.queries.SchemaQueriesFactory;
+import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -64,6 +65,7 @@ public class MetadataManagerTest {
   @Mock private EventBus eventBus;
   @Mock private SchemaQueriesFactory schemaQueriesFactory;
   @Mock private SchemaParserFactory schemaParserFactory;
+  @Mock protected MetricUpdaterFactory metricUpdaterFactory;
 
   private DefaultEventLoopGroup adminEventLoopGroup;
 
@@ -88,6 +90,8 @@ public class MetadataManagerTest {
     Mockito.when(context.eventBus()).thenReturn(eventBus);
     Mockito.when(context.schemaQueriesFactory()).thenReturn(schemaQueriesFactory);
     Mockito.when(context.schemaParserFactory()).thenReturn(schemaParserFactory);
+
+    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
 
     metadataManager = new TestMetadataManager(context);
   }
@@ -150,7 +154,7 @@ public class MetadataManagerTest {
   @Test
   public void should_refresh_single_node() {
     // Given
-    Node node = new DefaultNode(ADDRESS1);
+    Node node = new DefaultNode(ADDRESS1, context);
     NodeInfo info = Mockito.mock(NodeInfo.class);
     Mockito.when(info.getDatacenter()).thenReturn("dc1");
     Mockito.when(topologyMonitor.refreshNode(node))

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/NodeStateManagerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/NodeStateManagerTest.java
@@ -31,6 +31,7 @@ import com.datastax.oss.driver.internal.core.channel.ChannelEvent;
 import com.datastax.oss.driver.internal.core.context.EventBus;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.context.NettyOptions;
+import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
 import com.datastax.oss.driver.internal.core.util.concurrent.BlockingOperation;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -59,6 +60,7 @@ public class NodeStateManagerTest {
   @Mock private NettyOptions nettyOptions;
   @Mock private MetadataManager metadataManager;
   @Mock private Metadata metadata;
+  @Mock protected MetricUpdaterFactory metricUpdaterFactory;
   private DefaultNode node1, node2;
   private EventBus eventBus;
   private DefaultEventLoopGroup adminEventLoopGroup;
@@ -82,8 +84,9 @@ public class NodeStateManagerTest {
     Mockito.when(nettyOptions.adminEventExecutorGroup()).thenReturn(adminEventLoopGroup);
     Mockito.when(context.nettyOptions()).thenReturn(nettyOptions);
 
-    node1 = new DefaultNode(new InetSocketAddress("127.0.0.1", 9042));
-    node2 = new DefaultNode(new InetSocketAddress("127.0.0.2", 9042));
+    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+    node1 = new DefaultNode(new InetSocketAddress("127.0.0.1", 9042), context);
+    node2 = new DefaultNode(new InetSocketAddress("127.0.0.2", 9042), context);
     ImmutableMap<InetSocketAddress, Node> nodes =
         ImmutableMap.<InetSocketAddress, Node>builder()
             .put(node1.getConnectAddress(), node1)

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/RemoveNodeRefreshTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/RemoveNodeRefreshTest.java
@@ -18,11 +18,14 @@ package com.datastax.oss.driver.internal.core.metadata;
 import static com.datastax.oss.driver.Assertions.assertThat;
 
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
 import com.google.common.collect.ImmutableMap;
 import java.net.InetSocketAddress;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -31,10 +34,18 @@ public class RemoveNodeRefreshTest {
   private static final InetSocketAddress ADDRESS1 = new InetSocketAddress("127.0.0.1", 9042);
   private static final InetSocketAddress ADDRESS2 = new InetSocketAddress("127.0.0.2", 9042);
 
-  private static final DefaultNode node1 = new DefaultNode(ADDRESS1);
-  private static final DefaultNode node2 = new DefaultNode(ADDRESS2);
-
   @Mock private InternalDriverContext context;
+  @Mock protected MetricUpdaterFactory metricUpdaterFactory;
+
+  private DefaultNode node1;
+  private DefaultNode node2;
+
+  @Before
+  public void setup() {
+    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+    node1 = new DefaultNode(ADDRESS1, context);
+    node2 = new DefaultNode(ADDRESS2, context);
+  }
 
   @Test
   public void should_remove_existing_node() {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolKeyspaceTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolKeyspaceTest.java
@@ -44,7 +44,7 @@ public class ChannelPoolKeyspaceTest extends ChannelPoolTestBase {
             .build();
 
     CompletionStage<ChannelPool> poolFuture =
-        ChannelPool.init(NODE, null, NodeDistance.LOCAL, context, "test");
+        ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
     factoryHelper.waitForCalls(ADDRESS, 2);
     waitForPendingAdminTasks();
@@ -86,7 +86,7 @@ public class ChannelPoolKeyspaceTest extends ChannelPoolTestBase {
             .build();
 
     CompletionStage<ChannelPool> poolFuture =
-        ChannelPool.init(NODE, null, NodeDistance.LOCAL, context, "test");
+        ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
     factoryHelper.waitForCalls(ADDRESS, 2);
     waitForPendingAdminTasks();
@@ -96,7 +96,7 @@ public class ChannelPoolKeyspaceTest extends ChannelPoolTestBase {
 
     // Check that reconnection has kicked in, but do not complete it yet
     Mockito.verify(reconnectionSchedule).nextDelay();
-    Mockito.verify(eventBus).fire(ChannelEvent.reconnectionStarted(NODE));
+    Mockito.verify(eventBus).fire(ChannelEvent.reconnectionStarted(node));
     factoryHelper.waitForCalls(ADDRESS, 2);
 
     // Switch keyspace, it succeeds immediately since there is no active channel
@@ -110,7 +110,7 @@ public class ChannelPoolKeyspaceTest extends ChannelPoolTestBase {
     channel2Future.complete(channel2);
     waitForPendingAdminTasks();
 
-    Mockito.verify(eventBus).fire(ChannelEvent.reconnectionStopped(NODE));
+    Mockito.verify(eventBus).fire(ChannelEvent.reconnectionStopped(node));
     Mockito.verify(channel1).setKeyspace(newKeyspace);
     Mockito.verify(channel2).setKeyspace(newKeyspace);
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolReconnectTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolReconnectTest.java
@@ -57,7 +57,7 @@ public class ChannelPoolReconnectTest extends ChannelPoolTestBase {
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
-        ChannelPool.init(NODE, null, NodeDistance.LOCAL, context, "test");
+        ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
     factoryHelper.waitForCalls(ADDRESS, 2);
     waitForPendingAdminTasks();
@@ -65,22 +65,22 @@ public class ChannelPoolReconnectTest extends ChannelPoolTestBase {
     assertThat(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     assertThat(pool.channels).containsOnly(channel1, channel2);
-    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(NODE));
+    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
 
     // Simulate fatal error on channel2
     ((ChannelPromise) channel2.closeFuture())
         .setFailure(new Exception("mock channel init failure"));
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus).fire(ChannelEvent.channelClosed(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.channelClosed(node));
 
     Mockito.verify(reconnectionSchedule).nextDelay();
-    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(node));
     factoryHelper.waitForCall(ADDRESS);
 
     channel3Future.complete(channel3);
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(NODE));
-    Mockito.verify(eventBus).fire(ChannelEvent.reconnectionStopped(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(node));
+    Mockito.verify(eventBus).fire(ChannelEvent.reconnectionStopped(node));
 
     assertThat(pool.channels).containsOnly(channel1, channel3);
 
@@ -108,7 +108,7 @@ public class ChannelPoolReconnectTest extends ChannelPoolTestBase {
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
-        ChannelPool.init(NODE, null, NodeDistance.LOCAL, context, "test");
+        ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
     factoryHelper.waitForCalls(ADDRESS, 2);
     waitForPendingAdminTasks();
@@ -116,21 +116,21 @@ public class ChannelPoolReconnectTest extends ChannelPoolTestBase {
     assertThat(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     assertThat(pool.channels).containsOnly(channel1, channel2);
-    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(NODE));
+    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
 
     // Simulate graceful shutdown on channel2
     ((ChannelPromise) channel2.closeStartedFuture()).setSuccess();
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus).fire(ChannelEvent.channelClosed(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.channelClosed(node));
 
     Mockito.verify(reconnectionSchedule).nextDelay();
-    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(node));
     factoryHelper.waitForCall(ADDRESS);
 
     channel3Future.complete(channel3);
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(NODE));
-    Mockito.verify(eventBus).fire(ChannelEvent.reconnectionStopped(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(node));
+    Mockito.verify(eventBus).fire(ChannelEvent.reconnectionStopped(node));
 
     assertThat(pool.channels).containsOnly(channel1, channel3);
 
@@ -159,19 +159,19 @@ public class ChannelPoolReconnectTest extends ChannelPoolTestBase {
 
     // Initial connection
     CompletionStage<ChannelPool> poolFuture =
-        ChannelPool.init(NODE, null, NodeDistance.LOCAL, context, "test");
+        ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
     factoryHelper.waitForCalls(ADDRESS, 1);
     waitForPendingAdminTasks();
     assertThat(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
-    inOrder.verify(eventBus, times(1)).fire(ChannelEvent.channelOpened(NODE));
+    inOrder.verify(eventBus, times(1)).fire(ChannelEvent.channelOpened(node));
 
     // Kill channel1, reconnection begins and starts initializing channel2, but the initialization
     // is still pending (channel2Future not completed)
     ((ChannelPromise) channel1.closeStartedFuture()).setSuccess();
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus).fire(ChannelEvent.channelClosed(NODE));
-    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.channelClosed(node));
+    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(node));
     Mockito.verify(reconnectionSchedule).nextDelay();
     factoryHelper.waitForCalls(ADDRESS, 1);
 
@@ -184,8 +184,8 @@ public class ChannelPoolReconnectTest extends ChannelPoolTestBase {
     // Complete the initialization of channel2, reconnection succeeds
     channel2Future.complete(channel2);
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(NODE));
-    Mockito.verify(eventBus).fire(ChannelEvent.reconnectionStopped(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(node));
+    Mockito.verify(eventBus).fire(ChannelEvent.reconnectionStopped(node));
 
     assertThat(pool.channels).containsOnly(channel2);
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolResizeTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolResizeTest.java
@@ -53,7 +53,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
-        ChannelPool.init(NODE, null, NodeDistance.REMOTE, context, "test");
+        ChannelPool.init(node, null, NodeDistance.REMOTE, context, "test");
 
     factoryHelper.waitForCalls(ADDRESS, 4);
     waitForPendingAdminTasks();
@@ -61,12 +61,12 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     assertThat(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     assertThat(pool.channels).containsOnly(channel1, channel2, channel3, channel4);
-    inOrder.verify(eventBus, times(4)).fire(ChannelEvent.channelOpened(NODE));
+    inOrder.verify(eventBus, times(4)).fire(ChannelEvent.channelOpened(node));
 
     pool.resize(NodeDistance.LOCAL);
 
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelClosed(NODE));
+    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelClosed(node));
 
     assertThat(pool.channels).containsOnly(channel3, channel4);
 
@@ -100,19 +100,19 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
-        ChannelPool.init(NODE, null, NodeDistance.REMOTE, context, "test");
+        ChannelPool.init(node, null, NodeDistance.REMOTE, context, "test");
 
     factoryHelper.waitForCalls(ADDRESS, 4);
     waitForPendingAdminTasks();
 
-    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(NODE));
+    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
     assertThat(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     assertThat(pool.channels).containsOnly(channel1, channel2);
 
     // A reconnection should have been scheduled to add the missing channels, don't complete yet
     Mockito.verify(reconnectionSchedule).nextDelay();
-    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(node));
 
     pool.resize(NodeDistance.LOCAL);
 
@@ -126,9 +126,9 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     waitForPendingAdminTasks();
 
     // Pool should have shrinked back to 2. We keep the most recent channels so 1 and 2 get closed.
-    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(NODE));
-    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelClosed(NODE));
-    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStopped(NODE));
+    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
+    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelClosed(node));
+    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStopped(node));
     assertThat(pool.channels).containsOnly(channel3, channel4);
 
     factoryHelper.verifyNoMoreCalls();
@@ -157,11 +157,11 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
-        ChannelPool.init(NODE, null, NodeDistance.LOCAL, context, "test");
+        ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
     factoryHelper.waitForCalls(ADDRESS, 2);
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(NODE));
+    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
 
     assertThat(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
@@ -172,12 +172,12 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
 
     // The resizing should have triggered a reconnection
     Mockito.verify(reconnectionSchedule).nextDelay();
-    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(node));
 
     factoryHelper.waitForCalls(ADDRESS, 2);
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(NODE));
-    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStopped(NODE));
+    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
+    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStopped(node));
 
     assertThat(pool.channels).containsOnly(channel1, channel2, channel3, channel4);
 
@@ -212,11 +212,11 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
-        ChannelPool.init(NODE, null, NodeDistance.LOCAL, context, "test");
+        ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
     factoryHelper.waitForCalls(ADDRESS, 2);
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(node));
 
     assertThat(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
@@ -224,7 +224,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
 
     // A reconnection should have been scheduled to add the missing channel, don't complete yet
     Mockito.verify(reconnectionSchedule).nextDelay();
-    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(node));
 
     pool.resize(NodeDistance.REMOTE);
 
@@ -234,23 +234,23 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     channel2Future.complete(channel2);
     factoryHelper.waitForCall(ADDRESS);
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(node));
 
     assertThat(pool.channels).containsOnly(channel1, channel2);
 
     // A second attempt should have been scheduled since we're now still under the target size
     Mockito.verify(reconnectionSchedule, times(2)).nextDelay();
     // Same reconnection is still running, no additional events
-    inOrder.verify(eventBus, never()).fire(ChannelEvent.reconnectionStopped(NODE));
-    inOrder.verify(eventBus, never()).fire(ChannelEvent.reconnectionStarted(NODE));
+    inOrder.verify(eventBus, never()).fire(ChannelEvent.reconnectionStopped(node));
+    inOrder.verify(eventBus, never()).fire(ChannelEvent.reconnectionStarted(node));
 
     // Two more channels get opened, bringing us to the target count
     factoryHelper.waitForCalls(ADDRESS, 2);
     channel3Future.complete(channel3);
     channel4Future.complete(channel4);
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(NODE));
-    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStopped(NODE));
+    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
+    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStopped(node));
 
     assertThat(pool.channels).containsOnly(channel1, channel2, channel3, channel4);
 
@@ -279,11 +279,11 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
-        ChannelPool.init(NODE, null, NodeDistance.LOCAL, context, "test");
+        ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
     factoryHelper.waitForCalls(ADDRESS, 2);
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(NODE));
+    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
 
     assertThat(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
@@ -296,12 +296,12 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
 
     // It should have triggered a reconnection
     Mockito.verify(reconnectionSchedule).nextDelay();
-    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(node));
 
     factoryHelper.waitForCalls(ADDRESS, 2);
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(NODE));
-    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStopped(NODE));
+    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
+    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStopped(node));
 
     assertThat(pool.channels).containsOnly(channel1, channel2, channel3, channel4);
 
@@ -335,11 +335,11 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
-        ChannelPool.init(NODE, null, NodeDistance.LOCAL, context, "test");
+        ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
     factoryHelper.waitForCalls(ADDRESS, 2);
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(node));
 
     assertThat(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
@@ -347,7 +347,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
 
     // A reconnection should have been scheduled to add the missing channel, don't complete yet
     Mockito.verify(reconnectionSchedule).nextDelay();
-    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(node));
 
     // Simulate a configuration change
     Mockito.when(defaultProfile.getInt(CoreDriverOption.CONNECTION_POOL_LOCAL_SIZE)).thenReturn(4);
@@ -358,23 +358,23 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     channel2Future.complete(channel2);
     factoryHelper.waitForCall(ADDRESS);
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(NODE));
+    inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(node));
 
     assertThat(pool.channels).containsOnly(channel1, channel2);
 
     // A second attempt should have been scheduled since we're now still under the target size
     Mockito.verify(reconnectionSchedule, times(2)).nextDelay();
     // Same reconnection is still running, no additional events
-    inOrder.verify(eventBus, never()).fire(ChannelEvent.reconnectionStopped(NODE));
-    inOrder.verify(eventBus, never()).fire(ChannelEvent.reconnectionStarted(NODE));
+    inOrder.verify(eventBus, never()).fire(ChannelEvent.reconnectionStopped(node));
+    inOrder.verify(eventBus, never()).fire(ChannelEvent.reconnectionStarted(node));
 
     // Two more channels get opened, bringing us to the target count
     factoryHelper.waitForCalls(ADDRESS, 2);
     channel3Future.complete(channel3);
     channel4Future.complete(channel4);
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(NODE));
-    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStopped(NODE));
+    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
+    inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStopped(node));
 
     assertThat(pool.channels).containsOnly(channel1, channel2, channel3, channel4);
 
@@ -397,11 +397,11 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
-        ChannelPool.init(NODE, null, NodeDistance.LOCAL, context, "test");
+        ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
     factoryHelper.waitForCalls(ADDRESS, 2);
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(NODE));
+    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
 
     assertThat(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolShutdownTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolShutdownTest.java
@@ -57,11 +57,11 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
-        ChannelPool.init(NODE, null, NodeDistance.LOCAL, context, "test");
+        ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
     factoryHelper.waitForCalls(ADDRESS, 3);
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus, times(3)).fire(ChannelEvent.channelOpened(NODE));
+    inOrder.verify(eventBus, times(3)).fire(ChannelEvent.channelOpened(node));
 
     assertThat(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
@@ -69,7 +69,7 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
     // Simulate graceful shutdown on channel3
     ((ChannelPromise) channel3.closeStartedFuture()).setSuccess();
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus, times(1)).fire(ChannelEvent.channelClosed(NODE));
+    inOrder.verify(eventBus, times(1)).fire(ChannelEvent.channelClosed(node));
 
     // Reconnection should have kicked in and started to open channel4, do not complete it yet
     Mockito.verify(reconnectionSchedule).nextDelay();
@@ -81,7 +81,7 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
     // The two original channels were closed normally
     Mockito.verify(channel1).close();
     Mockito.verify(channel2).close();
-    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelClosed(NODE));
+    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelClosed(node));
     // The closing channel was not closed again
     Mockito.verify(channel3, never()).close();
 
@@ -92,8 +92,8 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
     // It should be force-closed once we find out the pool was closed
     Mockito.verify(channel4).forceClose();
     // No events because the channel was never really associated to the pool
-    inOrder.verify(eventBus, never()).fire(ChannelEvent.channelOpened(NODE));
-    inOrder.verify(eventBus, never()).fire(ChannelEvent.channelClosed(NODE));
+    inOrder.verify(eventBus, never()).fire(ChannelEvent.channelOpened(node));
+    inOrder.verify(eventBus, never()).fire(ChannelEvent.channelClosed(node));
 
     // We don't wait for reconnected channels to close, so the pool only depends on channel 1 to 3
     ((ChannelPromise) channel1.closeFuture()).setSuccess();
@@ -128,19 +128,19 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
-        ChannelPool.init(NODE, null, NodeDistance.LOCAL, context, "test");
+        ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
     factoryHelper.waitForCalls(ADDRESS, 3);
     waitForPendingAdminTasks();
 
     assertThat(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
-    inOrder.verify(eventBus, times(3)).fire(ChannelEvent.channelOpened(NODE));
+    inOrder.verify(eventBus, times(3)).fire(ChannelEvent.channelOpened(node));
 
     // Simulate graceful shutdown on channel3
     ((ChannelPromise) channel3.closeStartedFuture()).setSuccess();
     waitForPendingAdminTasks();
-    inOrder.verify(eventBus, times(1)).fire(ChannelEvent.channelClosed(NODE));
+    inOrder.verify(eventBus, times(1)).fire(ChannelEvent.channelClosed(node));
 
     // Reconnection should have kicked in and started to open a channel, do not complete it yet
     Mockito.verify(reconnectionSchedule).nextDelay();
@@ -154,7 +154,7 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
     Mockito.verify(channel2).forceClose();
     Mockito.verify(channel3).forceClose();
     // Only two events because the one for channel3 was sent earlier
-    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelClosed(NODE));
+    inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelClosed(node));
 
     // Complete the reconnecting channel
     channel4Future.complete(channel4);
@@ -163,8 +163,8 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
     // It should be force-closed once we find out the pool was closed
     Mockito.verify(channel4).forceClose();
     // No events because the channel was never really associated to the pool
-    inOrder.verify(eventBus, never()).fire(ChannelEvent.channelOpened(NODE));
-    inOrder.verify(eventBus, never()).fire(ChannelEvent.channelClosed(NODE));
+    inOrder.verify(eventBus, never()).fire(ChannelEvent.channelOpened(node));
+    inOrder.verify(eventBus, never()).fire(ChannelEvent.channelClosed(node));
 
     // We don't wait for reconnected channels to close, so the pool only depends on channel 1-3
     ((ChannelPromise) channel1.closeFuture()).setSuccess();

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolTestBase.java
@@ -22,13 +22,13 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
 import com.datastax.oss.driver.api.core.connection.ReconnectionPolicy;
-import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.internal.core.channel.ChannelFactory;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.context.EventBus;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.context.NettyOptions;
 import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
+import com.datastax.oss.driver.internal.core.metrics.NodeMetricUpdater;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.DefaultEventLoopGroup;
@@ -48,16 +48,17 @@ import org.mockito.MockitoAnnotations;
 abstract class ChannelPoolTestBase {
 
   static final InetSocketAddress ADDRESS = new InetSocketAddress("localhost", 9042);
-  static final Node NODE = new DefaultNode(ADDRESS);
 
-  @Mock InternalDriverContext context;
+  @Mock protected InternalDriverContext context;
   @Mock private DriverConfig config;
-  @Mock DriverConfigProfile defaultProfile;
+  @Mock protected DriverConfigProfile defaultProfile;
   @Mock private ReconnectionPolicy reconnectionPolicy;
-  @Mock ReconnectionPolicy.ReconnectionSchedule reconnectionSchedule;
+  @Mock protected ReconnectionPolicy.ReconnectionSchedule reconnectionSchedule;
   @Mock private NettyOptions nettyOptions;
-  @Mock ChannelFactory channelFactory;
-  EventBus eventBus;
+  @Mock protected ChannelFactory channelFactory;
+  @Mock protected DefaultNode node;
+  @Mock protected NodeMetricUpdater nodeMetricUpdater;
+  protected EventBus eventBus;
   private DefaultEventLoopGroup adminEventLoopGroup;
 
   @Before
@@ -79,6 +80,9 @@ abstract class ChannelPoolTestBase {
     // By default, set a large reconnection delay. Tests that care about reconnection will override
     // it.
     Mockito.when(reconnectionSchedule.nextDelay()).thenReturn(Duration.ofDays(1));
+
+    Mockito.when(node.getConnectAddress()).thenReturn(ADDRESS);
+    Mockito.when(node.getMetricUpdater()).thenReturn(nodeMetricUpdater);
   }
 
   @After

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/DefaultSessionPoolsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/DefaultSessionPoolsTest.java
@@ -46,6 +46,7 @@ import com.datastax.oss.driver.internal.core.metadata.LoadBalancingPolicyWrapper
 import com.datastax.oss.driver.internal.core.metadata.MetadataManager;
 import com.datastax.oss.driver.internal.core.metadata.NodeStateEvent;
 import com.datastax.oss.driver.internal.core.metadata.TopologyMonitor;
+import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
 import com.datastax.oss.driver.internal.core.pool.ChannelPool;
 import com.datastax.oss.driver.internal.core.pool.ChannelPoolFactory;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
@@ -88,6 +89,7 @@ public class DefaultSessionPoolsTest {
   @Mock private SpeculativeExecutionPolicy speculativeExecutionPolicy;
   @Mock private AddressTranslator addressTranslator;
   @Mock private ControlConnection controlConnection;
+  @Mock private MetricUpdaterFactory metricUpdaterFactory;
 
   private DefaultNode node1;
   private DefaultNode node2;
@@ -132,6 +134,8 @@ public class DefaultSessionPoolsTest {
     Mockito.when(context.loadBalancingPolicyWrapper()).thenReturn(loadBalancingPolicyWrapper);
 
     Mockito.when(context.configLoader()).thenReturn(configLoader);
+
+    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
 
     // Runtime behavior:
     Mockito.when(context.sessionName()).thenReturn("test");

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metrics/MetricsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metrics/MetricsIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codahale.metrics.Timer;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(ParallelizableTests.class)
+public class MetricsIT {
+
+  @ClassRule public static CcmRule ccmRule = CcmRule.getInstance();
+
+  @Test
+  public void should_expose_metrics() {
+    try (CqlSession session =
+        SessionUtils.newSession(ccmRule, "metrics.session.enabled = [ cql-requests ]")) {
+      for (int i = 0; i < 10; i++) {
+        session.execute("SELECT release_version FROM system.local");
+      }
+
+      // Metric names are prefixed with the session id, which depends on the number of other tests
+      // run before, so do a linear search to find the metric we're interested in.
+      Timer requestsTimer = null;
+      for (Map.Entry<String, Timer> entry : session.getMetricRegistry().getTimers().entrySet()) {
+        if (entry.getKey().endsWith(CoreSessionMetric.CQL_REQUESTS.getPath())) {
+          requestsTimer = entry.getValue();
+        }
+      }
+      assertThat(requestsTimer).isNotNull();
+
+      // No need to be very sophisticated, metrics are already covered individually in unit tests.
+      assertThat(requestsTimer.getCount()).isEqualTo(10);
+    }
+  }
+
+  @Test
+  public void should_not_expose_metrics_if_disabled() {
+    try (CqlSession session =
+        // cql_requests is disabled:
+        SessionUtils.newSession(ccmRule, "metrics.session.enabled = []")) {
+      for (int i = 0; i < 10; i++) {
+        session.execute("SELECT release_version FROM system.local");
+      }
+
+      Timer requestsTimer = null;
+      for (Map.Entry<String, Timer> entry : session.getMetricRegistry().getTimers().entrySet()) {
+        if (entry.getKey().endsWith(CoreSessionMetric.CQL_REQUESTS.name())) {
+          requestsTimer = entry.getValue();
+        }
+      }
+      assertThat(requestsTimer).isNull();
+    }
+  }
+}

--- a/integration-tests/src/test/resources/application.conf
+++ b/integration-tests/src/test/resources/application.conf
@@ -15,4 +15,9 @@ datastax-java-driver {
     # CcmBridge).
     local-datacenter = dc1
   }
+  metrics {
+    // Raise histogram bounds because the tests execute DDL queries with a higher timeout
+    session.cql_requests.highest_latency = 30 seconds
+    node.cql_messages.highest_latency = 30 seconds
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,16 @@
         <version>3.0.27</version>
       </dependency>
       <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-core</artifactId>
+        <version>4.0.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hdrhistogram</groupId>
+        <artifactId>HdrHistogram</artifactId>
+        <version>2.1.10</version>
+      </dependency>
+      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.12</version>


### PR DESCRIPTION
Design goals:
* metrics can be enabled or disabled individually.
* disabled metrics are transparent for the driver code (no `if (metricEnabled)` tests) and have minimal runtime overhead.
* metrics can be node-level or session-level.
* the driver simply exposes a `MetricRegistry` and makes no assumption about how they will be exported; JMX is trivial (as shown below), so I don't think we need to build it in. In the same vein, individual metric objects are not exposed directly through the API (I doubt many people used that in 3.x, 99% of the time they will be exported to a monitoring tool with a reporter).

Basic manual test:
```java
try (CqlSession session = CqlSession.builder().build();
    JmxReporter reporter =
        JmxReporter.forRegistry(session.getMetricRegistry())
            .inDomain("com.datastax.oss.driver")
            .build()) {

  reporter.start();
  for (int i = 0; i < 1000; i++) {
    session.execute("select release_version from system.local");
  }
  TimeUnit.MINUTES.sleep(10);
}
```
Then connect to the process with jvisualvm or jconsole to observe the JMX MBeans.

The first commit is a PoC with a minimal set of metrics. TODO:
- [x] add remaining metrics (figure out what we want per node vs. per session, if we allow redundancy...)
- [x] switch `Timer` to an HDRHistogram-based implementation (either 3rd-party or custom).
- [x] tests