### PR TITLE
Clone and build native protocol in ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: java
 jdk:
 - oraclejdk8
 sudo: false
+before_install:
+  - git clone --depth 1 https://github.com/datastax/native-protocol.git
+  - pushd native-protocol
+  - mvn install -Dmaven.javadoc.skip=true -B -V
+  - popd
+  - rm -rf native-protocol
 cache:
   directories:
   - $HOME/.m2

--- a/build.yaml
+++ b/build.yaml
@@ -8,6 +8,12 @@ cassandra:
   - '3.0'
   - '3.11'
 build:
+  - script: |
+      git clone --depth 1 https://github.com/datastax/native-protocol.git
+      pushd native-protocol
+      mvn install -Dmaven.javadoc.skip=true -B -V
+      popd
+      rm -rf native-protocol
   - type: maven
     version: 3.2.5
     goals: verify


### PR DESCRIPTION
There are times where we are developing against an unreleased version of native protocol.  Due to this, our CI builds may fail as this version is not in maven central yet.   To fix this, simply clone and build native-protocol as part of our CI processes.