### PR TITLE
JAVA-1761: Add OSGi descriptors and JAVA-1762: Shading

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha4 (in progress)
 
+- [new feature] JAVA-1762: Build alternate core artifact with Netty shaded
 - [new feature] JAVA-1761: Add OSGi descriptors
 - [bug] JAVA-1560: Correctly propagate policy initialization errors
 - [improvement] JAVA-1865: Add RelationMetadata.getPrimaryKey()

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha4 (in progress)
 
+- [new feature] JAVA-1761: Add OSGi descriptors
 - [bug] JAVA-1560: Correctly propagate policy initialization errors
 - [improvement] JAVA-1865: Add RelationMetadata.getPrimaryKey()
 - [improvement] JAVA-1862: Add ConsistencyLevel.isDcLocal and isSerial

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.datastax.oss</groupId>
+    <artifactId>java-driver-parent</artifactId>
+    <version>4.0.0-alpha4-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>java-driver-core-shaded</artifactId>
+  <packaging>bundle</packaging>
+
+  <name>DataStax Java driver for Apache Cassandra(R) - core with netty shaded</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- extract shaded manifest from core jar -->
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>unpack-manifest</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>com.datastax.oss</groupId>
+                  <artifactId>java-driver-core</artifactId>
+                  <version>${project.version}</version>
+                  <includes>META-INF-shaded/MANIFEST.MF</includes>
+                  <outputDirectory>${project.build.directory}</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>com.datastax.oss:java-driver-core</include>
+                  <include>io.netty:*</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>io.netty</pattern>
+                  <shadedPattern>com.datastax.oss.driver.shaded.netty</shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                  <resources>
+                    <resource>META-INF/MANIFEST.MF</resource>
+                    <resource>META-INF-shaded/MANIFEST.MF</resource>
+                    <resource>META-INF/maven/com.datastax.oss/java-driver-core/pom.xml</resource>
+                    <resource>META-INF/maven/com.datastax.oss/java-driver-core/pom.properties</resource>
+                    <resource>META-INF/maven/io.netty/netty-handler/pom.properties</resource>
+                    <resource>META-INF/maven/io.netty/netty-handler/pom.xml</resource>
+                    <resource>META-INF/maven/io.netty/netty-buffer/pom.properties</resource>
+                    <resource>META-INF/maven/io.netty/netty-buffer/pom.xml</resource>
+                    <resource>META-INF/maven/io.netty/netty-common/pom.properties</resource>
+                    <resource>META-INF/maven/io.netty/netty-common/pom.xml</resource>
+                    <resource>META-INF/maven/io.netty/netty-transport/pom.properties</resource>
+                    <resource>META-INF/maven/io.netty/netty-transport/pom.xml</resource>
+                    <resource>META-INF/maven/io.netty/netty-resolver/pom.properties</resource>
+                    <resource>META-INF/maven/io.netty/netty-resolver/pom.xml</resource>
+                    <resource>META-INF/maven/io.netty/netty-codec/pom.properties</resource>
+                    <resource>META-INF/maven/io.netty/netty-codec/pom.xml</resource>
+                    <!-- netty's shading of jctools does not remove its pom files -->
+                    <resource>META-INF/maven/org.jctools/jctools-core/pom.properties</resource>
+                    <resource>META-INF/maven/org.jctools/jctools-core/pom.xml</resource>
+                  </resources>
+                </transformer>
+                <!-- Pick up the alternate manifest that was extracted from the core module -->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                  <resource>META-INF/MANIFEST.MF</resource>
+                  <file>${project.build.directory}/META-INF-shaded/MANIFEST.MF</file>
+                </transformer>
+              </transformers>
+              <!-- Keep the dependencies of driver-core -->
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,7 +27,6 @@
   </parent>
 
   <artifactId>java-driver-core</artifactId>
-  <packaging>bundle</packaging>
 
   <name>DataStax Java driver for Apache Cassandra(R) - core</name>
 
@@ -140,6 +139,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
         <executions>
           <execution>
             <id>test-jar</id>
@@ -160,30 +164,16 @@
           </properties>
         </configuration>
       </plugin>
+      <!--
+      We avoid packaging bundle because it does not play nicely with the shade plugin, see
+      https://stackoverflow.com/questions/31262032/maven-shade-plugin-and-custom-packaging-type
+      -->
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
-          <manifestLocation>${project.build.outputDirectory}/META-INF</manifestLocation>
           <instructions>
             <Bundle-SymbolicName>com.datastax.oss.driver.core</Bundle-SymbolicName>
-            <!-- Allow importing code from other packages (so reflection-based loading of policies works) -->
-            <DynamicImport-Package>*</DynamicImport-Package>
-            <!-- Don't include JNR packages since some JNR modules are not OSGi bundles,
-                 jcip because its not an OSGi bundle, jctools because its shaded.
-                 Import sun.misc as jctools does this. -->
-            <Import-Package>
-              !net.jcip.annotations,!jnr.*,!org.jctools.*,sun.misc;resolution:=optional,*
-            </Import-Package>
-            <!-- Explicitly declare shaded jctools packages since this isn't covered by shade plugin -->
-            <Export-Package>
-              com.datastax.oss.driver.*.core.*,
-              com.datastax.oss.driver.shaded.jctools.util;version="${project.version}";uses:="sun.misc",
-              com.datastax.oss.driver.shaded.jctools.queues;version="${project.version}";uses:="com.datastax.oss.driver.shaded.jctools.queues.spec",
-              com.datastax.oss.driver.shaded.jctools.queues.spec;version="${project.version}",
-              com.datastax.oss.driver.shaded.jctools.queues.atomic;version="${project.version}";uses:="com.datastax.oss.driver.shaded.jctools.queues,com.datastax.oss.driver.shaded.jctools.queues.spec",
-              com.datastax.oss.driver.shaded.jctools.maps;version="${project.version}"
-            </Export-Package>
           </instructions>
           <!--
           Prevent customized manifest entries from the project's maven-jar-plugin configuration from being read, see
