### PR TITLE
JAVA-1824: Make policies overridable in profiles

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha4 (in progress)
 
+- [improvement] JAVA-1824: Make policies overridable in profiles
 - [bug] JAVA-1569: Allow null to be used in positional and named values in statements
 - [new feature] JAVA-1592: Expose request's total Frame size through API
 - [new feature] JAVA-1829: Add metrics for bytes-sent and bytes-received 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -54,8 +54,8 @@ public enum DefaultDriverOption implements DriverOption {
   REQUEST_SERIAL_CONSISTENCY("request.serial-consistency", true),
   REQUEST_WARN_IF_SET_KEYSPACE("request.warn-if-set-keyspace", true),
   REQUEST_DEFAULT_IDEMPOTENCE("request.default-idempotence", true),
-  RETRY_POLICY_CLASS("request.retry-policy.class", true),
-  SPECULATIVE_EXECUTION_POLICY_CLASS("request.speculative-execution-policy.class", true),
+  RETRY_POLICY("request.retry-policy", true),
+  SPECULATIVE_EXECUTION_POLICY("request.speculative-execution-policy", false),
   SPECULATIVE_EXECUTION_MAX("request.speculative-execution-policy.max-executions", false),
   SPECULATIVE_EXECUTION_DELAY("request.speculative-execution-policy.delay", false),
   REQUEST_TRACE_ATTEMPTS("request.trace.attempts", true),
@@ -89,7 +89,7 @@ public enum DefaultDriverOption implements DriverOption {
   COALESCER_MAX_RUNS("connection.coalescer.max-runs-with-no-work", false),
   COALESCER_INTERVAL("connection.coalescer.reschedule-interval", false),
 
-  LOAD_BALANCING_POLICY_CLASS("load-balancing-policy.class", true),
+  LOAD_BALANCING_POLICY("load-balancing-policy", true),
   LOAD_BALANCING_LOCAL_DATACENTER("load-balancing-policy.local-datacenter", false),
   LOAD_BALANCING_FILTER_CLASS("load-balancing-policy.filter.class", false),
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DriverConfig.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DriverConfig.java
@@ -32,18 +32,18 @@ public interface DriverConfig {
    * DriverConfigProfile#DEFAULT_NAME} and always present.
    */
   default DriverConfigProfile getDefaultProfile() {
-    return getNamedProfile(DriverConfigProfile.DEFAULT_NAME);
+    return getProfile(DriverConfigProfile.DEFAULT_NAME);
   }
 
   /** @throws IllegalArgumentException if there is no profile with this name. */
-  DriverConfigProfile getNamedProfile(String profileName);
+  DriverConfigProfile getProfile(String profileName);
 
   /**
    * Returns an <b>immutable</b> view of all named profiles (including the default profile).
    *
    * <p>Implementations typically return a defensive copy of their internal state; therefore this
-   * should not be used in performance-sensitive parts of the code, see {@link
-   * #getNamedProfile(String)} instead.
+   * should not be used in performance-sensitive parts of the code, see {@link #getProfile(String)}
+   * instead.
    */
-  Map<String, DriverConfigProfile> getNamedProfiles();
+  Map<String, DriverConfigProfile> getProfiles();
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DriverConfig.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DriverConfig.java
@@ -26,13 +26,20 @@ import java.util.Map;
  * "analytics" profile vs. a "transactional" profile).
  */
 public interface DriverConfig {
-  DriverConfigProfile getDefaultProfile();
+
+  /**
+   * Alias to get the default profile, which is stored under the name {@link
+   * DriverConfigProfile#DEFAULT_NAME} and always present.
+   */
+  default DriverConfigProfile getDefaultProfile() {
+    return getNamedProfile(DriverConfigProfile.DEFAULT_NAME);
+  }
 
   /** @throws IllegalArgumentException if there is no profile with this name. */
   DriverConfigProfile getNamedProfile(String profileName);
 
   /**
-   * Returns an <b>immutable</b> view of all the named profiles.
+   * Returns an <b>immutable</b> view of all named profiles (including the default profile).
    *
    * <p>Implementations typically return a defensive copy of their internal state; therefore this
    * should not be used in performance-sensitive parts of the code, see {@link

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DriverConfigProfile.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DriverConfigProfile.java
@@ -36,6 +36,22 @@ import java.util.SortedSet;
  * @see DriverConfig
  */
 public interface DriverConfigProfile {
+
+  /**
+   * The name of the default profile (the string {@value}).
+   *
+   * <p>Named profiles can't use this name. If you try to declare such a profile, a runtime error
+   * will be thrown.
+   */
+  String DEFAULT_NAME = "default";
+
+  /**
+   * The name of the profile in the configuration.
+   *
+   * <p>Derived profiles inherit the name of their parent.
+   */
+  String getName();
+
   boolean isDefined(DriverOption option);
 
   boolean getBoolean(DriverOption option);
@@ -66,6 +82,15 @@ public interface DriverConfigProfile {
   Duration getDuration(DriverOption option);
 
   DriverConfigProfile withDuration(DriverOption option, Duration value);
+
+  /**
+   * Returns a representation of all the child options under a given option.
+   *
+   * <p>This is only used to compare configuration sections across profiles, so the actual
+   * implementation does not matter, as long as identical sections (same options with same values,
+   * regardless of order) compare as equal and have the same {@code hashCode()}.
+   */
+  Object getComparisonKey(DriverOption option);
 
   /**
    * Enumerates all the entries in this profile, including those that were inherited from another

--- a/core/src/main/java/com/datastax/oss/driver/api/core/context/DriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/context/DriverContext.java
@@ -45,6 +45,7 @@ public interface DriverContext extends AttachmentPoint {
 
   default LoadBalancingPolicy loadBalancingPolicy(String profileName) {
     LoadBalancingPolicy policy = loadBalancingPolicies().get(profileName);
+    // Protect against a non-existent name
     return (policy != null)
         ? policy
         : loadBalancingPolicies().get(DriverConfigProfile.DEFAULT_NAME);

--- a/core/src/main/java/com/datastax/oss/driver/api/core/context/DriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/context/DriverContext.java
@@ -18,6 +18,7 @@ package com.datastax.oss.driver.api.core.context;
 import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
 import com.datastax.oss.driver.api.core.auth.AuthProvider;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
+import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
 import com.datastax.oss.driver.api.core.connection.ReconnectionPolicy;
 import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
 import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy;
@@ -26,6 +27,7 @@ import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.core.specex.SpeculativeExecutionPolicy;
 import com.datastax.oss.driver.api.core.ssl.SslEngineFactory;
 import com.datastax.oss.driver.api.core.time.TimestampGenerator;
+import java.util.Map;
 import java.util.Optional;
 
 /** Holds common components that are shared throughout a driver instance. */
@@ -39,13 +41,34 @@ public interface DriverContext extends AttachmentPoint {
 
   DriverConfig config();
 
-  LoadBalancingPolicy loadBalancingPolicy();
+  Map<String, LoadBalancingPolicy> loadBalancingPolicies();
+
+  default LoadBalancingPolicy loadBalancingPolicy(String profileName) {
+    LoadBalancingPolicy policy = loadBalancingPolicies().get(profileName);
+    return (policy != null)
+        ? policy
+        : loadBalancingPolicies().get(DriverConfigProfile.DEFAULT_NAME);
+  }
+
+  Map<String, RetryPolicy> retryPolicies();
+
+  default RetryPolicy retryPolicy(String profileName) {
+    RetryPolicy policy = retryPolicies().get(profileName);
+    return (policy != null) ? policy : retryPolicies().get(DriverConfigProfile.DEFAULT_NAME);
+  }
+
+  Map<String, SpeculativeExecutionPolicy> speculativeExecutionPolicies();
+
+  default SpeculativeExecutionPolicy speculativeExecutionPolicy(String profileName) {
+    SpeculativeExecutionPolicy policy = speculativeExecutionPolicies().get(profileName);
+    return (policy != null)
+        ? policy
+        : speculativeExecutionPolicies().get(DriverConfigProfile.DEFAULT_NAME);
+  }
+
+  TimestampGenerator timestampGenerator();
 
   ReconnectionPolicy reconnectionPolicy();
-
-  RetryPolicy retryPolicy();
-
-  SpeculativeExecutionPolicy speculativeExecutionPolicy();
 
   AddressTranslator addressTranslator();
 
@@ -54,6 +77,4 @@ public interface DriverContext extends AttachmentPoint {
 
   /** The SSL engine factory, if SSL was configured. */
   Optional<SslEngineFactory> sslEngineFactory();
-
-  TimestampGenerator timestampGenerator();
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metrics/Metrics.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metrics/Metrics.java
@@ -54,10 +54,22 @@ public interface Metrics {
    * Counter connectedNodes = getNodeMetric(node, DefaultSessionMetric.CONNECTED_NODES);
    * }</pre>
    *
+   * @param profileName the name of the execution profile, or {@code null} if the metric is not
+   *     associated to any profile. Note that this is only included for future extensibility: at
+   *     this time, the driver does not break up metrics per profile. Therefore you can always use
+   *     {@link #getSessionMetric(SessionMetric)} instead of this method.
    * @return the metric, or {@code null} if it is disabled.
    */
   @SuppressWarnings("TypeParameterUnusedInFormals")
-  <T extends Metric> T getSessionMetric(SessionMetric metric);
+  <T extends Metric> T getSessionMetric(SessionMetric metric, String profileName);
+
+  /**
+   * Shortcut for {@link #getSessionMetric(SessionMetric, String) getSessionMetric(metric, null)}.
+   */
+  @SuppressWarnings("TypeParameterUnusedInFormals")
+  default <T extends Metric> T getSessionMetric(SessionMetric metric) {
+    return getSessionMetric(metric, null);
+  }
 
   /**
    * Retrieves a node-level metric for a given node from the registry.
@@ -75,8 +87,21 @@ public interface Metrics {
    * Counter openConnections = getNodeMetric(node, DefaultNodeMetric.OPEN_CONNECTIONS);
    * }</pre>
    *
+   * @param profileName the name of the execution profile, or {@code null} if the metric is not
+   *     associated to any profile. Note that this is only included for future extensibility: at
+   *     this time, the driver does not break up metrics per profile. Therefore you can always use
+   *     {@link #getNodeMetric(Node, NodeMetric)} instead of this method.
    * @return the metric, or {@code null} if it is disabled.
    */
   @SuppressWarnings("TypeParameterUnusedInFormals")
-  <T extends Metric> T getNodeMetric(Node node, NodeMetric metric);
+  <T extends Metric> T getNodeMetric(Node node, NodeMetric metric, String profileName);
+
+  /**
+   * Shortcut for {@link #getNodeMetric(Node, NodeMetric, String) getNodeMetric(node, metric,
+   * null)}.
+   */
+  @SuppressWarnings("TypeParameterUnusedInFormals")
+  default <T extends Metric> T getNodeMetric(Node node, NodeMetric metric) {
+    return getNodeMetric(node, metric, null);
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/ThrottledAdminRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/ThrottledAdminRequestHandler.java
@@ -64,6 +64,7 @@ public class ThrottledAdminRequestHandler extends AdminRequestHandler implements
     if (wasDelayed) {
       metricUpdater.updateTimer(
           DefaultSessionMetric.THROTTLING_DELAY,
+          null,
           System.nanoTime() - startTimeNanos,
           TimeUnit.NANOSECONDS);
     }
@@ -72,7 +73,7 @@ public class ThrottledAdminRequestHandler extends AdminRequestHandler implements
 
   @Override
   public void onThrottleFailure(RequestThrottlingException error) {
-    metricUpdater.incrementCounter(DefaultSessionMetric.THROTTLING_ERRORS);
+    metricUpdater.incrementCounter(DefaultSessionMetric.THROTTLING_ERRORS, null);
     setFinalError(error);
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelFactory.java
@@ -274,15 +274,15 @@ public class ChannelFactory {
 
           // Only add meter handlers on the pipeline if metrics are enabled.
           SessionMetricUpdater sessionMetricUpdater = context.metricsFactory().getSessionUpdater();
-          if (nodeMetricUpdater.isEnabled(DefaultNodeMetric.BYTES_RECEIVED)
-              || sessionMetricUpdater.isEnabled(DefaultSessionMetric.BYTES_RECEIVED)) {
+          if (nodeMetricUpdater.isEnabled(DefaultNodeMetric.BYTES_RECEIVED, null)
+              || sessionMetricUpdater.isEnabled(DefaultSessionMetric.BYTES_RECEIVED, null)) {
             pipeline.addLast(
                 "inboundTrafficMeter",
                 new InboundTrafficMeter(nodeMetricUpdater, sessionMetricUpdater));
           }
 
-          if (nodeMetricUpdater.isEnabled(DefaultNodeMetric.BYTES_SENT)
-              || sessionMetricUpdater.isEnabled(DefaultSessionMetric.BYTES_SENT)) {
+          if (nodeMetricUpdater.isEnabled(DefaultNodeMetric.BYTES_SENT, null)
+              || sessionMetricUpdater.isEnabled(DefaultSessionMetric.BYTES_SENT, null)) {
             pipeline.addLast(
                 "outboundTrafficMeter",
                 new OutboundTrafficMeter(nodeMetricUpdater, sessionMetricUpdater));

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/InboundTrafficMeter.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/InboundTrafficMeter.java
@@ -38,8 +38,8 @@ public class InboundTrafficMeter extends ChannelInboundHandlerAdapter {
   public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
     if (msg instanceof ByteBuf) {
       int bytes = ((ByteBuf) msg).readableBytes();
-      nodeMetricUpdater.markMeter(DefaultNodeMetric.BYTES_RECEIVED, bytes);
-      sessionMetricUpdater.markMeter(DefaultSessionMetric.BYTES_RECEIVED, bytes);
+      nodeMetricUpdater.markMeter(DefaultNodeMetric.BYTES_RECEIVED, null, bytes);
+      sessionMetricUpdater.markMeter(DefaultSessionMetric.BYTES_RECEIVED, null, bytes);
     }
     super.channelRead(ctx, msg);
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/OutboundTrafficMeter.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/OutboundTrafficMeter.java
@@ -40,8 +40,8 @@ public class OutboundTrafficMeter extends ChannelOutboundHandlerAdapter {
       throws Exception {
     if (msg instanceof ByteBuf) {
       int bytes = ((ByteBuf) msg).readableBytes();
-      nodeMetricUpdater.markMeter(DefaultNodeMetric.BYTES_SENT, bytes);
-      sessionMetricUpdater.markMeter(DefaultSessionMetric.BYTES_SENT, bytes);
+      nodeMetricUpdater.markMeter(DefaultNodeMetric.BYTES_SENT, null, bytes);
+      sessionMetricUpdater.markMeter(DefaultSessionMetric.BYTES_SENT, null, bytes);
     }
     super.write(ctx, msg, promise);
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/config/typesafe/TypesafeDriverConfig.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/config/typesafe/TypesafeDriverConfig.java
@@ -130,7 +130,7 @@ public class TypesafeDriverConfig implements DriverConfig {
   }
 
   @Override
-  public DriverConfigProfile getNamedProfile(String profileName) {
+  public DriverConfigProfile getProfile(String profileName) {
     Preconditions.checkArgument(
         profiles.containsKey(profileName),
         "Unknown profile '%s'. Check your configuration.",
@@ -139,7 +139,7 @@ public class TypesafeDriverConfig implements DriverConfig {
   }
 
   @Override
-  public Map<String, DriverConfigProfile> getNamedProfiles() {
+  public Map<String, DriverConfigProfile> getProfiles() {
     return ImmutableMap.copyOf(profiles);
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/config/typesafe/TypesafeDriverConfigProfile.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/config/typesafe/TypesafeDriverConfigProfile.java
@@ -145,6 +145,12 @@ public abstract class TypesafeDriverConfigProfile implements DriverConfigProfile
   }
 
   @Override
+  public Object getComparisonKey(DriverOption option) {
+    // No need to cache this, it's only used for policy initialization
+    return getEffectiveOptions().getConfig(option.getPath());
+  }
+
+  @Override
   public SortedSet<Map.Entry<String, Object>> entrySet() {
     ImmutableSortedSet.Builder<Map.Entry<String, Object>> builder =
         ImmutableSortedSet.orderedBy(Comparator.comparing(Map.Entry::getKey));
@@ -176,11 +182,18 @@ public abstract class TypesafeDriverConfigProfile implements DriverConfigProfile
   @ThreadSafe
   static class Base extends TypesafeDriverConfigProfile {
 
+    private final String name;
     private volatile Config options;
     private volatile Set<Derived> derivedProfiles;
 
-    Base(Config options) {
+    Base(String name, Config options) {
+      this.name = name;
       this.options = options;
+    }
+
+    @Override
+    public String getName() {
+      return name;
     }
 
     @Override
@@ -247,6 +260,11 @@ public abstract class TypesafeDriverConfigProfile implements DriverConfigProfile
     void refresh() {
       this.effectiveOptions = addedOptions.withFallback(baseProfile.getEffectiveOptions());
       this.cache.clear();
+    }
+
+    @Override
+    public String getName() {
+      return baseProfile.getName();
     }
 
     @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/InternalDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/InternalDriverContext.java
@@ -105,8 +105,9 @@ public interface InternalDriverContext extends DriverContext {
   RequestTracker requestTracker();
 
   /**
-   * This is the filter from {@link SessionBuilder#withNodeFilter(Predicate)}. If the filter is
-   * specified through the configuration, this method will return {@code null}.
+   * This is the filter from {@link SessionBuilder#withNodeFilter(String, Predicate)}. If the filter
+   * for this profile was specified through the configuration instead, this method will return
+   * {@code null}.
    */
-  Predicate<Node> nodeFilter();
+  Predicate<Node> nodeFilter(String profileName);
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandlerBase.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandlerBase.java
@@ -124,7 +124,7 @@ public abstract class CqlPrepareHandlerBase implements Throttled {
       this.configProfile =
           (profileName == null || profileName.isEmpty())
               ? config.getDefaultProfile()
-              : config.getNamedProfile(profileName);
+              : config.getProfile(profileName);
     }
     this.queryPlan =
         context

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerBase.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerBase.java
@@ -149,7 +149,7 @@ public abstract class CqlRequestHandlerBase implements Throttled {
       this.configProfile =
           (profileName == null || profileName.isEmpty())
               ? config.getDefaultProfile()
-              : config.getNamedProfile(profileName);
+              : config.getProfile(profileName);
     }
     this.queryPlan =
         context

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
@@ -107,17 +107,19 @@ public class DefaultLoadBalancingPolicy implements LoadBalancingPolicy {
       Set<InetSocketAddress> contactPoints) {
     this.distanceReporter = distanceReporter;
 
-    if (contactPoints.isEmpty()) {
-      // No explicit contact points provided => the driver used the default one, and we allow
-      // inferring the local DC in this case
-      Node contactPoint = nodes.get(MetadataManager.DEFAULT_CONTACT_POINT);
-      localDc = contactPoint.getDatacenter();
-      LOG.debug("[{}] Local DC set from contact point {}: {}", logPrefix, contactPoint, localDc);
-    } else if (localDc == null) {
-      throw new IllegalStateException(
-          "You provided explicit contact points, the local DC must be specified (see "
-              + DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER.getPath()
-              + " in the config)");
+    if (localDc == null) {
+      if (contactPoints.isEmpty()) {
+        // No explicit contact points provided => the driver used the default (127.0.0.1:9042), and
+        // we allow inferring the local DC in this case
+        Node contactPoint = nodes.get(MetadataManager.DEFAULT_CONTACT_POINT);
+        localDc = contactPoint.getDatacenter();
+        LOG.debug("[{}] Local DC set from contact point {}: {}", logPrefix, contactPoint, localDc);
+      } else {
+        throw new IllegalStateException(
+            "You provided explicit contact points, the local DC must be specified (see "
+                + DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER.getPath()
+                + " in the config)");
+      }
     } else {
       ImmutableMap.Builder<InetSocketAddress, String> builder = ImmutableMap.builder();
       for (InetSocketAddress address : contactPoints) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
@@ -283,10 +283,7 @@ public class DefaultLoadBalancingPolicy implements LoadBalancingPolicy {
   }
 
   private static String getLocalDcFromConfig(DriverContext context, String profileName) {
-    DriverConfigProfile config =
-        (profileName.equals(DriverConfigProfile.DEFAULT_NAME))
-            ? context.config().getDefaultProfile()
-            : context.config().getNamedProfile(profileName);
+    DriverConfigProfile config = context.config().getNamedProfile(profileName);
     return (config.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER))
         ? config.getString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER)
         : null;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
@@ -283,7 +283,7 @@ public class DefaultLoadBalancingPolicy implements LoadBalancingPolicy {
   }
 
   private static String getLocalDcFromConfig(DriverContext context, String profileName) {
-    DriverConfigProfile config = context.config().getNamedProfile(profileName);
+    DriverConfigProfile config = context.config().getProfile(profileName);
     return (config.isDefined(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER))
         ? config.getString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER)
         : null;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DistanceEvent.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DistanceEvent.java
@@ -16,7 +16,6 @@
 package com.datastax.oss.driver.internal.core.metadata;
 
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
-import com.datastax.oss.driver.api.core.metadata.Node;
 import java.util.Objects;
 import net.jcip.annotations.Immutable;
 
@@ -24,7 +23,6 @@ import net.jcip.annotations.Immutable;
  * Indicates that the load balancing policy has assigned a new distance to a host.
  *
  * <p>This is informational only: firing this event manually does <b>not</b> change the distance.
- * For that, see {@link LoadBalancingPolicyWrapper#setDistance(Node, NodeDistance)}.
  */
 @Immutable
 public class DistanceEvent {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapper.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.driver.internal.core.metadata;
 
+import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
 import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy;
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
 import com.datastax.oss.driver.api.core.metadata.Metadata;
@@ -25,32 +26,38 @@ import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.util.concurrent.ReplayingEventFilter;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import net.jcip.annotations.GuardedBy;
 import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Wraps the user-provided LBP for internal use. This serves multiple purposes:
+ * Wraps the user-provided LBPs for internal use. This serves multiple purposes:
  *
  * <ul>
  *   <li>help enforce the guarantee that init is called exactly once, and before any other method.
- *   <li>handle the early stages of initialization (before first actual connect), where the LBP is
+ *   <li>handle the early stages of initialization (before first actual connect), where the LBPs are
  *       not ready yet.
- *   <li>handle incoming node state events from the outside world and propagate them to the policy.
- *   <li>process distance decisions from the policy and propagate them to the outside world.
+ *   <li>handle incoming node state events from the outside world and propagate them to the
+ *       policies.
+ *   <li>process distance decisions from the policies and propagate them to the outside world.
  * </ul>
  */
 @ThreadSafe
-public class LoadBalancingPolicyWrapper
-    implements LoadBalancingPolicy.DistanceReporter, AutoCloseable {
+public class LoadBalancingPolicyWrapper implements AutoCloseable {
 
   private static final Logger LOG = LoggerFactory.getLogger(LoadBalancingPolicyWrapper.class);
 
@@ -62,39 +69,74 @@ public class LoadBalancingPolicyWrapper
   }
 
   private final InternalDriverContext context;
-  private final LoadBalancingPolicy policy;
+  private final Set<LoadBalancingPolicy> policies;
+  private final Map<String, LoadBalancingPolicy> policiesPerProfile;
+  private final Map<LoadBalancingPolicy, SinglePolicyDistanceReporter> reporters;
+
+  private final Lock distancesLock = new ReentrantLock();
+
+  // Remember which distance each policy reported for each node. We assume that distance events will
+  // be rare, so don't try to be too clever, a global lock should suffice.
+  @GuardedBy("distancesLock")
+  private final Map<Node, Map<LoadBalancingPolicy, NodeDistance>> distances;
+
   private final String logPrefix;
   private final ReplayingEventFilter<NodeStateEvent> eventFilter =
       new ReplayingEventFilter<>(this::processNodeStateEvent);
   private AtomicReference<State> stateRef = new AtomicReference<>(State.BEFORE_INIT);
 
-  public LoadBalancingPolicyWrapper(InternalDriverContext context, LoadBalancingPolicy policy) {
+  public LoadBalancingPolicyWrapper(
+      InternalDriverContext context, Map<String, LoadBalancingPolicy> policiesPerProfile) {
     this.context = context;
-    this.policy = policy;
+
+    this.policiesPerProfile = policiesPerProfile;
+    ImmutableMap.Builder<LoadBalancingPolicy, SinglePolicyDistanceReporter> reportersBuilder =
+        ImmutableMap.builder();
+    // ImmutableMap.values does not remove duplicates, do it now so that we won't invoke a policy
+    // more than once if it's associated with multiple profiles
+    for (LoadBalancingPolicy policy : ImmutableSet.copyOf(policiesPerProfile.values())) {
+      reportersBuilder.put(policy, new SinglePolicyDistanceReporter(policy));
+    }
+    this.reporters = reportersBuilder.build();
+    // Just an alias to make the rest of the code more readable
+    this.policies = reporters.keySet();
+
+    this.distances = new HashMap<>();
+
     this.logPrefix = context.sessionName();
     context.eventBus().register(NodeStateEvent.class, this::onNodeStateEvent);
   }
 
   public void init() {
     if (stateRef.compareAndSet(State.BEFORE_INIT, State.DURING_INIT)) {
-      LOG.debug("[{}] Initializing policy", logPrefix);
+      LOG.debug("[{}] Initializing policies", logPrefix);
       // State events can happen concurrently with init, so we must record them and replay once the
       // policy is initialized.
       eventFilter.start();
       MetadataManager metadataManager = context.metadataManager();
       Metadata metadata = metadataManager.getMetadata();
-      policy.init(excludeDownHosts(metadata), this, metadataManager.getContactPoints());
+      for (LoadBalancingPolicy policy : policies) {
+        policy.init(
+            excludeDownHosts(metadata), reporters.get(policy), metadataManager.getContactPoints());
+      }
       if (stateRef.compareAndSet(State.DURING_INIT, State.RUNNING)) {
         eventFilter.markReady();
       } else { // closed during init
         assert stateRef.get() == State.CLOSING;
-        policy.close();
+        for (LoadBalancingPolicy policy : policies) {
+          policy.close();
+        }
       }
     }
   }
 
-  /** @see LoadBalancingPolicy#newQueryPlan(Request, Session) */
-  public Queue<Node> newQueryPlan(Request request, Session session) {
+  /**
+   * Note: we could infer the profile name from the request again in this method, but since that's
+   * already done in request processors, pass the value directly.
+   *
+   * @see LoadBalancingPolicy#newQueryPlan(Request, Session)
+   */
+  public Queue<Node> newQueryPlan(Request request, String configProfileName, Session session) {
     switch (stateRef.get()) {
       case BEFORE_INIT:
       case DURING_INIT:
@@ -105,6 +147,10 @@ public class LoadBalancingPolicyWrapper
         Collections.shuffle(nodes);
         return new ConcurrentLinkedQueue<>(nodes);
       case RUNNING:
+        LoadBalancingPolicy policy = policiesPerProfile.get(configProfileName);
+        if (policy == null) {
+          policy = policiesPerProfile.get(DriverConfigProfile.DEFAULT_NAME);
+        }
         return policy.newQueryPlan(request, session);
       default:
         return new ConcurrentLinkedQueue<>();
@@ -112,15 +158,7 @@ public class LoadBalancingPolicyWrapper
   }
 
   public Queue<Node> newQueryPlan() {
-    return newQueryPlan(null, null);
-  }
-
-  @Override
-  public void setDistance(Node node, NodeDistance distance) {
-    LOG.debug("[{}] LBP changed distance of {} to {}", logPrefix, node, distance);
-    DefaultNode defaultNode = (DefaultNode) node;
-    defaultNode.distance = distance;
-    context.eventBus().fire(new DistanceEvent(distance, defaultNode));
+    return newQueryPlan(null, DriverConfigProfile.DEFAULT_NAME, null);
   }
 
   // when it comes in from the outside
@@ -137,16 +175,18 @@ public class LoadBalancingPolicyWrapper
       case CLOSING:
         return; // ignore
       case RUNNING:
-        if (event.newState == NodeState.UP) {
-          policy.onUp(event.node);
-        } else if (event.newState == NodeState.DOWN || event.newState == NodeState.FORCED_DOWN) {
-          policy.onDown(event.node);
-        } else if (event.newState == NodeState.UNKNOWN) {
-          policy.onAdd(event.node);
-        } else if (event.newState == null) {
-          policy.onRemove(event.node);
-        } else {
-          LOG.warn("[{}] Unsupported event: {}", logPrefix, event);
+        for (LoadBalancingPolicy policy : policies) {
+          if (event.newState == NodeState.UP) {
+            policy.onUp(event.node);
+          } else if (event.newState == NodeState.DOWN || event.newState == NodeState.FORCED_DOWN) {
+            policy.onDown(event.node);
+          } else if (event.newState == NodeState.UNKNOWN) {
+            policy.onAdd(event.node);
+          } else if (event.newState == null) {
+            policy.onRemove(event.node);
+          } else {
+            LOG.warn("[{}] Unsupported event: {}", logPrefix, event);
+          }
         }
         break;
     }
@@ -173,10 +213,67 @@ public class LoadBalancingPolicyWrapper
         break;
       }
     }
-    // If BEFORE_INIT, no need to close because it was never initialized
+    // If BEFORE_INIT, no need to close because they were never initialized
     // If DURING_INIT, this will be handled in init()
     if (old == State.RUNNING) {
-      policy.close();
+      for (LoadBalancingPolicy policy : policies) {
+        policy.close();
+      }
+    }
+  }
+
+  // An individual distance reporter for one of the policies. The results are aggregated across all
+  // policies, the smallest distance for each node is used.
+  private class SinglePolicyDistanceReporter implements LoadBalancingPolicy.DistanceReporter {
+
+    private final LoadBalancingPolicy policy;
+
+    private SinglePolicyDistanceReporter(LoadBalancingPolicy policy) {
+      this.policy = policy;
+    }
+
+    @Override
+    public void setDistance(Node node, NodeDistance suggestedDistance) {
+      LOG.debug(
+          "[{}] {} suggested {} to {}, checking what other policies said",
+          logPrefix,
+          policy,
+          node,
+          suggestedDistance);
+      distancesLock.lock();
+      try {
+        Map<LoadBalancingPolicy, NodeDistance> distancesForNode =
+            distances.computeIfAbsent(node, (n) -> new HashMap<>());
+        distancesForNode.put(policy, suggestedDistance);
+        NodeDistance newDistance = aggregate(distancesForNode);
+        LOG.debug("[{}] Shortest distance across all policies is {}", logPrefix, newDistance);
+
+        // There is a small race condition here (check-then-act on a volatile field). However this
+        // would only happen if external code changes the distance, which is unlikely (and
+        // dangerous).
+        // The driver internals only ever set the distance here, and we're protected by the lock.
+        NodeDistance oldDistance = node.getDistance();
+        if (!oldDistance.equals(newDistance)) {
+          LOG.debug("[{}] {} was {}, changing to {}", logPrefix, node, oldDistance, newDistance);
+          DefaultNode defaultNode = (DefaultNode) node;
+          defaultNode.distance = newDistance;
+          context.eventBus().fire(new DistanceEvent(newDistance, defaultNode));
+        } else {
+          LOG.debug("[{}] {} was already {}, ignoring", logPrefix, node, oldDistance);
+        }
+      } finally {
+        distancesLock.unlock();
+      }
+    }
+
+    private NodeDistance aggregate(Map<LoadBalancingPolicy, NodeDistance> distances) {
+      NodeDistance minimum = NodeDistance.IGNORED;
+      for (NodeDistance candidate : distances.values()) {
+        if (candidate.compareTo(minimum) < 0) {
+          minimum = candidate;
+        }
+      }
+      return minimum;
     }
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DefaultMetrics.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DefaultMetrics.java
@@ -42,14 +42,14 @@ public class DefaultMetrics implements Metrics {
 
   @Override
   @SuppressWarnings("TypeParameterUnusedInFormals")
-  public <T extends Metric> T getSessionMetric(SessionMetric metric) {
-    return sessionUpdater.getMetric(metric);
+  public <T extends Metric> T getSessionMetric(SessionMetric metric, String profileName) {
+    return sessionUpdater.getMetric(metric, profileName);
   }
 
   @Override
   @SuppressWarnings("TypeParameterUnusedInFormals")
-  public <T extends Metric> T getNodeMetric(Node node, NodeMetric metric) {
+  public <T extends Metric> T getNodeMetric(Node node, NodeMetric metric, String profileName) {
     NodeMetricUpdater nodeUpdater = ((DefaultNode) node).getMetricUpdater();
-    return ((DropwizardNodeMetricUpdater) nodeUpdater).getMetric(metric);
+    return ((DropwizardNodeMetricUpdater) nodeUpdater).getMetric(metric, profileName);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DropwizardMetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DropwizardMetricUpdater.java
@@ -40,50 +40,50 @@ public abstract class DropwizardMetricUpdater<MetricT> implements MetricUpdater<
     this.registry = registry;
   }
 
-  protected abstract String buildFullName(MetricT metric);
+  protected abstract String buildFullName(MetricT metric, String profileName);
 
   @Override
-  public void incrementCounter(MetricT metric, long amount) {
-    if (isEnabled(metric)) {
-      registry.counter(buildFullName(metric)).inc(amount);
+  public void incrementCounter(MetricT metric, String profileName, long amount) {
+    if (isEnabled(metric, profileName)) {
+      registry.counter(buildFullName(metric, profileName)).inc(amount);
     }
   }
 
   @Override
-  public void updateHistogram(MetricT metric, long value) {
-    if (isEnabled(metric)) {
-      registry.histogram(buildFullName(metric)).update(value);
+  public void updateHistogram(MetricT metric, String profileName, long value) {
+    if (isEnabled(metric, profileName)) {
+      registry.histogram(buildFullName(metric, profileName)).update(value);
     }
   }
 
   @Override
-  public void markMeter(MetricT metric, long amount) {
-    if (isEnabled(metric)) {
-      registry.meter(buildFullName(metric)).mark(amount);
+  public void markMeter(MetricT metric, String profileName, long amount) {
+    if (isEnabled(metric, profileName)) {
+      registry.meter(buildFullName(metric, profileName)).mark(amount);
     }
   }
 
   @Override
-  public void updateTimer(MetricT metric, long duration, TimeUnit unit) {
-    if (isEnabled(metric)) {
-      registry.timer(buildFullName(metric)).update(duration, unit);
+  public void updateTimer(MetricT metric, String profileName, long duration, TimeUnit unit) {
+    if (isEnabled(metric, profileName)) {
+      registry.timer(buildFullName(metric, profileName)).update(duration, unit);
     }
   }
 
   @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
-  public <T extends Metric> T getMetric(MetricT metric) {
-    return (T) registry.getMetrics().get(buildFullName(metric));
+  public <T extends Metric> T getMetric(MetricT metric, String profileName) {
+    return (T) registry.getMetrics().get(buildFullName(metric, profileName));
   }
 
   @Override
-  public boolean isEnabled(MetricT metric) {
+  public boolean isEnabled(MetricT metric, String profileName) {
     return enabledMetrics.contains(metric);
   }
 
-  protected void initializeDefaultCounter(MetricT metric) {
-    if (isEnabled(metric)) {
+  protected void initializeDefaultCounter(MetricT metric, String profileName) {
+    if (isEnabled(metric, profileName)) {
       // Just initialize eagerly so that the metric appears even when it has no data yet
-      registry.counter(buildFullName(metric));
+      registry.counter(buildFullName(metric, profileName));
     }
   }
 
@@ -93,8 +93,9 @@ public abstract class DropwizardMetricUpdater<MetricT> implements MetricUpdater<
       DefaultDriverOption highestLatencyOption,
       DefaultDriverOption significantDigitsOption,
       DefaultDriverOption intervalOption) {
-    if (isEnabled(metric)) {
-      String fullName = buildFullName(metric);
+    String profileName = config.getName();
+    if (isEnabled(metric, profileName)) {
+      String fullName = buildFullName(metric, profileName);
 
       Duration highestLatency = config.getDuration(highestLatencyOption);
       final int significantDigits;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DropwizardNodeMetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DropwizardNodeMetricUpdater.java
@@ -50,7 +50,7 @@ public class DropwizardNodeMetricUpdater extends DropwizardMetricUpdater<NodeMet
 
     if (enabledMetrics.contains(DefaultNodeMetric.OPEN_CONNECTIONS)) {
       this.registry.register(
-          buildFullName(DefaultNodeMetric.OPEN_CONNECTIONS),
+          buildFullName(DefaultNodeMetric.OPEN_CONNECTIONS, null),
           (Gauge<Integer>) node::getOpenConnections);
     }
     initializePoolGauge(
@@ -64,31 +64,31 @@ public class DropwizardNodeMetricUpdater extends DropwizardMetricUpdater<NodeMet
         DefaultDriverOption.METRICS_NODE_CQL_MESSAGES_HIGHEST,
         DefaultDriverOption.METRICS_NODE_CQL_MESSAGES_DIGITS,
         DefaultDriverOption.METRICS_NODE_CQL_MESSAGES_INTERVAL);
-    initializeDefaultCounter(DefaultNodeMetric.UNSENT_REQUESTS);
-    initializeDefaultCounter(DefaultNodeMetric.ABORTED_REQUESTS);
-    initializeDefaultCounter(DefaultNodeMetric.WRITE_TIMEOUTS);
-    initializeDefaultCounter(DefaultNodeMetric.READ_TIMEOUTS);
-    initializeDefaultCounter(DefaultNodeMetric.UNAVAILABLES);
-    initializeDefaultCounter(DefaultNodeMetric.OTHER_ERRORS);
-    initializeDefaultCounter(DefaultNodeMetric.RETRIES);
-    initializeDefaultCounter(DefaultNodeMetric.RETRIES_ON_ABORTED);
-    initializeDefaultCounter(DefaultNodeMetric.RETRIES_ON_READ_TIMEOUT);
-    initializeDefaultCounter(DefaultNodeMetric.RETRIES_ON_WRITE_TIMEOUT);
-    initializeDefaultCounter(DefaultNodeMetric.RETRIES_ON_UNAVAILABLE);
-    initializeDefaultCounter(DefaultNodeMetric.RETRIES_ON_OTHER_ERROR);
-    initializeDefaultCounter(DefaultNodeMetric.IGNORES);
-    initializeDefaultCounter(DefaultNodeMetric.IGNORES_ON_ABORTED);
-    initializeDefaultCounter(DefaultNodeMetric.IGNORES_ON_READ_TIMEOUT);
-    initializeDefaultCounter(DefaultNodeMetric.IGNORES_ON_WRITE_TIMEOUT);
-    initializeDefaultCounter(DefaultNodeMetric.IGNORES_ON_UNAVAILABLE);
-    initializeDefaultCounter(DefaultNodeMetric.IGNORES_ON_OTHER_ERROR);
-    initializeDefaultCounter(DefaultNodeMetric.SPECULATIVE_EXECUTIONS);
-    initializeDefaultCounter(DefaultNodeMetric.CONNECTION_INIT_ERRORS);
-    initializeDefaultCounter(DefaultNodeMetric.AUTHENTICATION_ERRORS);
+    initializeDefaultCounter(DefaultNodeMetric.UNSENT_REQUESTS, null);
+    initializeDefaultCounter(DefaultNodeMetric.ABORTED_REQUESTS, null);
+    initializeDefaultCounter(DefaultNodeMetric.WRITE_TIMEOUTS, null);
+    initializeDefaultCounter(DefaultNodeMetric.READ_TIMEOUTS, null);
+    initializeDefaultCounter(DefaultNodeMetric.UNAVAILABLES, null);
+    initializeDefaultCounter(DefaultNodeMetric.OTHER_ERRORS, null);
+    initializeDefaultCounter(DefaultNodeMetric.RETRIES, null);
+    initializeDefaultCounter(DefaultNodeMetric.RETRIES_ON_ABORTED, null);
+    initializeDefaultCounter(DefaultNodeMetric.RETRIES_ON_READ_TIMEOUT, null);
+    initializeDefaultCounter(DefaultNodeMetric.RETRIES_ON_WRITE_TIMEOUT, null);
+    initializeDefaultCounter(DefaultNodeMetric.RETRIES_ON_UNAVAILABLE, null);
+    initializeDefaultCounter(DefaultNodeMetric.RETRIES_ON_OTHER_ERROR, null);
+    initializeDefaultCounter(DefaultNodeMetric.IGNORES, null);
+    initializeDefaultCounter(DefaultNodeMetric.IGNORES_ON_ABORTED, null);
+    initializeDefaultCounter(DefaultNodeMetric.IGNORES_ON_READ_TIMEOUT, null);
+    initializeDefaultCounter(DefaultNodeMetric.IGNORES_ON_WRITE_TIMEOUT, null);
+    initializeDefaultCounter(DefaultNodeMetric.IGNORES_ON_UNAVAILABLE, null);
+    initializeDefaultCounter(DefaultNodeMetric.IGNORES_ON_OTHER_ERROR, null);
+    initializeDefaultCounter(DefaultNodeMetric.SPECULATIVE_EXECUTIONS, null);
+    initializeDefaultCounter(DefaultNodeMetric.CONNECTION_INIT_ERRORS, null);
+    initializeDefaultCounter(DefaultNodeMetric.AUTHENTICATION_ERRORS, null);
   }
 
   @Override
-  public String buildFullName(NodeMetric metric) {
+  public String buildFullName(NodeMetric metric, String profileName) {
     return metricNamePrefix + metric.getPath();
   }
 
@@ -116,7 +116,7 @@ public class DropwizardNodeMetricUpdater extends DropwizardMetricUpdater<NodeMet
       InternalDriverContext context) {
     if (enabledMetrics.contains(metric)) {
       registry.register(
-          buildFullName(metric),
+          buildFullName(metric, null),
           (Gauge<Integer>)
               () -> {
                 ChannelPool pool = context.poolManager().getPools().get(node);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DropwizardSessionMetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DropwizardSessionMetricUpdater.java
@@ -45,7 +45,7 @@ public class DropwizardSessionMetricUpdater extends DropwizardMetricUpdater<Sess
 
     if (enabledMetrics.contains(DefaultSessionMetric.CONNECTED_NODES)) {
       this.registry.register(
-          buildFullName(DefaultSessionMetric.CONNECTED_NODES),
+          buildFullName(DefaultSessionMetric.CONNECTED_NODES, null),
           (Gauge<Integer>)
               () -> {
                 int count = 0;
@@ -59,7 +59,7 @@ public class DropwizardSessionMetricUpdater extends DropwizardMetricUpdater<Sess
     }
     if (enabledMetrics.contains(DefaultSessionMetric.THROTTLING_QUEUE_SIZE)) {
       this.registry.register(
-          buildFullName(DefaultSessionMetric.THROTTLING_QUEUE_SIZE),
+          buildFullName(DefaultSessionMetric.THROTTLING_QUEUE_SIZE, null),
           buildQueueGauge(context.requestThrottler(), context.sessionName()));
     }
     initializeHdrTimer(
@@ -68,18 +68,18 @@ public class DropwizardSessionMetricUpdater extends DropwizardMetricUpdater<Sess
         DefaultDriverOption.METRICS_SESSION_CQL_REQUESTS_HIGHEST,
         DefaultDriverOption.METRICS_SESSION_CQL_REQUESTS_DIGITS,
         DefaultDriverOption.METRICS_SESSION_CQL_REQUESTS_INTERVAL);
-    initializeDefaultCounter(DefaultSessionMetric.CQL_CLIENT_TIMEOUTS);
+    initializeDefaultCounter(DefaultSessionMetric.CQL_CLIENT_TIMEOUTS, null);
     initializeHdrTimer(
         DefaultSessionMetric.THROTTLING_DELAY,
         context.config().getDefaultProfile(),
         DefaultDriverOption.METRICS_SESSION_THROTTLING_HIGHEST,
         DefaultDriverOption.METRICS_SESSION_THROTTLING_DIGITS,
         DefaultDriverOption.METRICS_SESSION_THROTTLING_INTERVAL);
-    initializeDefaultCounter(DefaultSessionMetric.THROTTLING_ERRORS);
+    initializeDefaultCounter(DefaultSessionMetric.THROTTLING_ERRORS, null);
   }
 
   @Override
-  public String buildFullName(SessionMetric metric) {
+  public String buildFullName(SessionMetric metric, String profileName) {
     return metricNamePrefix + metric.getPath();
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/MetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/MetricUpdater.java
@@ -17,23 +17,29 @@ package com.datastax.oss.driver.internal.core.metrics;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Note about profiles names: they are included to keep the possibility to break up metrics per
+ * profile in the future, but right now the default updater implementations ignore them. The driver
+ * internals provide a profile name when it makes sense and is practical; in other cases, it passes
+ * {@code null}.
+ */
 public interface MetricUpdater<MetricT> {
 
-  void incrementCounter(MetricT metric, long amount);
+  void incrementCounter(MetricT metric, String profileName, long amount);
 
-  default void incrementCounter(MetricT metric) {
-    incrementCounter(metric, 1);
+  default void incrementCounter(MetricT metric, String profileName) {
+    incrementCounter(metric, profileName, 1);
   }
 
-  void updateHistogram(MetricT metric, long value);
+  void updateHistogram(MetricT metric, String profileName, long value);
 
-  void markMeter(MetricT metric, long amount);
+  void markMeter(MetricT metric, String profileName, long amount);
 
-  default void markMeter(MetricT metric) {
-    markMeter(metric, 1);
+  default void markMeter(MetricT metric, String profileName) {
+    markMeter(metric, profileName, 1);
   }
 
-  void updateTimer(MetricT metric, long duration, TimeUnit unit);
+  void updateTimer(MetricT metric, String profileName, long duration, TimeUnit unit);
 
-  boolean isEnabled(MetricT metric);
+  boolean isEnabled(MetricT metric, String profileName);
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/NoopNodeMetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/NoopNodeMetricUpdater.java
@@ -27,27 +27,27 @@ public class NoopNodeMetricUpdater implements NodeMetricUpdater {
   private NoopNodeMetricUpdater() {}
 
   @Override
-  public void incrementCounter(NodeMetric metric, long amount) {
+  public void incrementCounter(NodeMetric metric, String profileName, long amount) {
     // nothing to do
   }
 
   @Override
-  public void updateHistogram(NodeMetric metric, long value) {
+  public void updateHistogram(NodeMetric metric, String profileName, long value) {
     // nothing to do
   }
 
   @Override
-  public void markMeter(NodeMetric metric, long amount) {
+  public void markMeter(NodeMetric metric, String profileName, long amount) {
     // nothing to do
   }
 
   @Override
-  public void updateTimer(NodeMetric metric, long duration, TimeUnit unit) {
+  public void updateTimer(NodeMetric metric, String profileName, long duration, TimeUnit unit) {
     // nothing to do
   }
 
   @Override
-  public boolean isEnabled(NodeMetric metric) {
+  public boolean isEnabled(NodeMetric metric, String profileName) {
     // since methods don't do anything, return false
     return false;
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/NoopSessionMetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/NoopSessionMetricUpdater.java
@@ -27,27 +27,27 @@ public class NoopSessionMetricUpdater implements SessionMetricUpdater {
   private NoopSessionMetricUpdater() {}
 
   @Override
-  public void incrementCounter(SessionMetric metric, long amount) {
+  public void incrementCounter(SessionMetric metric, String profileName, long amount) {
     // nothing to do
   }
 
   @Override
-  public void updateHistogram(SessionMetric metric, long value) {
+  public void updateHistogram(SessionMetric metric, String profileName, long value) {
     // nothing to do
   }
 
   @Override
-  public void markMeter(SessionMetric metric, long amount) {
+  public void markMeter(SessionMetric metric, String profileName, long amount) {
     // nothing to do
   }
 
   @Override
-  public void updateTimer(SessionMetric metric, long duration, TimeUnit unit) {
+  public void updateTimer(SessionMetric metric, String profileName, long duration, TimeUnit unit) {
     // nothing to do
   }
 
   @Override
-  public boolean isEnabled(SessionMetric metric) {
+  public boolean isEnabled(SessionMetric metric, String profileName) {
     // since methods don't do anything, return false
     return false;
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java
@@ -295,7 +295,8 @@ public class ChannelPool implements AsyncAutoCloseable {
               .incrementCounter(
                   error instanceof AuthenticationException
                       ? DefaultNodeMetric.AUTHENTICATION_ERRORS
-                      : DefaultNodeMetric.CONNECTION_INIT_ERRORS);
+                      : DefaultNodeMetric.CONNECTION_INIT_ERRORS,
+                  null);
           if (error instanceof ClusterNameMismatchException
               || error instanceof UnsupportedProtocolVersionException) {
             // This will likely be thrown by all channels, but finish the loop cleanly

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/retry/DefaultRetryPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/retry/DefaultRetryPolicy.java
@@ -37,7 +37,9 @@ import net.jcip.annotations.ThreadSafe;
 @ThreadSafe
 public class DefaultRetryPolicy implements RetryPolicy {
 
-  public DefaultRetryPolicy(@SuppressWarnings("unused") DriverContext context) {
+  public DefaultRetryPolicy(
+      @SuppressWarnings("unused") DriverContext context,
+      @SuppressWarnings("unused") String profileName) {
     // nothing to do
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
@@ -417,16 +417,18 @@ public class DefaultSession implements CqlSession {
 
     private void closePolicies() {
       for (AutoCloseable closeable :
-          ImmutableList.of(
-              context.reconnectionPolicy(),
-              context.retryPolicy(),
-              context.loadBalancingPolicyWrapper(),
-              context.speculativeExecutionPolicy(),
-              context.addressTranslator(),
-              context.configLoader(),
-              context.nodeStateListener(),
-              context.schemaChangeListener(),
-              context.requestTracker())) {
+          ImmutableList.<AutoCloseable>builder()
+              .add(
+                  context.reconnectionPolicy(),
+                  context.loadBalancingPolicyWrapper(),
+                  context.addressTranslator(),
+                  context.configLoader(),
+                  context.nodeStateListener(),
+                  context.schemaChangeListener(),
+                  context.requestTracker())
+              .addAll(context.retryPolicies().values())
+              .addAll(context.speculativeExecutionPolicies().values())
+              .build()) {
         try {
           closeable.close();
         } catch (Throwable t) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/specex/ConstantSpeculativeExecutionPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/specex/ConstantSpeculativeExecutionPolicy.java
@@ -38,10 +38,7 @@ public class ConstantSpeculativeExecutionPolicy implements SpeculativeExecutionP
   private final long constantDelayMillis;
 
   public ConstantSpeculativeExecutionPolicy(DriverContext context, String profileName) {
-    DriverConfigProfile config =
-        (profileName.equals(DriverConfigProfile.DEFAULT_NAME))
-            ? context.config().getDefaultProfile()
-            : context.config().getNamedProfile(profileName);
+    DriverConfigProfile config = context.config().getNamedProfile(profileName);
     this.maxExecutions = config.getInt(DefaultDriverOption.SPECULATIVE_EXECUTION_MAX);
     if (this.maxExecutions < 1) {
       throw new IllegalArgumentException("Max must be at least 1");

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/specex/ConstantSpeculativeExecutionPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/specex/ConstantSpeculativeExecutionPolicy.java
@@ -38,7 +38,7 @@ public class ConstantSpeculativeExecutionPolicy implements SpeculativeExecutionP
   private final long constantDelayMillis;
 
   public ConstantSpeculativeExecutionPolicy(DriverContext context, String profileName) {
-    DriverConfigProfile config = context.config().getNamedProfile(profileName);
+    DriverConfigProfile config = context.config().getProfile(profileName);
     this.maxExecutions = config.getInt(DefaultDriverOption.SPECULATIVE_EXECUTION_MAX);
     if (this.maxExecutions < 1) {
       throw new IllegalArgumentException("Max must be at least 1");

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/specex/ConstantSpeculativeExecutionPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/specex/ConstantSpeculativeExecutionPolicy.java
@@ -37,8 +37,11 @@ public class ConstantSpeculativeExecutionPolicy implements SpeculativeExecutionP
   private final int maxExecutions;
   private final long constantDelayMillis;
 
-  public ConstantSpeculativeExecutionPolicy(DriverContext context) {
-    DriverConfigProfile config = context.config().getDefaultProfile();
+  public ConstantSpeculativeExecutionPolicy(DriverContext context, String profileName) {
+    DriverConfigProfile config =
+        (profileName.equals(DriverConfigProfile.DEFAULT_NAME))
+            ? context.config().getDefaultProfile()
+            : context.config().getNamedProfile(profileName);
     this.maxExecutions = config.getInt(DefaultDriverOption.SPECULATIVE_EXECUTION_MAX);
     if (this.maxExecutions < 1) {
       throw new IllegalArgumentException("Max must be at least 1");

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/specex/NoSpeculativeExecutionPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/specex/NoSpeculativeExecutionPolicy.java
@@ -26,7 +26,9 @@ import net.jcip.annotations.ThreadSafe;
 @ThreadSafe
 public class NoSpeculativeExecutionPolicy implements SpeculativeExecutionPolicy {
 
-  public NoSpeculativeExecutionPolicy(@SuppressWarnings("unused") DriverContext context) {
+  public NoSpeculativeExecutionPolicy(
+      @SuppressWarnings("unused") DriverContext context,
+      @SuppressWarnings("unused") String profileName) {
     // nothing to do
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/time/MonotonicTimestampGenerator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/time/MonotonicTimestampGenerator.java
@@ -19,7 +19,6 @@ import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
 import com.datastax.oss.driver.api.core.context.DriverContext;
 import com.datastax.oss.driver.api.core.time.TimestampGenerator;
-import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import java.util.concurrent.atomic.AtomicLong;
 import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
@@ -43,7 +42,6 @@ abstract class MonotonicTimestampGenerator implements TimestampGenerator {
     this(buildClock(context), context);
   }
 
-  @VisibleForTesting
   protected MonotonicTimestampGenerator(Clock clock, DriverContext context) {
     this.clock = clock;
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/Reflection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/Reflection.java
@@ -124,7 +124,7 @@ public class Reflection {
     // Find out how many distinct configurations we have
     ListMultimap<Object, String> profilesByConfig =
         MultimapBuilder.hashKeys().arrayListValues().build();
-    for (DriverConfigProfile profile : context.config().getNamedProfiles().values()) {
+    for (DriverConfigProfile profile : context.config().getProfiles().values()) {
       profilesByConfig.put(profile.getComparisonKey(rootOption), profile.getName());
     }
 
@@ -164,7 +164,7 @@ public class Reflection {
     DriverConfigProfile config =
         (profileName == null)
             ? context.config().getDefaultProfile()
-            : context.config().getNamedProfile(profileName);
+            : context.config().getProfile(profileName);
 
     String configPath = classNameOption.getPath();
     LOG.debug("Creating a {} from config option {}", expectedSuperType.getSimpleName(), configPath);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/Reflection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/Reflection.java
@@ -124,9 +124,6 @@ public class Reflection {
     // Find out how many distinct configurations we have
     ListMultimap<Object, String> profilesByConfig =
         MultimapBuilder.hashKeys().arrayListValues().build();
-    DriverConfigProfile defaultProfile = context.config().getDefaultProfile();
-    profilesByConfig.put(
-        defaultProfile.getComparisonKey(rootOption), DriverConfigProfile.DEFAULT_NAME);
     for (DriverConfigProfile profile : context.config().getNamedProfiles().values()) {
       profilesByConfig.put(profile.getComparisonKey(rootOption), profile.getName());
     }
@@ -165,7 +162,7 @@ public class Reflection {
       String... defaultPackages) {
 
     DriverConfigProfile config =
-        (profileName == null || profileName.equals(DriverConfigProfile.DEFAULT_NAME))
+        (profileName == null)
             ? context.config().getDefaultProfile()
             : context.config().getNamedProfile(profileName);
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -122,6 +122,16 @@ datastax-java-driver {
 
   # The policy that decides the "query plan" for each query; that is, which nodes to try as
   # coordinators, and in which order.
+  # It can be overridden in a profile. Note that the driver creates as few instances as possible:
+  # if a named profile inherits from the default profile, or if two sibling profiles have the
+  # exact same configuration, they will share a single policy instance at runtime.
+  #
+  # If there are multiple load balancing policies in a single driver instance, they work together in
+  # the following way:
+  # - each request gets a query plan from its profile's policy (or the default policy if the request
+  #   has no profile, or the profile does not override the policy).
+  # - when the policies assign distances to nodes, the driver uses the closest assigned distance for
+  #   any given node.
   load-balancing-policy {
     # The class of the policy. If it is not qualified, the driver assumes that it resides in the
     # package com.datastax.oss.driver.internal.core.loadbalancing.
@@ -129,7 +139,8 @@ datastax-java-driver {
     # The driver provides a single implementation out of the box: DefaultLoadBalancingPolicy.
     #
     # You can also specify a custom class that implements LoadBalancingPolicy and has a public
-    # constructor with a DriverContext argument.
+    # constructor with two arguments: the DriverContext and a String representing the profile
+    # name.
     class = DefaultLoadBalancingPolicy
 
     # The datacenter that is considered "local": the default policy will only include nodes from
@@ -445,6 +456,9 @@ datastax-java-driver {
     default-idempotence = false
 
     # The generator that assigns a microsecond timestamp to each request.
+    # It can be overridden in a profile. Note that the driver creates as few instances as possible:
+    # if a named profile inherits from the default profile, or if two sibling profiles have the
+    # exact same configuration, they will share a single generator instance at runtime.
     timestamp-generator {
       # The class of the generator. If it is not qualified, the driver assumes that it resides in the
       # package com.datastax.oss.driver.internal.core.time.
@@ -456,7 +470,8 @@ datastax-java-driver {
       # - ServerSideTimestampGenerator: do not generate timestamps, let the server assign them.
       #
       # You can also specify a custom class that implements LoadBalancingPolicy and has a public
-      # constructor with a DriverContext argument.
+      # constructor with two arguments: the DriverContext and a String representing the profile
+      # name.
       class = AtomicTimestampGenerator
 
       # To guarantee that queries are applied on the server in the same order as the client issued
@@ -481,6 +496,9 @@ datastax-java-driver {
     }
 
     # The policy that controls if the driver retries requests that have failed on one node.
+    # It can be overridden in a profile. Note that the driver creates as few instances as possible:
+    # if a named profile inherits from the default profile, or if two sibling profiles have the
+    # exact same configuration, they will share a single policy instance at runtime.
     retry-policy {
       # The class of the policy. If it is not qualified, the driver assumes that it resides in the
       # package com.datastax.oss.driver.internal.core.retry.
@@ -488,12 +506,15 @@ datastax-java-driver {
       # The driver provides a single implementation out of the box: DefaultRetryPolicy.
       #
       # You can also specify a custom class that implements RetryPolicy and has a public constructor
-      # with a DriverContext argument.
+      # with two arguments: the DriverContext and a String representing the profile name.
       class = DefaultRetryPolicy
     }
 
     # The policy that controls if the driver pre-emptively tries other nodes if a node takes too
     # long to respond.
+    # It can be overridden in a profile. Note that the driver creates as few instances as possible:
+    # if a named profile inherits from the default profile, or if two sibling profiles have the
+    # exact same configuration, they will share a single policy instance at runtime.
     speculative-execution-policy {
       # The class of the policy. If it is not qualified, the driver assumes that it resides in the
       # package com.datastax.oss.driver.internal.core.specex.
@@ -504,7 +525,8 @@ datastax-java-driver {
       #   requires the `max-executions` and `delay` options below.
       #
       # You can also specify a custom class that implements SpeculativeExecutionPolicy and has a
-      # public constructor with a DriverContext argument.
+      # public constructor with two arguments: the DriverContext and a String representing the
+      # profile name.
       class = NoSpeculativeExecutionPolicy
 
       # The maximum number of executions (including the initial, non-speculative execution).

--- a/core/src/test/java/com/datastax/oss/driver/api/core/retry/DefaultRetryPolicyTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/retry/DefaultRetryPolicyTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 public class DefaultRetryPolicyTest extends RetryPolicyTestBase {
 
   public DefaultRetryPolicyTest() {
-    super(new DefaultRetryPolicy(null));
+    super(new DefaultRetryPolicy(null, null));
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/api/core/specex/ConstantSpeculativeExecutionPolicyTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/specex/ConstantSpeculativeExecutionPolicyTest.java
@@ -41,7 +41,8 @@ public class ConstantSpeculativeExecutionPolicyTest {
   @Before
   public void setup() {
     Mockito.when(context.config()).thenReturn(config);
-    Mockito.when(config.getDefaultProfile()).thenReturn(defaultProfile);
+    Mockito.when(config.getNamedProfile(DriverConfigProfile.DEFAULT_NAME))
+        .thenReturn(defaultProfile);
   }
 
   private void mockOptions(int maxExecutions, long constantDelayMillis) {

--- a/core/src/test/java/com/datastax/oss/driver/api/core/specex/ConstantSpeculativeExecutionPolicyTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/specex/ConstantSpeculativeExecutionPolicyTest.java
@@ -41,8 +41,7 @@ public class ConstantSpeculativeExecutionPolicyTest {
   @Before
   public void setup() {
     Mockito.when(context.config()).thenReturn(config);
-    Mockito.when(config.getNamedProfile(DriverConfigProfile.DEFAULT_NAME))
-        .thenReturn(defaultProfile);
+    Mockito.when(config.getProfile(DriverConfigProfile.DEFAULT_NAME)).thenReturn(defaultProfile);
   }
 
   private void mockOptions(int maxExecutions, long constantDelayMillis) {

--- a/core/src/test/java/com/datastax/oss/driver/api/core/specex/ConstantSpeculativeExecutionPolicyTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/specex/ConstantSpeculativeExecutionPolicyTest.java
@@ -54,19 +54,20 @@ public class ConstantSpeculativeExecutionPolicyTest {
   @Test(expected = IllegalArgumentException.class)
   public void should_fail_if_delay_negative() {
     mockOptions(1, -10);
-    new ConstantSpeculativeExecutionPolicy(context);
+    new ConstantSpeculativeExecutionPolicy(context, DriverConfigProfile.DEFAULT_NAME);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void should_fail_if_max_less_than_one() {
     mockOptions(0, 10);
-    new ConstantSpeculativeExecutionPolicy(context);
+    new ConstantSpeculativeExecutionPolicy(context, DriverConfigProfile.DEFAULT_NAME);
   }
 
   @Test
   public void should_return_delay_until_max() {
     mockOptions(3, 10);
-    SpeculativeExecutionPolicy policy = new ConstantSpeculativeExecutionPolicy(context);
+    SpeculativeExecutionPolicy policy =
+        new ConstantSpeculativeExecutionPolicy(context, DriverConfigProfile.DEFAULT_NAME);
 
     // Initial execution starts, schedule first speculative execution
     assertThat(policy.nextExecution(null, null, request, 1)).isEqualTo(10);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/DriverConfigAssert.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/DriverConfigAssert.java
@@ -32,7 +32,7 @@ public class DriverConfigAssert extends AbstractAssert<DriverConfigAssert, Drive
   }
 
   public DriverConfigAssert hasIntOption(String profileName, DriverOption option, int expected) {
-    assertThat(actual.getNamedProfile(profileName).getInt(option)).isEqualTo(expected);
+    assertThat(actual.getProfile(profileName).getInt(option)).isEqualTo(expected);
     return this;
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/TypesafeDriverConfigTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/TypesafeDriverConfigTest.java
@@ -150,7 +150,7 @@ public class TypesafeDriverConfigTest {
     DriverConfigProfile derivedFromDefault =
         config.getDefaultProfile().withInt(MockOptions.OPTIONAL_INT, 50);
     DriverConfigProfile derivedFromProfile1 =
-        config.getNamedProfile("profile1").withInt(MockOptions.OPTIONAL_INT, 51);
+        config.getProfile("profile1").withInt(MockOptions.OPTIONAL_INT, 51);
 
     config.reload(
         ConfigFactory.parseString(
@@ -178,7 +178,7 @@ public class TypesafeDriverConfigTest {
             entry("auth_provider.auth_thing_two", "two"),
             entry("required_int", 42));
 
-    assertThat(config.getNamedProfile("profile1").entrySet())
+    assertThat(config.getProfile("profile1").entrySet())
         .containsExactly(
             entry("auth_provider.auth_thing_one", "one"),
             entry("auth_provider.auth_thing_three", "three"),

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/TypesafeDriverConfigTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/TypesafeDriverConfigTest.java
@@ -52,6 +52,11 @@ public class TypesafeDriverConfigTest {
     parse("");
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void should_fail_if_profile_uses_default_name() {
+    parse("required_int = 42\n profiles { default { required_int = 43 } }");
+  }
+
   @Test
   public void should_inherit_option_in_profile() {
     TypesafeDriverConfig config = parse("required_int = 42\n profiles { profile1 { } }");

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandlerTest.java
@@ -18,6 +18,7 @@ package com.datastax.oss.driver.internal.core.cql;
 import static com.datastax.oss.driver.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 
 import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
@@ -28,6 +29,7 @@ import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryDecision;
+import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import com.datastax.oss.driver.api.core.servererrors.OverloadedException;
 import com.datastax.oss.driver.internal.core.channel.ResponseCallback;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
@@ -235,7 +237,7 @@ public class CqlPrepareHandlerTest {
       Mockito.when(
               harness
                   .getContext()
-                  .retryPolicy()
+                  .retryPolicy(anyString())
                   .onErrorResponse(eq(PREPARE_REQUEST), any(OverloadedException.class), eq(0)))
           .thenReturn(RetryDecision.RETRY_NEXT);
 
@@ -274,7 +276,7 @@ public class CqlPrepareHandlerTest {
       Mockito.when(
               harness
                   .getContext()
-                  .retryPolicy()
+                  .retryPolicy(anyString())
                   .onErrorResponse(eq(PREPARE_REQUEST), any(OverloadedException.class), eq(0)))
           .thenReturn(RetryDecision.RETHROW);
 
@@ -311,11 +313,11 @@ public class CqlPrepareHandlerTest {
     try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
 
       // Make node1's error unrecoverable, will rethrow
+      RetryPolicy mockRetryPolicy =
+          harness.getContext().retryPolicy(DriverConfigProfile.DEFAULT_NAME);
       Mockito.when(
-              harness
-                  .getContext()
-                  .retryPolicy()
-                  .onErrorResponse(eq(PREPARE_REQUEST), any(OverloadedException.class), eq(0)))
+              mockRetryPolicy.onErrorResponse(
+                  eq(PREPARE_REQUEST), any(OverloadedException.class), eq(0)))
           .thenReturn(RetryDecision.IGNORE);
 
       CompletionStage<PreparedStatement> prepareFuture =

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerSpeculativeExecutionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerSpeculativeExecutionTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.eq;
 
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.NoNodeAvailableException;
+import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.metadata.Node;
@@ -50,7 +51,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
 
     try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
       SpeculativeExecutionPolicy speculativeExecutionPolicy =
-          harness.getContext().speculativeExecutionPolicy();
+          harness.getContext().speculativeExecutionPolicy(DriverConfigProfile.DEFAULT_NAME);
 
       new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
           .handle();
@@ -77,7 +78,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
 
     try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
       SpeculativeExecutionPolicy speculativeExecutionPolicy =
-          harness.getContext().speculativeExecutionPolicy();
+          harness.getContext().speculativeExecutionPolicy(DriverConfigProfile.DEFAULT_NAME);
       long firstExecutionDelay = 100L;
       long secondExecutionDelay = 200L;
       Mockito.when(
@@ -107,7 +108,9 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
           .isEqualTo(firstExecutionDelay);
       Mockito.verifyNoMoreInteractions(nodeMetricUpdater1);
       firstExecutionTask.run();
-      Mockito.verify(nodeMetricUpdater1).incrementCounter(DefaultNodeMetric.SPECULATIVE_EXECUTIONS);
+      Mockito.verify(nodeMetricUpdater1)
+          .incrementCounter(
+              DefaultNodeMetric.SPECULATIVE_EXECUTIONS, DriverConfigProfile.DEFAULT_NAME);
       node2Behavior.verifyWrite();
       node2Behavior.setWriteSuccess();
 
@@ -117,7 +120,9 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
           .isEqualTo(secondExecutionDelay);
       Mockito.verifyNoMoreInteractions(nodeMetricUpdater2);
       secondExecutionTask.run();
-      Mockito.verify(nodeMetricUpdater2).incrementCounter(DefaultNodeMetric.SPECULATIVE_EXECUTIONS);
+      Mockito.verify(nodeMetricUpdater2)
+          .incrementCounter(
+              DefaultNodeMetric.SPECULATIVE_EXECUTIONS, DriverConfigProfile.DEFAULT_NAME);
       node3Behavior.verifyWrite();
       node3Behavior.setWriteSuccess();
 
@@ -140,7 +145,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
 
     try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
       SpeculativeExecutionPolicy speculativeExecutionPolicy =
-          harness.getContext().speculativeExecutionPolicy();
+          harness.getContext().speculativeExecutionPolicy(DriverConfigProfile.DEFAULT_NAME);
       long firstExecutionDelay = 100L;
       Mockito.when(
               speculativeExecutionPolicy.nextExecution(
@@ -179,7 +184,11 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
       node2Behavior.verifyNoWrite();
 
       Mockito.verify(nodeMetricUpdater1)
-          .updateTimer(eq(DefaultNodeMetric.CQL_MESSAGES), anyLong(), eq(TimeUnit.NANOSECONDS));
+          .updateTimer(
+              eq(DefaultNodeMetric.CQL_MESSAGES),
+              eq(DriverConfigProfile.DEFAULT_NAME),
+              anyLong(),
+              eq(TimeUnit.NANOSECONDS));
       Mockito.verifyNoMoreInteractions(nodeMetricUpdater1);
     }
   }
@@ -193,7 +202,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
 
     try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
       SpeculativeExecutionPolicy speculativeExecutionPolicy =
-          harness.getContext().speculativeExecutionPolicy();
+          harness.getContext().speculativeExecutionPolicy(DriverConfigProfile.DEFAULT_NAME);
       long firstExecutionDelay = 100L;
       Mockito.when(
               speculativeExecutionPolicy.nextExecution(
@@ -224,7 +233,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
 
     try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
       SpeculativeExecutionPolicy speculativeExecutionPolicy =
-          harness.getContext().speculativeExecutionPolicy();
+          harness.getContext().speculativeExecutionPolicy(DriverConfigProfile.DEFAULT_NAME);
       long firstExecutionDelay = 100L;
       Mockito.when(
               speculativeExecutionPolicy.nextExecution(
@@ -277,7 +286,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
 
     try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
       SpeculativeExecutionPolicy speculativeExecutionPolicy =
-          harness.getContext().speculativeExecutionPolicy();
+          harness.getContext().speculativeExecutionPolicy(DriverConfigProfile.DEFAULT_NAME);
       long firstExecutionDelay = 100L;
       Mockito.when(
               speculativeExecutionPolicy.nextExecution(
@@ -334,7 +343,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
 
     try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
       SpeculativeExecutionPolicy speculativeExecutionPolicy =
-          harness.getContext().speculativeExecutionPolicy();
+          harness.getContext().speculativeExecutionPolicy(DriverConfigProfile.DEFAULT_NAME);
       long firstExecutionDelay = 100L;
       Mockito.when(
               speculativeExecutionPolicy.nextExecution(
@@ -383,7 +392,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
 
     try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
       SpeculativeExecutionPolicy speculativeExecutionPolicy =
-          harness.getContext().speculativeExecutionPolicy();
+          harness.getContext().speculativeExecutionPolicy(DriverConfigProfile.DEFAULT_NAME);
       long firstExecutionDelay = 100L;
       Mockito.when(
               speculativeExecutionPolicy.nextExecution(

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/RequestHandlerTestHarness.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/RequestHandlerTestHarness.java
@@ -97,6 +97,7 @@ public class RequestHandlerTestHarness implements AutoCloseable {
     Mockito.when(nettyOptions.ioEventLoopGroup()).thenReturn(eventLoopGroup);
     Mockito.when(context.nettyOptions()).thenReturn(nettyOptions);
 
+    Mockito.when(defaultConfigProfile.getName()).thenReturn(DriverConfigProfile.DEFAULT_NAME);
     // TODO make configurable in the test, also handle profiles
     Mockito.when(defaultConfigProfile.getDuration(DefaultDriverOption.REQUEST_TIMEOUT))
         .thenReturn(Duration.ofMillis(500));
@@ -114,18 +115,21 @@ public class RequestHandlerTestHarness implements AutoCloseable {
     Mockito.when(config.getDefaultProfile()).thenReturn(defaultConfigProfile);
     Mockito.when(context.config()).thenReturn(config);
 
-    Mockito.when(loadBalancingPolicyWrapper.newQueryPlan(any(Request.class), any(Session.class)))
+    Mockito.when(
+            loadBalancingPolicyWrapper.newQueryPlan(
+                any(Request.class), anyString(), any(Session.class)))
         .thenReturn(builder.buildQueryPlan());
     Mockito.when(context.loadBalancingPolicyWrapper()).thenReturn(loadBalancingPolicyWrapper);
 
-    Mockito.when(context.retryPolicy()).thenReturn(retryPolicy);
+    Mockito.when(context.retryPolicy(anyString())).thenReturn(retryPolicy);
 
     // Disable speculative executions by default
     Mockito.when(
             speculativeExecutionPolicy.nextExecution(
                 any(Node.class), any(CqlIdentifier.class), any(Request.class), anyInt()))
         .thenReturn(-1L);
-    Mockito.when(context.speculativeExecutionPolicy()).thenReturn(speculativeExecutionPolicy);
+    Mockito.when(context.speculativeExecutionPolicy(anyString()))
+        .thenReturn(speculativeExecutionPolicy);
 
     Mockito.when(context.codecRegistry()).thenReturn(new DefaultCodecRegistry("test"));
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyEventsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyEventsTest.java
@@ -39,7 +39,7 @@ public class DefaultLoadBalancingPolicyEventsTest extends DefaultLoadBalancingPo
   public void setup() {
     super.setup();
 
-    policy = new DefaultLoadBalancingPolicy("dc1", filter, context);
+    policy = new DefaultLoadBalancingPolicy("dc1", filter, context, true);
     policy.init(
         ImmutableMap.of(ADDRESS1, node1, ADDRESS2, node2),
         distanceReporter,

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyInitTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyInitTest.java
@@ -34,7 +34,7 @@ public class DefaultLoadBalancingPolicyInitTest extends DefaultLoadBalancingPoli
   @Test
   public void should_infer_local_dc_if_no_explicit_contact_points() {
     // Given
-    DefaultLoadBalancingPolicy policy = new DefaultLoadBalancingPolicy(null, filter, context);
+    DefaultLoadBalancingPolicy policy = new DefaultLoadBalancingPolicy(null, filter, context, true);
 
     // When
     policy.init(
@@ -49,7 +49,7 @@ public class DefaultLoadBalancingPolicyInitTest extends DefaultLoadBalancingPoli
   @Test
   public void should_require_local_dc_if_explicit_contact_points() {
     // Given
-    DefaultLoadBalancingPolicy policy = new DefaultLoadBalancingPolicy(null, filter, context);
+    DefaultLoadBalancingPolicy policy = new DefaultLoadBalancingPolicy(null, filter, context, true);
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("You provided explicit contact points, the local DC must be specified");
 
@@ -62,7 +62,8 @@ public class DefaultLoadBalancingPolicyInitTest extends DefaultLoadBalancingPoli
     // Given
     Mockito.when(node2.getDatacenter()).thenReturn("dc2");
     Mockito.when(node3.getDatacenter()).thenReturn("dc3");
-    DefaultLoadBalancingPolicy policy = new DefaultLoadBalancingPolicy("dc1", filter, context);
+    DefaultLoadBalancingPolicy policy =
+        new DefaultLoadBalancingPolicy("dc1", filter, context, true);
 
     // When
     policy.init(
@@ -85,7 +86,8 @@ public class DefaultLoadBalancingPolicyInitTest extends DefaultLoadBalancingPoli
   @Test
   public void should_include_nodes_from_local_dc() {
     // Given
-    DefaultLoadBalancingPolicy policy = new DefaultLoadBalancingPolicy("dc1", filter, context);
+    DefaultLoadBalancingPolicy policy =
+        new DefaultLoadBalancingPolicy("dc1", filter, context, true);
 
     // When
     policy.init(
@@ -105,7 +107,8 @@ public class DefaultLoadBalancingPolicyInitTest extends DefaultLoadBalancingPoli
     // Given
     Mockito.when(node2.getDatacenter()).thenReturn("dc2");
     Mockito.when(node3.getDatacenter()).thenReturn("dc3");
-    DefaultLoadBalancingPolicy policy = new DefaultLoadBalancingPolicy("dc1", filter, context);
+    DefaultLoadBalancingPolicy policy =
+        new DefaultLoadBalancingPolicy("dc1", filter, context, true);
 
     // When
     policy.init(
@@ -126,7 +129,8 @@ public class DefaultLoadBalancingPolicyInitTest extends DefaultLoadBalancingPoli
     Mockito.when(filter.test(node2)).thenReturn(false);
     Mockito.when(filter.test(node3)).thenReturn(false);
 
-    DefaultLoadBalancingPolicy policy = new DefaultLoadBalancingPolicy("dc1", filter, context);
+    DefaultLoadBalancingPolicy policy =
+        new DefaultLoadBalancingPolicy("dc1", filter, context, true);
 
     // When
     policy.init(

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyQueryPlanTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyQueryPlanTest.java
@@ -187,7 +187,7 @@ public class DefaultLoadBalancingPolicyQueryPlanTest extends DefaultLoadBalancin
   static class NonShufflingPolicy extends DefaultLoadBalancingPolicy {
     NonShufflingPolicy(
         String localDcFromConfig, Predicate<Node> filterFromConfig, DriverContext context) {
-      super(localDcFromConfig, filterFromConfig, context);
+      super(localDcFromConfig, filterFromConfig, context, true);
     }
 
     @Override

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolInitTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolInitTest.java
@@ -86,7 +86,7 @@ public class ChannelPoolInitTest extends ChannelPoolTestBase {
     assertThat(poolFuture).isSuccess(pool -> assertThat(pool.channels).isEmpty());
     Mockito.verify(eventBus, never()).fire(ChannelEvent.channelOpened(node));
     Mockito.verify(nodeMetricUpdater, times(3))
-        .incrementCounter(DefaultNodeMetric.CONNECTION_INIT_ERRORS);
+        .incrementCounter(DefaultNodeMetric.CONNECTION_INIT_ERRORS, null);
 
     factoryHelper.verifyNoMoreCalls();
   }
@@ -113,7 +113,7 @@ public class ChannelPoolInitTest extends ChannelPoolTestBase {
             pool -> {
               assertThat(pool.isInvalidKeyspace()).isTrue();
               Mockito.verify(nodeMetricUpdater, times(3))
-                  .incrementCounter(DefaultNodeMetric.CONNECTION_INIT_ERRORS);
+                  .incrementCounter(DefaultNodeMetric.CONNECTION_INIT_ERRORS, null);
             });
   }
 
@@ -140,7 +140,7 @@ public class ChannelPoolInitTest extends ChannelPoolTestBase {
     Mockito.verify(eventBus, never()).fire(ChannelEvent.channelOpened(node));
 
     Mockito.verify(nodeMetricUpdater, times(3))
-        .incrementCounter(DefaultNodeMetric.CONNECTION_INIT_ERRORS);
+        .incrementCounter(DefaultNodeMetric.CONNECTION_INIT_ERRORS, null);
     factoryHelper.verifyNoMoreCalls();
   }
 
@@ -188,7 +188,8 @@ public class ChannelPoolInitTest extends ChannelPoolTestBase {
 
     assertThat(pool.channels).containsOnly(channel1, channel2);
 
-    Mockito.verify(nodeMetricUpdater).incrementCounter(DefaultNodeMetric.CONNECTION_INIT_ERRORS);
+    Mockito.verify(nodeMetricUpdater)
+        .incrementCounter(DefaultNodeMetric.CONNECTION_INIT_ERRORS, null);
     factoryHelper.verifyNoMoreCalls();
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/DefaultSessionPoolsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/DefaultSessionPoolsTest.java
@@ -167,8 +167,9 @@ public class DefaultSessionPoolsTest {
 
     // Shutdown sequence:
     Mockito.when(context.reconnectionPolicy()).thenReturn(reconnectionPolicy);
-    Mockito.when(context.retryPolicy()).thenReturn(retryPolicy);
-    Mockito.when(context.speculativeExecutionPolicy()).thenReturn(speculativeExecutionPolicy);
+    Mockito.when(context.retryPolicy(DriverConfigProfile.DEFAULT_NAME)).thenReturn(retryPolicy);
+    Mockito.when(context.speculativeExecutionPolicies())
+        .thenReturn(ImmutableMap.of(DriverConfigProfile.DEFAULT_NAME, speculativeExecutionPolicy));
     Mockito.when(context.addressTranslator()).thenReturn(addressTranslator);
     Mockito.when(context.nodeStateListener()).thenReturn(nodeStateListener);
     Mockito.when(context.schemaChangeListener()).thenReturn(schemaChangeListener);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/util/ReflectionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/util/ReflectionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
+import com.datastax.oss.driver.api.core.config.DriverOption;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.specex.SpeculativeExecutionPolicy;
+import com.datastax.oss.driver.internal.core.config.typesafe.TypesafeDriverConfig;
+import com.datastax.oss.driver.internal.core.specex.ConstantSpeculativeExecutionPolicy;
+import com.datastax.oss.driver.internal.core.specex.NoSpeculativeExecutionPolicy;
+import com.typesafe.config.ConfigFactory;
+import java.util.Map;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ReflectionTest {
+
+  @Test
+  public void should_build_policies_per_profile() {
+    String configSource =
+        "request.speculative-execution-policy {\n"
+            + "  class = ConstantSpeculativeExecutionPolicy\n"
+            + "  max-executions = 3\n"
+            + "  delay = 100 milliseconds\n"
+            + "}\n"
+            + "profiles {\n"
+            // Inherits from default profile
+            + "  profile1 {}\n"
+            // Inherits but changes one option
+            + "  profile2 { \n"
+            + "    request.speculative-execution-policy.max-executions = 2"
+            + "  }\n"
+            // Same as previous profile, should share the same policy instance
+            + "  profile3 { \n"
+            + "    request.speculative-execution-policy.max-executions = 2"
+            + "  }\n"
+            // Completely overrides default profile
+            + "  profile4 { \n"
+            + "    request.speculative-execution-policy.class = NoSpeculativeExecutionPolicy\n"
+            + "  }\n"
+            + "}\n";
+    DriverContext context = Mockito.mock(DriverContext.class);
+    TypesafeDriverConfig config =
+        new TypesafeDriverConfig(ConfigFactory.parseString(configSource), new DriverOption[0]);
+    Mockito.when(context.config()).thenReturn(config);
+
+    Map<String, SpeculativeExecutionPolicy> policies =
+        Reflection.buildFromConfigProfiles(
+            context,
+            DefaultDriverOption.SPECULATIVE_EXECUTION_POLICY,
+            SpeculativeExecutionPolicy.class,
+            "com.datastax.oss.driver.internal.core.specex");
+
+    assertThat(policies).hasSize(5);
+    SpeculativeExecutionPolicy defaultPolicy = policies.get(DriverConfigProfile.DEFAULT_NAME);
+    SpeculativeExecutionPolicy policy1 = policies.get("profile1");
+    SpeculativeExecutionPolicy policy2 = policies.get("profile2");
+    SpeculativeExecutionPolicy policy3 = policies.get("profile3");
+    SpeculativeExecutionPolicy policy4 = policies.get("profile4");
+    assertThat(defaultPolicy)
+        .isInstanceOf(ConstantSpeculativeExecutionPolicy.class)
+        .isSameAs(policy1);
+    assertThat(policy2).isInstanceOf(ConstantSpeculativeExecutionPolicy.class).isSameAs(policy3);
+    assertThat(policy4).isInstanceOf(NoSpeculativeExecutionPolicy.class);
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/connection/FrameLengthIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/connection/FrameLengthIT.java
@@ -103,8 +103,8 @@ public class FrameLengthIT {
    * {@link AllNodesFailedException}).
    */
   public static class AlwaysRetryAbortedPolicy extends DefaultRetryPolicy {
-    public AlwaysRetryAbortedPolicy(DriverContext context) {
-      super(context);
+    public AlwaysRetryAbortedPolicy(DriverContext context, String profileName) {
+      super(context, profileName);
     }
 
     @Override

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/loadbalancing/PerProfileLoadBalancingPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/loadbalancing/PerProfileLoadBalancingPolicyIT.java
@@ -65,7 +65,7 @@ public class PerProfileLoadBalancingPolicyIT {
     // sanity checks
     DriverContext context = sessionRule.session().getContext();
     DriverConfig config = context.config();
-    assertThat(config.getNamedProfiles()).containsKeys("profile1", "profile2");
+    assertThat(config.getProfiles()).containsKeys("profile1", "profile2");
 
     assertThat(context.loadBalancingPolicies())
         .hasSize(3)

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/loadbalancing/PerProfileLoadBalancingPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/loadbalancing/PerProfileLoadBalancingPolicyIT.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.loadbalancing;
+
+import static com.datastax.oss.driver.assertions.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.DriverConfig;
+import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.cql.Statement;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.driver.internal.core.loadbalancing.DefaultLoadBalancingPolicy;
+import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(ParallelizableTests.class)
+public class PerProfileLoadBalancingPolicyIT {
+
+  // 3 2-node DCs
+  public static @ClassRule SimulacronRule simulacron =
+      new SimulacronRule(ClusterSpec.builder().withNodes(2, 2, 2));
+
+  // default lb policy should consider dc1 local, profile1 dc3, profile2 empty.
+  public static @ClassRule SessionRule<CqlSession> sessionRule =
+      SessionRule.builder(simulacron)
+          .withOptions(
+              "load-balancing-policy.local-datacenter = dc1",
+              "profiles.profile1.load-balancing-policy.local-datacenter = dc3",
+              "profiles.profile2 = {}")
+          .build();
+
+  private static String QUERY_STRING = "select * from foo";
+  private static final SimpleStatement QUERY = SimpleStatement.newInstance(QUERY_STRING);
+
+  @Before
+  public void clear() {
+    simulacron.cluster().clearLogs();
+  }
+
+  @BeforeClass
+  public static void setup() {
+    // sanity checks
+    DriverContext context = sessionRule.session().getContext();
+    DriverConfig config = context.config();
+    assertThat(config.getNamedProfiles()).containsKeys("profile1", "profile2");
+
+    assertThat(context.loadBalancingPolicies())
+        .hasSize(3)
+        .containsKeys(DriverConfigProfile.DEFAULT_NAME, "profile1", "profile2");
+
+    DefaultLoadBalancingPolicy defaultPolicy =
+        (DefaultLoadBalancingPolicy) context.loadBalancingPolicy(DriverConfigProfile.DEFAULT_NAME);
+    DefaultLoadBalancingPolicy policy1 =
+        (DefaultLoadBalancingPolicy) context.loadBalancingPolicy("profile1");
+    DefaultLoadBalancingPolicy policy2 =
+        (DefaultLoadBalancingPolicy) context.loadBalancingPolicy("profile2");
+
+    assertThat(defaultPolicy).isSameAs(policy2).isNotSameAs(policy1);
+
+    for (Node node : sessionRule.session().getMetadata().getNodes().values()) {
+      // if node is in dc2 it should be ignored, otherwise (dc1, dc3) it should be local.
+      NodeDistance expectedDistance =
+          node.getDatacenter().equals("dc2") ? NodeDistance.IGNORED : NodeDistance.LOCAL;
+      assertThat(node.getDistance()).isEqualTo(expectedDistance);
+    }
+  }
+
+  @Test
+  public void should_use_policy_from_request_profile() {
+    // Since profile1 uses dc3 as localDC, only those nodes should receive these queries.
+    Statement statement = QUERY.setConfigProfileName("profile1");
+    for (int i = 0; i < 10; i++) {
+      ResultSet result = sessionRule.session().execute(statement);
+      assertThat(result.getExecutionInfo().getCoordinator().getDatacenter()).isEqualTo("dc3");
+    }
+
+    assertQueryInDc(0, 0);
+    assertQueryInDc(1, 0);
+    assertQueryInDc(2, 5);
+  }
+
+  @Test
+  public void should_use_policy_from_config_when_not_configured_in_request_profile() {
+    // Since profile2 does not define an lbp config, it should use default which uses dc1.
+    Statement statement = QUERY.setConfigProfileName("profile2");
+    for (int i = 0; i < 10; i++) {
+      ResultSet result = sessionRule.session().execute(statement);
+      assertThat(result.getExecutionInfo().getCoordinator().getDatacenter()).isEqualTo("dc1");
+    }
+
+    assertQueryInDc(0, 5);
+    assertQueryInDc(1, 0);
+    assertQueryInDc(2, 0);
+  }
+
+  private void assertQueryInDc(int dc, int expectedPerNode) {
+    for (int i = 0; i < 2; i++) {
+      assertThat(
+              simulacron
+                  .cluster()
+                  .dc(dc)
+                  .node(i)
+                  .getLogs()
+                  .getQueryLogs()
+                  .stream()
+                  .filter(l -> l.getQuery().equals(QUERY_STRING)))
+          .as("Expected query count to be %d for dc %d", 5, i)
+          .hasSize(expectedPerNode);
+    }
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/retry/PerProfileRetryPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/retry/PerProfileRetryPolicyIT.java
@@ -86,7 +86,7 @@ public class PerProfileRetryPolicyIT {
     // sanity checks
     DriverContext context = sessionRule.session().getContext();
     DriverConfig config = context.config();
-    assertThat(config.getNamedProfiles()).containsKeys("profile1", "profile2");
+    assertThat(config.getProfiles()).containsKeys("profile1", "profile2");
 
     assertThat(context.retryPolicies())
         .hasSize(3)

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/retry/PerProfileRetryPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/retry/PerProfileRetryPolicyIT.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.retry;
+
+import static com.datastax.oss.driver.assertions.Assertions.assertThat;
+import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.noRows;
+import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.unavailable;
+import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.when;
+
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.DriverConfig;
+import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.servererrors.CoordinatorException;
+import com.datastax.oss.driver.api.core.servererrors.UnavailableException;
+import com.datastax.oss.driver.api.core.servererrors.WriteType;
+import com.datastax.oss.driver.api.core.session.Request;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.driver.internal.core.retry.DefaultRetryPolicy;
+import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(ParallelizableTests.class)
+public class PerProfileRetryPolicyIT {
+
+  // Shared across all tests methods.
+  public static @ClassRule SimulacronRule simulacron =
+      new SimulacronRule(ClusterSpec.builder().withNodes(2));
+
+  public static @ClassRule SessionRule<CqlSession> sessionRule =
+      SessionRule.builder(simulacron)
+          .withOptions(
+              "load-balancing-policy.class = com.datastax.oss.driver.api.testinfra.loadbalancing.SortingLoadBalancingPolicy",
+              "request.retry-policy.class = DefaultRetryPolicy",
+              "profiles.profile1.request.retry-policy.class = \"com.datastax.oss.driver.api.core.retry.PerProfileRetryPolicyIT$NoRetryPolicy\"",
+              "profiles.profile2 {}")
+          .build();
+
+  private static String QUERY_STRING = "select * from foo";
+  private static final SimpleStatement QUERY = SimpleStatement.newInstance(QUERY_STRING);
+
+  @Before
+  public void clear() {
+    simulacron.cluster().clearLogs();
+  }
+
+  @BeforeClass
+  public static void setup() {
+    // node 0 will return an unavailable to query.
+    simulacron
+        .cluster()
+        .node(0)
+        .prime(
+            when(QUERY_STRING)
+                .then(
+                    unavailable(
+                        com.datastax.oss.simulacron.common.codec.ConsistencyLevel.ONE, 1, 0)));
+    // node 1 will return a valid empty rows response.
+    simulacron.cluster().node(1).prime(when(QUERY_STRING).then(noRows()));
+
+    // sanity checks
+    DriverContext context = sessionRule.session().getContext();
+    DriverConfig config = context.config();
+    assertThat(config.getNamedProfiles()).containsKeys("profile1", "profile2");
+
+    assertThat(context.retryPolicies())
+        .hasSize(3)
+        .containsKeys(DriverConfigProfile.DEFAULT_NAME, "profile1", "profile2");
+
+    RetryPolicy defaultPolicy = context.retryPolicy(DriverConfigProfile.DEFAULT_NAME);
+    RetryPolicy policy1 = context.retryPolicy("profile1");
+    RetryPolicy policy2 = context.retryPolicy("profile2");
+    assertThat(defaultPolicy)
+        .isInstanceOf(DefaultRetryPolicy.class)
+        .isSameAs(policy2)
+        .isNotSameAs(policy1);
+    assertThat(policy1).isInstanceOf(NoRetryPolicy.class);
+  }
+
+  @Test(expected = UnavailableException.class)
+  public void should_use_policy_from_request_profile() {
+    // since profile1 uses a NoRetryPolicy, UnavailableException should surface to client.
+    sessionRule.session().execute(QUERY.setConfigProfileName("profile1"));
+  }
+
+  @Test
+  public void should_use_policy_from_config_when_not_configured_in_request_profile() {
+    // since profile2 has no configured retry policy, it should defer to configuration which uses
+    // DefaultRetryPolicy, which should try request on next host (host 1).
+    ResultSet result = sessionRule.session().execute(QUERY.setConfigProfileName("profile2"));
+
+    // expect an unavailable exception to be present in errors.
+    List<Map.Entry<Node, Throwable>> errors = result.getExecutionInfo().getErrors();
+    assertThat(errors).hasSize(1);
+    assertThat(errors.get(0).getValue()).isInstanceOf(UnavailableException.class);
+
+    assertQueryCount(0, 1);
+    assertQueryCount(1, 1);
+  }
+
+  private void assertQueryCount(int node, int expected) {
+    assertThat(
+            simulacron
+                .cluster()
+                .node(node)
+                .getLogs()
+                .getQueryLogs()
+                .stream()
+                .filter(l -> l.getQuery().equals(QUERY_STRING)))
+        .as("Expected query count to be %d for node %d", expected, node)
+        .hasSize(expected);
+  }
+
+  // A policy that simply rethrows always.
+  public static class NoRetryPolicy implements RetryPolicy {
+
+    public NoRetryPolicy(DriverContext context, String profileName) {}
+
+    @Override
+    public RetryDecision onReadTimeout(
+        Request request,
+        ConsistencyLevel cl,
+        int blockFor,
+        int received,
+        boolean dataPresent,
+        int retryCount) {
+      return RetryDecision.RETHROW;
+    }
+
+    @Override
+    public RetryDecision onWriteTimeout(
+        Request request,
+        ConsistencyLevel cl,
+        WriteType writeType,
+        int blockFor,
+        int received,
+        int retryCount) {
+      return RetryDecision.RETHROW;
+    }
+
+    @Override
+    public RetryDecision onUnavailable(
+        Request request, ConsistencyLevel cl, int required, int alive, int retryCount) {
+      return RetryDecision.RETHROW;
+    }
+
+    @Override
+    public RetryDecision onRequestAborted(Request request, Throwable error, int retryCount) {
+      return RetryDecision.RETHROW;
+    }
+
+    @Override
+    public RetryDecision onErrorResponse(
+        Request request, CoordinatorException error, int retryCount) {
+      return RetryDecision.RETHROW;
+    }
+
+    @Override
+    public void close() {}
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/specex/SpeculativeExecutionIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/specex/SpeculativeExecutionIT.java
@@ -394,7 +394,7 @@ public class SpeculativeExecutionIT {
     // validate profile data
     DriverContext context = session.getContext();
     DriverConfig driverConfig = context.config();
-    assertThat(driverConfig.getNamedProfiles()).containsKeys("profile1", "profile2");
+    assertThat(driverConfig.getProfiles()).containsKeys("profile1", "profile2");
 
     assertThat(context.speculativeExecutionPolicies())
         .hasSize(3)

--- a/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/api/GuavaSessionBuilder.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/api/GuavaSessionBuilder.java
@@ -27,6 +27,7 @@ import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.example.guava.internal.DefaultGuavaSession;
 import com.datastax.oss.driver.example.guava.internal.GuavaDriverContext;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 
 public class GuavaSessionBuilder extends SessionBuilder<GuavaSessionBuilder, GuavaSession> {
@@ -38,14 +39,14 @@ public class GuavaSessionBuilder extends SessionBuilder<GuavaSessionBuilder, Gua
       NodeStateListener nodeStateListener,
       SchemaChangeListener schemaChangeListener,
       RequestTracker requestTracker,
-      Predicate<Node> nodeFilter) {
+      Map<String, Predicate<Node>> nodeFilters) {
     return new GuavaDriverContext(
         configLoader,
         typeCodecs,
         nodeStateListener,
         schemaChangeListener,
         requestTracker,
-        nodeFilter);
+        nodeFilters);
   }
 
   @Override

--- a/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/GuavaDriverContext.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/GuavaDriverContext.java
@@ -34,6 +34,7 @@ import com.datastax.oss.driver.internal.core.session.RequestProcessorRegistry;
 import com.google.common.collect.MapMaker;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Predicate;
 
@@ -49,14 +50,14 @@ public class GuavaDriverContext extends DefaultDriverContext {
       NodeStateListener nodeStateListener,
       SchemaChangeListener schemaChangeListener,
       RequestTracker requestTracker,
-      Predicate<Node> nodeFilter) {
+      Map<String, Predicate<Node>> nodeFilters) {
     super(
         configLoader,
         typeCodecs,
         nodeStateListener,
         schemaChangeListener,
         requestTracker,
-        nodeFilter);
+        nodeFilters);
   }
 
   @Override

--- a/manual/core/configuration/README.md
+++ b/manual/core/configuration/README.md
@@ -134,10 +134,10 @@ The driver's context exposes a [DriverConfig] instance:
 ```java
 DriverConfig config = session.getContext().config();
 DriverConfigProfile defaultProfile = config.getDefaultProfile();
-DriverConfigProfile olapProfile = config.getNamedProfile("olap");
+DriverConfigProfile olapProfile = config.getProfile("olap");
 
 // This method creates a defensive copy of the map, do not use in performance-sensitive code:
-config.getNamedProfiles().forEach((name, profile) -> ...);
+config.getProfiles().forEach((name, profile) -> ...);
 ```
 
 [DriverConfigProfile] has typed option getters:

--- a/manual/core/query_timestamps/README.md
+++ b/manual/core/query_timestamps/README.md
@@ -114,6 +114,30 @@ This implementation always lets the server assign a timestamp.
 You can create your own generator by implementing [TimestampGenerator], and referencing your
 implementation class from the configuration.
 
+#### Using multiple generators
+
+The timestamp generator can be overridden in [configuration profiles](../configuration/#profiles):
+
+```
+datastax-java-driver {
+  request.timestamp-generator = AtomicTimestampGenerator
+  profiles {
+    profile1 {
+      request.timestamp-generator = ServerSideTimestampGenerator
+    }
+    profile2 {}
+  } 
+}
+```
+
+The `profile1` profile uses its own generator. The `profile2` profile inherits the default
+profile's. Note that this goes beyond configuration inheritance: the driver only creates a single
+`AtomicTimestampGenerator` instance and reuses it (this also occurs if two sibling profiles have the
+same configuration).
+
+Each request uses its declared profile's generator. If it doesn't declare any profile, or if the
+profile doesn't have a dedicated policy, then the default profile's generator is used.
+
 ### Per-statement timestamp
 
 Finally, you can assign a timestamp to a statement directly from application code:

--- a/manual/core/retries/README.md
+++ b/manual/core/retries/README.md
@@ -133,6 +133,35 @@ directly to the user. These include:
 * [FunctionFailureException];
 * [ProtocolError].
 
+### Using multiple policies
+
+The retry policy can be overridden in [configuration profiles](../configuration/#profiles):
+
+```
+datastax-java-driver {
+  request.retry-policy {
+    class = DefaultRetryPolicy
+  }
+  profiles {
+    custom-retries {
+      request.retry-policy {
+        class = CustomRetryPolicy
+      }
+    }
+    slow {
+      request.timeout = 30 seconds
+    }
+  }
+}
+```
+
+The `custom-retries` profile uses a dedicated policy. The `slow` profile inherits the default
+profile's. Note that this goes beyond configuration inheritance: the driver only creates a single
+`DefaultRetryPolicy` instance and reuses it (this also occurs if two sibling profiles have the same
+configuration).
+
+Each request uses its declared profile's policy. If it doesn't declare any profile, or if the
+profile doesn't have a dedicated policy, then the default profile's policy is used.
 
 [AllNodesFailedException]:   https://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/core/AllNodesFailedException.html
 [ClosedConnectionException]: https://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/core/connection/ClosedConnectionException.html

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/loadbalancing/SortingLoadBalancingPolicy.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/loadbalancing/SortingLoadBalancingPolicy.java
@@ -32,7 +32,7 @@ import java.util.TreeSet;
 public class SortingLoadBalancingPolicy implements LoadBalancingPolicy {
 
   @SuppressWarnings("unused")
-  public SortingLoadBalancingPolicy(DriverContext context) {
+  public SortingLoadBalancingPolicy(DriverContext context, String profileName) {
     // constructor needed for loading via config.
   }
 

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
@@ -118,15 +118,16 @@ public class SessionUtils {
       SchemaChangeListener schemaChangeListener,
       Predicate<Node> nodeFilter,
       String... options) {
-    return (SessionT)
+    SessionBuilder builder =
         baseBuilder()
             .addContactPoints(cassandraResource.getContactPoints())
             .withKeyspace(keyspace)
             .withNodeStateListener(nodeStateListener)
-            .withSchemaChangeListener(schemaChangeListener)
-            .withNodeFilter(nodeFilter)
-            .withConfigLoader(new TestConfigLoader(options))
-            .build();
+            .withSchemaChangeListener(schemaChangeListener);
+    if (nodeFilter != null) {
+      builder = builder.withNodeFilter(nodeFilter);
+    }
+    return (SessionT) builder.withConfigLoader(new TestConfigLoader(options)).build();
   }
 
   /**


### PR DESCRIPTION
For LBP, retry and speculative execution policy, and timestamp generators.

Profiles can have separate configuration. The driver traverses all profiles at startup, and initializes all distinct policies.