### PR TITLE
JAVA-1624: Expose ExecutionInfo on exceptions where applicable

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-alpha4 (in progress)
 
+- [improvement] JAVA-1624: Expose ExecutionInfo on exceptions where applicable
 - [improvement] JAVA-1766: Revisit nullability
 - [new feature] JAVA-1860: Allow reconnection at startup if no contact point is available
 - [improvement] JAVA-1866: Make all public policies implement AutoCloseable

--- a/core/src/main/java/com/datastax/oss/driver/api/core/AllNodesFailedException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/AllNodesFailedException.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.driver.api.core;
 
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.shaded.guava.common.base.Joiner;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
@@ -57,13 +58,16 @@ public class AllNodesFailedException extends DriverException {
 
   private final Map<Node, Throwable> errors;
 
-  protected AllNodesFailedException(@NonNull String message, @NonNull Map<Node, Throwable> errors) {
-    super(message, null, true);
+  protected AllNodesFailedException(
+      @NonNull String message,
+      @Nullable ExecutionInfo executionInfo,
+      @NonNull Map<Node, Throwable> errors) {
+    super(message, null, null, true);
     this.errors = errors;
   }
 
   private AllNodesFailedException(Map<Node, Throwable> errors) {
-    this(buildMessage(errors), errors);
+    this(buildMessage(errors), null, errors);
   }
 
   private static String buildMessage(Map<Node, Throwable> errors) {
@@ -85,6 +89,6 @@ public class AllNodesFailedException extends DriverException {
   @NonNull
   @Override
   public DriverException copy() {
-    return new AllNodesFailedException(getMessage(), errors);
+    return new AllNodesFailedException(getMessage(), getExecutionInfo(), errors);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/DriverExecutionException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/DriverExecutionException.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.driver.api.core;
 
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -27,12 +28,16 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public class DriverExecutionException extends DriverException {
   public DriverExecutionException(Throwable cause) {
-    super(null, cause, true);
+    this(null, cause);
+  }
+
+  private DriverExecutionException(ExecutionInfo executionInfo, Throwable cause) {
+    super(null, executionInfo, cause, true);
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new DriverExecutionException(getCause());
+    return new DriverExecutionException(getExecutionInfo(), getCause());
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/DriverTimeoutException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/DriverTimeoutException.java
@@ -15,17 +15,22 @@
  */
 package com.datastax.oss.driver.api.core;
 
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /** Thrown when a driver request timed out. */
 public class DriverTimeoutException extends DriverException {
   public DriverTimeoutException(@NonNull String message) {
-    super(message, null, true);
+    this(message, null);
+  }
+
+  private DriverTimeoutException(String message, ExecutionInfo executionInfo) {
+    super(message, executionInfo, null, true);
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new DriverTimeoutException(getMessage());
+    return new DriverTimeoutException(getMessage(), getExecutionInfo());
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/InvalidKeyspaceException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/InvalidKeyspaceException.java
@@ -15,17 +15,22 @@
  */
 package com.datastax.oss.driver.api.core;
 
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /** Thrown when a session gets created with an invalid keyspace. */
 public class InvalidKeyspaceException extends DriverException {
   public InvalidKeyspaceException(@NonNull String message) {
-    super(message, null, true);
+    this(message, null);
+  }
+
+  private InvalidKeyspaceException(String message, ExecutionInfo executionInfo) {
+    super(message, executionInfo, null, true);
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new InvalidKeyspaceException(getMessage());
+    return new InvalidKeyspaceException(getMessage(), getExecutionInfo());
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/NoNodeAvailableException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/NoNodeAvailableException.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.driver.api.core;
 
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
 
@@ -26,12 +27,16 @@ import java.util.Collections;
  */
 public class NoNodeAvailableException extends AllNodesFailedException {
   public NoNodeAvailableException() {
-    super("No node was available to execute the query", Collections.emptyMap());
+    this(null);
+  }
+
+  private NoNodeAvailableException(ExecutionInfo executionInfo) {
+    super("No node was available to execute the query", executionInfo, Collections.emptyMap());
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new NoNodeAvailableException();
+    return new NoNodeAvailableException(getExecutionInfo());
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/RequestThrottlingException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/RequestThrottlingException.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.driver.api.core;
 
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -27,12 +28,16 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class RequestThrottlingException extends DriverException {
 
   public RequestThrottlingException(@NonNull String message) {
-    super(message, null, true);
+    this(message, null);
+  }
+
+  private RequestThrottlingException(String message, ExecutionInfo executionInfo) {
+    super(message, executionInfo, null, true);
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new RequestThrottlingException(getMessage());
+    return new RequestThrottlingException(getMessage(), getExecutionInfo());
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/UnsupportedProtocolVersionException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/UnsupportedProtocolVersionException.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.driver.api.core;
 
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -42,7 +43,7 @@ public class UnsupportedProtocolVersionException extends DriverException {
     String message =
         String.format("[%s] Host does not support protocol version %s", address, attemptedVersion);
     return new UnsupportedProtocolVersionException(
-        address, message, Collections.singletonList(attemptedVersion));
+        address, message, Collections.singletonList(attemptedVersion), null);
   }
 
   @NonNull
@@ -54,14 +55,22 @@ public class UnsupportedProtocolVersionException extends DriverException {
                 + "Note that the driver does not support Cassandra 2.0 or lower.",
             address, attemptedVersions);
     return new UnsupportedProtocolVersionException(
-        address, message, ImmutableList.copyOf(attemptedVersions));
+        address, message, ImmutableList.copyOf(attemptedVersions), null);
   }
 
   public UnsupportedProtocolVersionException(
       @Nullable SocketAddress address, // technically nullable, but should never be in real life
       @NonNull String message,
       @NonNull List<ProtocolVersion> attemptedVersions) {
-    super(message, null, true);
+    this(address, message, attemptedVersions, null);
+  }
+
+  private UnsupportedProtocolVersionException(
+      SocketAddress address,
+      String message,
+      List<ProtocolVersion> attemptedVersions,
+      ExecutionInfo executionInfo) {
+    super(message, executionInfo, null, true);
     this.address = address;
     this.attemptedVersions = attemptedVersions;
   }
@@ -81,6 +90,7 @@ public class UnsupportedProtocolVersionException extends DriverException {
   @NonNull
   @Override
   public DriverException copy() {
-    return new UnsupportedProtocolVersionException(address, getMessage(), attemptedVersions);
+    return new UnsupportedProtocolVersionException(
+        address, getMessage(), attemptedVersions, getExecutionInfo());
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/connection/BusyConnectionException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/connection/BusyConnectionException.java
@@ -17,6 +17,7 @@ package com.datastax.oss.driver.api.core.connection;
 
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -33,16 +34,18 @@ public class BusyConnectionException extends DriverException {
     this(
         String.format(
             "Connection has exceeded its maximum of %d simultaneous requests", maxAvailableIds),
+        null,
         false);
   }
 
-  private BusyConnectionException(String message, boolean writableStackTrace) {
-    super(message, null, writableStackTrace);
+  private BusyConnectionException(
+      String message, ExecutionInfo executionInfo, boolean writableStackTrace) {
+    super(message, executionInfo, null, writableStackTrace);
   }
 
   @Override
   @NonNull
   public DriverException copy() {
-    return new BusyConnectionException(getMessage(), true);
+    return new BusyConnectionException(getMessage(), getExecutionInfo(), true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/connection/ClosedConnectionException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/connection/ClosedConnectionException.java
@@ -41,7 +41,7 @@ public class ClosedConnectionException extends DriverException {
 
   private ClosedConnectionException(
       @NonNull String message, @Nullable Throwable cause, boolean writableStackTrace) {
-    super(message, cause, writableStackTrace);
+    super(message, null, cause, writableStackTrace);
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/api/core/connection/ConnectionInitException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/connection/ConnectionInitException.java
@@ -17,6 +17,7 @@ package com.datastax.oss.driver.api.core.connection;
 
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
@@ -29,12 +30,16 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  */
 public class ConnectionInitException extends DriverException {
   public ConnectionInitException(@NonNull String message, @Nullable Throwable cause) {
-    super(message, cause, true);
+    super(message, null, cause, true);
+  }
+
+  private ConnectionInitException(String message, ExecutionInfo executionInfo, Throwable cause) {
+    super(message, executionInfo, cause, true);
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new ConnectionInitException(getMessage(), getCause());
+    return new ConnectionInitException(getMessage(), getExecutionInfo(), getCause());
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/connection/FrameTooLongException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/connection/FrameTooLongException.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.api.core.connection;
 
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.net.SocketAddress;
 
@@ -30,7 +31,12 @@ public class FrameTooLongException extends DriverException {
   private final SocketAddress address;
 
   public FrameTooLongException(@NonNull SocketAddress address, @NonNull String message) {
-    super(message, null, false);
+    this(address, message, null);
+  }
+
+  private FrameTooLongException(
+      SocketAddress address, String message, ExecutionInfo executionInfo) {
+    super(message, executionInfo, null, false);
     this.address = address;
   }
 
@@ -43,6 +49,6 @@ public class FrameTooLongException extends DriverException {
   @NonNull
   @Override
   public DriverException copy() {
-    return new FrameTooLongException(address, getMessage());
+    return new FrameTooLongException(address, getMessage(), getExecutionInfo());
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/connection/HeartbeatException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/connection/HeartbeatException.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.api.core.connection;
 
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import com.datastax.oss.driver.api.core.session.Request;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -36,7 +37,12 @@ public class HeartbeatException extends DriverException {
 
   public HeartbeatException(
       @NonNull SocketAddress address, @Nullable String message, @Nullable Throwable cause) {
-    super(message, cause, true);
+    this(address, message, null, cause);
+  }
+
+  public HeartbeatException(
+      SocketAddress address, String message, ExecutionInfo executionInfo, Throwable cause) {
+    super(message, executionInfo, cause, true);
     this.address = address;
   }
 
@@ -49,6 +55,6 @@ public class HeartbeatException extends DriverException {
   @NonNull
   @Override
   public DriverException copy() {
-    return new HeartbeatException(address, getMessage(), getCause());
+    return new HeartbeatException(address, getMessage(), getExecutionInfo(), getCause());
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/AlreadyExistsException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/AlreadyExistsException.java
@@ -16,9 +16,11 @@
 package com.datastax.oss.driver.api.core.servererrors;
 
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Thrown when a query attempts to create a keyspace or table that already exists.
@@ -33,7 +35,7 @@ public class AlreadyExistsException extends QueryValidationException {
 
   public AlreadyExistsException(
       @NonNull Node coordinator, @NonNull String keyspace, @NonNull String table) {
-    this(coordinator, makeMessage(keyspace, table), keyspace, table, false);
+    this(coordinator, makeMessage(keyspace, table), keyspace, table, null, false);
   }
 
   private AlreadyExistsException(
@@ -41,8 +43,9 @@ public class AlreadyExistsException extends QueryValidationException {
       @NonNull String message,
       @NonNull String keyspace,
       @NonNull String table,
+      @Nullable ExecutionInfo executionInfo,
       boolean writableStackTrace) {
-    super(coordinator, message, writableStackTrace);
+    super(coordinator, message, executionInfo, writableStackTrace);
     this.keyspace = keyspace;
     this.table = table;
   }
@@ -58,6 +61,7 @@ public class AlreadyExistsException extends QueryValidationException {
   @NonNull
   @Override
   public DriverException copy() {
-    return new AlreadyExistsException(getCoordinator(), getMessage(), keyspace, table, true);
+    return new AlreadyExistsException(
+        getCoordinator(), getMessage(), keyspace, table, getExecutionInfo(), true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/BootstrappingException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/BootstrappingException.java
@@ -17,9 +17,11 @@ package com.datastax.oss.driver.api.core.servererrors;
 
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Thrown when the coordinator was bootstrapping when it received a query.
@@ -31,17 +33,20 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class BootstrappingException extends QueryExecutionException {
 
   public BootstrappingException(@NonNull Node coordinator) {
-    super(coordinator, String.format("%s is bootstrapping", coordinator), false);
+    this(coordinator, String.format("%s is bootstrapping", coordinator), null, false);
   }
 
   private BootstrappingException(
-      @NonNull Node coordinator, @NonNull String message, boolean writableStackTrace) {
-    super(coordinator, message, writableStackTrace);
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @Nullable ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(coordinator, message, executionInfo, writableStackTrace);
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new BootstrappingException(getCoordinator(), getMessage(), true);
+    return new BootstrappingException(getCoordinator(), getMessage(), getExecutionInfo(), true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/CoordinatorException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/CoordinatorException.java
@@ -16,20 +16,29 @@
 package com.datastax.oss.driver.api.core.servererrors;
 
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /** A server-side error thrown by the coordinator node in response to a driver request. */
 public abstract class CoordinatorException extends DriverException {
 
+  // This is also present on ExecutionInfo. But the execution info is only set for errors that are
+  // rethrown to the client, not on errors that get retried. It can be useful to know the node in
+  // the retry policy, so store it here, it might be duplicated but that doesn't matter.
   private final Node coordinator;
 
   protected CoordinatorException(
-      @NonNull Node coordinator, @NonNull String message, boolean writableStackTrace) {
-    super(message, null, writableStackTrace);
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @Nullable ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(message, executionInfo, null, writableStackTrace);
     this.coordinator = coordinator;
   }
 
+  @NonNull
   public Node getCoordinator() {
     return coordinator;
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/FunctionFailureException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/FunctionFailureException.java
@@ -16,9 +16,11 @@
 package com.datastax.oss.driver.api.core.servererrors;
 
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * An error during the execution of a CQL function.
@@ -29,17 +31,20 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class FunctionFailureException extends QueryExecutionException {
 
   public FunctionFailureException(@NonNull Node coordinator, @NonNull String message) {
-    this(coordinator, message, false);
+    this(coordinator, message, null, false);
   }
 
   private FunctionFailureException(
-      @NonNull Node coordinator, @NonNull String message, boolean writableStackTrace) {
-    super(coordinator, message, writableStackTrace);
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @Nullable ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(coordinator, message, executionInfo, writableStackTrace);
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new FunctionFailureException(getCoordinator(), getMessage(), true);
+    return new FunctionFailureException(getCoordinator(), getMessage(), getExecutionInfo(), true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/InvalidConfigurationInQueryException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/InvalidConfigurationInQueryException.java
@@ -16,9 +16,11 @@
 package com.datastax.oss.driver.api.core.servererrors;
 
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Indicates that a query is invalid because of some configuration problem.
@@ -32,17 +34,21 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class InvalidConfigurationInQueryException extends QueryValidationException {
 
   public InvalidConfigurationInQueryException(@NonNull Node coordinator, @NonNull String message) {
-    this(coordinator, message, false);
+    this(coordinator, message, null, false);
   }
 
   private InvalidConfigurationInQueryException(
-      @NonNull Node coordinator, @NonNull String message, boolean writableStackTrace) {
-    super(coordinator, message, writableStackTrace);
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @Nullable ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(coordinator, message, executionInfo, writableStackTrace);
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new InvalidConfigurationInQueryException(getCoordinator(), getMessage(), true);
+    return new InvalidConfigurationInQueryException(
+        getCoordinator(), getMessage(), getExecutionInfo(), true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/InvalidQueryException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/InvalidQueryException.java
@@ -16,9 +16,11 @@
 package com.datastax.oss.driver.api.core.servererrors;
 
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Indicates a syntactically correct, but invalid query.
@@ -29,17 +31,20 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class InvalidQueryException extends QueryValidationException {
 
   public InvalidQueryException(@NonNull Node coordinator, @NonNull String message) {
-    this(coordinator, message, false);
+    this(coordinator, message, null, false);
   }
 
   private InvalidQueryException(
-      @NonNull Node coordinator, @NonNull String message, boolean writableStackTrace) {
-    super(coordinator, message, writableStackTrace);
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @Nullable ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(coordinator, message, executionInfo, writableStackTrace);
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new InvalidQueryException(getCoordinator(), getMessage(), true);
+    return new InvalidQueryException(getCoordinator(), getMessage(), getExecutionInfo(), true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/OverloadedException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/OverloadedException.java
@@ -17,10 +17,12 @@ package com.datastax.oss.driver.api.core.servererrors;
 
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import com.datastax.oss.driver.api.core.session.Request;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Thrown when the coordinator reported itself as being overloaded.
@@ -33,17 +35,20 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class OverloadedException extends QueryExecutionException {
 
   public OverloadedException(@NonNull Node coordinator) {
-    super(coordinator, String.format("%s is bootstrapping", coordinator), false);
+    super(coordinator, String.format("%s is bootstrapping", coordinator), null, false);
   }
 
   private OverloadedException(
-      @NonNull Node coordinator, @NonNull String message, boolean writableStackTrace) {
-    super(coordinator, message, writableStackTrace);
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @Nullable ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(coordinator, message, executionInfo, writableStackTrace);
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new OverloadedException(getCoordinator(), getMessage(), true);
+    return new OverloadedException(getCoordinator(), getMessage(), getExecutionInfo(), true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/ProtocolError.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/ProtocolError.java
@@ -16,9 +16,11 @@
 package com.datastax.oss.driver.api.core.servererrors;
 
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Indicates that the contacted node reported a protocol error.
@@ -33,17 +35,20 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class ProtocolError extends CoordinatorException {
 
   public ProtocolError(@NonNull Node coordinator, @NonNull String message) {
-    this(coordinator, message, false);
+    this(coordinator, message, null, false);
   }
 
   private ProtocolError(
-      @NonNull Node coordinator, @NonNull String message, boolean writableStackTrace) {
-    super(coordinator, message, writableStackTrace);
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @Nullable ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(coordinator, message, executionInfo, writableStackTrace);
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new ProtocolError(getCoordinator(), getMessage(), true);
+    return new ProtocolError(getCoordinator(), getMessage(), getExecutionInfo(), true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/QueryConsistencyException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/QueryConsistencyException.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.api.core.servererrors;
 
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -43,8 +44,9 @@ public abstract class QueryConsistencyException extends QueryExecutionException 
       @NonNull ConsistencyLevel consistencyLevel,
       int received,
       int blockFor,
+      ExecutionInfo executionInfo,
       boolean writableStackTrace) {
-    super(coordinator, message, writableStackTrace);
+    super(coordinator, message, executionInfo, writableStackTrace);
     this.consistencyLevel = consistencyLevel;
     this.received = received;
     this.blockFor = blockFor;

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/QueryExecutionException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/QueryExecutionException.java
@@ -15,14 +15,19 @@
  */
 package com.datastax.oss.driver.api.core.servererrors;
 
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /** A server-side error thrown when a valid query cannot be executed. */
 public abstract class QueryExecutionException extends CoordinatorException {
 
   protected QueryExecutionException(
-      @NonNull Node coordinator, @NonNull String message, boolean writableStackTrace) {
-    super(coordinator, message, writableStackTrace);
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @Nullable ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(coordinator, message, executionInfo, writableStackTrace);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/QueryValidationException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/QueryValidationException.java
@@ -15,8 +15,10 @@
  */
 package com.datastax.oss.driver.api.core.servererrors;
 
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A server-side error thrown when a query cannot be executed because it is syntactically incorrect,
@@ -25,7 +27,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public abstract class QueryValidationException extends CoordinatorException {
 
   protected QueryValidationException(
-      @NonNull Node coordinator, @NonNull String message, boolean writableStackTrace) {
-    super(coordinator, message, writableStackTrace);
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @Nullable ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(coordinator, message, executionInfo, writableStackTrace);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/ReadFailureException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/ReadFailureException.java
@@ -18,10 +18,12 @@ package com.datastax.oss.driver.api.core.servererrors;
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import com.datastax.oss.driver.api.core.session.Request;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.net.InetAddress;
 import java.util.Map;
 
@@ -62,6 +64,7 @@ public class ReadFailureException extends QueryConsistencyException {
         numFailures,
         dataPresent,
         reasonMap,
+        null,
         false);
   }
 
@@ -74,8 +77,16 @@ public class ReadFailureException extends QueryConsistencyException {
       int numFailures,
       boolean dataPresent,
       @NonNull Map<InetAddress, Integer> reasonMap,
+      @Nullable ExecutionInfo executionInfo,
       boolean writableStackTrace) {
-    super(coordinator, message, consistencyLevel, received, blockFor, writableStackTrace);
+    super(
+        coordinator,
+        message,
+        consistencyLevel,
+        received,
+        blockFor,
+        executionInfo,
+        writableStackTrace);
     this.numFailures = numFailures;
     this.dataPresent = dataPresent;
     this.reasonMap = reasonMap;
@@ -134,6 +145,7 @@ public class ReadFailureException extends QueryConsistencyException {
         numFailures,
         dataPresent,
         reasonMap,
+        getExecutionInfo(),
         true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/ReadTimeoutException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/ReadTimeoutException.java
@@ -18,6 +18,7 @@ package com.datastax.oss.driver.api.core.servererrors;
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import com.datastax.oss.driver.api.core.session.Request;
@@ -50,6 +51,7 @@ public class ReadTimeoutException extends QueryConsistencyException {
         received,
         blockFor,
         dataPresent,
+        null,
         false);
   }
 
@@ -60,8 +62,16 @@ public class ReadTimeoutException extends QueryConsistencyException {
       int received,
       int blockFor,
       boolean dataPresent,
+      ExecutionInfo executionInfo,
       boolean writableStackTrace) {
-    super(coordinator, message, consistencyLevel, received, blockFor, writableStackTrace);
+    super(
+        coordinator,
+        message,
+        consistencyLevel,
+        received,
+        blockFor,
+        executionInfo,
+        writableStackTrace);
     this.dataPresent = dataPresent;
   }
 
@@ -98,6 +108,7 @@ public class ReadTimeoutException extends QueryConsistencyException {
         getReceived(),
         getBlockFor(),
         dataPresent,
+        getExecutionInfo(),
         true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/ServerError.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/ServerError.java
@@ -17,10 +17,12 @@ package com.datastax.oss.driver.api.core.servererrors;
 
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import com.datastax.oss.driver.api.core.session.Request;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Indicates that the contacted node reported an internal error.
@@ -35,17 +37,20 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class ServerError extends CoordinatorException {
 
   public ServerError(@NonNull Node coordinator, @NonNull String message) {
-    this(coordinator, message, false);
+    this(coordinator, message, null, false);
   }
 
   private ServerError(
-      @NonNull Node coordinator, @NonNull String message, boolean writableStackTrace) {
-    super(coordinator, message, writableStackTrace);
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @Nullable ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(coordinator, message, executionInfo, writableStackTrace);
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new ServerError(getCoordinator(), getMessage(), true);
+    return new ServerError(getCoordinator(), getMessage(), getExecutionInfo(), true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/SyntaxError.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/SyntaxError.java
@@ -16,9 +16,11 @@
 package com.datastax.oss.driver.api.core.servererrors;
 
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A syntax error in a query.
@@ -29,17 +31,20 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class SyntaxError extends QueryValidationException {
 
   public SyntaxError(@NonNull Node coordinator, @NonNull String message) {
-    this(coordinator, message, false);
+    this(coordinator, message, null, false);
   }
 
   private SyntaxError(
-      @NonNull Node coordinator, @NonNull String message, boolean writableStackTrace) {
-    super(coordinator, message, writableStackTrace);
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @Nullable ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(coordinator, message, executionInfo, writableStackTrace);
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new SyntaxError(getCoordinator(), getMessage(), true);
+    return new SyntaxError(getCoordinator(), getMessage(), getExecutionInfo(), true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/TruncateException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/TruncateException.java
@@ -17,10 +17,12 @@ package com.datastax.oss.driver.api.core.servererrors;
 
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import com.datastax.oss.driver.api.core.session.Request;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * An error during a truncation operation.
@@ -33,17 +35,20 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class TruncateException extends QueryExecutionException {
 
   public TruncateException(@NonNull Node coordinator, @NonNull String message) {
-    this(coordinator, message, false);
+    this(coordinator, message, null, false);
   }
 
   private TruncateException(
-      @NonNull Node coordinator, @NonNull String message, boolean writableStackTrace) {
-    super(coordinator, message, writableStackTrace);
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @Nullable ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(coordinator, message, executionInfo, writableStackTrace);
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new TruncateException(getCoordinator(), getMessage(), true);
+    return new TruncateException(getCoordinator(), getMessage(), getExecutionInfo(), true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/UnauthorizedException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/UnauthorizedException.java
@@ -16,9 +16,11 @@
 package com.datastax.oss.driver.api.core.servererrors;
 
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Indicates that a query cannot be performed due to the authorization restrictions of the logged
@@ -30,17 +32,20 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class UnauthorizedException extends QueryValidationException {
 
   public UnauthorizedException(@NonNull Node coordinator, @NonNull String message) {
-    this(coordinator, message, false);
+    this(coordinator, message, null, false);
   }
 
   private UnauthorizedException(
-      @NonNull Node coordinator, @NonNull String message, boolean writableStackTrace) {
-    super(coordinator, message, writableStackTrace);
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @Nullable ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(coordinator, message, executionInfo, writableStackTrace);
   }
 
   @NonNull
   @Override
   public DriverException copy() {
-    return new UnauthorizedException(getCoordinator(), getMessage(), true);
+    return new UnauthorizedException(getCoordinator(), getMessage(), getExecutionInfo(), true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/UnavailableException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/UnavailableException.java
@@ -18,6 +18,7 @@ package com.datastax.oss.driver.api.core.servererrors;
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import com.datastax.oss.driver.api.core.session.Request;
@@ -50,6 +51,7 @@ public class UnavailableException extends QueryExecutionException {
         consistencyLevel,
         required,
         alive,
+        null,
         false);
   }
 
@@ -59,8 +61,9 @@ public class UnavailableException extends QueryExecutionException {
       @NonNull ConsistencyLevel consistencyLevel,
       int required,
       int alive,
+      ExecutionInfo executionInfo,
       boolean writableStackTrace) {
-    super(coordinator, message, writableStackTrace);
+    super(coordinator, message, executionInfo, writableStackTrace);
     this.consistencyLevel = consistencyLevel;
     this.required = required;
     this.alive = alive;
@@ -92,6 +95,12 @@ public class UnavailableException extends QueryExecutionException {
   @Override
   public DriverException copy() {
     return new UnavailableException(
-        getCoordinator(), getMessage(), consistencyLevel, required, alive, true);
+        getCoordinator(),
+        getMessage(),
+        consistencyLevel,
+        required,
+        alive,
+        getExecutionInfo(),
+        true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/WriteFailureException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/WriteFailureException.java
@@ -18,10 +18,12 @@ package com.datastax.oss.driver.api.core.servererrors;
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import com.datastax.oss.driver.api.core.session.Request;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.net.InetAddress;
 import java.util.Map;
 
@@ -62,6 +64,7 @@ public class WriteFailureException extends QueryConsistencyException {
         writeType,
         numFailures,
         reasonMap,
+        null,
         false);
   }
 
@@ -74,8 +77,16 @@ public class WriteFailureException extends QueryConsistencyException {
       @NonNull WriteType writeType,
       int numFailures,
       @NonNull Map<InetAddress, Integer> reasonMap,
+      @Nullable ExecutionInfo executionInfo,
       boolean writableStackTrace) {
-    super(coordinator, message, consistencyLevel, received, blockFor, writableStackTrace);
+    super(
+        coordinator,
+        message,
+        consistencyLevel,
+        received,
+        blockFor,
+        executionInfo,
+        writableStackTrace);
     this.writeType = writeType;
     this.numFailures = numFailures;
     this.reasonMap = reasonMap;
@@ -128,6 +139,7 @@ public class WriteFailureException extends QueryConsistencyException {
         writeType,
         numFailures,
         reasonMap,
+        getExecutionInfo(),
         true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/WriteTimeoutException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/WriteTimeoutException.java
@@ -18,10 +18,12 @@ package com.datastax.oss.driver.api.core.servererrors;
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import com.datastax.oss.driver.api.core.session.Request;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A server-side timeout during a write query.
@@ -51,6 +53,7 @@ public class WriteTimeoutException extends QueryConsistencyException {
         received,
         blockFor,
         writeType,
+        null,
         false);
   }
 
@@ -61,8 +64,16 @@ public class WriteTimeoutException extends QueryConsistencyException {
       int received,
       int blockFor,
       @NonNull WriteType writeType,
+      @Nullable ExecutionInfo executionInfo,
       boolean writableStackTrace) {
-    super(coordinator, message, consistencyLevel, received, blockFor, writableStackTrace);
+    super(
+        coordinator,
+        message,
+        consistencyLevel,
+        received,
+        blockFor,
+        executionInfo,
+        writableStackTrace);
     this.writeType = writeType;
   }
 
@@ -82,6 +93,7 @@ public class WriteTimeoutException extends QueryConsistencyException {
         getReceived(),
         getBlockFor(),
         writeType,
+        getExecutionInfo(),
         true);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultExecutionInfo.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultExecutionInfo.java
@@ -90,7 +90,7 @@ public class DefaultExecutionInfo implements ExecutionInfo {
     return statement;
   }
 
-  @NonNull
+  @Nullable
   @Override
   public Node getCoordinator() {
     return coordinator;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/session/ExceptionIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/session/ExceptionIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.session;
+
+import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.unavailable;
+import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.servererrors.InvalidQueryException;
+import com.datastax.oss.driver.api.core.servererrors.UnavailableException;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+import com.datastax.oss.simulacron.common.stubbing.PrimeDsl;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(ParallelizableTests.class)
+public class ExceptionIT {
+
+  @ClassRule
+  public static SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(2));
+
+  @ClassRule
+  public static SessionRule<CqlSession> sessionRule =
+      SessionRule.builder(simulacron)
+          .withOptions(
+              "basic.load-balancing-policy.class = com.datastax.oss.driver.api.testinfra.loadbalancing.SortingLoadBalancingPolicy",
+              "advanced.retry-policy.class = DefaultRetryPolicy")
+          .build();
+
+  private static String QUERY_STRING = "select * from foo";
+
+  @Before
+  public void clear() {
+    simulacron.cluster().clearLogs();
+  }
+
+  @Test
+  public void should_expose_execution_info_on_exceptions() {
+    // Given
+    simulacron
+        .cluster()
+        .node(0)
+        .prime(
+            when(QUERY_STRING)
+                .then(
+                    unavailable(
+                        com.datastax.oss.simulacron.common.codec.ConsistencyLevel.ONE, 1, 0)));
+    simulacron
+        .cluster()
+        .node(1)
+        .prime(when(QUERY_STRING).then(PrimeDsl.invalid("Mock error message")));
+
+    // Then
+    assertThatThrownBy(() -> sessionRule.session().execute(QUERY_STRING))
+        .isInstanceOf(InvalidQueryException.class)
+        .satisfies(
+            exception -> {
+              ExecutionInfo info = ((InvalidQueryException) exception).getExecutionInfo();
+              assertThat(info).isNotNull();
+              assertThat(info.getCoordinator().getConnectAddress())
+                  .isEqualTo(simulacron.cluster().node(1).inetSocketAddress());
+              assertThat(((SimpleStatement) info.getStatement()).getQuery())
+                  .isEqualTo(QUERY_STRING);
+
+              // specex disabled => the initial execution completed the response
+              assertThat(info.getSpeculativeExecutionCount()).isEqualTo(0);
+              assertThat(info.getSuccessfulExecutionIndex()).isEqualTo(0);
+
+              assertThat(info.getTracingId()).isNull();
+              assertThat(info.getPagingState()).isNull();
+              assertThat(info.getIncomingPayload()).isEmpty();
+              assertThat(info.getWarnings()).isEmpty();
+              assertThat(info.isSchemaInAgreement()).isTrue();
+              assertThat(info.getResponseSizeInBytes())
+                  .isEqualTo(info.getCompressedResponseSizeInBytes())
+                  .isEqualTo(-1);
+
+              List<Map.Entry<Node, Throwable>> errors = info.getErrors();
+              assertThat(errors).hasSize(1);
+              Map.Entry<Node, Throwable> entry0 = errors.get(0);
+              assertThat(entry0.getKey().getConnectAddress())
+                  .isEqualTo(simulacron.cluster().node(0).inetSocketAddress());
+              Throwable node0Exception = entry0.getValue();
+              assertThat(node0Exception).isInstanceOf(UnavailableException.class);
+              // ExecutionInfo is not exposed for retried errors
+              assertThat(((UnavailableException) node0Exception).getExecutionInfo()).isNull();
+            });
+  }
+}


### PR DESCRIPTION
New field: `DriverException.getExecutionInfo()`.

The challenge is that exceptions are sometimes thrown from deeper into the stack, where we don't have all the information to build the `ExecutionInfo`. To solve this, the field is set later, in `CqlRequestHandlerBase.setFinalError()`. This requires making it volatile which is not particularly elegant, but since we're dealing with exceptional conditions I think that's a fair compromise.

TODO
- [x] update nullability annotations (from #1036) on `ExecutionInfo` if needed