@@ -193,6 +183,64 @@
             <forced>true</forced>
           </archive>
         </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <manifestLocation>${project.build.outputDirectory}/META-INF</manifestLocation>
+              <instructions>
+                <!-- Allow importing code from other packages (so reflection-based loading of policies works) -->
+                <DynamicImport-Package>*</DynamicImport-Package>
+                <!-- Don't include JNR packages since some JNR modules are not OSGi bundles,
+                     jcip because its not an OSGi bundle, jctools because its shaded.
+                     Import sun.misc as jctools does this. -->
+                <Import-Package>
+                  !net.jcip.annotations,!jnr.*,!org.jctools.*,sun.misc;resolution:=optional,*
+                </Import-Package>
+                <!-- Explicitly declare shaded jctools packages since this isn't covered by shade plugin -->
+                <Export-Package>
+                  com.datastax.oss.driver.*.core.*,
+                  com.datastax.oss.driver.shaded.jctools.util;version="${project.version}";uses:="sun.misc",
+                  com.datastax.oss.driver.shaded.jctools.queues;version="${project.version}";uses:="com.datastax.oss.driver.shaded.jctools.queues.spec",
+                  com.datastax.oss.driver.shaded.jctools.queues.spec;version="${project.version}",
+                  com.datastax.oss.driver.shaded.jctools.queues.atomic;version="${project.version}";uses:="com.datastax.oss.driver.shaded.jctools.queues,com.datastax.oss.driver.shaded.jctools.queues.spec",
+                  com.datastax.oss.driver.shaded.jctools.maps;version="${project.version}"
+                </Export-Package>
+              </instructions>
+            </configuration>
+          </execution>
+          <!-- Alternate execution to generate the manifest to be used by the java-driver-core-shaded module -->
+          <execution>
+            <id>bundle-manifest-shaded</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <manifestLocation>${project.build.directory}/classes/META-INF-shaded</manifestLocation>
+              <instructions>
+                <Bundle-Name>DataStax Java driver for Apache Cassandra(R) - core netty shaded</Bundle-Name>
+                <DynamicImport-Package>*</DynamicImport-Package>
+                <!-- Don't include netty since it will be shaded, import javax.security.cert as needed by netty ssl -->
+                <Import-Package>
+                  !net.jcip.annotations,!jnr.*,!org.jctools.*,sun.misc;resolution:=optional,!io.netty.*,javax.security.cert,*
+                </Import-Package>
+                <Export-Package>
+                  com.datastax.oss.driver.*.core.*,
+                  com.datastax.oss.driver.shaded.jctools.util;version="${project.version}";uses:="sun.misc",
+                  com.datastax.oss.driver.shaded.jctools.queues;version="${project.version}";uses:="com.datastax.oss.driver.shaded.jctools.queues.spec",
+                  com.datastax.oss.driver.shaded.jctools.queues.spec;version="${project.version}",
+                  com.datastax.oss.driver.shaded.jctools.queues.atomic;version="${project.version}";uses:="com.datastax.oss.driver.shaded.jctools.queues,com.datastax.oss.driver.shaded.jctools.queues.spec",
+                  com.datastax.oss.driver.shaded.jctools.maps;version="${project.version}"
+                </Export-Package>
+              </instructions>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <!-- shade jctools -->
       <plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,9 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -25,7 +27,7 @@
   </parent>
 
   <artifactId>java-driver-core</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
 
   <name>DataStax Java driver for Apache Cassandra(R) - core</name>
 
@@ -74,6 +76,10 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jctools</groupId>
+      <artifactId>jctools-core</artifactId>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
@@ -153,6 +159,75 @@
             </property>
           </properties>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <manifestLocation>${project.build.outputDirectory}/META-INF</manifestLocation>
+          <instructions>
+            <Bundle-SymbolicName>com.datastax.oss.driver.core</Bundle-SymbolicName>
+            <!-- Allow importing code from other packages (so reflection-based loading of policies works) -->
+            <DynamicImport-Package>*</DynamicImport-Package>
+            <!-- Don't include JNR packages since some JNR modules are not OSGi bundles,
+                 jcip because its not an OSGi bundle, jctools because its shaded.
+                 Import sun.misc as jctools does this. -->
+            <Import-Package>
+              !net.jcip.annotations,!jnr.*,!org.jctools.*,sun.misc;resolution:=optional,*
+            </Import-Package>
+            <!-- Explicitly declare shaded jctools packages since this isn't covered by shade plugin -->
+            <Export-Package>
+              com.datastax.oss.driver.*.core.*,
+              com.datastax.oss.driver.shaded.jctools.util;version="${project.version}";uses:="sun.misc",
+              com.datastax.oss.driver.shaded.jctools.queues;version="${project.version}";uses:="com.datastax.oss.driver.shaded.jctools.queues.spec",
+              com.datastax.oss.driver.shaded.jctools.queues.spec;version="${project.version}",
+              com.datastax.oss.driver.shaded.jctools.queues.atomic;version="${project.version}";uses:="com.datastax.oss.driver.shaded.jctools.queues,com.datastax.oss.driver.shaded.jctools.queues.spec",
+              com.datastax.oss.driver.shaded.jctools.maps;version="${project.version}"
+            </Export-Package>
+          </instructions>
+          <!--
+          Prevent customized manifest entries from the project's maven-jar-plugin configuration from being read, see
+          http://apache-felix.18485.x6.nabble.com/how-lt-manifestLocation-gt-is-used-in-maven-bundle-plugin-td4835566.html
+          -->
+          <archive>
+            <forced>true</forced>
+          </archive>
+        </configuration>
+      </plugin>
+      <!-- shade jctools -->
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>org.jctools:jctools-core</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>org.jctools</pattern>
+                  <shadedPattern>com.datastax.oss.driver.shaded.jctools</shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer
+                        implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                  <resources>
+                    <resource>META-INF/maven/org.jctools/jctools-core/pom.properties</resource>
+                    <resource>META-INF/maven/org.jctools/jctools-core/pom.xml</resource>
+                  </resources>
+                </transformer>
+              </transformers>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
@@ -68,6 +68,7 @@ public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
   protected RequestTracker requestTracker;
   private ImmutableMap.Builder<String, Predicate<Node>> nodeFilters = ImmutableMap.builder();
   protected CqlIdentifier keyspace;
