### PR TITLE
JAVA-1536: Add request throttling

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha4 (in progress)
 
+- [new feature] JAVA-1536: Add request throttling
 - [improvement] JAVA-1772: Revisit multi-response callbacks
 - [new feature] JAVA-1537: Add remaining socket options
 - [bug] JAVA-1756: Propagate custom payload when preparing a statement

--- a/core/src/main/java/com/datastax/oss/driver/api/core/RequestThrottlingException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/RequestThrottlingException.java
@@ -13,14 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datastax.oss.driver.internal.core.metrics;
+package com.datastax.oss.driver.api.core;
 
-import com.datastax.oss.driver.api.core.metadata.Node;
+/**
+ * Thrown if the session uses a request throttler, and it didn't allow the current request to
+ * execute.
+ *
+ * <p>This can happen either when the session is overloaded, or at shutdown for requests that had
+ * been enqueued.
+ */
+public class RequestThrottlingException extends DriverException {
 
-public interface MetricUpdaterFactory {
+  public RequestThrottlingException(String message) {
+    super(message, null, true);
+  }
 
-  /** @return the unique instance for this session (this must return the same object every time). */
-  SessionMetricUpdater getSessionUpdater();
-
-  NodeMetricUpdater newNodeUpdater(Node node);
+  @Override
+  public DriverException copy() {
+    return new RequestThrottlingException(getMessage());
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -61,6 +61,11 @@ public enum DefaultDriverOption implements DriverOption {
   REQUEST_TRACE_ATTEMPTS("request.trace.attempts", true),
   REQUEST_TRACE_INTERVAL("request.trace.interval", true),
   REQUEST_TRACE_CONSISTENCY("request.trace.consistency", true),
+  REQUEST_THROTTLER_CLASS("request.throttler.class", true),
+  REQUEST_THROTTLER_MAX_CONCURRENT_REQUESTS("request.throttler.max-concurrent-requests", false),
+  REQUEST_THROTTLER_MAX_REQUESTS_PER_SECOND("request.throttler.max-requests-per-second", false),
+  REQUEST_THROTTLER_MAX_QUEUE_SIZE("request.throttler.max-queue-size", false),
+  REQUEST_THROTTLER_DRAIN_INTERVAL("request.throttler.drain-interval", false),
 
   CONTROL_CONNECTION_TIMEOUT("connection.control-connection.timeout", true),
   CONTROL_CONNECTION_AGREEMENT_INTERVAL(
@@ -121,6 +126,9 @@ public enum DefaultDriverOption implements DriverOption {
   METRICS_SESSION_CQL_REQUESTS_HIGHEST("metrics.session.cql-requests.highest-latency", false),
   METRICS_SESSION_CQL_REQUESTS_DIGITS("metrics.session.cql-requests.significant-digits", false),
   METRICS_SESSION_CQL_REQUESTS_INTERVAL("metrics.session.cql-requests.refresh-interval", false),
+  METRICS_SESSION_THROTTLING_HIGHEST("metrics.session.throttling.delay.highest-latency", false),
+  METRICS_SESSION_THROTTLING_DIGITS("metrics.session.throttling.delay.significant-digits", false),
+  METRICS_SESSION_THROTTLING_INTERVAL("metrics.session.throttling.delay.refresh-interval", false),
   METRICS_NODE_CQL_MESSAGES_HIGHEST("metrics.node.cql-messages.highest-latency", false),
   METRICS_NODE_CQL_MESSAGES_DIGITS("metrics.node.cql-messages.significant-digits", false),
   METRICS_NODE_CQL_MESSAGES_INTERVAL("metrics.node.cql-messages.refresh-interval", false),

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metrics/DefaultSessionMetric.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metrics/DefaultSessionMetric.java
@@ -23,6 +23,9 @@ public enum DefaultSessionMetric implements SessionMetric {
   CONNECTED_NODES("connected-nodes"),
   CQL_REQUESTS("cql-requests"),
   CQL_CLIENT_TIMEOUTS("cql-client-timeouts"),
+  THROTTLING_DELAY("throttling.delay"),
+  THROTTLING_QUEUE_SIZE("throttling.queue-size"),
+  THROTTLING_ERRORS("throttling.errors"),
   ;
 
   private static final Map<String, DefaultSessionMetric> BY_PATH = sortByPath();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/ThrottledAdminRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/ThrottledAdminRequestHandler.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.adminrequest;
+
+import com.datastax.oss.driver.api.core.DriverTimeoutException;
+import com.datastax.oss.driver.api.core.RequestThrottlingException;
+import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+import com.datastax.oss.driver.internal.core.channel.DriverChannel;
+import com.datastax.oss.driver.internal.core.metrics.SessionMetricUpdater;
+import com.datastax.oss.driver.internal.core.session.throttling.RequestThrottler;
+import com.datastax.oss.driver.internal.core.session.throttling.Throttled;
+import com.datastax.oss.protocol.internal.Message;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+public class ThrottledAdminRequestHandler extends AdminRequestHandler implements Throttled {
+
+  private final long startTimeNanos;
+  private final RequestThrottler throttler;
+  private final SessionMetricUpdater metricUpdater;
+
+  public ThrottledAdminRequestHandler(
+      DriverChannel channel,
+      Message message,
+      Map<String, ByteBuffer> customPayload,
+      Duration timeout,
+      RequestThrottler throttler,
+      SessionMetricUpdater metricUpdater,
+      String logPrefix,
+      String debugString) {
+    super(channel, message, customPayload, timeout, logPrefix, debugString);
+    this.startTimeNanos = System.nanoTime();
+    this.throttler = throttler;
+    this.metricUpdater = metricUpdater;
+  }
+
+  @Override
+  public CompletionStage<AdminResult> start() {
+    // Don't write request yet, wait for green light from throttler
+    throttler.register(this);
+    return result;
+  }
+
+  @Override
+  public void onThrottleReady(boolean wasDelayed) {
+    if (wasDelayed) {
+      metricUpdater.updateTimer(
+          DefaultSessionMetric.THROTTLING_DELAY,
+          System.nanoTime() - startTimeNanos,
+          TimeUnit.NANOSECONDS);
+    }
+    super.start();
+  }
+
+  @Override
+  public void onThrottleFailure(RequestThrottlingException error) {
+    metricUpdater.incrementCounter(DefaultSessionMetric.THROTTLING_ERRORS);
+    setFinalError(error);
+  }
+
+  @Override
+  protected boolean setFinalResult(AdminResult result) {
+    boolean wasSet = super.setFinalResult(result);
+    if (wasSet) {
+      throttler.signalSuccess(this);
+    }
+    return wasSet;
+  }
+
+  @Override
+  protected boolean setFinalError(Throwable error) {
+    boolean wasSet = super.setFinalError(error);
+    if (wasSet) {
+      if (error instanceof DriverTimeoutException) {
+        throttler.signalTimeout(this);
+      } else if (!(error instanceof RequestThrottlingException)) {
+        throttler.signalError(this, error);
+      }
+    }
+    return wasSet;
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/InternalDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/InternalDriverContext.java
@@ -34,6 +34,7 @@ import com.datastax.oss.driver.internal.core.pool.ChannelPoolFactory;
 import com.datastax.oss.driver.internal.core.servererrors.WriteTypeRegistry;
 import com.datastax.oss.driver.internal.core.session.PoolManager;
 import com.datastax.oss.driver.internal.core.session.RequestProcessorRegistry;
+import com.datastax.oss.driver.internal.core.session.throttling.RequestThrottler;
 import com.datastax.oss.driver.internal.core.ssl.SslHandlerFactory;
 import com.datastax.oss.protocol.internal.Compressor;
 import com.datastax.oss.protocol.internal.FrameCodec;
@@ -88,4 +89,6 @@ public interface InternalDriverContext extends DriverContext {
   PoolManager poolManager();
 
   MetricUpdaterFactory metricUpdaterFactory();
+
+  RequestThrottler requestThrottler();
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandlerBase.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandlerBase.java
@@ -283,9 +283,11 @@ public abstract class CqlPrepareHandlerBase {
       return CompletableFuture.completedFuture(null);
     } else {
       AdminRequestHandler handler =
-          new AdminRequestHandler(channel, message, timeout, logPrefix, message.toString());
+          new AdminRequestHandler(
+              channel, message, request.getCustomPayload(), timeout, logPrefix, message.toString());
+
       return handler
-          .start(request.getCustomPayload())
+          .start()
           .handle(
               (result, error) -> {
                 if (error == null) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerBase.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerBase.java
@@ -476,11 +476,12 @@ public abstract class CqlRequestHandlerBase {
             new AdminRequestHandler(
                 channel,
                 reprepareMessage,
+                repreparePayload.customPayload,
                 timeout,
                 logPrefix,
                 "Reprepare " + reprepareMessage.toString());
         reprepareHandler
-            .start(repreparePayload.customPayload)
+            .start()
             .handle(
                 (result, exception) -> {
                   if (exception != null) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DefaultMetricUpdaterFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DefaultMetricUpdaterFactory.java
@@ -36,22 +36,23 @@ public class DefaultMetricUpdaterFactory implements MetricUpdaterFactory {
 
   private final String logPrefix;
   private final InternalDriverContext context;
-  private final Set<SessionMetric> enabledSessionMetrics;
   private final Set<NodeMetric> enabledNodeMetrics;
+  private final SessionMetricUpdater sessionMetricUpdater;
 
   public DefaultMetricUpdaterFactory(InternalDriverContext context) {
     this.logPrefix = context.sessionName();
     this.context = context;
     DriverConfigProfile config = context.config().getDefaultProfile();
-    this.enabledSessionMetrics =
+    Set<SessionMetric> enabledSessionMetrics =
         parseSessionMetricPaths(config.getStringList(DefaultDriverOption.METRICS_SESSION_ENABLED));
+    this.sessionMetricUpdater = new DefaultSessionMetricUpdater(enabledSessionMetrics, context);
     this.enabledNodeMetrics =
         parseNodeMetricPaths(config.getStringList(DefaultDriverOption.METRICS_NODE_ENABLED));
   }
 
   @Override
-  public SessionMetricUpdater newSessionUpdater() {
-    return new DefaultSessionMetricUpdater(enabledSessionMetrics, context);
+  public SessionMetricUpdater getSessionUpdater() {
+    return sessionMetricUpdater;
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
@@ -104,7 +104,7 @@ public class DefaultSession implements CqlSession {
     this.processorRegistry = context.requestProcessorRegistry();
     this.poolManager = context.poolManager();
     this.logPrefix = context.sessionName();
-    this.metricUpdater = context.metricUpdaterFactory().newSessionUpdater();
+    this.metricUpdater = context.metricUpdaterFactory().getSessionUpdater();
   }
 
   private CompletionStage<CqlSession> init(CqlIdentifier keyspace) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUp.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUp.java
@@ -17,14 +17,15 @@ package com.datastax.oss.driver.internal.core.session;
 
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
-import com.datastax.oss.driver.internal.core.adminrequest.AdminRequestHandler;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminResult;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
+import com.datastax.oss.driver.internal.core.adminrequest.ThrottledAdminRequestHandler;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.cql.CqlRequestHandlerBase;
-import com.datastax.oss.driver.internal.core.metadata.TopologyMonitor;
+import com.datastax.oss.driver.internal.core.metrics.SessionMetricUpdater;
 import com.datastax.oss.driver.internal.core.pool.ChannelPool;
+import com.datastax.oss.driver.internal.core.session.throttling.RequestThrottler;
 import com.datastax.oss.driver.internal.core.util.concurrent.RunOrSchedule;
 import com.datastax.oss.protocol.internal.Message;
 import com.datastax.oss.protocol.internal.request.Prepare;
@@ -63,12 +64,13 @@ class ReprepareOnUp {
   private final String logPrefix;
   private final DriverChannel channel;
   private final Map<ByteBuffer, RepreparePayload> repreparePayloads;
-  private final TopologyMonitor topologyMonitor;
   private final Runnable whenPrepared;
   private final boolean checkSystemTable;
   private final int maxStatements;
   private final int maxParallelism;
   private final Duration timeout;
+  private final RequestThrottler throttler;
+  private final SessionMetricUpdater metricUpdater;
 
   // After the constructor, everything happens on the channel's event loop, so these fields do not
   // need any synchronization.
@@ -86,8 +88,8 @@ class ReprepareOnUp {
     this.logPrefix = logPrefix;
     this.channel = pool.next();
     this.repreparePayloads = repreparePayloads;
-    this.topologyMonitor = context.topologyMonitor();
     this.whenPrepared = whenPrepared;
+    this.throttler = context.requestThrottler();
 
     DriverConfig config = context.config();
     this.checkSystemTable =
@@ -97,6 +99,8 @@ class ReprepareOnUp {
         config.getDefaultProfile().getInt(DefaultDriverOption.REPREPARE_MAX_STATEMENTS);
     this.maxParallelism =
         config.getDefaultProfile().getInt(DefaultDriverOption.REPREPARE_MAX_PARALLELISM);
+
+    this.metricUpdater = context.metricUpdaterFactory().getSessionUpdater();
   }
 
   void start() {
@@ -231,8 +235,16 @@ class ReprepareOnUp {
   @VisibleForTesting
   protected CompletionStage<AdminResult> queryAsync(
       Message message, Map<String, ByteBuffer> customPayload, String debugString) {
-    AdminRequestHandler reprepareHandler =
-        new AdminRequestHandler(channel, message, customPayload, timeout, logPrefix, debugString);
+    ThrottledAdminRequestHandler reprepareHandler =
+        new ThrottledAdminRequestHandler(
+            channel,
+            message,
+            customPayload,
+            timeout,
+            throttler,
+            metricUpdater,
+            logPrefix,
+            debugString);
     return reprepareHandler.start();
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUp.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUp.java
@@ -232,7 +232,7 @@ class ReprepareOnUp {
   protected CompletionStage<AdminResult> queryAsync(
       Message message, Map<String, ByteBuffer> customPayload, String debugString) {
     AdminRequestHandler reprepareHandler =
-        new AdminRequestHandler(channel, message, timeout, logPrefix, debugString);
-    return reprepareHandler.start(customPayload);
+        new AdminRequestHandler(channel, message, customPayload, timeout, logPrefix, debugString);
+    return reprepareHandler.start();
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/throttling/ConcurrencyLimitingRequestThrottler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/throttling/ConcurrencyLimitingRequestThrottler.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.session.throttling;
+
+import com.datastax.oss.driver.api.core.RequestThrottlingException;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.locks.ReentrantLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** A request throttler that limits the number of concurrent requests. */
+public class ConcurrencyLimitingRequestThrottler implements RequestThrottler {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ConcurrencyLimitingRequestThrottler.class);
+
+  private final String logPrefix;
+  private final int maxConcurrentRequests;
+  private final int maxQueueSize;
+
+  private final ReentrantLock lock = new ReentrantLock();
+
+  // guarded by lock
+  private int concurrentRequests;
+  // guarded by lock
+  private Deque<Throttled> queue = new ArrayDeque<>();
+  // guarded by lock
+  private boolean closed;
+
+  public ConcurrencyLimitingRequestThrottler(DriverContext context) {
+    this.logPrefix = context.sessionName();
+    DriverConfigProfile config = context.config().getDefaultProfile();
+    this.maxConcurrentRequests =
+        config.getInt(DefaultDriverOption.REQUEST_THROTTLER_MAX_CONCURRENT_REQUESTS);
+    this.maxQueueSize = config.getInt(DefaultDriverOption.REQUEST_THROTTLER_MAX_QUEUE_SIZE);
+    LOG.debug(
+        "[{}] Initializing with maxConcurrentRequests = {}, maxQueueSize = {}",
+        logPrefix,
+        maxConcurrentRequests,
+        maxQueueSize);
+  }
+
+  @Override
+  public void register(Throttled request) {
+    lock.lock();
+    try {
+      if (closed) {
+        LOG.trace("[{}] Rejecting request after shutdown", logPrefix);
+        fail(request, "The session is shutting down");
+      } else if (queue.isEmpty() && concurrentRequests < maxConcurrentRequests) {
+        // We have capacity for one more concurrent request
+        LOG.trace("[{}] Starting newly registered request", logPrefix);
+        concurrentRequests += 1;
+        request.onThrottleReady(false);
+      } else if (queue.size() < maxQueueSize) {
+        LOG.trace("[{}] Enqueuing request", logPrefix);
+        queue.add(request);
+      } else {
+        LOG.trace("[{}] Rejecting request because of full queue", logPrefix);
+        fail(
+            request,
+            String.format(
+                "The session has reached its maximum capacity "
+                    + "(concurrent requests: %d, queue size: %d)",
+                maxConcurrentRequests, maxQueueSize));
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public void signalSuccess(Throttled request) {
+    lock.lock();
+    try {
+      onRequestDone();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public void signalError(Throttled request, Throwable error) {
+    signalSuccess(request); // not treated differently
+  }
+
+  @Override
+  public void signalTimeout(Throttled request) {
+    lock.lock();
+    try {
+      if (!closed) {
+        if (queue.remove(request)) { // The request timed out before it was active
+          LOG.trace("[{}] Removing timed out request from the queue", logPrefix);
+        } else {
+          onRequestDone();
+        }
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void onRequestDone() {
+    assert lock.isHeldByCurrentThread();
+    if (!closed) {
+      if (queue.isEmpty()) {
+        concurrentRequests -= 1;
+      } else {
+        LOG.trace("[{}] Starting dequeued request", logPrefix);
+        queue.poll().onThrottleReady(true);
+        // don't touch concurrentRequests since we finished one but started another
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    lock.lock();
+    try {
+      closed = true;
+      LOG.trace("[{}] Rejecting {} queued requests after shutdown", logPrefix, queue.size());
+      for (Throttled request : queue) {
+        fail(request, "The session is shutting down");
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  public int getQueueSize() {
+    lock.lock();
+    try {
+      return queue.size();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @VisibleForTesting
+  int getConcurrentRequests() {
+    lock.lock();
+    try {
+      return concurrentRequests;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @VisibleForTesting
+  Deque<Throttled> getQueue() {
+    lock.lock();
+    try {
+      return queue;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private static void fail(Throttled request, String message) {
+    request.onThrottleFailure(new RequestThrottlingException(message));
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/throttling/NanoClock.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/throttling/NanoClock.java
@@ -13,14 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datastax.oss.driver.internal.core.metrics;
+package com.datastax.oss.driver.internal.core.session.throttling;
 
-import com.datastax.oss.driver.api.core.metadata.Node;
-
-public interface MetricUpdaterFactory {
-
-  /** @return the unique instance for this session (this must return the same object every time). */
-  SessionMetricUpdater getSessionUpdater();
-
-  NodeMetricUpdater newNodeUpdater(Node node);
+/** A thin wrapper around {@link System#nanoTime()}, to simplify testing. */
+interface NanoClock {
+  long nanoTime();
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/throttling/PassThroughRequestThrottler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/throttling/PassThroughRequestThrottler.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.session.throttling;
+
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import java.io.IOException;
+
+/**
+ * A request throttler that does not enforce any kind of limitation: requests are always executed
+ * immediately.
+ */
+public class PassThroughRequestThrottler implements RequestThrottler {
+
+  @SuppressWarnings("unused")
+  public PassThroughRequestThrottler(DriverContext context) {
+    // nothing to do
+  }
+
+  @Override
+  public void register(Throttled request) {
+    request.onThrottleReady(false);
+  }
+
+  @Override
+  public void signalSuccess(Throttled request) {
+    // nothing to do
+  }
+
+  @Override
+  public void signalError(Throttled request, Throwable error) {
+    // nothing to do
+  }
+
+  @Override
+  public void signalTimeout(Throttled request) {
+    // nothing to do
+  }
+
+  @Override
+  public void close() throws IOException {
+    // nothing to do
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/throttling/RateLimitingRequestThrottler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/throttling/RateLimitingRequestThrottler.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.session.throttling;
+
+import com.datastax.oss.driver.api.core.RequestThrottlingException;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.google.common.annotations.VisibleForTesting;
+import io.netty.util.concurrent.EventExecutor;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** A request throttler that limits the rate of requests per second. */
+public class RateLimitingRequestThrottler implements RequestThrottler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RateLimitingRequestThrottler.class);
+
+  private final String logPrefix;
+  private final NanoClock clock;
+  private final int maxRequestsPerSecond;
+  private final int maxQueueSize;
+  private final long drainIntervalNanos;
+  private final EventExecutor scheduler;
+
+  private final ReentrantLock lock = new ReentrantLock();
+
+  // guarded by lock
+  private long lastUpdateNanos;
+  // guarded by lock
+  private int storedPermits;
+  // guarded by lock
+  private final Deque<Throttled> queue = new ArrayDeque<>();
+  // guarded by lock
+  private boolean closed;
+
+  @SuppressWarnings("unused")
+  public RateLimitingRequestThrottler(DriverContext context) {
+    this(context, System::nanoTime);
+  }
+
+  @VisibleForTesting
+  RateLimitingRequestThrottler(DriverContext context, NanoClock clock) {
+    this.logPrefix = context.sessionName();
+    this.clock = clock;
+
+    DriverConfigProfile config = context.config().getDefaultProfile();
+
+    this.maxRequestsPerSecond =
+        config.getInt(DefaultDriverOption.REQUEST_THROTTLER_MAX_REQUESTS_PER_SECOND);
+    this.maxQueueSize = config.getInt(DefaultDriverOption.REQUEST_THROTTLER_MAX_QUEUE_SIZE);
+    Duration drainInterval =
+        config.getDuration(DefaultDriverOption.REQUEST_THROTTLER_DRAIN_INTERVAL);
+    this.drainIntervalNanos = drainInterval.toNanos();
+
+    this.lastUpdateNanos = clock.nanoTime();
+    // Start with one second worth of permits to avoid delaying initial requests
+    this.storedPermits = maxRequestsPerSecond;
+
+    this.scheduler =
+        ((InternalDriverContext) context).nettyOptions().adminEventExecutorGroup().next();
+
+    LOG.debug(
+        "[{}] Initializing with maxRequestsPerSecond = {}, maxQueueSize = {}, drainInterval = {}",
+        logPrefix,
+        maxRequestsPerSecond,
+        maxQueueSize,
+        drainInterval);
+  }
+
+  @Override
+  public void register(Throttled request) {
+    long now = clock.nanoTime();
+    lock.lock();
+    try {
+      if (closed) {
+        LOG.trace("[{}] Rejecting request after shutdown", logPrefix);
+        fail(request, "The session is shutting down");
+      } else if (queue.isEmpty() && acquire(now, 1) == 1) {
+        LOG.trace("[{}] Starting newly registered request", logPrefix);
+        request.onThrottleReady(false);
+      } else if (queue.size() < maxQueueSize) {
+        LOG.trace("[{}] Enqueuing request", logPrefix);
+        if (queue.isEmpty()) {
+          scheduler.schedule(this::drain, drainIntervalNanos, TimeUnit.NANOSECONDS);
+        }
+        queue.add(request);
+      } else {
+        LOG.trace("[{}] Rejecting request because of full queue", logPrefix);
+        fail(
+            request,
+            String.format(
+                "The session has reached its maximum capacity "
+                    + "(requests/s: %d, queue size: %d)",
+                maxRequestsPerSecond, maxQueueSize));
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  // Runs periodically when the queue is not empty. It tries to dequeue as much as possible while
+  // staying under the target rate. If it does not completely drain the queue, it reschedules
+  // itself.
+  private void drain() {
+    assert scheduler.inEventLoop();
+    long now = clock.nanoTime();
+    lock.lock();
+    try {
+      if (closed || queue.isEmpty()) {
+        return;
+      }
+      int toDequeue = acquire(now, queue.size());
+      LOG.trace("[{}] Dequeuing {}/{} elements", logPrefix, toDequeue, queue.size());
+      for (int i = 0; i < toDequeue; i++) {
+        LOG.trace("[{}] Starting dequeued request", logPrefix);
+        queue.poll().onThrottleReady(true);
+      }
+      if (!queue.isEmpty()) {
+        LOG.trace(
+            "[{}] {} elements remaining in queue, rescheduling drain task",
+            logPrefix,
+            queue.size());
+        scheduler.schedule(this::drain, drainIntervalNanos, TimeUnit.NANOSECONDS);
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public void signalSuccess(Throttled request) {
+    // nothing to do
+  }
+
+  @Override
+  public void signalError(Throttled request, Throwable error) {
+    // nothing to do
+  }
+
+  @Override
+  public void signalTimeout(Throttled request) {
+    lock.lock();
+    try {
+      if (!closed && queue.remove(request)) { // The request timed out before it was active
+        LOG.trace("[{}] Removing timed out request from the queue", logPrefix);
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @Override
+  public void close() {
+    lock.lock();
+    try {
+      closed = true;
+      LOG.trace("[{}] Rejecting {} queued requests after shutdown", logPrefix, queue.size());
+      for (Throttled request : queue) {
+        fail(request, "The session is shutting down");
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private int acquire(long currentTimeNanos, int wantedPermits) {
+    assert lock.isHeldByCurrentThread() && !closed;
+
+    long elapsedNanos = currentTimeNanos - lastUpdateNanos;
+
+    if (elapsedNanos >= 1_000_000_000) {
+      // created more than the max, so whatever was stored, the sum will be capped to the max
+      storedPermits = maxRequestsPerSecond;
+      lastUpdateNanos = currentTimeNanos;
+    } else if (elapsedNanos > 0) {
+      int createdPermits = (int) (elapsedNanos * maxRequestsPerSecond / 1_000_000_000);
+      if (createdPermits > 0) {
+        // Only reset interval if we've generated permits, otherwise we might continually reset
+        // before we get the chance to generate anything.
+        lastUpdateNanos = currentTimeNanos;
+      }
+      storedPermits = Math.min(storedPermits + createdPermits, maxRequestsPerSecond);
+    }
+
+    int returned = (storedPermits >= wantedPermits) ? wantedPermits : storedPermits;
+    storedPermits = Math.max(storedPermits - wantedPermits, 0);
+    return returned;
+  }
+
+  public int getQueueSize() {
+    lock.lock();
+    try {
+      return queue.size();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @VisibleForTesting
+  int getStoredPermits() {
+    lock.lock();
+    try {
+      return storedPermits;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  @VisibleForTesting
+  Deque<Throttled> getQueue() {
+    lock.lock();
+    try {
+      return queue;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private static void fail(Throttled request, String message) {
+    request.onThrottleFailure(new RequestThrottlingException(message));
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/throttling/RequestThrottler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/throttling/RequestThrottler.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.session.throttling;
+
+import java.io.Closeable;
+
+/** Limits the number of concurrent requests executed by the driver. */
+public interface RequestThrottler extends Closeable {
+
+  /**
+   * Registers a new request to be throttled. The throttler will invoke {@link
+   * Throttled#onThrottleReady()} when the request is allowed to proceed.
+   */
+  void register(Throttled request);
+
+  /**
+   * Signals that a request has succeeded. This indicates to the throttler that another request
+   * might be started.
+   */
+  void signalSuccess(Throttled request);
+
+  /**
+   * Signals that a request has failed. This indicates to the throttler that another request might
+   * be started.
+   */
+  void signalError(Throttled request, Throwable error);
+
+  /**
+   * Signals that a request has timed out. This indicates to the throttler that this request has
+   * stopped (if it was running already), or that it doesn't need to be started in the future.
+   *
+   * <p>Note: requests are responsible for handling their own timeout. The throttler does not
+   * perform time-based eviction on pending requests.
+   */
+  void signalTimeout(Throttled request);
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/throttling/Throttled.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/throttling/Throttled.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.session.throttling;
+
+import com.datastax.oss.driver.api.core.RequestThrottlingException;
+
+/** A request that may be subjected to throttling by a {@link RequestThrottler}. */
+public interface Throttled {
+
+  /**
+   * Invoked by the throttler to indicate that the request can now start. The request must wait for
+   * this call until it does any "actual" work (typically, writing to a connection).
+   *
+   * @param wasDelayed indicates whether the throttler delayed at all; this is so that requests
+   *     don't have to rely on measuring time to determine it (this is useful for metrics).
+   */
+  void onThrottleReady(boolean wasDelayed);
+
+  /**
+   * Invoked by the throttler to indicate that the request cannot be fulfilled. Typically, this
+   * means we've reached maximum capacity, and the request can't even be enqueued. This error must
+   * be rethrown to the client.
+   *
+   * @param error the error that the request should be completed (exceptionally) with.
+   */
+  void onThrottleFailure(RequestThrottlingException error);
+}

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -475,6 +475,58 @@ datastax-java-driver {
       # trace id.
       consistency = ONE
     }
+
+    # A session-wide component that controls the rate at which requests are executed.
+    #
+    # Implementations vary, but throttlers generally track a metric that represents the level of
+    # utilization of the session, and prevent new requests from starting when that metric exceeds a
+    # threshold. Pending requests may be enqueued and retried later.
+    #
+    # From the public API's point of view, this process is mostly transparent: any time that the
+    # request is throttled is included in the session.execute() or session.executeAsync() call.
+    # Similarly, the request timeout encompasses throttling: the timeout starts ticking before the
+    # throttler has started processing the request; a request may time out while it is still in the
+    # throttler's queue, before the driver has even tried to send it to a node.
+    #
+    # The only visible effect is that a request may fail with a RequestThrottlingException, if the
+    # throttler has determined that it can neither allow the request to proceed now, nor enqueue it;
+    # this indicates that your session is overloaded.
+    throttler {
+      # The following implementations are provided out of the box (all located in the package
+      # com.datastax.oss.driver.internal.core.session.throttling):
+      #
+      # - PassThroughRequestThrottler: does not perform any kind of throttling, all requests are
+      #   allowed to proceed immediately. Required options: none.
+      #
+      # - ConcurrencyLimitingRequestThrottler: limits the number of requests that can be executed
+      #   in parallel. Required options: max-concurrent-requests, max-queue-size.
+      #
+      # - RateLimitingRequestThrottler: limits the request rate per second. Required options:
+      #   max-requests-per-second, max-queue-size, drain-interval.
+      class = com.datastax.oss.driver.internal.core.session.throttling.PassThroughRequestThrottler
+
+      # The maximum number of requests that can be enqueued when the throttling threshold is
+      # exceeded. Beyond that size, requests will fail with a RequestThrottlingException.
+      // max-queue-size = 10000
+
+      # The maximum number of requests that are allowed to execute in parallel.
+      # Only used by ConcurrencyLimitingRequestThrottler.
+      // max-concurrent-requests = 10000
+
+      # The maximum allowed request rate.
+      # Only used by RateLimitingRequestThrottler.
+      // max-requests-per-second = 10000
+
+      # How often the throttler attempts to dequeue requests. This is the only way for rate-based
+      # throttling, because the completion of an active request does not necessarily free a "slot"
+      # for a queued one (the rate might still be too high).
+      #
+      # You want to set this high enough that each attempt will process multiple entries in the
+      # queue, but not delay requests too much. A few milliseconds is probably a happy medium.
+      #
+      # Only used by RateLimitingRequestThrottler.
+      // drain-interval = 10 milliseconds
+    }
   }
 
   prepared-statements {
@@ -628,6 +680,23 @@ datastax-java-driver {
         # The number of CQL requests that timed out -- that is, the session.execute() call failed
         # with a DriverTimeoutException (exposed as a Counter).
         // cql-client-timeouts,
+
+        # How long requests are being throttled (exposed as a Timer).
+        #
+        # This is the time between the start of the session.execute() call, and the moment when the
+        # throttler allows the request to proceed.
+        // throttling.delay,
+
+        # The size of the throttling queue (exposed as a Gauge<Integer>).
+        #
+        # This is the number of requests that the throttler is currently delaying in order to
+        # preserve its SLA. This metric only works with the built-in concurrency- and rate-based
+        # throttlers; in other cases, it will always be 0.
+        // throttling.queue-size,
+
+        # The number of times a request was rejected with a RequestThrottlingException (exposed as a
+        # Counter)
+        // throttling.errors,
       ]
 
       # Extra configuration (for the metrics that need it)
@@ -664,6 +733,12 @@ datastax-java-driver {
         #
         # Note that this does not apply to the total count and rates (those are updated in real
         # time).
+        refresh-interval = 5 minutes
+      }
+
+      throttling.delay {
+        highest-latency = 3 seconds
+        significant-digits = 3
         refresh-interval = 5 minutes
       }
     }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/RequestHandlerTestHarness.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/RequestHandlerTestHarness.java
@@ -43,6 +43,7 @@ import com.datastax.oss.driver.internal.core.metrics.SessionMetricUpdater;
 import com.datastax.oss.driver.internal.core.pool.ChannelPool;
 import com.datastax.oss.driver.internal.core.servererrors.DefaultWriteTypeRegistry;
 import com.datastax.oss.driver.internal.core.session.DefaultSession;
+import com.datastax.oss.driver.internal.core.session.throttling.PassThroughRequestThrottler;
 import com.datastax.oss.driver.internal.core.type.codec.registry.DefaultCodecRegistry;
 import com.datastax.oss.driver.internal.core.util.concurrent.ScheduledTaskCapturingEventLoop;
 import com.datastax.oss.protocol.internal.Frame;
@@ -160,6 +161,8 @@ public class RequestHandlerTestHarness implements AutoCloseable {
         .thenReturn(new DefaultConsistencyLevelRegistry());
 
     Mockito.when(context.writeTypeRegistry()).thenReturn(new DefaultWriteTypeRegistry());
+
+    Mockito.when(context.requestThrottler()).thenReturn(new PassThroughRequestThrottler(context));
   }
 
   public DefaultSession getSession() {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUpTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUpTest.java
@@ -25,6 +25,8 @@ import com.datastax.oss.driver.internal.core.adminrequest.AdminResult;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metadata.TopologyMonitor;
+import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
+import com.datastax.oss.driver.internal.core.metrics.SessionMetricUpdater;
 import com.datastax.oss.driver.internal.core.pool.ChannelPool;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.protocol.internal.Message;
@@ -63,6 +65,8 @@ public class ReprepareOnUpTest {
   @Mock private DriverConfig config;
   @Mock private DriverConfigProfile defaultConfigProfile;
   @Mock private TopologyMonitor topologyMonitor;
+  @Mock private MetricUpdaterFactory metricUpdaterFactory;
+  @Mock private SessionMetricUpdater metricUpdater;
   private Runnable whenPrepared;
   private CompletionStage<Void> done;
 
@@ -84,6 +88,9 @@ public class ReprepareOnUpTest {
     Mockito.when(defaultConfigProfile.getInt(DefaultDriverOption.REPREPARE_MAX_PARALLELISM))
         .thenReturn(100);
     Mockito.when(context.config()).thenReturn(config);
+
+    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+    Mockito.when(metricUpdaterFactory.getSessionUpdater()).thenReturn(metricUpdater);
 
     done = new CompletableFuture<>();
     whenPrepared = () -> ((CompletableFuture<Void>) done).complete(null);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/throttling/ConcurrencyLimitingRequestThrottlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/throttling/ConcurrencyLimitingRequestThrottlerTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.session.throttling;
+
+import static com.datastax.oss.driver.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.RequestThrottlingException;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfig;
+import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.google.common.collect.Lists;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConcurrencyLimitingRequestThrottlerTest {
+
+  @Mock private DriverContext context;
+  @Mock private DriverConfig config;
+  @Mock private DriverConfigProfile defaultProfile;
+
+  private ConcurrencyLimitingRequestThrottler throttler;
+
+  @Before
+  public void setup() {
+    Mockito.when(context.config()).thenReturn(config);
+    Mockito.when(config.getDefaultProfile()).thenReturn(defaultProfile);
+
+    Mockito.when(
+            defaultProfile.getInt(DefaultDriverOption.REQUEST_THROTTLER_MAX_CONCURRENT_REQUESTS))
+        .thenReturn(5);
+    Mockito.when(defaultProfile.getInt(DefaultDriverOption.REQUEST_THROTTLER_MAX_QUEUE_SIZE))
+        .thenReturn(10);
+
+    throttler = new ConcurrencyLimitingRequestThrottler(context);
+  }
+
+  @Test
+  public void should_start_immediately_when_under_capacity() {
+    // Given
+    MockThrottled request = new MockThrottled();
+
+    // When
+    throttler.register(request);
+
+    // Then
+    assertThat(request.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
+    assertThat(throttler.getConcurrentRequests()).isEqualTo(1);
+    assertThat(throttler.getQueue()).isEmpty();
+  }
+
+  @Test
+  public void should_allow_new_request_when_active_one_succeeds() {
+    should_allow_new_request_when_active_one_completes(throttler::signalSuccess);
+  }
+
+  @Test
+  public void should_allow_new_request_when_active_one_fails() {
+    should_allow_new_request_when_active_one_completes(
+        request -> throttler.signalError(request, new RuntimeException("mock error")));
+  }
+
+  @Test
+  public void should_allow_new_request_when_active_one_times_out() {
+    should_allow_new_request_when_active_one_completes(throttler::signalTimeout);
+  }
+
+  private void should_allow_new_request_when_active_one_completes(
+      Consumer<Throttled> completeCallback) {
+    // Given
+    MockThrottled first = new MockThrottled();
+    throttler.register(first);
+    assertThat(first.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
+    for (int i = 0; i < 4; i++) { // fill to capacity
+      throttler.register(new MockThrottled());
+    }
+    assertThat(throttler.getConcurrentRequests()).isEqualTo(5);
+    assertThat(throttler.getQueue()).isEmpty();
+
+    // When
+    completeCallback.accept(first);
+    assertThat(throttler.getConcurrentRequests()).isEqualTo(4);
+    assertThat(throttler.getQueue()).isEmpty();
+    MockThrottled incoming = new MockThrottled();
+    throttler.register(incoming);
+
+    // Then
+    assertThat(incoming.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
+    assertThat(throttler.getConcurrentRequests()).isEqualTo(5);
+    assertThat(throttler.getQueue()).isEmpty();
+  }
+
+  @Test
+  public void should_enqueue_when_over_capacity() {
+    // Given
+    for (int i = 0; i < 5; i++) {
+      throttler.register(new MockThrottled());
+    }
+    assertThat(throttler.getConcurrentRequests()).isEqualTo(5);
+    assertThat(throttler.getQueue()).isEmpty();
+
+    // When
+    MockThrottled incoming = new MockThrottled();
+    throttler.register(incoming);
+
+    // Then
+    assertThat(incoming.started).isNotDone();
+    assertThat(throttler.getConcurrentRequests()).isEqualTo(5);
+    assertThat(throttler.getQueue()).containsExactly(incoming);
+  }
+
+  @Test
+  public void should_dequeue_when_active_succeeds() {
+    should_dequeue_when_active_completes(throttler::signalSuccess);
+  }
+
+  @Test
+  public void should_dequeue_when_active_fails() {
+    should_dequeue_when_active_completes(
+        request -> throttler.signalError(request, new RuntimeException("mock error")));
+  }
+
+  @Test
+  public void should_dequeue_when_active_times_out() {
+    should_dequeue_when_active_completes(throttler::signalTimeout);
+  }
+
+  private void should_dequeue_when_active_completes(Consumer<Throttled> completeCallback) {
+    // Given
+    MockThrottled first = new MockThrottled();
+    throttler.register(first);
+    assertThat(first.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
+    for (int i = 0; i < 4; i++) {
+      throttler.register(new MockThrottled());
+    }
+
+    MockThrottled incoming = new MockThrottled();
+    throttler.register(incoming);
+    assertThat(incoming.started).isNotDone();
+
+    // When
+    completeCallback.accept(first);
+
+    // Then
+    assertThat(incoming.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isTrue());
+    assertThat(throttler.getConcurrentRequests()).isEqualTo(5);
+    assertThat(throttler.getQueue()).isEmpty();
+  }
+
+  @Test
+  public void should_reject_when_queue_is_full() {
+    // Given
+    for (int i = 0; i < 15; i++) {
+      throttler.register(new MockThrottled());
+    }
+    assertThat(throttler.getConcurrentRequests()).isEqualTo(5);
+    assertThat(throttler.getQueue()).hasSize(10);
+
+    // When
+    MockThrottled incoming = new MockThrottled();
+    throttler.register(incoming);
+
+    // Then
+    assertThat(incoming.started)
+        .isFailed(error -> assertThat(error).isInstanceOf(RequestThrottlingException.class));
+  }
+
+  @Test
+  public void should_remove_timed_out_request_from_queue() {
+    // Given
+    for (int i = 0; i < 5; i++) {
+      throttler.register(new MockThrottled());
+    }
+    MockThrottled queued1 = new MockThrottled();
+    throttler.register(queued1);
+    MockThrottled queued2 = new MockThrottled();
+    throttler.register(queued2);
+
+    // When
+    throttler.signalTimeout(queued1);
+
+    // Then
+    assertThat(queued2.started).isNotDone();
+    assertThat(throttler.getConcurrentRequests()).isEqualTo(5);
+    assertThat(throttler.getQueue()).hasSize(1);
+  }
+
+  @Test
+  public void should_reject_enqueued_when_closing() {
+    // Given
+    for (int i = 0; i < 5; i++) {
+      throttler.register(new MockThrottled());
+    }
+    List<MockThrottled> enqueued = Lists.newArrayList();
+    for (int i = 0; i < 10; i++) {
+      MockThrottled request = new MockThrottled();
+      throttler.register(request);
+      assertThat(request.started).isNotDone();
+      enqueued.add(request);
+    }
+
+    // When
+    throttler.close();
+
+    // Then
+    for (MockThrottled request : enqueued) {
+      assertThat(request.started)
+          .isFailed(error -> assertThat(error).isInstanceOf(RequestThrottlingException.class));
+    }
+
+    // When
+    MockThrottled request = new MockThrottled();
+    throttler.register(request);
+
+    // Then
+    assertThat(request.started)
+        .isFailed(error -> assertThat(error).isInstanceOf(RequestThrottlingException.class));
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/throttling/MockThrottled.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/throttling/MockThrottled.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.session.throttling;
+
+import com.datastax.oss.driver.api.core.RequestThrottlingException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+class MockThrottled implements Throttled {
+
+  final CompletionStage<Boolean> started = new CompletableFuture<>();
+
+  @Override
+  public void onThrottleReady(boolean wasDelayed) {
+    started.toCompletableFuture().complete(wasDelayed);
+  }
+
+  @Override
+  public void onThrottleFailure(RequestThrottlingException error) {
+    started.toCompletableFuture().completeExceptionally(error);
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/throttling/RateLimitingRequestThrottlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/throttling/RateLimitingRequestThrottlerTest.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.session.throttling;
+
+import static com.datastax.oss.driver.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.RequestThrottlingException;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfig;
+import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.context.NettyOptions;
+import com.datastax.oss.driver.internal.core.util.concurrent.ScheduledTaskCapturingEventLoop;
+import com.google.common.collect.Lists;
+import io.netty.channel.EventLoopGroup;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class RateLimitingRequestThrottlerTest {
+
+  private static final long ONE_HUNDRED_MILLISECONDS =
+      TimeUnit.NANOSECONDS.convert(100, TimeUnit.MILLISECONDS);
+  private static final long TWO_HUNDRED_MILLISECONDS =
+      TimeUnit.NANOSECONDS.convert(200, TimeUnit.MILLISECONDS);
+  private static final long TWO_SECONDS = TimeUnit.NANOSECONDS.convert(2, TimeUnit.SECONDS);
+
+  // Note: we trigger scheduled task manually, so this is for verification purposes only, it doesn't
+  // need to be consistent with the actual throttling rate.
+  private static final Duration DRAIN_INTERVAL = Duration.ofMillis(10);
+
+  @Mock private InternalDriverContext context;
+  @Mock private DriverConfig config;
+  @Mock private DriverConfigProfile defaultProfile;
+  @Mock private NettyOptions nettyOptions;
+  @Mock private EventLoopGroup adminGroup;
+
+  private ScheduledTaskCapturingEventLoop adminExecutor;
+  private SettableNanoClock clock = new SettableNanoClock();
+
+  private RateLimitingRequestThrottler throttler;
+
+  @Before
+  public void setup() {
+    Mockito.when(context.config()).thenReturn(config);
+    Mockito.when(config.getDefaultProfile()).thenReturn(defaultProfile);
+
+    Mockito.when(
+            defaultProfile.getInt(DefaultDriverOption.REQUEST_THROTTLER_MAX_REQUESTS_PER_SECOND))
+        .thenReturn(5);
+    Mockito.when(defaultProfile.getInt(DefaultDriverOption.REQUEST_THROTTLER_MAX_QUEUE_SIZE))
+        .thenReturn(10);
+
+    // Set to match the time to reissue one permit. Although it does not matter in practice, since
+    // the executor is mocked and we trigger tasks manually.
+    Mockito.when(defaultProfile.getDuration(DefaultDriverOption.REQUEST_THROTTLER_DRAIN_INTERVAL))
+        .thenReturn(DRAIN_INTERVAL);
+
+    Mockito.when(context.nettyOptions()).thenReturn(nettyOptions);
+    Mockito.when(nettyOptions.adminEventExecutorGroup()).thenReturn(adminGroup);
+    adminExecutor = new ScheduledTaskCapturingEventLoop(adminGroup);
+    Mockito.when(adminGroup.next()).thenReturn(adminExecutor);
+
+    throttler = new RateLimitingRequestThrottler(context, clock);
+  }
+
+  /** Note: the throttler starts with 1 second worth of permits, so at t=0 we have 5 available. */
+  @Test
+  public void should_start_immediately_when_under_capacity() {
+    // Given
+    MockThrottled request = new MockThrottled();
+
+    // When
+    throttler.register(request);
+
+    // Then
+    assertThat(request.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
+    assertThat(throttler.getStoredPermits()).isEqualTo(4);
+    assertThat(throttler.getQueue()).isEmpty();
+  }
+
+  @Test
+  public void should_allow_new_request_when_under_rate() {
+    // Given
+    for (int i = 0; i < 5; i++) {
+      throttler.register(new MockThrottled());
+    }
+    assertThat(throttler.getStoredPermits()).isEqualTo(0);
+
+    // When
+    clock.add(TWO_HUNDRED_MILLISECONDS);
+    MockThrottled request = new MockThrottled();
+    throttler.register(request);
+
+    // Then
+    assertThat(request.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
+    assertThat(throttler.getStoredPermits()).isEqualTo(0);
+    assertThat(throttler.getQueue()).isEmpty();
+  }
+
+  @Test
+  public void should_enqueue_when_over_rate() {
+    // Given
+    for (int i = 0; i < 5; i++) {
+      throttler.register(new MockThrottled());
+    }
+    assertThat(throttler.getStoredPermits()).isEqualTo(0);
+
+    // When
+    // (do not advance time)
+    MockThrottled request = new MockThrottled();
+    throttler.register(request);
+
+    // Then
+    assertThat(request.started).isNotDone();
+    assertThat(throttler.getStoredPermits()).isEqualTo(0);
+    assertThat(throttler.getQueue()).containsExactly(request);
+
+    ScheduledTaskCapturingEventLoop.CapturedTask<?> task = adminExecutor.nextTask();
+    assertThat(task).isNotNull();
+    assertThat(task.getInitialDelay(TimeUnit.NANOSECONDS)).isEqualTo(DRAIN_INTERVAL.toNanos());
+  }
+
+  @Test
+  public void should_reject_when_queue_is_full() {
+    // Given
+    for (int i = 0; i < 15; i++) {
+      throttler.register(new MockThrottled());
+    }
+    assertThat(throttler.getStoredPermits()).isEqualTo(0);
+    assertThat(throttler.getQueue()).hasSize(10);
+
+    // When
+    clock.add(TWO_HUNDRED_MILLISECONDS); // even if time has passed, queued items have priority
+    MockThrottled request = new MockThrottled();
+    throttler.register(request);
+
+    // Then
+    assertThat(request.started)
+        .isFailed(error -> assertThat(error).isInstanceOf(RequestThrottlingException.class));
+  }
+
+  @Test
+  public void should_remove_timed_out_request_from_queue() {
+    // Given
+    for (int i = 0; i < 5; i++) {
+      throttler.register(new MockThrottled());
+    }
+    MockThrottled queued1 = new MockThrottled();
+    throttler.register(queued1);
+    MockThrottled queued2 = new MockThrottled();
+    throttler.register(queued2);
+
+    // When
+    throttler.signalTimeout(queued1);
+
+    // Then
+    assertThat(queued2.started).isNotDone();
+    assertThat(throttler.getStoredPermits()).isEqualTo(0);
+    assertThat(throttler.getQueue()).containsExactly(queued2);
+  }
+
+  @Test
+  public void should_dequeue_when_draining_task_runs() {
+    // Given
+    for (int i = 0; i < 5; i++) {
+      throttler.register(new MockThrottled());
+    }
+
+    MockThrottled queued1 = new MockThrottled();
+    throttler.register(queued1);
+    assertThat(queued1.started).isNotDone();
+    MockThrottled queued2 = new MockThrottled();
+    throttler.register(queued2);
+    assertThat(queued2.started).isNotDone();
+    assertThat(throttler.getStoredPermits()).isEqualTo(0);
+    assertThat(throttler.getQueue()).hasSize(2);
+
+    ScheduledTaskCapturingEventLoop.CapturedTask<?> task = adminExecutor.nextTask();
+    assertThat(task).isNotNull();
+    assertThat(task.getInitialDelay(TimeUnit.NANOSECONDS)).isEqualTo(DRAIN_INTERVAL.toNanos());
+
+    // When
+    // (do not advance clock => no new permits)
+    task.run();
+
+    // Then
+    assertThat(throttler.getStoredPermits()).isEqualTo(0);
+    assertThat(throttler.getQueue()).containsExactly(queued1, queued2);
+    // task reschedules itself since it did not empty the queue
+    task = adminExecutor.nextTask();
+    assertThat(task).isNotNull();
+    assertThat(task.getInitialDelay(TimeUnit.NANOSECONDS)).isEqualTo(DRAIN_INTERVAL.toNanos());
+
+    // When
+    clock.add(TWO_HUNDRED_MILLISECONDS); // 1 extra permit issued
+    task.run();
+
+    // Then
+    assertThat(queued1.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isTrue());
+    assertThat(queued2.started).isNotDone();
+    assertThat(throttler.getStoredPermits()).isEqualTo(0);
+    assertThat(throttler.getQueue()).containsExactly(queued2);
+    // task reschedules itself since it did not empty the queue
+    task = adminExecutor.nextTask();
+    assertThat(task).isNotNull();
+    assertThat(task.getInitialDelay(TimeUnit.NANOSECONDS)).isEqualTo(DRAIN_INTERVAL.toNanos());
+
+    // When
+    clock.add(TWO_HUNDRED_MILLISECONDS);
+    task.run();
+
+    // Then
+    assertThat(queued2.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isTrue());
+    assertThat(throttler.getStoredPermits()).isEqualTo(0);
+    assertThat(throttler.getQueue()).isEmpty();
+    assertThat(adminExecutor.nextTask()).isNull();
+  }
+
+  @Test
+  public void should_store_new_permits_up_to_threshold() {
+    // Given
+    for (int i = 0; i < 5; i++) {
+      throttler.register(new MockThrottled());
+    }
+    assertThat(throttler.getStoredPermits()).isEqualTo(0);
+
+    // When
+    clock.add(TWO_SECONDS); // should store at most 1 second worth of permits
+
+    // Then
+    // acquire to trigger the throttler to update its permits
+    throttler.register(new MockThrottled());
+    assertThat(throttler.getStoredPermits()).isEqualTo(4);
+  }
+
+  /**
+   * Ensure that permits are still created if we try to acquire faster than the minimal interval to
+   * create one permit. In an early version of the code there was a bug where we would reset the
+   * elapsed time on each acquisition attempt, and never regenerate permits.
+   */
+  @Test
+  public void should_keep_accumulating_time_if_no_permits_created() {
+    // Given
+    for (int i = 0; i < 5; i++) {
+      throttler.register(new MockThrottled());
+    }
+    assertThat(throttler.getStoredPermits()).isEqualTo(0);
+
+    // When
+    clock.add(ONE_HUNDRED_MILLISECONDS);
+
+    // Then
+    MockThrottled queued = new MockThrottled();
+    throttler.register(queued);
+    assertThat(queued.started).isNotDone();
+
+    // When
+    clock.add(ONE_HUNDRED_MILLISECONDS);
+    adminExecutor.nextTask().run();
+
+    // Then
+    assertThat(queued.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isTrue());
+  }
+
+  @Test
+  public void should_reject_enqueued_when_closing() {
+    // Given
+    for (int i = 0; i < 5; i++) {
+      throttler.register(new MockThrottled());
+    }
+    List<MockThrottled> enqueued = Lists.newArrayList();
+    for (int i = 0; i < 10; i++) {
+      MockThrottled request = new MockThrottled();
+      throttler.register(request);
+      assertThat(request.started).isNotDone();
+      enqueued.add(request);
+    }
+
+    // When
+    throttler.close();
+
+    // Then
+    for (MockThrottled request : enqueued) {
+      assertThat(request.started)
+          .isFailed(error -> assertThat(error).isInstanceOf(RequestThrottlingException.class));
+    }
+
+    // When
+    MockThrottled request = new MockThrottled();
+    throttler.register(request);
+
+    // Then
+    assertThat(request.started)
+        .isFailed(error -> assertThat(error).isInstanceOf(RequestThrottlingException.class));
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/throttling/SettableNanoClock.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/throttling/SettableNanoClock.java
@@ -13,14 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datastax.oss.driver.internal.core.metrics;
+package com.datastax.oss.driver.internal.core.session.throttling;
 
-import com.datastax.oss.driver.api.core.metadata.Node;
+class SettableNanoClock implements NanoClock {
 
-public interface MetricUpdaterFactory {
+  private volatile long nanoTime;
 
-  /** @return the unique instance for this session (this must return the same object every time). */
-  SessionMetricUpdater getSessionUpdater();
+  @Override
+  public long nanoTime() {
+    return nanoTime;
+  }
 
-  NodeMetricUpdater newNodeUpdater(Node node);
+  // This is racy, but in our tests it's never read concurrently
+  @SuppressWarnings("NonAtomicVolatileUpdate")
+  void add(long increment) {
+    nanoTime += increment;
+  }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/throttling/ThrottlingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/throttling/ThrottlingIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.throttling;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.RequestThrottlingException;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.internal.core.session.throttling.ConcurrencyLimitingRequestThrottler;
+import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+import com.datastax.oss.simulacron.common.stubbing.PrimeDsl;
+import java.util.concurrent.TimeUnit;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ThrottlingIT {
+
+  private static final String QUERY = "select * from foo";
+
+  @Rule public SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(1));
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void should_reject_request_when_throttling_by_concurrency() {
+
+    // Add a delay so that requests don't complete during the test
+    simulacron
+        .cluster()
+        .prime(PrimeDsl.when(QUERY).then(PrimeDsl.noRows()).delay(5, TimeUnit.SECONDS));
+
+    int maxConcurrentRequests = 10;
+    int maxQueueSize = 10;
+
+    try (CqlSession session =
+        SessionUtils.newSession(
+            simulacron,
+            "request.throttler.class = " + ConcurrencyLimitingRequestThrottler.class.getName(),
+            "request.throttler.max-concurrent-requests = " + maxConcurrentRequests,
+            "request.throttler.max-queue-size = " + maxQueueSize)) {
+
+      // Saturate the session and fill the queue
+      for (int i = 0; i < maxConcurrentRequests + maxQueueSize; i++) {
+        session.executeAsync(QUERY);
+      }
+
+      // The next query should be rejected
+      thrown.expect(RequestThrottlingException.class);
+      thrown.expectMessage(
+          "The session has reached its maximum capacity "
+              + "(concurrent requests: 10, queue size: 10)");
+
+      session.execute(QUERY);
+    }
+  }
+}

--- a/manual/core/throttling/README.md
+++ b/manual/core/throttling/README.md
@@ -1,0 +1,143 @@
+## Request throttling
+
+Throttling allows you to limit how many requests a session can execute concurrently. This is
+useful if you have multiple applications connecting to the same Cassandra cluster, and want to
+enforce some kind of SLA to ensure fair resource allocation.
+
+The request throttler tracks the level of utilization of the session, and lets requests proceed as
+long as it is under a predefined threshold. When that threshold is exceeded, requests are enqueued
+and will be allowed to proceed when utilization goes back to normal.
+
+From a user's perspective, this process is mostly transparent: any time spent in the queue is
+included in the `session.execute()` or `session.executeAsync()` call. Similarly, the request timeout
+encompasses throttling: it starts ticking before the request is passed to the throttler; in other
+words, a request may time out while it is still in the throttler's queue, before the driver has even
+tried to send it to a node.
+
+The only visible effect is that a request may fail with a [RequestThrottlingException], if the
+throttler has determined that it can neither allow the request to proceed now, nor enqueue it;
+this indicates that your session is overloaded. How you react to that is specific to your
+application; typically, you could display an error asking the end user to retry later.
+
+Note that the following requests are also affected by throttling:
+
+* preparing a statement (either directly, or indirectly when the driver reprepares on other nodes,
+  or when a node comes back up -- see
+  [how the driver prepares](../statements/prepared/#how-the-driver-prepares));
+* fetching the next page of a result set (which happens in the background when you iterate the
+  synchronous variant `ResultSet`).
+* fetching a [query trace](../tracing/).
+
+### Configuration
+
+Request throttling is parameterized in the [configuration](../configuration/) under
+`request.throttler`. There are various implementations, detailed in the following sections:
+
+#### Pass through
+
+```
+datastax-java-driver {
+  request.throttler {
+    class = com.datastax.oss.driver.internal.core.session.throttling.PassThroughRequestThrottler
+  }
+}
+```
+
+This is a no-op implementation: requests are simply allowed to proceed all the time, never enqueued.
+
+Note that you will still hit a limit if all your connections run out of stream ids. In that case,
+requests will fail with an [AllNodesFailedException], with the `getErrors()` method returning a
+[BusyConnectionException] for each node.
+
+<!-- TODO link to the "pooling" section (when that gets added) -->
+
+#### Concurrency-based
+
+```
+datastax-java-driver {
+  request.throttler {
+    class = com.datastax.oss.driver.internal.core.session.throttling.ConcurrencyLimitingRequestThrottler
+    
+    # Note: the values below are for illustration purposes only, not prescriptive
+    max-concurrent-requests = 10000
+    max-queue-size = 100000
+  }
+}
+```
+
+This implementation limits the number of requests that are allowed to execute simultaneously.
+Additional requests get enqueued up to the configured limit. Every time an active request completes
+(either by succeeding, failing or timing out), the oldest enqueued request is allowed to proceed.
+
+Make sure you pick a threshold that is consistent with your pooling settings; the driver should
+never run out of stream ids before reaching the maximum concurrency, otherwise requests will fail
+with [BusyConnectionException] instead of being throttled. The total number of stream ids is a
+function of the number of connected nodes and the `connection.pool.*.size` and
+`connection.max-requests-per-connection` configuration options. Keep in mind that aggressive
+speculative executions and timeout options can inflate stream id consumption, so keep a safety
+margin. One good way to get this right is to track the `pool.available-streams` [metric](../metrics)
+on every node, and make sure it never reaches 0.
+
+<!-- TODO link to the "pooling" section (when that gets added) -->
+
+#### Rate-based
+
+```
+datastax-java-driver {
+  request.throttler {
+    class = com.datastax.oss.driver.internal.core.session.throttling.RateLimitingRequestThrottler
+    
+    # Note: the values below are for illustration purposes only, not prescriptive
+    max-requests-per-second = 5000
+    max-queue-size = 50000
+    drain-interval = 1 millisecond
+  }
+}
+```
+
+This implementation tracks the rate at which requests start, and enqueues when it exceeds the
+configured threshold.
+
+With this approach, we can't dequeue when requests complete, because having less active requests
+does not necessarily mean that the rate is back to normal. So instead the throttler re-checks the
+rate periodically and dequeues when possible, this is controlled by the `drain-interval` option.
+Picking the right interval is a matter of balance: too low might consume too many resources and only
+dequeue a few requests at a time, but too high will delay your requests too much; start with a few
+milliseconds and use the `cql-requests` [metric](../metrics/) to check the impact on your latencies.
+
+Like with the concurrency-based throttler, you should make sure that your target rate is in line
+with the pooling options; see the recommendations in the previous section.
+
+### Monitoring
+
+Enable the following [metrics](../metrics/) to monitor how the throttler is performing:
+
+```
+datastax-java-driver {
+  metrics.session.enabled = [
+    # How long requests are being throttled (exposed as a Timer).
+    #
+    # This is the time between the start of the session.execute() call, and the moment when the
+    # throttler allows the request to proceed.
+    throttling.delay,
+    
+    # The size of the throttling queue (exposed as a Gauge<Integer>).
+    #
+    # This is the number of requests that the throttler is currently delaying in order to
+    # preserve its SLA. This metric only works with the built-in concurrency- and rate-based
+    # throttlers; in other cases, it will always be 0.
+    throttling.queue-size,
+    
+    # The number of times a request was rejected with a RequestThrottlingException (exposed as a
+    # Counter)
+    throttling.errors,
+  ]
+}
+```
+
+If you enable `throttling.delay`, make sure to also check the associated extra options to correctly
+size the underlying histograms (`metrics.session.throttling.delay.*`).
+
+[RequestThrottlingException]: http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/core/RequestThrottlingException.html
+[AllNodesFailedException]:    http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/core/AllNodesFailedException.html
+[BusyConnectionException]:    http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/core/connection/BusyConnectionException.html


### PR DESCRIPTION
Entry points: `RequestThrottler` interface and `request.throttler` in the config.
General design goals: requests register themselves with the throttler, and wait for its signal to start. This is so that various request types (including custom ones) can be all throttled together (since we don't know in advance what the result types are, it would have been complicated to do something generic in `Session.execute`).

TODO:
- [x] more tests
- [x] manual (make sure to explain that throttling is included in client timeout)
- ~~4th implementation that only starts enqueuing when we get `BusyConnectionException` on all nodes (maximizing stream id usage in a way)~~