### PR TITLE
JAVA-1769: Allocate exact buffer size for outgoing requests

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha4 (in progress)
 
+- [improvement] JAVA-1769: Allocate exact buffer size for outgoing requests
 - [documentation] JAVA-1780: Add manual section about case sensitivity
 - [new feature] JAVA-1536: Add request throttling
 - [improvement] JAVA-1772: Revisit multi-response callbacks

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/ByteBufPrimitiveCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/ByteBufPrimitiveCodec.java
@@ -35,7 +35,7 @@ public class ByteBufPrimitiveCodec implements PrimitiveCodec<ByteBuf> {
 
   @Override
   public ByteBuf allocate(int size) {
-    return allocator.ioBuffer();
+    return allocator.ioBuffer(size, size);
   }
 
   @Override

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/protocol/ByteBufPrimitiveCodecTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/protocol/ByteBufPrimitiveCodecTest.java
@@ -240,7 +240,7 @@ public class ByteBufPrimitiveCodecTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage(
         "Not enough bytes to read an UTF-8 serialized string of size 4");
-    ByteBuf source = codec.allocate(2);
+    ByteBuf source = codec.allocate(4);
     source.writeInt(4);
 
     codec.readLongString(source);


### PR DESCRIPTION
I re-ran the whole integration suite, and the native-protocol unit tests already cover message sizes.