### PR TITLE
JAVA-1851: Make dependency to JCIP annotations non optional

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha4 (in progress)
 
+- [improvement] JAVA-1851: Make dependency to JCIP annotations non optional
 - [improvement] JAVA-1830: Surface response frame size in ExecutionInfo
 - [improvement] JAVA-1853: Add newValue(Object...) to TupleType and UserDefinedType
 - [improvement] JAVA-1815: Reorganize configuration into basic/advanced categories

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -84,9 +84,8 @@
       <artifactId>HdrHistogram</artifactId>
     </dependency>
     <dependency>
-      <groupId>net.jcip</groupId>
+      <groupId>com.github.stephenc.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -115,9 +115,9 @@
         <version>2.1.10</version>
       </dependency>
       <dependency>
-        <groupId>net.jcip</groupId>
+        <groupId>com.github.stephenc.jcip</groupId>
         <artifactId>jcip-annotations</artifactId>
-        <version>1.0</version>
+        <version>1.0-1</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>

--- a/query-builder/pom.xml
+++ b/query-builder/pom.xml
@@ -42,9 +42,8 @@
       <artifactId>java-driver-shaded-guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>net.jcip</groupId>
+      <groupId>com.github.stephenc.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Also switch to an Apache-licensed implementation, to avoid issues with
the Creative-Commons license.