### PR TITLE
JAVA-1872: Retain table's views when processing table update

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 3.5.1
+
+- [bug] JAVA-1872: Retain table's views when processing table update.
+
+
 ### 3.5.0
 
 - [improvement] JAVA-1448: TokenAwarePolicy should respect child policy ordering.

--- a/driver-core/src/main/java/com/datastax/driver/core/MaterializedViewMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/MaterializedViewMetadata.java
@@ -30,7 +30,7 @@ public class MaterializedViewMetadata extends AbstractTableMetadata {
 
     private static final Logger logger = LoggerFactory.getLogger(MaterializedViewMetadata.class);
 
-    private final TableMetadata baseTable;
+    private volatile TableMetadata baseTable;
 
     private final boolean includeAllColumns;
 
@@ -211,6 +211,15 @@ public class MaterializedViewMetadata extends AbstractTableMetadata {
         appendOptions(sb, formatted);
         return sb.toString();
 
+    }
+
+    /**
+     * Updates the base table for this view and adds it to that table.  This is used when a table update
+     * is processed and the views need to be carried over.
+     */
+    void setBaseTable(TableMetadata table) {
+        this.baseTable = table;
+        table.add(this);
     }
 
     @Override

--- a/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/SchemaParser.java
@@ -307,8 +307,16 @@ abstract class SchemaParser {
             TableMetadata oldTable = oldTables.put(newTable.getName(), newTable);
             if (oldTable == null) {
                 metadata.triggerOnTableAdded(newTable);
-            } else if (!oldTable.equals(newTable)) {
-                metadata.triggerOnTableChanged(newTable, oldTable);
+            } else {
+                // if we're updating a table only, we need to copy views from old table to the new table.
+                if (tableToRebuild != null) {
+                    for (MaterializedViewMetadata view : oldTable.getViews()) {
+                        view.setBaseTable(newTable);
+                    }
+                }
+                if (!oldTable.equals(newTable)) {
+                    metadata.triggerOnTableChanged(newTable, oldTable);
+                }
             }
         }
     }


### PR DESCRIPTION
Motivation:

When a table update schema change event is received, the driver
creates a new TableMetadata instance for it and replaces the
existing one.

If that table has associated views, the driver currently does not
retain those views on the newly created TableMetadata instance.  This
change fixes that.

Modifications:

When a table update is received, update the base table on the views
tied to the old TableMetadata instance to the new one.  Added
MaterializedViewMetadata.setBaseTable to handle this.

Add SchemaChangesTest.should_retain_view_on_table_update to verify
this fix.

Result:

Views are now retained on table update schema events.