### PR TITLE
JAVA-1853: Add newValue(Object...) to TupleType and UserDefinedType

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha4 (in progress)
 
+- [improvement] JAVA-1853: Add newValue(Object...) to TupleType and UserDefinedType
 - [improvement] JAVA-1815: Reorganize configuration into basic/advanced categories
 - [improvement] JAVA-1848: Add logs to DefaultRetryPolicy
 - [new feature] JAVA-1832: Add Ec2MultiRegionAddressTranslator

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/BoundStatementBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/BoundStatementBuilder.java
@@ -20,7 +20,6 @@ import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
 import com.datastax.oss.driver.internal.core.cql.DefaultBoundStatement;
-import com.datastax.oss.protocol.internal.ProtocolConstants;
 import java.nio.ByteBuffer;
 import net.jcip.annotations.NotThreadSafe;
 
@@ -37,16 +36,14 @@ public class BoundStatementBuilder extends StatementBuilder<BoundStatementBuilde
   public BoundStatementBuilder(
       PreparedStatement preparedStatement,
       ColumnDefinitions variableDefinitions,
+      ByteBuffer[] values,
       CqlIdentifier routingKeyspace,
       CodecRegistry codecRegistry,
       ProtocolVersion protocolVersion) {
     this.preparedStatement = preparedStatement;
     this.variableDefinitions = variableDefinitions;
     this.routingKeyspace = routingKeyspace;
-    this.values = new ByteBuffer[variableDefinitions.size()];
-    for (int i = 0; i < values.length; i++) {
-      values[i] = ProtocolConstants.UNSET_VALUE;
-    }
+    this.values = values;
     this.codecRegistry = codecRegistry;
     this.protocolVersion = protocolVersion;
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/PreparedStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/PreparedStatement.java
@@ -115,7 +115,7 @@ public interface PreparedStatement {
    * multiple execution parameters on the bound statement (such as {@link
    * BoundStatement#setConfigProfileName(String)}, {@link
    * BoundStatement#setPagingState(ByteBuffer)}, etc.), consider using {@link
-   * #boundStatementBuilder()} instead to avoid unnecessary allocations.
+   * #boundStatementBuilder(Object...)} instead to avoid unnecessary allocations.
    */
   BoundStatement bind(Object... values);
 
@@ -124,5 +124,5 @@ public interface PreparedStatement {
    *
    * @see #bind(Object...)
    */
-  BoundStatementBuilder boundStatementBuilder();
+  BoundStatementBuilder boundStatementBuilder(Object... values);
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/StatementBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/StatementBuilder.java
@@ -29,7 +29,7 @@ import net.jcip.annotations.NotThreadSafe;
  *
  * @see SimpleStatement#builder(String)
  * @see BatchStatement#builder(BatchType)
- * @see PreparedStatement#boundStatementBuilder()
+ * @see PreparedStatement#boundStatementBuilder(Object...)
  */
 @NotThreadSafe
 public abstract class StatementBuilder<T extends StatementBuilder<T, S>, S extends Statement<S>> {

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/TupleType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/TupleType.java
@@ -17,6 +17,7 @@ package com.datastax.oss.driver.api.core.type;
 
 import com.datastax.oss.driver.api.core.data.TupleValue;
 import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
+import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
 import java.util.List;
 
@@ -24,6 +25,21 @@ public interface TupleType extends DataType {
   List<DataType> getComponentTypes();
 
   TupleValue newValue();
+
+  /**
+   * Creates a new instance with the specified values for the fields.
+   *
+   * <p>The values must be in the same order as the fields in the tuple's definition. You can
+   * specify less values than there are fields (the remaining ones will be set to NULL), but not
+   * more (a runtime exception will be thrown).
+   *
+   * <p>To encode the values, this method uses the {@link CodecRegistry} that this type is {@link
+   * #getAttachmentPoint() attached} to; it looks for the best codec to handle the target CQL type
+   * and actual runtime type of each value (see {@link CodecRegistry#codecFor(DataType, Object)}).
+   *
+   * @throws IllegalArgumentException if there are too many values.
+   */
+  TupleValue newValue(Object... values);
 
   AttachmentPoint getAttachmentPoint();
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/UserDefinedType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/UserDefinedType.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.data.UdtValue;
 import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
 import com.datastax.oss.driver.api.core.metadata.schema.Describable;
+import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
 import com.datastax.oss.driver.internal.core.metadata.schema.ScriptBuilder;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
 import java.util.List;
@@ -49,6 +50,21 @@ public interface UserDefinedType extends DataType, Describable {
   UserDefinedType copy(boolean newFrozen);
 
   UdtValue newValue();
+
+  /**
+   * Creates a new instance with the specified values for the fields.
+   *
+   * <p>The values must be in the same order as the fields in the type's definition. You can specify
+   * less values than there are fields (the remaining ones will be set to NULL), but not more (a
+   * runtime exception will be thrown).
+   *
+   * <p>To encode the values, this method uses the {@link CodecRegistry} that this type is {@link
+   * #getAttachmentPoint() attached} to; it looks for the best codec to handle the target CQL type
+   * and actual runtime type of each value (see {@link CodecRegistry#codecFor(DataType, Object)}).
+   *
+   * @throws IllegalArgumentException if there are too many values.
+   */
+  UdtValue newValue(Object... fields);
 
   AttachmentPoint getAttachmentPoint();
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultPreparedStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultPreparedStatement.java
@@ -145,7 +145,8 @@ public class DefaultPreparedStatement implements PreparedStatement {
           throw new IllegalArgumentException("Unsupported token type " + value.getClass());
         }
       } else {
-        TypeCodec<Object> codec = codecRegistry.codecFor(variableDefinitions.get(i).getType());
+        TypeCodec<Object> codec =
+            codecRegistry.codecFor(variableDefinitions.get(i).getType(), value);
         encodedValue = codec.encode(value, protocolVersion);
       }
       encodedValues[i] = encodedValue;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/data/DefaultTupleValue.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/data/DefaultTupleValue.java
@@ -40,6 +40,16 @@ public class DefaultTupleValue implements TupleValue {
     this(type, new ByteBuffer[type.getComponentTypes().size()]);
   }
 
+  public DefaultTupleValue(TupleType type, Object... values) {
+    this(
+        type,
+        ValuesHelper.encodeValues(
+            values,
+            type.getComponentTypes(),
+            type.getAttachmentPoint().codecRegistry(),
+            type.getAttachmentPoint().protocolVersion()));
+  }
+
   private DefaultTupleValue(TupleType type, ByteBuffer[] values) {
     Preconditions.checkNotNull(type);
     this.type = type;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/data/DefaultUdtValue.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/data/DefaultUdtValue.java
@@ -42,6 +42,16 @@ public class DefaultUdtValue implements UdtValue {
     this(type, new ByteBuffer[type.getFieldTypes().size()]);
   }
 
+  public DefaultUdtValue(UserDefinedType type, Object... values) {
+    this(
+        type,
+        ValuesHelper.encodeValues(
+            values,
+            type.getFieldTypes(),
+            type.getAttachmentPoint().codecRegistry(),
+            type.getAttachmentPoint().protocolVersion()));
+  }
+
   private DefaultUdtValue(UserDefinedType type, ByteBuffer[] values) {
     Preconditions.checkNotNull(type);
     this.type = type;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/data/ValuesHelper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/data/ValuesHelper.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.data;
+
+import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.metadata.token.Token;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
+import com.datastax.oss.driver.internal.core.metadata.token.ByteOrderedToken;
+import com.datastax.oss.driver.internal.core.metadata.token.Murmur3Token;
+import com.datastax.oss.driver.internal.core.metadata.token.RandomToken;
+import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+public class ValuesHelper {
+
+  public static ByteBuffer[] encodeValues(
+      Object[] values,
+      List<DataType> fieldTypes,
+      CodecRegistry codecRegistry,
+      ProtocolVersion protocolVersion) {
+    Preconditions.checkArgument(
+        values.length <= fieldTypes.size(),
+        "Too many values (expected %s, got %s)",
+        fieldTypes.size(),
+        values.length);
+
+    ByteBuffer[] encodedValues = new ByteBuffer[fieldTypes.size()];
+    for (int i = 0; i < values.length; i++) {
+      Object value = values[i];
+      ByteBuffer encodedValue;
+      if (value instanceof Token) {
+        if (value instanceof Murmur3Token) {
+          encodedValue =
+              TypeCodecs.BIGINT.encode(((Murmur3Token) value).getValue(), protocolVersion);
+        } else if (value instanceof ByteOrderedToken) {
+          encodedValue =
+              TypeCodecs.BLOB.encode(((ByteOrderedToken) value).getValue(), protocolVersion);
+        } else if (value instanceof RandomToken) {
+          encodedValue =
+              TypeCodecs.VARINT.encode(((RandomToken) value).getValue(), protocolVersion);
+        } else {
+          throw new IllegalArgumentException("Unsupported token type " + value.getClass());
+        }
+      } else {
+        TypeCodec<Object> codec = codecRegistry.codecFor(fieldTypes.get(i), value);
+        encodedValue = codec.encode(value, protocolVersion);
+      }
+      encodedValues[i] = encodedValue;
+    }
+    return encodedValues;
+  }
+
+  public static ByteBuffer[] encodePreparedValues(
+      Object[] values,
+      ColumnDefinitions variableDefinitions,
+      CodecRegistry codecRegistry,
+      ProtocolVersion protocolVersion) {
+
+    // Almost same as encodeValues, but we can't reuse because of variableDefinitions. Rebuilding a
+    // list of datatypes is not worth it, so duplicate the code.
+
+    Preconditions.checkArgument(
+        values.length <= variableDefinitions.size(),
+        "Too many variables (expected %s, got %s)",
+        variableDefinitions.size(),
+        values.length);
+
+    ByteBuffer[] encodedValues = new ByteBuffer[variableDefinitions.size()];
+    int i;
+    for (i = 0; i < values.length; i++) {
+      Object value = values[i];
+      ByteBuffer encodedValue;
+      if (value instanceof Token) {
+        if (value instanceof Murmur3Token) {
+          encodedValue =
+              TypeCodecs.BIGINT.encode(((Murmur3Token) value).getValue(), protocolVersion);
+        } else if (value instanceof ByteOrderedToken) {
+          encodedValue =
+              TypeCodecs.BLOB.encode(((ByteOrderedToken) value).getValue(), protocolVersion);
+        } else if (value instanceof RandomToken) {
+          encodedValue =
+              TypeCodecs.VARINT.encode(((RandomToken) value).getValue(), protocolVersion);
+        } else {
+          throw new IllegalArgumentException("Unsupported token type " + value.getClass());
+        }
+      } else {
+        TypeCodec<Object> codec =
+            codecRegistry.codecFor(variableDefinitions.get(i).getType(), value);
+        encodedValue = codec.encode(value, protocolVersion);
+      }
+      encodedValues[i] = encodedValue;
+    }
+    for (; i < encodedValues.length; i++) {
+      encodedValues[i] = ProtocolConstants.UNSET_VALUE;
+    }
+    return encodedValues;
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/ShallowUserDefinedType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/ShallowUserDefinedType.java
@@ -101,6 +101,12 @@ public class ShallowUserDefinedType implements UserDefinedType {
   }
 
   @Override
+  public UdtValue newValue(Object... fields) {
+    throw new UnsupportedOperationException(
+        "This implementation should only be used internally, this is likely a driver bug");
+  }
+
+  @Override
   public AttachmentPoint getAttachmentPoint() {
     throw new UnsupportedOperationException(
         "This implementation should only be used internally, this is likely a driver bug");

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultTupleType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultTupleType.java
@@ -59,6 +59,11 @@ public class DefaultTupleType implements TupleType {
   }
 
   @Override
+  public TupleValue newValue(Object... values) {
+    return new DefaultTupleValue(this, values);
+  }
+
+  @Override
   public boolean isDetached() {
     return attachmentPoint == AttachmentPoint.NONE;
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultUserDefinedType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultUserDefinedType.java
@@ -132,6 +132,11 @@ public class DefaultUserDefinedType implements UserDefinedType {
   }
 
   @Override
+  public UdtValue newValue(Object... fields) {
+    return new DefaultUdtValue(this, fields);
+  }
+
+  @Override
   public boolean isDetached() {
     return attachmentPoint == AttachmentPoint.NONE;
   }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/data/DefaultTupleValueTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/data/DefaultTupleValueTest.java
@@ -37,6 +37,13 @@ public class DefaultTupleValueTest extends AccessibleByIndexTestBase<TupleValue>
     return type.newValue();
   }
 
+  @Override
+  protected TupleValue newInstance(
+      List<DataType> dataTypes, List<Object> values, AttachmentPoint attachmentPoint) {
+    DefaultTupleType type = new DefaultTupleType(dataTypes, attachmentPoint);
+    return type.newValue(values.toArray());
+  }
+
   @Test
   public void should_serialize_and_deserialize() {
     DefaultTupleType type =

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/data/DefaultUdtValueTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/data/DefaultUdtValueTest.java
@@ -44,6 +44,20 @@ public class DefaultUdtValueTest extends AccessibleByIdTestBase<UdtValue> {
     return userDefinedType.newValue();
   }
 
+  @Override
+  protected UdtValue newInstance(
+      List<DataType> dataTypes, List<Object> values, AttachmentPoint attachmentPoint) {
+    UserDefinedTypeBuilder builder =
+        new UserDefinedTypeBuilder(
+            CqlIdentifier.fromInternal("ks"), CqlIdentifier.fromInternal("type"));
+    for (int i = 0; i < dataTypes.size(); i++) {
+      builder.withField(CqlIdentifier.fromInternal("field" + i), dataTypes.get(i));
+    }
+    UserDefinedType userDefinedType = builder.build();
+    userDefinedType.attach(attachmentPoint);
+    return userDefinedType.newValue(values.toArray());
+  }
+
   @Test
   public void should_serialize_and_deserialize() {
     UserDefinedType type =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/data/DataTypeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/data/DataTypeIT.java
@@ -222,6 +222,10 @@ public class DataTypeIT {
               setValue(1, tupleValue, dataType, o[1]);
               samples.add(new Object[] {tupleType, tupleValue});
 
+              // tuple of int, type, created using newValue
+              TupleValue tupleValue2 = tupleType.newValue(1, o[1]);
+              samples.add(new Object[] {tupleType, tupleValue2});
+
               // udt of int, type.
               final AtomicInteger fieldNameCounter = new AtomicInteger();
               List<CqlIdentifier> typeNames =
@@ -243,6 +247,10 @@ public class DataTypeIT {
               udtValue.setInt(0, 0);
               setValue(1, udtValue, dataType, o[1]);
               samples.add(new Object[] {udt, udtValue});
+
+              // udt of int, type, created using newValue
+              UdtValue udtValue2 = udt.newValue(1, o[1]);
+              samples.add(new Object[] {udt, udtValue2});
 
               return samples.stream();
             })

--- a/integration-tests/src/test/java/com/datastax/oss/driver/internal/core/type/codec/CqlIntToStringCodec.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/internal/core/type/codec/CqlIntToStringCodec.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.type.codec;
+
+import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import java.nio.ByteBuffer;
+
+/**
+ * A sample user codec implementation that we use in our tests.
+ *
+ * <p>It maps a CQL string to a Java string containing its textual representation.
+ */
+public class CqlIntToStringCodec implements TypeCodec<String> {
+
+  @Override
+  public GenericType<String> getJavaType() {
+    return GenericType.STRING;
+  }
+
+  @Override
+  public DataType getCqlType() {
+    return DataTypes.INT;
+  }
+
+  @Override
+  public ByteBuffer encode(String value, ProtocolVersion protocolVersion) {
+    if (value == null) {
+      return null;
+    } else {
+      return TypeCodecs.INT.encode(Integer.parseInt(value), protocolVersion);
+    }
+  }
+
+  @Override
+  public String decode(ByteBuffer bytes, ProtocolVersion protocolVersion) {
+    return TypeCodecs.INT.decode(bytes, protocolVersion).toString();
+  }
+
+  @Override
+  public String format(String value) {
+    throw new UnsupportedOperationException("Not implemented for this test");
+  }
+
+  @Override
+  public String parse(String value) {
+    throw new UnsupportedOperationException("Not implemented for this test");
+  }
+}


### PR DESCRIPTION
Requires `codecFor(cqlType, value)` (1st commit) to properly handle custom codecs. This was also wrong in the existing bound statement method (2nd commit).

TODO:
- [x] JAVA-1863