### PR TITLE
JAVA-1789: Account for flags in Prepare encodedSize

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -16,6 +16,7 @@
 - [new feature] JAVA-708: Add means to measure request sizes.
 - [documentation] JAVA-1788: Add example for enabling host name verification to SSL docs.
 - [improvement] JAVA-1791: Revert "JAVA-1677: Warn if auth is configured on the client but not the server."
+- [bug] JAVA-1789: Account for flags in Prepare encodedSize.
 
 
 ### 3.4.0

--- a/driver-core/src/main/java/com/datastax/driver/core/Message.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Message.java
@@ -343,7 +343,7 @@ abstract class Message {
 
             coder.encode(request, body, protocolVersion);
             if (body.capacity() != messageSize) {
-                logger.warn("Detected buffer resizing while encoding {} message ({} => {}), " +
+                logger.debug("Detected buffer resizing while encoding {} message ({} => {}), " +
                                 "this is a driver bug " +
                                 "(ultimately it does not affect the query, but leads to a small inefficiency)",
                         request.type, messageSize, body.capacity());

--- a/driver-core/src/main/java/com/datastax/driver/core/Requests.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Requests.java
@@ -591,7 +591,12 @@ class Requests {
 
             @Override
             public int encodedSize(Prepare msg, ProtocolVersion version) {
-                return CBUtil.sizeOfLongString(msg.query);
+                int size = CBUtil.sizeOfLongString(msg.query);
+
+                if (version.compareTo(ProtocolVersion.V5) >= 0) {
+                    size += 4; //flags
+                }
+                return size;
             }
         };
 


### PR DESCRIPTION
For [JAVA-1789](https://datastax-oss.atlassian.net/browse/JAVA-1789)