+  private ClassLoader classLoader = null;
 
   /**
    * Sets the configuration loader to use.
@@ -223,6 +224,20 @@ public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
   }
 
   /**
+   * The {@link ClassLoader} to use to reflectively load class names defined in configuration.
+   *
+   * <p>This is typically only needed when using OSGi or other in environments where there are
+   * complex class loading requirements.
+   *
+   * <p>If null, the driver attempts to use {@link Thread#getContextClassLoader()} of the current
+   * thread or the same {@link ClassLoader} that loaded the core driver classes.
+   */
+  public SelfT withClassLoader(ClassLoader classLoader) {
+    this.classLoader = classLoader;
+    return self;
+  }
+
+  /**
    * Creates the session with the options set by this builder.
    *
    * @return a completion stage that completes with the session when it is fully initialized.
@@ -269,7 +284,8 @@ public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
                   nodeStateListener,
                   schemaChangeListener,
                   requestTracker,
-                  nodeFilters.build()),
+                  nodeFilters.build(),
+                  classLoader),
           contactPoints,
           keyspace);
 
@@ -290,14 +306,16 @@ public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
       NodeStateListener nodeStateListener,
       SchemaChangeListener schemaChangeListener,
       RequestTracker requestTracker,
-      Map<String, Predicate<Node>> nodeFilters) {
+      Map<String, Predicate<Node>> nodeFilters,
+      ClassLoader classLoader) {
     return new DefaultDriverContext(
         configLoader,
         typeCodecs,
         nodeStateListener,
         schemaChangeListener,
         requestTracker,
-        nodeFilters);
+        nodeFilters,
+        classLoader);
   }
 
   private static <T> T buildIfNull(T value, Supplier<T> builder) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DefaultWriteCoalescer.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DefaultWriteCoalescer.java
@@ -22,7 +22,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
-import io.netty.util.internal.shaded.org.jctools.queues.atomic.MpscLinkedAtomicQueue;
 import java.util.HashSet;
 import java.util.Queue;
 import java.util.Set;
@@ -31,6 +30,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import net.jcip.annotations.ThreadSafe;
+import org.jctools.queues.atomic.MpscLinkedAtomicQueue;
 
 /**
  * Default write coalescing strategy.

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
@@ -189,6 +189,7 @@ public class DefaultDriverContext implements InternalDriverContext {
   private final SchemaChangeListener schemaChangeListenerFromBuilder;
   private final RequestTracker requestTrackerFromBuilder;
   private final Map<String, Predicate<Node>> nodeFiltersFromBuilder;
+  private final ClassLoader classLoader;
 
   public DefaultDriverContext(
       DriverConfigLoader configLoader,
@@ -196,7 +197,8 @@ public class DefaultDriverContext implements InternalDriverContext {
       NodeStateListener nodeStateListener,
       SchemaChangeListener schemaChangeListener,
       RequestTracker requestTracker,
-      Map<String, Predicate<Node>> nodeFilters) {
+      Map<String, Predicate<Node>> nodeFilters,
+      ClassLoader classLoader) {
     this.config = configLoader.getInitialConfig();
     this.configLoader = configLoader;
     DriverConfigProfile defaultProfile = config.getDefaultProfile();
@@ -223,6 +225,7 @@ public class DefaultDriverContext implements InternalDriverContext {
         new LazyReference<>(
             "requestTracker", () -> buildRequestTracker(requestTrackerFromBuilder), cycleDetector);
     this.nodeFiltersFromBuilder = nodeFilters;
+    this.classLoader = classLoader;
   }
 
   protected Map<String, LoadBalancingPolicy> buildLoadBalancingPolicies() {
@@ -669,6 +672,11 @@ public class DefaultDriverContext implements InternalDriverContext {
   @Override
   public Predicate<Node> nodeFilter(String profileName) {
     return nodeFiltersFromBuilder.get(profileName);
+  }
+
+  @Override
+  public ClassLoader classLoader() {
+    return classLoader;
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/InternalDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/InternalDriverContext.java
@@ -95,4 +95,11 @@ public interface InternalDriverContext extends DriverContext {
    * {@code null}.
    */
   Predicate<Node> nodeFilter(String profileName);
