### PR TITLE
JAVA-1815: Reorganize configuration into basic/advanced categories

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha4 (in progress)
 
+- [improvement] JAVA-1815: Reorganize configuration into basic/advanced categories
 - [improvement] JAVA-1848: Add logs to DefaultRetryPolicy
 - [new feature] JAVA-1832: Add Ec2MultiRegionAddressTranslator
 - [improvement] JAVA-1825: Add remaining Typesafe config primitive types to DriverConfigProfile

--- a/core/console.scala
+++ b/core/console.scala
@@ -18,7 +18,7 @@ import java.net.InetSocketAddress
 import CqlSession
 
 // Heartbeat logs every 30 seconds are annoying in the console, raise the interval
-System.setProperty("datastax-java-driver.connection.heartbeat.interval", "1 hour")
+System.setProperty("datastax-java-driver.advanced.heartbeat.interval", "1 hour")
 
 val address1 = new InetSocketAddress("127.0.0.1", 9042)
 val address2 = new InetSocketAddress("127.0.0.2", 9042)

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -21,137 +21,151 @@ package com.datastax.oss.driver.api.core.config;
  * <p>Refer to {@code reference.conf} in the driver codebase for a full description of each option.
  */
 public enum DefaultDriverOption implements DriverOption {
-  CONTACT_POINTS("contact-points", false),
+  CONTACT_POINTS("basic.contact-points", false),
+  SESSION_NAME("basic.session-name", false),
+  SESSION_KEYSPACE("basic.session-keyspace", false),
+  CONFIG_RELOAD_INTERVAL("basic.config-reload-interval", false),
 
-  PROTOCOL_VERSION("protocol.version", false),
-  PROTOCOL_MAX_FRAME_LENGTH("protocol.max-frame-length", true),
-  PROTOCOL_COMPRESSOR_CLASS("protocol.compressor.class", false),
+  REQUEST_TIMEOUT("basic.request.timeout", true),
+  REQUEST_CONSISTENCY("basic.request.consistency", true),
+  REQUEST_PAGE_SIZE("basic.request.page-size", true),
+  REQUEST_SERIAL_CONSISTENCY("basic.request.serial-consistency", true),
+  REQUEST_DEFAULT_IDEMPOTENCE("basic.request.default-idempotence", true),
 
-  SESSION_NAME("session-name", false),
-  SESSION_KEYSPACE("session-keyspace", false),
-  CONFIG_RELOAD_INTERVAL("config-reload-interval", false),
+  LOAD_BALANCING_POLICY("basic.load-balancing-policy", true),
+  LOAD_BALANCING_LOCAL_DATACENTER("basic.load-balancing-policy.local-datacenter", false),
+  LOAD_BALANCING_FILTER_CLASS("basic.load-balancing-policy.filter.class", false),
 
-  CONNECTION_INIT_QUERY_TIMEOUT("connection.init-query-timeout", true),
-  CONNECTION_SET_KEYSPACE_TIMEOUT("connection.set-keyspace-timeout", true),
-  CONNECTION_MAX_REQUESTS("connection.max-requests-per-connection", true),
-  CONNECTION_HEARTBEAT_INTERVAL("connection.heartbeat.interval", true),
-  CONNECTION_HEARTBEAT_TIMEOUT("connection.heartbeat.timeout", true),
-  CONNECTION_MAX_ORPHAN_REQUESTS("connection.max-orphan-requests", true),
-  CONNECTION_WARN_INIT_ERROR("connection.warn-on-init-error", true),
-  CONNECTION_POOL_LOCAL_SIZE("connection.pool.local.size", true),
-  CONNECTION_POOL_REMOTE_SIZE("connection.pool.remote.size", true),
+  CONNECTION_INIT_QUERY_TIMEOUT("advanced.connection.init-query-timeout", true),
+  CONNECTION_SET_KEYSPACE_TIMEOUT("advanced.connection.set-keyspace-timeout", true),
+  CONNECTION_MAX_REQUESTS("advanced.connection.max-requests-per-connection", true),
+  CONNECTION_MAX_ORPHAN_REQUESTS("advanced.connection.max-orphan-requests", true),
+  CONNECTION_WARN_INIT_ERROR("advanced.connection.warn-on-init-error", true),
+  CONNECTION_POOL_LOCAL_SIZE("advanced.connection.pool.local.size", true),
+  CONNECTION_POOL_REMOTE_SIZE("advanced.connection.pool.remote.size", true),
 
-  CONNECTION_SOCKET_TCP_NODELAY("connection.socket.tcpNoDelay", true),
-  CONNECTION_SOCKET_KEEP_ALIVE("connection.socket.keepAlive", false),
-  CONNECTION_SOCKET_REUSE_ADDRESS("connection.socket.reuseAddress", false),
-  CONNECTION_SOCKET_LINGER_INTERVAL("connection.socket.lingerInterval", false),
-  CONNECTION_SOCKET_RECEIVE_BUFFER_SIZE("connection.socket.receiveBufferSize", false),
-  CONNECTION_SOCKET_SEND_BUFFER_SIZE("connection.socket.sendBufferSize", false),
+  RECONNECTION_POLICY_CLASS("advanced.reconnection-policy.class", true),
+  RECONNECTION_BASE_DELAY("advanced.reconnection-policy.base-delay", false),
+  RECONNECTION_MAX_DELAY("advanced.reconnection-policy.max-delay", false),
 
-  REQUEST_TIMEOUT("request.timeout", true),
-  REQUEST_CONSISTENCY("request.consistency", true),
-  REQUEST_PAGE_SIZE("request.page-size", true),
-  REQUEST_SERIAL_CONSISTENCY("request.serial-consistency", true),
-  REQUEST_WARN_IF_SET_KEYSPACE("request.warn-if-set-keyspace", true),
-  REQUEST_DEFAULT_IDEMPOTENCE("request.default-idempotence", true),
-  RETRY_POLICY("request.retry-policy", true),
-  SPECULATIVE_EXECUTION_POLICY("request.speculative-execution-policy", false),
-  SPECULATIVE_EXECUTION_MAX("request.speculative-execution-policy.max-executions", false),
-  SPECULATIVE_EXECUTION_DELAY("request.speculative-execution-policy.delay", false),
-  REQUEST_TRACE_ATTEMPTS("request.trace.attempts", true),
-  REQUEST_TRACE_INTERVAL("request.trace.interval", true),
-  REQUEST_TRACE_CONSISTENCY("request.trace.consistency", true),
-  REQUEST_THROTTLER_CLASS("request.throttler.class", true),
-  REQUEST_THROTTLER_MAX_CONCURRENT_REQUESTS("request.throttler.max-concurrent-requests", false),
-  REQUEST_THROTTLER_MAX_REQUESTS_PER_SECOND("request.throttler.max-requests-per-second", false),
-  REQUEST_THROTTLER_MAX_QUEUE_SIZE("request.throttler.max-queue-size", false),
-  REQUEST_THROTTLER_DRAIN_INTERVAL("request.throttler.drain-interval", false),
-  REQUEST_TRACKER_CLASS("request.tracker.class", false),
+  RETRY_POLICY("advanced.retry-policy", true),
 
-  REQUEST_LOGGER_SUCCESS_ENABLED("request.tracker.logs.success.enabled", false),
-  REQUEST_LOGGER_SLOW_THRESHOLD("request.tracker.logs.slow.threshold", false),
-  REQUEST_LOGGER_SLOW_ENABLED("request.tracker.logs.slow.enabled", false),
-  REQUEST_LOGGER_ERROR_ENABLED("request.tracker.logs.error.enabled", false),
-  REQUEST_LOGGER_MAX_QUERY_LENGTH("request.tracker.logs.max-query-length", false),
-  REQUEST_LOGGER_VALUES("request.tracker.logs.show-values", false),
-  REQUEST_LOGGER_MAX_VALUE_LENGTH("request.tracker.logs.max-value-length", false),
-  REQUEST_LOGGER_MAX_VALUES("request.tracker.logs.max-values", false),
-  REQUEST_LOGGER_STACK_TRACES("request.tracker.logs.show-stack-traces", false),
+  SPECULATIVE_EXECUTION_POLICY("advanced.speculative-execution-policy", false),
+  SPECULATIVE_EXECUTION_MAX("advanced.speculative-execution-policy.max-executions", false),
+  SPECULATIVE_EXECUTION_DELAY("advanced.speculative-execution-policy.delay", false),
 
-  CONTROL_CONNECTION_TIMEOUT("connection.control-connection.timeout", true),
-  CONTROL_CONNECTION_AGREEMENT_INTERVAL(
-      "connection.control-connection.schema-agreement.interval", true),
-  CONTROL_CONNECTION_AGREEMENT_TIMEOUT(
-      "connection.control-connection.schema-agreement.timeout", true),
-  CONTROL_CONNECTION_AGREEMENT_WARN(
-      "connection.control-connection.schema-agreement.warn-on-failure", true),
+  AUTH_PROVIDER_CLASS("advanced.auth-provider.class", false),
+  AUTH_PROVIDER_USER_NAME("advanced.auth-provider.username", false),
+  AUTH_PROVIDER_PASSWORD("advanced.auth-provider.password", false),
 
-  COALESCER_MAX_RUNS("connection.coalescer.max-runs-with-no-work", false),
-  COALESCER_INTERVAL("connection.coalescer.reschedule-interval", false),
+  SSL_ENGINE_FACTORY_CLASS("advanced.ssl-engine-factory.class", false),
+  SSL_CIPHER_SUITES("advanced.ssl-engine-factory.cipher-suites", false),
 
-  LOAD_BALANCING_POLICY("load-balancing-policy", true),
-  LOAD_BALANCING_LOCAL_DATACENTER("load-balancing-policy.local-datacenter", false),
-  LOAD_BALANCING_FILTER_CLASS("load-balancing-policy.filter.class", false),
-
-  RECONNECTION_POLICY_CLASS("connection.reconnection-policy.class", true),
-  RECONNECTION_BASE_DELAY("connection.reconnection-policy.base-delay", false),
-  RECONNECTION_MAX_DELAY("connection.reconnection-policy.max-delay", false),
-
-  PREPARE_ON_ALL_NODES("prepared-statements.prepare-on-all-nodes", true),
-  REPREPARE_ENABLED("prepared-statements.reprepare-on-up.enabled", true),
-  REPREPARE_CHECK_SYSTEM_TABLE("prepared-statements.reprepare-on-up.check-system-table", false),
-  REPREPARE_MAX_STATEMENTS("prepared-statements.reprepare-on-up.max-statements", false),
-  REPREPARE_MAX_PARALLELISM("prepared-statements.reprepare-on-up.max-parallelism", false),
-  REPREPARE_TIMEOUT("prepared-statements.reprepare-on-up.timeout", false),
-
-  ADDRESS_TRANSLATOR_CLASS("address-translator.class", true),
-
-  AUTH_PROVIDER_CLASS("protocol.auth-provider.class", false),
-  AUTH_PROVIDER_USER_NAME("protocol.auth-provider.username", false),
-  AUTH_PROVIDER_PASSWORD("protocol.auth-provider.password", false),
-
-  SSL_ENGINE_FACTORY_CLASS("ssl-engine-factory.class", false),
-  SSL_CIPHER_SUITES("ssl-engine-factory.cipher-suites", false),
-
-  METADATA_TOPOLOGY_WINDOW("metadata.topology-event-debouncer.window", true),
-  METADATA_TOPOLOGY_MAX_EVENTS("metadata.topology-event-debouncer.max-events", true),
-  METADATA_SCHEMA_ENABLED("metadata.schema.enabled", true),
-  METADATA_SCHEMA_REQUEST_TIMEOUT("metadata.schema.request-timeout", true),
-  METADATA_SCHEMA_REQUEST_PAGE_SIZE("metadata.schema.request-page-size", true),
-  METADATA_SCHEMA_REFRESHED_KEYSPACES("metadata.schema.refreshed-keyspaces", false),
-  METADATA_SCHEMA_WINDOW("metadata.schema.debouncer.window", true),
-  METADATA_SCHEMA_MAX_EVENTS("metadata.schema.debouncer.max-events", true),
-  METADATA_TOKEN_MAP_ENABLED("metadata.token-map.enabled", true),
-  METADATA_NODE_STATE_LISTENER_CLASS("metadata.node-state-listener.class", false),
-  METADATA_SCHEMA_CHANGE_LISTENER_CLASS("metadata.schema-change-listener.class", false),
-
-  TIMESTAMP_GENERATOR_CLASS("request.timestamp-generator.class", true),
-  TIMESTAMP_GENERATOR_FORCE_JAVA_CLOCK("request.timestamp-generator.force-java-clock", false),
+  TIMESTAMP_GENERATOR_CLASS("advanced.timestamp-generator.class", true),
+  TIMESTAMP_GENERATOR_FORCE_JAVA_CLOCK("advanced.timestamp-generator.force-java-clock", false),
   TIMESTAMP_GENERATOR_DRIFT_WARNING_THRESHOLD(
-      "request.timestamp-generator.drift-warning.threshold", false),
+      "advanced.timestamp-generator.drift-warning.threshold", false),
   TIMESTAMP_GENERATOR_DRIFT_WARNING_INTERVAL(
-      "request.timestamp-generator.drift-warning.interval", false),
+      "advanced.timestamp-generator.drift-warning.interval", false),
 
-  METRICS_SESSION_ENABLED("metrics.session.enabled", false),
-  METRICS_NODE_ENABLED("metrics.node.enabled", false),
-  METRICS_SESSION_CQL_REQUESTS_HIGHEST("metrics.session.cql-requests.highest-latency", false),
-  METRICS_SESSION_CQL_REQUESTS_DIGITS("metrics.session.cql-requests.significant-digits", false),
-  METRICS_SESSION_CQL_REQUESTS_INTERVAL("metrics.session.cql-requests.refresh-interval", false),
-  METRICS_SESSION_THROTTLING_HIGHEST("metrics.session.throttling.delay.highest-latency", false),
-  METRICS_SESSION_THROTTLING_DIGITS("metrics.session.throttling.delay.significant-digits", false),
-  METRICS_SESSION_THROTTLING_INTERVAL("metrics.session.throttling.delay.refresh-interval", false),
-  METRICS_NODE_CQL_MESSAGES_HIGHEST("metrics.node.cql-messages.highest-latency", false),
-  METRICS_NODE_CQL_MESSAGES_DIGITS("metrics.node.cql-messages.significant-digits", false),
-  METRICS_NODE_CQL_MESSAGES_INTERVAL("metrics.node.cql-messages.refresh-interval", false),
+  REQUEST_TRACKER_CLASS("advanced.request-tracker.class", false),
+  REQUEST_LOGGER_SUCCESS_ENABLED("advanced.request-tracker.logs.success.enabled", false),
+  REQUEST_LOGGER_SLOW_THRESHOLD("advanced.request-tracker.logs.slow.threshold", false),
+  REQUEST_LOGGER_SLOW_ENABLED("advanced.request-tracker.logs.slow.enabled", false),
+  REQUEST_LOGGER_ERROR_ENABLED("advanced.request-tracker.logs.error.enabled", false),
+  REQUEST_LOGGER_MAX_QUERY_LENGTH("advanced.request-tracker.logs.max-query-length", false),
+  REQUEST_LOGGER_VALUES("advanced.request-tracker.logs.show-values", false),
+  REQUEST_LOGGER_MAX_VALUE_LENGTH("advanced.request-tracker.logs.max-value-length", false),
+  REQUEST_LOGGER_MAX_VALUES("advanced.request-tracker.logs.max-values", false),
+  REQUEST_LOGGER_STACK_TRACES("advanced.request-tracker.logs.show-stack-traces", false),
 
