### PR TITLE
Run ErrorProne as part of the build

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/CassandraVersion.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/CassandraVersion.java
@@ -271,7 +271,7 @@ public class CassandraVersion implements Comparable<CassandraVersion> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(major, minor, patch, dsePatch, preReleases, build);
+    return Objects.hash(major, minor, patch, dsePatch, Arrays.hashCode(preReleases), build);
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/api/core/CoreProtocolVersion.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/CoreProtocolVersion.java
@@ -47,6 +47,7 @@ public enum CoreProtocolVersion implements ProtocolVersion {
     this.beta = beta;
   }
 
+  @Override
   public int getCode() {
     return code;
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DriverConfigLoader.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DriverConfigLoader.java
@@ -35,5 +35,6 @@ public interface DriverConfigLoader extends AutoCloseable {
    * Called when the cluster closes. This is a good time to release any external resource, for
    * example cancel a scheduled reloading task.
    */
+  @Override
   void close();
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/connection/ExponentialReconnectionPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/connection/ExponentialReconnectionPolicy.java
@@ -58,7 +58,7 @@ public class ExponentialReconnectionPolicy implements ReconnectionPolicy {
 
     // Maximum number of attempts after which we overflow
     int ceil = (baseDelayMs & (baseDelayMs - 1)) == 0 ? 0 : 1;
-    this.maxAttempts = 64 - Long.numberOfLeadingZeros(Long.MAX_VALUE / baseDelayMs) - ceil;
+    this.maxAttempts = 64L - Long.numberOfLeadingZeros(Long.MAX_VALUE / baseDelayMs) - ceil;
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/Bindable.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/Bindable.java
@@ -31,6 +31,7 @@ public interface Bindable<T extends Bindable<T>>
    *
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
+  @SuppressWarnings("ReferenceEquality")
   default boolean isSet(int i) {
     return getBytesUnsafe(i) != ProtocolConstants.UNSET_VALUE;
   }
@@ -43,6 +44,7 @@ public interface Bindable<T extends Bindable<T>>
    *
    * @throws IndexOutOfBoundsException if the id is invalid.
    */
+  @SuppressWarnings("ReferenceEquality")
   default boolean isSet(CqlIdentifier id) {
     return getBytesUnsafe(id) != ProtocolConstants.UNSET_VALUE;
   }
@@ -55,6 +57,7 @@ public interface Bindable<T extends Bindable<T>>
    *
    * @throws IndexOutOfBoundsException if the name is invalid.
    */
+  @SuppressWarnings("ReferenceEquality")
   default boolean isSet(String name) {
     return getBytesUnsafe(name) != ProtocolConstants.UNSET_VALUE;
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/SimpleStatementBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/SimpleStatementBuilder.java
@@ -121,6 +121,7 @@ public class SimpleStatementBuilder
     return this;
   }
 
+  @Override
   public SimpleStatement build() {
     return new DefaultSimpleStatement(
         query,

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlDuration.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlDuration.java
@@ -351,7 +351,10 @@ public final class CqlDuration {
     public Builder addYears(long numberOfYears) {
       validateOrder(1);
       validateMonths(numberOfYears, MONTHS_PER_YEAR);
-      months += numberOfYears * MONTHS_PER_YEAR;
+      // Cast to avoid http://errorprone.info/bugpattern/NarrowingCompoundAssignment
+      // We could also change the method to accept an int, but keeping long allows us to keep the
+      // calling code generic.
+      months += (int) numberOfYears * MONTHS_PER_YEAR;
       return this;
     }
 
@@ -364,7 +367,7 @@ public final class CqlDuration {
     public Builder addMonths(long numberOfMonths) {
       validateOrder(2);
       validateMonths(numberOfMonths, 1);
-      months += numberOfMonths;
+      months += (int) numberOfMonths;
       return this;
     }
 
@@ -377,7 +380,7 @@ public final class CqlDuration {
     public Builder addWeeks(long numberOfWeeks) {
       validateOrder(3);
       validateDays(numberOfWeeks, DAYS_PER_WEEK);
-      days += numberOfWeeks * DAYS_PER_WEEK;
+      days += (int) numberOfWeeks * DAYS_PER_WEEK;
       return this;
     }
 
@@ -390,7 +393,7 @@ public final class CqlDuration {
     public Builder addDays(long numberOfDays) {
       validateOrder(4);
       validateDays(numberOfDays, 1);
-      days += numberOfDays;
+      days += (int) numberOfDays;
       return this;
     }
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlDuration.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlDuration.java
@@ -123,10 +123,12 @@ public final class CqlDuration {
     String source = isNegative ? input.substring(1) : input;
 
     if (source.startsWith("P")) {
-      if (source.endsWith("W")) return parseIso8601WeekFormat(isNegative, source);
-
-      if (source.contains("-")) return parseIso8601AlternativeFormat(isNegative, source);
-
+      if (source.endsWith("W")) {
+        return parseIso8601WeekFormat(isNegative, source);
+      }
+      if (source.contains("-")) {
+        return parseIso8601AlternativeFormat(isNegative, source);
+      }
       return parseIso8601Format(isNegative, source);
     }
     return parseStandardFormat(isNegative, source);
@@ -139,29 +141,36 @@ public final class CqlDuration {
           String.format("Unable to convert '%s' to a duration", source));
 
     Builder builder = new Builder(isNegative);
-    if (matcher.group(1) != null) builder.addYears(groupAsLong(matcher, 2));
-
-    if (matcher.group(3) != null) builder.addMonths(groupAsLong(matcher, 4));
-
-    if (matcher.group(5) != null) builder.addDays(groupAsLong(matcher, 6));
-
+    if (matcher.group(1) != null) {
+      builder.addYears(groupAsLong(matcher, 2));
+    }
+    if (matcher.group(3) != null) {
+      builder.addMonths(groupAsLong(matcher, 4));
+    }
+    if (matcher.group(5) != null) {
+      builder.addDays(groupAsLong(matcher, 6));
+    }
     // Checks if the String contains time information
     if (matcher.group(7) != null) {
-      if (matcher.group(8) != null) builder.addHours(groupAsLong(matcher, 9));
-
-      if (matcher.group(10) != null) builder.addMinutes(groupAsLong(matcher, 11));
-
-      if (matcher.group(12) != null) builder.addSeconds(groupAsLong(matcher, 13));
+      if (matcher.group(8) != null) {
+        builder.addHours(groupAsLong(matcher, 9));
+      }
+      if (matcher.group(10) != null) {
+        builder.addMinutes(groupAsLong(matcher, 11));
+      }
+      if (matcher.group(12) != null) {
+        builder.addSeconds(groupAsLong(matcher, 13));
+      }
     }
     return builder.build();
   }
 
   private static CqlDuration parseIso8601AlternativeFormat(boolean isNegative, String source) {
     Matcher matcher = ISO8601_ALTERNATIVE_PATTERN.matcher(source);
-    if (!matcher.matches())
+    if (!matcher.matches()) {
       throw new IllegalArgumentException(
           String.format("Unable to convert '%s' to a duration", source));
-
+    }
     return new Builder(isNegative)
         .addYears(groupAsLong(matcher, 1))
         .addMonths(groupAsLong(matcher, 2))
@@ -174,19 +183,19 @@ public final class CqlDuration {
 
   private static CqlDuration parseIso8601WeekFormat(boolean isNegative, String source) {
     Matcher matcher = ISO8601_WEEK_PATTERN.matcher(source);
-    if (!matcher.matches())
+    if (!matcher.matches()) {
       throw new IllegalArgumentException(
           String.format("Unable to convert '%s' to a duration", source));
-
+    }
     return new Builder(isNegative).addWeeks(groupAsLong(matcher, 1)).build();
   }
 
   private static CqlDuration parseStandardFormat(boolean isNegative, String source) {
     Matcher matcher = STANDARD_PATTERN.matcher(source);
-    if (!matcher.find())
+    if (!matcher.find()) {
       throw new IllegalArgumentException(
           String.format("Unable to convert '%s' to a duration", source));
-
+    }
     Builder builder = new Builder(isNegative);
     boolean done;
 
@@ -197,10 +206,10 @@ public final class CqlDuration {
       done = matcher.end() == source.length();
     } while (matcher.find());
 
-    if (!done)
+    if (!done) {
       throw new IllegalArgumentException(
           String.format("Unable to convert '%s' to a duration", source));
-
+    }
     return builder.build();
   }
 
@@ -244,8 +253,9 @@ public final class CqlDuration {
    * @return the remainder of the division
    */
   private static long append(StringBuilder builder, long dividend, long divisor, String unit) {
-    if (dividend == 0 || dividend < divisor) return dividend;
-
+    if (dividend == 0 || dividend < divisor) {
+      return dividend;
+    }
     builder.append(dividend / divisor).append(unit);
     return dividend % divisor;
   }
@@ -300,8 +310,9 @@ public final class CqlDuration {
   public String toString() {
     StringBuilder builder = new StringBuilder();
 
-    if (months < 0 || days < 0 || nanoseconds < 0) builder.append('-');
-
+    if (months < 0 || days < 0 || nanoseconds < 0) {
+      builder.append('-');
+    }
     long remainder = append(builder, Math.abs(months), MONTHS_PER_YEAR, "y");
     append(builder, remainder, 1, "mo");
 
@@ -512,17 +523,17 @@ public final class CqlDuration {
      * @param unitIndex the unit index (e.g. years=1, months=2, ...)
      */
     private void validateOrder(int unitIndex) {
-      if (unitIndex == currentUnitIndex)
+      if (unitIndex == currentUnitIndex) {
         throw new IllegalArgumentException(
             String.format(
                 "Invalid duration. The %s are specified multiple times", getUnitName(unitIndex)));
-
-      if (unitIndex <= currentUnitIndex)
+      }
+      if (unitIndex <= currentUnitIndex) {
         throw new IllegalArgumentException(
             String.format(
                 "Invalid duration. The %s should be after %s",
                 getUnitName(currentUnitIndex), getUnitName(unitIndex)));
-
+      }
       currentUnitIndex = unitIndex;
     }
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/CustomType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/CustomType.java
@@ -29,6 +29,7 @@ public interface CustomType extends DataType {
     return String.format("'%s'", getClassName());
   }
 
+  @Override
   default int getProtocolCode() {
     return ProtocolConstants.DataType.CUSTOM;
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/ListType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/ListType.java
@@ -28,6 +28,7 @@ public interface ListType extends DataType {
     return String.format(template, getElementType().asCql(includeFrozen, pretty));
   }
 
+  @Override
   default int getProtocolCode() {
     return ProtocolConstants.DataType.LIST;
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/MapType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/MapType.java
@@ -33,6 +33,7 @@ public interface MapType extends DataType {
         getValueType().asCql(includeFrozen, pretty));
   }
 
+  @Override
   default int getProtocolCode() {
     return ProtocolConstants.DataType.MAP;
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/SetType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/SetType.java
@@ -28,6 +28,7 @@ public interface SetType extends DataType {
     return String.format(template, getElementType().asCql(includeFrozen, pretty));
   }
 
+  @Override
   default int getProtocolCode() {
     return ProtocolConstants.DataType.SET;
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/TupleType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/TupleType.java
@@ -47,6 +47,7 @@ public interface TupleType extends DataType {
     return builder.toString();
   }
 
+  @Override
   default int getProtocolCode() {
     return ProtocolConstants.DataType.TUPLE;
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/UserDefinedType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/UserDefinedType.java
@@ -91,6 +91,7 @@ public interface UserDefinedType extends DataType, Describable {
     return describe(pretty);
   }
 
+  @Override
   default int getProtocolCode() {
     return ProtocolConstants.DataType.UDT;
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelHandlerRequest.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelHandlerRequest.java
@@ -17,6 +17,7 @@ package com.datastax.oss.driver.internal.core.channel;
 
 import com.datastax.oss.driver.api.core.DriverTimeoutException;
 import com.datastax.oss.driver.internal.core.util.ProtocolUtils;
+import com.datastax.oss.driver.internal.core.util.concurrent.UncaughtExceptions;
 import com.datastax.oss.protocol.internal.Frame;
 import com.datastax.oss.protocol.internal.Message;
 import com.datastax.oss.protocol.internal.response.Error;
@@ -91,7 +92,7 @@ abstract class ChannelHandlerRequest implements ResponseCallback {
     fail(new DriverTimeoutException(describe() + ": timed out after " + timeoutMillis + " ms"));
     if (!channel.closeFuture().isDone()) {
       // Cancel the response callback
-      channel.writeAndFlush(this);
+      channel.writeAndFlush(this).addListener(UncaughtExceptions::log);
     }
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/StreamIdGenerator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/StreamIdGenerator.java
@@ -37,6 +37,7 @@ class StreamIdGenerator {
     this.availableIds = this.maxAvailableIds;
   }
 
+  @SuppressWarnings("NonAtomicVolatileUpdate") // see explanation in class Javadoc
   int acquire() {
     int id = ids.nextClearBit(0);
     if (id >= maxAvailableIds) {
@@ -47,6 +48,7 @@ class StreamIdGenerator {
     return id;
   }
 
+  @SuppressWarnings("NonAtomicVolatileUpdate")
   void release(int id) {
     if (ids.get(id)) {
       availableIds++;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultTraceEvent.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultTraceEvent.java
@@ -56,6 +56,7 @@ public class DefaultTraceEvent implements TraceEvent {
     return source;
   }
 
+  @Override
   public int getSourceElapsedMicros() {
     return sourceElapsedMicros;
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/MultiPageResultSet.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/MultiPageResultSet.java
@@ -24,9 +24,10 @@ import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.internal.core.util.CountingIterator;
 import com.datastax.oss.driver.internal.core.util.concurrent.BlockingOperation;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 
 public class MultiPageResultSet implements ResultSet {
@@ -81,7 +82,7 @@ public class MultiPageResultSet implements ResultSet {
 
   private class RowIterator extends CountingIterator<Row> {
     // The pages fetched so far. The first is the one we're currently iterating.
-    private LinkedList<AsyncResultSet> pages = new LinkedList<>();
+    private Deque<AsyncResultSet> pages = new ArrayDeque<>();
     private Iterator<Row> currentRows;
 
     private RowIterator(AsyncResultSet firstPage) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultNode.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultNode.java
@@ -98,6 +98,7 @@ public class DefaultNode implements Node {
     return state;
   }
 
+  @Override
   public int getOpenConnections() {
     return openConnections;
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/NodeStateManager.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/NodeStateManager.java
@@ -115,6 +115,8 @@ public class NodeStateManager implements AsyncAutoCloseable {
       isInitialized = true;
     }
 
+    // Updates to DefaultNode's volatile fields are confined to the admin thread
+    @SuppressWarnings("NonAtomicVolatileUpdate")
     private void onChannelEvent(ChannelEvent event) {
       assert adminExecutor.inEventLoop();
       if (closeWasCalled) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultIndexMetadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultIndexMetadata.java
@@ -70,6 +70,7 @@ public class DefaultIndexMetadata implements IndexMetadata {
     return target;
   }
 
+  @Override
   public Map<String, String> getOptions() {
     return options;
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/RelationParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/RelationParser.java
@@ -114,7 +114,7 @@ public abstract class RelationParser {
    * The columns of the system table that are turned into entries in {@link
    * RelationMetadata#getOptions()}.
    */
-  public static final Map<String, TypeCodec<?>> OPTION_CODECS =
+  public static final ImmutableMap<String, TypeCodec<?>> OPTION_CODECS =
       ImmutableMap.<String, TypeCodec<?>>builder()
           .put("bloom_filter_fp_chance", TypeCodecs.DOUBLE)
           // In C* <= 2.2, this is a string, not a map (this is special-cased in parseOptions):

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/TableParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/TableParser.java
@@ -292,9 +292,9 @@ class TableParser extends RelationParser {
     if (options.containsKey("index_keys_and_values")) {
       return String.format("entries(%s)", columnName);
     }
-    if (columnType instanceof ListType && ((ListType) columnType).isFrozen()
-        || columnType instanceof SetType && ((SetType) columnType).isFrozen()
-        || columnType instanceof MapType && ((MapType) columnType).isFrozen()) {
+    if ((columnType instanceof ListType && ((ListType) columnType).isFrozen())
+        || (columnType instanceof SetType && ((SetType) columnType).isFrozen())
+        || (columnType instanceof MapType && ((MapType) columnType).isFrozen())) {
       return String.format("full(%s)", columnName);
     }
     // Note: the keyword 'values' is not accepted as a valid index target function until 3.0

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/TableParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/TableParser.java
@@ -179,6 +179,8 @@ class TableParser extends RelationParser {
           clusteringColumnsBuilder.put(
               column, raw.reversed ? ClusteringOrder.DESC : ClusteringOrder.ASC);
           break;
+        default:
+          // nothing to do
       }
       allColumnsBuilder.put(column.getName(), column);
 
@@ -237,6 +239,9 @@ class TableParser extends RelationParser {
           break;
         case STATIC:
           column.kind = RawColumn.Kind.REGULAR;
+          break;
+        default:
+          // nothing to do
       }
     }
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/ViewParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/ViewParser.java
@@ -116,6 +116,8 @@ class ViewParser extends RelationParser {
           clusteringColumnsBuilder.put(
               column, raw.reversed ? ClusteringOrder.DESC : ClusteringOrder.ASC);
           break;
+        default:
+          // nothing to do
       }
       allColumnsBuilder.put(column.getName(), column);
     }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/DefaultSchemaQueriesFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/DefaultSchemaQueriesFactory.java
@@ -35,6 +35,7 @@ public class DefaultSchemaQueriesFactory implements SchemaQueriesFactory {
     this.context = context;
   }
 
+  @Override
   public SchemaQueries newInstance(CompletableFuture<Metadata> refreshFuture) {
     String logPrefix = context.sessionName();
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/Murmur3TokenFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/Murmur3TokenFactory.java
@@ -106,37 +106,50 @@ public class Murmur3TokenFactory implements TokenFactory {
     switch (length & 15) {
       case 15:
         k2 ^= ((long) data.get(offset + 14)) << 48;
+        // fall through
       case 14:
         k2 ^= ((long) data.get(offset + 13)) << 40;
+        // fall through
       case 13:
         k2 ^= ((long) data.get(offset + 12)) << 32;
+        // fall through
       case 12:
         k2 ^= ((long) data.get(offset + 11)) << 24;
+        // fall through
       case 11:
         k2 ^= ((long) data.get(offset + 10)) << 16;
+        // fall through
       case 10:
         k2 ^= ((long) data.get(offset + 9)) << 8;
+        // fall through
       case 9:
         k2 ^= ((long) data.get(offset + 8));
         k2 *= c2;
         k2 = rotl64(k2, 33);
         k2 *= c1;
         h2 ^= k2;
-
+        // fall through
       case 8:
         k1 ^= ((long) data.get(offset + 7)) << 56;
+        // fall through
       case 7:
         k1 ^= ((long) data.get(offset + 6)) << 48;
+        // fall through
       case 6:
         k1 ^= ((long) data.get(offset + 5)) << 40;
+        // fall through
       case 5:
         k1 ^= ((long) data.get(offset + 4)) << 32;
+        // fall through
       case 4:
         k1 ^= ((long) data.get(offset + 3)) << 24;
+        // fall through
       case 3:
         k1 ^= ((long) data.get(offset + 2)) << 16;
+        // fall through
       case 2:
         k1 ^= ((long) data.get(offset + 1)) << 8;
+        // fall through
       case 1:
         k1 ^= ((long) data.get(offset));
         k1 *= c1;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUp.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUp.java
@@ -33,9 +33,9 @@ import com.datastax.oss.protocol.internal.util.Bytes;
 import com.google.common.annotations.VisibleForTesting;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
@@ -161,7 +161,7 @@ class ReprepareOnUp {
 
   private void gatherPayloadsToReprepare() {
     assert channel.eventLoop().inEventLoop();
-    toReprepare = new LinkedList<>();
+    toReprepare = new ArrayDeque<>();
     for (RepreparePayload payload : repreparePayloads.values()) {
       if (serverKnownIds.contains(payload.id)) {
         LOG.trace(

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/util/VIntCoding.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/util/VIntCoding.java
@@ -96,9 +96,9 @@ public class VIntCoding {
     return 0xff >> extraBytesToRead;
   }
 
-  private static int encodeExtraBytesToRead(int extraBytesToRead) {
+  private static byte encodeExtraBytesToRead(int extraBytesToRead) {
     // because we have an extra bit in the value mask, we just need to invert it
-    return ~firstByteValueMask(extraBytesToRead);
+    return (byte) ~firstByteValueMask(extraBytesToRead);
   }
 
   private static int numberOfExtraBytesToRead(int firstByte) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/DirectedGraph.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/DirectedGraph.java
@@ -21,9 +21,9 @@ import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -67,7 +67,7 @@ public class DirectedGraph<V> {
     Preconditions.checkState(!wasSorted);
     wasSorted = true;
 
-    Queue<V> queue = new LinkedList<V>();
+    Queue<V> queue = new ArrayDeque<>();
 
     for (Map.Entry<V, Integer> entry : vertices.entrySet()) {
       if (entry.getValue() == 0) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/Strings.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/Strings.java
@@ -255,7 +255,7 @@ public class Strings {
 
   private Strings() {}
 
-  private static final Set<String> RESERVED_KEYWORDS =
+  private static final ImmutableSet<String> RESERVED_KEYWORDS =
       ImmutableSet.of(
           // See https://github.com/apache/cassandra/blob/trunk/doc/cql3/CQL.textile#appendixA
           "add",

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/concurrent/CycleDetector.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/concurrent/CycleDetector.java
@@ -74,7 +74,7 @@ public class CycleDetector {
       synchronized (this) {
         Thread me = Thread.currentThread();
         LOG.debug("{} is done initializing {}", me, reference.getName());
-        graph.removeEdge(reference.getName(), me);
+        graph.removeEdge(reference.getName(), me.getName());
       }
     }
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/concurrent/UncaughtExceptions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/concurrent/UncaughtExceptions.java
@@ -50,6 +50,7 @@ public class UncaughtExceptions {
     }
   }
 
+  @SuppressWarnings("TypeParameterUnusedInFormals") // type parameter is only needed for chaining
   public static <T> T log(Throwable t) {
     Loggers.warnWithException(LOG, "Uncaught exception in scheduled task", t);
     return null;

--- a/core/src/test/java/com/datastax/oss/driver/api/core/CassandraVersionAssert.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/CassandraVersionAssert.java
@@ -59,6 +59,7 @@ public class CassandraVersionAssert
     return this;
   }
 
+  @Override
   public CassandraVersionAssert hasToString(String string) {
     Assertions.assertThat(actual.toString()).isEqualTo(string);
     return this;

--- a/core/src/test/java/com/datastax/oss/driver/internal/SerializationHelper.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/SerializationHelper.java
@@ -36,6 +36,8 @@ public abstract class SerializationHelper {
     }
   }
 
+  // the calling code performs validations on the result, so this doesn't matter
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   public static <T> T deserialize(byte[] bytes) {
     try {
       ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes));

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryAvailableIdsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryAvailableIdsTest.java
@@ -36,6 +36,7 @@ public class ChannelFactoryAvailableIdsTest extends ChannelFactoryTestBase {
   @Mock private ResponseCallback responseCallback;
 
   @Before
+  @Override
   public void setup() throws InterruptedException {
     super.setup();
     Mockito.when(defaultConfigProfile.isDefined(CoreDriverOption.PROTOCOL_VERSION))

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryTestBase.java
@@ -121,7 +121,7 @@ public abstract class ChannelFactoryTestBase {
     Mockito.when(defaultConfigProfile.getInt(CoreDriverOption.CONNECTION_MAX_REQUESTS))
         .thenReturn(1);
     Mockito.when(defaultConfigProfile.getDuration(CoreDriverOption.CONNECTION_HEARTBEAT_INTERVAL))
-        .thenReturn(Duration.ofMillis(30000));
+        .thenReturn(Duration.ofSeconds(30));
 
     Mockito.when(context.protocolVersionRegistry()).thenReturn(protocolVersionRegistry);
     Mockito.when(context.nettyOptions()).thenReturn(nettyOptions);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/DriverChannelTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/DriverChannelTest.java
@@ -25,7 +25,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.Future;
 import java.util.AbstractMap;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.Map;
 import java.util.Queue;
 import org.junit.Before;
@@ -142,7 +142,7 @@ public class DriverChannelTest extends ChannelHandlerTestBase {
   // Simple implementation that holds all the writes, and flushes them when it's explicitly
   // triggered.
   private class MockWriteCoalescer implements WriteCoalescer {
-    private Queue<Map.Entry<Object, ChannelPromise>> messages = new LinkedList<>();
+    private Queue<Map.Entry<Object, ChannelPromise>> messages = new ArrayDeque<>();
 
     @Override
     public ChannelFuture writeAndFlush(Channel channel, Object message) {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/MockChannelFactoryHelper.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/MockChannelFactoryHelper.java
@@ -20,8 +20,9 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Sets;
 import java.net.SocketAddress;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -148,7 +149,7 @@ public class MockChannelFactoryHelper {
 
     private void stub() {
       for (SocketAddress address : invocations.keySet()) {
-        LinkedList<CompletionStage<DriverChannel>> results = new LinkedList<>();
+        Deque<CompletionStage<DriverChannel>> results = new ArrayDeque<>();
         for (Object object : invocations.get(address)) {
           if (object instanceof DriverChannel) {
             results.add(CompletableFuture.completedFuture(((DriverChannel) object)));

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/MockResponseCallback.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/MockResponseCallback.java
@@ -16,12 +16,12 @@
 package com.datastax.oss.driver.internal.core.channel;
 
 import com.datastax.oss.protocol.internal.Frame;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.Queue;
 
 class MockResponseCallback implements ResponseCallback {
   private final boolean holdStreamId;
-  private final Queue<Object> responses = new LinkedList<>();
+  private final Queue<Object> responses = new ArrayDeque<>();
 
   volatile int streamId = -1;
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandlerTest.java
@@ -93,7 +93,7 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     Mockito.when(defaultConfigProfile.getDuration(CoreDriverOption.CONNECTION_INIT_QUERY_TIMEOUT))
         .thenReturn(Duration.ofMillis(QUERY_TIMEOUT_MILLIS));
     Mockito.when(defaultConfigProfile.getDuration(CoreDriverOption.CONNECTION_HEARTBEAT_INTERVAL))
-        .thenReturn(Duration.ofMillis(30000));
+        .thenReturn(Duration.ofSeconds(30));
     Mockito.when(
             defaultConfigProfile.getBoolean(CoreDriverOption.AUTH_PROVIDER_WARN_IF_NO_SERVER_AUTH))
         .thenReturn(true);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTestBase.java
@@ -31,8 +31,8 @@ import com.google.common.collect.ImmutableList;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import org.junit.Before;
@@ -83,7 +83,7 @@ public abstract class CqlRequestHandlerTestBase {
             null,
             new int[] {},
             null);
-    Queue<List<ByteBuffer>> data = new LinkedList<>();
+    Queue<List<ByteBuffer>> data = new ArrayDeque<>();
     data.add(ImmutableList.of(Bytes.fromHexString("0x68656C6C6F2C20776F726C64")));
     return new DefaultRows(metadata, data);
   }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/DefaultAsyncResultSetTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/DefaultAsyncResultSetTest.java
@@ -16,12 +16,12 @@
 package com.datastax.oss.driver.internal.core.cql;
 
 import com.datastax.oss.driver.api.core.CoreProtocolVersion;
+import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
 import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.cql.Statement;
-import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
@@ -29,7 +29,7 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.protocol.internal.util.Bytes;
 import com.google.common.collect.Lists;
 import java.nio.ByteBuffer;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
@@ -67,7 +67,7 @@ public class DefaultAsyncResultSetTest {
     // When
     DefaultAsyncResultSet resultSet =
         new DefaultAsyncResultSet(
-            columnDefinitions, executionInfo, new LinkedList<>(), session, context);
+            columnDefinitions, executionInfo, new ArrayDeque<>(), session, context);
 
     // Then
     assertThat(resultSet.hasMorePages()).isFalse();
@@ -89,7 +89,7 @@ public class DefaultAsyncResultSetTest {
     // When
     DefaultAsyncResultSet resultSet =
         new DefaultAsyncResultSet(
-            columnDefinitions, executionInfo, new LinkedList<>(), session, context);
+            columnDefinitions, executionInfo, new ArrayDeque<>(), session, context);
     assertThat(resultSet.hasMorePages()).isTrue();
     CompletionStage<AsyncResultSet> nextPageFuture = resultSet.fetchNextPage();
 
@@ -107,7 +107,7 @@ public class DefaultAsyncResultSetTest {
     // When
     DefaultAsyncResultSet resultSet =
         new DefaultAsyncResultSet(
-            columnDefinitions, executionInfo, new LinkedList<>(), session, context);
+            columnDefinitions, executionInfo, new ArrayDeque<>(), session, context);
 
     // Then
     assertThat(resultSet.wasApplied()).isTrue();
@@ -117,7 +117,7 @@ public class DefaultAsyncResultSetTest {
   public void should_report_applied_if_column_not_present_and_not_empty() {
     // Given
     Mockito.when(columnDefinitions.contains("[applied]")).thenReturn(false);
-    Queue<List<ByteBuffer>> data = new LinkedList<>();
+    Queue<List<ByteBuffer>> data = new ArrayDeque<>();
     data.add(Lists.newArrayList(Bytes.fromHexString("0xffff")));
 
     // When
@@ -138,7 +138,7 @@ public class DefaultAsyncResultSetTest {
     Mockito.when(columnDefinitions.firstIndexOf("[applied]")).thenReturn(0);
     Mockito.when(columnDefinitions.get(0)).thenReturn(columnDefinition);
 
-    Queue<List<ByteBuffer>> data = new LinkedList<>();
+    Queue<List<ByteBuffer>> data = new ArrayDeque<>();
     data.add(Lists.newArrayList(TypeCodecs.BOOLEAN.encode(false, CoreProtocolVersion.DEFAULT)));
 
     // When
@@ -159,7 +159,7 @@ public class DefaultAsyncResultSetTest {
     Mockito.when(columnDefinitions.firstIndexOf("[applied]")).thenReturn(0);
     Mockito.when(columnDefinitions.get(0)).thenReturn(columnDefinition);
 
-    Queue<List<ByteBuffer>> data = new LinkedList<>();
+    Queue<List<ByteBuffer>> data = new ArrayDeque<>();
     data.add(Lists.newArrayList(TypeCodecs.BOOLEAN.encode(true, CoreProtocolVersion.DEFAULT)));
 
     // When
@@ -181,7 +181,7 @@ public class DefaultAsyncResultSetTest {
     // When
     DefaultAsyncResultSet resultSet =
         new DefaultAsyncResultSet(
-            columnDefinitions, executionInfo, new LinkedList<>(), session, context);
+            columnDefinitions, executionInfo, new ArrayDeque<>(), session, context);
 
     // Then
     resultSet.wasApplied();

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyEventsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyEventsTest.java
@@ -35,6 +35,7 @@ public class DefaultLoadBalancingPolicyEventsTest extends DefaultLoadBalancingPo
   private DefaultLoadBalancingPolicy policy;
 
   @Before
+  @Override
   public void setup() {
     super.setup();
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyQueryPlanTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyQueryPlanTest.java
@@ -60,6 +60,7 @@ public class DefaultLoadBalancingPolicyQueryPlanTest extends DefaultLoadBalancin
   private DefaultLoadBalancingPolicy policy;
 
   @Before
+  @Override
   public void setup() {
     super.setup();
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
@@ -32,10 +32,10 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
@@ -245,7 +245,7 @@ public class DefaultTopologyMonitorTest {
   /** Mocks the query execution logic. */
   private static class TestTopologyMonitor extends DefaultTopologyMonitor {
 
-    private final Queue<StubbedQuery> queries = new LinkedList<>();
+    private final Queue<StubbedQuery> queries = new ArrayDeque<>();
 
     private TestTopologyMonitor(InternalDriverContext context) {
       super(context);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
@@ -243,7 +243,7 @@ public class MetadataManagerTest {
     assertThat(refresh.toRemove).isEqualTo(ADDRESS1);
   }
 
-  private class TestMetadataManager extends MetadataManager {
+  private static class TestMetadataManager extends MetadataManager {
 
     private List<MetadataRefresh> refreshes = new CopyOnWriteArrayList<>();
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/SchemaAgreementCheckerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/SchemaAgreementCheckerTest.java
@@ -33,8 +33,8 @@ import io.netty.channel.EventLoop;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
 import java.util.UUID;
@@ -273,7 +273,7 @@ public class SchemaAgreementCheckerTest {
   /** Extend to mock the query execution logic. */
   private static class TestSchemaAgreementChecker extends SchemaAgreementChecker {
 
-    private final Queue<StubbedQuery> queries = new LinkedList<>();
+    private final Queue<StubbedQuery> queries = new ArrayDeque<>();
 
     TestSchemaAgreementChecker(DriverChannel channel, InternalDriverContext context) {
       super(channel, context, 9042, "test");

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/TableParserTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/TableParserTest.java
@@ -40,7 +40,7 @@ public class TableParserTest extends SchemaParserTestBase {
           "ks",
           "foo",
           "org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.UTF8Type)");
-  private static final Iterable<AdminRow> COLUMN_ROWS_2_2 =
+  private static final ImmutableList<AdminRow> COLUMN_ROWS_2_2 =
       ImmutableList.of(
           mockLegacyColumnRow(
               "ks", "foo", "k2", "partition_key", "org.apache.cassandra.db.marshal.UTF8Type", 1),
@@ -67,14 +67,14 @@ public class TableParserTest extends SchemaParserTestBase {
               "{}"));
 
   static final AdminRow TABLE_ROW_3_0 = mockModernTableRow("ks", "foo");
-  static final Iterable<AdminRow> COLUMN_ROWS_3_0 =
+  static final ImmutableList<AdminRow> COLUMN_ROWS_3_0 =
       ImmutableList.of(
           mockModernColumnRow("ks", "foo", "k2", "partition_key", "text", "none", 1),
           mockModernColumnRow("ks", "foo", "k1", "partition_key", "int", "none", 0),
           mockModernColumnRow("ks", "foo", "cc1", "clustering", "int", "asc", 0),
           mockModernColumnRow("ks", "foo", "cc2", "clustering", "int", "desc", 1),
           mockModernColumnRow("ks", "foo", "v", "regular", "int", "none", -1));
-  static final Iterable<AdminRow> INDEX_ROWS_3_0 =
+  static final ImmutableList<AdminRow> INDEX_ROWS_3_0 =
       ImmutableList.of(
           mockIndexRow("ks", "foo", "foo_v_idx", "COMPOSITES", ImmutableMap.of("target", "v")));
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/ViewParserTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/ViewParserTest.java
@@ -32,7 +32,7 @@ public class ViewParserTest extends SchemaParserTestBase {
 
   static final AdminRow VIEW_ROW_3_0 =
       mockViewRow("ks", "alltimehigh", "scores", false, "game IS NOT NULL");
-  static final Iterable<AdminRow> COLUMN_ROWS_3_0 =
+  static final ImmutableList<AdminRow> COLUMN_ROWS_3_0 =
       ImmutableList.of(
           mockModernColumnRow("ks", "alltimehigh", "game", "partition_key", "text", "none", 0),
           mockModernColumnRow("ks", "alltimehigh", "score", "clustering", "int", "desc", 0),

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra3SchemaQueriesTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra3SchemaQueriesTest.java
@@ -34,6 +34,7 @@ import static com.datastax.oss.driver.Assertions.assertThat;
 public class Cassandra3SchemaQueriesTest extends SchemaQueriesTest {
 
   @Before
+  @Override
   public void setup() {
     super.setup();
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/MockChannelPoolFactoryHelper.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/MockChannelPoolFactoryHelper.java
@@ -25,8 +25,9 @@ import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Sets;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -157,7 +158,7 @@ public class MockChannelPoolFactoryHelper {
 
     private void stub() {
       for (Params params : invocations.keySet()) {
-        LinkedList<CompletionStage<ChannelPool>> results = new LinkedList<>();
+        Deque<CompletionStage<ChannelPool>> results = new ArrayDeque<>();
         for (Object object : invocations.get(params)) {
           if (object instanceof ChannelPool) {
             results.add(CompletableFuture.completedFuture(((ChannelPool) object)));

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUpTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUpTest.java
@@ -40,8 +40,8 @@ import com.google.common.collect.ImmutableMap;
 import io.netty.channel.EventLoop;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -312,7 +312,7 @@ public class ReprepareOnUpTest {
   /** Bypasses the channel to make testing easier. */
   private static class MockReprepareOnUp extends ReprepareOnUp {
 
-    private Queue<MockAdminQuery> queries = new LinkedList<>();
+    private Queue<MockAdminQuery> queries = new ArrayDeque<>();
 
     MockReprepareOnUp(
         String logPrefix,
@@ -352,7 +352,7 @@ public class ReprepareOnUpTest {
             RawType.PRIMITIVES.get(ProtocolConstants.DataType.BLOB));
     RowsMetadata rowsMetadata =
         new RowsMetadata(ImmutableList.of(preparedIdSpec), null, null, null);
-    Queue<List<ByteBuffer>> data = new LinkedList<>();
+    Queue<List<ByteBuffer>> data = new ArrayDeque<>();
     for (char value : values) {
       data.add(ImmutableList.of(Bytes.fromHexString("0x0" + value)));
     }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/TupleCodecTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/TupleCodecTest.java
@@ -150,7 +150,7 @@ public class TupleCodecTest extends CodecTestBase<TupleValue> {
     TupleValue tuple = parse("(1,NULL,'a')");
 
     assertThat(tuple.getInt(0)).isEqualTo(1);
-    assertThat(tuple.isNull(1));
+    assertThat(tuple.isNull(1)).isTrue();
     assertThat(tuple.getString(2)).isEqualTo("a");
 
     Mockito.verify(intCodec).parse("1");

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/UdtCodecTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/UdtCodecTest.java
@@ -159,7 +159,7 @@ public class UdtCodecTest extends CodecTestBase<UdtValue> {
     UdtValue udt = parse("{field1:1,field2:NULL,field3:'a'}");
 
     assertThat(udt.getInt(0)).isEqualTo(1);
-    assertThat(udt.isNull(1));
+    assertThat(udt.isNull(1)).isTrue();
     assertThat(udt.getString(2)).isEqualTo("a");
 
     Mockito.verify(intCodec).parse("1");

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/util/concurrent/CycleDetectorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/util/concurrent/CycleDetectorTest.java
@@ -36,6 +36,7 @@ public class CycleDetectorTest {
     CyclicContext context = new CyclicContext(checker, false);
     try {
       context.a.get();
+      fail("Expected an exception");
     } catch (Exception e) {
       assertThat(e)
           .isInstanceOf(IllegalStateException.class)

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/util/concurrent/ScheduledTaskCapturingEventLoop.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/util/concurrent/ScheduledTaskCapturingEventLoop.java
@@ -41,6 +41,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
  *
  * <p>This is used to make unit tests independent of time.
  */
+@SuppressWarnings("FunctionalInterfaceClash") // does not matter for test code
 public class ScheduledTaskCapturingEventLoop extends DefaultEventLoop {
 
   private final BlockingQueue<CapturedTask> capturedTasks = new ArrayBlockingQueue<>(100);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ProtocolVersionInitialNegotiationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ProtocolVersionInitialNegotiationIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /** Covers protocol negotiation for the initial connection to the first contact point. */
 @Category(ParallelizableTests.class)
@@ -54,6 +55,7 @@ public class ProtocolVersionInitialNegotiationIT {
     try (CqlSession session = SessionUtils.newSession(ccm, "protocol.version = V4")) {
       assertThat(session.getContext().protocolVersion().getCode()).isEqualTo(3);
       session.execute("select * from system.local");
+      fail("Expected an AllNodesFailedException");
     } catch (AllNodesFailedException anfe) {
       Throwable cause = anfe.getErrors().values().iterator().next();
       assertThat(cause).isInstanceOf(UnsupportedProtocolVersionException.class);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverConfigProfileReloadIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverConfigProfileReloadIT.java
@@ -15,8 +15,8 @@
  */
 package com.datastax.oss.driver.api.core.config;
 
-import com.datastax.oss.driver.api.core.DriverTimeoutException;
 import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.DriverTimeoutException;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
 import com.datastax.oss.driver.internal.core.config.ConfigChangeEvent;
@@ -147,7 +147,8 @@ public class DriverConfigProfileReloadIT {
       configSource.set("profiles.slow.request.timeout = 2s");
       waitForConfigChange(session, 3, TimeUnit.SECONDS);
 
-      // Execute again, should expect to fail again because doesn't allow to dynamically define profile.
+      // Execute again, should expect to fail again because doesn't allow to dynamically define
+      // profile.
       thrown.expect(IllegalArgumentException.class);
       session.execute(SimpleStatement.builder(query).withConfigProfileName("slow").build());
     }
@@ -200,7 +201,7 @@ public class DriverConfigProfileReloadIT {
       boolean success = latch.await(timeout, unit);
       assertThat(success).isTrue();
     } catch (InterruptedException e) {
-      fail("Interrupted while waiting for config change event");
+      throw new AssertionError("Interrupted while waiting for config change event", e);
     }
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/data/DataTypeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/data/DataTypeIT.java
@@ -503,6 +503,7 @@ public class DataTypeIT {
           bs = bs.setCqlDuration(index, (CqlDuration) value);
           break;
         }
+        // fall through
       case ProtocolConstants.DataType.LIST:
       case ProtocolConstants.DataType.SET:
       case ProtocolConstants.DataType.MAP:
@@ -593,6 +594,7 @@ public class DataTypeIT {
           bs = bs.setCqlDuration(name, (CqlDuration) value);
           break;
         }
+        // fall through
       case ProtocolConstants.DataType.LIST:
       case ProtocolConstants.DataType.SET:
       case ProtocolConstants.DataType.MAP:
@@ -702,6 +704,7 @@ public class DataTypeIT {
           assertThat(row.getCqlDuration(0)).isEqualTo(expectedValue);
           break;
         }
+        // fall through
       case ProtocolConstants.DataType.LIST:
       case ProtocolConstants.DataType.MAP:
       case ProtocolConstants.DataType.SET:

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/data/DataTypeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/data/DataTypeIT.java
@@ -17,10 +17,10 @@ package com.datastax.oss.driver.api.core.data;
 
 import com.datastax.oss.driver.api.core.CassandraVersion;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
-import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
@@ -100,11 +100,11 @@ public class DataTypeIT {
 
   @DataProvider
   public static Object[][] primitiveTypeSamples() {
-    InetAddress address = null;
+    InetAddress address;
     try {
       address = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
     } catch (UnknownHostException uhae) {
-      fail("Could not get address from 127.0.0.1 for some reason");
+      throw new AssertionError("Could not get address from 127.0.0.1", uhae);
     }
 
     Object[][] samples =
@@ -254,7 +254,8 @@ public class DataTypeIT {
   @BeforeClass
   public static void createTable() {
     // Create a table with all types being tested with.
-    // This is a bit more lenient than creating a table for each sample, which would put a lot of burden on C* and
+    // This is a bit more lenient than creating a table for each sample, which would put a lot of
+    // burden on C* and
     // the filesystem.
     int counter = 0;
 
@@ -437,7 +438,8 @@ public class DataTypeIT {
             ? sessionRule.session().getContext().codecRegistry().codecFor(dataType)
             : null;
 
-    // set to null if value is null instead of getting possible NPE when casting from null to primitive.
+    // set to null if value is null instead of getting possible NPE when casting from null to
+    // primitive.
     if (value == null) {
       return bs.setToNull(index);
     }
@@ -528,7 +530,8 @@ public class DataTypeIT {
             ? sessionRule.session().getContext().codecRegistry().codecFor(dataType)
             : null;
 
-    // set to null if value is null instead of getting possible NPE when casting from null to primitive.
+    // set to null if value is null instead of getting possible NPE when casting from null to
+    // primitive.
     if (value == null) {
       return bs.setToNull(name);
     }
@@ -725,9 +728,10 @@ public class DataTypeIT {
           assertThat(returnedValue.get(i, typeCodec)).isEqualTo(exValue.get(i, typeCodec));
         }
 
-        //assertThat(row.getTupleValue(columnName)).isEqualTo(expectedValue);
-        //assertThat(row.getTupleValue(0)).isEqualTo(expectedValue);
-        return; // return instead of break here since we don't want to compare using decode output since it has same problem.
+        // assertThat(row.getTupleValue(columnName)).isEqualTo(expectedValue);
+        // assertThat(row.getTupleValue(0)).isEqualTo(expectedValue);
+        return; // return instead of break here since we don't want to compare using decode output
+        // since it has same problem.
       case ProtocolConstants.DataType.UDT:
         // TODO: Replace this when JAVA-1572 is fixed
         UdtValue returnedUdtValue = row.getUdtValue(columnName);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/heartbeat/HeartbeatIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/heartbeat/HeartbeatIT.java
@@ -232,7 +232,7 @@ public class HeartbeatIT {
             false,
             (l) ->
                 IS_OPTION_REQUEST.test(l)
-                    && regularConnection ^ l.getConnection().equals(controlConnectionAddress));
+                    && (regularConnection ^ l.getConnection().equals(controlConnectionAddress)));
     return count;
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/NodeStateIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/NodeStateIT.java
@@ -586,22 +586,12 @@ public class NodeStateIT {
    * AvailablePortFinder.
    */
   private static synchronized int findAvailablePort() throws RuntimeException {
-    ServerSocket ss = null;
-    try {
-      // let the system pick an ephemeral port
-      ss = new ServerSocket(0);
+    // let the system pick an ephemeral port
+    try (ServerSocket ss = new ServerSocket(0)) {
       ss.setReuseAddress(true);
       return ss.getLocalPort();
     } catch (IOException e) {
       throw new AssertionError(e);
-    } finally {
-      if (ss != null) {
-        try {
-          ss.close();
-        } catch (IOException e) {
-          throw new AssertionError(e);
-        }
-      }
     }
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/retry/DefaultRetryPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/retry/DefaultRetryPolicyIT.java
@@ -375,6 +375,7 @@ public class DefaultRetryPolicyIT {
     try {
       // when executing a query.
       sessionRule.session().execute(queryStr);
+      fail("Expected an UnavailableException");
     } catch (UnavailableException ue) {
       // then we should get an unavailable exception with the host being node 1 (since it was second tried).
       assertThat(ue.getCoordinator().getConnectAddress())
@@ -398,6 +399,7 @@ public class DefaultRetryPolicyIT {
     try {
       // when executing a query.
       sessionRule.session().execute(queryStr);
+      fail("Expected an AllNodesFailedException");
     } catch (AllNodesFailedException e) {
       // then we should get an all nodes failed exception, indicating the query was tried each node.
       assertThat(e.getErrors()).hasSize(3);
@@ -426,6 +428,7 @@ public class DefaultRetryPolicyIT {
       sessionRule
           .session()
           .execute(SimpleStatement.builder(queryStr).withIdempotence(false).build());
+      fail("Expected a ServerError");
     } catch (ServerError e) {
       // then should get a server error from first host.
       assertThat(e.getMessage()).isEqualTo("this is a server error");

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistryIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistryIT.java
@@ -340,7 +340,7 @@ public class CodecRegistryIT {
       // next row (at key 1) should be absent (null value).
       row = rows.next();
       // value should be null.
-      assertThat(row.isNull(0));
+      assertThat(row.isNull(0)).isTrue();
       // getting with codec should return Optional.empty()
       assertThat(row.get(0, optionalMapCodec.getJavaType())).isEqualTo(absentMap);
       // getting with map should return an empty map.

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistryIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistryIT.java
@@ -243,8 +243,8 @@ public class CodecRegistryIT {
     Predicate<T> isAbsent =
         (i) ->
             i == null
-                || (i instanceof Collection && ((Collection) i).isEmpty())
-                || (i instanceof Map) && ((Map) i).isEmpty();
+                || ((i instanceof Collection && ((Collection) i).isEmpty()))
+                || ((i instanceof Map) && ((Map) i).isEmpty());
 
     OptionalCodec(TypeCodec<T> innerCodec) {
       super(

--- a/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/KeyRequestProcessor.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/KeyRequestProcessor.java
@@ -62,7 +62,7 @@ public class KeyRequestProcessor implements RequestProcessor<KeyRequest, Integer
     return new KeyRequestHandler(subHandler);
   }
 
-  class KeyRequestHandler implements RequestHandler<KeyRequest, Integer> {
+  static class KeyRequestHandler implements RequestHandler<KeyRequest, Integer> {
 
     private final RequestHandler<Statement<?>, ResultSet> subHandler;
 

--- a/pom.xml
+++ b/pom.xml
@@ -216,14 +216,28 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
+          <compilerId>javac-with-errorprone</compilerId>
+          <forceJavacCompilerUse>true</forceJavacCompilerUse>
           <source>1.8</source>
           <target>1.8</target>
-          <optimize>true</optimize>
-          <showDeprecation>true</showDeprecation>
+          <compilerArgs combine.children="override">
+            <compilerArg>-Xep:FutureReturnValueIgnored:OFF</compilerArg>
+          </compilerArgs>
           <showWarnings>true</showWarnings>
-          <!-- this actually means: use incremental compilation (MCOMPILER-209) -->
-          <useIncrementalCompilation>false</useIncrementalCompilation>
+          <failOnWarning>true</failOnWarning>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-javac-errorprone</artifactId>
+            <version>2.8</version>
+          </dependency>
+          <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_core</artifactId>
+            <version>2.2.0</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>com.coveo</groupId>

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/cluster/SessionUtils.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/cluster/SessionUtils.java
@@ -96,17 +96,19 @@ public class SessionUtils {
    * in the 0th DC of the provided Cassandra resource as contact points, and the default
    * configuration augmented with the provided options.
    */
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   public static <SessionT extends Session> SessionT newSession(
       CassandraResourceRule cassandraResource, String... options) {
     return newSession(cassandraResource, null, new NodeStateListener[0], options);
   }
 
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   public static <SessionT extends Session> SessionT newSession(
       CassandraResourceRule cassandraResource, CqlIdentifier keyspace, String... options) {
     return newSession(cassandraResource, keyspace, new NodeStateListener[0], options);
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
   public static <SessionT extends Session> SessionT newSession(
       CassandraResourceRule cassandraResource,
       CqlIdentifier keyspace,

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/loadbalancing/SortingLoadBalancingPolicy.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/loadbalancing/SortingLoadBalancingPolicy.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.oss.driver.api.testinfra.loadbalancing;
 
-import com.datastax.oss.driver.api.core.config.DriverOption;
 import com.datastax.oss.driver.api.core.context.DriverContext;
 import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy;
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
@@ -24,7 +23,7 @@ import com.datastax.oss.driver.api.core.session.Request;
 import com.datastax.oss.driver.api.core.session.Session;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
@@ -75,7 +74,7 @@ public class SortingLoadBalancingPolicy implements LoadBalancingPolicy {
 
   @Override
   public Queue<Node> newQueryPlan(Request request, Session session) {
-    return new LinkedList<>(nodes);
+    return new ArrayDeque<>(nodes);
   }
 
   @Override


### PR DESCRIPTION
http://errorprone.info

This is a proposal. As with any automatic checker there are pros and cons, but I've found this one to be very good at detecting some serious bugs (see "errors" commit -- except the switch/case comments).

The most problematic warning is [FutureReturnValueIgnored](http://errorprone.info/bugpattern/FutureReturnValueIgnored). Swallowing exceptions in futures is a real issue, but it's already addressed correctly in the driver, most of the occurrences are either:
* false positives, such as Netty's `addListener`.
* cases where the action is "fire and forget", we have no way to propagate the error upstream. I've elected to either ignore the error (e.g. when closing a channel), or log unexpected errors so that users would report a bug (see usages of `UncaughtException#log`).

What also sucks is that ErrorProne uses `@SuppressWarnings` as a suppression mechanism, and annotations do not apply to individual statements. So most of the time we would have to annotate the enclosing element, which casts our net too wide. So maybe we could explicitly exclude `FutureReturnValueIgnored` and rely on good development/review practices.