### PR TITLE
JAVA-1759: Revisit metrics API

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha4 (in progress)
 
+- [improvement] JAVA-1759: Revisit metrics API
 - [improvement] JAVA-1776: Use concurrency annotations
 - [improvement] JAVA-1799: Use CqlIdentifier for simple statement named values
 - [new feature] JAVA-1515: Add query builder

--- a/core/src/main/java/com/datastax/oss/driver/api/core/context/DriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/context/DriverContext.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.oss.driver.api.core.context;
 
-import com.codahale.metrics.MetricRegistry;
 import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
 import com.datastax.oss.driver.api.core.auth.AuthProvider;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
@@ -57,6 +56,4 @@ public interface DriverContext extends AttachmentPoint {
   Optional<SslEngineFactory> sslEngineFactory();
 
   TimestampGenerator timestampGenerator();
-
-  MetricRegistry metricRegistry();
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metrics/Metrics.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metrics/Metrics.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.metrics;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.datastax.oss.driver.api.core.metadata.Node;
+
+/**
+ * A wrapper around a {@link MetricRegistry} to expose the driver's metrics.
+ *
+ * <p>This type exists mainly to avoid a hard dependency to Dropwizard Metrics (that is, the JAR can
+ * be completely removed from the classpath if metrics are disabled). It also provides convenience
+ * methods to access individual metrics programatically.
+ */
+public interface Metrics {
+
+  /**
+   * Returns the underlying Dropwizard registry.
+   *
+   * <p>Typically, this can be used to configure a reporter.
+   *
+   * @see <a href="http://metrics.dropwizard.io/4.0.0/manual/core.html#reporters">Reporters
+   *     (Dropwizard Metrics manual)</a>
+   */
+  MetricRegistry getRegistry();
+
+  /**
+   * Retrieves a session-level metric from the registry.
+   *
+   * <p>To determine the type of each metric, refer to the comments in the default {@code
+   * reference.conf} (included in the driver's codebase and JAR file). Note that the method does not
+   * check that this type is correct (there is no way to do this at runtime because some metrics are
+   * generic); if you use the wrong type, you will get a {@code ClassCastException} in your code:
+   *
+   * <pre>{@code
+   * // Correct:
+   * Gauge<Integer> connectedNodes = getNodeMetric(node, DefaultSessionMetric.CONNECTED_NODES);
+   *
+   * // Wrong, will throw CCE:
+   * Counter connectedNodes = getNodeMetric(node, DefaultSessionMetric.CONNECTED_NODES);
+   * }</pre>
+   *
+   * @return the metric, or {@code null} if it is disabled.
+   */
+  @SuppressWarnings("TypeParameterUnusedInFormals")
+  <T extends Metric> T getSessionMetric(SessionMetric metric);
+
+  /**
+   * Retrieves a node-level metric for a given node from the registry.
+   *
+   * <p>To determine the type of each metric, refer to the comments in the default {@code
+   * reference.conf} (included in the driver's codebase and JAR file). Note that the method does not
+   * check that this type is correct (there is no way to do this at runtime because some metrics are
+   * generic); if you use the wrong type, you will get a {@code ClassCastException} in your code:
+   *
+   * <pre>{@code
+   * // Correct:
+   * Gauge<Integer> openConnections = getNodeMetric(node, DefaultNodeMetric.OPEN_CONNECTIONS);
+   *
+   * // Wrong, will throw CCE:
+   * Counter openConnections = getNodeMetric(node, DefaultNodeMetric.OPEN_CONNECTIONS);
+   * }</pre>
+   *
+   * @return the metric, or {@code null} if it is disabled.
+   */
+  @SuppressWarnings("TypeParameterUnusedInFormals")
+  <T extends Metric> T getNodeMetric(Node node, NodeMetric metric);
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metrics/SessionMetric.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metrics/SessionMetric.java
@@ -18,15 +18,7 @@ package com.datastax.oss.driver.api.core.metrics;
 import com.datastax.oss.driver.api.core.session.Session;
 
 /**
- * A session-level metric exposed through {@link Session#getMetricRegistry()}.
- *
- * <p>Note that the actual key in the registry is composed of the {@link Session#getName() name of
- * the session} followed by the path of the metric, for example:
- *
- * <pre>
- * // Retrieve the `cql_requests` metric for session `s0`:
- * Timer requestsTimer = session.getMetricRegistry().timer("s0.cql_requests");
- * </pre>
+ * A session-level metric exposed through {@link Session#getMetrics()}.
  *
  * <p>All metrics exposed out of the box by the driver are instances of {@link DefaultSessionMetric}
  * (this interface only exists to allow custom metrics in driver extensions).

--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/Session.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/Session.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.oss.driver.api.core.session;
 
-import com.codahale.metrics.MetricRegistry;
 import com.datastax.oss.driver.api.core.AsyncAutoCloseable;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -27,9 +26,11 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
 import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
+import com.datastax.oss.driver.api.core.metrics.Metrics;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import com.datastax.oss.driver.internal.core.util.concurrent.BlockingOperation;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
+import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.concurrent.CompletionStage;
 
@@ -180,15 +181,10 @@ public interface Session extends AsyncAutoCloseable {
   CqlIdentifier getKeyspace();
 
   /**
-   * The registry of driver metrics.
-   *
-   * <p>The driver is instrumented with DropWizard metrics, use this object to register metric
-   * reporters.
-   *
-   * @see <a href="http://metrics.dropwizard.io/4.0.0/manual/core.html#reporters">Reporters
-   *     (DropWizard Metrics manual)</a>
+   * Returns a gateway to the driver's metrics, or {@link Optional#empty()} if all metrics are
+   * disabled.
    */
-  MetricRegistry getMetricRegistry();
+  Optional<? extends Metrics> getMetrics();
 
   /**
    * Executes an arbitrary request.

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.oss.driver.internal.core.context;
 
-import com.codahale.metrics.MetricRegistry;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
 import com.datastax.oss.driver.api.core.auth.AuthProvider;
@@ -51,8 +50,8 @@ import com.datastax.oss.driver.internal.core.metadata.token.DefaultReplicationSt
 import com.datastax.oss.driver.internal.core.metadata.token.DefaultTokenFactoryRegistry;
 import com.datastax.oss.driver.internal.core.metadata.token.ReplicationStrategyFactory;
 import com.datastax.oss.driver.internal.core.metadata.token.TokenFactoryRegistry;
-import com.datastax.oss.driver.internal.core.metrics.DefaultMetricUpdaterFactory;
-import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
+import com.datastax.oss.driver.internal.core.metrics.DropwizardMetricsFactory;
+import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.internal.core.pool.ChannelPoolFactory;
 import com.datastax.oss.driver.internal.core.protocol.ByteBufPrimitiveCodec;
 import com.datastax.oss.driver.internal.core.servererrors.DefaultWriteTypeRegistry;
@@ -162,10 +161,8 @@ public class DefaultDriverContext implements InternalDriverContext {
           "replicationStrategyFactory", this::buildReplicationStrategyFactory, cycleDetector);
   private final LazyReference<PoolManager> poolManagerRef =
       new LazyReference<>("poolManager", this::buildPoolManager, cycleDetector);
-  private final LazyReference<MetricRegistry> metricRegistryRef =
-      new LazyReference<>("metricRegistry", this::buildMetricRegistry, cycleDetector);
-  private final LazyReference<MetricUpdaterFactory> metricUpdaterFactoryRef =
-      new LazyReference<>("metricUpdaterFactory", this::buildMetricUpdaterFactory, cycleDetector);
+  private final LazyReference<MetricsFactory> metricsFactoryRef =
+      new LazyReference<>("metricsFactory", this::buildMetricsFactory, cycleDetector);
   private final LazyReference<RequestThrottler> requestThrottlerRef =
       new LazyReference<>("requestThrottler", this::buildRequestThrottler, cycleDetector);
 
@@ -366,12 +363,8 @@ public class DefaultDriverContext implements InternalDriverContext {
     return new PoolManager(this);
   }
 
-  protected MetricRegistry buildMetricRegistry() {
-    return new MetricRegistry();
-  }
-
-  protected MetricUpdaterFactory buildMetricUpdaterFactory() {
-    return new DefaultMetricUpdaterFactory(this);
+  protected MetricsFactory buildMetricsFactory() {
+    return new DropwizardMetricsFactory(this);
   }
 
   protected RequestThrottler buildRequestThrottler() {
@@ -546,13 +539,8 @@ public class DefaultDriverContext implements InternalDriverContext {
   }
 
   @Override
-  public MetricRegistry metricRegistry() {
-    return metricRegistryRef.get();
-  }
-
-  @Override
-  public MetricUpdaterFactory metricUpdaterFactory() {
-    return metricUpdaterFactoryRef.get();
+  public MetricsFactory metricsFactory() {
+    return metricsFactoryRef.get();
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/InternalDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/InternalDriverContext.java
@@ -29,7 +29,7 @@ import com.datastax.oss.driver.internal.core.metadata.schema.parsing.SchemaParse
 import com.datastax.oss.driver.internal.core.metadata.schema.queries.SchemaQueriesFactory;
 import com.datastax.oss.driver.internal.core.metadata.token.ReplicationStrategyFactory;
 import com.datastax.oss.driver.internal.core.metadata.token.TokenFactoryRegistry;
-import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
+import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.internal.core.pool.ChannelPoolFactory;
 import com.datastax.oss.driver.internal.core.servererrors.WriteTypeRegistry;
 import com.datastax.oss.driver.internal.core.session.PoolManager;
@@ -88,7 +88,7 @@ public interface InternalDriverContext extends DriverContext {
 
   PoolManager poolManager();
 
-  MetricUpdaterFactory metricUpdaterFactory();
+  MetricsFactory metricsFactory();
 
   RequestThrottler requestThrottler();
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultNode.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultNode.java
@@ -66,7 +66,7 @@ public class DefaultNode implements Node {
     this.extras = Collections.emptyMap();
     // We leak a reference to a partially constructed object (this), but in practice this won't be a
     // problem because the node updater only needs the connect address to initialize.
-    this.metricUpdater = context.metricUpdaterFactory().newNodeUpdater(this);
+    this.metricUpdater = context.metricsFactory().newNodeUpdater(this);
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DefaultMetrics.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DefaultMetrics.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metrics;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metrics.Metrics;
+import com.datastax.oss.driver.api.core.metrics.NodeMetric;
+import com.datastax.oss.driver.api.core.metrics.SessionMetric;
+import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
+import net.jcip.annotations.ThreadSafe;
+
+@ThreadSafe
+public class DefaultMetrics implements Metrics {
+
+  private final MetricRegistry registry;
+  private final DropwizardSessionMetricUpdater sessionUpdater;
+
+  public DefaultMetrics(MetricRegistry registry, DropwizardSessionMetricUpdater sessionUpdater) {
+    this.registry = registry;
+    this.sessionUpdater = sessionUpdater;
+  }
+
+  @Override
+  public MetricRegistry getRegistry() {
+    return registry;
+  }
+
+  @Override
+  @SuppressWarnings("TypeParameterUnusedInFormals")
+  public <T extends Metric> T getSessionMetric(SessionMetric metric) {
+    return sessionUpdater.getMetric(metric);
+  }
+
+  @Override
+  @SuppressWarnings("TypeParameterUnusedInFormals")
+  public <T extends Metric> T getNodeMetric(Node node, NodeMetric metric) {
+    NodeMetricUpdater nodeUpdater = ((DefaultNode) node).getMetricUpdater();
+    return ((DropwizardNodeMetricUpdater) nodeUpdater).getMetric(metric);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DropwizardSessionMetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DropwizardSessionMetricUpdater.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.metrics;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
@@ -30,20 +31,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class DefaultSessionMetricUpdater extends MetricUpdaterBase<SessionMetric>
+public class DropwizardSessionMetricUpdater extends DropwizardMetricUpdater<SessionMetric>
     implements SessionMetricUpdater {
 
-  private static final Logger LOG = LoggerFactory.getLogger(DefaultSessionMetricUpdater.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DropwizardSessionMetricUpdater.class);
 
   private final String metricNamePrefix;
 
-  public DefaultSessionMetricUpdater(
-      Set<SessionMetric> enabledMetrics, InternalDriverContext context) {
-    super(enabledMetrics, context.metricRegistry());
+  public DropwizardSessionMetricUpdater(
+      Set<SessionMetric> enabledMetrics, MetricRegistry registry, InternalDriverContext context) {
+    super(enabledMetrics, registry);
     this.metricNamePrefix = context.sessionName() + ".";
 
     if (enabledMetrics.contains(DefaultSessionMetric.CONNECTED_NODES)) {
-      metricRegistry.register(
+      this.registry.register(
           buildFullName(DefaultSessionMetric.CONNECTED_NODES),
           (Gauge<Integer>)
               () -> {
@@ -57,7 +58,7 @@ public class DefaultSessionMetricUpdater extends MetricUpdaterBase<SessionMetric
               });
     }
     if (enabledMetrics.contains(DefaultSessionMetric.THROTTLING_QUEUE_SIZE)) {
-      metricRegistry.register(
+      this.registry.register(
           buildFullName(DefaultSessionMetric.THROTTLING_QUEUE_SIZE),
           buildQueueGauge(context.requestThrottler(), context.sessionName()));
     }
@@ -78,7 +79,7 @@ public class DefaultSessionMetricUpdater extends MetricUpdaterBase<SessionMetric
   }
 
   @Override
-  protected String buildFullName(SessionMetric metric) {
+  public String buildFullName(SessionMetric metric) {
     return metricNamePrefix + metric.getPath();
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/MetricsFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/MetricsFactory.java
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datastax.oss.driver.api.core.metrics;
+package com.datastax.oss.driver.internal.core.metrics;
 
-import com.datastax.oss.driver.api.core.session.Session;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metrics.Metrics;
+import java.util.Optional;
 
-/**
- * A node-level metric exposed through {@link Session#getMetrics()}.
- *
- * <p>All metrics exposed out of the box by the driver are instances of {@link DefaultNodeMetric}
- * (this interface only exists to allow custom metrics in driver extensions).
- *
- * @see SessionMetric
- */
-public interface NodeMetric {
-  String getPath();
+public interface MetricsFactory {
+
+  Optional<? extends Metrics> getMetrics();
+
+  /** @return the unique instance for this session (this must return the same object every time). */
+  SessionMetricUpdater getSessionUpdater();
+
+  NodeMetricUpdater newNodeUpdater(Node node);
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/NoopNodeMetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/NoopNodeMetricUpdater.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metrics;
+
+import com.datastax.oss.driver.api.core.metrics.NodeMetric;
+import java.util.concurrent.TimeUnit;
+import net.jcip.annotations.ThreadSafe;
+
+@ThreadSafe
+public class NoopNodeMetricUpdater implements NodeMetricUpdater {
+
+  @Override
+  public void incrementCounter(NodeMetric metric, long amount) {
+    // nothing to do
+  }
+
+  @Override
+  public void updateHistogram(NodeMetric metric, long value) {
+    // nothing to do
+  }
+
+  @Override
+  public void markMeter(NodeMetric metric, long amount) {
+    // nothing to do
+  }
+
+  @Override
+  public void updateTimer(NodeMetric metric, long duration, TimeUnit unit) {
+    // nothing to do
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/NoopSessionMetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/NoopSessionMetricUpdater.java
@@ -15,12 +15,30 @@
  */
 package com.datastax.oss.driver.internal.core.metrics;
 
-import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metrics.SessionMetric;
+import java.util.concurrent.TimeUnit;
+import net.jcip.annotations.ThreadSafe;
 
-public interface MetricUpdaterFactory {
+@ThreadSafe
+public class NoopSessionMetricUpdater implements SessionMetricUpdater {
 
-  /** @return the unique instance for this session (this must return the same object every time). */
-  SessionMetricUpdater getSessionUpdater();
+  @Override
+  public void incrementCounter(SessionMetric metric, long amount) {
+    // nothing to do
+  }
 
-  NodeMetricUpdater newNodeUpdater(Node node);
+  @Override
+  public void updateHistogram(SessionMetric metric, long value) {
+    // nothing to do
+  }
+
+  @Override
+  public void markMeter(SessionMetric metric, long amount) {
+    // nothing to do
+  }
+
+  @Override
+  public void updateTimer(SessionMetric metric, long duration, TimeUnit unit) {
+    // nothing to do
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.oss.driver.internal.core.session;
 
-import com.codahale.metrics.MetricRegistry;
 import com.datastax.oss.driver.api.core.AsyncAutoCloseable;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -28,6 +27,7 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
 import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
+import com.datastax.oss.driver.api.core.metrics.Metrics;
 import com.datastax.oss.driver.api.core.session.Request;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -106,7 +107,7 @@ public class DefaultSession implements CqlSession {
     this.processorRegistry = context.requestProcessorRegistry();
     this.poolManager = context.poolManager();
     this.logPrefix = context.sessionName();
-    this.metricUpdater = context.metricUpdaterFactory().getSessionUpdater();
+    this.metricUpdater = context.metricsFactory().getSessionUpdater();
   }
 
   private CompletionStage<CqlSession> init(CqlIdentifier keyspace) {
@@ -155,8 +156,8 @@ public class DefaultSession implements CqlSession {
   }
 
   @Override
-  public MetricRegistry getMetricRegistry() {
-    return context.metricRegistry();
+  public Optional<? extends Metrics> getMetrics() {
+    return context.metricsFactory().getMetrics();
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUp.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUp.java
@@ -102,7 +102,7 @@ class ReprepareOnUp {
     this.maxParallelism =
         config.getDefaultProfile().getInt(DefaultDriverOption.REPREPARE_MAX_PARALLELISM);
 
-    this.metricUpdater = context.metricUpdaterFactory().getSessionUpdater();
+    this.metricUpdater = context.metricsFactory().getSessionUpdater();
   }
 
   void start() {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/SessionWrapper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/SessionWrapper.java
@@ -15,15 +15,16 @@
  */
 package com.datastax.oss.driver.internal.core.session;
 
-import com.codahale.metrics.MetricRegistry;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.context.DriverContext;
 import com.datastax.oss.driver.api.core.metadata.Metadata;
 import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
 import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
+import com.datastax.oss.driver.api.core.metrics.Metrics;
 import com.datastax.oss.driver.api.core.session.Request;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import net.jcip.annotations.ThreadSafe;
 
@@ -94,8 +95,8 @@ public class SessionWrapper implements Session {
   }
 
   @Override
-  public MetricRegistry getMetricRegistry() {
-    return delegate.getMetricRegistry();
+  public Optional<? extends Metrics> getMetrics() {
+    return delegate.getMetrics();
   }
 
   @Override

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
@@ -31,7 +31,7 @@ import com.datastax.oss.driver.internal.core.context.NettyOptions;
 import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
 import com.datastax.oss.driver.internal.core.metadata.LoadBalancingPolicyWrapper;
 import com.datastax.oss.driver.internal.core.metadata.MetadataManager;
-import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
+import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.DefaultEventLoopGroup;
@@ -66,7 +66,7 @@ abstract class ControlConnectionTestBase {
   protected Exchanger<CompletableFuture<DriverChannel>> channelFactoryFuture;
   @Mock protected LoadBalancingPolicyWrapper loadBalancingPolicyWrapper;
   @Mock protected MetadataManager metadataManager;
-  @Mock protected MetricUpdaterFactory metricUpdaterFactory;
+  @Mock protected MetricsFactory metricsFactory;
 
   protected AddressTranslator addressTranslator;
   protected DefaultNode node1;
@@ -103,7 +103,7 @@ abstract class ControlConnectionTestBase {
 
     Mockito.when(context.loadBalancingPolicyWrapper()).thenReturn(loadBalancingPolicyWrapper);
 
-    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+    Mockito.when(context.metricsFactory()).thenReturn(metricsFactory);
     node1 = new DefaultNode(ADDRESS1, context);
     node2 = new DefaultNode(ADDRESS2, context);
     mockQueryPlan(node1, node2);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/AddNodeRefreshTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/AddNodeRefreshTest.java
@@ -20,7 +20,7 @@ import static com.datastax.oss.driver.Assertions.assertThat;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.uuid.Uuids;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
-import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
+import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import java.net.InetSocketAddress;
 import java.util.Map;
@@ -38,13 +38,13 @@ public class AddNodeRefreshTest {
   private static final InetSocketAddress ADDRESS2 = new InetSocketAddress("127.0.0.2", 9042);
 
   @Mock private InternalDriverContext context;
-  @Mock protected MetricUpdaterFactory metricUpdaterFactory;
+  @Mock protected MetricsFactory metricsFactory;
 
   private DefaultNode node1;
 
   @Before
   public void setup() {
-    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+    Mockito.when(context.metricsFactory()).thenReturn(metricsFactory);
     node1 = new DefaultNode(ADDRESS1, context);
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
@@ -30,7 +30,7 @@ import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.control.ControlConnection;
-import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
+import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import com.datastax.oss.driver.shaded.guava.common.collect.Iterators;
@@ -63,7 +63,7 @@ public class DefaultTopologyMonitorTest {
   @Mock private DriverConfigProfile defaultConfig;
   @Mock private ControlConnection controlConnection;
   @Mock private DriverChannel channel;
-  @Mock protected MetricUpdaterFactory metricUpdaterFactory;
+  @Mock protected MetricsFactory metricsFactory;
 
   private AddressTranslator addressTranslator;
   private DefaultNode node1;
@@ -87,7 +87,7 @@ public class DefaultTopologyMonitorTest {
     Mockito.when(controlConnection.channel()).thenReturn(channel);
     Mockito.when(context.controlConnection()).thenReturn(controlConnection);
 
-    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+    Mockito.when(context.metricsFactory()).thenReturn(metricsFactory);
 
     node1 = new DefaultNode(ADDRESS1, context);
     node2 = new DefaultNode(ADDRESS2, context);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/FullNodeListRefreshTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/FullNodeListRefreshTest.java
@@ -19,7 +19,7 @@ import static com.datastax.oss.driver.Assertions.assertThat;
 
 import com.datastax.oss.driver.api.core.uuid.Uuids;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
-import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
+import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import java.net.InetSocketAddress;
@@ -39,7 +39,7 @@ public class FullNodeListRefreshTest {
   private static final InetSocketAddress ADDRESS3 = new InetSocketAddress("127.0.0.3", 9042);
 
   @Mock private InternalDriverContext context;
-  @Mock protected MetricUpdaterFactory metricUpdaterFactory;
+  @Mock protected MetricsFactory metricsFactory;
 
   private DefaultNode node1;
   private DefaultNode node2;
@@ -47,7 +47,7 @@ public class FullNodeListRefreshTest {
 
   @Before
   public void setup() {
-    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+    Mockito.when(context.metricsFactory()).thenReturn(metricsFactory);
 
     node1 = new DefaultNode(ADDRESS1, context);
     node2 = new DefaultNode(ADDRESS2, context);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/InitContactPointsRefreshTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/InitContactPointsRefreshTest.java
@@ -18,7 +18,7 @@ package com.datastax.oss.driver.internal.core.metadata;
 import static com.datastax.oss.driver.Assertions.assertThat;
 
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
-import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
+import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import java.net.InetSocketAddress;
 import org.junit.Before;
@@ -35,11 +35,11 @@ public class InitContactPointsRefreshTest {
   private static final InetSocketAddress ADDRESS2 = new InetSocketAddress("127.0.0.2", 9042);
 
   @Mock private InternalDriverContext context;
-  @Mock private MetricUpdaterFactory metricUpdaterFactory;
+  @Mock private MetricsFactory metricsFactory;
 
   @Before
   public void setup() {
-    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+    Mockito.when(context.metricsFactory()).thenReturn(metricsFactory);
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapperTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapperTest.java
@@ -29,7 +29,7 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.datastax.oss.driver.internal.core.context.EventBus;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
-import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
+import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
@@ -60,7 +60,7 @@ public class LoadBalancingPolicyWrapperTest {
   private EventBus eventBus;
   @Mock private MetadataManager metadataManager;
   @Mock private Metadata metadata;
-  @Mock protected MetricUpdaterFactory metricUpdaterFactory;
+  @Mock protected MetricsFactory metricsFactory;
 
   private LoadBalancingPolicyWrapper wrapper;
 
@@ -68,7 +68,7 @@ public class LoadBalancingPolicyWrapperTest {
   public void setup() {
     MockitoAnnotations.initMocks(this);
 
-    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+    Mockito.when(context.metricsFactory()).thenReturn(metricsFactory);
 
     node1 = new DefaultNode(new InetSocketAddress("127.0.0.1", 9042), context);
     node2 = new DefaultNode(new InetSocketAddress("127.0.0.2", 9042), context);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
@@ -28,7 +28,7 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.context.NettyOptions;
 import com.datastax.oss.driver.internal.core.metadata.schema.parsing.SchemaParserFactory;
 import com.datastax.oss.driver.internal.core.metadata.schema.queries.SchemaQueriesFactory;
-import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
+import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
@@ -65,7 +65,7 @@ public class MetadataManagerTest {
   @Mock private EventBus eventBus;
   @Mock private SchemaQueriesFactory schemaQueriesFactory;
   @Mock private SchemaParserFactory schemaParserFactory;
-  @Mock protected MetricUpdaterFactory metricUpdaterFactory;
+  @Mock protected MetricsFactory metricsFactory;
 
   private DefaultEventLoopGroup adminEventLoopGroup;
 
@@ -92,7 +92,7 @@ public class MetadataManagerTest {
     Mockito.when(context.schemaQueriesFactory()).thenReturn(schemaQueriesFactory);
     Mockito.when(context.schemaParserFactory()).thenReturn(schemaParserFactory);
 
-    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+    Mockito.when(context.metricsFactory()).thenReturn(metricsFactory);
 
     metadataManager = new TestMetadataManager(context);
   }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/NodeStateManagerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/NodeStateManagerTest.java
@@ -31,7 +31,7 @@ import com.datastax.oss.driver.internal.core.channel.ChannelEvent;
 import com.datastax.oss.driver.internal.core.context.EventBus;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.context.NettyOptions;
-import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
+import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.internal.core.util.concurrent.BlockingOperation;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
@@ -60,7 +60,7 @@ public class NodeStateManagerTest {
   @Mock private NettyOptions nettyOptions;
   @Mock private MetadataManager metadataManager;
   @Mock private Metadata metadata;
-  @Mock protected MetricUpdaterFactory metricUpdaterFactory;
+  @Mock protected MetricsFactory metricsFactory;
   private DefaultNode node1, node2;
   private EventBus eventBus;
   private DefaultEventLoopGroup adminEventLoopGroup;
@@ -84,7 +84,7 @@ public class NodeStateManagerTest {
     Mockito.when(nettyOptions.adminEventExecutorGroup()).thenReturn(adminEventLoopGroup);
     Mockito.when(context.nettyOptions()).thenReturn(nettyOptions);
 
-    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+    Mockito.when(context.metricsFactory()).thenReturn(metricsFactory);
     node1 = new DefaultNode(new InetSocketAddress("127.0.0.1", 9042), context);
     node2 = new DefaultNode(new InetSocketAddress("127.0.0.2", 9042), context);
     ImmutableMap<InetSocketAddress, Node> nodes =

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/RemoveNodeRefreshTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/RemoveNodeRefreshTest.java
@@ -18,7 +18,7 @@ package com.datastax.oss.driver.internal.core.metadata;
 import static com.datastax.oss.driver.Assertions.assertThat;
 
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
-import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
+import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import java.net.InetSocketAddress;
 import org.junit.Before;
@@ -35,14 +35,14 @@ public class RemoveNodeRefreshTest {
   private static final InetSocketAddress ADDRESS2 = new InetSocketAddress("127.0.0.2", 9042);
 
   @Mock private InternalDriverContext context;
-  @Mock protected MetricUpdaterFactory metricUpdaterFactory;
+  @Mock protected MetricsFactory metricsFactory;
 
   private DefaultNode node1;
   private DefaultNode node2;
 
   @Before
   public void setup() {
-    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+    Mockito.when(context.metricsFactory()).thenReturn(metricsFactory);
     node1 = new DefaultNode(ADDRESS1, context);
     node2 = new DefaultNode(ADDRESS2, context);
   }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/DefaultSessionPoolsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/DefaultSessionPoolsTest.java
@@ -46,7 +46,7 @@ import com.datastax.oss.driver.internal.core.metadata.LoadBalancingPolicyWrapper
 import com.datastax.oss.driver.internal.core.metadata.MetadataManager;
 import com.datastax.oss.driver.internal.core.metadata.NodeStateEvent;
 import com.datastax.oss.driver.internal.core.metadata.TopologyMonitor;
-import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
+import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.internal.core.pool.ChannelPool;
 import com.datastax.oss.driver.internal.core.pool.ChannelPoolFactory;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
@@ -89,7 +89,7 @@ public class DefaultSessionPoolsTest {
   @Mock private SpeculativeExecutionPolicy speculativeExecutionPolicy;
   @Mock private AddressTranslator addressTranslator;
   @Mock private ControlConnection controlConnection;
-  @Mock private MetricUpdaterFactory metricUpdaterFactory;
+  @Mock private MetricsFactory metricsFactory;
 
   private DefaultNode node1;
   private DefaultNode node2;
@@ -135,7 +135,7 @@ public class DefaultSessionPoolsTest {
 
     Mockito.when(context.configLoader()).thenReturn(configLoader);
 
-    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
+    Mockito.when(context.metricsFactory()).thenReturn(metricsFactory);
 
     // Runtime behavior:
     Mockito.when(context.sessionName()).thenReturn("test");

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUpTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUpTest.java
@@ -25,7 +25,7 @@ import com.datastax.oss.driver.internal.core.adminrequest.AdminResult;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metadata.TopologyMonitor;
-import com.datastax.oss.driver.internal.core.metrics.MetricUpdaterFactory;
+import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.internal.core.metrics.SessionMetricUpdater;
 import com.datastax.oss.driver.internal.core.pool.ChannelPool;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
@@ -65,7 +65,7 @@ public class ReprepareOnUpTest {
   @Mock private DriverConfig config;
   @Mock private DriverConfigProfile defaultConfigProfile;
   @Mock private TopologyMonitor topologyMonitor;
-  @Mock private MetricUpdaterFactory metricUpdaterFactory;
+  @Mock private MetricsFactory metricsFactory;
   @Mock private SessionMetricUpdater metricUpdater;
   private Runnable whenPrepared;
   private CompletionStage<Void> done;
@@ -89,8 +89,8 @@ public class ReprepareOnUpTest {
         .thenReturn(100);
     Mockito.when(context.config()).thenReturn(config);
 
-    Mockito.when(context.metricUpdaterFactory()).thenReturn(metricUpdaterFactory);
-    Mockito.when(metricUpdaterFactory.getSessionUpdater()).thenReturn(metricUpdater);
+    Mockito.when(context.metricsFactory()).thenReturn(metricsFactory);
+    Mockito.when(metricsFactory.getSessionUpdater()).thenReturn(metricUpdater);
 
     done = new CompletableFuture<>();
     whenPrepared = () -> ((CompletableFuture<Void>) done).complete(null);

--- a/manual/core/metrics/README.md
+++ b/manual/core/metrics/README.md
@@ -47,8 +47,8 @@ refer to `reference.conf` for more details.
 
 ### Export
 
-The Dropwizard `MetricRegistry` is exposed via `session.getMetricRegistry()`. You can retrieve it
-and configure a `Reporter` to send the metrics to a monitoring tool.
+The Dropwizard `MetricRegistry` is exposed via `session.getMetrics()`. You can retrieve it and
+configure a `Reporter` to send the metrics to a monitoring tool.
 
 #### JMX
 
@@ -68,8 +68,12 @@ dependency of the driver):
 Then create a JMX reporter for the registry:
 
 ```java
+MetricRegistry registry = session.getMetrics()
+    .orElseThrow(() -> new IllegalStateException("Metrics are disabled"))
+    .getRegistry();
+
 JmxReporter reporter =
-    JmxReporter.forRegistry(session.getMetricRegistry())
+    JmxReporter.forRegistry(registry)
         .inDomain("com.datastax.oss.driver")
         .build();
 reporter.start();
@@ -110,7 +114,7 @@ ObjectNameFactory objectNameFactory = (type, domain, name) -> {
 };
 
 JmxReporter reporter =
-    JmxReporter.forRegistry(session.getMetricRegistry())
+    JmxReporter.forRegistry(registry)
         .inDomain("com.datastax.oss.driver")
         .createsObjectNamesWith(objectNameFactory)
         .build();


### PR DESCRIPTION
- allow excluding Dropwizard completely if metrics are disabled
- expose methods to access individual metrics programatically (this was feedback from @adutra that I forgot to address in the original PR)
- open the door to switch metrics framework

TODO:
- [x] add concurrency annotations