-  NETTY_IO_SIZE("netty.io-group.size", false),
-  NETTY_IO_SHUTDOWN_QUIET_PERIOD("netty.io-group.shutdown.quiet-period", false),
-  NETTY_IO_SHUTDOWN_TIMEOUT("netty.io-group.shutdown.timeout", false),
-  NETTY_IO_SHUTDOWN_UNIT("netty.io-group.shutdown.unit", false),
-  NETTY_ADMIN_SIZE("netty.admin-group.size", false),
-  NETTY_ADMIN_SHUTDOWN_QUIET_PERIOD("netty.admin-group.shutdown.quiet-period", false),
-  NETTY_ADMIN_SHUTDOWN_TIMEOUT("netty.admin-group.shutdown.timeout", false),
-  NETTY_ADMIN_SHUTDOWN_UNIT("netty.admin-group.shutdown.unit", false),
+  REQUEST_THROTTLER_CLASS("advanced.throttler.class", true),
+  REQUEST_THROTTLER_MAX_CONCURRENT_REQUESTS("advanced.throttler.max-concurrent-requests", false),
+  REQUEST_THROTTLER_MAX_REQUESTS_PER_SECOND("advanced.throttler.max-requests-per-second", false),
+  REQUEST_THROTTLER_MAX_QUEUE_SIZE("advanced.throttler.max-queue-size", false),
+  REQUEST_THROTTLER_DRAIN_INTERVAL("advanced.throttler.drain-interval", false),
+
+  METADATA_NODE_STATE_LISTENER_CLASS("advanced.node-state-listener.class", false),
+
+  METADATA_SCHEMA_CHANGE_LISTENER_CLASS("advanced.schema-change-listener.class", false),
+
+  COMPRESSOR_CLASS("advanced.compressor.class", false),
+
+  ADDRESS_TRANSLATOR_CLASS("advanced.address-translator.class", true),
+
+  PROTOCOL_VERSION("advanced.protocol.version", false),
+  PROTOCOL_MAX_FRAME_LENGTH("advanced.protocol.max-frame-length", true),
+
+  REQUEST_WARN_IF_SET_KEYSPACE("advanced.request.warn-if-set-keyspace", true),
+  REQUEST_TRACE_ATTEMPTS("advanced.request.trace.attempts", true),
+  REQUEST_TRACE_INTERVAL("advanced.request.trace.interval", true),
+  REQUEST_TRACE_CONSISTENCY("advanced.request.trace.consistency", true),
+
+  METRICS_SESSION_ENABLED("advanced.metrics.session.enabled", false),
+  METRICS_NODE_ENABLED("advanced.metrics.node.enabled", false),
+  METRICS_SESSION_CQL_REQUESTS_HIGHEST(
+      "advanced.metrics.session.cql-requests.highest-latency", false),
+  METRICS_SESSION_CQL_REQUESTS_DIGITS(
+      "advanced.metrics.session.cql-requests.significant-digits", false),
+  METRICS_SESSION_CQL_REQUESTS_INTERVAL(
+      "advanced.metrics.session.cql-requests.refresh-interval", false),
+  METRICS_SESSION_THROTTLING_HIGHEST(
+      "advanced.metrics.session.throttling.delay.highest-latency", false),
+  METRICS_SESSION_THROTTLING_DIGITS(
+      "advanced.metrics.session.throttling.delay.significant-digits", false),
+  METRICS_SESSION_THROTTLING_INTERVAL(
+      "advanced.metrics.session.throttling.delay.refresh-interval", false),
+  METRICS_NODE_CQL_MESSAGES_HIGHEST("advanced.metrics.node.cql-messages.highest-latency", false),
+  METRICS_NODE_CQL_MESSAGES_DIGITS("advanced.metrics.node.cql-messages.significant-digits", false),
+  METRICS_NODE_CQL_MESSAGES_INTERVAL("advanced.metrics.node.cql-messages.refresh-interval", false),
+
+  SOCKET_TCP_NODELAY("advanced.socket.tcp-no-delay", true),
+  SOCKET_KEEP_ALIVE("advanced.socket.keep-alive", false),
+  SOCKET_REUSE_ADDRESS("advanced.socket.reuse-address", false),
+  SOCKET_LINGER_INTERVAL("advanced.socket.linger-interval", false),
+  SOCKET_RECEIVE_BUFFER_SIZE("advanced.socket.receive-buffer-size", false),
+  SOCKET_SEND_BUFFER_SIZE("advanced.socket.send-buffer-size", false),
+
+  HEARTBEAT_INTERVAL("advanced.heartbeat.interval", true),
+  HEARTBEAT_TIMEOUT("advanced.heartbeat.timeout", true),
+
+  METADATA_TOPOLOGY_WINDOW("advanced.metadata.topology-event-debouncer.window", true),
+  METADATA_TOPOLOGY_MAX_EVENTS("advanced.metadata.topology-event-debouncer.max-events", true),
+  METADATA_SCHEMA_ENABLED("advanced.metadata.schema.enabled", true),
+  METADATA_SCHEMA_REQUEST_TIMEOUT("advanced.metadata.schema.request-timeout", true),
+  METADATA_SCHEMA_REQUEST_PAGE_SIZE("advanced.metadata.schema.request-page-size", true),
+  METADATA_SCHEMA_REFRESHED_KEYSPACES("advanced.metadata.schema.refreshed-keyspaces", false),
+  METADATA_SCHEMA_WINDOW("advanced.metadata.schema.debouncer.window", true),
+  METADATA_SCHEMA_MAX_EVENTS("advanced.metadata.schema.debouncer.max-events", true),
+  METADATA_TOKEN_MAP_ENABLED("advanced.metadata.token-map.enabled", true),
+
+  CONTROL_CONNECTION_TIMEOUT("advanced.control-connection.timeout", true),
+  CONTROL_CONNECTION_AGREEMENT_INTERVAL(
+      "advanced.control-connection.schema-agreement.interval", true),
+  CONTROL_CONNECTION_AGREEMENT_TIMEOUT(
+      "advanced.control-connection.schema-agreement.timeout", true),
+  CONTROL_CONNECTION_AGREEMENT_WARN(
+      "advanced.control-connection.schema-agreement.warn-on-failure", true),
+
+  PREPARE_ON_ALL_NODES("advanced.prepared-statements.prepare-on-all-nodes", true),
+  REPREPARE_ENABLED("advanced.prepared-statements.reprepare-on-up.enabled", true),
+  REPREPARE_CHECK_SYSTEM_TABLE(
+      "advanced.prepared-statements.reprepare-on-up.check-system-table", false),
+  REPREPARE_MAX_STATEMENTS("advanced.prepared-statements.reprepare-on-up.max-statements", false),
+  REPREPARE_MAX_PARALLELISM("advanced.prepared-statements.reprepare-on-up.max-parallelism", false),
+  REPREPARE_TIMEOUT("advanced.prepared-statements.reprepare-on-up.timeout", false),
+
+  NETTY_IO_SIZE("advanced.netty.io-group.size", false),
+  NETTY_IO_SHUTDOWN_QUIET_PERIOD("advanced.netty.io-group.shutdown.quiet-period", false),
+  NETTY_IO_SHUTDOWN_TIMEOUT("advanced.netty.io-group.shutdown.timeout", false),
+  NETTY_IO_SHUTDOWN_UNIT("advanced.netty.io-group.shutdown.unit", false),
+  NETTY_ADMIN_SIZE("advanced.netty.admin-group.size", false),
+  NETTY_ADMIN_SHUTDOWN_QUIET_PERIOD("advanced.netty.admin-group.shutdown.quiet-period", false),
+  NETTY_ADMIN_SHUTDOWN_TIMEOUT("advanced.netty.admin-group.shutdown.timeout", false),
+  NETTY_ADMIN_SHUTDOWN_UNIT("advanced.netty.admin-group.shutdown.unit", false),
+
+  COALESCER_MAX_RUNS("advanced.coalescer.max-runs-with-no-work", false),
+  COALESCER_INTERVAL("advanced.coalescer.reschedule-interval", false),
   ;
 
   private final String path;

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -89,11 +89,10 @@ public enum DefaultDriverOption implements DriverOption {
 
   METADATA_SCHEMA_CHANGE_LISTENER_CLASS("advanced.schema-change-listener.class", false),
 
-  COMPRESSOR_CLASS("advanced.compressor.class", false),
-
   ADDRESS_TRANSLATOR_CLASS("advanced.address-translator.class", true),
 
   PROTOCOL_VERSION("advanced.protocol.version", false),
+  PROTOCOL_COMPRESSION("advanced.protocol.compression", false),
   PROTOCOL_MAX_FRAME_LENGTH("advanced.protocol.max-frame-length", true),
 
   REQUEST_WARN_IF_SET_KEYSPACE("advanced.request.warn-if-set-keyspace", true),

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelFactory.java
@@ -149,31 +149,30 @@ public class ChannelFactory {
 
     DriverConfigProfile config = context.config().getDefaultProfile();
 
-    boolean tcpNoDelay = config.getBoolean(DefaultDriverOption.CONNECTION_SOCKET_TCP_NODELAY);
+    boolean tcpNoDelay = config.getBoolean(DefaultDriverOption.SOCKET_TCP_NODELAY);
     bootstrap = bootstrap.option(ChannelOption.TCP_NODELAY, tcpNoDelay);
-    if (config.isDefined(DefaultDriverOption.CONNECTION_SOCKET_KEEP_ALIVE)) {
-      boolean keepAlive = config.getBoolean(DefaultDriverOption.CONNECTION_SOCKET_KEEP_ALIVE);
+    if (config.isDefined(DefaultDriverOption.SOCKET_KEEP_ALIVE)) {
+      boolean keepAlive = config.getBoolean(DefaultDriverOption.SOCKET_KEEP_ALIVE);
       bootstrap = bootstrap.option(ChannelOption.SO_KEEPALIVE, keepAlive);
     }
-    if (config.isDefined(DefaultDriverOption.CONNECTION_SOCKET_REUSE_ADDRESS)) {
-      boolean reuseAddress = config.getBoolean(DefaultDriverOption.CONNECTION_SOCKET_REUSE_ADDRESS);
+    if (config.isDefined(DefaultDriverOption.SOCKET_REUSE_ADDRESS)) {
+      boolean reuseAddress = config.getBoolean(DefaultDriverOption.SOCKET_REUSE_ADDRESS);
       bootstrap = bootstrap.option(ChannelOption.SO_REUSEADDR, reuseAddress);
     }
-    if (config.isDefined(DefaultDriverOption.CONNECTION_SOCKET_LINGER_INTERVAL)) {
-      int lingerInterval = config.getInt(DefaultDriverOption.CONNECTION_SOCKET_LINGER_INTERVAL);
+    if (config.isDefined(DefaultDriverOption.SOCKET_LINGER_INTERVAL)) {
+      int lingerInterval = config.getInt(DefaultDriverOption.SOCKET_LINGER_INTERVAL);
       bootstrap = bootstrap.option(ChannelOption.SO_LINGER, lingerInterval);
     }
-    if (config.isDefined(DefaultDriverOption.CONNECTION_SOCKET_RECEIVE_BUFFER_SIZE)) {
-      int receiveBufferSize =
-          config.getInt(DefaultDriverOption.CONNECTION_SOCKET_RECEIVE_BUFFER_SIZE);
+    if (config.isDefined(DefaultDriverOption.SOCKET_RECEIVE_BUFFER_SIZE)) {
+      int receiveBufferSize = config.getInt(DefaultDriverOption.SOCKET_RECEIVE_BUFFER_SIZE);
       bootstrap =
           bootstrap
               .option(ChannelOption.SO_RCVBUF, receiveBufferSize)
               .option(
                   ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(receiveBufferSize));
     }
-    if (config.isDefined(DefaultDriverOption.CONNECTION_SOCKET_SEND_BUFFER_SIZE)) {
-      int sendBufferSize = config.getInt(DefaultDriverOption.CONNECTION_SOCKET_SEND_BUFFER_SIZE);
+    if (config.isDefined(DefaultDriverOption.SOCKET_SEND_BUFFER_SIZE)) {
+      int sendBufferSize = config.getInt(DefaultDriverOption.SOCKET_SEND_BUFFER_SIZE);
       bootstrap = bootstrap.option(ChannelOption.SO_SNDBUF, sendBufferSize);
     }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/HeartbeatHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/HeartbeatHandler.java
@@ -40,10 +40,7 @@ class HeartbeatHandler extends IdleStateHandler {
 
   HeartbeatHandler(DriverConfigProfile defaultConfigProfile) {
     super(
-        (int)
-            defaultConfigProfile
-                .getDuration(DefaultDriverOption.CONNECTION_HEARTBEAT_INTERVAL)
-                .getSeconds(),
+        (int) defaultConfigProfile.getDuration(DefaultDriverOption.HEARTBEAT_INTERVAL).getSeconds(),
         0,
         0);
     this.defaultConfigProfile = defaultConfigProfile;
@@ -56,18 +53,14 @@ class HeartbeatHandler extends IdleStateHandler {
         LOG.warn(
             "Not sending heartbeat because a previous one is still in progress. "
                 + "Check that {} is not lower than {}.",
-            DefaultDriverOption.CONNECTION_HEARTBEAT_INTERVAL.getPath(),
-            DefaultDriverOption.CONNECTION_HEARTBEAT_TIMEOUT.getPath());
+            DefaultDriverOption.HEARTBEAT_INTERVAL.getPath(),
+            DefaultDriverOption.HEARTBEAT_TIMEOUT.getPath());
       } else {
         LOG.debug(
             "Connection was inactive for {} seconds, sending heartbeat",
-            defaultConfigProfile
-                .getDuration(DefaultDriverOption.CONNECTION_HEARTBEAT_INTERVAL)
-                .getSeconds());
+            defaultConfigProfile.getDuration(DefaultDriverOption.HEARTBEAT_INTERVAL).getSeconds());
         long timeoutMillis =
-            defaultConfigProfile
-                .getDuration(DefaultDriverOption.CONNECTION_HEARTBEAT_TIMEOUT)
-                .toMillis();
+            defaultConfigProfile.getDuration(DefaultDriverOption.HEARTBEAT_TIMEOUT).toMillis();
         this.request = new HeartbeatRequest(ctx, timeoutMillis);
         this.request.send();
       }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
@@ -314,7 +314,7 @@ public class DefaultDriverContext implements InternalDriverContext {
     return (Compressor<ByteBuf>)
         Reflection.buildFromConfig(
                 this,
-                DefaultDriverOption.PROTOCOL_COMPRESSOR_CLASS,
+                DefaultDriverOption.COMPRESSOR_CLASS,
                 Compressor.class,
                 "com.datastax.oss.driver.internal.core.protocol")
             .orElse(Compressor.none());

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1,104 +1,54 @@
 # Reference configuration for the DataStax Java driver for Apache Cassandra®.
 #
-# Unless you use a custom mechanism to load your configuration (see DriverContext), all the values
-# declared here will be used as defaults if you don't override them in your own `application.conf`.
+# Unless you use a custom mechanism to load your configuration (see
+# SessionBuilder.withConfigLoader), all the values declared here will be used as defaults. You can
+# place your own `application.conf` in the classpath to override them.
 #
-# Unless explicitly stated otherwise:
-# - options are required;
-# - they can not be overridden in a profile;
-# - runtime changes are ignored.
+# Options are classified into two categories:
+# - basic: what is most likely to be customized first when kickstarting a new application.
+# - advanced: more elaborate tuning options, or "expert"-level customizations.
 #
 # This file is in HOCON format, see https://github.com/typesafehub/config/blob/master/HOCON.md.
 datastax-java-driver {
+
+  # BASIC OPTIONS ----------------------------------------------------------------------------------
+
   # The contact points to use for the initial connection to the cluster.
   #
   # These are addresses of Cassandra nodes that the driver uses to discover the cluster topology.
   # Only one contact point is required (the driver will retrieve the address of the other nodes
-  # automatically), but it is usually a good idea to provide more than one contact point, because
-  # if that single contact point is unavailable, the driver cannot initialize itself correctly.
+  # automatically), but it is usually a good idea to provide more than one contact point, because if
+  # that single contact point is unavailable, the driver cannot initialize itself correctly.
   #
   # This must be a list of strings with each contact point specified as "host:port". If the host is
-  # a DNS name that resolves to multiple A-records, all the corresponding addresses will be used.
-  # Do not use "localhost" as the host name (since it resolves to both IPv4 and IPv6 addresses on
-  # some platforms).
+  # a DNS name that resolves to multiple A-records, all the corresponding addresses will be used. Do
+  # not use "localhost" as the host name (since it resolves to both IPv4 and IPv6 addresses on some
+  # platforms).
   #
-  # Note that the current version of Cassandra (3.11) requires all nodes in a cluster to share the
-  # same port.
+  # Note that Cassandra 3 and below requires all nodes in a cluster to share the same port (see
+  # CASSANDRA-7544).
   #
-  # This option is not required. Contact points can also be provided programmatically when you build
-  # a cluster instance. If both are specified, they will be merged. If both are absent, the driver
-  # will default to 127.0.0.1:9042.
-  // contact-points = [ "127.0.0.1:9042", "127.0.0.2:9042" ]
-
-  protocol {
-    # The native protocol version to use.
-    #
-    # This option is not required. If it is absent, the driver looks up the versions of the nodes at
-    # startup (by default in system.peers.release_version), and chooses the highest common protocol
-    # version. For  example, if you have a mixed cluster with Apache Cassandra 2.1 nodes (protocol
-    # v3) and Apache Cassandra 3.0 nodes (protocol v3 and v4), then protocol v3 is chosen. If the
-    # nodes don't have a common protocol version, initialization fails.
-    #
-    # If this option is set, then the given version will be used for all connections, without any
-    # negotiation or downgrading. If any of the contact points doesn't support it, it will be
-    # skipped.
-    #
-    # Once the protocol version is set, it can't change for the rest of the driver's lifetime; if an
-    # incompatible node joins the cluster later, connection will fail and the driver will force it
-    # down (i.e. never try to connect to it again).
-    #
-    # You can check the actual version at runtime with Cluster.getContext().protocolVersion().
-    // version = V4
-
-    # The maximum length of the frames supported by the driver. Beyond that limit, requests will
-    # fail with an exception
-    #
-    # This option can be changed at runtime, the new value will be used for new connections created
-    # after the change.
-    max-frame-length = 256 MB
-
-    # The component that handles authentication on each new connection.
-    auth-provider {
-      # The class of the provider. If it is not qualified, the driver assumes that it resides in the
-      # package com.datastax.oss.driver.internal.core.auth.
-      #
-      # The driver provides a single implementation out of the box: PlainTextAuthProvider, that uses
-      # plain-text credentials. It requires the `username` and `password` options below.
-      #
-      # You can also specify a custom class that implements AuthProvider and has a public
-      # constructor with a DriverContext argument.
-      #
-      # This property is optional; if it is not present, no authentication will occur.
-      // class = PlainTextAuthProvider
-
-      # Sample configuration for the plain-text provider:
-      // username = cassandra
-      // password = cassandra
-    }
-
-    # The compressor to use for protocol frames. If it is not qualified, the driver assumes that it
-    # resides in the package com.datastax.oss.driver.internal.core.protocol.
-    #
-    # The driver provides two built-in implementations for the algorithms supported by Cassandra:
-    # - Lz4Compressor: requires org.xerial.snappy:snappy-java in the classpath.
-    # - SnappyCompressor: requires net.jpountz.lz4:lz4 in the classpath.
-    #
-    # The driver depends on the compression libraries, but they are optional. Make sure you
-    # redeclare an explicit dependency in your project. Refer to the driver's POM or manual for the
-    # exact version.
-    #
-    # If this property is absent, protocol frames are not compressed.
-    // compressor.class =
-  }
+  # Contact points can also be provided programmatically when you build a cluster instance. If both
+  # are specified, they will be merged. If both are absent, the driver will default to
+  # 127.0.0.1:9042.
+  #
+  # Required: no
+  # Modifiable at runtime: no
+  # Overridable in a profile: no
+  // basic.contact-points = [ "127.0.0.1:9042", "127.0.0.2:9042" ]
 
   # A name that uniquely identifies the driver instance created from this configuration. This is
   # used as a prefix for log messages and metrics.
-  # This option is not required; if it is not specified, the driver will generate an identifier
-  # composed of the letter 's' followed by an incrementing counter.
-  # If you provide a different value, try to keep it short to keep the logs readable. Also, make
-  # sure it is unique: reusing the same value will not break the driver, but it will mix up the logs
-  # and metrics.
-  // session-name = my_session
+  #
+  # If this option is absent, the driver will generate an identifier composed of the letter 's'
+  # followed by an incrementing counter. If you provide a different value, try to keep it short to
+  # keep the logs readable. Also, make sure it is unique: reusing the same value will not break the
+  # driver, but it will mix up the logs and metrics.
+  #
+  # Required: no
+  # Modifiable at runtime: no
+  # Overridable in a profile: no
+  // basic.session-name = my_session
 
   # The name of the keyspace that the session should initially be connected to.
   #
@@ -107,40 +57,101 @@ datastax-java-driver {
   #    session-keyspace = case_insensitive_name
   #    session-keyspace = \"CaseSensitiveName\"
   #
-  # This option is not required; if it is left unspecified, the session won't be connected to any
-  # keyspace, and you'll have to either qualify table names in your queries, or use the per-query
-  # keyspace feature available in Cassandra 4 and above (see Request.getKeyspace()).
+  # If this option is absent, the session won't be connected to any keyspace, and you'll have to
+  # either qualify table names in your queries, or use the per-query keyspace feature available in
+  # Cassandra 4 and above (see Request.getKeyspace()).
   #
   # This can also be provided programatically in CqlSessionBuilder.
-  // session-keyspace = my_keyspace
+  #
+  # Required: no
+  # Modifiable at runtime: no
+  # Overridable in a profile: no
+  // basic.session-keyspace = my_keyspace
 
   # How often the driver tries to reload the configuration.
-  # This option is required, except if you use a different config loader than the driver's built-in
-  # one. Runtime changes are taken into account.
+  #
   # To disable periodic reloading, set this to 0.
-  config-reload-interval = 5 minutes
+  #
+  # Required: yes (unless you pass a different ConfigLoader to the session builder).
+  # Modifiable at runtime: yes, the new value will be used after the next time the configuration
+  #   gets reloaded.
+  # Overridable in a profile: no
+  basic.config-reload-interval = 5 minutes
+
+  basic.request {
+    # How long the driver waits for a request to complete. This is a global limit on the duration of
+    # a session.execute() call, including any internal retries the driver might do.
+    #
+    # By default, this value is set pretty high to ensure that DDL queries don't time out, in order
+    # to provide the best experience for new users trying the driver with the out-of-the-box
+    # configuration.
+    # For any serious deployment, we recommend that you use separate configuration profiles for DDL
+    # and DML; you can then set the DML timeout much lower (down to a few milliseconds if needed).
+    #
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for requests issued after the change.
+    # Overridable in a profile: yes
+    timeout = 2 seconds
+
+    # The consistency level.
+    #
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for requests issued after the change.
+    # Overridable in a profile: yes
+    consistency = LOCAL_ONE
+
+    # The page size. This controls how many rows will be retrieved simultaneously in a single
+    # network roundtrip (the goal being to avoid loading too many results in memory at the same
+    # time). If there are more results, additional requests will be used to retrieve them (either
+    # automatically if you iterate with the sync API, or explicitly with the async API's
+    # fetchNextPage method).
+    # If the value is 0 or negative, it will be ignored and the request will not be paged.
+    #
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for requests issued after the change.
+    # Overridable in a profile: yes
+    page-size = 5000
+
+    # The serial consistency level.
+    # The allowed values are SERIAL and LOCAL_SERIAL.
+    #
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for requests issued after the change.
+    # Overridable in a profile: yes
+    serial-consistency = SERIAL
+
+    # The default idempotence of a request, that will be used for all `Request` instances where
+    # `isIdempotent()` returns null.
+    #
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for requests issued after the change.
+    # Overridable in a profile: yes
+    default-idempotence = false
+  }
 
   # The policy that decides the "query plan" for each query; that is, which nodes to try as
   # coordinators, and in which order.
-  # It can be overridden in a profile. Note that the driver creates as few instances as possible:
-  # if a named profile inherits from the default profile, or if two sibling profiles have the
-  # exact same configuration, they will share a single policy instance at runtime.
   #
-  # If there are multiple load balancing policies in a single driver instance, they work together in
-  # the following way:
-  # - each request gets a query plan from its profile's policy (or the default policy if the request
-  #   has no profile, or the profile does not override the policy).
-  # - when the policies assign distances to nodes, the driver uses the closest assigned distance for
-  #   any given node.
-  load-balancing-policy {
+  # Required: yes
+  # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+  #   and allow child options to be changed at runtime).
+  # Overridable in a profile: yes. Note that the driver creates as few instances as possible: if a
+  #   named profile inherits from the default profile, or if two sibling profiles have the exact
+  #   same configuration, they will share a single policy instance at runtime.
+  #   If there are multiple load balancing policies in a single driver instance, they work together
+  #   in the following way:
+  #   - each request gets a query plan from its profile's policy (or the default policy if the
+  #     request has no profile, or the profile does not override the policy).
+  #   - when the policies assign distances to nodes, the driver uses the closest assigned distance
+  #     for any given node.
+  basic.load-balancing-policy {
     # The class of the policy. If it is not qualified, the driver assumes that it resides in the
     # package com.datastax.oss.driver.internal.core.loadbalancing.
     #
     # The driver provides a single implementation out of the box: DefaultLoadBalancingPolicy.
     #
     # You can also specify a custom class that implements LoadBalancingPolicy and has a public
-    # constructor with two arguments: the DriverContext and a String representing the profile
-    # name.
+    # constructor with two arguments: the DriverContext and a String representing the profile name.
     class = DefaultLoadBalancingPolicy
 
     # The datacenter that is considered "local": the default policy will only include nodes from
@@ -170,29 +181,55 @@ datastax-java-driver {
     // filter.class=
   }
 
-  connection {
+
+  # ADVANCED OPTIONS -------------------------------------------------------------------------------
+
+  advanced.connection {
     # The timeout to use for internal queries that run as part of the initialization process, just
     # after we open a connection. If this timeout fires, the initialization of the connection will
     # fail. If this is the first connection ever, the driver will fail to initialize as well,
     # otherwise it will retry the connection later.
     #
-    # This option can be changed at runtime, the new value will be used for new connections created
-    # after the change.
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for connections created after the
+    #   change.
+    # Overridable in a profile: no
     init-query-timeout = 500 milliseconds
 
     # The timeout to use when the driver changes the keyspace on a connection at runtime (this
-    # happens when the client issues a `USE ...` query, and all connections belonging to the
-    # current session need to be updated).
+    # happens when the client issues a `USE ...` query, and all connections belonging to the current
+    # session need to be updated).
     #
-    # This option can be changed at runtime, the new value will be used for new connections created
-    # after the change.
-    set-keyspace-timeout = ${datastax-java-driver.connection.init-query-timeout}
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for connections created after the
+    #   change.
+    # Overridable in a profile: no
+    set-keyspace-timeout = ${datastax-java-driver.advanced.connection.init-query-timeout}
+
+    # The driver maintains a connection pool to each node, according to the distance assigned to it
+    # by the load balancing policy. If the distance is IGNORED, no connections are maintained.
+    pool {
+      local {
+        # The number of connections in the pool.
+        #
+        # Required: yes
+        # Modifiable at runtime: yes; when the change is detected, all active pools will be notified
+        #   and will adjust their size.
+        # Overridable in a profile: no
+        size = 1
+      }
+      remote {
+        size = 1
+      }
+    }
 
     # The maximum number of requests that can be executed concurrently on a connection. This must be
     # between 1 and 32768.
     #
-    # This option can be changed at runtime, the new value will be used for new connections created
-    # after the change.
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for connections created after the
+    #   change.
+    # Overridable in a profile: no
     max-requests-per-connection = 1024
 
     # The maximum number of "orphaned" requests before a connection gets closed automatically.
@@ -203,11 +240,13 @@ datastax-java-driver {
     # marked as "orphaned" until we get a response from the node.
     #
     # If the response never comes (or is lost because of a network issue), orphaned ids can
-    # accumulate over time, eventually affecting the connection's throughput. So we monitor them and
-    # close the connection above a given threshold (the pool will replace it).
+    # accumulate over time, eventually affecting the connection's throughput. So we monitor them
+    # and close the connection above a given threshold (the pool will replace it).
     #
-    # This option can be changed at runtime, the new value will be used for new connections created
-    # after the change.
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for connections created after the
+    #   change.
+    # Overridable in a profile: no
     max-orphan-requests = 24576
 
     # Whether to log non-fatal errors when the driver tries to open a new connection.
@@ -216,225 +255,411 @@ datastax-java-driver {
     # policy. Therefore some users see them as unnecessary clutter in the logs. On the other hand,
     # those logs can be handy to debug a misbehaving node.
     #
-    # This option can be changed at runtime, the new value will be used for new connections created
-    # after the change.
-    #
     # Note that some type of errors are always logged, regardless of this option:
     # - protocol version mismatches (the node gets forced down)
     # - when the cluster name in system.local doesn't match the other nodes (the node gets forced
     #   down)
     # - authentication errors (will be retried)
+    #
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for connections created after the
+    #   change.
+    # Overridable in a profile: no
     warn-on-init-error = true
+  }
 
-    heartbeat {
-      # The heartbeat interval. If a connection stays idle for that duration (no reads), the driver
-      # sends a dummy message on it to make sure it's still alive. If not, the connection is
-      # trashed and replaced.
-      #
-      # This option can be changed at runtime, the new value will be used for new connections
-      # created after the change.
-      interval = 30 seconds
+  # The policy that controls how often the driver tries to re-establish connections to down nodes.
+  #
+  # Required: yes
+  # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+  #   and allow child options to be changed at runtime).
+  # Overridable in a profile: no
+  advanced.reconnection-policy {
+    # The class of the policy. If it is not qualified, the driver assumes that it resides in the
+    # package com.datastax.oss.driver.internal.core.connection.
+    #
+    # The driver provides two implementations out of the box: ExponentialReconnectionPolicy and
+    # ConstantReconnectionPolicy.
+    #
+    # You can also specify a custom class that implements ReconnectionPolicy and has a public
+    # constructor with a DriverContext argument.
+    class = ExponentialReconnectionPolicy
 
-      # How long the driver waits for the response to a heartbeat. If this timeout fires, the
-      # heartbeat is considered failed.
-      #
-      # This option can be changed at runtime, the new value will be used for heartbeat queries
-      # issued after the change.
-      timeout = ${datastax-java-driver.connection.init-query-timeout}
+    # ExponentialReconnectionPolicy starts with the base delay, and doubles it after each failed
+    # reconnection attempt, up to the maximum delay (after that it stays constant).
+    #
+    # ConstantReconnectionPolicy only uses the base-delay value, the interval never changes.
+    base-delay = 1 second
+    max-delay = 60 seconds
+  }
+
+  # The policy that controls if the driver retries requests that have failed on one node.
+  #
+  # Required: yes
+  # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+  #   and allow child options to be changed at runtime).
+  # Overridable in a profile: yes. Note that the driver creates as few instances as possible: if a
+  #   named profile inherits from the default profile, or if two sibling profiles have the exact
+  #   same configuration, they will share a single policy instance at runtime.
+  advanced.retry-policy {
+    # The class of the policy. If it is not qualified, the driver assumes that it resides in the
+    # package com.datastax.oss.driver.internal.core.retry.
+    #
+    # The driver provides a single implementation out of the box: DefaultRetryPolicy.
+    #
+    # You can also specify a custom class that implements RetryPolicy and has a public constructor
+    # with two arguments: the DriverContext and a String representing the profile name.
+    class = DefaultRetryPolicy
+  }
+
+  # The policy that controls if the driver pre-emptively tries other nodes if a node takes too long
+  # to respond.
+  #
+  # Required: yes
+  # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+  #   and allow child options to be changed at runtime).
+  # Overridable in a profile: yes. Note that the driver creates as few instances as possible: if a
+  #   named profile inherits from the default profile, or if two sibling profiles have the exact
+  #   same configuration, they will share a single policy instance at runtime.
+  advanced.speculative-execution-policy {
+    # The class of the policy. If it is not qualified, the driver assumes that it resides in the
+    # package com.datastax.oss.driver.internal.core.specex.
+    #
+    # The following implementations are available out of the box:
+    # - NoSpeculativeExecutionPolicy: never schedule any speculative execution
+    # - ConstantSpeculativeExecutionPolicy: schedule executions based on constant delays. This
+    #   requires the `max-executions` and `delay` options below.
+    #
+    # You can also specify a custom class that implements SpeculativeExecutionPolicy and has a
+    # public constructor with two arguments: the DriverContext and a String representing the
+    # profile name.
+    class = NoSpeculativeExecutionPolicy
+
+    # The maximum number of executions (including the initial, non-speculative execution).
+    # This must be at least one.
+    // max-executions = 3
+
+    # The delay between each execution. 0 is allowed, and will result in all executions being sent
+    # simultaneously when the request starts.
+    # Note that sub-millisecond precision is not supported, any excess precision information will be
+    # dropped; in particular, delays of less than 1 millisecond are equivalent to 0.
+    # This must be positive or 0.
+    // delay = 100 milliseconds
+  }
+
+  # The component that handles authentication on each new connection.
+  #
+  # Required: no. If the 'class' child option is absent, no authentication will occur.
+  # Modifiable at runtime: no
+  # Overridable in a profile: no
+  advanced.auth-provider {
+    # The class of the provider. If it is not qualified, the driver assumes that it resides in the
+    # package com.datastax.oss.driver.internal.core.auth.
+    #
+    # The driver provides a single implementation out of the box: PlainTextAuthProvider, that uses
+    # plain-text credentials. It requires the `username` and `password` options below.
+    #
+    # You can also specify a custom class that implements AuthProvider and has a public
+    # constructor with a DriverContext argument.
+    // class = PlainTextAuthProvider
+
+    # Sample configuration for the plain-text provider:
+    // username = cassandra
+    // password = cassandra
+  }
+
+  # The SSL engine factory that will initialize an SSL engine for each new connection to a server.
+  #
+  # Required: no. If the 'class' child option is absent, SSL won't be activated.
+  # Modifiable at runtime: no
+  # Overridable in a profile: no
+  advanced.ssl-engine-factory {
+    # The class of the factory. If it is not qualified, the driver assumes that it resides in the
+    # package com.datastax.oss.driver.internal.core.ssl.
+    #
+    # The driver provides a single implementation out of the box: DefaultSslEngineFactory, that uses
+    # the JDK's built-in SSL implementation.
+    #
+    # You can also specify a custom class that implements SslEngineFactory and has a public
+    # constructor with a DriverContext argument.
+    // class = DefaultSslEngineFactory
+
+    # Sample configuration for the default SSL factory:
+    # The cipher suites to enable when creating an SSLEngine for a connection.
+    # This property is optional. If it is not present, the driver won't explicitly enable cipher
+    # suites on the engine, which according to the JDK documentations results in "a minimum quality
+    # of service".
+    // cipher-suites = [ "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA" ]
+  }
+
+  # The generator that assigns a microsecond timestamp to each request.
+  #
+  # Required: yes
+  # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+  #   and allow child options to be changed at runtime).
+  # Overridable in a profile: yes. Note that the driver creates as few instances as possible: if a
+  #   named profile inherits from the default profile, or if two sibling profiles have the exact
+  #   same configuration, they will share a single generator instance at runtime.
+  advanced.timestamp-generator {
+    # The class of the generator. If it is not qualified, the driver assumes that it resides in the
+    # package com.datastax.oss.driver.internal.core.time.
+    #
+    # The driver provides the following implementations out of the box:
+    # - AtomicTimestampGenerator: timestamps are guaranteed to be unique across all client threads.
+    # - ThreadLocalTimestampGenerator: timestamps that are guaranteed to be unique within each
+    #   thread only.
+    # - ServerSideTimestampGenerator: do not generate timestamps, let the server assign them.
+    #
+    # You can also specify a custom class that implements TimestampGenerator and has a public
+    # constructor with two arguments: the DriverContext and a String representing the profile name.
+    class = AtomicTimestampGenerator
+
+    # To guarantee that queries are applied on the server in the same order as the client issued
+    # them, timestamps must be strictly increasing. But this means that, if the driver sends more
+    # than one query per microsecond, timestamps will drift in the future. While this could happen
+    # occasionally under high load, it should not be a regular occurrence. Therefore the built-in
+    # implementations log a warning to detect potential issues.
+    drift-warning {
+      # How far in the future timestamps are allowed to drift before the warning is logged.
+      # If it is undefined or set to 0, warnings are disabled.
+      threshold = 1 second
+
+      # How often the warning will be logged if timestamps keep drifting above the threshold.
+      interval = 10 seconds
     }
 
-    # The policy that controls how often the driver tries to re-establish connections to down nodes.
-    reconnection-policy {
-      # The class of the policy. If it is not qualified, the driver assumes that it resides in the
-      # package com.datastax.oss.driver.internal.core.connection.
-      #
-      # The driver provides two implementations out of the box: ExponentialReconnectionPolicy
-      # and ConstantReconnectionPolicy.
-      #
-      # You can also specify a custom class that implements ReconnectionPolicy and has a public
-      # constructor with a DriverContext argument.
-      class = ExponentialReconnectionPolicy
+    # Whether to force the driver to use Java's millisecond-precision system clock.
+    # If this is false, the driver will try to access the microsecond-precision OS clock via native
+    # calls (and fallback to the Java one if the native calls fail).
+    # Unless you explicitly want to avoid native calls, there's no reason to change this.
+    force-java-clock = false
+  }
 
-      # ExponentialReconnectionPolicy starts with the base delay, and doubles it after each failed
-      # reconnection attempt, up to the maximum delay (after that it stays constant).
-      #
-      # ConstantReconnectionPolicy only uses the base-delay value, the interval never changes.
-      base-delay = 1 second
-      max-delay = 60 seconds
-    }
+  # A session-wide component that tracks the outcome of requests.
+  #
+  # Required: yes
+  # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+  #   and allow child options to be changed at runtime).
+  # Overridable in a profile: no
+  advanced.request-tracker {
+    # The class of the tracker. If it is not qualified, the driver assumes that it resides in the
+    # package com.datastax.oss.driver.internal.core.tracker.
+    #
+    # The driver provides the following implementations out of the box:
+    # - NoopRequestTracker: does nothing.
+    # - RequestLogger: logs requests (see the parameters below).
+    #
+    # You can also specify a custom class that implements RequestTracker and has a public
+    # constructor with a DriverContext argument.
+    class = NoopRequestTracker
 
-    control-connection {
-      # How long the driver waits for responses to control queries (e.g. fetching the list of
-      # nodes, refreshing the schema).
-      timeout = 500 milliseconds
-      # Allow for ports to be discovered by querying the system.peers_v2 table. If enabled This
-      # discovery will override any ports defined in the contact points. If the system.peers_v2
-      # table is not present it will fall back to ports provided in contact points.
-      allow-port-discovery = true
-      # Due to the distributed nature of Cassandra, schema changes made on one node might not be
-      # immediately visible to others. Under certain circumstances, the driver waits until all nodes
-      # agree on a common schema version (namely: before a schema refresh, before repreparing all
-      # queries on a newly up node, and before completing a successful schema-altering query).
-      # To do so, it queries system tables to find out the schema version of all nodes that are
-      # currently UP. If all the versions match, the check succeeds, otherwise it is retried
-      # periodically, until a given timeout.
-      #
-      # A schema agreement failure is not fatal, but it might produce unexpected results (for
-      # example, getting an "unconfigured table" error for a table that you created right before,
-      # just because the two queries went to different coordinators).
-      #
-      # Note that schema agreement never succeeds in a mixed-version cluster (it would be
-      # challenging because the way the schema version is computed varies across server versions);
-      # the assumption is that schema updates are unlikely to happen during a rolling upgrade
-      # anyway.
-      schema-agreement {
-        # The interval between each attempt.
-        # This option can be changed at runtime, the new value will be used for checks issued after
-        # the change.
-        interval = 200 milliseconds
+    # Parameters for RequestLogger. All of them can be overridden in a profile, and changed at
+    # runtime (the new values will be taken into account for requests logged after the change).
+    logs {
+      # Whether to log successful requests.
+      // success.enabled = true
 
-        # The timeout after which schema agreement fails.
-        # If this is set to 0, schema agreement is skipped and will always fail.
-        # This option can be changed at runtime, the new value will be used for checks issued after
-        # the change.
-        timeout = 10 seconds
+      slow {
+        # The threshold to classify a successful request as "slow". If this is unset, all successful
+        # requests will be considered as normal.
+        // threshold = 1 second
 
-        # Whether to log a warning if schema agreement fails.
-        # You might want to change this if you've set the timeout to 0.
-        # This option can be changed at runtime, the new value will be used for checks issued after
-        # the change.
-        warn-on-failure = true
+        # Whether to log slow requests.
+        // enabled = true
       }
-    }
 
-    # The component that coalesces writes on the connections.
-    # This is exposed mainly to facilitate tuning during development. You shouldn't have to adjust
-    # this.
-    coalescer {
-      # How many times the coalescer is allowed to reschedule itself when it did no work.
-      max-runs-with-no-work = 5
+      # Whether to log failed requests.
+      // error.enabled = true
 
-      # The reschedule interval.
-      reschedule-interval = 10 microseconds
-    }
+      # The maximum length of the query string in the log message. If it is longer than that, it
+      # will be truncated.
+      // max-query-length = 500
 
-    # The driver maintains a connection pool to each node, according to the distance assigned to it
-    # by the load balancing policy. If the distance is IGNORED, no connections are maintained.
-    pool {
-      local {
-        # The number of connections in the pool.
-        #
-        # This option can be changed at runtime; when the change is detected, all active pools will
-        # adjust their size.
-        size = 1
-      }
-      remote {
-        size = 1
-      }
-    }
+      # Whether to log bound values in addition to the query string.
+      // show-values = true
 
-    socket {
+      # The maximum length for bound values in the log message. If the formatted representation of a
+      # value is longer than that, it will be truncated.
+      // max-value-length = 50
 
-      # Whether or not to disable the Nagle algorithm.
-      #
-      # By default, this option is set to true (Nagle disabled), because the driver has its own
-      # internal message coalescing algorithm.
-      #
-      # See java.net.StandardSocketOptions.TCP_NODELAY.
-      #
-      # This option can be changed at runtime, the new value will be used for new connections created
-      # after the change.
-      tcpNoDelay = true
+      # The maximum number of bound values to log. If a request has more values, the list of values
+      # will be truncated.
+      // max-values = 50
 
-      # All other socket options are unset by default. The actual value depends on the underlying
-      # Netty transport:
-      # - NIO uses the defaults from java.net.Socket (refer to the javadocs of
-      #   java.net.StandardSocketOptions for each option).
-      # - Epoll delegates to the underlying file descriptor, which uses the O/S defaults.
-
-      # Whether or not to enable TCP keep-alive probes.
-      #
-      # See java.net.StandardSocketOptions.SO_KEEPALIVE.
-      #
-      # This option can be changed at runtime, the new value will be used for new connections created
-      # after the change.
-      //keepAlive = false
-
-      # Whether or not to allow address reuse.
-      #
-      # See java.net.StandardSocketOptions.SO_REUSEADDR.
-      #
-      # This option can be changed at runtime, the new value will be used for new connections created
-      # after the change.
-      //reuseAddress = true
-
-      # Sets the linger interval.
-      #
-      # If the value is zero or greater, then it represents a timeout value, in seconds;
-      # if the value is negative, it means that this option is disabled.
-      #
-      # See java.net.StandardSocketOptions.SO_LINGER.
-      #
-      # This option can be changed at runtime, the new value will be used for new connections created
-      # after the change.
-      //lingerInterval = 0
-
-      # Sets a hint to the size of the underlying buffers for incoming network I/O.
-      # 
-      # See java.net.StandardSocketOptions.SO_RCVBUF.
-      #
-      # This option can be changed at runtime, the new value will be used for new connections created
-      # after the change.
-      //receiveBufferSize = 65535
-
-      # Sets a hint to the size of the underlying buffers for outgoing network I/O.
-      # 
-      # See java.net.StandardSocketOptions.SO_SNDBUF.
-      #
-      # This option can be changed at runtime, the new value will be used for new connections created
-      # after the change.
-      //sendBufferSize = 65535
+      # Whether to log stack traces for failed queries. If this is disabled, the log will just
+      # include the exception's string representation (generally the class name and message).
+      // show-stack-traces = true
     }
   }
 
-  request {
-    # How long the driver waits for a request to complete. This is a global limit on the duration
-    # of a session.execute() call, including any internal retries the driver might do.
+  # A session-wide component that controls the rate at which requests are executed.
+  #
+  # Implementations vary, but throttlers generally track a metric that represents the level of
+  # utilization of the session, and prevent new requests from starting when that metric exceeds a
+  # threshold. Pending requests may be enqueued and retried later.
+  #
+  # From the public API's point of view, this process is mostly transparent: any time that the
+  # request is throttled is included in the session.execute() or session.executeAsync() call.
+  # Similarly, the request timeout encompasses throttling: the timeout starts ticking before the
+  # throttler has started processing the request; a request may time out while it is still in the
+  # throttler's queue, before the driver has even tried to send it to a node.
+  #
+  # The only visible effect is that a request may fail with a RequestThrottlingException, if the
+  # throttler has determined that it can neither allow the request to proceed now, nor enqueue it;
+  # this indicates that your session is overloaded.
+  #
+  # Required: yes
+  # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+  #   and allow child options to be changed at runtime).
+  # Overridable in a profile: no
+  advanced.throttler {
+    # The class of the throttler. If it is not qualified, the driver assumes that it resides in
+    # the package com.datastax.oss.driver.internal.core.session.throttling.
     #
-    # This option can be changed at runtime, the new value will be used for requests issued after
-    # the change. It can be overridden in a profile.
+    # The driver provides the following implementations out of the box:
     #
-    # By default, this value is set pretty high to ensure that DDL queries don't time out, in order
-    # to provide the best experience for new users trying the driver with the out-of-the-box
-    # configuration.
-    # For any serious deployment, we recommend that you use separate configuration profiles for DDL
-    # and DML; you can then set the DML timeout much lower (down to a few milliseconds if needed).
-    timeout = 2 seconds
+    # - PassThroughRequestThrottler: does not perform any kind of throttling, all requests are
+    #   allowed to proceed immediately. Required options: none.
+    #
+    # - ConcurrencyLimitingRequestThrottler: limits the number of requests that can be executed in
+    #   parallel. Required options: max-concurrent-requests, max-queue-size.
+    #
+    # - RateLimitingRequestThrottler: limits the request rate per second. Required options:
+    #   max-requests-per-second, max-queue-size, drain-interval.
+    #
+    # You can also specify a custom class that implements RequestThrottler and has a public
+    # constructor with a DriverContext argument.
+    class = PassThroughRequestThrottler
 
-    # The consistency level.
-    #
-    # This option can be changed at runtime, the new value will be used for requests issued after
-    # the change. It can be overridden in a profile.
-    consistency = LOCAL_ONE
+    # The maximum number of requests that can be enqueued when the throttling threshold is exceeded.
+    # Beyond that size, requests will fail with a RequestThrottlingException.
+    // max-queue-size = 10000
 
-    # The page size. This controls how many rows will be retrieved simultaneously in a single
-    # network roundtrip (the goal being to avoid loading too many results in memory at the same
-    # time). If there are more results, additional requests will be used to retrieve them (either
-    # automatically if you iterate with the sync API, or explicitly with the async API's
-    # fetchNextPage method).
-    # If the value is 0 or negative, it will be ignored and the request will not be paged.
-    #
-    # This option can be changed at runtime, the new value will be used for requests issued after
-    # the change. It can be overridden in a profile.
-    page-size = 5000
+    # The maximum number of requests that are allowed to execute in parallel.
+    # Only used by ConcurrencyLimitingRequestThrottler.
+    // max-concurrent-requests = 10000
 
-    # The serial consistency level.
-    # The allowed values are SERIAL and LOCAL_SERIAL.
-    #
-    # This option can be changed at runtime, the new value will be used for requests issued after
-    # the change. It can be overridden in a profile.
-    serial-consistency = SERIAL
+    # The maximum allowed request rate.
+    # Only used by RateLimitingRequestThrottler.
+    // max-requests-per-second = 10000
 
+    # How often the throttler attempts to dequeue requests. This is the only way for rate-based
+    # throttling, because the completion of an active request does not necessarily free a "slot" for
+    # a queued one (the rate might still be too high).
+    #
+    # You want to set this high enough that each attempt will process multiple entries in the queue,
+    # but not delay requests too much. A few milliseconds is probably a happy medium.
+    #
+    # Only used by RateLimitingRequestThrottler.
+    // drain-interval = 10 milliseconds
+  }
+
+  # A session-wide component that listens for node state changes. If it is not qualified, the driver
+  # assumes that it resides in the package com.datastax.oss.driver.internal.core.metadata.
+  #
+  # The driver provides a single no-op implementation out of the box: NoopNodeStateListener.
+  #
+  # You can also specify a custom class that implements NodeStateListener and has a public
+  # constructor with a DriverContext argument.
+  #
+  # Alternatively, you can pass an instance of your listener programmatically with
+  # CqlSession.builder().withNodeStateListener(). In that case, this option will be ignored.
+  #
+  # Required: unless a listener has been provided programmatically
+  # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+  #   and allow child options to be changed at runtime).
+  # Overridable in a profile: no
+  advanced.node-state-listener.class = NoopNodeStateListener
+
+  # A session-wide component that listens for node state changes. If it is not qualified, the driver
+  # assumes that it resides in the package com.datastax.oss.driver.internal.core.metadata.schema.
+  #
+  # The driver provides a single no-op implementation out of the box: NoopSchemaChangeListener.
+  #
+  # You can also specify a custom class that implements SchemaChangeListener and has a public
+  # constructor with a DriverContext argument.
+  #
+  # Alternatively, you can pass an instance of your listener programmatically with
+  # CqlSession.builder().withSchemaChangeListener(). In that case, this option will be ignored.
+  #
+  # Required: unless a listener has been provided programmatically
+  # Modifiable at runtime: no (but custom implementations may elect to watch configuration changes
+  #   and allow child options to be changed at runtime).
+  # Overridable in a profile: no
+  advanced.schema-change-listener.class = NoopSchemaChangeListener
+
+  # The compressor to use for protocol frames. If it is not qualified, the driver assumes that it
+  # resides in the package com.datastax.oss.driver.internal.core.protocol.
+  #
+  # The driver provides two built-in implementations for the algorithms supported by Cassandra:
+  # - Lz4Compressor: requires org.xerial.snappy:snappy-java in the classpath.
+  # - SnappyCompressor: requires net.jpountz.lz4:lz4 in the classpath.
+  #
+  # The driver depends on the compression libraries, but they are optional. Make sure you redeclare
+  # an explicit dependency in your project. Refer to the driver's POM or manual for the exact
+  # version.
+  #
+  # Required: no. If the option is absent, protocol frames are not compressed.
+  # Modifiable at runtime: no
+  # Overridable in a profile: no
+  // advanced.compressor.class =
+
+  # The address translator to use to convert the addresses sent by Cassandra nodes into ones that
+  # the driver uses to connect.
+  # This is only needed if the nodes are not directly reachable from the driver (for example, the
+  # driver is in a different network region and needs to use a public IP, or it connects through a
+  # proxy).
+  #
+  # Required: yes
+  # Modifiable at runtime: no
+  # Overridable in a profile: no
+  advanced.address-translator {
+    # The class of the translator. If it is not qualified, the driver assumes that it resides in
+    # the package com.datastax.oss.driver.internal.core.addresstranslation.
+    #
+    # The driver provides the following implementations out of the box:
+    # - PassThroughAddressTranslator: returns all addresses unchanged
+    #
+    # You can also specify a custom class that implements AddressTranslator and has a public
+    # constructor with a DriverContext argument.
+    class = PassThroughAddressTranslator
+  }
+
+  advanced.protocol {
+    # The native protocol version to use.
+    #
+    # If this option is absent, the driver looks up the versions of the nodes at startup (by default
+    # in system.peers.release_version), and chooses the highest common protocol version.
+    # For example, if you have a mixed cluster with Apache Cassandra 2.1 nodes (protocol v3) and
+    # Apache Cassandra 3.0 nodes (protocol v3 and v4), then protocol v3 is chosen. If the nodes
+    # don't have a common protocol version, initialization fails.
+    #
+    # If this option is set, then the given version will be used for all connections, without any
+    # negotiation or downgrading. If any of the contact points doesn't support it, that contact
+    # point will be skipped.
+    #
+    # Once the protocol version is set, it can't change for the rest of the driver's lifetime; if
+    # an incompatible node joins the cluster later, connection will fail and the driver will force
+    # it down (i.e. never try to connect to it again).
+    #
+    # You can check the actual version at runtime with Cluster.getContext().protocolVersion().
+    #
+    # Required: no
+    # Modifiable at runtime: no
+    # Overridable in a profile: no
+    // version = V4
+
+    # The maximum length of the frames supported by the driver. Beyond that limit, requests will
+    # fail with an exception
+    #
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for connections created after the
+    #   change.
+    # Overridable in a profile: no
+    max-frame-length = 256 MB
+  }
+
+  advanced.request {
     # Whether a warning is logged when a request (such as a CQL `USE ...`) changes the active
     # keyspace.
     # Switching keyspace at runtime is highly discouraged, because it is inherently unsafe (other
@@ -444,397 +669,49 @@ datastax-java-driver {
     # executing synchronous queries (such as a cqlsh-like interpreter). In other cases, clients
     # should prefix table names in their queries instead.
     #
-    # Note that CASSANDRA-10145 (scheduled for C* 4.0) will introduce a per-request keyspace
-    # option as a workaround to this issue.
+    # Note that CASSANDRA-10145 (scheduled for C* 4.0) will introduce a per-request keyspace option
+    # as a workaround to this issue.
     #
-    # This option can be changed at runtime, it will apply to keyspace switches occurring after the
-    # change.
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for keyspace switches occurring after
+    #   the change.
+    # Overridable in a profile: no
     warn-if-set-keyspace = true
 
-    # The default idempotence of a request, that will be used for all `Request` instances where
-    # `isIdempotent()` returns null.
-    #
-    # This option can be changed at runtime, the new value will be used for requests issued after
-    # the change. It can be overridden in a profile.
-    default-idempotence = false
-
-    # The generator that assigns a microsecond timestamp to each request.
-    # It can be overridden in a profile. Note that the driver creates as few instances as possible:
-    # if a named profile inherits from the default profile, or if two sibling profiles have the
-    # exact same configuration, they will share a single generator instance at runtime.
-    timestamp-generator {
-      # The class of the generator. If it is not qualified, the driver assumes that it resides in the
-      # package com.datastax.oss.driver.internal.core.time.
-      #
-      # The driver provides the following implementations out of the box:
-      # - AtomicTimestampGenerator: timestamps are guaranteed to be unique across all client threads.
-      # - ThreadLocalTimestampGenerator: timestamps that are guaranteed to be unique within each
-      #   thread only.
-      # - ServerSideTimestampGenerator: do not generate timestamps, let the server assign them.
-      #
-      # You can also specify a custom class that implements LoadBalancingPolicy and has a public
-      # constructor with two arguments: the DriverContext and a String representing the profile
-      # name.
-      class = AtomicTimestampGenerator
-
-      # To guarantee that queries are applied on the server in the same order as the client issued
-      # them, timestamps must be strictly increasing. But this means that, if the driver sends more
-      # than one query per microsecond, timestamps will drift in the future. While this could happen
-      # occasionally under high load, it should not be a regular occurrence. Therefore the built-in
-      # implementations log a warning to detect potential issues.
-      drift-warning {
-        # How far in the future timestamps are allowed to drift before the warning is logged.
-        # If it is undefined or set to 0, warnings are disabled.
-        threshold = 1 second
-
-        # How often the warning will be logged if timestamps keep drifting above the threshold.
-        interval = 10 seconds
-      }
-
-      # Whether to force the driver to use Java's millisecond-precision system clock.
-      # If this is false, the driver will try to access the microsecond-precision OS clock via native
-      # calls (and fallback to the Java one if the native calls fail).
-      # Unless you explicitly want to avoid native calls, there's no reason to change this.
-      force-java-clock = false
-    }
-
-    # The policy that controls if the driver retries requests that have failed on one node.
-    # It can be overridden in a profile. Note that the driver creates as few instances as possible:
-    # if a named profile inherits from the default profile, or if two sibling profiles have the
-    # exact same configuration, they will share a single policy instance at runtime.
-    retry-policy {
-      # The class of the policy. If it is not qualified, the driver assumes that it resides in the
-      # package com.datastax.oss.driver.internal.core.retry.
-      #
-      # The driver provides a single implementation out of the box: DefaultRetryPolicy.
-      #
-      # You can also specify a custom class that implements RetryPolicy and has a public constructor
-      # with two arguments: the DriverContext and a String representing the profile name.
-      class = DefaultRetryPolicy
-    }
-
-    # The policy that controls if the driver pre-emptively tries other nodes if a node takes too
-    # long to respond.
-    # It can be overridden in a profile. Note that the driver creates as few instances as possible:
-    # if a named profile inherits from the default profile, or if two sibling profiles have the
-    # exact same configuration, they will share a single policy instance at runtime.
-    speculative-execution-policy {
-      # The class of the policy. If it is not qualified, the driver assumes that it resides in the
-      # package com.datastax.oss.driver.internal.core.specex.
-      #
-      # The following implementations are available out of the box:
-      # - NoSpeculativeExecutionPolicy: never schedule any speculative execution
-      # - ConstantSpeculativeExecutionPolicy: schedule executions based on constant delays. This
-      #   requires the `max-executions` and `delay` options below.
-      #
-      # You can also specify a custom class that implements SpeculativeExecutionPolicy and has a
-      # public constructor with two arguments: the DriverContext and a String representing the
-      # profile name.
-      class = NoSpeculativeExecutionPolicy
-
-      # The maximum number of executions (including the initial, non-speculative execution).
-      # This must be at least one.
-      // max-executions = 3
-
-      # The delay between each execution. 0 is allowed, and will result in all executions being sent
-      # simultaneously when the request starts.
-      # Note that sub-millisecond precision is not supported, any excess precision information will
-      # be dropped; in particular, delays of less than 1 millisecond are equivalent to 0.
-      # This must be positive or 0.
-      // delay = 100 milliseconds
-    }
-
     # If tracing is enabled for a query, this controls how the trace is fetched.
-    # These options can be changed at runtime, the new values will be used for requests issued after
-    # the change. They can be overridden in a profile.
     trace {
       # How many times the driver will attempt to fetch the query if it is not ready yet.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for traces fetched after the change.
+      # Overridable in a profile: yes
       attempts = 5
 
       # The interval between each attempt.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for traces fetched after the change.
+      # Overridable in a profile: yes
       interval = 3 milliseconds
 
       # The consistency level to use for trace queries.
       # Note that the default replication strategy for the system_traces keyspace is SimpleStrategy
       # with RF=2, therefore LOCAL_ONE might not work if the local DC has no replicas for a given
       # trace id.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for traces fetched after the change.
+      # Overridable in a profile: yes
       consistency = ONE
     }
-
-    # A session-wide component that controls the rate at which requests are executed.
-    #
-    # Implementations vary, but throttlers generally track a metric that represents the level of
-    # utilization of the session, and prevent new requests from starting when that metric exceeds a
-    # threshold. Pending requests may be enqueued and retried later.
-    #
-    # From the public API's point of view, this process is mostly transparent: any time that the
-    # request is throttled is included in the session.execute() or session.executeAsync() call.
-    # Similarly, the request timeout encompasses throttling: the timeout starts ticking before the
-    # throttler has started processing the request; a request may time out while it is still in the
-    # throttler's queue, before the driver has even tried to send it to a node.
-    #
-    # The only visible effect is that a request may fail with a RequestThrottlingException, if the
-    # throttler has determined that it can neither allow the request to proceed now, nor enqueue it;
-    # this indicates that your session is overloaded.
-    throttler {
-      # The class of the throttler. If it is not qualified, the driver assumes that it resides in the
-      # package com.datastax.oss.driver.internal.core.session.throttling.
-      #
-      # The driver provides the following implementations out of the box:
-      #
-      # - PassThroughRequestThrottler: does not perform any kind of throttling, all requests are
-      #   allowed to proceed immediately. Required options: none.
-      #
-      # - ConcurrencyLimitingRequestThrottler: limits the number of requests that can be executed
-      #   in parallel. Required options: max-concurrent-requests, max-queue-size.
-      #
-      # - RateLimitingRequestThrottler: limits the request rate per second. Required options:
-      #   max-requests-per-second, max-queue-size, drain-interval.
-      #
-      # You can also specify a custom class that implements LoadBalancingPolicy and has a public
-      # constructor with a DriverContext argument.
-      class = PassThroughRequestThrottler
-
-      # The maximum number of requests that can be enqueued when the throttling threshold is
-      # exceeded. Beyond that size, requests will fail with a RequestThrottlingException.
-      // max-queue-size = 10000
-
-      # The maximum number of requests that are allowed to execute in parallel.
-      # Only used by ConcurrencyLimitingRequestThrottler.
-      // max-concurrent-requests = 10000
-
-      # The maximum allowed request rate.
-      # Only used by RateLimitingRequestThrottler.
-      // max-requests-per-second = 10000
-
-      # How often the throttler attempts to dequeue requests. This is the only way for rate-based
-      # throttling, because the completion of an active request does not necessarily free a "slot"
-      # for a queued one (the rate might still be too high).
-      #
-      # You want to set this high enough that each attempt will process multiple entries in the
-      # queue, but not delay requests too much. A few milliseconds is probably a happy medium.
-      #
-      # Only used by RateLimitingRequestThrottler.
-      // drain-interval = 10 milliseconds
-    }
-
-    # A session-wide component that tracks the outcome of requests.
-    tracker {
-      # The class of the tracker. If it is not qualified, the driver assumes that it resides in the
-      # package com.datastax.oss.driver.internal.core.tracker.
-      #
-      # The driver provides the following implementations out of the box:
-      # - NoopRequestTracker: does nothing.
-      # - RequestLogger: logs requests (see the parameters below).
-      #
-      # You can also specify a custom class that implements RequestTracker and has a public
-      # constructor with a DriverContext argument.
-      class = NoopRequestTracker
-
-      # Parameters for RequestLogger. All of them can be overridden in a profile, and
-      # changed at runtime (the new values will be taken into account for requests logged after the
-      # change).
-      logs {
-        # Whether to log successful requests.
-        // success.enabled = true
-
-        slow {
-          # The threshold to classify a successful request as "slow". If this is unset, all successful
-          # requests will be considered as normal.
-          // threshold = 1 second
-
-          # Whether to log slow requests.
-          // enabled = true
-        }
-
-        # Whether to log failed requests.
-        // error.enabled = true
-
-        # The maximum length of the query string in the log message. If it is longer than that, it
-        # will be truncated.
-        // max-query-length = 500
-
-        # Whether to log bound values in addition to the query string.
-        // show-values = true
-
-        # The maximum length for bound values in the log message. If the formatted representation of
-        # a value is longer than that, it will be truncated.
-        // max-value-length = 50
-
-        # The maximum number of bound values to log. If a request has more values, the list of
-        # values will be truncated.
-        // max-values = 50
-
-        # Whether to log stack traces for failed queries. If this is disabled, the log will just
-        # include the exception's string representation (generally the class name and message).
-        // show-stack-traces = true
-      }
-    }
   }
 
-  prepared-statements {
-    # Whether `Session.prepare` calls should be sent to all nodes in the cluster.
-    #
-    # A request to prepare is handled in two steps:
-    # 1) send to a single node first (to rule out simple errors like malformed queries).
-    # 2) if step 1 succeeds, re-send to all other active nodes (i.e. not ignored by the load
-    # balancing policy).
-    # This option controls whether step 2 is executed.
-    #
-    # The reason why you might want to disable it is to optimize network usage if you have a large
-    # number of clients preparing the same set of statements at startup. If your load balancing
-    # policy distributes queries randomly, each client will pick a different host to prepare its
-    # statements, and on the whole each host has a good chance of having been hit by at least one
-    # client for each statement.
-    # On the other hand, if that assumption turns out to be wrong and one host hasn't prepared a
-    # given statement, it needs to be re-prepared on the fly the first time it gets executed; this
-    # causes a performance penalty (one extra roundtrip to resend the query to prepare, and another
-    # to retry the execution).
-    #
-    # This option can be changed at runtime, the new value will be used for prepares issued after
-    # the change. It can be overridden in a profile.
-    prepare-on-all-nodes = true
-
-    # How the driver replicates prepared statements on a node that just came back up or joined the
-    # cluster.
-    # These options can be changed at runtime, the new values will be used for prepares issued after
-    # the change. However they can not be overridden in a profile.
-    reprepare-on-up {
-      # Whether the driver tries to prepare on new nodes at all.
-      #
-      # The reason why you might want to disable it is to optimize reconnection time when you
-      # believe nodes often get marked down because of temporary network issues, rather than the
-      # node really crashing. In that case, the node still has prepared statements in its cache when
-      # the driver reconnects, so re-preparing is redundant.
-      #
-      # On the other hand, if that assumption turns out to be wrong and the node had really
-      # restarted, its prepared statement cache is empty (before CASSANDRA-8831), and statements
-      # need to be re-prepared on the fly the first time they get executed; this causes a
-      # performance penalty (one extra roundtrip to resend the query to prepare, and another to
-      # retry the execution).
-      enabled = true
-
-      # Whether to check `system.prepared_statements` on the target node before repreparing.
-      #
-      # This table exists since CASSANDRA-8831 (merged in 3.10). It stores the statements already
-      # prepared on the node, and preserves them across restarts.
-      #
-      # Checking the table first avoids repreparing unnecessarily, but the cost of the query is not
-      # always worth the improvement, especially if the number of statements is low.
-      #
-      # If the table does not exist, or the query fails for any other reason, the error is ignored
-      # and the driver proceeds to reprepare statements according to the other parameters.
-      check-system-table = false
-
-      # The maximum number of statements that should be reprepared. 0 or a negative value means no
-      # limit.
-      max-statements = 0
-
-      # The maximum number of concurrent requests when repreparing.
-      max-parallelism = 100
-
-      # The request timeout. This applies both to querying the system.prepared_statements table (if
-      # relevant), and the prepare requests themselves.
-      timeout = ${datastax-java-driver.connection.init-query-timeout}
-    }
-  }
-
-  metadata {
-    # Topology events are external signals that inform the driver of the state of Cassandra nodes
-    # (by default, they correspond to gossip events received on the control connection).
-    # The debouncer helps smoothen out oscillations if conflicting events are sent out in short
-    # bursts.
-    # Debouncing may be disabled by setting the window to 0 or max-events to 1 (this is not
-    # recommended).
-    topology-event-debouncer {
-      # How long the driver waits to propagate an event. If another event is received within that
-      # time, the window is reset and a batch of accumulated events will be delivered.
-      window = 1 second
-
-      # The maximum number of events that can accumulate. If this count is reached, the events are
-      # delivered immediately and the time window is reset. This avoids holding events indefinitely
-      # if the window keeps getting reset.
-      max-events = 20
-    }
-
-    # Options relating to schema metadata (Cluster.getMetadata.getKeyspaces).
-    # This metadata is exposed by the driver for informational purposes, and is also necessary for
-    # token-aware routing.
-    schema {
-      # Whether schema metadata is enabled.
-      # If this is false, the schema will remain empty, or to the last known value.
-      # This option can be changed at runtime, the new value will be used for refreshes issued after
-      # the change. It can also be overridden programmatically via Cluster.setSchemaMetadataEnabled.
-      enabled = true
-
-      # The list of keyspaces for which schema and token metadata should be maintained. If this
-      # property is absent or empty, all existing keyspaces are processed.
-      # This option can be changed at runtime, the new value will be used for refreshes issued after
-      # the change.
-      // refreshed-keyspaces = [ "ks1", "ks2" ]
-
-      # The timeout for the requests to the schema tables.
-      # This option can be changed at runtime, the new value will be used for refreshes issued after
-      # the change.
-      request-timeout = ${datastax-java-driver.request.timeout}
-
-      # The page size for the requests to the schema tables.
-      # This option can be changed at runtime, the new value will be used for refreshes issued after
-      # the change.
-      request-page-size = ${datastax-java-driver.request.page-size}
-
-      # Protects against bursts of schema updates (for example when a client issues a sequence of
-      # DDL queries), by coalescing them into a single update.
-      # Debouncing may be disabled by setting the window to 0 or max-events to 1 (this is highly
-      # discouraged for schema refreshes).
-      debouncer {
-        # How long the driver waits to apply a refresh. If another refresh is requested within that
-        # time, the window is reset and a single refresh will be triggered when it ends.
-        window = 1 second
-
-        # The maximum number of refreshes that can accumulate. If this count is reached, a refresh
-        # is done immediately and the window is reset.
-        max-events = 20
-      }
-    }
-
-    # Whether token metadata (Cluster.getMetadata.getTokenMap) is enabled.
-    # This metadata is exposed by the driver for informational purposes, and is also necessary for
-    # token-aware routing.
-    # If this is false, it will remain empty, or to the last known value. Note that its computation
-    # requires information about the schema; therefore if schema metadata is disabled or filtered to
-    # a subset of keyspaces, the token map will be incomplete, regardless of the value of this
-    # property.
-    # This option can be changed at runtime, the new value will be used for refreshes issued after
-    # the change.
-    token-map.enabled = true
-
-    # A session-wide component that listens for node state changes. If it is not qualified, the
-    # driver assumes that it resides in the package com.datastax.oss.driver.internal.core.metadata.
-    #
-    # The driver provides a single no-op implementation out of the box: NoopNodeStateListener.
-    #
-    # You can also specify a custom class that implements NodeStateListener and has a public
-    # constructor with a DriverContext argument.
-    # Alternatively, you can pass an instance of your listener to
-    # CqlSession.builder().withNodeStateListener(). In that case, this option will be ignored.
-    node-state-listener.class = NoopNodeStateListener
-
-    # A session-wide component that listens for node state changes. If it is not qualified, the
-    # driver assumes that it resides in the package
-    # com.datastax.oss.driver.internal.core.metadata.schema.
-    #
-    # The driver provides a single no-op implementation out of the box: NoopSchemaChangeListener.
-    #
-    # You can also specify a custom class that implements SchemaChangeListener and has a public
-    # constructor with a DriverContext argument.
-    # Alternatively, you can pass an instance of your listener to
-    # CqlSession.builder().withSchemaChangeListener(). In that case, this option will be ignored.
-    schema-change-listener.class = NoopSchemaChangeListener
-  }
-
-  metrics {
+  advanced.metrics {
     # The session-level metrics (all disabled by default).
+    #
+    # Required: yes
+    # Modifiable at runtime: no
+    # Overridable in a profile: no
     session {
       enabled = [
         # The number and rate of bytes sent for the entire session (exposed as a Meter).
@@ -859,8 +736,8 @@ datastax-java-driver {
 
         # How long requests are being throttled (exposed as a Timer).
         #
-        # This is the time between the start of the session.execute() call, and the moment when the
-        # throttler allows the request to proceed.
+        # This is the time between the start of the session.execute() call, and the moment when
+        # the throttler allows the request to proceed.
         // throttling.delay,
 
         # The size of the throttling queue (exposed as a Gauge<Integer>).
@@ -870,12 +747,16 @@ datastax-java-driver {
         # throttlers; in other cases, it will always be 0.
         // throttling.queue-size,
 
-        # The number of times a request was rejected with a RequestThrottlingException (exposed as a
-        # Counter)
+        # The number of times a request was rejected with a RequestThrottlingException (exposed as
+        # a Counter)
         // throttling.errors,
       ]
 
       # Extra configuration (for the metrics that need it)
+
+      # Required: if the 'cql-requests' metric is enabled
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
       cql-requests {
         # The largest latency that we expect to record.
         #
@@ -886,32 +767,36 @@ datastax-java-driver {
         # runtime, it is discarded and a warning is logged.
         highest-latency = 3 seconds
 
-        # The number of significant decimal digits to which internal structures will maintain value
-        # resolution and separation (for example, 3 means that recordings up to 1 second will be
-        # recorded with a resolution of 1 millisecond or better).
+        # The number of significant decimal digits to which internal structures will maintain
+        # value resolution and separation (for example, 3 means that recordings up to 1 second
+        # will be recorded with a resolution of 1 millisecond or better).
         #
-        # This must be between 0 and 5. If the value is out of range, it defaults to 3 and a warning
-        # is logged.
+        # This must be between 0 and 5. If the value is out of range, it defaults to 3 and a
+        # warning is logged.
         significant-digits = 3
 
         # The interval at which percentile data is refreshed.
         #
         # The driver records latency data in a "live" histogram, and serves results from a cached
-        # snapshot. Each time the snapshot gets older than the interval, the two are switched. Note
-        # that this switch happens upon fetching the metrics, so if you never fetch the recording
-        # interval might grow higher (that shouldn't be an issue in a production environment because
-        # you would typically have a metrics reporter that exports to a monitoring tool at a regular
-        # interval).
+        # snapshot. Each time the snapshot gets older than the interval, the two are switched.
+        # Note that this switch happens upon fetching the metrics, so if you never fetch the
+        # recording interval might grow higher (that shouldn't be an issue in a production
+        # environment because you would typically have a metrics reporter that exports to a
+        # monitoring tool at a regular interval).
         #
         # In practice, this means that if you set this to 5 minutes, you're looking at data from a
-        # 5-minute interval in the past, that is at most 5 minutes old. If you fetch the metrics at
-        # a faster pace, you will observe the same data for 5 minutes until the interval expires.
+        # 5-minute interval in the past, that is at most 5 minutes old. If you fetch the metrics
+        # at a faster pace, you will observe the same data for 5 minutes until the interval
+        # expires.
         #
         # Note that this does not apply to the total count and rates (those are updated in real
         # time).
         refresh-interval = 5 minutes
       }
 
+      # Required: if the 'throttling.delay' metric is enabled
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
       throttling.delay {
         highest-latency = 3 seconds
         significant-digits = 3
@@ -919,22 +804,26 @@ datastax-java-driver {
       }
     }
     # The node-level metrics (all disabled by default).
+    #
+    # Required: yes
+    # Modifiable at runtime: no
+    # Overridable in a profile: no
     node {
       enabled = [
         # The number of connections open to this node for regular requests (exposed as a
         # Gauge<Integer>).
         #
-        # This includes the control connection (which uses at most one extra connection to a random
-        # node in the cluster).
+        # This includes the control connection (which uses at most one extra connection to a
+        # random node in the cluster).
         // pool.open-connections,
 
         # The number of stream ids available on the connections to this node (exposed as a
         # Gauge<Integer>).
         #
-        # Stream ids are used to multiplex requests on each connection, so this is an indication of
-        # how many more requests the node could handle concurrently before becoming saturated (note
-        # that this is a driver-side only consideration, there might be other limitations on the
-        # server that prevent reaching that theoretical limit).
+        # Stream ids are used to multiplex requests on each connection, so this is an indication
+        # of how many more requests the node could handle concurrently before becoming saturated
+        # (note that this is a driver-side only consideration, there might be other limitations on
+        # the server that prevent reaching that theoretical limit).
         // pool.available-streams,
 
         # The number of requests currently executing on the connections to this node (exposed as a
@@ -957,9 +846,9 @@ datastax-java-driver {
         # part of an overall request (exposed as a Timer).
         #
         # Note that this does not necessarily correspond to the overall duration of the
-        # session.execute() call, since the driver might query multiple nodes because of retries and
-        # speculative executions. Therefore a single "request" (as seen from a client of the driver)
-        # can be composed of more than one of the "messages" measured by this metric.
+        # session.execute() call, since the driver might query multiple nodes because of retries
+        # and speculative executions. Therefore a single "request" (as seen from a client of the
+        # driver) can be composed of more than one of the "messages" measured by this metric.
         #
         # Therefore this metric is intended as an insight into the performance of this particular
         # node. For statistics on overall request completion, use the session-level cql-requests.
@@ -972,12 +861,12 @@ datastax-java-driver {
         # on the next node automatically (without going through the retry policy).
         // errors.request.unsent,
 
-        # The number of times a request was aborted before the driver even received a response from
-        # this node (exposed as a Counter).
+        # The number of times a request was aborted before the driver even received a response
+        # from this node (exposed as a Counter).
         #
-        # This can happen in two cases: if the connection was closed due to an external event (such
-        # as a network error or heartbeat failure); or if there was an unexpected error while
-        # decoding the response (this can only be a driver bug).
+        # This can happen in two cases: if the connection was closed due to an external event
+        # (such as a network error or heartbeat failure); or if there was an unexpected error
+        # while decoding the response (this can only be a driver bug).
         // errors.request.aborted,
 
         # The number of times this node replied with a WRITE_TIMEOUT error (exposed as a Counter).
@@ -998,8 +887,8 @@ datastax-java-driver {
         # by the RetryPolicy.
         // errors.request.unavailables,
 
-        # The number of times this node replied with an error that doesn't fall under other errors.*
-        # metrics (exposed as a Counter).
+        # The number of times this node replied with an error that doesn't fall under other
+        # 'errors.*' metrics (exposed as a Counter).
         // errors.request.others,
 
         # The total number of errors on this node that caused the RetryPolicy to trigger a retry
@@ -1016,8 +905,8 @@ datastax-java-driver {
         // retries.unavailable,
         // retries.other,
 
-        # The total number of errors on this node that were ignored by the RetryPolicy (exposed as a
-        # Counter).
+        # The total number of errors on this node that were ignored by the RetryPolicy (exposed as
+        # a Counter).
         #
         # This is a sum of all the other ignores.* metrics.
         // ignores.total,
@@ -1030,28 +919,32 @@ datastax-java-driver {
         // ignores.unavailable,
         // ignores.other,
 
-        # The number of speculative executions triggered by a slow response from this node (exposed
-        # as a Counter).
+        # The number of speculative executions triggered by a slow response from this node
+        # (exposed as a Counter).
         // speculative-executions,
 
         # The number of errors encountered while trying to establish a connection to this node
         # (exposed as a Counter).
         #
-        # Connection errors are not a fatal issue for the driver, failed connections will be retried
-        # periodically according to the reconnection policy. You can choose whether or not to log
-        # those errors at WARN level with the connection.warn-on-init-error option.
+        # Connection errors are not a fatal issue for the driver, failed connections will be
+        # retried periodically according to the reconnection policy. You can choose whether or not
+        # to log those errors at WARN level with the connection.warn-on-init-error option.
         #
         # Authentication errors are not included in this counter, they are tracked separately in
         # errors.connection.auth.
         // errors.connection.init,
 
-        # The number of authentication errors encountered while trying to establish a connection to
-        # this node (exposed as a Counter).
+        # The number of authentication errors encountered while trying to establish a connection
+        # to this node (exposed as a Counter).
         # Authentication errors are also logged at WARN level.
         // errors.connection.auth,
       ]
 
-      // See cql-requests in the `session` section
+      # See cql-requests in the `session` section
+      #
+      # Required: if the 'cql-messages' metric is enabled
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
       cql-messages {
         highest-latency = 3 seconds
         significant-digits = 3
@@ -1060,56 +953,361 @@ datastax-java-driver {
     }
   }
 
-  # The address translator to use to convert the addresses sent by Cassandra nodes into ones that
-  # the driver uses to connect.
-  # This is only needed if the nodes are not directly reachable from the driver (for example, the
-  # driver is in a different network region and needs to use a public IP, or it connects through
-  # a proxy).
-  address-translator {
-    # The class of the translator. If it is not qualified, the driver assumes that it resides in the
-    # package com.datastax.oss.driver.internal.core.addresstranslation.
+  advanced.socket {
+    # Whether or not to disable the Nagle algorithm.
     #
-    # The driver provides the following implementations out of the box:
-    # - PassThroughAddressTranslator: returns all addresses unchanged
+    # By default, this option is set to true (Nagle disabled), because the driver has its own
+    # internal message coalescing algorithm.
     #
-    # You can also specify a custom class that implements AddressTranslator and has a public
-    # constructor with a DriverContext argument.
-    class = PassThroughAddressTranslator
+    # See java.net.StandardSocketOptions.TCP_NODELAY.
+    #
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for connections created after the
+    #   change.
+    # Overridable in a profile: no
+    tcp-no-delay = true
+
+    # All other socket options are unset by default. The actual value depends on the underlying
+    # Netty transport:
+    # - NIO uses the defaults from java.net.Socket (refer to the javadocs of
+    #   java.net.StandardSocketOptions for each option).
+    # - Epoll delegates to the underlying file descriptor, which uses the O/S defaults.
+
+    # Whether or not to enable TCP keep-alive probes.
+    #
+    # See java.net.StandardSocketOptions.SO_KEEPALIVE.
+    #
+    # Required: no
+    # Modifiable at runtime: yes, the new value will be used for connections created after the
+    #   change.
+    # Overridable in a profile: no
+    //keep-alive = false
+
+    # Whether or not to allow address reuse.
+    #
+    # See java.net.StandardSocketOptions.SO_REUSEADDR.
+    #
+    # Required: no
+    # Modifiable at runtime: yes, the new value will be used for connections created after the
+    #   change.
+    # Overridable in a profile: no
+    //reuse-address = true
+
+    # Sets the linger interval.
+    #
+    # If the value is zero or greater, then it represents a timeout value, in seconds;
+    # if the value is negative, it means that this option is disabled.
+    #
+    # See java.net.StandardSocketOptions.SO_LINGER.
+    #
+    # Required: no
+    # Modifiable at runtime: yes, the new value will be used for connections created after the
+    #   change.
+    # Overridable in a profile: no
+    //linger-interval = 0
+
+    # Sets a hint to the size of the underlying buffers for incoming network I/O.
+    #
+    # See java.net.StandardSocketOptions.SO_RCVBUF.
+    #
+    # Required: no
+    # Modifiable at runtime: yes, the new value will be used for connections created after the
+    #   change.
+    # Overridable in a profile: no
+    //receive-buffer-size = 65535
+
+    # Sets a hint to the size of the underlying buffers for outgoing network I/O.
+    #
+    # See java.net.StandardSocketOptions.SO_SNDBUF.
+    #
+    # Required: no
+    # Modifiable at runtime: yes, the new value will be used for connections created after the
+    #   change.
+    # Overridable in a profile: no
+    //send-buffer-size = 65535
   }
 
-  # The SSL engine factory that will initialize an SSL engine for each new connection to a server.
-  ssl-engine-factory {
-    # The class of the factory. If it is not qualified, the driver assumes that it resides in the
-    # package com.datastax.oss.driver.internal.core.ssl.
+  advanced.heartbeat {
+    # The heartbeat interval. If a connection stays idle for that duration (no reads), the driver
+    # sends a dummy message on it to make sure it's still alive. If not, the connection is trashed
+    # and replaced.
     #
-    # The driver provides a single implementation out of the box: DefaultSslEngineFactory, that uses
-    # the JDK's built-in SSL implementation.
-    #
-    # You can also specify a custom class that implements SslEngineFactory and has a public
-    # constructor with a DriverContext argument.
-    #
-    # This property is optional; if it is not present, SSL won't be activated.
-    // class = DefaultSslEngineFactory
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for connections created after the
+    #   change.
+    # Overridable in a profile: no
+    interval = 30 seconds
 
-    # Sample configuration for the default SSL factory:
-    # The cipher suites to enable when creating an SSLEngine for a connection.
-    # This property is optional. If it is not present, the driver won't explicitly enable cipher
-    # suites on the engine, which according to the JDK documentations results in "a minimum
-    # quality of service".
-    // cipher-suites = [ "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA" ]
+    # How long the driver waits for the response to a heartbeat. If this timeout fires, the
+    # heartbeat is considered failed.
+    #
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for connections created after the
+    #   change.
+    # Overridable in a profile: no
+    timeout = ${datastax-java-driver.advanced.connection.init-query-timeout}
+  }
+
+  advanced.metadata {
+    # Topology events are external signals that inform the driver of the state of Cassandra nodes
+    # (by default, they correspond to gossip events received on the control connection).
+    # The debouncer helps smoothen out oscillations if conflicting events are sent out in short
+    # bursts.
+    # Debouncing may be disabled by setting the window to 0 or max-events to 1 (this is not
+    # recommended).
+    topology-event-debouncer {
+      # How long the driver waits to propagate an event. If another event is received within that
+      # time, the window is reset and a batch of accumulated events will be delivered.
+      #
+      # Required: yes
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
+      window = 1 second
+
+      # The maximum number of events that can accumulate. If this count is reached, the events are
+      # delivered immediately and the time window is reset. This avoids holding events indefinitely
+      # if the window keeps getting reset.
+      #
+      # Required: yes
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
+      max-events = 20
+    }
+
+    # Options relating to schema metadata (Cluster.getMetadata.getKeyspaces).
+    # This metadata is exposed by the driver for informational purposes, and is also necessary for
+    # token-aware routing.
+    schema {
+      # Whether schema metadata is enabled.
+      # If this is false, the schema will remain empty, or to the last known value.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for refreshes issued after the
+      #   change. It can also be overridden programmatically via Cluster.setSchemaMetadataEnabled.
+      # Overridable in a profile: no
+      enabled = true
+
+      # The list of keyspaces for which schema and token metadata should be maintained. If this
+      # property is absent or empty, all existing keyspaces are processed.
+      #
+      # Required: no
+      # Modifiable at runtime: yes, the new value will be used for refreshes issued after the
+      #   change.
+      # Overridable in a profile: no
+      // refreshed-keyspaces = [ "ks1", "ks2" ]
+
+      # The timeout for the requests to the schema tables.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for refreshes issued after the
+      #   change.
+      # Overridable in a profile: no
+      request-timeout = ${datastax-java-driver.basic.request.timeout}
+
+      # The page size for the requests to the schema tables.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for refreshes issued after the
+      #   change.
+      # Overridable in a profile: no
+      request-page-size = ${datastax-java-driver.basic.request.page-size}
+
+      # Protects against bursts of schema updates (for example when a client issues a sequence of
+      # DDL queries), by coalescing them into a single update.
+      # Debouncing may be disabled by setting the window to 0 or max-events to 1 (this is highly
+      # discouraged for schema refreshes).
+      debouncer {
+        # How long the driver waits to apply a refresh. If another refresh is requested within that
+        # time, the window is reset and a single refresh will be triggered when it ends.
+        #
+        # Required: yes
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        window = 1 second
+
+        # The maximum number of refreshes that can accumulate. If this count is reached, a refresh
+        # is done immediately and the window is reset.
+        #
+        # Required: yes
+        # Modifiable at runtime: no
+        # Overridable in a profile: no
+        max-events = 20
+      }
+    }
+
+    # Whether token metadata (Cluster.getMetadata.getTokenMap) is enabled.
+    # This metadata is exposed by the driver for informational purposes, and is also necessary for
+    # token-aware routing.
+    # If this is false, it will remain empty, or to the last known value. Note that its computation
+    # requires information about the schema; therefore if schema metadata is disabled or filtered to
+    # a subset of keyspaces, the token map will be incomplete, regardless of the value of this
+    # property.
+    #
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for refreshes issued after the change.
+    # Overridable in a profile: no
+    token-map.enabled = true
+  }
+
+  advanced.control-connection {
+    # How long the driver waits for responses to control queries (e.g. fetching the list of nodes,
+    # refreshing the schema).
+    #
+    # Required: yes
+    # Modifiable at runtime: no
+    # Overridable in a profile: no
+    timeout = ${datastax-java-driver.advanced.connection.init-query-timeout}
+
+    # Due to the distributed nature of Cassandra, schema changes made on one node might not be
+    # immediately visible to others. Under certain circumstances, the driver waits until all nodes
+    # agree on a common schema version (namely: before a schema refresh, before repreparing all
+    # queries on a newly up node, and before completing a successful schema-altering query). To do
+    # so, it queries system tables to find out the schema version of all nodes that are currently
+    # UP. If all the versions match, the check succeeds, otherwise it is retried periodically, until
+    # a given timeout.
+    #
+    # A schema agreement failure is not fatal, but it might produce unexpected results (for example,
+    # getting an "unconfigured table" error for a table that you created right before, just because
+    # the two queries went to different coordinators).
+    #
+    # Note that schema agreement never succeeds in a mixed-version cluster (it would be challenging
+    # because the way the schema version is computed varies across server versions); the assumption
+    # is that schema updates are unlikely to happen during a rolling upgrade anyway.
+    schema-agreement {
+      # The interval between each attempt.
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for checks issued after the change.
+      # Overridable in a profile: no
+      interval = 200 milliseconds
+
+      # The timeout after which schema agreement fails.
+      # If this is set to 0, schema agreement is skipped and will always fail.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for checks issued after the change.
+      # Overridable in a profile: no
+      timeout = 10 seconds
+
+      # Whether to log a warning if schema agreement fails.
+      # You might want to change this if you've set the timeout to 0.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for checks issued after the change.
+      # Overridable in a profile: no
+      warn-on-failure = true
+    }
+  }
+
+  advanced.prepared-statements {
+    # Whether `Session.prepare` calls should be sent to all nodes in the cluster.
+    #
+    # A request to prepare is handled in two steps:
+    # 1) send to a single node first (to rule out simple errors like malformed queries).
+    # 2) if step 1 succeeds, re-send to all other active nodes (i.e. not ignored by the load
+    # balancing policy).
+    # This option controls whether step 2 is executed.
+    #
+    # The reason why you might want to disable it is to optimize network usage if you have a large
+    # number of clients preparing the same set of statements at startup. If your load balancing
+    # policy distributes queries randomly, each client will pick a different host to prepare its
+    # statements, and on the whole each host has a good chance of having been hit by at least one
+    # client for each statement.
+    # On the other hand, if that assumption turns out to be wrong and one host hasn't prepared a
+    # given statement, it needs to be re-prepared on the fly the first time it gets executed; this
+    # causes a performance penalty (one extra roundtrip to resend the query to prepare, and another
+    # to retry the execution).
+    #
+    # Required: yes
+    # Modifiable at runtime: yes, the new value will be used for prepares issued after the change.
+    # Overridable in a profile: yes
+    prepare-on-all-nodes = true
+
+    # How the driver replicates prepared statements on a node that just came back up or joined the
+    # cluster.
+    reprepare-on-up {
+      # Whether the driver tries to prepare on new nodes at all.
+      #
+      # The reason why you might want to disable it is to optimize reconnection time when you
+      # believe nodes often get marked down because of temporary network issues, rather than the
+      # node really crashing. In that case, the node still has prepared statements in its cache when
+      # the driver reconnects, so re-preparing is redundant.
+      #
+      # On the other hand, if that assumption turns out to be wrong and the node had really
+      # restarted, its prepared statement cache is empty (before CASSANDRA-8831), and statements
+      # need to be re-prepared on the fly the first time they get executed; this causes a
+      # performance penalty (one extra roundtrip to resend the query to prepare, and another to
+      # retry the execution).
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for nodes that come back up after the
+      #   change.
+      # Overridable in a profile: no
+      enabled = true
+
+      # Whether to check `system.prepared_statements` on the target node before repreparing.
+      #
+      # This table exists since CASSANDRA-8831 (merged in 3.10). It stores the statements already
+      # prepared on the node, and preserves them across restarts.
+      #
+      # Checking the table first avoids repreparing unnecessarily, but the cost of the query is not
+      # always worth the improvement, especially if the number of statements is low.
+      #
+      # If the table does not exist, or the query fails for any other reason, the error is ignored
+      # and the driver proceeds to reprepare statements according to the other parameters.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for nodes that come back up after the
+      #   change.
+      # Overridable in a profile: no
+      check-system-table = false
+
+      # The maximum number of statements that should be reprepared. 0 or a negative value means no
+      # limit.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for nodes that come back up after the
+      #   change.
+      # Overridable in a profile: no
+      max-statements = 0
+
+      # The maximum number of concurrent requests when repreparing.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for nodes that come back up after the
+      #   change.
+      # Overridable in a profile: no
+      max-parallelism = 100
+
+      # The request timeout. This applies both to querying the system.prepared_statements table (if
+      # relevant), and the prepare requests themselves.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for nodes that come back up after the
+      #   change.
+      # Overridable in a profile: no
+      timeout = ${datastax-java-driver.advanced.connection.init-query-timeout}
+    }
   }
 
   # Options related to the Netty event loop groups used internally by the driver.
-  netty {
+  advanced.netty {
     # The event loop group used for I/O operations (reading and writing to Cassandra nodes).
     io-group {
       # The number of threads.
       # If this is set to 0, the driver will use `Runtime.getRuntime().availableProcessors() * 2`.
+      #
+      # Required: yes
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
       size = 0
 
       # The options to shut down the event loop group gracefully when the driver closes. If a task
-      # gets submitted during the quiet period, it is accepted and the quiet period starts over. The
-      # timeout limits the overall shutdown time.
+      # gets submitted during the quiet period, it is accepted and the quiet period starts over.
+      # The timeout limits the overall shutdown time.
+      #
+      # Required: yes
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
       shutdown {quiet-period = 2, timeout = 15, unit = SECONDS}
     }
     # The event loop group used for admin tasks not related to request I/O (handle cluster events,
@@ -1121,10 +1319,29 @@ datastax-java-driver {
     }
   }
 
+  # The component that coalesces writes on the connections.
+  # This is exposed mainly to facilitate tuning during development. You shouldn't have to adjust
+  # this.
+  advanced.coalescer {
+    # How many times the coalescer is allowed to reschedule itself when it did no work.
+    #
+    # Required: yes
+    # Modifiable at runtime: no
+    # Overridable in a profile: no
+    max-runs-with-no-work = 5
+
+    # The reschedule interval.
+    #
+    # Required: yes
+    # Modifiable at runtime: no
+    # Overridable in a profile: no
+    reschedule-interval = 10 microseconds
+  }
+
   profiles {
     # This is where your custom profiles go, for example:
     # olap {
-    #   request.timeout = 5 seconds
+    #   basic.request.timeout = 5 seconds
     # }
   }
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -588,22 +588,6 @@ datastax-java-driver {
   # Overridable in a profile: no
   advanced.schema-change-listener.class = NoopSchemaChangeListener
 
-  # The compressor to use for protocol frames. If it is not qualified, the driver assumes that it
-  # resides in the package com.datastax.oss.driver.internal.core.protocol.
-  #
-  # The driver provides two built-in implementations for the algorithms supported by Cassandra:
-  # - Lz4Compressor: requires org.xerial.snappy:snappy-java in the classpath.
-  # - SnappyCompressor: requires net.jpountz.lz4:lz4 in the classpath.
-  #
-  # The driver depends on the compression libraries, but they are optional. Make sure you redeclare
-  # an explicit dependency in your project. Refer to the driver's POM or manual for the exact
-  # version.
-  #
-  # Required: no. If the option is absent, protocol frames are not compressed.
-  # Modifiable at runtime: no
-  # Overridable in a profile: no
-  // advanced.compressor.class =
-
   # The address translator to use to convert the addresses sent by Cassandra nodes into ones that
   # the driver uses to connect.
   # This is only needed if the nodes are not directly reachable from the driver (for example, the
@@ -648,6 +632,21 @@ datastax-java-driver {
     # Modifiable at runtime: no
     # Overridable in a profile: no
     // version = V4
+
+    # The name of the algorithm used to compress protocol frames.
+    #
+    # The possible values are:
+    # - lz4: requires net.jpountz.lz4:lz4 in the classpath.
+    # - snappy: requires org.xerial.snappy:snappy-java in the classpath.
+    #
+    # The driver depends on the compression libraries, but they are optional. Make sure you
+    # redeclare an explicit dependency in your project. Refer to the driver's POM or manual for the
+    # exact version.
+    #
+    # Required: no. If the option is absent, protocol frames are not compressed.
+    # Modifiable at runtime: no
+    # Overridable in a profile: no
+    // compression = lz4
 
     # The maximum length of the frames supported by the driver. Beyond that limit, requests will
     # fail with an exception

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryTestBase.java
@@ -123,8 +123,7 @@ public abstract class ChannelFactoryTestBase {
         .thenReturn(Duration.ofMillis(TIMEOUT_MILLIS));
     Mockito.when(defaultConfigProfile.getInt(DefaultDriverOption.CONNECTION_MAX_REQUESTS))
         .thenReturn(1);
-    Mockito.when(
-            defaultConfigProfile.getDuration(DefaultDriverOption.CONNECTION_HEARTBEAT_INTERVAL))
+    Mockito.when(defaultConfigProfile.getDuration(DefaultDriverOption.HEARTBEAT_INTERVAL))
         .thenReturn(Duration.ofSeconds(30));
 
     Mockito.when(context.protocolVersionRegistry()).thenReturn(protocolVersionRegistry);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandlerTest.java
@@ -80,8 +80,7 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     Mockito.when(
             defaultConfigProfile.getDuration(DefaultDriverOption.CONNECTION_INIT_QUERY_TIMEOUT))
         .thenReturn(Duration.ofMillis(QUERY_TIMEOUT_MILLIS));
-    Mockito.when(
-            defaultConfigProfile.getDuration(DefaultDriverOption.CONNECTION_HEARTBEAT_INTERVAL))
+    Mockito.when(defaultConfigProfile.getDuration(DefaultDriverOption.HEARTBEAT_INTERVAL))
         .thenReturn(Duration.ofSeconds(30));
     Mockito.when(internalDriverContext.protocolVersionRegistry())
         .thenReturn(protocolVersionRegistry);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/util/ReflectionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/util/ReflectionTest.java
@@ -35,7 +35,7 @@ public class ReflectionTest {
   @Test
   public void should_build_policies_per_profile() {
     String configSource =
-        "request.speculative-execution-policy {\n"
+        "advanced.speculative-execution-policy {\n"
             + "  class = ConstantSpeculativeExecutionPolicy\n"
             + "  max-executions = 3\n"
             + "  delay = 100 milliseconds\n"
@@ -45,15 +45,15 @@ public class ReflectionTest {
             + "  profile1 {}\n"
             // Inherits but changes one option
             + "  profile2 { \n"
-            + "    request.speculative-execution-policy.max-executions = 2"
+            + "    advanced.speculative-execution-policy.max-executions = 2"
             + "  }\n"
             // Same as previous profile, should share the same policy instance
             + "  profile3 { \n"
-            + "    request.speculative-execution-policy.max-executions = 2"
+            + "    advanced.speculative-execution-policy.max-executions = 2"
             + "  }\n"
             // Completely overrides default profile
             + "  profile4 { \n"
-            + "    request.speculative-execution-policy.class = NoSpeculativeExecutionPolicy\n"
+            + "    advanced.speculative-execution-policy.class = NoSpeculativeExecutionPolicy\n"
             + "  }\n"
             + "}\n";
     DriverContext context = Mockito.mock(DriverContext.class);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ProtocolVersionInitialNegotiationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ProtocolVersionInitialNegotiationIT.java
@@ -52,7 +52,7 @@ public class ProtocolVersionInitialNegotiationIT {
   )
   @Test
   public void should_fail_if_provided_version_isnt_supported() {
-    try (CqlSession session = SessionUtils.newSession(ccm, "protocol.version = V4")) {
+    try (CqlSession session = SessionUtils.newSession(ccm, "advanced.protocol.version = V4")) {
       assertThat(session.getContext().protocolVersion().getCode()).isEqualTo(3);
       session.execute("select * from system.local");
       fail("Expected an AllNodesFailedException");
@@ -78,7 +78,7 @@ public class ProtocolVersionInitialNegotiationIT {
   @CassandraRequirement(min = "2.2", description = "required to use an older protocol version")
   @Test
   public void should_use_explicitly_provided_protocol_version() {
-    try (CqlSession session = SessionUtils.newSession(ccm, "protocol.version = V3")) {
+    try (CqlSession session = SessionUtils.newSession(ccm, "advanced.protocol.version = V3")) {
       assertThat(session.getContext().protocolVersion().getCode()).isEqualTo(3);
       session.execute("select * from system.local");
     }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ProtocolVersionMixedClusterIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ProtocolVersionMixedClusterIT.java
@@ -52,7 +52,7 @@ public class ProtocolVersionMixedClusterIT {
         CqlSession session =
             CqlSession.builder()
                 .addContactPoint(contactPoint.inetSocketAddress())
-                .withConfigLoader(new TestConfigLoader("metadata.schema.enabled = false"))
+                .withConfigLoader(new TestConfigLoader("advanced.metadata.schema.enabled = false"))
                 .build()) {
 
       InternalDriverContext context = (InternalDriverContext) session.getContext();
@@ -94,7 +94,7 @@ public class ProtocolVersionMixedClusterIT {
         CqlSession session =
             CqlSession.builder()
                 .addContactPoint(contactPoint.inetSocketAddress())
-                .withConfigLoader(new TestConfigLoader("metadata.schema.enabled = false"))
+                .withConfigLoader(new TestConfigLoader("advanced.metadata.schema.enabled = false"))
                 .build()) {
 
       InternalDriverContext context = (InternalDriverContext) session.getContext();
@@ -136,7 +136,8 @@ public class ProtocolVersionMixedClusterIT {
                 .addContactPoint(contactPoint.inetSocketAddress())
                 .withConfigLoader(
                     new TestConfigLoader(
-                        "protocol.version = V4", "metadata.schema.enabled = false"))
+                        "advanced.protocol.version = V4",
+                        "advanced.metadata.schema.enabled = false"))
                 .build()) {
       assertThat(session.getContext().protocolVersion()).isEqualTo(DefaultProtocolVersion.V4);
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/auth/PlainTextAuthProviderIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/auth/PlainTextAuthProviderIT.java
@@ -48,9 +48,9 @@ public class PlainTextAuthProviderIT {
     try (CqlSession session =
         SessionUtils.newSession(
             ccm,
-            "protocol.auth-provider.class = PlainTextAuthProvider",
-            "protocol.auth-provider.username = cassandra",
-            "protocol.auth-provider.password = cassandra")) {
+            "advanced.auth-provider.class = PlainTextAuthProvider",
+            "advanced.auth-provider.username = cassandra",
+            "advanced.auth-provider.password = cassandra")) {
       session.execute("select * from system.local");
     }
   }
@@ -60,9 +60,9 @@ public class PlainTextAuthProviderIT {
     try (CqlSession session =
         SessionUtils.newSession(
             ccm,
-            "protocol.auth-provider.class = PlainTextAuthProvider",
-            "protocol.auth-provider.username = baduser",
-            "protocol.auth-provider.password = badpass")) {
+            "advanced.auth-provider.class = PlainTextAuthProvider",
+            "advanced.auth-provider.username = baduser",
+            "advanced.auth-provider.password = badpass")) {
       session.execute("select * from system.local");
     }
   }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/compression/DirectCompressionIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/compression/DirectCompressionIT.java
@@ -56,7 +56,7 @@ public class DirectCompressionIT {
    */
   @Test
   public void should_execute_queries_with_snappy_compression() throws Exception {
-    createAndCheckCluster("advanced.compressor.class = SnappyCompressor");
+    createAndCheckCluster("advanced.protocol.compression = snappy");
   }
 
   /**
@@ -68,7 +68,7 @@ public class DirectCompressionIT {
    */
   @Test
   public void should_execute_queries_with_lz4_compression() throws Exception {
-    createAndCheckCluster("advanced.compressor.class = Lz4Compressor");
+    createAndCheckCluster("advanced.protocol.compression = lz4");
   }
 
   private void createAndCheckCluster(String compressorOption) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/compression/DirectCompressionIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/compression/DirectCompressionIT.java
@@ -38,7 +38,7 @@ public class DirectCompressionIT {
 
   @ClassRule
   public static SessionRule<CqlSession> schemaSessionRule =
-      new SessionRule<>(ccmRule, "request.timeout = 30 seconds");
+      new SessionRule<>(ccmRule, "basic.request.timeout = 30 seconds");
 
   @BeforeClass
   public static void setup() {
@@ -56,7 +56,7 @@ public class DirectCompressionIT {
    */
   @Test
   public void should_execute_queries_with_snappy_compression() throws Exception {
-    createAndCheckCluster("protocol.compressor.class = SnappyCompressor");
+    createAndCheckCluster("advanced.compressor.class = SnappyCompressor");
   }
 
   /**
@@ -68,7 +68,7 @@ public class DirectCompressionIT {
    */
   @Test
   public void should_execute_queries_with_lz4_compression() throws Exception {
-    createAndCheckCluster("protocol.compressor.class = Lz4Compressor");
+    createAndCheckCluster("advanced.compressor.class = Lz4Compressor");
   }
 
   private void createAndCheckCluster(String compressorOption) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/compression/HeapCompressionIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/compression/HeapCompressionIT.java
@@ -43,7 +43,7 @@ public class HeapCompressionIT {
 
   @ClassRule
   public static SessionRule<CqlSession> schemaSessionRule =
-      new SessionRule<>(ccmRule, "request.timeout = 30 seconds");
+      new SessionRule<>(ccmRule, "basic.request.timeout = 30 seconds");
 
   @BeforeClass
   public static void setup() {
@@ -60,7 +60,7 @@ public class HeapCompressionIT {
    */
   @Test
   public void should_execute_queries_with_snappy_compression() throws Exception {
-    createAndCheckCluster("protocol.compressor.class = SnappyCompressor");
+    createAndCheckCluster("advanced.compressor.class = SnappyCompressor");
   }
 
   /**
@@ -71,7 +71,7 @@ public class HeapCompressionIT {
    */
   @Test
   public void should_execute_queries_with_lz4_compression() throws Exception {
-    createAndCheckCluster("protocol.compressor.class = Lz4Compressor");
+    createAndCheckCluster("advanced.compressor.class = Lz4Compressor");
   }
 
   private void createAndCheckCluster(String compressorOption) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/compression/HeapCompressionIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/compression/HeapCompressionIT.java
@@ -60,7 +60,7 @@ public class HeapCompressionIT {
    */
   @Test
   public void should_execute_queries_with_snappy_compression() throws Exception {
-    createAndCheckCluster("advanced.compressor.class = SnappyCompressor");
+    createAndCheckCluster("advanced.protocol.compression = snappy");
   }
 
   /**
@@ -71,7 +71,7 @@ public class HeapCompressionIT {
    */
   @Test
   public void should_execute_queries_with_lz4_compression() throws Exception {
-    createAndCheckCluster("advanced.compressor.class = Lz4Compressor");
+    createAndCheckCluster("advanced.protocol.compression = lz4");
   }
 
   private void createAndCheckCluster(String compressorOption) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverConfigProfileIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverConfigProfileIT.java
@@ -73,7 +73,7 @@ public class DriverConfigProfileIT {
   @Test
   public void should_use_profile_request_timeout() {
     try (CqlSession session =
-        SessionUtils.newSession(simulacron, "profiles.olap.request.timeout = 10s")) {
+        SessionUtils.newSession(simulacron, "profiles.olap.basic.request.timeout = 10s")) {
       String query = "mockquery";
       // configure query with delay of 4 seconds.
       simulacron.cluster().prime(when(query).then(noRows()).delay(4, TimeUnit.SECONDS));
@@ -94,7 +94,8 @@ public class DriverConfigProfileIT {
   @Test
   public void should_use_profile_default_idempotence() {
     try (CqlSession session =
-        SessionUtils.newSession(simulacron, "profiles.idem.request.default-idempotence = true")) {
+        SessionUtils.newSession(
+            simulacron, "profiles.idem.basic.request.default-idempotence = true")) {
       String query = "mockquery";
       // configure query with server error which should invoke onRequestError in retry policy.
       simulacron.cluster().prime(when(query).then(serverError("fail")));
@@ -118,8 +119,8 @@ public class DriverConfigProfileIT {
     try (CqlSession session =
         SessionUtils.newSession(
             simulacron,
-            "profiles.cl.request.consistency = LOCAL_QUORUM",
-            "profiles.cl.request.serial-consistency = LOCAL_SERIAL")) {
+            "profiles.cl.basic.request.consistency = LOCAL_QUORUM",
+            "profiles.cl.basic.request.serial-consistency = LOCAL_SERIAL")) {
       String query = "mockquery";
 
       // Execute query without profile, should use default CLs (LOCAL_ONE, SERIAL).
@@ -170,7 +171,9 @@ public class DriverConfigProfileIT {
   public void should_use_profile_page_size() {
     try (CqlSession session =
         SessionUtils.newSession(
-            ccm, "request.page-size = 100", "profiles.smallpages.request.page-size = 10")) {
+            ccm,
+            "basic.request.page-size = 100",
+            "profiles.smallpages.basic.request.page-size = 10")) {
 
       CqlIdentifier keyspace = SessionUtils.uniqueKeyspaceId();
       DriverConfigProfile slowProfile = SessionUtils.slowProfile(session);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverConfigProfileReloadIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverConfigProfileReloadIT.java
@@ -52,7 +52,8 @@ public class DriverConfigProfileReloadIT {
     DefaultDriverConfigLoader loader =
         new DefaultDriverConfigLoader(
             () ->
-                ConfigFactory.parseString("config-reload-interval = 2s\n" + configSource.get())
+                ConfigFactory.parseString(
+                        "basic.config-reload-interval = 2s\n" + configSource.get())
                     .withFallback(DEFAULT_CONFIG_SUPPLIER.get()),
             DefaultDriverOption.values());
     try (CqlSession session =
@@ -71,7 +72,7 @@ public class DriverConfigProfileReloadIT {
       }
 
       // Bump up request timeout to 10 seconds and wait for config to reload.
-      configSource.set("request.timeout = 10s");
+      configSource.set("basic.request.timeout = 10s");
       waitForConfigChange(session, 3, TimeUnit.SECONDS);
 
       // Execute again, should not timeout.
@@ -87,7 +88,7 @@ public class DriverConfigProfileReloadIT {
     DefaultDriverConfigLoader loader =
         new DefaultDriverConfigLoader(
             () ->
-                ConfigFactory.parseString("config-reload-interval = 0\n" + configSource.get())
+                ConfigFactory.parseString("basic.config-reload-interval = 0\n" + configSource.get())
                     .withFallback(DEFAULT_CONFIG_SUPPLIER.get()),
             DefaultDriverOption.values());
     try (CqlSession session =
@@ -106,7 +107,7 @@ public class DriverConfigProfileReloadIT {
       }
 
       // Bump up request timeout to 10 seconds and trigger a manual reload.
-      configSource.set("request.timeout = 10s");
+      configSource.set("basic.request.timeout = 10s");
       ((InternalDriverContext) session.getContext())
           .eventBus()
           .fire(ForceReloadConfigEvent.INSTANCE);
@@ -125,7 +126,8 @@ public class DriverConfigProfileReloadIT {
     DefaultDriverConfigLoader loader =
         new DefaultDriverConfigLoader(
             () ->
-                ConfigFactory.parseString("config-reload-interval = 2s\n" + configSource.get())
+                ConfigFactory.parseString(
+                        "basic.config-reload-interval = 2s\n" + configSource.get())
                     .withFallback(DEFAULT_CONFIG_SUPPLIER.get()),
             DefaultDriverOption.values());
     try (CqlSession session =
@@ -144,7 +146,7 @@ public class DriverConfigProfileReloadIT {
       }
 
       // Bump up request timeout to 10 seconds on profile and wait for config to reload.
-      configSource.set("profiles.slow.request.timeout = 2s");
+      configSource.set("profiles.slow.basic.request.timeout = 2s");
       waitForConfigChange(session, 3, TimeUnit.SECONDS);
 
       // Execute again, should expect to fail again because doesn't allow to dynamically define
@@ -164,7 +166,7 @@ public class DriverConfigProfileReloadIT {
         new DefaultDriverConfigLoader(
             () ->
                 ConfigFactory.parseString(
-                        "profiles.slow.request.consistency = ONE\nconfig-reload-interval = 2s\n"
+                        "profiles.slow.basic.request.consistency = ONE\nbasic.config-reload-interval = 2s\n"
                             + configSource.get())
                     .withFallback(DEFAULT_CONFIG_SUPPLIER.get()),
             DefaultDriverOption.values());
@@ -184,7 +186,7 @@ public class DriverConfigProfileReloadIT {
       }
 
       // Bump up request timeout to 10 seconds on profile and wait for config to reload.
-      configSource.set("profiles.slow.request.timeout = 10s");
+      configSource.set("profiles.slow.basic.request.timeout = 10s");
       waitForConfigChange(session, 3, TimeUnit.SECONDS);
 
       // Execute again, should succeed because profile timeout was increased.

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/connection/ChannelSocketOptionsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/connection/ChannelSocketOptionsIT.java
@@ -15,12 +15,12 @@
  */
 package com.datastax.oss.driver.api.core.connection;
 
-import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.CONNECTION_SOCKET_KEEP_ALIVE;
-import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.CONNECTION_SOCKET_LINGER_INTERVAL;
-import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.CONNECTION_SOCKET_RECEIVE_BUFFER_SIZE;
-import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.CONNECTION_SOCKET_REUSE_ADDRESS;
-import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.CONNECTION_SOCKET_SEND_BUFFER_SIZE;
-import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.CONNECTION_SOCKET_TCP_NODELAY;
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.SOCKET_KEEP_ALIVE;
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.SOCKET_LINGER_INTERVAL;
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.SOCKET_RECEIVE_BUFFER_SIZE;
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.SOCKET_REUSE_ADDRESS;
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.SOCKET_SEND_BUFFER_SIZE;
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.SOCKET_TCP_NODELAY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
@@ -48,23 +48,23 @@ public class ChannelSocketOptionsIT {
   public static SessionRule<DefaultSession> sessionRule =
       new SessionRule<>(
           simulacron,
-          "connection.socket.tcpNoDelay = true",
-          "connection.socket.keepAlive = false",
-          "connection.socket.reuseAddress = false",
-          "connection.socket.lingerInterval = 10",
-          "connection.socket.receiveBufferSize = 123456",
-          "connection.socket.sendBufferSize = 123456");
+          "advanced.socket.tcp-no-delay = true",
+          "advanced.socket.keep-alive = false",
+          "advanced.socket.reuse-address = false",
+          "advanced.socket.linger-interval = 10",
+          "advanced.socket.receive-buffer-size = 123456",
+          "advanced.socket.send-buffer-size = 123456");
 
   @Test
   public void should_report_socket_options() {
     DefaultSession session = sessionRule.session();
     DriverConfigProfile config = session.getContext().config().getDefaultProfile();
-    assertThat(config.getBoolean(CONNECTION_SOCKET_TCP_NODELAY)).isTrue();
-    assertThat(config.getBoolean(CONNECTION_SOCKET_KEEP_ALIVE)).isFalse();
-    assertThat(config.getBoolean(CONNECTION_SOCKET_REUSE_ADDRESS)).isFalse();
-    assertThat(config.getInt(CONNECTION_SOCKET_LINGER_INTERVAL)).isEqualTo(10);
-    assertThat(config.getInt(CONNECTION_SOCKET_RECEIVE_BUFFER_SIZE)).isEqualTo(123456);
-    assertThat(config.getInt(CONNECTION_SOCKET_SEND_BUFFER_SIZE)).isEqualTo(123456);
+    assertThat(config.getBoolean(SOCKET_TCP_NODELAY)).isTrue();
+    assertThat(config.getBoolean(SOCKET_KEEP_ALIVE)).isFalse();
+    assertThat(config.getBoolean(SOCKET_REUSE_ADDRESS)).isFalse();
+    assertThat(config.getInt(SOCKET_LINGER_INTERVAL)).isEqualTo(10);
+    assertThat(config.getInt(SOCKET_RECEIVE_BUFFER_SIZE)).isEqualTo(123456);
+    assertThat(config.getInt(SOCKET_SEND_BUFFER_SIZE)).isEqualTo(123456);
     Node node = session.getMetadata().getNodes().values().iterator().next();
     DriverChannel channel = session.getChannel(node, null);
     assertThat(channel.config()).isInstanceOf(SocketChannelConfig.class);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/connection/FrameLengthIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/connection/FrameLengthIT.java
@@ -51,9 +51,9 @@ public class FrameLengthIT {
   public static SessionRule<CqlSession> sessionRule =
       new SessionRule<>(
           simulacron,
-          "load-balancing-policy.class = com.datastax.oss.driver.api.testinfra.loadbalancing.SortingLoadBalancingPolicy",
-          "request.retry-policy.class = \"com.datastax.oss.driver.api.core.connection.FrameLengthIT$AlwaysRetryAbortedPolicy\"",
-          "protocol.max-frame-length = 100 kilobytes");
+          "basic.load-balancing-policy.class = com.datastax.oss.driver.api.testinfra.loadbalancing.SortingLoadBalancingPolicy",
+          "advanced.retry-policy.class = \"com.datastax.oss.driver.api.core.connection.FrameLengthIT$AlwaysRetryAbortedPolicy\"",
+          "advanced.protocol.max-frame-length = 100 kilobytes");
 
   private static final SimpleStatement LARGE_QUERY =
       SimpleStatement.newInstance("select * from foo").setIdempotent(true);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/AsyncResultSetIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/AsyncResultSetIT.java
@@ -42,7 +42,7 @@ public class AsyncResultSetIT {
 
   @ClassRule
   public static SessionRule<CqlSession> sessionRule =
-      new SessionRule<>(ccm, "request.page-size = " + PAGE_SIZE);
+      new SessionRule<>(ccm, "basic.request.page-size = " + PAGE_SIZE);
 
   @BeforeClass
   public static void setupSchema() {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BatchStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BatchStatementIT.java
@@ -324,7 +324,7 @@ public class BatchStatementIT {
   public void should_not_allow_unset_value_when_protocol_less_than_v4() {
     //    CREATE TABLE test (k0 text, k1 int, v int, PRIMARY KEY (k0, k1))
     try (CqlSession v3Session =
-        SessionUtils.newSession(ccm, sessionRule.keyspace(), "protocol.version = V3")) {
+        SessionUtils.newSession(ccm, sessionRule.keyspace(), "advanced.protocol.version = V3")) {
       PreparedStatement prepared =
           v3Session.prepare("INSERT INTO test (k0, k1, v) values (?, ?, ?)");
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BoundStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BoundStatementIT.java
@@ -35,7 +35,8 @@ public class BoundStatementIT {
   @Rule public CcmRule ccm = CcmRule.getInstance();
 
   @Rule
-  public SessionRule<CqlSession> sessionRule = new SessionRule<>(ccm, "request.page-size = 20");
+  public SessionRule<CqlSession> sessionRule =
+      new SessionRule<>(ccm, "basic.request.page-size = 20");
 
   @Rule public TestName name = new TestName();
 
@@ -55,7 +56,7 @@ public class BoundStatementIT {
   @Test(expected = IllegalStateException.class)
   public void should_not_allow_unset_value_when_protocol_less_than_v4() {
     try (CqlSession v3Session =
-        SessionUtils.newSession(ccm, sessionRule.keyspace(), "protocol.version = V3")) {
+        SessionUtils.newSession(ccm, sessionRule.keyspace(), "advanced.protocol.version = V3")) {
       PreparedStatement prepared = v3Session.prepare("INSERT INTO test2 (k, v0) values (?, ?)");
 
       BoundStatement boundStatement =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/PerRequestKeyspaceIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/PerRequestKeyspaceIT.java
@@ -35,7 +35,7 @@ import org.junit.rules.TestName;
  * test against a local build, run with
  *
  * <pre>
- *   -Dccm.version=4.0.0 -Dccm.directory=/path/to/cassandra -Ddatastax-java-driver.protocol.version=V5
+ *   -Dccm.version=4.0.0 -Dccm.directory=/path/to/cassandra -Ddatastax-java-driver.advanced.protocol.version=V5
  * </pre>
  */
 @Category(ParallelizableTests.class)
@@ -93,7 +93,7 @@ public class PerRequestKeyspaceIT {
   }
 
   private void should_reject_statement_with_keyspace_in_protocol_v4(Statement statement) {
-    try (CqlSession session = SessionUtils.newSession(ccmRule, "protocol.version = V4")) {
+    try (CqlSession session = SessionUtils.newSession(ccmRule, "advanced.protocol.version = V4")) {
       thrown.expect(IllegalArgumentException.class);
       thrown.expectMessage("Can't use per-request keyspace with protocol V4");
       session.execute(statement);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/PreparedStatementInvalidationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/PreparedStatementInvalidationIT.java
@@ -40,7 +40,7 @@ import org.junit.rules.ExpectedException;
  * version. To test against a local build, run with
  *
  * <pre>
- *   -Dccm.version=4.0.0 -Dccm.directory=/path/to/cassandra -Ddatastax-java-driver.protocol.version=V5
+ *   -Dccm.version=4.0.0 -Dccm.directory=/path/to/cassandra -Ddatastax-java-driver.advanced.protocol.version=V5
  * </pre>
  */
 @Category(ParallelizableTests.class)
@@ -50,7 +50,8 @@ public class PreparedStatementInvalidationIT {
 
   @Rule
   public SessionRule<CqlSession> sessionRule =
-      new SessionRule<>(ccmRule, "request.page-size = 2", "request.timeout = 30 seconds");
+      new SessionRule<>(
+          ccmRule, "basic.request.page-size = 2", "basic.request.timeout = 30 seconds");
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
@@ -224,8 +225,8 @@ public class PreparedStatementInvalidationIT {
         SessionUtils.newSession(
             ccmRule,
             sessionRule.keyspace(),
-            "protocol.version = V4",
-            "request.timeout = 30 seconds")) {
+            "advanced.protocol.version = V4",
+            "basic.request.timeout = 30 seconds")) {
       should_not_store_metadata_for_conditional_updates(session);
     }
   }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/SimpleStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/SimpleStatementIT.java
@@ -38,7 +38,8 @@ public class SimpleStatementIT {
   @ClassRule public static CcmRule ccm = CcmRule.getInstance();
 
   @ClassRule
-  public static SessionRule<CqlSession> cluster = new SessionRule<>(ccm, "request.page-size = 20");
+  public static SessionRule<CqlSession> cluster =
+      new SessionRule<>(ccm, "basic.request.page-size = 20");
 
   @Rule public TestName name = new TestName();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/heartbeat/HeartbeatDisabledIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/heartbeat/HeartbeatDisabledIT.java
@@ -37,7 +37,7 @@ public class HeartbeatDisabledIT {
     // Disable heartbeats entirely, wait longer than the default timeout and make sure we didn't
     // receive any
     try (CqlSession session =
-        SessionUtils.newSession(simulacron, "connection.heartbeat.interval = 0 second")) {
+        SessionUtils.newSession(simulacron, "advanced.heartbeat.interval = 0 second")) {
       AtomicInteger heartbeats = registerHeartbeatListener();
       SECONDS.sleep(35);
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/heartbeat/HeartbeatIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/heartbeat/HeartbeatIT.java
@@ -115,7 +115,7 @@ public class HeartbeatIT {
     try (CqlSession session =
         newSession(
             // Ensure we only have the control connection
-            "connection.pool.local.size = 0")) {
+            "advanced.connection.pool.local.size = 0")) {
       AtomicInteger heartbeats = countHeartbeatsOnControlConnection();
       checkThat(() -> heartbeats.get() > 0).becomesTrue();
     }
@@ -203,10 +203,10 @@ public class HeartbeatIT {
   private CqlSession newSession(String... extraOptions) {
     String[] defaultOptions =
         new String[] {
-          "connection.heartbeat.interval = 1 second",
-          "connection.heartbeat.timeout = 500 milliseconds",
-          "connection.init-query-timeout = 2 seconds",
-          "connection.reconnection-policy.max-delay = 1 second"
+          "advanced.heartbeat.interval = 1 second",
+          "advanced.heartbeat.timeout = 500 milliseconds",
+          "advanced.connection.init-query-timeout = 2 seconds",
+          "advanced.connection.reconnection-policy.max-delay = 1 second"
         };
     String[] allOptions =
         Arrays.copyOf(defaultOptions, defaultOptions.length + extraOptions.length);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
@@ -58,7 +58,7 @@ public class DefaultLoadBalancingPolicyIT {
   public static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(ccmRule)
           .withKeyspace(false)
-          .withOptions("request.timeout = 30 seconds")
+          .withOptions("basic.request.timeout = 30 seconds")
           .build();
 
   @BeforeClass

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/loadbalancing/PerProfileLoadBalancingPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/loadbalancing/PerProfileLoadBalancingPolicyIT.java
@@ -47,8 +47,8 @@ public class PerProfileLoadBalancingPolicyIT {
   public static @ClassRule SessionRule<CqlSession> sessionRule =
       SessionRule.builder(simulacron)
           .withOptions(
-              "load-balancing-policy.local-datacenter = dc1",
-              "profiles.profile1.load-balancing-policy.local-datacenter = dc3",
+              "basic.load-balancing-policy.local-datacenter = dc1",
+              "profiles.profile1.basic.load-balancing-policy.local-datacenter = dc3",
               "profiles.profile2 = {}")
           .build();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/ByteOrderedTokenIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/ByteOrderedTokenIT.java
@@ -30,7 +30,7 @@ public class ByteOrderedTokenIT extends TokenITBase {
 
   @ClassRule
   public static SessionRule<CqlSession> sessionRule =
-      new SessionRule<>(ccmRule, false, null, null, "request.timeout = 30 seconds");
+      new SessionRule<>(ccmRule, false, null, null, "basic.request.timeout = 30 seconds");
 
   public ByteOrderedTokenIT() {
     super(ByteOrderedToken.class, false);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/ByteOrderedTokenVnodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/ByteOrderedTokenVnodesIT.java
@@ -34,7 +34,7 @@ public class ByteOrderedTokenVnodesIT extends TokenITBase {
 
   @ClassRule
   public static SessionRule<CqlSession> sessionRule =
-      new SessionRule<>(ccmRule, false, null, null, "request.timeout = 30 seconds");
+      new SessionRule<>(ccmRule, false, null, null, "basic.request.timeout = 30 seconds");
 
   public ByteOrderedTokenVnodesIT() {
     super(ByteOrderedToken.class, true);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/DescribeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/DescribeIT.java
@@ -52,8 +52,9 @@ public class DescribeIT {
           false,
           null,
           null,
-          "request.timeout = 30 seconds",
-          "metadata.schema.debouncer.window = 0 seconds"); // disable debouncer to speed up test.
+          "basic.request.timeout = 30 seconds",
+          "advanced.metadata.schema.debouncer.window = 0 seconds"); // disable debouncer to speed up
+  // test.
 
   /**
    * Creates a keyspace using a variety of features and ensures {@link

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/Murmur3TokenIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/Murmur3TokenIT.java
@@ -28,7 +28,7 @@ public class Murmur3TokenIT extends TokenITBase {
 
   @ClassRule
   public static SessionRule<CqlSession> sessionRule =
-      new SessionRule<>(ccmRule, false, null, null, "request.timeout = 30 seconds");
+      new SessionRule<>(ccmRule, false, null, null, "basic.request.timeout = 30 seconds");
 
   public Murmur3TokenIT() {
     super(Murmur3Token.class, false);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/Murmur3TokenVnodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/Murmur3TokenVnodesIT.java
@@ -30,7 +30,7 @@ public class Murmur3TokenVnodesIT extends TokenITBase {
 
   @ClassRule
   public static SessionRule<CqlSession> sessionRule =
-      new SessionRule<>(ccmRule, false, null, null, "request.timeout = 30 seconds");
+      new SessionRule<>(ccmRule, false, null, null, "basic.request.timeout = 30 seconds");
 
   public Murmur3TokenVnodesIT() {
     super(Murmur3Token.class, true);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/NodeStateIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/NodeStateIT.java
@@ -80,10 +80,10 @@ public class NodeStateIT {
   public @Rule SessionRule<CqlSession> sessionRule =
       SessionRule.builder(simulacron)
           .withOptions(
-              "connection.pool.local.size = 2",
-              "connection.reconnection-policy.max-delay = 1 second",
+              "advanced.connection.pool.local.size = 2",
+              "advanced.reconnection-policy.max-delay = 1 second",
               String.format(
-                  "load-balancing-policy.class = \"%s$ConfigurableIgnoresPolicy\"",
+                  "basic.load-balancing-policy.class = \"%s$ConfigurableIgnoresPolicy\"",
                   NodeStateIT.class.getName()))
           .withNodeStateListener(nodeStateListener)
           .build();
@@ -311,8 +311,8 @@ public class NodeStateIT {
             localNodeStateListener,
             null,
             null,
-            "connection.reconnection-policy.base-delay = 1 hour",
-            "connection.reconnection-policy.max-delay = 1 hour")) {
+            "advanced.reconnection-policy.base-delay = 1 hour",
+            "advanced.reconnection-policy.max-delay = 1 hour")) {
 
       BoundNode localSimulacronNode = simulacron.cluster().getNodes().iterator().next();
       assertThat(localSimulacronNode).isNotNull();
@@ -443,10 +443,10 @@ public class NodeStateIT {
             .withNodeStateListener(localNodeStateListener)
             .withConfigLoader(
                 new TestConfigLoader(
-                    "connection.reconnection-policy.base-delay = 1 hour",
-                    "connection.reconnection-policy.max-delay = 1 hour",
+                    "avanced.reconnection-policy.base-delay = 1 hour",
+                    "advanced.reconnection-policy.max-delay = 1 hour",
                     // Ensure we only have the control connection
-                    "connection.pool.local.size = 0"))
+                    "advanced.connection.pool.local.size = 0"))
             .build()) {
 
       Map<InetSocketAddress, Node> nodes = localSession.getMetadata().getNodes();
@@ -477,8 +477,8 @@ public class NodeStateIT {
             .withNodeStateListener(localNodeStateListener)
             .withConfigLoader(
                 new TestConfigLoader(
-                    "connection.reconnection-policy.base-delay = 1 hour",
-                    "connection.reconnection-policy.max-delay = 1 hour"))
+                    "advanced.reconnection-policy.base-delay = 1 hour",
+                    "advanced.reconnection-policy.max-delay = 1 hour"))
             .build()) {
 
       Map<InetSocketAddress, Node> nodes = localSession.getMetadata().getNodes();
@@ -524,8 +524,8 @@ public class NodeStateIT {
                 .withNodeStateListener(localNodeStateListener)
                 .withConfigLoader(
                     new TestConfigLoader(
-                        "connection.reconnection-policy.base-delay = 1 hour",
-                        "connection.reconnection-policy.max-delay = 1 hour"))
+                        "advanced.reconnection-policy.base-delay = 1 hour",
+                        "advanced.reconnection-policy.max-delay = 1 hour"))
                 .build()) {
 
           Map<InetSocketAddress, Node> nodes = localSession.getMetadata().getNodes();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/RandomTokenIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/RandomTokenIT.java
@@ -30,7 +30,7 @@ public class RandomTokenIT extends TokenITBase {
 
   @ClassRule
   public static SessionRule<CqlSession> sessionRule =
-      new SessionRule<>(ccmRule, false, null, null, "request.timeout = 30 seconds");
+      new SessionRule<>(ccmRule, false, null, null, "basic.request.timeout = 30 seconds");
 
   public RandomTokenIT() {
     super(RandomToken.class, false);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/RandomTokenVnodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/RandomTokenVnodesIT.java
@@ -34,7 +34,7 @@ public class RandomTokenVnodesIT extends TokenITBase {
 
   @ClassRule
   public static SessionRule<CqlSession> sessionRule =
-      new SessionRule<>(ccmRule, false, null, null, "request.timeout = 30 seconds");
+      new SessionRule<>(ccmRule, false, null, null, "basic.request.timeout = 30 seconds");
 
   public RandomTokenVnodesIT() {
     super(RandomToken.class, true);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaAgreementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaAgreementIT.java
@@ -35,9 +35,9 @@ public class SchemaAgreementIT {
   private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(ccm)
           .withOptions(
-              "request.timeout = 30s",
-              "load-balancing-policy.class = com.datastax.oss.driver.api.testinfra.loadbalancing.SortingLoadBalancingPolicy",
-              "connection.control-connection.schema-agreement.timeout = 3s")
+              "basic.request.timeout = 30s",
+              "basic.load-balancing-policy.class = com.datastax.oss.driver.api.testinfra.loadbalancing.SortingLoadBalancingPolicy",
+              "advanced.control-connection.schema-agreement.timeout = 3s")
           .build();
 
   @ClassRule public static RuleChain ruleChain = RuleChain.outerRule(ccm).around(sessionRule);
@@ -86,8 +86,8 @@ public class SchemaAgreementIT {
         SessionUtils.newSession(
             ccm,
             sessionRule.keyspace(),
-            "request.timeout = 30s",
-            "connection.control-connection.schema-agreement.timeout = 0s")) {
+            "basic.request.timeout = 30s",
+            "advanced.control-connection.schema-agreement.timeout = 0s")) {
       ResultSet result = createTable(session);
 
       // Should not agree because schema metadata is disabled

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaChangesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaChangesIT.java
@@ -49,7 +49,9 @@ public class SchemaChangesIT {
   @Rule
   public SessionRule<CqlSession> adminSessionRule =
       new SessionRule<>(
-          ccmRule, "request.timeout = 30 seconds", "metadata.schema.debouncer.window = 0 seconds");
+          ccmRule,
+          "basic.request.timeout = 30 seconds",
+          "advanced.metadata.schema.debouncer.window = 0 seconds");
 
   @Before
   public void setup() {
@@ -406,7 +408,7 @@ public class SchemaChangesIT {
     String keyspaceStr =
         Arrays.stream(keyspaces).map(i -> i.asCql(false)).collect(Collectors.joining(","));
 
-    return String.format("metadata.schema.refreshed-keyspaces = [%s]", keyspaceStr);
+    return String.format("advanced.metadata.schema.refreshed-keyspaces = [%s]", keyspaceStr);
   }
 
   private <T> void should_handle_creation(
@@ -433,7 +435,7 @@ public class SchemaChangesIT {
                 null,
                 listener1,
                 null,
-                "request.timeout = 30 seconds",
+                "basic.request.timeout = 30 seconds",
                 keyspaceFilterOption(keyspaces));
         CqlSession session2 =
             SessionUtils.newSession(
@@ -477,7 +479,7 @@ public class SchemaChangesIT {
                 null,
                 listener1,
                 null,
-                "request.timeout = 30 seconds",
+                "basic.request.timeout = 30 seconds",
                 keyspaceFilterOption(keyspaces));
         CqlSession session2 =
             SessionUtils.newSession(
@@ -521,7 +523,7 @@ public class SchemaChangesIT {
                 null,
                 listener1,
                 null,
-                "request.timeout = 30 seconds",
+                "basic.request.timeout = 30 seconds",
                 keyspaceFilterOption(keyspaces));
         CqlSession session2 =
             SessionUtils.newSession(
@@ -569,7 +571,7 @@ public class SchemaChangesIT {
                 null,
                 listener1,
                 null,
-                "request.timeout = 30 seconds",
+                "basic.request.timeout = 30 seconds",
                 keyspaceFilterOption(keyspaces));
         CqlSession session2 =
             SessionUtils.newSession(

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaIT.java
@@ -60,7 +60,7 @@ public class SchemaIT {
         SessionUtils.newSession(
             ccmRule,
             String.format(
-                "metadata.schema.refreshed-keyspaces = [ \"%s\"] ",
+                "advanced.metadata.schema.refreshed-keyspaces = [ \"%s\"] ",
                 sessionRule.keyspace().asInternal()))) {
 
       assertThat(session.getMetadata().getKeyspaces()).containsOnlyKeys(sessionRule.keyspace());
@@ -74,7 +74,8 @@ public class SchemaIT {
 
   @Test
   public void should_not_load_schema_if_disabled_in_config() {
-    try (CqlSession session = SessionUtils.newSession(ccmRule, "metadata.schema.enabled = false")) {
+    try (CqlSession session =
+        SessionUtils.newSession(ccmRule, "advanced.metadata.schema.enabled = false")) {
 
       assertThat(session.isSchemaMetadataEnabled()).isFalse();
       assertThat(session.getMetadata().getKeyspaces()).isEmpty();
@@ -83,7 +84,8 @@ public class SchemaIT {
 
   @Test
   public void should_enable_schema_programmatically_when_disabled_in_config() {
-    try (CqlSession session = SessionUtils.newSession(ccmRule, "metadata.schema.enabled = false")) {
+    try (CqlSession session =
+        SessionUtils.newSession(ccmRule, "advanced.metadata.schema.enabled = false")) {
 
       assertThat(session.isSchemaMetadataEnabled()).isFalse();
       assertThat(session.getMetadata().getKeyspaces()).isEmpty();
@@ -134,7 +136,8 @@ public class SchemaIT {
 
   @Test
   public void should_refresh_schema_manually() {
-    try (CqlSession session = SessionUtils.newSession(ccmRule, "metadata.schema.enabled = false")) {
+    try (CqlSession session =
+        SessionUtils.newSession(ccmRule, "advanced.metadata.schema.enabled = false")) {
 
       assertThat(session.isSchemaMetadataEnabled()).isFalse();
       assertThat(session.getMetadata().getKeyspaces()).isEmpty();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metrics/MetricsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metrics/MetricsIT.java
@@ -36,7 +36,7 @@ public class MetricsIT {
   @Test
   public void should_expose_metrics() {
     try (CqlSession session =
-        SessionUtils.newSession(ccmRule, "metrics.session.enabled = [ cql-requests ]")) {
+        SessionUtils.newSession(ccmRule, "advanced.metrics.session.enabled = [ cql-requests ]")) {
       for (int i = 0; i < 10; i++) {
         session.execute("SELECT release_version FROM system.local");
       }
@@ -59,8 +59,8 @@ public class MetricsIT {
     try (CqlSession session =
         SessionUtils.newSession(
             ccmRule,
-            "metrics.session.enabled = [ bytes-sent, bytes-received ]",
-            "metrics.node.enabled = [ bytes-sent, bytes-received ]")) {
+            "advanced.metrics.session.enabled = [ bytes-sent, bytes-received ]",
+            "advanced.metrics.node.enabled = [ bytes-sent, bytes-received ]")) {
       for (int i = 0; i < 10; i++) {
         session.execute("SELECT release_version FROM system.local");
       }
@@ -94,7 +94,9 @@ public class MetricsIT {
   public void should_not_expose_metrics_if_disabled() {
     try (CqlSession session =
         SessionUtils.newSession(
-            ccmRule, "metrics.session.enabled = []", "metrics.node.enabled = []")) {
+            ccmRule,
+            "advanced.metrics.session.enabled = []",
+            "advanced.metrics.node.enabled = []")) {
       for (int i = 0; i < 10; i++) {
         session.execute("SELECT release_version FROM system.local");
       }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/retry/PerProfileRetryPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/retry/PerProfileRetryPolicyIT.java
@@ -55,9 +55,9 @@ public class PerProfileRetryPolicyIT {
   public static @ClassRule SessionRule<CqlSession> sessionRule =
       SessionRule.builder(simulacron)
           .withOptions(
-              "load-balancing-policy.class = com.datastax.oss.driver.api.testinfra.loadbalancing.SortingLoadBalancingPolicy",
-              "request.retry-policy.class = DefaultRetryPolicy",
-              "profiles.profile1.request.retry-policy.class = \"com.datastax.oss.driver.api.core.retry.PerProfileRetryPolicyIT$NoRetryPolicy\"",
+              "basic.load-balancing-policy.class = com.datastax.oss.driver.api.testinfra.loadbalancing.SortingLoadBalancingPolicy",
+              "advanced.retry-policy.class = DefaultRetryPolicy",
+              "profiles.profile1.advanced.retry-policy.class = \"com.datastax.oss.driver.api.core.retry.PerProfileRetryPolicyIT$NoRetryPolicy\"",
               "profiles.profile2 {}")
           .build();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/specex/SpeculativeExecutionIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/specex/SpeculativeExecutionIT.java
@@ -327,14 +327,14 @@ public class SpeculativeExecutionIT {
   private CqlSession buildSession(int maxSpeculativeExecutions, long speculativeDelayMs) {
     return SessionUtils.newSession(
         simulacron,
-        String.format("request.timeout = %d milliseconds", SPECULATIVE_DELAY * 10),
-        "request.default-idempotence = true",
-        "load-balancing-policy.class = com.datastax.oss.driver.api.testinfra.loadbalancing.SortingLoadBalancingPolicy",
-        "request.speculative-execution-policy.class = ConstantSpeculativeExecutionPolicy",
+        String.format("basic.request.timeout = %d milliseconds", SPECULATIVE_DELAY * 10),
+        "basic.request.default-idempotence = true",
+        "basic.load-balancing-policy.class = com.datastax.oss.driver.api.testinfra.loadbalancing.SortingLoadBalancingPolicy",
+        "advanced.speculative-execution-policy.class = ConstantSpeculativeExecutionPolicy",
         String.format(
-            "request.speculative-execution-policy.max-executions = %d", maxSpeculativeExecutions),
+            "advanced.speculative-execution-policy.max-executions = %d", maxSpeculativeExecutions),
         String.format(
-            "request.speculative-execution-policy.delay = %d milliseconds", speculativeDelayMs));
+            "advanced.speculative-execution-policy.delay = %d milliseconds", speculativeDelayMs));
   }
 
   private CqlSession buildSessionWithProfile(
@@ -344,47 +344,48 @@ public class SpeculativeExecutionIT {
       long profile1SpeculativeDelayMs) {
 
     List<String> config = Lists.newArrayList();
-    config.add(String.format("request.timeout = %d milliseconds", SPECULATIVE_DELAY * 10));
-    config.add("request.default-idempotence = true");
+    config.add(String.format("basic.request.timeout = %d milliseconds", SPECULATIVE_DELAY * 10));
+    config.add("basic.request.default-idempotence = true");
     config.add(
-        "load-balancing-policy.class = com.datastax.oss.driver.api.testinfra.loadbalancing.SortingLoadBalancingPolicy");
+        "basic.load-balancing-policy.class = com.datastax.oss.driver.api.testinfra.loadbalancing.SortingLoadBalancingPolicy");
 
     if (defaultMaxSpeculativeExecutions != -1 || defaultSpeculativeDelayMs != -1) {
-      config.add("request.speculative-execution-policy.class = ConstantSpeculativeExecutionPolicy");
+      config.add(
+          "advanced.speculative-execution-policy.class = ConstantSpeculativeExecutionPolicy");
       if (defaultMaxSpeculativeExecutions != -1) {
         config.add(
             String.format(
-                "request.speculative-execution-policy.max-executions = %d",
+                "advanced.speculative-execution-policy.max-executions = %d",
                 defaultMaxSpeculativeExecutions));
       }
       if (defaultSpeculativeDelayMs != -1) {
         config.add(
             String.format(
-                "request.speculative-execution-policy.delay = %d milliseconds",
+                "advanced.speculative-execution-policy.delay = %d milliseconds",
                 defaultSpeculativeDelayMs));
       }
     } else {
-      config.add("request.speculative-execution-policy.class = NoSpeculativeExecutionPolicy");
+      config.add("advanced.speculative-execution-policy.class = NoSpeculativeExecutionPolicy");
     }
 
     if (profile1MaxSpeculativeExecutions != -1 || profile1SpeculativeDelayMs != -1) {
       config.add(
-          "profiles.profile1.request.speculative-execution-policy.class = ConstantSpeculativeExecutionPolicy");
+          "profiles.profile1.advanced.speculative-execution-policy.class = ConstantSpeculativeExecutionPolicy");
       if (profile1MaxSpeculativeExecutions != -1) {
         config.add(
             String.format(
-                "profiles.profile1.request.speculative-execution-policy.max-executions = %d",
+                "profiles.profile1.advanced.speculative-execution-policy.max-executions = %d",
                 profile1MaxSpeculativeExecutions));
       }
       if (profile1SpeculativeDelayMs != -1) {
         config.add(
             String.format(
-                "profiles.profile1.request.speculative-execution-policy.delay = %d milliseconds",
+                "profiles.profile1.advanced.speculative-execution-policy.delay = %d milliseconds",
                 profile1SpeculativeDelayMs));
       }
     } else {
       config.add(
-          "profiles.profile1.request.speculative-execution-policy.class = NoSpeculativeExecutionPolicy");
+          "profiles.profile1.advanced.speculative-execution-policy.class = NoSpeculativeExecutionPolicy");
     }
 
     config.add("profiles.profile2 = {}");

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ssl/DefaultSslEngineFactoryIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ssl/DefaultSslEngineFactoryIT.java
@@ -36,7 +36,8 @@ public class DefaultSslEngineFactoryIT {
     System.setProperty(
         "javax.net.ssl.trustStorePassword", CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_PASSWORD);
     try (CqlSession session =
-        SessionUtils.newSession(ccm, "ssl-engine-factory.class = DefaultSslEngineFactory")) {
+        SessionUtils.newSession(
+            ccm, "advanced.ssl-engine-factory.class = DefaultSslEngineFactory")) {
       session.execute("select * from system.local");
     }
   }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ssl/DefaultSslEngineFactoryWithClientAuthIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ssl/DefaultSslEngineFactoryWithClientAuthIT.java
@@ -40,7 +40,8 @@ public class DefaultSslEngineFactoryWithClientAuthIT {
     System.setProperty(
         "javax.net.ssl.trustStorePassword", CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_PASSWORD);
     try (CqlSession session =
-        SessionUtils.newSession(ccm, "ssl-engine-factory.class = DefaultSslEngineFactory")) {
+        SessionUtils.newSession(
+            ccm, "advanced.ssl-engine-factory.class = DefaultSslEngineFactory")) {
       session.execute("select * from system.local");
     }
   }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ssl/DefaultSslEngineFactoryWithClientAuthNotProvidedIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ssl/DefaultSslEngineFactoryWithClientAuthNotProvidedIT.java
@@ -37,7 +37,8 @@ public class DefaultSslEngineFactoryWithClientAuthNotProvidedIT {
     System.setProperty(
         "javax.net.ssl.trustStorePassword", CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_PASSWORD);
     try (CqlSession session =
-        SessionUtils.newSession(ccm, "ssl-engine-factory.class = DefaultSslEngineFactory")) {
+        SessionUtils.newSession(
+            ccm, "advanced.ssl-engine-factory.class = DefaultSslEngineFactory")) {
       session.execute("select * from system.local");
     }
   }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/throttling/ThrottlingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/throttling/ThrottlingIT.java
@@ -48,10 +48,10 @@ public class ThrottlingIT {
     try (CqlSession session =
         SessionUtils.newSession(
             simulacron,
-            "request.throttler.class = "
+            "advanced.throttler.class = "
                 + ConcurrencyLimitingRequestThrottler.class.getSimpleName(),
-            "request.throttler.max-concurrent-requests = " + maxConcurrentRequests,
-            "request.throttler.max-queue-size = " + maxQueueSize)) {
+            "advanced.throttler.max-concurrent-requests = " + maxConcurrentRequests,
+            "advanced.throttler.max-queue-size = " + maxQueueSize)) {
 
       // Saturate the session and fill the queue
       for (int i = 0; i < maxConcurrentRequests + maxQueueSize; i++) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/tracker/RequestLoggerIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/tracker/RequestLoggerIT.java
@@ -64,20 +64,20 @@ public class RequestLoggerIT {
   public SessionRule<CqlSession> sessionRule =
       SessionRule.builder(simulacronRule)
           .withOptions(
-              "request.tracker.class = com.datastax.oss.driver.internal.core.tracker.RequestLogger",
-              "request.tracker.logs.success.enabled = true",
-              "request.tracker.logs.slow.enabled = true",
-              "request.tracker.logs.error.enabled = true",
-              "request.tracker.logs.max-query-length = 500",
-              "request.tracker.logs.show-values = true",
-              "request.tracker.logs.max-value-length = 50",
-              "request.tracker.logs.max-values = 50",
-              "request.tracker.logs.show-stack-traces = true",
-              "profiles.low-threshold.request.tracker.logs.slow.threshold = 1 nanosecond",
-              "profiles.no-logs.request.tracker.logs.success.enabled = false",
-              "profiles.no-logs.request.tracker.logs.slow.enabled = false",
-              "profiles.no-logs.request.tracker.logs.error.enabled = false",
-              "profiles.no-traces.request.tracker.logs.show-stack-traces = false")
+              "advanced.request-tracker.class = com.datastax.oss.driver.internal.core.tracker.RequestLogger",
+              "advanced.request-tracker.logs.success.enabled = true",
+              "advanced.request-tracker.logs.slow.enabled = true",
+              "advanced.request-tracker.logs.error.enabled = true",
+              "advanced.request-tracker.logs.max-query-length = 500",
+              "advanced.request-tracker.logs.show-values = true",
+              "advanced.request-tracker.logs.max-value-length = 50",
+              "advanced.request-tracker.logs.max-values = 50",
+              "advanced.request-tracker.logs.show-stack-traces = true",
+              "profiles.low-threshold.advanced.request-tracker.logs.slow.threshold = 1 nanosecond",
+              "profiles.no-logs.advanced.request-tracker.logs.success.enabled = false",
+              "profiles.no-logs.advanced.request-tracker.logs.slow.enabled = false",
+              "profiles.no-logs.advanced.request-tracker.logs.error.enabled = false",
+              "profiles.no-traces.advanced.request-tracker.logs.show-stack-traces = false")
           .build();
 
   @Captor private ArgumentCaptor<ILoggingEvent> loggingEventCaptor;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/internal/core/retry/DefaultRetryPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/internal/core/retry/DefaultRetryPolicyIT.java
@@ -73,8 +73,8 @@ public class DefaultRetryPolicyIT {
   public @Rule SessionRule<CqlSession> sessionRule =
       new SessionRule<>(
           simulacron,
-          "request.default-idempotence = true",
-          "load-balancing-policy.class = com.datastax.oss.driver.api.testinfra.loadbalancing.SortingLoadBalancingPolicy");
+          "basic.request.default-idempotence = true",
+          "basic.load-balancing-policy.class = com.datastax.oss.driver.api.testinfra.loadbalancing.SortingLoadBalancingPolicy");
 
   private static String queryStr = "select * from foo";
   private static final SimpleStatement query = SimpleStatement.builder(queryStr).build();

--- a/integration-tests/src/test/resources/application.conf
+++ b/integration-tests/src/test/resources/application.conf
@@ -1,23 +1,29 @@
 # Configuration overrides for integration tests
 datastax-java-driver {
-  connection {
-    init-query-timeout = 5 seconds
-    set-keyspace-timeout = 5 seconds
-    heartbeat.timeout = 5 seconds
+  basic {
+    load-balancing-policy {
+      # Since our test infra always specifies explicit contact points, we need to set the local DC
+      # as well.
+      # Note that we rely on a hack to ensure that this name is always the same, even with one DC
+      # (see CcmBridge).
+      local-datacenter = dc1
+    }
+  }
+  advanced {
+    connection {
+      init-query-timeout = 5 seconds
+      set-keyspace-timeout = 5 seconds
+      heartbeat.timeout = 5 seconds
+    }
     control-connection.timeout = 5 seconds
-  }
-  request.trace.interval = 1 second
-  request.warn-if-set-keyspace = false
-  load-balancing-policy {
-    # Since our test infra always specifies explicit contact points, we need to set the local DC as
-    # well.
-    # Note that we rely on a hack to ensure that this name is always the same, even with one DC (see
-    # CcmBridge).
-    local-datacenter = dc1
-  }
-  metrics {
-    // Raise histogram bounds because the tests execute DDL queries with a higher timeout
-    session.cql_requests.highest_latency = 30 seconds
-    node.cql_messages.highest_latency = 30 seconds
+    request {
+      trace.interval = 1 second
+      warn-if-set-keyspace = false
+    }
+    metrics {
+      // Raise histogram bounds because the tests execute DDL queries with a higher timeout
+      session.cql_requests.highest_latency = 30 seconds
+      node.cql_messages.highest_latency = 30 seconds
+    }
   }
 }

--- a/manual/core/README.md
+++ b/manual/core/README.md
@@ -65,7 +65,9 @@ You can also specify a keyspace at construction time, either through the
 [configuration](configuration/):
 
 ```
-session-keyspace = my_keyspace
+datastax-java-driver {
+  basic.session-keyspace = my_keyspace
+}
 ```
 
 Or with the builder:

--- a/manual/core/address_resolution/README.md
+++ b/manual/core/address_resolution/README.md
@@ -82,7 +82,7 @@ public class MyAddressTranslator implements AddressTranslator {
 Then reference this class from the [configuration](../configuration/):
 
 ```
-datastax-java-driver.address-translator.class = com.mycompany.MyAddressTranslator
+datastax-java-driver.advanced.address-translator.class = com.mycompany.MyAddressTranslator
 ```
 
 Note: the contact points provided while creating the `CqlSession` are not translated, only addresses
@@ -100,7 +100,7 @@ The driver provides [Ec2MultiRegionAddressTranslator] which does exactly that.  
 the [configuration](../configuration/):
 
 ```
-datastax-java-driver.address-translator.class = Ec2MultiRegionAddressTranslator
+datastax-java-driver.advanced.address-translator.class = Ec2MultiRegionAddressTranslator
 ```
 
 With this configuration, you keep broadcasting public RPC addresses. But each time the driver connects to a new

--- a/manual/core/configuration/README.md
+++ b/manual/core/configuration/README.md
@@ -14,7 +14,7 @@ For a complete list of built-in options, see the [reference configuration][refer
 #### Options
 
 Essentially, an option is a path in the configuration with an expected type, for example
-`connection.heartbeat.interval`, representing a duration.
+`basic.request.timeout`, representing a duration.
 
 #### Profiles
 
@@ -29,12 +29,12 @@ Instead of manually adjusting the options on every request, you can create confi
 datastax-java-driver {
   profiles {
     oltp {
-      request.timeout = 100 milliseconds
-      request.consistency = ONE
+      basic.request.timeout = 100 milliseconds
+      basic.request.consistency = ONE
     }
     olap {
-      request.timeout = 5 seconds
-      request.consistency = QUORUM
+      basic.request.timeout = 5 seconds
+      basic.request.consistency = QUORUM
     }
 }
 ```
@@ -82,10 +82,10 @@ override:
 ```
 # Sample application.conf: overrides one option and adds a profile
 datastax-java-driver {
-  protocol.version = V4
+  advanced.protocol.version = V4
   profiles {
     slow {
-      request.timeout = 10 seconds
+      basic.request.timeout = 10 seconds
     }
   }
 }
@@ -100,7 +100,7 @@ changed at runtime and will be ignored). The reload interval is defined in the c
 
 ```
 # To disable periodic reloading, set this to 0.
-datastax-java-driver.config-reload-interval = 5 minutes
+datastax-java-driver.basic.config-reload-interval = 5 minutes
 ```
 
 As mentioned previously, system properties can also be used to override individual options. This is
@@ -108,7 +108,7 @@ great for temporary changes, for example in your development environment:
  
 ```
 # Increase heartbeat interval to limit the amount of debug logs:
-java -Ddatastax-java-driver.connection.heartbeat.interval="5 minutes" ...
+java -Ddatastax-java-driver.advanced.heartbeat.interval="5 minutes" ...
 ```
 
 We recommend reserving system properties for the early phases of the project; in production, having
@@ -195,13 +195,13 @@ VM, but with different configurations. What you want instead is separate option 
 ```
 # application.conf
 session1 {
-  session-name = "session1"
-  protocol-version = V4
+  basic.session-name = "session1"
+  advanced.protocol-version = V4
   // etc.
 }
 session2 {
-  session-name = "session2"
-  protocol-version = V3
+  basic.session-name = "session2"
+  advanced.protocol-version = V3
   // etc.
 }
 ```
@@ -330,7 +330,7 @@ The preferred way to instantiate policies (load balancing policy, retry policy, 
 configuration:
 
 ```
-reconnection-policy {
+advanced.reconnection-policy {
   class = com.datastax.oss.driver.internal.core.connection.ExponentialReconnectionPolicy
   base-delay = 1 second
   max-delay = 60 seconds

--- a/manual/core/load_balancing/README.md
+++ b/manual/core/load_balancing/README.md
@@ -9,7 +9,7 @@ abbreviated LBP) is a central component that determines:
 It is defined in the [configuration](../configuration/):
 
 ```
-datastax-java-driver.load-balancing-policy {
+datastax-java-driver.basic.load-balancing-policy {
   class = com.datastax.oss.driver.internal.core.loadbalancing.DefaultLoadBalancingPolicy
 }
 ```
@@ -96,7 +96,7 @@ Therefore the default policy does not allow remote nodes; it only ever assigns t
 `IGNORED` distance, based on the local datacenter name specified in the configuration:
 
 ```
-datastax-java-driver.load-balancing-policy {
+datastax-java-driver.basic.load-balancing-policy {
   class = com.datastax.oss.driver.internal.core.loadbalancing.DefaultLoadBalancingPolicy
   local-datacenter = datacenter1
 }
@@ -197,7 +197,7 @@ for inclusion in the local DC. If a node doesn't pass this test, it will be set 
 `IGNORED` and the driver will never try to connect to it.
 
 ```
-datastax-java-driver.load-balancing-policy {
+datastax-java-driver.basic.load-balancing-policy {
   class = com.datastax.oss.driver.internal.core.loadbalancing.DefaultLoadBalancingPolicy
   local-datacenter = datacenter1
   filter-class = com.acme.MyNodeFilter
@@ -218,12 +218,12 @@ The load balancing policy can be overridden in [configuration profiles](../confi
 
 ```
 datastax-java-driver {
-  load-balancing-policy {
+  basic.load-balancing-policy {
     class = DefaultLoadBalancingPolicy
   }
   profiles {
     custom-lbp {
-      load-balancing-policy {
+      basic.load-balancing-policy {
         class = CustomLoadBalancingPolicy
       }
     }

--- a/manual/core/metadata/schema/README.md
+++ b/manual/core/metadata/schema/README.md
@@ -49,7 +49,7 @@ convenience implementation with empty methods, for when you only need to overrid
 You can disable schema metadata globally from the configuration:
 
 ```
-datastax-java-driver.metadata.schema.enabled = false
+datastax-java-driver.advanced.metadata.schema.enabled = false
 ```
 
 If it is disabled at startup, [Metadata#getKeyspaces] will stay empty. If you disable it at runtime,
@@ -80,7 +80,7 @@ the API), a refresh is triggered immediately.
 You can also limit the metadata to a subset of keyspaces: 
 
 ```
-datastax-java-driver.metadata.schema.refreshed-keyspaces = [ "users", "products" ]
+datastax-java-driver.advanced.metadata.schema.refreshed-keyspaces = [ "users", "products" ]
 ```
 
 If the property is absent or the list is empty, it is interpreted as "all keyspaces".
@@ -158,7 +158,7 @@ UP. If all the versions match, the check succeeds, otherwise it is retried perio
 given timeout. This process is tunable in the driver's configuration:
 
 ```
-datastax-java-driver.connection.control-connection.schema-agreement {
+datastax-java-driver.advanced.control-connection.schema-agreement {
   interval = 200 milliseconds
   timeout = 10 seconds
   warn-on-failure = true

--- a/manual/core/metadata/token/README.md
+++ b/manual/core/metadata/token/README.md
@@ -145,7 +145,7 @@ Set<TokenRange> ranges2 = tokenMap.getTokenRanges(CqlIdentifier.fromCql("ks2"), 
 You can disable token metadata globally from the configuration:
 
 ```
-datastax-java-driver.metadata.token-map.enabled = false
+datastax-java-driver.advanced.metadata.token-map.enabled = false
 ```
 
 If it is disabled at startup, [Metadata#getTokenMap] will stay empty, and token-aware routing won't

--- a/manual/core/metrics/README.md
+++ b/manual/core/metrics/README.md
@@ -30,7 +30,7 @@ By default, all metrics are disabled. You can turn them on individually in the c
 adding their name to these lists:
 
 ```
-datastax-java-driver.metrics {
+datastax-java-driver.advanced.metrics {
   session.enabled = [ connected-nodes, cql-requests ]
   node.enabled = [ pool.open-connections, pool.in-flight ]
 }

--- a/manual/core/paging/README.md
+++ b/manual/core/paging/README.md
@@ -10,10 +10,10 @@ The page size specifies how many rows the server will return in each network fra
 in the configuration:
 
 ```
-datastax-java-driver.request.page-size = 5000
+datastax-java-driver.basic.request.page-size = 5000
 ```
 
-It can be changed at runtime ()the new value will be used for requests issued after the change). If
+It can be changed at runtime (the new value will be used for requests issued after the change). If
 you have categories of queries that require different page sizes, use
 [configuration profiles](../configuration#profiles).
 

--- a/manual/core/pooling/README.md
+++ b/manual/core/pooling/README.md
@@ -36,7 +36,7 @@ Pool sizes are defined in the `connection` section of the [configuration](../con
 are the relevant options with their default values:
 
 ```
-datastax-java-driver.connection {
+datastax-java-driver.advanced.connection {
   max-requests-per-connection = 1024
   pool {
     local.size = 1
@@ -61,14 +61,12 @@ by writing a dummy request to it. If that request fails, the connection is trash
 This feature is enabled by default. Here are the default values in the configuration:
 
 ```
-datastax-java-driver.connection {
-  heartbeat {
-    interval = 30 seconds
-  
-    # How long the driver waits for the response to a heartbeat. If this timeout fires, the heartbeat
-    # is considered failed.
-    timeout = 500 milliseconds
-  }
+datastax-java-driver.advanced.heartbeat {
+  interval = 30 seconds
+
+  # How long the driver waits for the response to a heartbeat. If this timeout fires, the heartbeat
+  # is considered failed.
+  timeout = 500 milliseconds
 }
 ```
 
@@ -82,7 +80,7 @@ are disabled by default, you'll need to change your configuration to enable them
 
 ```
 datastax-java-driver {
-  metrics.node.enabled = [
+  advanced.metrics.node.enabled = [
     # The number of connections open to this node for regular requests (exposed as a
     # Gauge<Integer>).
     #

--- a/manual/core/query_timestamps/README.md
+++ b/manual/core/query_timestamps/README.md
@@ -24,7 +24,7 @@ The timestamp generator is defined in the [configuration](../configuration/).
 #### AtomicTimestampGenerator
 
 ```
-datastax-java-driver.request.timestamp-generator {
+datastax-java-driver.advanced.timestamp-generator {
   class = com.datastax.oss.driver.internal.core.time.AtomicTimestampGenerator
 }
 ```
@@ -45,7 +45,7 @@ returned timestamps will be artificially incremented to guarantee monotonicity.
 You can control that message with these options:
 
 ```
-datastax-java-driver.request.timestamp-generator {
+datastax-java-driver.advanced.timestamp-generator {
   drift-warning {
     # How far in the future timestamps are allowed to drift before the warning is logged.
     # If it is undefined or set to 0, warnings are disabled.
@@ -67,7 +67,7 @@ On some systems, however, it is possible to have a better granularity by using a
 with this configuration option: 
 
 ```
-datastax-java-driver.request.timestamp-generator {
+datastax-java-driver.advanced.timestamp-generator {
   force-java-clock = true
 }
 ```
@@ -83,7 +83,7 @@ initialization:
 #### ThreadLocalTimestampGenerator
 
 ```
-datastax-java-driver.request.timestamp-generator {
+datastax-java-driver.advanced.timestamp-generator {
   class = com.datastax.oss.driver.internal.core.time.ThreadLocalTimestampGenerator
 }
 ```
@@ -102,7 +102,7 @@ section for details.
 #### ServerSideTimestampGenerator
 
 ```
-datastax-java-driver.request.timestamp-generator {
+datastax-java-driver.advanced.timestamp-generator {
   class = com.datastax.oss.driver.internal.core.time.ServerSideTimestampGenerator
 }
 ```
@@ -120,10 +120,10 @@ The timestamp generator can be overridden in [configuration profiles](../configu
 
 ```
 datastax-java-driver {
-  request.timestamp-generator = AtomicTimestampGenerator
+  advanced.timestamp-generator = AtomicTimestampGenerator
   profiles {
     profile1 {
-      request.timestamp-generator = ServerSideTimestampGenerator
+      advanced.timestamp-generator = ServerSideTimestampGenerator
     }
     profile2 {}
   } 

--- a/manual/core/request_tracker/README.md
+++ b/manual/core/request_tracker/README.md
@@ -9,7 +9,7 @@ The tracker is enabled in the [configuration](../configuration/). The default im
 nothing:
 
 ```
-datastax-java-driver.request.tracker {
+datastax-java-driver.advanced.request-tracker {
   class = com.datastax.oss.driver.internal.core.tracker.NoopRequestTracker
 }
 ```
@@ -34,7 +34,7 @@ The request logger is a built-in implementation that logs every request. It has 
 requests as "slow" above a given threshold, limit the line size for large queries, etc:
 
 ```
-datastax-java-driver.request.tracker {
+datastax-java-driver.advanced.request-tracker {
   class = com.datastax.oss.driver.internal.core.tracker.RequestLogger
 
   logs {

--- a/manual/core/retries/README.md
+++ b/manual/core/retries/README.md
@@ -5,7 +5,7 @@ might work on a different node. The driver uses a *retry policy* to determine wh
 It is defined in the [configuration](../configuration/):
                      
 ```
-datastax-java-driver.request.retry-policy {
+datastax-java-driver.advanced.retry-policy {
   class = com.datastax.oss.driver.internal.core.retry.DefaultRetryPolicy
 }
 ```
@@ -139,12 +139,12 @@ The retry policy can be overridden in [configuration profiles](../configuration/
 
 ```
 datastax-java-driver {
-  request.retry-policy {
+  advanced.retry-policy {
     class = DefaultRetryPolicy
   }
   profiles {
     custom-retries {
-      request.retry-policy {
+      advanced.retry-policy {
         class = CustomRetryPolicy
       }
     }

--- a/manual/core/speculative_execution/README.md
+++ b/manual/core/speculative_execution/README.md
@@ -69,7 +69,7 @@ Speculative executions are controlled by a policy defined in the [configuration]
 The default implementation never schedules an execution:
 
 ```
-datastax-java-driver.request.speculative-execution-policy {
+datastax-java-driver.advanced.speculative-execution-policy {
   class = com.datastax.oss.driver.internal.core.specex.NoSpeculativeExecutionPolicy
 }
 ```
@@ -77,7 +77,7 @@ datastax-java-driver.request.speculative-execution-policy {
 The "constant" policy schedules executions at a fixed delay:
 
 ```
-datastax-java-driver.request.speculative-execution-policy {
+datastax-java-driver.advanced.speculative-execution-policy {
   class = com.datastax.oss.driver.internal.core.specex.ConstantSpeculativeExecutionPolicy
   
   # The maximum number of executions (including the initial, non-speculative execution).
@@ -213,20 +213,18 @@ profiles](../configuration/#profiles):
 
 ```
 datastax-java-driver {
-  request.speculative-execution-policy {
+  advanced.speculative-execution-policy {
     class = ConstantSpeculativeExecutionPolicy
     max-executions = 3
     delay = 100 milliseconds
   }
   profiles {
     oltp {
-      request.timeout = 100 milliseconds
+      basic.request.timeout = 100 milliseconds
     }
     olap {
-      request {
-        timeout = 30 seconds
-        speculative-execution-policy.class = NoSpeculativeExecutionPolicy
-      }
+      basic.request.timeout = 30 seconds
+      advanced.speculative-execution-policy.class = NoSpeculativeExecutionPolicy
     }
   }
 }

--- a/manual/core/statements/prepared/README.md
+++ b/manual/core/statements/prepared/README.md
@@ -230,10 +230,10 @@ achieve this:
 
 You can customize these strategies through the [configuration](../../configuration/):
 
-* `datastax-java-driver.prepared-statements.prepare-on-all-nodes` controls whether statements are 
-  initially re-prepared on other hosts (step 1 above);
-* `datastax-java-driver.prepared-statements.reprepare-on-up` controls how statements are re-prepared
-  on a node that comes back up (step 2 above).
+* `datastax-java-driver.advanced.prepared-statements.prepare-on-all-nodes` controls whether
+  statements are initially re-prepared on other hosts (step 1 above);
+* `datastax-java-driver.advanced.prepared-statements.reprepare-on-up` controls how statements are
+  re-prepared on a node that comes back up (step 2 above).
 
 Read the [reference configuration](../../configuration/reference/) for a detailed description of each
 of those options.

--- a/manual/core/throttling/README.md
+++ b/manual/core/throttling/README.md
@@ -31,13 +31,13 @@ Note that the following requests are also affected by throttling:
 ### Configuration
 
 Request throttling is parameterized in the [configuration](../configuration/) under
-`request.throttler`. There are various implementations, detailed in the following sections:
+`advanced.throttler`. There are various implementations, detailed in the following sections:
 
 #### Pass through
 
 ```
 datastax-java-driver {
-  request.throttler {
+  advanced.throttler {
     class = com.datastax.oss.driver.internal.core.session.throttling.PassThroughRequestThrottler
   }
 }
@@ -55,7 +55,7 @@ requests will fail with an [AllNodesFailedException], with the `getErrors()` met
 
 ```
 datastax-java-driver {
-  request.throttler {
+  advanced.throttler {
     class = com.datastax.oss.driver.internal.core.session.throttling.ConcurrencyLimitingRequestThrottler
     
     # Note: the values below are for illustration purposes only, not prescriptive
@@ -84,7 +84,7 @@ on every node, and make sure it never reaches 0.
 
 ```
 datastax-java-driver {
-  request.throttler {
+  advanced.throttler {
     class = com.datastax.oss.driver.internal.core.session.throttling.RateLimitingRequestThrottler
     
     # Note: the values below are for illustration purposes only, not prescriptive
@@ -114,7 +114,7 @@ Enable the following [metrics](../metrics/) to monitor how the throttler is perf
 
 ```
 datastax-java-driver {
-  metrics.session.enabled = [
+  advanced.metrics.session.enabled = [
     # How long requests are being throttled (exposed as a Timer).
     #
     # This is the time between the start of the session.execute() call, and the moment when the

--- a/manual/core/tracing/README.md
+++ b/manual/core/tracing/README.md
@@ -69,7 +69,7 @@ control this behavior through the configuration:
 ```
 # These options can be changed at runtime, the new values will be used for requests issued after
 # the change. They can be overridden in a profile.
-datastax-java-driver.request.trace {
+datastax-java-driver.advanced.request.trace {
   # How many times the driver will attempt to fetch the query if it is not ready yet.
   attempts = 5
   


### PR DESCRIPTION
Please no debates about what should or should not be considered basic. @csplinter and I agreed on the current layout.

TODO:
- [x] update example in address translator EC2 section (JAVA-1832)