### PR TITLE
Change signature of AsyncResultSet.fetchNextPage()

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/AsyncResultSet.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/AsyncResultSet.java
@@ -66,7 +66,7 @@ public interface AsyncResultSet {
    * @throws IllegalStateException if there are no more pages. Use {@link #hasMorePages()} to check
    *     if you can call this method.
    */
-  CompletionStage<AsyncResultSet> fetchNextPage() throws IllegalStateException;
+  CompletionStage<? extends AsyncResultSet> fetchNextPage() throws IllegalStateException;
 
   /**
    * If the query that produced this result was a conditional update, indicate whether it was


### PR DESCRIPTION
Motivation:
Its return type should reflect that AsyncResultSet is an interface,
so what is actually returned is a future of some concrete implementation,
hence the correct return type should be CompletionStage<? extends AsyncResultSet>.