### PR TITLE
JAVA-1592: Expose statement's total Frame size through API.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha4 (in progress)
 
+- [new feature] JAVA-1592: Expose request's total Frame size through API
 - [new feature] JAVA-1829: Add metrics for bytes-sent and bytes-received 
 - [improvement] JAVA-1755: Normalize usage of DEBUG/TRACE log levels
 - [improvement] JAVA-1803: Log driver version on first use

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/Statement.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/Statement.java
@@ -18,6 +18,7 @@ package com.datastax.oss.driver.api.core.cql;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
+import com.datastax.oss.driver.api.core.context.DriverContext;
 import com.datastax.oss.driver.api.core.metadata.token.Token;
 import com.datastax.oss.driver.api.core.session.Request;
 import com.datastax.oss.driver.api.core.session.Session;
@@ -164,6 +165,20 @@ public interface Statement<T extends Statement<T>> extends Request {
    * if you do so, you must override {@link #copy(ByteBuffer)}.
    */
   T setPagingState(ByteBuffer newPagingState);
+
+  /**
+   * Calculates the approximate size in bytes that the statement will have when encoded.
+   *
+   * <p>The size might be over-estimated by a few bytes due to global options that may be defined on
+   * a {@link Session} but not explicitly set on the statement itself.
+   *
+   * <p>The result of this method is not cached, calling it will cause some encoding to be done in
+   * order to determine some of the statement's attributes sizes. Therefore, use this method
+   * sparingly in order to avoid unnecessary computation.
+   *
+   * @return the approximate number of bytes this statement will take when encoded.
+   */
+  int computeSizeInBytes(DriverContext context);
 
   /**
    * Creates a <b>new instance</b> with a different paging state.

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/Sizes.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/Sizes.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.util;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.cql.BatchableStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.cql.Statement;
+import com.datastax.oss.driver.api.core.session.Request;
+import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
+import com.datastax.oss.driver.internal.core.cql.Conversions;
+import com.datastax.oss.protocol.internal.FrameCodec;
+import com.datastax.oss.protocol.internal.PrimitiveSizes;
+import com.datastax.oss.protocol.internal.request.query.QueryOptions;
+import com.datastax.oss.protocol.internal.request.query.Values;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Sizes {
+
+  /** Returns a common size for all kinds of Request implementations. */
+  public static int minimumRequestSize(Request request) {
+
+    // Header and payload are common inside a Frame at the protocol level
+
+    // Frame header has a fixed size of 9 for protocol version >= V3, which includes Frame flags
+    // size
+    int size = FrameCodec.headerEncodedSize();
+
+    if (!request.getCustomPayload().isEmpty()) {
+      // Custom payload is not supported in v3, but assume user won't have a custom payload set if
+      // they use this version
+      size += PrimitiveSizes.sizeOfBytesMap(request.getCustomPayload());
+    }
+
+    return size;
+  }
+
+  public static int minimumStatementSize(Statement statement, DriverContext context) {
+    int size = minimumRequestSize(statement);
+
+    // These are options in the protocol inside a frame that are common to all Statements
+
+    size += QueryOptions.queryFlagsSize(context.protocolVersion().getCode());
+
+    size += PrimitiveSizes.SHORT; // size of consistency level
+    size += PrimitiveSizes.SHORT; // size of serial consistency level
+
+    return size;
+  }
+
+  /**
+   * Returns the size in bytes of a simple statement's values, depending on whether the values are
+   * named or positional.
+   */
+  public static int sizeOfSimpleStatementValues(
+      SimpleStatement simpleStatement,
+      ProtocolVersion protocolVersion,
+      CodecRegistry codecRegistry) {
+    int size = 0;
+
+    if (!simpleStatement.getPositionalValues().isEmpty()) {
+
+      List<ByteBuffer> positionalValues =
+          new ArrayList<>(simpleStatement.getPositionalValues().size());
+      for (Object value : simpleStatement.getPositionalValues()) {
+        positionalValues.add(Conversions.encode(value, codecRegistry, protocolVersion));
+      }
+
+      size += Values.sizeOfPositionalValues(positionalValues);
+
+    } else if (!simpleStatement.getNamedValues().isEmpty()) {
+
+      Map<String, ByteBuffer> namedValues = new HashMap<>(simpleStatement.getNamedValues().size());
+      for (Map.Entry<CqlIdentifier, Object> value : simpleStatement.getNamedValues().entrySet()) {
+        namedValues.put(
+            value.getKey().asInternal(),
+            Conversions.encode(value.getValue(), codecRegistry, protocolVersion));
+      }
+
+      size += Values.sizeOfNamedValues(namedValues);
+    }
+    return size;
+  }
+
+  /** Return the size in bytes of a bound statement's values. */
+  public static int sizeOfBoundStatementValues(BoundStatement boundStatement) {
+    return Values.sizeOfPositionalValues(boundStatement.getValues());
+  }
+
+  /**
+   * The size of a statement inside a batch query is different from the size of a complete
+   * Statement. The inner batch statements only include the query or prepared ID, and the values of
+   * the statement.
+   */
+  public static Integer sizeOfInnerBatchStatementInBytes(
+      BatchableStatement statement, ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
+    int size = 0;
+
+    size +=
+        PrimitiveSizes
+            .BYTE; // for each inner statement, there is one byte for the "kind": prepared or string
+
+    if (statement instanceof SimpleStatement) {
+      size += PrimitiveSizes.sizeOfLongString(((SimpleStatement) statement).getQuery());
+      size +=
+          sizeOfSimpleStatementValues(
+              ((SimpleStatement) statement), protocolVersion, codecRegistry);
+    } else if (statement instanceof BoundStatement) {
+      size +=
+          PrimitiveSizes.sizeOfShortBytes(
+              ((BoundStatement) statement).getPreparedStatement().getId().array());
+      size += sizeOfBoundStatementValues(((BoundStatement) statement));
+    }
+    return size;
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/StatementSizeTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/StatementSizeTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.cql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
+import com.datastax.oss.driver.api.core.config.DriverConfig;
+import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
+import com.datastax.oss.driver.api.core.cql.BatchStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.DefaultBatchType;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.cql.Statement;
+import com.datastax.oss.driver.api.core.time.TimestampGenerator;
+import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
+import com.datastax.oss.driver.internal.core.CassandraProtocolVersionRegistry;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.time.AtomicTimestampGenerator;
+import com.datastax.oss.driver.shaded.guava.common.base.Charsets;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
+import com.datastax.oss.protocol.internal.response.result.ColumnSpec;
+import com.datastax.oss.protocol.internal.response.result.RawType;
+import com.datastax.oss.protocol.internal.util.Bytes;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+public class StatementSizeTest {
+
+  private static final byte[] MOCK_PAGING_STATE = Bytes.getArray(Bytes.fromHexString("0xdeadbeef"));
+  private static final ByteBuffer MOCK_PAYLOAD_VALUE1 = Bytes.fromHexString("0xabcd");
+  private static final ByteBuffer MOCK_PAYLOAD_VALUE2 = Bytes.fromHexString("0xef");
+  private static final ImmutableMap<String, ByteBuffer> MOCK_PAYLOAD =
+      ImmutableMap.of("key1", MOCK_PAYLOAD_VALUE1, "key2", MOCK_PAYLOAD_VALUE2);
+  private static final byte[] PREPARED_ID = Bytes.getArray(Bytes.fromHexString("0xaaaa"));
+  private static final byte[] RESULT_METADATA_ID = Bytes.getArray(Bytes.fromHexString("0xbbbb"));
+
+  @Mock PreparedStatement preparedStatement;
+  @Mock InternalDriverContext driverContext;
+  @Mock DriverConfig config;
+  @Mock DriverConfigProfile defaultConfigProfile;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+
+    ByteBuffer preparedId = ByteBuffer.wrap(PREPARED_ID);
+    Mockito.when(preparedStatement.getId()).thenReturn(preparedId);
+    ByteBuffer resultMetadataId = ByteBuffer.wrap(RESULT_METADATA_ID);
+    Mockito.when(preparedStatement.getResultMetadataId()).thenReturn(resultMetadataId);
+
+    ColumnDefinitions columnDefinitions =
+        DefaultColumnDefinitions.valueOf(
+            ImmutableList.of(
+                phonyColumnDef("ks", "table", "c1", -1, ProtocolConstants.DataType.INT),
+                phonyColumnDef("ks", "table", "c2", -1, ProtocolConstants.DataType.VARCHAR)));
+
+    Mockito.when(preparedStatement.getVariableDefinitions()).thenReturn(columnDefinitions);
+
+    Mockito.when(driverContext.protocolVersion()).thenReturn(DefaultProtocolVersion.V5);
+    Mockito.when(driverContext.codecRegistry()).thenReturn(CodecRegistry.DEFAULT);
+    Mockito.when(driverContext.protocolVersionRegistry())
+        .thenReturn(new CassandraProtocolVersionRegistry(null));
+    Mockito.when(config.getDefaultProfile()).thenReturn(defaultConfigProfile);
+    Mockito.when(driverContext.config()).thenReturn(config);
+    TimestampGenerator timestampGenerator = new AtomicTimestampGenerator(driverContext);
+    Mockito.when(driverContext.timestampGenerator()).thenReturn(timestampGenerator);
+  }
+
+  private ColumnDefinition phonyColumnDef(
+      String keyspace, String table, String column, int index, int typeCode) {
+    return new DefaultColumnDefinition(
+        new ColumnSpec(keyspace, table, column, index, RawType.PRIMITIVES.get(typeCode)), null);
+  }
+
+  @Test
+  public void should_measure_size_of_simple_statement() {
+    String queryString = "SELECT release_version FROM system.local WHERE key = ?";
+    SimpleStatement statement = SimpleStatement.newInstance(queryString);
+    int expectedSize =
+        9 // header
+            + (4 + queryString.getBytes(Charsets.UTF_8).length) // query string
+            + 2 // consistency level
+            + 2 // serial consistency level
+            + 4 // fetch size
+            + 8 // timestamp
+            + 4; // flags
+
+    assertThat(v5SizeOf(statement)).isEqualTo(expectedSize);
+
+    String value1 = "local";
+    SimpleStatement statementWithAnonymousValue = SimpleStatement.newInstance(queryString, value1);
+    assertThat(v5SizeOf(statementWithAnonymousValue))
+        .isEqualTo(
+            expectedSize
+                + 2 // size of number of values
+                + (4 + value1.getBytes(Charsets.UTF_8).length) // value
+            );
+
+    String key1 = "key";
+    SimpleStatement statementWithNamedValue =
+        SimpleStatement.newInstance(queryString, ImmutableMap.of(key1, value1));
+    assertThat(v5SizeOf(statementWithNamedValue))
+        .isEqualTo(
+            expectedSize
+                + 2 // size of number of values
+                + (2 + key1.getBytes(Charsets.UTF_8).length) // key
+                + (4 + value1.getBytes(Charsets.UTF_8).length) // value
+            );
+
+    SimpleStatement statementWithPagingState =
+        statement.setPagingState(ByteBuffer.wrap(MOCK_PAGING_STATE));
+    assertThat(v5SizeOf(statementWithPagingState))
+        .isEqualTo(expectedSize + 4 + MOCK_PAGING_STATE.length);
+
+    SimpleStatement statementWithPayload = statement.setCustomPayload(MOCK_PAYLOAD);
+    assertThat(v5SizeOf(statementWithPayload))
+        .isEqualTo(
+            expectedSize
+                + 2 // size of number of keys in the map
+                // size of each key/value pair
+                + (2 + "key1".getBytes(Charsets.UTF_8).length)
+                + (4 + MOCK_PAYLOAD_VALUE1.remaining())
+                + (2 + "key2".getBytes(Charsets.UTF_8).length)
+                + (4 + MOCK_PAYLOAD_VALUE2.remaining()));
+
+    SimpleStatement statementWithKeyspace = statement.setKeyspace("testKeyspace");
+    assertThat(v5SizeOf(statementWithKeyspace))
+        .isEqualTo(expectedSize + 2 + "testKeyspace".getBytes(Charsets.UTF_8).length);
+  }
+
+  @Test
+  public void should_measure_size_of_bound_statement() {
+
+    BoundStatement statement =
+        newBoundStatement(
+            preparedStatement,
+            new ByteBuffer[] {ProtocolConstants.UNSET_VALUE, ProtocolConstants.UNSET_VALUE});
+
+    int expectedSize =
+        9 // header size
+            + 4 // flags
+            + 2 // consistency level
+            + 2 // serial consistency level
+            + 8 // timestamp
+            + (2 + PREPARED_ID.length)
+            + (2 + RESULT_METADATA_ID.length)
+            + 2 // size of value list
+            + 2 * (4) // two null values (size = -1)
+            + 4 // fetch size
+        ;
+    assertThat(v5SizeOf(statement)).isEqualTo(expectedSize);
+
+    BoundStatement withValues = statement.setInt(0, 0).setString(1, "test");
+    expectedSize +=
+        4 // the size of the int value
+            + "test".getBytes(Charsets.UTF_8).length;
+    assertThat(v5SizeOf(withValues)).isEqualTo(expectedSize);
+
+    BoundStatement withPagingState = withValues.setPagingState(ByteBuffer.wrap(MOCK_PAGING_STATE));
+    expectedSize += 4 + MOCK_PAGING_STATE.length;
+    assertThat(v5SizeOf(withPagingState)).isEqualTo(expectedSize);
+
+    BoundStatement withPayload = withPagingState.setCustomPayload(MOCK_PAYLOAD);
+    expectedSize +=
+        2 // size of number of keys in the map
+            // size of each key/value pair
+            + (2 + "key1".getBytes(Charsets.UTF_8).length)
+            + (4 + MOCK_PAYLOAD_VALUE1.remaining())
+            + (2 + "key2".getBytes(Charsets.UTF_8).length)
+            + (4 + MOCK_PAYLOAD_VALUE2.remaining());
+    assertThat(v5SizeOf(withPayload)).isEqualTo(expectedSize);
+  }
+
+  @Test
+  public void should_measure_size_of_batch_statement() {
+    String queryString = "SELECT release_version FROM system.local";
+    String key1 = "key";
+    String value1 = "value";
+    SimpleStatement statement1 =
+        SimpleStatement.newInstance(queryString, ImmutableMap.of(key1, value1));
+
+    BoundStatement statement2 =
+        newBoundStatement(
+                preparedStatement,
+                new ByteBuffer[] {ProtocolConstants.UNSET_VALUE, ProtocolConstants.UNSET_VALUE})
+            .setInt(0, 0)
+            .setString(1, "test");
+    BoundStatement statement3 =
+        newBoundStatement(
+                preparedStatement,
+                new ByteBuffer[] {ProtocolConstants.UNSET_VALUE, ProtocolConstants.UNSET_VALUE})
+            .setInt(0, 0)
+            .setString(1, "test2");
+
+    BatchStatement batchStatement =
+        BatchStatement.newInstance(DefaultBatchType.UNLOGGED)
+            .add(statement1)
+            .add(statement2)
+            .add(statement3);
+
+    int expectedSize =
+        9 // header size
+            + 1
+            + 2 // batch type + number of queries
+            // statements' type of id + id (query string/prepared id):
+            + 1
+            + (4 + queryString.getBytes(Charsets.UTF_8).length)
+            + 1
+            + (2 + PREPARED_ID.length)
+            + 1
+            + (2 + PREPARED_ID.length)
+            // simple statement values
+            + 2 // size of number of values
+            + (2 + key1.getBytes(Charsets.UTF_8).length) // key
+            + (4 + value1.getBytes(Charsets.UTF_8).length) // value
+            // bound statements values
+            + (2 + (4 + 4) + (4 + "test".getBytes(Charsets.UTF_8).length))
+            + (2 + (4 + 4) + (4 + "test2".getBytes(Charsets.UTF_8).length))
+            + 2 // consistency level
+            + 2 // serial consistency level
+            + 8 // timestamp
+            + 4; // flags
+    assertThat(v5SizeOf(batchStatement)).isEqualTo(expectedSize);
+
+    BatchStatement withPayload = batchStatement.setCustomPayload(MOCK_PAYLOAD);
+    expectedSize +=
+        2 // size of number of keys in the map
+            // size of each key/value pair
+            + (2 + "key1".getBytes(Charsets.UTF_8).length)
+            + (4 + MOCK_PAYLOAD_VALUE1.remaining())
+            + (2 + "key2".getBytes(Charsets.UTF_8).length)
+            + (4 + MOCK_PAYLOAD_VALUE2.remaining());
+    assertThat(v5SizeOf(withPayload)).isEqualTo(expectedSize);
+  }
+
+  private int v5SizeOf(Statement statement) {
+    return statement.computeSizeInBytes(driverContext);
+  }
+
+  private BoundStatement newBoundStatement(
+      PreparedStatement preparedStatement, ByteBuffer[] initialValues) {
+    return new DefaultBoundStatement(
+        preparedStatement,
+        preparedStatement.getVariableDefinitions(),
+        initialValues,
+        null,
+        null,
+        null,
+        null,
+        null,
+        Collections.emptyMap(),
+        null,
+        false,
+        -1,
+        null,
+        CodecRegistry.DEFAULT,
+        DefaultProtocolVersion.V5);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>native-protocol</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
## Notes for reviewers
- requires some changes from the `native-protocol` project that I [pushed on a `java1592` branch on the repo](https://github.com/datastax/native-protocol/tree/java1592) - these aren't hugely important, but it seemed to make more sense to have these changes there. To compile this PR you'd need to compile and install the native-protocol project of that branch.
- the method to compute a statement's size requires a `DriverContext`. It is the only way I have found to be able to use `protocolVersionRegistry.supports(ProtocolVersion, ProtocolFeature)` feature.
- It is a complete re-write from the original JAVA-708 PR since most of the codebase has changed and wasn't compatible.