### PR TITLE
JAVA-1772: Revisit multi-response callbacks

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha4 (in progress)
 
+- [improvement] JAVA-1772: Revisit multi-response callbacks
 - [new feature] JAVA-1537: Add remaining socket options
 - [bug] JAVA-1756: Propagate custom payload when preparing a statement
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
@@ -88,16 +88,6 @@ public class DriverChannel {
   }
 
   /**
-   * Releases a stream id if the client was holding onto it, and has now determined that it can be
-   * safely reused.
-   *
-   * @see ResponseCallback#holdStreamId()
-   */
-  public void release(int streamId) {
-    channel.pipeline().fireUserEventTriggered(new ReleaseEvent(streamId));
-  }
-
-  /**
    * Switches the underlying Cassandra connection to a new keyspace (as if a {@code USE ...}
    * statement was issued).
    *
@@ -241,14 +231,6 @@ public class DriverChannel {
       this.tracing = tracing;
       this.customPayload = customPayload;
       this.responseCallback = responseCallback;
-    }
-  }
-
-  static class ReleaseEvent {
-    final int streamId;
-
-    ReleaseEvent(int streamId) {
-      this.streamId = streamId;
     }
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryAvailableIdsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryAvailableIdsTest.java
@@ -47,6 +47,8 @@ public class ChannelFactoryAvailableIdsTest extends ChannelFactoryTestBase {
 
     Mockito.when(defaultConfigProfile.getInt(DefaultDriverOption.CONNECTION_MAX_REQUESTS))
         .thenReturn(128);
+
+    Mockito.when(responseCallback.isLastResponse(any(Frame.class))).thenReturn(true);
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/MockResponseCallback.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/MockResponseCallback.java
@@ -18,19 +18,20 @@ package com.datastax.oss.driver.internal.core.channel;
 import com.datastax.oss.protocol.internal.Frame;
 import java.util.ArrayDeque;
 import java.util.Queue;
+import java.util.function.Predicate;
 
 class MockResponseCallback implements ResponseCallback {
-  private final boolean holdStreamId;
   private final Queue<Object> responses = new ArrayDeque<>();
+  private final Predicate<Frame> isLastResponse;
 
   volatile int streamId = -1;
 
   MockResponseCallback() {
-    this(false);
+    this(f -> true);
   }
 
-  MockResponseCallback(boolean holdStreamId) {
-    this.holdStreamId = holdStreamId;
+  MockResponseCallback(Predicate<Frame> isLastResponse) {
+    this.isLastResponse = isLastResponse;
   }
 
   @Override
@@ -44,8 +45,8 @@ class MockResponseCallback implements ResponseCallback {
   }
 
   @Override
-  public boolean holdStreamId() {
-    return holdStreamId;
+  public boolean isLastResponse(Frame responseFrame) {
+    return isLastResponse.test(responseFrame);
   }
 
   @Override


### PR DESCRIPTION
Motivation:

In the previous version, multi-response ResponseCallback implementations
had to explicitly indicate when to release the stream id. It's simpler
to do it directly in InFlightHandler, provided that we have a simple way
to test when a Frame is the last that the server will send (and we
should ensure that this is always the case for future multi-response
requests).

Modifications:

Replace ResponseCallback.holdStreamId() by isLastResponse(Frame).
Remove DriverChannel.release(int).
Keep track of orphaned ResponseCallbacks in InFlightHandler, and release
them (and the stream id) when their last response is received.

Result:

ResponseCallbacks now only need to indicate how to identify the last
frame, InFlightHandler handles the rest.
Cancelled multi-response callbacks will be properly released.