+
+  /**
+   * The {@link ClassLoader} to use to reflectively load class names defined in configuration. If
+   * null, the driver attempts to use {@link Thread#getContextClassLoader()} of the current thread
+   * or {@link com.datastax.oss.driver.internal.core.util.Reflection}'s {@link ClassLoader}.
+   */
+  ClassLoader classLoader();
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
@@ -298,7 +298,7 @@ public class DefaultLoadBalancingPolicy implements LoadBalancingPolicy {
         ? filterFromBuilder
         : (Predicate<Node>)
             Reflection.buildFromConfig(
-                    context,
+                    (InternalDriverContext) context,
                     profileName,
                     DefaultDriverOption.LOAD_BALANCING_FILTER_CLASS,
                     Predicate.class)

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/util/ReflectionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/util/ReflectionTest.java
@@ -19,9 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
-import com.datastax.oss.driver.api.core.context.DriverContext;
 import com.datastax.oss.driver.api.core.specex.SpeculativeExecutionPolicy;
 import com.datastax.oss.driver.internal.core.config.typesafe.TypesafeDriverConfig;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.specex.ConstantSpeculativeExecutionPolicy;
 import com.datastax.oss.driver.internal.core.specex.NoSpeculativeExecutionPolicy;
 import com.typesafe.config.ConfigFactory;
@@ -55,7 +55,7 @@ public class ReflectionTest {
             + "    advanced.speculative-execution-policy.class = NoSpeculativeExecutionPolicy\n"
             + "  }\n"
             + "}\n";
-    DriverContext context = Mockito.mock(DriverContext.class);
+    InternalDriverContext context = Mockito.mock(InternalDriverContext.class);
     TypesafeDriverConfig config = new TypesafeDriverConfig(ConfigFactory.parseString(configSource));
     Mockito.when(context.config()).thenReturn(config);
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -43,6 +43,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-query-builder</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.tngtech.java</groupId>
       <artifactId>junit-dataprovider</artifactId>
       <scope>test</scope>
@@ -72,6 +78,26 @@
       <artifactId>lz4-java</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-container-native</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-link-mvn</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.framework</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -89,7 +115,51 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- Not needed for maven build but useful for testing from intellij -->
+          <systemPropertyVariables>
+            <project.version>${project.version}</project.version>
+            <assertj.version>${assertj.version}</assertj.version>
+            <config.version>${config.version}</config.version>
+            <commons-exec.version>${commons-exec.version}</commons-exec.version>
+            <guava.version>${guava.version}</guava.version>
+            <hdrhistogram.version>${hdrhistogram.version}</hdrhistogram.version>
+            <jackson.version>${jackson.version}</jackson.version>
+            <logback.version>${logback.version}</logback.version>
+            <lz4.version>${lz4.version}</lz4.version>
+            <metrics.version>${metrics.version}</metrics.version>
+            <native-protocol.version>${native-protocol.version}</native-protocol.version>
+            <netty.version>${netty.version}</netty.version>
+            <simulacron.version>${simulacron.version}</simulacron.version>
+            <slf4j.version>${slf4j.version}</slf4j.version>
+            <snappy.version>${snappy.version}</snappy.version>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <!-- provide version properties for OSGi tests -->
+          <systemPropertyVariables>
+            <project.version>${project.version}</project.version>
+            <assertj.version>${assertj.version}</assertj.version>
+            <config.version>${config.version}</config.version>
+            <commons-exec.version>${commons-exec.version}</commons-exec.version>
+            <guava.version>${guava.version}</guava.version>
+            <hdrhistogram.version>${hdrhistogram.version}</hdrhistogram.version>
+            <jackson.version>${jackson.version}</jackson.version>
+            <logback.version>${logback.version}</logback.version>
+            <lz4.version>${lz4.version}</lz4.version>
+            <metrics.version>${metrics.version}</metrics.version>
+            <native-protocol.version>${native-protocol.version}</native-protocol.version>
+            <netty.version>${netty.version}</netty.version>
+            <simulacron.version>${simulacron.version}</simulacron.version>
+            <slf4j.version>${slf4j.version}</slf4j.version>
+            <snappy.version>${snappy.version}</snappy.version>
+          </systemPropertyVariables>
+        </configuration>
         <executions>
           <execution>
             <id>parallelizable-tests</id>

--- a/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/api/GuavaSessionBuilder.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/api/GuavaSessionBuilder.java
@@ -39,14 +39,16 @@ public class GuavaSessionBuilder extends SessionBuilder<GuavaSessionBuilder, Gua
       NodeStateListener nodeStateListener,
       SchemaChangeListener schemaChangeListener,
       RequestTracker requestTracker,
-      Map<String, Predicate<Node>> nodeFilters) {
+      Map<String, Predicate<Node>> nodeFilters,
+      ClassLoader classLoader) {
     return new GuavaDriverContext(
         configLoader,
         typeCodecs,
         nodeStateListener,
         schemaChangeListener,
         requestTracker,
-        nodeFilters);
+        nodeFilters,
+        classLoader);
   }
 
   @Override

--- a/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/GuavaDriverContext.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/GuavaDriverContext.java
@@ -50,14 +50,16 @@ public class GuavaDriverContext extends DefaultDriverContext {
       NodeStateListener nodeStateListener,
       SchemaChangeListener schemaChangeListener,
       RequestTracker requestTracker,
-      Map<String, Predicate<Node>> nodeFilters) {
+      Map<String, Predicate<Node>> nodeFilters,
+      ClassLoader classLoader) {
     super(
         configLoader,
         typeCodecs,
         nodeStateListener,
         schemaChangeListener,
         requestTracker,
-        nodeFilters);
+        nodeFilters,
+        classLoader);
   }
 
   @Override

