### PR TITLE
fix example to match `TypeCodec`s documentation

### DIFF
--- a/manual/custom_codecs/README.md
+++ b/manual/custom_codecs/README.md
@@ -296,12 +296,12 @@ public class AddressCodec extends TypeCodec<Address> {
 
     @Override
     public Address parse(String value) throws InvalidTypeException {
-        return value == null || value.isEmpty() || value.equals(NULL) ? null : toAddress(innerCodec.parse(value));
+        return value == null || value.isEmpty() || value.equalsIgnoreCase("NULL") ? null : toAddress(innerCodec.parse(value));
     }
 
     @Override
     public String format(Address value) throws InvalidTypeException {
-        return value == null ? null : innerCodec.format(toUDTValue(value));
+        return value == null ? "NULL" : innerCodec.format(toUDTValue(value));
     }
 
     protected Address toAddress(UDTValue value) {

--- a/manual/custom_codecs/README.md
+++ b/manual/custom_codecs/README.md
@@ -296,7 +296,8 @@ public class AddressCodec extends TypeCodec<Address> {
 
     @Override
     public Address parse(String value) throws InvalidTypeException {
-        return value == null || value.isEmpty() || value.equalsIgnoreCase("NULL") ? null : toAddress(innerCodec.parse(value));
+        return value == null || value.isEmpty() || value.equalsIgnoreCase("NULL") ? 
+            null : toAddress(innerCodec.parse(value));
     }
 
     @Override


### PR DESCRIPTION
- for `parse`:  Null values and empty Strings should be accepted, as well as the string
  `NULL`; in most cases, implementations should interpret these inputs has equivalent to
  a null reference.
- for `format`: Null values should be accepted; in most cases, implementations should
  return the CQL keyword `NULL` for null inputs.