### PR TITLE
JAVA-1829: Add metrics for bytes-sent and bytes-received

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha4 (in progress)
 
+- [new feature] JAVA-1829: Add metrics for bytes-sent and bytes-received 
 - [improvement] JAVA-1755: Normalize usage of DEBUG/TRACE log levels
 - [improvement] JAVA-1803: Log driver version on first use
 - [improvement] JAVA-1792: Add AuthProvider callback to handle missing challenge from server
@@ -24,6 +25,7 @@
 - [improvement] JAVA-1772: Revisit multi-response callbacks
 - [new feature] JAVA-1537: Add remaining socket options
 - [bug] JAVA-1756: Propagate custom payload when preparing a statement
+- [improvement] JAVA-1829: Add metrics for bytes-sent and bytes-received
 
 ### 4.0.0-alpha3
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metrics/DefaultNodeMetric.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metrics/DefaultNodeMetric.java
@@ -24,6 +24,8 @@ public enum DefaultNodeMetric implements NodeMetric {
   AVAILABLE_STREAMS("pool.available-streams"),
   IN_FLIGHT("pool.in-flight"),
   ORPHANED_STREAMS("pool.orphaned-streams"),
+  BYTES_SENT("bytes-sent"),
+  BYTES_RECEIVED("bytes-received"),
   CQL_MESSAGES("cql-messages"),
   UNSENT_REQUESTS("errors.request.unsent"),
   ABORTED_REQUESTS("errors.request.aborted"),

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metrics/DefaultSessionMetric.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metrics/DefaultSessionMetric.java
@@ -20,6 +20,8 @@ import java.util.Map;
 
 /** See {@code reference.conf} for a description of each metric. */
 public enum DefaultSessionMetric implements SessionMetric {
+  BYTES_SENT("bytes-sent"),
+  BYTES_RECEIVED("bytes-received"),
   CONNECTED_NODES("connected-nodes"),
   CQL_REQUESTS("cql-requests"),
   CQL_CLIENT_TIMEOUTS("cql-client-timeouts"),

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/InboundTrafficMeter.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/InboundTrafficMeter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.channel;
+
+import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+import com.datastax.oss.driver.internal.core.metrics.NodeMetricUpdater;
+import com.datastax.oss.driver.internal.core.metrics.SessionMetricUpdater;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+public class InboundTrafficMeter extends ChannelInboundHandlerAdapter {
+
+  private final NodeMetricUpdater nodeMetricUpdater;
+  private final SessionMetricUpdater sessionMetricUpdater;
+
+  InboundTrafficMeter(
+      NodeMetricUpdater nodeMetricUpdater, SessionMetricUpdater sessionMetricUpdater) {
+    this.nodeMetricUpdater = nodeMetricUpdater;
+    this.sessionMetricUpdater = sessionMetricUpdater;
+  }
+
+  @Override
+  public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+    if (msg instanceof ByteBuf) {
+      int bytes = ((ByteBuf) msg).readableBytes();
+      nodeMetricUpdater.markMeter(DefaultNodeMetric.BYTES_RECEIVED, bytes);
+      sessionMetricUpdater.markMeter(DefaultSessionMetric.BYTES_RECEIVED, bytes);
+    }
+    super.channelRead(ctx, msg);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/OutboundTrafficMeter.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/OutboundTrafficMeter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.channel;
+
+import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+import com.datastax.oss.driver.internal.core.metrics.NodeMetricUpdater;
+import com.datastax.oss.driver.internal.core.metrics.SessionMetricUpdater;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+
+public class OutboundTrafficMeter extends ChannelOutboundHandlerAdapter {
+
+  private final NodeMetricUpdater nodeMetricUpdater;
+  private final SessionMetricUpdater sessionMetricUpdater;
+
+  OutboundTrafficMeter(
+      NodeMetricUpdater nodeMetricUpdater, SessionMetricUpdater sessionMetricUpdater) {
+    this.nodeMetricUpdater = nodeMetricUpdater;
+    this.sessionMetricUpdater = sessionMetricUpdater;
+  }
+
+  @Override
+  public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
+      throws Exception {
+    if (msg instanceof ByteBuf) {
+      int bytes = ((ByteBuf) msg).readableBytes();
+      nodeMetricUpdater.markMeter(DefaultNodeMetric.BYTES_SENT, bytes);
+      sessionMetricUpdater.markMeter(DefaultSessionMetric.BYTES_SENT, bytes);
+    }
+    super.write(ctx, msg, promise);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -277,7 +277,7 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
         LOG.debug("[{}] Trying to establish a connection to {}", logPrefix, node);
         context
             .channelFactory()
-            .connect(node.getConnectAddress(), channelOptions)
+            .connect(node, channelOptions)
             .whenCompleteAsync(
                 (channel, error) -> {
                   try {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DropwizardMetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DropwizardMetricUpdater.java
@@ -44,28 +44,28 @@ public abstract class DropwizardMetricUpdater<MetricT> implements MetricUpdater<
 
   @Override
   public void incrementCounter(MetricT metric, long amount) {
-    if (enabledMetrics.contains(metric)) {
+    if (isEnabled(metric)) {
       registry.counter(buildFullName(metric)).inc(amount);
     }
   }
 
   @Override
   public void updateHistogram(MetricT metric, long value) {
-    if (enabledMetrics.contains(metric)) {
+    if (isEnabled(metric)) {
       registry.histogram(buildFullName(metric)).update(value);
     }
   }
 
   @Override
   public void markMeter(MetricT metric, long amount) {
-    if (enabledMetrics.contains(metric)) {
+    if (isEnabled(metric)) {
       registry.meter(buildFullName(metric)).mark(amount);
     }
   }
 
   @Override
   public void updateTimer(MetricT metric, long duration, TimeUnit unit) {
-    if (enabledMetrics.contains(metric)) {
+    if (isEnabled(metric)) {
       registry.timer(buildFullName(metric)).update(duration, unit);
     }
   }
@@ -75,8 +75,13 @@ public abstract class DropwizardMetricUpdater<MetricT> implements MetricUpdater<
     return (T) registry.getMetrics().get(buildFullName(metric));
   }
 
+  @Override
+  public boolean isEnabled(MetricT metric) {
+    return enabledMetrics.contains(metric);
+  }
+
   protected void initializeDefaultCounter(MetricT metric) {
-    if (enabledMetrics.contains(metric)) {
+    if (isEnabled(metric)) {
       // Just initialize eagerly so that the metric appears even when it has no data yet
       registry.counter(buildFullName(metric));
     }
@@ -88,7 +93,7 @@ public abstract class DropwizardMetricUpdater<MetricT> implements MetricUpdater<
       DefaultDriverOption highestLatencyOption,
       DefaultDriverOption significantDigitsOption,
       DefaultDriverOption intervalOption) {
-    if (enabledMetrics.contains(metric)) {
+    if (isEnabled(metric)) {
       String fullName = buildFullName(metric);
 
       Duration highestLatency = config.getDuration(highestLatencyOption);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DropwizardMetricsFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DropwizardMetricsFactory.java
@@ -59,7 +59,7 @@ public class DropwizardMetricsFactory implements MetricsFactory {
     if (enabledSessionMetrics.isEmpty() && enabledNodeMetrics.isEmpty()) {
       LOG.debug("[{}] All metrics are disabled, Session.getMetrics will be empty", logPrefix);
       this.registry = null;
-      this.sessionUpdater = new NoopSessionMetricUpdater();
+      this.sessionUpdater = NoopSessionMetricUpdater.INSTANCE;
       this.metrics = Optional.empty();
     } else {
       this.registry = new MetricRegistry();
@@ -83,7 +83,7 @@ public class DropwizardMetricsFactory implements MetricsFactory {
   @Override
   public NodeMetricUpdater newNodeUpdater(Node node) {
     return (registry == null)
-        ? new NoopNodeMetricUpdater()
+        ? NoopNodeMetricUpdater.INSTANCE
         : new DropwizardNodeMetricUpdater(node, enabledNodeMetrics, registry, context);
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/MetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/MetricUpdater.java
@@ -34,4 +34,6 @@ public interface MetricUpdater<MetricT> {
   }
 
   void updateTimer(MetricT metric, long duration, TimeUnit unit);
+
+  boolean isEnabled(MetricT metric);
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/NoopNodeMetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/NoopNodeMetricUpdater.java
@@ -22,6 +22,10 @@ import net.jcip.annotations.ThreadSafe;
 @ThreadSafe
 public class NoopNodeMetricUpdater implements NodeMetricUpdater {
 
+  public static NoopNodeMetricUpdater INSTANCE = new NoopNodeMetricUpdater();
+
+  private NoopNodeMetricUpdater() {}
+
   @Override
   public void incrementCounter(NodeMetric metric, long amount) {
     // nothing to do
@@ -40,5 +44,11 @@ public class NoopNodeMetricUpdater implements NodeMetricUpdater {
   @Override
   public void updateTimer(NodeMetric metric, long duration, TimeUnit unit) {
     // nothing to do
+  }
+
+  @Override
+  public boolean isEnabled(NodeMetric metric) {
+    // since methods don't do anything, return false
+    return false;
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/NoopSessionMetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/NoopSessionMetricUpdater.java
@@ -22,6 +22,10 @@ import net.jcip.annotations.ThreadSafe;
 @ThreadSafe
 public class NoopSessionMetricUpdater implements SessionMetricUpdater {
 
+  public static NoopSessionMetricUpdater INSTANCE = new NoopSessionMetricUpdater();
+
+  private NoopSessionMetricUpdater() {}
+
   @Override
   public void incrementCounter(SessionMetric metric, long amount) {
     // nothing to do
@@ -40,5 +44,11 @@ public class NoopSessionMetricUpdater implements SessionMetricUpdater {
   @Override
   public void updateTimer(SessionMetric metric, long duration, TimeUnit unit) {
     // nothing to do
+  }
+
+  @Override
+  public boolean isEnabled(SessionMetric metric) {
+    // since methods don't do anything, return false
+    return false;
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/pool/ChannelPool.java
@@ -274,8 +274,7 @@ public class ChannelPool implements AsyncAutoCloseable {
               .withOwnerLogPrefix(sessionLogPrefix)
               .build();
       for (int i = 0; i < missing; i++) {
-        CompletionStage<DriverChannel> channelFuture =
-            channelFactory.connect(node.getConnectAddress(), options);
+        CompletionStage<DriverChannel> channelFuture = channelFactory.connect(node, options);
         pendingChannels.add(channelFuture);
       }
       return CompletableFutures.allDone(pendingChannels)

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -812,6 +812,12 @@ datastax-java-driver {
     # The session-level metrics (all disabled by default).
     session {
       enabled = [
+        # The number and rate of bytes sent for the entire session (exposed as a Meter).
+        // bytes-sent,
+
+        # The number and rate of bytes received for the entire session (exposed as a Meter).
+        // bytes-received
+
         # The number of nodes to which the driver has at least one active connection (exposed as a
         # Gauge<Integer>).
         // connected-nodes,
@@ -915,6 +921,12 @@ datastax-java-driver {
         #
         # See the description of the connection.max-orphan-requests option for more details.
         // pool.orphaned-streams,
+
+        # The number and rate of bytes sent to this node (exposed as a Meter).
+        // bytes-sent,
+
+        # The number and rate of bytes received from this node (exposed as a Meter).
+        // bytes-received,
 
         # The throughput and latency percentiles of individual CQL messages sent to this node as
         # part of an overall request (exposed as a Timer).

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryAvailableIdsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryAvailableIdsTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.timeout;
 
 import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.internal.core.metrics.NoopNodeMetricUpdater;
 import com.datastax.oss.protocol.internal.Frame;
 import com.datastax.oss.protocol.internal.request.Query;
 import com.datastax.oss.protocol.internal.response.result.Void;
@@ -58,7 +59,8 @@ public class ChannelFactoryAvailableIdsTest extends ChannelFactoryTestBase {
 
     // When
     CompletionStage<DriverChannel> channelFuture =
-        factory.connect(SERVER_ADDRESS, DriverChannelOptions.builder().build());
+        factory.connect(
+            SERVER_ADDRESS, DriverChannelOptions.builder().build(), NoopNodeMetricUpdater.INSTANCE);
     completeSimpleChannelInit();
 
     // Then

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryClusterNameTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryClusterNameTest.java
@@ -20,6 +20,7 @@ import static com.datastax.oss.driver.Assertions.assertThat;
 import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.internal.core.TestResponses;
+import com.datastax.oss.driver.internal.core.metrics.NoopNodeMetricUpdater;
 import com.datastax.oss.protocol.internal.response.Ready;
 import java.util.concurrent.CompletionStage;
 import org.junit.Test;
@@ -37,7 +38,8 @@ public class ChannelFactoryClusterNameTest extends ChannelFactoryTestBase {
 
     // When
     CompletionStage<DriverChannel> channelFuture =
-        factory.connect(SERVER_ADDRESS, DriverChannelOptions.DEFAULT);
+        factory.connect(
+            SERVER_ADDRESS, DriverChannelOptions.DEFAULT, NoopNodeMetricUpdater.INSTANCE);
 
     writeInboundFrame(readOutboundFrame(), new Ready());
     writeInboundFrame(readOutboundFrame(), TestResponses.clusterNameResponse("mockClusterName"));
@@ -57,13 +59,16 @@ public class ChannelFactoryClusterNameTest extends ChannelFactoryTestBase {
 
     // When
     CompletionStage<DriverChannel> channelFuture =
-        factory.connect(SERVER_ADDRESS, DriverChannelOptions.DEFAULT);
+        factory.connect(
+            SERVER_ADDRESS, DriverChannelOptions.DEFAULT, NoopNodeMetricUpdater.INSTANCE);
     // open a first connection that will define the cluster name
     writeInboundFrame(readOutboundFrame(), new Ready());
     writeInboundFrame(readOutboundFrame(), TestResponses.clusterNameResponse("mockClusterName"));
     assertThat(channelFuture).isSuccess();
     // open a second connection that returns the same cluster name
-    channelFuture = factory.connect(SERVER_ADDRESS, DriverChannelOptions.DEFAULT);
+    channelFuture =
+        factory.connect(
+            SERVER_ADDRESS, DriverChannelOptions.DEFAULT, NoopNodeMetricUpdater.INSTANCE);
     writeInboundFrame(readOutboundFrame(), new Ready());
     writeInboundFrame(readOutboundFrame(), TestResponses.clusterNameResponse("mockClusterName"));
 
@@ -72,7 +77,9 @@ public class ChannelFactoryClusterNameTest extends ChannelFactoryTestBase {
 
     // When
     // open a third connection that returns a different cluster name
-    channelFuture = factory.connect(SERVER_ADDRESS, DriverChannelOptions.DEFAULT);
+    channelFuture =
+        factory.connect(
+            SERVER_ADDRESS, DriverChannelOptions.DEFAULT, NoopNodeMetricUpdater.INSTANCE);
     writeInboundFrame(readOutboundFrame(), new Ready());
     writeInboundFrame(readOutboundFrame(), TestResponses.clusterNameResponse("wrongClusterName"));
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryProtocolNegotiationTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryProtocolNegotiationTest.java
@@ -21,6 +21,7 @@ import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
 import com.datastax.oss.driver.api.core.UnsupportedProtocolVersionException;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.internal.core.TestResponses;
+import com.datastax.oss.driver.internal.core.metrics.NoopNodeMetricUpdater;
 import com.datastax.oss.protocol.internal.Frame;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
 import com.datastax.oss.protocol.internal.response.Error;
@@ -46,7 +47,8 @@ public class ChannelFactoryProtocolNegotiationTest extends ChannelFactoryTestBas
 
     // When
     CompletionStage<DriverChannel> channelFuture =
-        factory.connect(SERVER_ADDRESS, DriverChannelOptions.DEFAULT);
+        factory.connect(
+            SERVER_ADDRESS, DriverChannelOptions.DEFAULT, NoopNodeMetricUpdater.INSTANCE);
 
     completeSimpleChannelInit();
 
@@ -69,7 +71,8 @@ public class ChannelFactoryProtocolNegotiationTest extends ChannelFactoryTestBas
 
     // When
     CompletionStage<DriverChannel> channelFuture =
-        factory.connect(SERVER_ADDRESS, DriverChannelOptions.DEFAULT);
+        factory.connect(
+            SERVER_ADDRESS, DriverChannelOptions.DEFAULT, NoopNodeMetricUpdater.INSTANCE);
 
     Frame requestFrame = readOutboundFrame();
     assertThat(requestFrame.protocolVersion).isEqualTo(DefaultProtocolVersion.V4.getCode());
@@ -99,7 +102,8 @@ public class ChannelFactoryProtocolNegotiationTest extends ChannelFactoryTestBas
 
     // When
     CompletionStage<DriverChannel> channelFuture =
-        factory.connect(SERVER_ADDRESS, DriverChannelOptions.DEFAULT);
+        factory.connect(
+            SERVER_ADDRESS, DriverChannelOptions.DEFAULT, NoopNodeMetricUpdater.INSTANCE);
 
     Frame requestFrame = readOutboundFrame();
     assertThat(requestFrame.protocolVersion).isEqualTo(DefaultProtocolVersion.V4.getCode());
@@ -127,7 +131,8 @@ public class ChannelFactoryProtocolNegotiationTest extends ChannelFactoryTestBas
 
     // When
     CompletionStage<DriverChannel> channelFuture =
-        factory.connect(SERVER_ADDRESS, DriverChannelOptions.DEFAULT);
+        factory.connect(
+            SERVER_ADDRESS, DriverChannelOptions.DEFAULT, NoopNodeMetricUpdater.INSTANCE);
 
     Frame requestFrame = readOutboundFrame();
     assertThat(requestFrame.protocolVersion).isEqualTo(DefaultProtocolVersion.V4.getCode());
@@ -163,7 +168,8 @@ public class ChannelFactoryProtocolNegotiationTest extends ChannelFactoryTestBas
 
     // When
     CompletionStage<DriverChannel> channelFuture =
-        factory.connect(SERVER_ADDRESS, DriverChannelOptions.DEFAULT);
+        factory.connect(
+            SERVER_ADDRESS, DriverChannelOptions.DEFAULT, NoopNodeMetricUpdater.INSTANCE);
 
     Frame requestFrame = readOutboundFrame();
     assertThat(requestFrame.protocolVersion).isEqualTo(DefaultProtocolVersion.V4.getCode());

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryTestBase.java
@@ -27,6 +27,7 @@ import com.datastax.oss.driver.internal.core.TestResponses;
 import com.datastax.oss.driver.internal.core.context.EventBus;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.context.NettyOptions;
+import com.datastax.oss.driver.internal.core.metrics.NodeMetricUpdater;
 import com.datastax.oss.driver.internal.core.protocol.ByteBufPrimitiveCodec;
 import com.datastax.oss.protocol.internal.Compressor;
 import com.datastax.oss.protocol.internal.Frame;
@@ -229,6 +230,7 @@ public abstract class ChannelFactoryTestBase {
         SocketAddress address,
         ProtocolVersion protocolVersion,
         DriverChannelOptions options,
+        NodeMetricUpdater nodeMetricUpdater,
         CompletableFuture<DriverChannel> resultFuture) {
       return new ChannelInitializer<Channel>() {
         @Override

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionEventsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionEventsTest.java
@@ -40,7 +40,7 @@ public class ControlConnectionEventsTest extends ControlConnectionTestBase {
     DriverChannel channel1 = newMockDriverChannel(1);
     ArgumentCaptor<DriverChannelOptions> optionsCaptor =
         ArgumentCaptor.forClass(DriverChannelOptions.class);
-    Mockito.when(channelFactory.connect(eq(ADDRESS1), optionsCaptor.capture()))
+    Mockito.when(channelFactory.connect(eq(node1), optionsCaptor.capture()))
         .thenReturn(CompletableFuture.completedFuture(channel1));
 
     // When
@@ -63,7 +63,7 @@ public class ControlConnectionEventsTest extends ControlConnectionTestBase {
     DriverChannel channel1 = newMockDriverChannel(1);
     ArgumentCaptor<DriverChannelOptions> optionsCaptor =
         ArgumentCaptor.forClass(DriverChannelOptions.class);
-    Mockito.when(channelFactory.connect(eq(ADDRESS1), optionsCaptor.capture()))
+    Mockito.when(channelFactory.connect(eq(node1), optionsCaptor.capture()))
         .thenReturn(CompletableFuture.completedFuture(channel1));
 
     // When
@@ -83,7 +83,7 @@ public class ControlConnectionEventsTest extends ControlConnectionTestBase {
     DriverChannel channel1 = newMockDriverChannel(1);
     ArgumentCaptor<DriverChannelOptions> optionsCaptor =
         ArgumentCaptor.forClass(DriverChannelOptions.class);
-    Mockito.when(channelFactory.connect(eq(ADDRESS1), optionsCaptor.capture()))
+    Mockito.when(channelFactory.connect(eq(node1), optionsCaptor.capture()))
         .thenReturn(CompletableFuture.completedFuture(channel1));
     controlConnection.init(true, false);
     waitForPendingAdminTasks();
@@ -105,7 +105,7 @@ public class ControlConnectionEventsTest extends ControlConnectionTestBase {
     DriverChannel channel1 = newMockDriverChannel(1);
     ArgumentCaptor<DriverChannelOptions> optionsCaptor =
         ArgumentCaptor.forClass(DriverChannelOptions.class);
-    Mockito.when(channelFactory.connect(eq(ADDRESS1), optionsCaptor.capture()))
+    Mockito.when(channelFactory.connect(eq(node1), optionsCaptor.capture()))
         .thenReturn(CompletableFuture.completedFuture(channel1));
     controlConnection.init(true, false);
     waitForPendingAdminTasks();
@@ -127,7 +127,7 @@ public class ControlConnectionEventsTest extends ControlConnectionTestBase {
     DriverChannel channel1 = newMockDriverChannel(1);
     ArgumentCaptor<DriverChannelOptions> optionsCaptor =
         ArgumentCaptor.forClass(DriverChannelOptions.class);
-    Mockito.when(channelFactory.connect(eq(ADDRESS1), optionsCaptor.capture()))
+    Mockito.when(channelFactory.connect(eq(node1), optionsCaptor.capture()))
         .thenReturn(CompletableFuture.completedFuture(channel1));
     controlConnection.init(false, false);
     waitForPendingAdminTasks();

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTest.java
@@ -50,11 +50,11 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     // Given
     DriverChannel channel1 = newMockDriverChannel(1);
     MockChannelFactoryHelper factoryHelper =
-        MockChannelFactoryHelper.builder(channelFactory).success(ADDRESS1, channel1).build();
+        MockChannelFactoryHelper.builder(channelFactory).success(node1, channel1).build();
 
     // When
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
     waitForPendingAdminTasks();
 
     // Then
@@ -70,11 +70,11 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     // Given
     DriverChannel channel1 = newMockDriverChannel(1);
     MockChannelFactoryHelper factoryHelper =
-        MockChannelFactoryHelper.builder(channelFactory).success(ADDRESS1, channel1).build();
+        MockChannelFactoryHelper.builder(channelFactory).success(node1, channel1).build();
 
     // When
     CompletionStage<Void> initFuture1 = controlConnection.init(false, false);
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
     CompletionStage<Void> initFuture2 = controlConnection.init(false, false);
 
     // Then
@@ -89,14 +89,14 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     DriverChannel channel2 = newMockDriverChannel(2);
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
-            .failure(ADDRESS1, "mock failure")
-            .success(ADDRESS2, channel2)
+            .failure(node1, "mock failure")
+            .success(node2, channel2)
             .build();
 
     // When
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
-    factoryHelper.waitForCall(ADDRESS1);
-    factoryHelper.waitForCall(ADDRESS2);
+    factoryHelper.waitForCall(node1);
+    factoryHelper.waitForCall(node2);
     waitForPendingAdminTasks();
 
     // Then
@@ -115,14 +115,14 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     // Given
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
-            .failure(ADDRESS1, "mock failure")
-            .failure(ADDRESS2, "mock failure")
+            .failure(node1, "mock failure")
+            .failure(node2, "mock failure")
             .build();
 
     // When
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
-    factoryHelper.waitForCall(ADDRESS1);
-    factoryHelper.waitForCall(ADDRESS2);
+    factoryHelper.waitForCall(node1);
+    factoryHelper.waitForCall(node2);
     waitForPendingAdminTasks();
 
     // Then
@@ -143,13 +143,13 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     DriverChannel channel2 = newMockDriverChannel(2);
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
-            .success(ADDRESS1, channel1)
-            .failure(ADDRESS1, "mock failure")
-            .success(ADDRESS2, channel2)
+            .success(node1, channel1)
+            .failure(node1, "mock failure")
+            .success(node2, channel2)
             .build();
 
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
 
     waitForPendingAdminTasks();
     assertThat(initFuture).isSuccess();
@@ -163,8 +163,8 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     // Then
     // a reconnection was started
     Mockito.verify(reconnectionSchedule).nextDelay();
-    factoryHelper.waitForCall(ADDRESS1);
-    factoryHelper.waitForCall(ADDRESS2);
+    factoryHelper.waitForCall(node1);
+    factoryHelper.waitForCall(node2);
     waitForPendingAdminTasks();
     assertThat(controlConnection.channel()).isEqualTo(channel2);
     Mockito.verify(eventBus).fire(ChannelEvent.channelClosed(node1));
@@ -183,12 +183,12 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     DriverChannel channel2 = newMockDriverChannel(2);
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
-            .success(ADDRESS1, channel1)
-            .success(ADDRESS2, channel2)
+            .success(node1, channel1)
+            .success(node2, channel2)
             .build();
 
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
 
     waitForPendingAdminTasks();
     assertThat(initFuture).isSuccess();
@@ -203,7 +203,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     // Then
     // an immediate reconnection was started
     Mockito.verify(reconnectionSchedule, never()).nextDelay();
-    factoryHelper.waitForCall(ADDRESS2);
+    factoryHelper.waitForCall(node2);
     waitForPendingAdminTasks();
     assertThat(controlConnection.channel()).isEqualTo(channel2);
     Mockito.verify(eventBus).fire(ChannelEvent.channelClosed(node1));
@@ -231,12 +231,12 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     DriverChannel channel2 = newMockDriverChannel(2);
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
-            .success(ADDRESS1, channel1)
-            .success(ADDRESS2, channel2)
+            .success(node1, channel1)
+            .success(node2, channel2)
             .build();
 
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
 
     waitForPendingAdminTasks();
     assertThat(initFuture).isSuccess();
@@ -251,7 +251,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     // Then
     // an immediate reconnection was started
     Mockito.verify(reconnectionSchedule, never()).nextDelay();
-    factoryHelper.waitForCall(ADDRESS2);
+    factoryHelper.waitForCall(node2);
     waitForPendingAdminTasks();
     assertThat(controlConnection.channel()).isEqualTo(channel2);
     Mockito.verify(eventBus).fire(ChannelEvent.channelClosed(node1));
@@ -273,14 +273,14 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
             // init
-            .success(ADDRESS1, channel1)
+            .success(node1, channel1)
             // reconnection
-            .pending(ADDRESS2, channel2Future)
-            .success(ADDRESS1, channel3)
+            .pending(node2, channel2Future)
+            .success(node1, channel3)
             .build();
 
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
 
     waitForPendingAdminTasks();
     assertThat(initFuture).isSuccess();
@@ -294,7 +294,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     Mockito.verify(eventBus).fire(ChannelEvent.channelClosed(node1));
     Mockito.verify(reconnectionSchedule).nextDelay();
     // the reconnection to node2 is in progress
-    factoryHelper.waitForCall(ADDRESS2);
+    factoryHelper.waitForCall(node2);
 
     // When
     // node2 becomes ignored
@@ -306,7 +306,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     // Then
     // The channel should get closed and we should try the next node
     Mockito.verify(channel2).forceClose();
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
   }
 
   @Test
@@ -330,14 +330,14 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
             // init
-            .success(ADDRESS1, channel1)
+            .success(node1, channel1)
             // reconnection
-            .pending(ADDRESS2, channel2Future)
-            .success(ADDRESS1, channel3)
+            .pending(node2, channel2Future)
+            .success(node1, channel3)
             .build();
 
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
 
     waitForPendingAdminTasks();
     assertThat(initFuture).isSuccess();
@@ -351,7 +351,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     Mockito.verify(eventBus).fire(ChannelEvent.channelClosed(node1));
     Mockito.verify(reconnectionSchedule).nextDelay();
     // the reconnection to node2 is in progress
-    factoryHelper.waitForCall(ADDRESS2);
+    factoryHelper.waitForCall(node2);
 
     // When
     // node2 goes into the new state
@@ -363,7 +363,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     // Then
     // The channel should get closed and we should try the next node
     Mockito.verify(channel2).forceClose();
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
   }
 
   @Test
@@ -375,13 +375,13 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     DriverChannel channel2 = newMockDriverChannel(2);
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
-            .success(ADDRESS1, channel1)
-            .failure(ADDRESS1, "mock failure")
-            .success(ADDRESS2, channel2)
+            .success(node1, channel1)
+            .failure(node1, "mock failure")
+            .success(node2, channel2)
             .build();
 
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
     waitForPendingAdminTasks();
     assertThat(initFuture).isSuccess();
     assertThat(controlConnection.channel()).isEqualTo(channel1);
@@ -395,8 +395,8 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
 
     // When
     controlConnection.reconnectNow();
-    factoryHelper.waitForCall(ADDRESS1);
-    factoryHelper.waitForCall(ADDRESS2);
+    factoryHelper.waitForCall(node1);
+    factoryHelper.waitForCall(node2);
     waitForPendingAdminTasks();
 
     // Then
@@ -413,13 +413,13 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     DriverChannel channel2 = newMockDriverChannel(2);
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
-            .success(ADDRESS1, channel1)
-            .failure(ADDRESS1, "mock failure")
-            .success(ADDRESS2, channel2)
+            .success(node1, channel1)
+            .failure(node1, "mock failure")
+            .success(node2, channel2)
             .build();
 
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
     waitForPendingAdminTasks();
     assertThat(initFuture).isSuccess();
     assertThat(controlConnection.channel()).isEqualTo(channel1);
@@ -429,8 +429,8 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     controlConnection.reconnectNow();
 
     // Then
-    factoryHelper.waitForCall(ADDRESS1);
-    factoryHelper.waitForCall(ADDRESS2);
+    factoryHelper.waitForCall(node1);
+    factoryHelper.waitForCall(node2);
     waitForPendingAdminTasks();
     assertThat(controlConnection.channel()).isEqualTo(channel2);
     Mockito.verify(channel1).forceClose();
@@ -455,9 +455,9 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     // Given
     DriverChannel channel1 = newMockDriverChannel(1);
     MockChannelFactoryHelper factoryHelper =
-        MockChannelFactoryHelper.builder(channelFactory).success(ADDRESS1, channel1).build();
+        MockChannelFactoryHelper.builder(channelFactory).success(node1, channel1).build();
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
     waitForPendingAdminTasks();
     assertThat(initFuture).isSuccess();
     CompletionStage<Void> closeFuture = controlConnection.forceCloseAsync();
@@ -478,10 +478,10 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     // Given
     DriverChannel channel1 = newMockDriverChannel(1);
     MockChannelFactoryHelper factoryHelper =
-        MockChannelFactoryHelper.builder(channelFactory).success(ADDRESS1, channel1).build();
+        MockChannelFactoryHelper.builder(channelFactory).success(node1, channel1).build();
 
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
     waitForPendingAdminTasks();
     assertThat(initFuture).isSuccess();
 
@@ -506,13 +506,13 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     CompletableFuture<DriverChannel> channel2Future = new CompletableFuture<>();
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
-            .success(ADDRESS1, channel1)
-            .failure(ADDRESS1, "mock failure")
-            .pending(ADDRESS2, channel2Future)
+            .success(node1, channel1)
+            .failure(node1, "mock failure")
+            .pending(node2, channel2Future)
             .build();
 
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
     waitForPendingAdminTasks();
     assertThat(initFuture).isSuccess();
     assertThat(controlConnection.channel()).isEqualTo(channel1);
@@ -523,9 +523,9 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     waitForPendingAdminTasks();
     Mockito.verify(eventBus).fire(ChannelEvent.channelClosed(node1));
     Mockito.verify(reconnectionSchedule).nextDelay();
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
     // channel2 starts initializing (but the future is not completed yet)
-    factoryHelper.waitForCall(ADDRESS2);
+    factoryHelper.waitForCall(node2);
 
     // When
     // the control connection gets closed before channel2 initialization is complete
@@ -553,13 +553,13 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     CompletableFuture<DriverChannel> channel1Future = new CompletableFuture<>();
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
-            .success(ADDRESS1, channel1)
-            .pending(ADDRESS1, channel1Future)
-            .success(ADDRESS2, channel2)
+            .success(node1, channel1)
+            .pending(node1, channel1Future)
+            .success(node2, channel2)
             .build();
 
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
     waitForPendingAdminTasks();
     assertThat(initFuture).isSuccess();
     assertThat(controlConnection.channel()).isEqualTo(channel1);
@@ -571,7 +571,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     Mockito.verify(eventBus).fire(ChannelEvent.channelClosed(node1));
     Mockito.verify(reconnectionSchedule).nextDelay();
     // channel1 starts initializing (but the future is not completed yet)
-    factoryHelper.waitForCall(ADDRESS1);
+    factoryHelper.waitForCall(node1);
 
     // When
     // the control connection gets closed before channel1 initialization fails

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
@@ -38,7 +38,6 @@ import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.Future;
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -87,7 +86,7 @@ abstract class ControlConnectionTestBase {
     Mockito.when(context.channelFactory()).thenReturn(channelFactory);
 
     channelFactoryFuture = new Exchanger<>();
-    Mockito.when(channelFactory.connect(any(SocketAddress.class), any(DriverChannelOptions.class)))
+    Mockito.when(channelFactory.connect(any(Node.class), any(DriverChannelOptions.class)))
         .thenAnswer(
             invocation -> {
               CompletableFuture<DriverChannel> channelFuture = new CompletableFuture<>();

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolInitTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolInitTest.java
@@ -47,15 +47,15 @@ public class ChannelPoolInitTest extends ChannelPoolTestBase {
     DriverChannel channel3 = newMockDriverChannel(3);
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
-            .success(ADDRESS, channel1)
-            .success(ADDRESS, channel2)
-            .success(ADDRESS, channel3)
+            .success(node, channel1)
+            .success(node, channel2)
+            .success(node, channel3)
             .build();
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 3);
+    factoryHelper.waitForCalls(node, 3);
     waitForPendingAdminTasks();
 
     assertThat(poolFuture)
@@ -72,15 +72,15 @@ public class ChannelPoolInitTest extends ChannelPoolTestBase {
 
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
-            .failure(ADDRESS, "mock channel init failure")
-            .failure(ADDRESS, "mock channel init failure")
-            .failure(ADDRESS, "mock channel init failure")
+            .failure(node, "mock channel init failure")
+            .failure(node, "mock channel init failure")
+            .failure(node, "mock channel init failure")
             .build();
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 3);
+    factoryHelper.waitForCalls(node, 3);
     waitForPendingAdminTasks();
 
     assertThat(poolFuture).isSuccess(pool -> assertThat(pool.channels).isEmpty());
@@ -98,15 +98,15 @@ public class ChannelPoolInitTest extends ChannelPoolTestBase {
 
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
-            .failure(ADDRESS, new InvalidKeyspaceException("invalid keyspace"))
-            .failure(ADDRESS, new InvalidKeyspaceException("invalid keyspace"))
-            .failure(ADDRESS, new InvalidKeyspaceException("invalid keyspace"))
+            .failure(node, new InvalidKeyspaceException("invalid keyspace"))
+            .failure(node, new InvalidKeyspaceException("invalid keyspace"))
+            .failure(node, new InvalidKeyspaceException("invalid keyspace"))
             .build();
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 3);
+    factoryHelper.waitForCalls(node, 3);
     waitForPendingAdminTasks();
     assertThat(poolFuture)
         .isSuccess(
@@ -126,14 +126,14 @@ public class ChannelPoolInitTest extends ChannelPoolTestBase {
         new ClusterNameMismatchException(ADDRESS, "actual", "expected");
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
-            .failure(ADDRESS, error)
-            .failure(ADDRESS, error)
-            .failure(ADDRESS, error)
+            .failure(node, error)
+            .failure(node, error)
+            .failure(node, error)
             .build();
 
     ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 3);
+    factoryHelper.waitForCalls(node, 3);
     waitForPendingAdminTasks();
 
     Mockito.verify(eventBus).fire(TopologyEvent.forceDown(ADDRESS));
@@ -158,17 +158,17 @@ public class ChannelPoolInitTest extends ChannelPoolTestBase {
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
             // Init: 1 channel fails, the other succeeds
-            .failure(ADDRESS, "mock channel init failure")
-            .success(ADDRESS, channel1)
+            .failure(node, "mock channel init failure")
+            .success(node, channel1)
             // 1st reconnection
-            .pending(ADDRESS, channel2Future)
+            .pending(node, channel2Future)
             .build();
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 2);
+    factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
 
     assertThat(poolFuture).isSuccess();
@@ -181,7 +181,7 @@ public class ChannelPoolInitTest extends ChannelPoolTestBase {
     inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(node));
 
     channel2Future.complete(channel2);
-    factoryHelper.waitForCalls(ADDRESS, 1);
+    factoryHelper.waitForCalls(node, 1);
     waitForPendingAdminTasks();
     inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(node));
     inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStopped(node));

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolKeyspaceTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolKeyspaceTest.java
@@ -40,14 +40,14 @@ public class ChannelPoolKeyspaceTest extends ChannelPoolTestBase {
     DriverChannel channel2 = newMockDriverChannel(2);
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
-            .success(ADDRESS, channel1)
-            .success(ADDRESS, channel2)
+            .success(node, channel1)
+            .success(node, channel2)
             .build();
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 2);
+    factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
 
     assertThat(poolFuture).isSuccess();
@@ -80,17 +80,17 @@ public class ChannelPoolKeyspaceTest extends ChannelPoolTestBase {
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
             // init
-            .failure(ADDRESS, "mock channel init failure")
-            .failure(ADDRESS, "mock channel init failure")
+            .failure(node, "mock channel init failure")
+            .failure(node, "mock channel init failure")
             // reconnection
-            .pending(ADDRESS, channel1Future)
-            .pending(ADDRESS, channel2Future)
+            .pending(node, channel1Future)
+            .pending(node, channel2Future)
             .build();
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 2);
+    factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
 
     assertThat(poolFuture).isSuccess();
@@ -99,7 +99,7 @@ public class ChannelPoolKeyspaceTest extends ChannelPoolTestBase {
     // Check that reconnection has kicked in, but do not complete it yet
     Mockito.verify(reconnectionSchedule).nextDelay();
     Mockito.verify(eventBus).fire(ChannelEvent.reconnectionStarted(node));
-    factoryHelper.waitForCalls(ADDRESS, 2);
+    factoryHelper.waitForCalls(node, 2);
 
     // Switch keyspace, it succeeds immediately since there is no active channel
     CqlIdentifier newKeyspace = CqlIdentifier.fromCql("new_keyspace");

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolReconnectTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolReconnectTest.java
@@ -50,17 +50,17 @@ public class ChannelPoolReconnectTest extends ChannelPoolTestBase {
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
             // init
-            .success(ADDRESS, channel1)
-            .success(ADDRESS, channel2)
+            .success(node, channel1)
+            .success(node, channel2)
             // reconnection
-            .pending(ADDRESS, channel3Future)
+            .pending(node, channel3Future)
             .build();
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 2);
+    factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
 
     assertThat(poolFuture).isSuccess();
@@ -76,7 +76,7 @@ public class ChannelPoolReconnectTest extends ChannelPoolTestBase {
 
     Mockito.verify(reconnectionSchedule).nextDelay();
     inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(node));
-    factoryHelper.waitForCall(ADDRESS);
+    factoryHelper.waitForCall(node);
 
     channel3Future.complete(channel3);
     waitForPendingAdminTasks();
@@ -102,17 +102,17 @@ public class ChannelPoolReconnectTest extends ChannelPoolTestBase {
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
             // init
-            .success(ADDRESS, channel1)
-            .success(ADDRESS, channel2)
+            .success(node, channel1)
+            .success(node, channel2)
             // reconnection
-            .pending(ADDRESS, channel3Future)
+            .pending(node, channel3Future)
             .build();
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 2);
+    factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
 
     assertThat(poolFuture).isSuccess();
@@ -127,7 +127,7 @@ public class ChannelPoolReconnectTest extends ChannelPoolTestBase {
 
     Mockito.verify(reconnectionSchedule).nextDelay();
     inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(node));
-    factoryHelper.waitForCall(ADDRESS);
+    factoryHelper.waitForCall(node);
 
     channel3Future.complete(channel3);
     waitForPendingAdminTasks();
@@ -153,9 +153,9 @@ public class ChannelPoolReconnectTest extends ChannelPoolTestBase {
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
             // init
-            .success(ADDRESS, channel1)
+            .success(node, channel1)
             // reconnection
-            .pending(ADDRESS, channel2Future)
+            .pending(node, channel2Future)
             .build();
 
     InOrder inOrder = Mockito.inOrder(eventBus);
@@ -163,7 +163,7 @@ public class ChannelPoolReconnectTest extends ChannelPoolTestBase {
     // Initial connection
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
-    factoryHelper.waitForCalls(ADDRESS, 1);
+    factoryHelper.waitForCalls(node, 1);
     waitForPendingAdminTasks();
     assertThat(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
@@ -176,7 +176,7 @@ public class ChannelPoolReconnectTest extends ChannelPoolTestBase {
     inOrder.verify(eventBus).fire(ChannelEvent.channelClosed(node));
     inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(node));
     Mockito.verify(reconnectionSchedule).nextDelay();
-    factoryHelper.waitForCalls(ADDRESS, 1);
+    factoryHelper.waitForCalls(node, 1);
 
     // Force a reconnection, should not try to create a new channel since we have a pending one
     pool.reconnectNow();

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolResizeTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolResizeTest.java
@@ -47,17 +47,17 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     DriverChannel channel4 = newMockDriverChannel(4);
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
-            .success(ADDRESS, channel1)
-            .success(ADDRESS, channel2)
-            .success(ADDRESS, channel3)
-            .success(ADDRESS, channel4)
+            .success(node, channel1)
+            .success(node, channel2)
+            .success(node, channel3)
+            .success(node, channel4)
             .build();
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.REMOTE, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 4);
+    factoryHelper.waitForCalls(node, 4);
     waitForPendingAdminTasks();
 
     assertThat(poolFuture).isSuccess();
@@ -93,20 +93,20 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
             // init
-            .success(ADDRESS, channel1)
-            .success(ADDRESS, channel2)
-            .failure(ADDRESS, "mock channel init failure")
-            .failure(ADDRESS, "mock channel init failure")
+            .success(node, channel1)
+            .success(node, channel2)
+            .failure(node, "mock channel init failure")
+            .failure(node, "mock channel init failure")
             // reconnection
-            .pending(ADDRESS, channel3Future)
-            .pending(ADDRESS, channel4Future)
+            .pending(node, channel3Future)
+            .pending(node, channel4Future)
             .build();
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.REMOTE, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 4);
+    factoryHelper.waitForCalls(node, 4);
     waitForPendingAdminTasks();
 
     inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
@@ -126,7 +126,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     channel3Future.complete(channel3);
     channel4Future.complete(channel4);
 
-    factoryHelper.waitForCalls(ADDRESS, 2);
+    factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
 
     // Pool should have shrinked back to 2. We keep the most recent channels so 1 and 2 get closed.
@@ -154,18 +154,18 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
             // init
-            .success(ADDRESS, channel1)
-            .success(ADDRESS, channel2)
+            .success(node, channel1)
+            .success(node, channel2)
             // growth attempt
-            .success(ADDRESS, channel3)
-            .success(ADDRESS, channel4)
+            .success(node, channel3)
+            .success(node, channel4)
             .build();
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 2);
+    factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
     inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
 
@@ -180,7 +180,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     Mockito.verify(reconnectionSchedule).nextDelay();
     inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(node));
 
-    factoryHelper.waitForCalls(ADDRESS, 2);
+    factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
     inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
     inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStopped(node));
@@ -209,20 +209,20 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
             // init
-            .success(ADDRESS, channel1)
-            .failure(ADDRESS, "mock channel init failure")
+            .success(node, channel1)
+            .failure(node, "mock channel init failure")
             // first reconnection attempt
-            .pending(ADDRESS, channel2Future)
+            .pending(node, channel2Future)
             // extra reconnection attempt after we realize the pool must grow
-            .pending(ADDRESS, channel3Future)
-            .pending(ADDRESS, channel4Future)
+            .pending(node, channel3Future)
+            .pending(node, channel4Future)
             .build();
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 2);
+    factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
     inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(node));
 
@@ -240,7 +240,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
 
     // Complete the channel for the first reconnection, bringing the count to 2
     channel2Future.complete(channel2);
-    factoryHelper.waitForCall(ADDRESS);
+    factoryHelper.waitForCall(node);
     waitForPendingAdminTasks();
     inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(node));
 
@@ -253,7 +253,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     inOrder.verify(eventBus, never()).fire(ChannelEvent.reconnectionStarted(node));
 
     // Two more channels get opened, bringing us to the target count
-    factoryHelper.waitForCalls(ADDRESS, 2);
+    factoryHelper.waitForCalls(node, 2);
     channel3Future.complete(channel3);
     channel4Future.complete(channel4);
     waitForPendingAdminTasks();
@@ -279,18 +279,18 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
             // init
-            .success(ADDRESS, channel1)
-            .success(ADDRESS, channel2)
+            .success(node, channel1)
+            .success(node, channel2)
             // growth attempt
-            .success(ADDRESS, channel3)
-            .success(ADDRESS, channel4)
+            .success(node, channel3)
+            .success(node, channel4)
             .build();
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 2);
+    factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
     inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
 
@@ -308,7 +308,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     Mockito.verify(reconnectionSchedule).nextDelay();
     inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStarted(node));
 
-    factoryHelper.waitForCalls(ADDRESS, 2);
+    factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
     inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
     inOrder.verify(eventBus).fire(ChannelEvent.reconnectionStopped(node));
@@ -335,20 +335,20 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
             // init
-            .success(ADDRESS, channel1)
-            .failure(ADDRESS, "mock channel init failure")
+            .success(node, channel1)
+            .failure(node, "mock channel init failure")
             // first reconnection attempt
-            .pending(ADDRESS, channel2Future)
+            .pending(node, channel2Future)
             // extra reconnection attempt after we realize the pool must grow
-            .pending(ADDRESS, channel3Future)
-            .pending(ADDRESS, channel4Future)
+            .pending(node, channel3Future)
+            .pending(node, channel4Future)
             .build();
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 2);
+    factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
     inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(node));
 
@@ -368,7 +368,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
 
     // Complete the channel for the first reconnection, bringing the count to 2
     channel2Future.complete(channel2);
-    factoryHelper.waitForCall(ADDRESS);
+    factoryHelper.waitForCall(node);
     waitForPendingAdminTasks();
     inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(node));
 
@@ -381,7 +381,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     inOrder.verify(eventBus, never()).fire(ChannelEvent.reconnectionStarted(node));
 
     // Two more channels get opened, bringing us to the target count
-    factoryHelper.waitForCalls(ADDRESS, 2);
+    factoryHelper.waitForCalls(node, 2);
     channel3Future.complete(channel3);
     channel4Future.complete(channel4);
     waitForPendingAdminTasks();
@@ -404,15 +404,15 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     DriverChannel channel2 = newMockDriverChannel(2);
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
-            .success(ADDRESS, channel1)
-            .success(ADDRESS, channel2)
+            .success(node, channel1)
+            .success(node, channel2)
             .build();
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 2);
+    factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
     inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolShutdownTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolShutdownTest.java
@@ -49,18 +49,18 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
             // init
-            .success(ADDRESS, channel1)
-            .success(ADDRESS, channel2)
-            .success(ADDRESS, channel3)
+            .success(node, channel1)
+            .success(node, channel2)
+            .success(node, channel3)
             // reconnection
-            .pending(ADDRESS, channel4Future)
+            .pending(node, channel4Future)
             .build();
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 3);
+    factoryHelper.waitForCalls(node, 3);
     waitForPendingAdminTasks();
     inOrder.verify(eventBus, times(3)).fire(ChannelEvent.channelOpened(node));
 
@@ -74,7 +74,7 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
 
     // Reconnection should have kicked in and started to open channel4, do not complete it yet
     Mockito.verify(reconnectionSchedule).nextDelay();
-    factoryHelper.waitForCalls(ADDRESS, 1);
+    factoryHelper.waitForCalls(node, 1);
 
     CompletionStage<Void> closeFuture = pool.closeAsync();
     waitForPendingAdminTasks();
@@ -121,18 +121,18 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
     MockChannelFactoryHelper factoryHelper =
         MockChannelFactoryHelper.builder(channelFactory)
             // init
-            .success(ADDRESS, channel1)
-            .success(ADDRESS, channel2)
-            .success(ADDRESS, channel3)
+            .success(node, channel1)
+            .success(node, channel2)
+            .success(node, channel3)
             // reconnection
-            .pending(ADDRESS, channel4Future)
+            .pending(node, channel4Future)
             .build();
     InOrder inOrder = Mockito.inOrder(eventBus);
 
     CompletionStage<ChannelPool> poolFuture =
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
 
-    factoryHelper.waitForCalls(ADDRESS, 3);
+    factoryHelper.waitForCalls(node, 3);
     waitForPendingAdminTasks();
 
     assertThat(poolFuture).isSuccess();
@@ -146,7 +146,7 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
 
     // Reconnection should have kicked in and started to open a channel, do not complete it yet
     Mockito.verify(reconnectionSchedule).nextDelay();
-    factoryHelper.waitForCalls(ADDRESS, 1);
+    factoryHelper.waitForCalls(node, 1);
 
     CompletionStage<Void> closeFuture = pool.forceCloseAsync();
     waitForPendingAdminTasks();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metrics/MetricsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metrics/MetricsIT.java
@@ -17,8 +17,10 @@ package com.datastax.oss.driver.api.core.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.categories.ParallelizableTests;
@@ -48,6 +50,42 @@ public class MetricsIT {
                 // No need to be very sophisticated, metrics are already covered individually in
                 // unit tests.
                 assertThat(requestsTimer.getCount()).isEqualTo(10);
+              });
+    }
+  }
+
+  @Test
+  public void should_expose_bytes_sent_and_received() {
+    try (CqlSession session =
+        SessionUtils.newSession(
+            ccmRule,
+            "metrics.session.enabled = [ bytes-sent, bytes-received ]",
+            "metrics.node.enabled = [ bytes-sent, bytes-received ]")) {
+      for (int i = 0; i < 10; i++) {
+        session.execute("SELECT release_version FROM system.local");
+      }
+
+      assertThat(session.getMetrics())
+          .hasValueSatisfying(
+              metrics -> {
+                Meter bytesSent = metrics.getSessionMetric(DefaultSessionMetric.BYTES_SENT);
+                assertThat(bytesSent).isNotNull();
+                // Can't be precise here as payload can be dependent on protocol version.
+                assertThat(bytesSent.getCount()).isGreaterThan(0);
+
+                Meter bytesReceived = metrics.getSessionMetric(DefaultSessionMetric.BYTES_RECEIVED);
+                assertThat(bytesReceived).isNotNull();
+                assertThat(bytesReceived.getCount()).isGreaterThan(0);
+
+                // get only node in cluster and evaluate its metrics.
+                Node node = session.getMetadata().getNodes().values().iterator().next();
+                bytesSent = metrics.getNodeMetric(node, DefaultNodeMetric.BYTES_SENT);
+                assertThat(bytesSent).isNotNull();
+                assertThat(bytesSent.getCount()).isGreaterThan(0);
+
+                bytesReceived = metrics.getNodeMetric(node, DefaultNodeMetric.BYTES_RECEIVED);
+                assertThat(bytesReceived).isNotNull();
+                assertThat(bytesReceived.getCount()).isGreaterThan(0);
               });
     }
   }


### PR DESCRIPTION
Motivation:

JAVA-708 added metrics to java driver 3.x for tracking the number of
bytes added and received for a Cluster instance.  For feature parity,
these metrics should also be tracked at a Session and Node level in java
driver 4.x.

Modifications:

- Add 'pools.bytes-sent' and 'pools-bytes-received' to node-level
  metrics and 'bytes-sent' and 'bytes-received' to session-level
  metrics.

- Add InboundTrafficMeter and OutboundTrafficMeter to pipeline in
  ChannelFactory.initializer.

- Update ChannelFactory.connect methods to accept Node instead of
  SocketAddress.  Previous connect method retained for unit testing.

- Updated unit tests to reason with Node instead of SocketAddress where
  connect is involved and a Node instance is available.

- Added static singleton instance of NoopNodeMetricUpdater.

Result:

Additional metrics added for tracking bytes sent and received at both
Session and Node level.