### PR TITLE
JAVA-1751: Include defaultTimestamp length in encodedSize for >= V3

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 3.5.0 (In progress)
+
+- [bug] JAVA-1751: Include defaultTimestamp length in encodedSize for protocol version >= 3.
+
+
 ### 3.4.0
 
 - [improvement] JAVA-1671: Remove unnecessary test on prepared statement metadata.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,7 @@
 ### 3.5.0 (In progress)
 
 - [bug] JAVA-1751: Include defaultTimestamp length in encodedSize for protocol version >= 3.
+- [bug] JAVA-1770: Fix message size when using Custom Payload.
 
 
 ### 3.4.0

--- a/driver-core/src/main/java/com/datastax/driver/core/CBUtil.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/CBUtil.java
@@ -113,22 +113,17 @@ abstract class CBUtil { // TODO rename
         }
     }
 
-    public static void writeBytes(byte[] bytes, ByteBuf cb) {
+    public static void writeShortBytes(byte[] bytes, ByteBuf cb) {
         cb.writeShort(bytes.length);
         cb.writeBytes(bytes);
     }
 
-    public static void writeBytes(ByteBuffer bytes, ByteBuf cb) {
-        cb.writeShort(bytes.remaining());
-        cb.writeBytes(bytes.duplicate());
-    }
-
-    public static int sizeOfBytes(byte[] bytes) {
+    public static int sizeOfShortBytes(byte[] bytes) {
         return 2 + bytes.length;
     }
 
     public static int sizeOfBytes(ByteBuffer bytes) {
-        return 2 + bytes.remaining();
+        return 4 + bytes.remaining();
     }
 
     public static Map<String, ByteBuffer> readBytesMap(ByteBuf cb) {

--- a/driver-core/src/main/java/com/datastax/driver/core/Message.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Message.java
@@ -342,6 +342,12 @@ abstract class Message {
             }
 
             coder.encode(request, body, protocolVersion);
+            if (body.capacity() != messageSize) {
+                logger.warn("Detected buffer resizing while encoding {} message ({} => {}), " +
+                                "this is a driver bug " +
+                                "(ultimately it does not affect the query, but leads to a small inefficiency)",
+                        request.type, messageSize, body.capacity());
+            }
             out.add(Frame.create(protocolVersion, request.type.opcode, request.getStreamId(), flags, body));
         }
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/Requests.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Requests.java
@@ -402,7 +402,7 @@ class Requests {
                         size += CBUtil.sizeOfValue(pagingState);
                     if (flags.contains(QueryFlag.SERIAL_CONSISTENCY))
                         size += CBUtil.sizeOfConsistencyLevel(serialConsistency);
-                    if (version == ProtocolVersion.V3 && flags.contains(QueryFlag.DEFAULT_TIMESTAMP))
+                    if (version.compareTo(ProtocolVersion.V3) >= 0 && flags.contains(QueryFlag.DEFAULT_TIMESTAMP))
                         size += 8;
                     return size;
                 default:

--- a/driver-core/src/main/java/com/datastax/driver/core/Requests.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Requests.java
@@ -187,17 +187,17 @@ class Requests {
         static final Message.Coder<Execute> coder = new Message.Coder<Execute>() {
             @Override
             public void encode(Execute msg, ByteBuf dest, ProtocolVersion version) {
-                CBUtil.writeBytes(msg.statementId.bytes, dest);
+                CBUtil.writeShortBytes(msg.statementId.bytes, dest);
                 if (ProtocolFeature.PREPARED_METADATA_CHANGES.isSupportedBy(version))
-                    CBUtil.writeBytes(msg.resultMetadataId.bytes, dest);
+                    CBUtil.writeShortBytes(msg.resultMetadataId.bytes, dest);
                 msg.options.encode(dest, version);
             }
 
             @Override
             public int encodedSize(Execute msg, ProtocolVersion version) {
-                int size = CBUtil.sizeOfBytes(msg.statementId.bytes);
+                int size = CBUtil.sizeOfShortBytes(msg.statementId.bytes);
                 if (ProtocolFeature.PREPARED_METADATA_CHANGES.isSupportedBy(version))
-                    size += CBUtil.sizeOfBytes(msg.resultMetadataId.bytes);
+                    size += CBUtil.sizeOfShortBytes(msg.resultMetadataId.bytes);
                 size += msg.options.encodedSize(version);
                 return size;
             }
@@ -434,7 +434,7 @@ class Requests {
                     if (q instanceof String)
                         CBUtil.writeLongString((String) q, dest);
                     else
-                        CBUtil.writeBytes(((MD5Digest) q).bytes, dest);
+                        CBUtil.writeShortBytes(((MD5Digest) q).bytes, dest);
 
                     CBUtil.writeValueList(msg.values.get(i), dest);
                 }
@@ -449,7 +449,7 @@ class Requests {
                     Object q = msg.queryOrIdList.get(i);
                     size += 1 + (q instanceof String
                             ? CBUtil.sizeOfLongString((String) q)
-                            : CBUtil.sizeOfBytes(((MD5Digest) q).bytes));
+                            : CBUtil.sizeOfShortBytes(((MD5Digest) q).bytes));
 
                     size += CBUtil.sizeOfValueList(msg.values.get(i));
                 }

--- a/driver-core/src/test/java/com/datastax/driver/core/CustomPayloadTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CustomPayloadTest.java
@@ -258,8 +258,8 @@ public class CustomPayloadTest extends CCMTestsSupport {
             session().execute(statement);
             String logs = appender.waitAndGet(10000);
             assertThat(logs)
-                    .contains("Sending payload: {k1:0x010203, k2:0x040506} (20 bytes total)")
-                    .contains("Received payload: {k1:0x010203, k2:0x040506} (20 bytes total)");
+                    .contains("Sending payload: {k1:0x010203, k2:0x040506} (24 bytes total)")
+                    .contains("Received payload: {k1:0x010203, k2:0x040506} (24 bytes total)");
         } finally {
             logger.setLevel(null);
             logger.removeAppender(appender);


### PR DESCRIPTION
QueryProtocolOptions.encodedSize previously incorrectly only accounted
for defaultTimestamp length if protocol version was equal to V3.  It
should be included for all protocol versions >= V3.