### PR TITLE
JAVA-1864: Add DataType.getTypeArguments()

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha4 (in progress)
 
+- [improvement] JAVA-1864: Add DataType.getTypeArguments()
 - [bug] JAVA-1560: Correctly propagate policy initialization errors
 - [improvement] JAVA-1865: Add RelationMetadata.getPrimaryKey()
 - [improvement] JAVA-1862: Add ConsistencyLevel.isDcLocal and isSerial

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/CustomType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/CustomType.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.api.core.type;
 
 import com.datastax.oss.protocol.internal.ProtocolConstants;
+import java.util.Collections;
 
 public interface CustomType extends DataType {
   /**
@@ -23,6 +24,11 @@ public interface CustomType extends DataType {
    * that represents this type server-side.
    */
   String getClassName();
+
+  @Override
+  default Iterable<DataType> getTypeArguments() {
+    return Collections.emptyList();
+  }
 
   @Override
   default String asCql(boolean includeFrozen, boolean pretty) {

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/DataType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/DataType.java
@@ -32,6 +32,18 @@ public interface DataType extends Detachable {
   int getProtocolCode();
 
   /**
+   * The type arguments of this type.
+   *
+   * <ul>
+   *   <li>for list and set types: the element type;
+   *   <li>for map types: the key type and the value type;
+   *   <li>for tuples and user defined types: the types of the fields;
+   *   <li>for all other types: an empty iterable.
+   * </ul>
+   */
+  Iterable<DataType> getTypeArguments();
+
+  /**
    * Builds an appropriate representation for use in a CQL query.
    *
    * @param includeFrozen whether to include the {@code frozen<...>} keyword if applicable. This

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/ListType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/ListType.java
@@ -15,10 +15,16 @@
  */
 package com.datastax.oss.driver.api.core.type;
 
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
 
 public interface ListType extends DataType {
   DataType getElementType();
+
+  @Override
+  default Iterable<DataType> getTypeArguments() {
+    return ImmutableList.of(getElementType());
+  }
 
   boolean isFrozen();
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/MapType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/MapType.java
@@ -15,12 +15,18 @@
  */
 package com.datastax.oss.driver.api.core.type;
 
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
 
 public interface MapType extends DataType {
   DataType getKeyType();
 
   DataType getValueType();
+
+  @Override
+  default Iterable<DataType> getTypeArguments() {
+    return ImmutableList.of(getKeyType(), getValueType());
+  }
 
   boolean isFrozen();
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/SetType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/SetType.java
@@ -15,10 +15,16 @@
  */
 package com.datastax.oss.driver.api.core.type;
 
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
 
 public interface SetType extends DataType {
   DataType getElementType();
+
+  @Override
+  default Iterable<DataType> getTypeArguments() {
+    return ImmutableList.of(getElementType());
+  }
 
   boolean isFrozen();
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/TupleType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/TupleType.java
@@ -24,6 +24,11 @@ import java.util.List;
 public interface TupleType extends DataType {
   List<DataType> getComponentTypes();
 
+  @Override
+  default Iterable<DataType> getTypeArguments() {
+    return getComponentTypes();
+  }
+
   TupleValue newValue();
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/UserDefinedType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/UserDefinedType.java
@@ -47,6 +47,11 @@ public interface UserDefinedType extends DataType, Describable {
 
   List<DataType> getFieldTypes();
 
+  @Override
+  default Iterable<DataType> getTypeArguments() {
+    return getFieldTypes();
+  }
+
   UserDefinedType copy(boolean newFrozen);
 
   UdtValue newValue();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/PrimitiveType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/PrimitiveType.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
 import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
 import java.io.Serializable;
+import java.util.Collections;
 import net.jcip.annotations.Immutable;
 
 @Immutable
@@ -34,6 +35,11 @@ public class PrimitiveType implements DataType, Serializable {
   @Override
   public int getProtocolCode() {
     return protocolCode;
+  }
+
+  @Override
+  public Iterable<DataType> getTypeArguments() {
+    return Collections.emptyList();
   }
 
   @Override


### PR DESCRIPTION
As simple as it is, I'm having seconds thoughts about this. The same arguments as for other methods in the original ticket apply: it doesn't add any functionality that isn't already available, the client can do it on their side in about 20 lines of code and a few `instanceof` checks (and arguably more efficiently if they don't need to allocate collections). So why extend our API surface with it?