--- a/integration-tests/src/test/java/com/datastax/oss/driver/osgi/BundleOptions.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/osgi/BundleOptions.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.osgi;
+
+import static org.ops4j.pax.exam.CoreOptions.bundle;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+
+import org.ops4j.pax.exam.options.CompositeOption;
+import org.ops4j.pax.exam.options.MavenArtifactProvisionOption;
+import org.ops4j.pax.exam.options.UrlProvisionOption;
+import org.ops4j.pax.exam.util.PathUtils;
+
+public class BundleOptions {
+
+  public static CompositeOption baseOptions() {
+    return () ->
+        options(
+            nettyBundles(),
+            mavenBundle(
+                "com.datastax.oss", "java-driver-shaded-guava", getVersion("guava.version")),
+            mavenBundle("io.dropwizard.metrics", "metrics-core", getVersion("metrics.version")),
+            mavenBundle("org.slf4j", "slf4j-api", getVersion("slf4j.version")),
+            mavenBundle("org.hdrhistogram", "HdrHistogram", getVersion("hdrhistogram.version")),
+            mavenBundle("com.typesafe", "config", getVersion("config.version")),
+            mavenBundle(
+                "com.datastax.oss", "native-protocol", getVersion("native-protocol.version")),
+            logbackBundles(),
+            systemProperty("logback.configurationFile")
+                .value("file:" + PathUtils.getBaseDir() + "/src/test/resources/logback-test.xml"),
+            testBundles());
+  }
+
+  public static UrlProvisionOption driverCoreBundle() {
+    return bundle(
+        "reference:file:"
+            + PathUtils.getBaseDir()
+            + "/../core/target/java-driver-core-"
+            + getVersion("project.version")
+            + ".jar");
+  }
+
+  public static UrlProvisionOption driverQueryBuilderBundle() {
+    return bundle(
+        "reference:file:"
+            + PathUtils.getBaseDir()
+            + "/../query-builder/target/java-driver-query-builder-"
+            + getVersion("project.version")
+            + ".jar");
+  }
+
+  public static UrlProvisionOption driverTestInfraBundle() {
+    return bundle(
+        "reference:file:"
+            + PathUtils.getBaseDir()
+            + "/../test-infra/target/java-driver-test-infra-"
+            + getVersion("project.version")
+            + ".jar");
+  }
+
+  public static CompositeOption testBundles() {
+    return () ->
+        options(
+            driverTestInfraBundle(),
+            simulacronBundles(),
+            jacksonBundles(),
+            mavenBundle(
+                "org.apache.commons", "commons-exec", System.getProperty("commons-exec.version")),
+            mavenBundle("org.assertj", "assertj-core", System.getProperty("assertj.version")),
+            junitBundles());
+  }
+
+  public static CompositeOption nettyBundles() {
+    String nettyVersion = getVersion("netty.version");
+    return () ->
+        options(
+            mavenBundle("io.netty", "netty-handler", nettyVersion),
+            mavenBundle("io.netty", "netty-buffer", nettyVersion),
+            mavenBundle("io.netty", "netty-codec", nettyVersion),
+            mavenBundle("io.netty", "netty-common", nettyVersion),
+            mavenBundle("io.netty", "netty-transport", nettyVersion),
+            mavenBundle("io.netty", "netty-resolver", nettyVersion));
+  }
+
+  public static CompositeOption logbackBundles() {
+    String logbackVersion = getVersion("logback.version");
+    return () ->
+        options(
+            mavenBundle("ch.qos.logback", "logback-classic", logbackVersion),
+            mavenBundle("ch.qos.logback", "logback-core", logbackVersion));
+  }
+
+  public static CompositeOption jacksonBundles() {
+    String jacksonVersion = getVersion("jackson.version");
+    return () ->
+        options(
+            mavenBundle("com.fasterxml.jackson.core", "jackson-databind", jacksonVersion),
+            mavenBundle("com.fasterxml.jackson.core", "jackson-core", jacksonVersion),
+            mavenBundle("com.fasterxml.jackson.core", "jackson-annotations", jacksonVersion));
+  }
+
+  public static CompositeOption simulacronBundles() {
+    String simulacronVersion = getVersion("simulacron.version");
+    return () ->
+        options(
+            mavenBundle(
+                "com.datastax.oss.simulacron", "simulacron-native-server", simulacronVersion),
+            mavenBundle("com.datastax.oss.simulacron", "simulacron-common", simulacronVersion),
+            mavenBundle(
+                "com.datastax.oss.simulacron",
+                "simulacron-native-protocol-json",
+                simulacronVersion));
+  }
+
+  public static MavenArtifactProvisionOption lz4Bundle() {
+    return mavenBundle("org.lz4", "lz4-java", getVersion("lz4.version"));
+  }
+
+  public static MavenArtifactProvisionOption snappyBundle() {
+    return mavenBundle("org.xerial.snappy", "snappy-java", getVersion("snappy.version"));
+  }
+
+  public static String getVersion(String propertyName) {
+    String value = System.getProperty(propertyName);
+    if (value == null) {
+      throw new IllegalArgumentException(propertyName + " system property is not set");
+    }
+    return value;
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/osgi/BundleOptions.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/osgi/BundleOptions.java
@@ -55,6 +55,15 @@ public class BundleOptions {
             + ".jar");
   }
 
+  public static UrlProvisionOption driverCoreShadedBundle() {
+    return bundle(
+        "reference:file:"
+            + PathUtils.getBaseDir()
+            + "/../core-shaded/target/java-driver-core-shaded-"
+            + getVersion("project.version")
+            + ".jar");
+  }
+
   public static UrlProvisionOption driverQueryBuilderBundle() {
     return bundle(
         "reference:file:"

--- a/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiBaseIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiBaseIT.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.osgi;
+
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilderDsl.selectFrom;
+import static com.datastax.oss.driver.osgi.BundleOptions.baseOptions;
+import static com.datastax.oss.driver.osgi.BundleOptions.driverCoreBundle;
+import static com.datastax.oss.driver.osgi.BundleOptions.driverQueryBuilderBundle;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.session.SessionBuilder;
+import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import com.datastax.oss.driver.categories.IsolatedTests;
+import com.datastax.oss.driver.internal.testinfra.session.TestConfigLoader;
+import com.google.common.collect.ObjectArrays;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+/**
+ * Tests the capability of using the driver in an OSGi environment. Note that this relies on
+ * relative locations of jars in the target directory of their respective modules. It is therefore
+ * required that you at least run {@code mvn package} before running these tests.
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+@Category(IsolatedTests.class)
+public abstract class OsgiBaseIT {
+
+  @ClassRule public static CustomCcmRule ccmRule = CustomCcmRule.builder().withNodes(1).build();
+
+  /** @return Additional options that should be used in OSGi environment configuration. */
+  public abstract Option[] additionalOptions();
+
+  @Configuration
+  public Option[] config() {
+    return ObjectArrays.concat(
+        options(driverCoreBundle(), driverQueryBuilderBundle(), baseOptions()),
+        additionalOptions(),
+        Option.class);
+  }
+
+  /** @return Additional options that should be used during session construction. */
+  public abstract String[] sessionOptions();
+
+  /**
+   * A very simple test that ensures a session can be established and a query made when running in
+   * an OSGi container.
+   */
+  @Test
+  @SuppressWarnings("unchecked")
+  public void should_connect_and_query() {
+    SessionBuilder<CqlSessionBuilder, CqlSession> builder =
+        SessionUtils.baseBuilder()
+            .addContactPoints(ccmRule.getContactPoints())
+            // use the driver's ClassLoader instead of the OSGI application thread's.
+            .withClassLoader(CqlSession.class.getClassLoader())
+            .withConfigLoader(new TestConfigLoader(sessionOptions()));
+    try (CqlSession session = builder.build()) {
+      ResultSet result = session.execute(selectFrom("system", "local").all().build());
+
+      assertThat(result.getAvailableWithoutFetching()).isEqualTo(1);
+
+      Row row = result.one();
+      assertThat(row.getString("key")).isEqualTo("local");
+    }
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiCustomLoadBalancingPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiCustomLoadBalancingPolicyIT.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.osgi;
+
+import org.ops4j.pax.exam.Option;
+
+/**
+ * Test that uses a policy from a separate bundle from the core driver to ensure that the driver is
+ * able to load that policy via Reflection. To support this, the driver uses <code>
+ * DynamicImport-Package: *</code>.
+ */
+public class OsgiCustomLoadBalancingPolicyIT extends OsgiBaseIT {
+  @Override
+  public Option[] additionalOptions() {
+    return new Option[0];
+  }
+
+  @Override
+  public String[] sessionOptions() {
+    return new String[] {
+      "basic.load-balancing-policy.class = com.datastax.oss.driver.api.testinfra.loadbalancing.SortingLoadBalancingPolicy"
+    };
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiIT.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.osgi;
+
+import org.ops4j.pax.exam.Option;
+
+public class OsgiIT extends OsgiBaseIT {
+
+  @Override
+  public Option[] additionalOptions() {
+    return new Option[0];
+  }
+
+  @Override
+  public String[] sessionOptions() {
+    return new String[0];
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiLz4IT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiLz4IT.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.osgi;
+
+import static com.datastax.oss.driver.osgi.BundleOptions.lz4Bundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+import org.ops4j.pax.exam.Option;
+
+public class OsgiLz4IT extends OsgiBaseIT {
+
+  @Override
+  public Option[] additionalOptions() {
+    return options(lz4Bundle());
+  }
+
+  @Override
+  public String[] sessionOptions() {
+    return new String[] {"advanced.protocol.compression = lz4"};
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiShadedIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiShadedIT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.osgi;
+
+import static com.datastax.oss.driver.osgi.BundleOptions.baseOptions;
+import static com.datastax.oss.driver.osgi.BundleOptions.driverCoreShadedBundle;
+import static com.datastax.oss.driver.osgi.BundleOptions.driverQueryBuilderBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+import com.google.common.collect.ObjectArrays;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+
+public class OsgiShadedIT extends OsgiBaseIT {
+
+  @Override
+  @Configuration
+  public Option[] config() {
+    return ObjectArrays.concat(
+        options(driverCoreShadedBundle(), driverQueryBuilderBundle(), baseOptions()),
+        additionalOptions(),
+        Option.class);
+  }
+
+  @Override
+  public Option[] additionalOptions() {
+    return new Option[0];
+  }
+
+  @Override
+  public String[] sessionOptions() {
+    return new String[0];
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiSnappyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiSnappyIT.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.osgi;
+
+import static com.datastax.oss.driver.osgi.BundleOptions.snappyBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+import org.ops4j.pax.exam.Option;
+
+public class OsgiSnappyIT extends OsgiBaseIT {
+
+  @Override
+  public Option[] additionalOptions() {
+    return options(snappyBundle());
+  }
+
+  @Override
+  public String[] sessionOptions() {
+    return new String[] {"advanced.protocol.compression = snappy"};
+  }
+}

--- a/manual/.nav
+++ b/manual/.nav
@@ -1,3 +1,4 @@
 core
 api_conventions
 case_sensitivity
+osgi

--- a/manual/README.md
+++ b/manual/README.md
@@ -9,3 +9,4 @@ Common topics:
 
 * [API conventions](api_conventions/)
 * [Case sensitivity](case_sensitivity/)
+* [OSGi](osgi/)

--- a/manual/core/shaded_jar/README.md
+++ b/manual/core/shaded_jar/README.md
@@ -1,0 +1,39 @@
+## Using the shaded JAR
+
+The default driver JAR depends on [Netty](http://netty.io/), which is
+used internally for networking.
+
+This explicit dependency can be a problem if your application already
+uses another Netty version. To avoid conflicts, we provide a "shaded"
+version of the JAR, which bundles the Netty classes under a different
+package name:
+
+```xml
+<dependency>
+  <groupId>com.datastax.oss</groupId>
+  <artifactId>java-driver-core-shaded</artifactId>
+  <version>4.0.0-alpha3</version>
+</dependency>
+```
+
+If you also use the query-builder or some other library that depends on java-driver-core, you need to remove its
+dependency to the non-shaded JAR:
+
+```xml
+<dependency>
+  <groupId>com.datastax.oss</groupId>
+  <artifactId>java-driver-core-shaded</artifactId>
+  <version>4.0.0-alpha3</version>
+</dependency>
+<dependency>
+  <groupId>com.datastax.oss</groupId>
+  <artifactId>java-driver-query-builder</artifactId>
+  <version>4.0.0-alpha3</version>
+  <exclusions>
+    <exclusion>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-core</artifactId>
+    </exclusion>
+  </exclusions>
+</dependency>
+```

--- a/manual/osgi/README.md
+++ b/manual/osgi/README.md
@@ -1,0 +1,75 @@
+# OSGi
+
+The driver is available as an [OSGi] bundle.  More specifically, the following maven artifacts are
+valid OSGi bundles:
+
+- `java-driver-core`
+- `java-driver-query-builder`
+- `java-driver-core-shaded`
+
+## Using the shaded jar
+
+`java-driver-core-shaded` shares the same bundle name as `java-driver-core`
+(`com.datastax.oss.driver.core`).  It can be used as a drop-in replacement in cases where you have
+an explicit version of dependency in your project different than that of the driver's.  Refer to
+[shaded jar](../core/shaded_jar/) for more information.
+
+## Using a custom `ClassLoader`
+
+In several places of the [driver configuration] it is possible to specify the class name of
+something to be instantiated by the driver such as the reconnection policy. This is accomplished
+using reflection, which uses a `ClassLoader`.  By default, the driver uses `Thread.currentThread
+.getContextClassLoader()` if available, otherwise it uses its own `ClassLoader`.  This is typically
+adequate except in environments like application containers or OSGi frameworks where class loading
+logic is much more deliberate and libraries are isolated from each other.
+
+If the chosen `ClassLoader` is not able to ascertain whether a loaded class is the same instance
+as its expected parent type, you may encounter an error such as:
+
+    java.lang.IllegalArgumentException: Expected class ExponentialReconnectionPolicy
+    (specified by advanced.reconnection-policy.class) to be a subtype of
+    com.datastax.oss.driver.api.core.connection.ReconnectionPolicy
+
+This is occurring because there is a disparity in the `ClassLoader`s used between the driver code
+and the `ClassLoader` used to reflectively load the class (in this case,
+`ExponentialReconnectionPolicy`).
+
+You may also encounter `ClassNotFoundException` if the `ClassLoader` does not have access to the
+class being loaded.
+
+To overcome these issues, you may specify a `ClassLoader` instance when constructing a `Session`
+by using [withClassLoader()].   In a lot of cases, it may be adequate to pass in the `ClassLoader`
+from a `Class` that is part of the core driver, i.e.:
+
+```java
+CqlSession session = CqlSession.builder()
+    .withClassLoader(CqlSession.class.getClassLoader())
+    .build();
+```
+
+## What does the "Error loading libc" DEBUG message mean?
+
+The driver is able to perform native system calls through [JNR] in some cases, for example to
+achieve microsecond resolution when [generating timestamps](../core/query_timestamps/).
+
+Unfortunately, some of the JNR artifacts available from Maven are not valid OSGi bundles and cannot
+be used in OSGi applications.
+
+[JAVA-1127] has been created to track this issue, and there is currently no simple workaround short
+of embedding the dependency, which we've chosen not to do.
+
+Because native calls are not available, it is also normal to see the following log lines when
+starting the driver:
+
+    [main] DEBUG - Error loading libc
+    java.lang.NoClassDefFoundError: jnr/ffi/LibraryLoader
+    ...
+    [main] INFO - Could not access native clock (see debug logs for details), falling back to Java
+    system clock
+
+
+[driver configuration]: ../core/configuration
+[OSGi]:https://www.osgi.org
+[JNR]: https://github.com/jnr/jnr-ffi
+[withClassLoader()]: https://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withClassLoader-java.lang.ClassLoader-
+[JAVA-1127]:https://datastax-oss.atlassian.net/browse/JAVA-1127

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
   <modules>
     <module>core</module>
+    <module>core-shaded</module>
     <module>query-builder</module>
     <module>test-infra</module>
     <module>integration-tests</module>

--- a/pom.xml
+++ b/pom.xml
@@ -35,15 +35,33 @@
 
   <modules>
     <module>core</module>
+    <module>query-builder</module>
     <module>test-infra</module>
     <module>integration-tests</module>
-    <module>query-builder</module>
   </modules>
 
   <properties>
     <format.validateOnly>true</format.validateOnly>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <config.version>1.3.1</config.version>
+    <guava.version>25.1-jre</guava.version>
+    <hdrhistogram.version>2.1.10</hdrhistogram.version>
+    <metrics.version>4.0.2</metrics.version>
+    <native-protocol.version>1.4.3-SNAPSHOT</native-protocol.version>
+    <netty.version>4.1.9.Final</netty.version>
+    <slf4j.version>1.7.25</slf4j.version>
+    <!-- optional dependencies -->
+    <snappy.version>1.1.2.6</snappy.version>
+    <lz4.version>1.4.1</lz4.version>
+    <!-- test dependencies -->
+    <assertj.version>3.6.2</assertj.version>
+    <commons-exec.version>1.3</commons-exec.version>
+    <jackson.version>2.9.5</jackson.version>
+    <junit.version>4.12</junit.version>
+    <logback.version>1.2.3</logback.version>
+    <pax-exam.version>4.11.0</pax-exam.version>
+    <simulacron.version>0.8.3</simulacron.version>
   </properties>
 
   <dependencyManagement>
@@ -51,38 +69,38 @@
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>native-protocol</artifactId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>${native-protocol.version}</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.1.9.Final</version>
+        <version>${netty.version}</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-shaded-guava</artifactId>
-        <version>24.1-jre</version>
+        <version>${guava.version}</version>
       </dependency>
       <dependency>
         <!-- Only for integration tests, use the shaded JAR for production code -->
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>24.1-jre</version>
+        <version>${guava.version}</version>
       </dependency>
       <dependency>
         <groupId>com.typesafe</groupId>
         <artifactId>config</artifactId>
-        <version>1.3.1</version>
+        <version>${config.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.25</version>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.2.3</version>
+        <version>${logback.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.jnr</groupId>
@@ -92,12 +110,12 @@
       <dependency>
         <groupId>org.xerial.snappy</groupId>
         <artifactId>snappy-java</artifactId>
-        <version>1.1.2.6</version>
+        <version>${snappy.version}</version>
       </dependency>
       <dependency>
         <groupId>org.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.4.1</version>
+        <version>${lz4.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.jnr</groupId>
@@ -107,12 +125,17 @@
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-core</artifactId>
-        <version>4.0.2</version>
+        <version>${metrics.version}</version>
       </dependency>
       <dependency>
         <groupId>org.hdrhistogram</groupId>
         <artifactId>HdrHistogram</artifactId>
-        <version>2.1.10</version>
+        <version>${hdrhistogram.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jctools</groupId>
+        <artifactId>jctools-core</artifactId>
+        <version>2.1.2</version>
       </dependency>
       <dependency>
         <groupId>com.github.stephenc.jcip</groupId>
@@ -122,7 +145,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.12</version>
+        <version>${junit.version}</version>
       </dependency>
       <dependency>
         <groupId>com.tngtech.java</groupId>
@@ -132,7 +155,7 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.6.2</version>
+        <version>${assertj.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
@@ -142,12 +165,32 @@
       <dependency>
         <groupId>com.datastax.oss.simulacron</groupId>
         <artifactId>simulacron-native-server</artifactId>
-        <version>0.8.1</version>
+        <version>${simulacron.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-exec</artifactId>
-        <version>1.3</version>
+        <version>${commons-exec.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-junit4</artifactId>
+        <version>${pax-exam.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-container-native</artifactId>
+        <version>${pax-exam.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>pax-exam-link-mvn</artifactId>
+        <version>${pax-exam.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>org.apache.felix.framework</artifactId>
+        <version>5.6.10</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -231,6 +274,11 @@
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>0.7.9</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>3.5.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -429,6 +477,22 @@ limitations under the License.]]>
           <goals>deploy</goals>
           <!-- Our integration tests are too long to run during a release, we run them in CI -->
           <arguments>-DskipParallelizableITs -DskipSerialITs -DskipIsolatedITs</arguments>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <_include>-osgi.bnd</_include>
+          </instructions>
+          <supportedProjectTypes>
+            <supportedProjectType>jar</supportedProjectType>
+            <supportedProjectType>bundle</supportedProjectType>
+            <supportedProjectType>pom</supportedProjectType>
+          </supportedProjectTypes>
         </configuration>
       </plugin>
     </plugins>

--- a/query-builder/pom.xml
+++ b/query-builder/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>java-driver-query-builder</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
 
   <name>DataStax Java driver for Apache Cassandra(R) - query builder</name>
 
@@ -56,4 +56,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.datastax.oss.driver.querybuilder</Bundle-SymbolicName>
+            <Import-Package>!net.jcip.annotations,*</Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/test-infra/pom.xml
+++ b/test-infra/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <artifactId>java-driver-test-infra</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
 
   <name>DataStax Java driver for Apache Cassandra(R) - test infrastructure tools</name>
 
@@ -52,4 +52,21 @@
       <artifactId>commons-exec</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>com.datastax.oss.driver.testinfra</Bundle-SymbolicName>
+            <!-- TODO: Only needed to use TestConfigLoader in integration-tests, remove this when we have
+                 a programmatic solution in core -->
+            <Export-Package>com.datastax.oss.driver.*.testinfra.*,com.datastax.oss.driver.assertions,com.datastax.oss.driver.categories</Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Motivation:

To enable the driver to be used in OSGi containers.

Modifications:

Use maven-bundle-plugin to add OSGi information to the generated
MANIFEST.MF.

Add jctools as a dependency instead of using netty-shaded
MpscLinkedAtomicQueue in DefaultWriteCoalescer.  This was required
because netty does not export its shaded jctools packages in its
Export-Package definition.

Change Reflection.buildFromConfig to use the expectedSuperType's
ClassLoader instead of the current Thread's ClassLoader when loading a
class.  This enables the driver to load classes from the core bundle in
OSGi, but may be problematic in other situations so this may be an
incomplete solution.

Add OSGi integration tests.

Make all dependency versions properties so they may be passed to
failsafe plugin for use in OSGi tests.

Result:

The driver now supports OSGi.