### PR TITLE
JAVA-1832: Add Ec2MultiRegionAddressTranslator

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha4 (in progress)
 
+- [new feature] JAVA-1832: Add Ec2MultiRegionAddressTranslator
 - [improvement] JAVA-1825: Add remaining Typesafe config primitive types to DriverConfigProfile
 - [new feature] JAVA-1846: Add ConstantReconnectionPolicy
 - [improvement] JAVA-1824: Make policies overridable in profiles

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/Ec2MultiRegionAddressTranslator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/Ec2MultiRegionAddressTranslator.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.addresstranslation;
+
+import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.internal.core.util.Loggers;
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import javax.naming.Context;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link AddressTranslator} implementation for a multi-region EC2 deployment <b>where clients are
+ * also deployed in EC2</b>.
+ *
+ * <p>Its distinctive feature is that it translates addresses according to the location of the
+ * Cassandra host:
+ *
+ * <ul>
+ *   <li>addresses in different EC2 regions (than the client) are unchanged;
+ *   <li>addresses in the same EC2 region are <b>translated to private IPs</b>.
+ * </ul>
+ *
+ * This optimizes network costs, because Amazon charges more for communication over public IPs.
+ *
+ * <p>Implementation note: this class performs a reverse DNS lookup of the origin address, to find
+ * the domain name of the target instance. Then it performs a forward DNS lookup of the domain name;
+ * the EC2 DNS does the private/public switch automatically based on location.
+ */
+public class Ec2MultiRegionAddressTranslator implements AddressTranslator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Ec2MultiRegionAddressTranslator.class);
+
+  private final DirContext ctx;
+  private final String logPrefix;
+
+  public Ec2MultiRegionAddressTranslator(@SuppressWarnings("unused") DriverContext context) {
+    this.logPrefix = context.sessionName();
+    @SuppressWarnings("JdkObsolete")
+    Hashtable<Object, Object> env = new Hashtable<>();
+    env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
+    try {
+      ctx = new InitialDirContext(env);
+    } catch (NamingException e) {
+      throw new RuntimeException("Could not create translator", e);
+    }
+  }
+
+  @VisibleForTesting
+  Ec2MultiRegionAddressTranslator(DirContext ctx) {
+    this.logPrefix = "test";
+    this.ctx = ctx;
+  }
+
+  @Override
+  public InetSocketAddress translate(InetSocketAddress socketAddress) {
+    InetAddress address = socketAddress.getAddress();
+    try {
+      // InetAddress#getHostName() is supposed to perform a reverse DNS lookup, but for some reason
+      // it doesn't work within the same EC2 region (it returns the IP address itself).
+      // We use an alternate implementation:
+      String domainName = lookupPtrRecord(reverse(address));
+      if (domainName == null) {
+        LOG.warn("[{}] Found no domain name for {}, returning it as-is", logPrefix, address);
+        return socketAddress;
+      }
+
+      InetAddress translatedAddress = InetAddress.getByName(domainName);
+      LOG.debug("[{}] Resolved {} to {}", logPrefix, address, translatedAddress);
+      return new InetSocketAddress(translatedAddress, socketAddress.getPort());
+    } catch (Exception e) {
+      Loggers.warnWithException(
+          LOG, "[{}] Error resolving {}, returning it as-is", logPrefix, address, e);
+      return socketAddress;
+    }
+  }
+
+  private String lookupPtrRecord(String reversedDomain) throws Exception {
+    Attributes attrs = ctx.getAttributes(reversedDomain, new String[] {"PTR"});
+    for (NamingEnumeration ae = attrs.getAll(); ae.hasMoreElements(); ) {
+      Attribute attr = (Attribute) ae.next();
+      Enumeration<?> vals = attr.getAll();
+      if (vals.hasMoreElements()) {
+        return vals.nextElement().toString();
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public void close() {
+    try {
+      ctx.close();
+    } catch (NamingException e) {
+      Loggers.warnWithException(LOG, "Error closing translator", e);
+    }
+  }
+
+  // Builds the "reversed" domain name in the ARPA domain to perform the reverse lookup
+  @VisibleForTesting
+  static String reverse(InetAddress address) {
+    byte[] bytes = address.getAddress();
+    if (bytes.length == 4) return reverseIpv4(bytes);
+    else return reverseIpv6(bytes);
+  }
+
+  private static String reverseIpv4(byte[] bytes) {
+    StringBuilder builder = new StringBuilder();
+    for (int i = bytes.length - 1; i >= 0; i--) {
+      builder.append(bytes[i] & 0xFF).append('.');
+    }
+    builder.append("in-addr.arpa");
+    return builder.toString();
+  }
+
+  private static String reverseIpv6(byte[] bytes) {
+    StringBuilder builder = new StringBuilder();
+    for (int i = bytes.length - 1; i >= 0; i--) {
+      byte b = bytes[i];
+      int lowNibble = b & 0x0F;
+      int highNibble = b >> 4 & 0x0F;
+      builder
+          .append(Integer.toHexString(lowNibble))
+          .append('.')
+          .append(Integer.toHexString(highNibble))
+          .append('.');
+    }
+    builder.append("ip6.arpa");
+    return builder.toString();
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/Ec2MultiRegionAddressTranslatorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/Ec2MultiRegionAddressTranslatorTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.addresstranslation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import javax.naming.NamingException;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.directory.InitialDirContext;
+import org.junit.Test;
+
+public class Ec2MultiRegionAddressTranslatorTest {
+
+  @Test
+  public void should_return_same_address_when_no_entry_found() throws Exception {
+    InitialDirContext mock = mock(InitialDirContext.class);
+    when(mock.getAttributes(anyString(), any(String[].class))).thenReturn(new BasicAttributes());
+    Ec2MultiRegionAddressTranslator translator = new Ec2MultiRegionAddressTranslator(mock);
+
+    InetSocketAddress address = new InetSocketAddress("192.0.2.5", 9042);
+    assertThat(translator.translate(address)).isEqualTo(address);
+  }
+
+  @Test
+  public void should_return_same_address_when_exception_encountered() throws Exception {
+    InitialDirContext mock = mock(InitialDirContext.class);
+    when(mock.getAttributes(anyString(), any(String[].class)))
+        .thenThrow(new NamingException("Problem resolving address (not really)."));
+    Ec2MultiRegionAddressTranslator translator = new Ec2MultiRegionAddressTranslator(mock);
+
+    InetSocketAddress address = new InetSocketAddress("192.0.2.5", 9042);
+    assertThat(translator.translate(address)).isEqualTo(address);
+  }
+
+  @Test
+  public void should_return_new_address_when_match_found() throws Exception {
+    InetSocketAddress expectedAddress = new InetSocketAddress("54.32.55.66", 9042);
+
+    InitialDirContext mock = mock(InitialDirContext.class);
+    when(mock.getAttributes("5.2.0.192.in-addr.arpa", new String[] {"PTR"}))
+        .thenReturn(new BasicAttributes("PTR", expectedAddress.getHostName()));
+    Ec2MultiRegionAddressTranslator translator = new Ec2MultiRegionAddressTranslator(mock);
+
+    InetSocketAddress address = new InetSocketAddress("192.0.2.5", 9042);
+    assertThat(translator.translate(address)).isEqualTo(expectedAddress);
+  }
+
+  @Test
+  public void should_close_context_when_closed() throws Exception {
+    InitialDirContext mock = mock(InitialDirContext.class);
+    Ec2MultiRegionAddressTranslator translator = new Ec2MultiRegionAddressTranslator(mock);
+
+    // ensure close has not been called to this point.
+    verify(mock, times(0)).close();
+    translator.close();
+    // ensure close is closed.
+    verify(mock).close();
+  }
+
+  @Test
+  public void should_build_reversed_domain_name_for_ip_v4() throws Exception {
+    InetAddress address = InetAddress.getByName("192.0.2.5");
+    assertThat(Ec2MultiRegionAddressTranslator.reverse(address))
+        .isEqualTo("5.2.0.192.in-addr.arpa");
+  }
+
+  @Test
+  public void should_build_reversed_domain_name_for_ip_v6() throws Exception {
+    InetAddress address = InetAddress.getByName("2001:db8::567:89ab");
+    assertThat(Ec2MultiRegionAddressTranslator.reverse(address))
+        .isEqualTo("b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa");
+  }
+}


### PR DESCRIPTION
For [JAVA-1832](https://datastax-oss.atlassian.net/browse/JAVA-1832).

Ported from 3.x.

Tested in EC2 with a cluster with `Ec2MultiRegionSnitch` with nodes in `us-east-1` and `us-west-1`.