### PR TITLE
JAVA-1845: Include reference.conf in the manual

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -8,6 +8,11 @@ sections:
     sources:
       - type:  markdown
         files: 'manual/**/*.md'
+  - title:     Reference configuration
+    prefix:    /manual/core/configuration/reference
+    sources:
+      - type: rst
+        files: 'manual/core/configuration/reference/*.rst'
   - title:     Changelog
     prefix:    /changelog
     sources:

--- a/manual/core/README.md
+++ b/manual/core/README.md
@@ -50,8 +50,8 @@ variants that return a `CompletionStage`).
 customization is done through the driver configuration (refer to the
 [corresponding section](configuration/) of this manual for full details).
 
-We recommend that you take a look at the `reference.conf` file bundled with the driver for the list
-of available options, and cross-reference with the sub-sections in this manual for more
+We recommend that you take a look at the [reference configuration](configuration/reference/) for the
+list of available options, and cross-reference with the sub-sections in this manual for more
 explanations.
 
 By default, a session isn't tied to any specific keyspace. You'll need to prefix table names in your

--- a/manual/core/configuration/README.md
+++ b/manual/core/configuration/README.md
@@ -6,7 +6,7 @@ it can define *profiles* that customize a set of options for a particular kind o
 The default implementation is based on the Typesafe Config framework. It can be completely
 overridden if needed.
 
-For a complete list of built-in options, see [reference.conf] in the driver sources.
+For a complete list of built-in options, see the [reference configuration][reference.conf].
 
 
 ### Concepts
@@ -447,6 +447,6 @@ config.getDefaultProfile().getInt(MyCustomOption.AWESOMENESS_FACTOR);
 
 [Typesafe Config]: https://github.com/typesafehub/config
 [config standard behavior]: https://github.com/typesafehub/config#standard-behavior
-[reference.conf]: https://github.com/datastax/java-driver/blob/4.x/core/src/main/resources/reference.conf
+[reference.conf]: reference/
 [HOCON]: https://github.com/typesafehub/config/blob/master/HOCON.md
 [API conventions]: ../../api_conventions

--- a/manual/core/configuration/reference/README.rst
+++ b/manual/core/configuration/reference/README.rst
@@ -1,0 +1,16 @@
+Reference configuration
+-----------------------
+
+The following is a copy of the ``reference.conf`` file matching the version of this documentation.
+It is packaged in the ``java-driver-core`` JAR artifact, and used at runtime to provide the default
+values for all configuration options (in the sources, it can be found under
+``core/src/main/resources``).
+
+See the `configuration page <../>`_ for more explanations.
+
+.. raw:: html
+
+   <style>span.comment { color: grey; font-style: italic; } </style>
+
+.. include:: core/src/main/resources/reference.conf
+   :code: properties

--- a/manual/core/metrics/README.md
+++ b/manual/core/metrics/README.md
@@ -36,14 +36,13 @@ datastax-java-driver.metrics {
 }
 ```
 
-To find out which metrics are available, see to the [reference.conf] file corresponding to your
-version of the driver (it can be found in the driver's JAR or in the sources). It contains a
+To find out which metrics are available, see the [reference configuration]. It contains a
 commented-out line for each metric, with detailed explanations on its intended usage.
 
 If you specify a metric that doesn't exist, it will be ignored and a warning will be logged.
 
 The `metrics` section may also contain additional configuration for some specific metrics; again,
-refer to `reference.conf` for more details.
+see the [reference configuration] for more details.
 
 ### Export
 
@@ -129,4 +128,4 @@ CSV files, SLF4J logs and Graphite. Refer to their [manual][Dropwizard manual] f
 
 [Dropwizard Metrics]: http://metrics.dropwizard.io/4.0.0/manual/index.html
 [Dropwizard Manual]: http://metrics.dropwizard.io/4.0.0/getting-started.html#reporting-via-http
-[reference.conf]: https://github.com/datastax/java-driver/blob/4.x/core/src/main/resources/reference.conf
+[reference configuration]: ../configuration/reference/

--- a/manual/core/statements/prepared/README.md
+++ b/manual/core/statements/prepared/README.md
@@ -235,8 +235,8 @@ You can customize these strategies through the [configuration](../../configurati
 * `datastax-java-driver.prepared-statements.reprepare-on-up` controls how statements are re-prepared
   on a node that comes back up (step 2 above).
 
-Read the `reference.conf` file provided with the driver for a detailed description of each of those
-options.
+Read the [reference configuration](../../configuration/reference/) for a detailed description of each
+of those options.
 
 ### Avoid preparing 'SELECT *' queries (Cassandra 3 and below)
 


### PR DESCRIPTION
Prerequisites for local generation:
```
pip install docutils
pip install pygments
```