### PR TITLE
JAVA-1858: Implement Serializable in implementations, not interfaces

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha4 (in progress)
 
+- [improvement] JAVA-1858: Implement Serializable in implementations, not interfaces
 - [improvement] JAVA-1851: Make dependency to JCIP annotations non optional
 - [improvement] JAVA-1830: Surface response frame size in ExecutionInfo
 - [improvement] JAVA-1853: Add newValue(Object...) to TupleType and UserDefinedType

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/ColumnDefinition.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/ColumnDefinition.java
@@ -18,10 +18,15 @@ package com.datastax.oss.driver.api.core.cql;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.detach.Detachable;
 import com.datastax.oss.driver.api.core.type.DataType;
-import java.io.Serializable;
 
-/** Metadata about a CQL column. */
-public interface ColumnDefinition extends Detachable, Serializable {
+/**
+ * Metadata about a CQL column.
+ *
+ * <p>The default implementation returned by the driver is immutable and serializable. If you write
+ * your own implementation, it should at least be thread-safe; serializability is not mandatory, but
+ * recommended for use with some 3rd-party tools like Apache Spark &trade;.
+ */
+public interface ColumnDefinition extends Detachable {
 
   CqlIdentifier getKeyspace();
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/ColumnDefinitions.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/ColumnDefinitions.java
@@ -18,10 +18,15 @@ package com.datastax.oss.driver.api.core.cql;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.data.AccessibleByName;
 import com.datastax.oss.driver.api.core.detach.Detachable;
-import java.io.Serializable;
 
-/** Metadata about a set of CQL columns. */
-public interface ColumnDefinitions extends Iterable<ColumnDefinition>, Detachable, Serializable {
+/**
+ * Metadata about a set of CQL columns.
+ *
+ * <p>The default implementation returned by the driver is immutable and serializable. If you write
+ * your own implementation, it should at least be thread-safe; serializability is not mandatory, but
+ * recommended for use with some 3rd-party tools like Apache Spark &trade;.
+ */
+public interface ColumnDefinitions extends Iterable<ColumnDefinition>, Detachable {
   int size();
 
   ColumnDefinition get(int i);

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/Row.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/Row.java
@@ -19,11 +19,15 @@ import com.datastax.oss.driver.api.core.data.GettableById;
 import com.datastax.oss.driver.api.core.data.GettableByIndex;
 import com.datastax.oss.driver.api.core.data.GettableByName;
 import com.datastax.oss.driver.api.core.detach.Detachable;
-import java.io.Serializable;
 
-/** A row from a CQL table. */
-public interface Row
-    extends GettableByIndex, GettableByName, GettableById, Detachable, Serializable {
+/**
+ * A row from a CQL table.
+ *
+ * <p>The default implementation returned by the driver is immutable and serializable. If you write
+ * your own implementation, it should at least be thread-safe; serializability is not mandatory, but
+ * recommended for use with some 3rd-party tools like Apache Spark &trade;.
+ */
+public interface Row extends GettableByIndex, GettableByName, GettableById, Detachable {
 
   ColumnDefinitions getColumnDefinitions();
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/TupleValue.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/TupleValue.java
@@ -17,7 +17,6 @@ package com.datastax.oss.driver.api.core.data;
 
 import com.datastax.oss.driver.api.core.detach.Detachable;
 import com.datastax.oss.driver.api.core.type.TupleType;
-import java.io.Serializable;
 
 /**
  * Driver-side representation of a CQL {@code tuple} value.
@@ -25,7 +24,11 @@ import java.io.Serializable;
  * <p>It is an ordered set of anonymous, typed fields.
  *
  * <p>A tuple value is attached if and only if its type is attached (see {@link Detachable}).
+ *
+ * <p>The default implementation returned by the driver is immutable and serializable. If you write
+ * your own implementation, it should at least be thread-safe; serializability is not mandatory, but
+ * recommended for use with some 3rd-party tools like Apache Spark &trade;.
  */
-public interface TupleValue extends GettableByIndex, SettableByIndex<TupleValue>, Serializable {
+public interface TupleValue extends GettableByIndex, SettableByIndex<TupleValue> {
   TupleType getType();
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/UdtValue.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/UdtValue.java
@@ -17,7 +17,6 @@ package com.datastax.oss.driver.api.core.data;
 
 import com.datastax.oss.driver.api.core.detach.Detachable;
 import com.datastax.oss.driver.api.core.type.UserDefinedType;
-import java.io.Serializable;
 
 /**
  * Driver-side representation of an instance of a CQL user defined type.
@@ -25,13 +24,13 @@ import java.io.Serializable;
  * <p>It is an ordered set of named, typed fields.
  *
  * <p>A tuple value is attached if and only if its type is attached (see {@link Detachable}).
+ *
+ * <p>The default implementation returned by the driver is immutable and serializable. If you write
+ * your own implementation, it should at least be thread-safe; serializability is not mandatory, but
+ * recommended for use with some 3rd-party tools like Apache Spark &trade;.
  */
 public interface UdtValue
-    extends GettableById,
-        GettableByName,
-        SettableById<UdtValue>,
-        SettableByName<UdtValue>,
-        Serializable {
+    extends GettableById, GettableByName, SettableById<UdtValue>, SettableByName<UdtValue> {
 
   UserDefinedType getType();
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/DataType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/DataType.java
@@ -17,14 +17,17 @@ package com.datastax.oss.driver.api.core.type;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.detach.Detachable;
-import java.io.Serializable;
 
 /**
  * The type of a CQL column, field or function argument.
  *
+ * <p>The default implementations returned by the driver are immutable and serializable. If you
+ * write your own implementations, they should at least be thread-safe; serializability is not
+ * mandatory, but recommended for use with some 3rd-party tools like Apache Spark &trade;.
+ *
  * @see DataTypes
  */
-public interface DataType extends Detachable, Serializable {
+public interface DataType extends Detachable {
   /** The code of the data type in the native protocol specification. */
   int getProtocolCode();
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultColumnDefinition.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultColumnDefinition.java
@@ -21,10 +21,11 @@ import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
 import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.driver.internal.core.type.DataTypeHelper;
 import com.datastax.oss.protocol.internal.response.result.ColumnSpec;
+import java.io.Serializable;
 import net.jcip.annotations.Immutable;
 
 @Immutable
-public class DefaultColumnDefinition implements ColumnDefinition {
+public class DefaultColumnDefinition implements ColumnDefinition, Serializable {
 
   private static final long serialVersionUID = 1;
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultColumnDefinitions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultColumnDefinitions.java
@@ -29,7 +29,7 @@ import java.util.List;
 import net.jcip.annotations.Immutable;
 
 @Immutable
-public class DefaultColumnDefinitions implements ColumnDefinitions {
+public class DefaultColumnDefinitions implements ColumnDefinitions, Serializable {
 
   public static ColumnDefinitions valueOf(List<ColumnDefinition> definitions) {
     return definitions.isEmpty()

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultRow.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultRow.java
@@ -32,7 +32,7 @@ import java.util.List;
 import net.jcip.annotations.Immutable;
 
 @Immutable
-public class DefaultRow implements Row {
+public class DefaultRow implements Row, Serializable {
 
   private final ColumnDefinitions definitions;
   private final List<ByteBuffer> data;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/data/DefaultTupleValue.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/data/DefaultTupleValue.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 import net.jcip.annotations.Immutable;
 
 @Immutable
-public class DefaultTupleValue implements TupleValue {
+public class DefaultTupleValue implements TupleValue, Serializable {
 
   private static final long serialVersionUID = 1;
   private final TupleType type;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/data/DefaultUdtValue.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/data/DefaultUdtValue.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 import net.jcip.annotations.Immutable;
 
 @Immutable
-public class DefaultUdtValue implements UdtValue {
+public class DefaultUdtValue implements UdtValue, Serializable {
 
   private static final long serialVersionUID = 1;
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/ShallowUserDefinedType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/ShallowUserDefinedType.java
@@ -24,6 +24,7 @@ import com.datastax.oss.driver.internal.core.type.DefaultUserDefinedType;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.List;
 import net.jcip.annotations.Immutable;
 
@@ -37,7 +38,9 @@ import net.jcip.annotations.Immutable;
  * definitions by the actual instance (which will be a {@link DefaultUserDefinedType}).
  */
 @Immutable
-public class ShallowUserDefinedType implements UserDefinedType {
+public class ShallowUserDefinedType implements UserDefinedType, Serializable {
+
+  private static final long serialVersionUID = 1;
 
   private final CqlIdentifier keyspace;
   private final CqlIdentifier name;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultCustomType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultCustomType.java
@@ -20,10 +20,11 @@ import com.datastax.oss.driver.api.core.type.CustomType;
 import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serializable;
 import net.jcip.annotations.Immutable;
 
 @Immutable
-public class DefaultCustomType implements CustomType {
+public class DefaultCustomType implements CustomType, Serializable {
 
   private static final long serialVersionUID = 1;
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultListType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultListType.java
@@ -21,11 +21,12 @@ import com.datastax.oss.driver.api.core.type.ListType;
 import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serializable;
 import java.util.Objects;
 import net.jcip.annotations.Immutable;
 
 @Immutable
-public class DefaultListType implements ListType {
+public class DefaultListType implements ListType, Serializable {
 
   private static final long serialVersionUID = 1;
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultMapType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultMapType.java
@@ -21,11 +21,12 @@ import com.datastax.oss.driver.api.core.type.MapType;
 import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serializable;
 import java.util.Objects;
 import net.jcip.annotations.Immutable;
 
 @Immutable
-public class DefaultMapType implements MapType {
+public class DefaultMapType implements MapType, Serializable {
 
   private static final long serialVersionUID = 1;
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultSetType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultSetType.java
@@ -21,11 +21,12 @@ import com.datastax.oss.driver.api.core.type.SetType;
 import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serializable;
 import java.util.Objects;
 import net.jcip.annotations.Immutable;
 
 @Immutable
-public class DefaultSetType implements SetType {
+public class DefaultSetType implements SetType, Serializable {
 
   private static final long serialVersionUID = 1;
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultTupleType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultTupleType.java
@@ -25,11 +25,12 @@ import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serializable;
 import java.util.List;
 import net.jcip.annotations.Immutable;
 
 @Immutable
-public class DefaultTupleType implements TupleType {
+public class DefaultTupleType implements TupleType, Serializable {
 
   private static final long serialVersionUID = 1;
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultUserDefinedType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultUserDefinedType.java
@@ -26,12 +26,13 @@ import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 import net.jcip.annotations.Immutable;
 
 @Immutable
-public class DefaultUserDefinedType implements UserDefinedType {
+public class DefaultUserDefinedType implements UserDefinedType, Serializable {
 
   private static final long serialVersionUID = 1;
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/PrimitiveType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/PrimitiveType.java
@@ -18,10 +18,11 @@ package com.datastax.oss.driver.internal.core.type;
 import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
 import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
+import java.io.Serializable;
 import net.jcip.annotations.Immutable;
 
 @Immutable
-public class PrimitiveType implements DataType {
+public class PrimitiveType implements DataType, Serializable {
 
   /** @serial */
   private final int protocolCode;


### PR DESCRIPTION
Motivation:

A few of our types are serializable (row, data types, etc.), this is
mainly for integration with Spark. By making our interfaces extend
Serializable, we signal that all possible implementations should do it,
this is not necessarily the case if someone writes their own version in
an application that doesn't use Spark.

Modifications:

Remove `extends Serializable` from the interfaces, have the default
classes implement it instead.
Document in the interfaces that serializability is recommended, but not
strictly mandatory.

Result:

Less burden on implementors if they're not interested in Spark
integration.