### PR TITLE
Add oraclejdk10 to ci matrix, jdk10 changes for testing

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4,13 +4,14 @@ schedules:
     schedule: per_commit
     matrix:
       exclude:
+        # Exclude all builds on old jdk versions (which are done on trusty)
+        - os: ubuntu/trusty64/java-driver
+        - os: ubuntu/bionic64/java-driver
+          java: ['openjdk6','openjdk7']
         # Exclude java8 with all versions exception 2.1 and latest
         - java: oraclejdk8
           cassandra: ['2.2', '3.0']
-        # Exclude all java 7 builds
-        - java: openjdk7
-        # Exclude java6 with all versions except latest
-        - java: openjdk6
+        - java: oraclejdk10
           cassandra: ['2.1', '2.2', '3.0']
     env_vars: |
       TEST_GROUP="short"
@@ -21,6 +22,13 @@ schedules:
   nightly:
     # Run full suite nightly on change for all primary branches if they have changes.
     schedule: nightly
+    matrix:
+      exclude:
+        # Run jdk8 and 10 on bionic, 6 and 7 on trusty
+        - os: ubuntu/trusty64/java-driver
+          java: ['oraclejdk8','oraclejdk10']
+        - os: ubuntu/bionic64/java-driver
+          java: ['openjdk6','openjdk7']
     branches:
       # regex matches primary branch format (2.1, 3.x, 3.0.x, 3.1.x, etc).
       include: ["/\\d+(\\.[\\dx]+)+/"]
@@ -33,6 +41,13 @@ schedules:
   adhoc:
     # Adhoc job for non-primary braches that doesn't have a schedule but may be used to run all configs.
     schedule: adhoc
+    matrix:
+      exclude:
+        # Run jdk8 and 10 on bionic, 6 and 7 on trusty
+        - os: ubuntu/trusty64/java-driver
+          java: ['oraclejdk8','oraclejdk10']
+        - os: ubuntu/bionic64/java-driver
+          java: ['openjdk6','openjdk7']
     branches:
       # regex matches primary branch format (2.1, 3.x, 3.0.x, 3.1.x, etc).
       exclude: ["/\\d+(\\.[\\dx]+)+/"]
@@ -46,8 +61,10 @@ java:
   - openjdk6
   - openjdk7
   - oraclejdk8
+  - oraclejdk10
 os:
-  - ubuntu/trusty64/m3.large
+  - ubuntu/trusty64/java-driver
+  - ubuntu/bionic64/java-driver
 cassandra:
   - '2.1'
   - '2.2'

--- a/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/RecommissionedNodeTest.java
@@ -144,8 +144,8 @@ public class RecommissionedNodeTest {
                 .isNotReconnectingFromDown();
     }
 
-    @Test(groups = "long")
-    @CassandraVersion("2.0.0")
+    @Test(groups = "long", enabled=false, description="Disabled because requires specific C* version, not essential")
+    @CassandraVersion("3.0.0")
     public void should_ignore_node_that_does_not_support_protocol_version_on_session_init() throws Exception {
         // Simulate the bug before starting the cluster
         mainCcmBuilder = CCMBridge.builder().withNodes(2);
@@ -157,7 +157,7 @@ public class RecommissionedNodeTest {
                 .withStoragePort(mainCcm.getStoragePort())
                 .withThriftPort(mainCcm.getThriftPort())
                 .withBinaryPort(mainCcm.getBinaryPort())
-                .withVersion(VersionNumber.parse("1.2.19"));
+                .withVersion(VersionNumber.parse("2.1.20"));
         otherCcm = CCMCache.get(otherCcmBuilder);
         otherCcm.waitForUp(1);
 

--- a/pom.xml
+++ b/pom.xml
@@ -1084,6 +1084,16 @@ limitations under the License.
             </build>
         </profile>
 
+        <profile>
+            <id>jdk10</id>
+            <activation>
+                <jdk>10.0</jdk>
+            </activation>
+            <properties>
+                <!-- skip osgi testing for JDK 10 as pax-exam does not support it yet. -->
+                <test.osgi.skip>true</test.osgi.skip>
+            </properties>
+        </profile>
     </profiles>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -747,6 +747,7 @@ limitations under the License.
                     <configuration>
                         <groups>${test.groups}</groups>
                         <useFile>false</useFile>
+                        <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
                         <systemPropertyVariables>
                             <cassandra.version>${cassandra.version}</cassandra.version>
                             <ipprefix>${ipprefix}</ipprefix>


### PR DESCRIPTION
Adds JDK 10 to our CI matrix and other test framework changes for JDK 10 support.

Changes to matrix:

- Add oraclejdk10
- Update os labels for new images (bionic -> jdk8/10, trusty -> jdk6/7)
- No longer run openjdk6 in per commit builds, nightly only

Changes to tests:

- Skip OSGi tests if using JDK 10 (pax-exam does not support JDK 10 yet, we also use very old version)
- Add -Djdk.attach.allowAttachSelf=true to surefire config for bmunit.  Required with JDK9+ requirement that does not allow dynamic agent attaching by default.
- Disable RecommissionedNodeTest protocol version test.  This test spun up a C* 1.2.19 node which is no longer supported.  Updated test to use C* 2.1.20, but since the test is slow and not very important I disabled it as well.

Will merge this shortly as CI builds with this seem to be working well and want to use the new images we have.