### PR TITLE
JAVA-1765: Update dependencies to latest patch versions

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 3.5.0 (In progress)
+
+* [improvement] JAVA-1765: Update dependencies to latest patch versions.
+
+
 ### 3.4.0
 
 - [improvement] JAVA-1671: Remove unnecessary test on prepared statement metadata.

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -74,8 +74,8 @@
         </dependency>
 
         <dependency>
-            <groupId>net.jpountz.lz4</groupId>
-            <artifactId>lz4</artifactId>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
@@ -76,7 +76,7 @@ public class BundleOptions {
             public Option[] getOptions() {
                 return options(
                         systemProperty("cassandra.compression").value(ProtocolOptions.Compression.LZ4.name()),
-                        mavenBundle("net.jpountz.lz4", "lz4", getVersion("lz4.version"))
+                        mavenBundle("org.lz4", "lz4-java", getVersion("lz4.version"))
                 );
             }
         };

--- a/manual/compression/README.md
+++ b/manual/compression/README.md
@@ -25,9 +25,9 @@ Maven dependency:
 
 ```xml
 <dependency>
-    <groupId>net.jpountz.lz4</groupId>
-    <artifactId>lz4</artifactId>
-    <version>1.3.0</version>
+    <groupId>org.lz4</groupId>
+    <artifactId>lz4-java</artifactId>
+    <version>1.4.1</version>
 </dependency>
 ```
 

--- a/manual/speculative_execution/README.md
+++ b/manual/speculative_execution/README.md
@@ -117,7 +117,7 @@ explicitly depend on it:
 <dependency>
   <groupId>org.hdrhistogram</groupId>
   <artifactId>HdrHistogram</artifactId>
-  <version>2.1.9</version>
+  <version>2.1.10</version>
 </dependency>
 ```
 

--- a/manual/ssl/README.md
+++ b/manual/ssl/README.md
@@ -153,7 +153,7 @@ add it to your dependencies.
 
 There are known runtime incompatibilities between newer versions of
 netty-tcnative and the version of netty that the driver uses.  For best
-results, use version 2.0.1.Final.
+results, use version 2.0.7.Final.
 
 Using netty-tcnative requires JDK 1.7 or above and requires the presence of
 OpenSSL on the system.  It will not fall back to the JDK implementation.

--- a/pom.xml
+++ b/pom.xml
@@ -45,25 +45,25 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <cassandra.version>3.11.1</cassandra.version>
+        <cassandra.version>3.11.2</cassandra.version>
         <java.version>1.6</java.version>
         <log4j.version>1.2.17</log4j.version>
         <slf4j.version>1.7.25</slf4j.version>
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
         <guava.version>19.0</guava.version>
-        <netty.version>4.0.47.Final</netty.version>
+        <netty.version>4.0.56.Final</netty.version>
         <metrics.version>3.2.2</metrics.version>
-        <snappy.version>1.1.2.6</snappy.version>
+        <snappy.version>1.1.7.1</snappy.version>
         <lz4.version>1.3.0</lz4.version>
-        <hdr.version>2.1.9</hdr.version>
-        <jackson.version>2.8.8</jackson.version>
+        <hdr.version>2.1.10</hdr.version>
+        <jackson.version>2.8.11</jackson.version>
         <!-- jackson-databind 2.7.x is the last to support java 6 -->
-        <jackson-databind.version>2.7.9.2</jackson-databind.version>
-        <joda.version>2.9.1</joda.version>
+        <jackson-databind.version>2.7.9.3</jackson-databind.version>
+        <joda.version>2.9.9</joda.version>
         <jsr353-api.version>1.0</jsr353-api.version>
         <jsr353-ri.version>1.0.4</jsr353-ri.version>
-        <jnr-ffi.version>2.0.7</jnr-ffi.version>
-        <jnr-posix.version>3.0.27</jnr-posix.version>
+        <jnr-ffi.version>2.0.9</jnr-ffi.version>
+        <jnr-posix.version>3.0.44</jnr-posix.version>
         <groovy.version>2.4.7</groovy.version>
         <jax-rs.version>2.0.1</jax-rs.version>
         <jersey.version>2.23.1</jersey.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <netty.version>4.0.56.Final</netty.version>
         <netty-tcnative.version>2.0.7.Final</netty-tcnative.version>
         <metrics.version>3.2.2</metrics.version>
-        <snappy.version>1.1.4</snappy.version>
+        <snappy.version>1.1.2.6</snappy.version>
         <lz4.version>1.4.1</lz4.version>
         <hdr.version>2.1.10</hdr.version>
         <jackson.version>2.8.11</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,10 @@
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
         <guava.version>19.0</guava.version>
         <netty.version>4.0.56.Final</netty.version>
+        <netty-tcnative.version>2.0.7.Final</netty-tcnative.version>
         <metrics.version>3.2.2</metrics.version>
         <snappy.version>1.1.7.1</snappy.version>
-        <lz4.version>1.3.0</lz4.version>
+        <lz4.version>1.4.1</lz4.version>
         <hdr.version>2.1.10</hdr.version>
         <jackson.version>2.8.11</jackson.version>
         <!-- jackson-databind 2.7.x is the last to support java 6 -->
@@ -165,8 +166,8 @@
             </dependency>
 
             <dependency>
-                <groupId>net.jpountz.lz4</groupId>
-                <artifactId>lz4</artifactId>
+                <groupId>org.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
                 <version>${lz4.version}</version>
             </dependency>
 
@@ -341,7 +342,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative</artifactId>
-                <version>2.0.1.Final</version>
+                <version>${netty-tcnative.version}</version>
                 <classifier>${os.detected.classifier}</classifier>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -516,8 +516,8 @@
                                 <version>${snappy.version}</version>
                             </additionalDependency>
                             <additionalDependency>
-                                <groupId>net.jpountz.lz4</groupId>
-                                <artifactId>lz4</artifactId>
+                                <groupId>org.lz4</groupId>
+                                <artifactId>lz4-java</artifactId>
                                 <version>${lz4.version}</version>
                             </additionalDependency>
                             <additionalDependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <netty.version>4.0.56.Final</netty.version>
         <netty-tcnative.version>2.0.7.Final</netty-tcnative.version>
         <metrics.version>3.2.2</metrics.version>
-        <snappy.version>1.1.7.1</snappy.version>
+        <snappy.version>1.1.4</snappy.version>
         <lz4.version>1.4.1</lz4.version>
         <hdr.version>2.1.10</hdr.version>
         <jackson.version>2.8.11</jackson.version>


### PR DESCRIPTION
For [JAVA-1765](https://datastax-oss.atlassian.net/browse/JAVA-1765):

* jnr-ffi, 2.0.7 -> 2.0.9
* jnr-posix, 3.0.27 -> 3.0.44
* metrics-core, 3.2.2 -> 3.2.6
* netty, 4.0.47.Final -> 4.0.56.Final
* netty-tcnative, 2.0.1.Final -> 2.0.7.Final
* HdrHistogram, 2.1.9 -> 2.1.10
* ~snappy-java, 1.1.2.6 -> 1.1.7.1~ (newer versions require java 1.7)
* jackson-core, 2.8.8 -> 2.8.11
* jackson-databind, 2.7.9.2 -> 2.7.9.3
* joda-time, 2.9.1 -> 2.9.9
* lz4-java, 1.3.0 -> 1.4.1 (also new coordinates)