### PR TITLE
Fix eclipse problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -843,6 +843,7 @@ limitations under the License.
                             <pluginExecutions>
                                 <pluginExecution>
                                     <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
                                         <artifactId>maven-jar-plugin</artifactId>
                                         <versionRange>[2.2,)</versionRange>
                                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -854,6 +854,32 @@ limitations under the License.
                                         <ignore />
                                     </action>
                                 </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.codehaus.mojo</groupId>
+                                        <artifactId>clirr-maven-plugin</artifactId>
+                                        <versionRange>[2.7,)</versionRange>
+                                        <goals>
+                                            <goal>check</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore />
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.codehaus.gmaven</groupId>
+                                        <artifactId>gmaven-plugin</artifactId>
+                                        <versionRange>[1.5,)</versionRange>
+                                        <goals>
+                                            <goal>testCompile</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore />
+                                    </action>
+                                </pluginExecution>
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
                     </configuration>


### PR DESCRIPTION
There were 2 problems with importing Java driver into Eclipse:

1.  no `groupId` specified, so m2e plugin couldn't import the project correctly
2. no m2e connectors for 2 plugins  - they were just marked as ignored in m2e configuration