### PR TITLE
JAVA-1897: Improve extensibility of schema metadata classes

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-beta1 (in progress)
 
+- [improvement] JAVA-1897: Improve extensibility of schema metadata classes
 - [improvement] JAVA-1437: Enable SSL hostname validation by default
 - [improvement] JAVA-1879: Duplicate basic.request options as Request/Statement attributes
 - [improvement] JAVA-1870: Use sensible defaults in RequestLogger if config options are missing

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/Metadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/Metadata.java
@@ -53,10 +53,10 @@ public interface Metadata {
    * @see DefaultDriverOption#METADATA_SCHEMA_REFRESHED_KEYSPACES
    */
   @NonNull
-  Map<CqlIdentifier, KeyspaceMetadata> getKeyspaces();
+  Map<CqlIdentifier, ? extends KeyspaceMetadata> getKeyspaces();
 
   @NonNull
-  default Optional<KeyspaceMetadata> getKeyspace(@NonNull CqlIdentifier keyspaceId) {
+  default Optional<? extends KeyspaceMetadata> getKeyspace(@NonNull CqlIdentifier keyspaceId) {
     return Optional.ofNullable(getKeyspaces().get(keyspaceId));
   }
 
@@ -65,7 +65,7 @@ public interface Metadata {
    * getKeyspace(CqlIdentifier.fromCql(keyspaceName))}.
    */
   @NonNull
-  default Optional<KeyspaceMetadata> getKeyspace(@NonNull String keyspaceName) {
+  default Optional<? extends KeyspaceMetadata> getKeyspace(@NonNull String keyspaceName) {
     return getKeyspace(CqlIdentifier.fromCql(keyspaceName));
   }
 
@@ -78,5 +78,5 @@ public interface Metadata {
    * @see DefaultDriverOption#METADATA_TOKEN_MAP_ENABLED
    */
   @NonNull
-  Optional<TokenMap> getTokenMap();
+  Optional<? extends TokenMap> getTokenMap();
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/schema/KeyspaceMetadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/schema/KeyspaceMetadata.java
@@ -39,25 +39,26 @@ public interface KeyspaceMetadata extends Describable {
   Map<String, String> getReplication();
 
   @NonNull
-  Map<CqlIdentifier, TableMetadata> getTables();
+  Map<CqlIdentifier, ? extends TableMetadata> getTables();
 
   @NonNull
-  default Optional<TableMetadata> getTable(@NonNull CqlIdentifier tableId) {
+  default Optional<? extends TableMetadata> getTable(@NonNull CqlIdentifier tableId) {
     return Optional.ofNullable(getTables().get(tableId));
   }
 
   /** Shortcut for {@link #getTable(CqlIdentifier) getTable(CqlIdentifier.fromCql(tableName))}. */
   @NonNull
-  default Optional<TableMetadata> getTable(@NonNull String tableName) {
+  default Optional<? extends TableMetadata> getTable(@NonNull String tableName) {
     return getTable(CqlIdentifier.fromCql(tableName));
   }
 
   @NonNull
-  Map<CqlIdentifier, ViewMetadata> getViews();
+  Map<CqlIdentifier, ? extends ViewMetadata> getViews();
 
   /** Gets the views based on a given table. */
   @NonNull
-  default Map<CqlIdentifier, ViewMetadata> getViewsOnTable(@NonNull CqlIdentifier tableId) {
+  default Map<CqlIdentifier, ? extends ViewMetadata> getViewsOnTable(
+      @NonNull CqlIdentifier tableId) {
     ImmutableMap.Builder<CqlIdentifier, ViewMetadata> builder = ImmutableMap.builder();
     for (ViewMetadata view : getViews().values()) {
       if (view.getBaseTable().equals(tableId)) {
@@ -68,21 +69,21 @@ public interface KeyspaceMetadata extends Describable {
   }
 
   @NonNull
-  default Optional<ViewMetadata> getView(@NonNull CqlIdentifier viewId) {
+  default Optional<? extends ViewMetadata> getView(@NonNull CqlIdentifier viewId) {
     return Optional.ofNullable(getViews().get(viewId));
   }
 
   /** Shortcut for {@link #getView(CqlIdentifier) getView(CqlIdentifier.fromCql(viewName))}. */
   @NonNull
-  default Optional<ViewMetadata> getView(@NonNull String viewName) {
+  default Optional<? extends ViewMetadata> getView(@NonNull String viewName) {
     return getView(CqlIdentifier.fromCql(viewName));
   }
 
   @NonNull
-  Map<CqlIdentifier, UserDefinedType> getUserDefinedTypes();
+  Map<CqlIdentifier, ? extends UserDefinedType> getUserDefinedTypes();
 
   @NonNull
-  default Optional<UserDefinedType> getUserDefinedType(@NonNull CqlIdentifier typeId) {
+  default Optional<? extends UserDefinedType> getUserDefinedType(@NonNull CqlIdentifier typeId) {
     return Optional.ofNullable(getUserDefinedTypes().get(typeId));
   }
 
@@ -91,20 +92,21 @@ public interface KeyspaceMetadata extends Describable {
    * getUserDefinedType(CqlIdentifier.fromCql(typeName))}.
    */
   @NonNull
-  default Optional<UserDefinedType> getUserDefinedType(@NonNull String typeName) {
+  default Optional<? extends UserDefinedType> getUserDefinedType(@NonNull String typeName) {
     return getUserDefinedType(CqlIdentifier.fromCql(typeName));
   }
 
   @NonNull
-  Map<FunctionSignature, FunctionMetadata> getFunctions();
+  Map<FunctionSignature, ? extends FunctionMetadata> getFunctions();
 
   @NonNull
-  default Optional<FunctionMetadata> getFunction(@NonNull FunctionSignature functionSignature) {
+  default Optional<? extends FunctionMetadata> getFunction(
+      @NonNull FunctionSignature functionSignature) {
     return Optional.ofNullable(getFunctions().get(functionSignature));
   }
 
   @NonNull
-  default Optional<FunctionMetadata> getFunction(
+  default Optional<? extends FunctionMetadata> getFunction(
       @NonNull CqlIdentifier functionId, @NonNull Iterable<DataType> parameterTypes) {
     return Optional.ofNullable(
         getFunctions().get(new FunctionSignature(functionId, parameterTypes)));
@@ -115,7 +117,7 @@ public interface KeyspaceMetadata extends Describable {
    * getFunction(CqlIdentifier.fromCql(functionName), parameterTypes)}.
    */
   @NonNull
-  default Optional<FunctionMetadata> getFunction(
+  default Optional<? extends FunctionMetadata> getFunction(
       @NonNull String functionName, @NonNull Iterable<DataType> parameterTypes) {
     return getFunction(CqlIdentifier.fromCql(functionName), parameterTypes);
   }
@@ -124,7 +126,7 @@ public interface KeyspaceMetadata extends Describable {
    * @param parameterTypes neither the individual types, nor the vararg array itself, can be null.
    */
   @NonNull
-  default Optional<FunctionMetadata> getFunction(
+  default Optional<? extends FunctionMetadata> getFunction(
       @NonNull CqlIdentifier functionId, @NonNull DataType... parameterTypes) {
     return Optional.ofNullable(
         getFunctions().get(new FunctionSignature(functionId, parameterTypes)));
@@ -137,21 +139,22 @@ public interface KeyspaceMetadata extends Describable {
    * @param parameterTypes neither the individual types, nor the vararg array itself, can be null.
    */
   @NonNull
-  default Optional<FunctionMetadata> getFunction(
+  default Optional<? extends FunctionMetadata> getFunction(
       @NonNull String functionName, @NonNull DataType... parameterTypes) {
     return getFunction(CqlIdentifier.fromCql(functionName), parameterTypes);
   }
 
   @NonNull
-  Map<FunctionSignature, AggregateMetadata> getAggregates();
+  Map<FunctionSignature, ? extends AggregateMetadata> getAggregates();
 
   @NonNull
-  default Optional<AggregateMetadata> getAggregate(@NonNull FunctionSignature aggregateSignature) {
+  default Optional<? extends AggregateMetadata> getAggregate(
+      @NonNull FunctionSignature aggregateSignature) {
     return Optional.ofNullable(getAggregates().get(aggregateSignature));
   }
 
   @NonNull
-  default Optional<AggregateMetadata> getAggregate(
+  default Optional<? extends AggregateMetadata> getAggregate(
       @NonNull CqlIdentifier aggregateId, @NonNull Iterable<DataType> parameterTypes) {
     return Optional.ofNullable(
         getAggregates().get(new FunctionSignature(aggregateId, parameterTypes)));
@@ -162,7 +165,7 @@ public interface KeyspaceMetadata extends Describable {
    * getAggregate(CqlIdentifier.fromCql(aggregateName), parameterTypes)}.
    */
   @NonNull
-  default Optional<AggregateMetadata> getAggregate(
+  default Optional<? extends AggregateMetadata> getAggregate(
       @NonNull String aggregateName, @NonNull Iterable<DataType> parameterTypes) {
     return getAggregate(CqlIdentifier.fromCql(aggregateName), parameterTypes);
   }
@@ -171,7 +174,7 @@ public interface KeyspaceMetadata extends Describable {
    * @param parameterTypes neither the individual types, nor the vararg array itself, can be null.
    */
   @NonNull
-  default Optional<AggregateMetadata> getAggregate(
+  default Optional<? extends AggregateMetadata> getAggregate(
       @NonNull CqlIdentifier aggregateId, @NonNull DataType... parameterTypes) {
     return Optional.ofNullable(
         getAggregates().get(new FunctionSignature(aggregateId, parameterTypes)));
@@ -184,7 +187,7 @@ public interface KeyspaceMetadata extends Describable {
    * @param parameterTypes neither the individual types, nor the vararg array itself, can be null.
    */
   @NonNull
-  default Optional<AggregateMetadata> getAggregate(
+  default Optional<? extends AggregateMetadata> getAggregate(
       @NonNull String aggregateName, @NonNull DataType... parameterTypes) {
     return getAggregate(CqlIdentifier.fromCql(aggregateName), parameterTypes);
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/schema/RelationMetadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/schema/RelationMetadata.java
@@ -46,7 +46,7 @@ public interface RelationMetadata extends Describable {
    * @see #getClusteringColumns()
    */
   @NonNull
-  default List<ColumnMetadata> getPrimaryKey() {
+  default List<? extends ColumnMetadata> getPrimaryKey() {
     return ImmutableList.<ColumnMetadata>builder()
         .addAll(getPartitionKey())
         .addAll(getClusteringColumns().keySet())
@@ -54,16 +54,16 @@ public interface RelationMetadata extends Describable {
   }
 
   @NonNull
-  List<ColumnMetadata> getPartitionKey();
+  List<? extends ColumnMetadata> getPartitionKey();
 
   @NonNull
-  Map<ColumnMetadata, ClusteringOrder> getClusteringColumns();
+  Map<? extends ColumnMetadata, ClusteringOrder> getClusteringColumns();
 
   @NonNull
-  Map<CqlIdentifier, ColumnMetadata> getColumns();
+  Map<CqlIdentifier, ? extends ColumnMetadata> getColumns();
 
   @NonNull
-  default Optional<ColumnMetadata> getColumn(@NonNull CqlIdentifier columnId) {
+  default Optional<? extends ColumnMetadata> getColumn(@NonNull CqlIdentifier columnId) {
     return Optional.ofNullable(getColumns().get(columnId));
   }
 
@@ -71,7 +71,7 @@ public interface RelationMetadata extends Describable {
    * Shortcut for {@link #getColumn(CqlIdentifier) getColumn(CqlIdentifier.fromCql(columnName))}.
    */
   @NonNull
-  default Optional<ColumnMetadata> getColumn(@NonNull String columnName) {
+  default Optional<? extends ColumnMetadata> getColumn(@NonNull String columnName) {
     return getColumn(CqlIdentifier.fromCql(columnName));
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/schema/TableMetadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/schema/TableMetadata.java
@@ -27,7 +27,7 @@ public interface TableMetadata extends RelationMetadata {
   boolean isCompactStorage();
 
   @NonNull
-  Map<CqlIdentifier, IndexMetadata> getIndexes();
+  Map<CqlIdentifier, ? extends IndexMetadata> getIndexes();
 
   @NonNull
   @Override
@@ -82,7 +82,8 @@ public interface TableMetadata extends RelationMetadata {
     if (getClusteringColumns().containsValue(ClusteringOrder.DESC)) {
       builder.andWith().append("CLUSTERING ORDER BY (");
       boolean first = true;
-      for (Map.Entry<ColumnMetadata, ClusteringOrder> entry : getClusteringColumns().entrySet()) {
+      for (Map.Entry<? extends ColumnMetadata, ClusteringOrder> entry :
+          getClusteringColumns().entrySet()) {
         if (first) {
           first = false;
         } else {

--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/Session.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/Session.java
@@ -113,7 +113,7 @@ public interface Session extends AsyncAutoCloseable {
    *     complete. Otherwise, a completed future with the current metadata.
    */
   @NonNull
-  CompletionStage<Metadata> setSchemaMetadataEnabled(@Nullable Boolean newValue);
+  CompletionStage<? extends Metadata> setSchemaMetadataEnabled(@Nullable Boolean newValue);
 
   /**
    * Force an immediate refresh of the schema metadata, even if it is currently disabled (either in
@@ -123,7 +123,7 @@ public interface Session extends AsyncAutoCloseable {
    * #getMetadata()} when that future completes).
    */
   @NonNull
-  CompletionStage<Metadata> refreshSchemaAsync();
+  CompletionStage<? extends Metadata> refreshSchemaAsync();
 
   /**
    * Convenience method to call {@link #refreshSchemaAsync()} and block for the result.

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/CqlIdentifiers.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/CqlIdentifiers.java
@@ -18,11 +18,12 @@ package com.datastax.oss.driver.internal.core;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import java.util.List;
 import java.util.Map;
 
 public class CqlIdentifiers {
 
-  public static Iterable<CqlIdentifier> wrap(Iterable<String> in) {
+  public static List<CqlIdentifier> wrap(Iterable<String> in) {
     ImmutableList.Builder<CqlIdentifier> out = ImmutableList.builder();
     for (String name : in) {
       out.add(CqlIdentifier.fromCql(name));

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
@@ -243,7 +243,7 @@ public class DefaultLoadBalancingPolicy implements LoadBalancingPolicy {
       return Collections.emptySet();
     }
 
-    Optional<TokenMap> maybeTokenMap = metadataManager.getMetadata().getTokenMap();
+    Optional<? extends TokenMap> maybeTokenMap = metadataManager.getMetadata().getTokenMap();
     if (maybeTokenMap.isPresent()) {
       TokenMap tokenMap = maybeTokenMap.get();
       return (token != null)

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultMetadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultMetadata.java
@@ -45,19 +45,16 @@ import org.slf4j.LoggerFactory;
 @Immutable
 public class DefaultMetadata implements Metadata {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultMetadata.class);
-  public static DefaultMetadata EMPTY = new DefaultMetadata(Collections.emptyMap());
+  public static DefaultMetadata EMPTY =
+      new DefaultMetadata(Collections.emptyMap(), Collections.emptyMap(), null);
 
-  private final Map<InetSocketAddress, Node> nodes;
-  private final Map<CqlIdentifier, KeyspaceMetadata> keyspaces;
-  private final TokenMap tokenMap;
+  protected final Map<InetSocketAddress, Node> nodes;
+  protected final Map<CqlIdentifier, ? extends KeyspaceMetadata> keyspaces;
+  protected final TokenMap tokenMap;
 
-  public DefaultMetadata(Map<InetSocketAddress, Node> nodes) {
-    this(ImmutableMap.copyOf(nodes), Collections.emptyMap(), null);
-  }
-
-  private DefaultMetadata(
+  protected DefaultMetadata(
       Map<InetSocketAddress, Node> nodes,
-      Map<CqlIdentifier, KeyspaceMetadata> keyspaces,
+      Map<CqlIdentifier, ? extends KeyspaceMetadata> keyspaces,
       TokenMap tokenMap) {
     this.nodes = nodes;
     this.keyspaces = keyspaces;
@@ -72,7 +69,7 @@ public class DefaultMetadata implements Metadata {
 
   @NonNull
   @Override
-  public Map<CqlIdentifier, KeyspaceMetadata> getKeyspaces() {
+  public Map<CqlIdentifier, ? extends KeyspaceMetadata> getKeyspaces() {
     return keyspaces;
   }
 
@@ -121,9 +118,9 @@ public class DefaultMetadata implements Metadata {
   }
 
   @Nullable
-  private TokenMap rebuildTokenMap(
+  protected TokenMap rebuildTokenMap(
       Map<InetSocketAddress, Node> newNodes,
-      Map<CqlIdentifier, KeyspaceMetadata> newKeyspaces,
+      Map<CqlIdentifier, ? extends KeyspaceMetadata> newKeyspaces,
       boolean tokenMapEnabled,
       boolean forceFullRebuild,
       TokenFactory tokenFactory,

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/InitContactPointsRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/InitContactPointsRefresh.java
@@ -39,7 +39,7 @@ class InitContactPointsRefresh implements MetadataRefresh {
   @Override
   public Result compute(
       DefaultMetadata oldMetadata, boolean tokenMapEnabled, InternalDriverContext context) {
-    assert oldMetadata == DefaultMetadata.EMPTY;
+
     String logPrefix = context.sessionName();
     LOG.debug("[{}] Initializing node metadata with contact points {}", logPrefix, contactPoints);
 
@@ -47,7 +47,13 @@ class InitContactPointsRefresh implements MetadataRefresh {
     for (InetSocketAddress address : contactPoints) {
       newNodes.put(address, new DefaultNode(address, context));
     }
-    return new Result(new DefaultMetadata(newNodes.build()));
-    // No token map refresh, because we don't have enough information yet
+    return new Result(
+        oldMetadata.withNodes(
+            newNodes.build(),
+            // At this stage there is no token map and we don't have the info to refresh it yet
+            false,
+            false,
+            null,
+            context));
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
@@ -69,13 +69,17 @@ public class MetadataManager implements AsyncAutoCloseable {
   private volatile Set<InetSocketAddress> providedContactPoints;
 
   public MetadataManager(InternalDriverContext context) {
+    this(context, DefaultMetadata.EMPTY);
+  }
+
+  protected MetadataManager(InternalDriverContext context, DefaultMetadata initialMetadata) {
     this.context = context;
+    this.metadata = initialMetadata;
     this.logPrefix = context.sessionName();
     this.adminExecutor = context.nettyOptions().adminEventExecutorGroup().next();
     this.config = context.config().getDefaultProfile();
     this.singleThreaded = new SingleThreaded(context, config);
     this.controlConnection = context.controlConnection();
-    this.metadata = DefaultMetadata.EMPTY;
     this.schemaEnabledInConfig = config.getBoolean(DefaultDriverOption.METADATA_SCHEMA_ENABLED);
     this.refreshedKeyspaces =
         config.getStringList(
@@ -417,7 +421,7 @@ public class MetadataManager implements AsyncAutoCloseable {
 
     private Void parseAndApplySchemaRows(SchemaRows schemaRows) {
       assert adminExecutor.inEventLoop();
-      assert schemaRows.refreshFuture == currentSchemaRefresh;
+      assert schemaRows.refreshFuture() == currentSchemaRefresh;
       try {
         SchemaRefresh schemaRefresh = schemaParserFactory.newInstance(schemaRows).parse();
         long start = System.nanoTime();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/AggregateParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/AggregateParser.java
@@ -31,16 +31,16 @@ import java.util.Map;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
-class AggregateParser {
+public class AggregateParser {
   private final DataTypeParser dataTypeParser;
   private final InternalDriverContext context;
 
-  AggregateParser(DataTypeParser dataTypeParser, InternalDriverContext context) {
+  public AggregateParser(DataTypeParser dataTypeParser, InternalDriverContext context) {
     this.dataTypeParser = dataTypeParser;
     this.context = context;
   }
 
-  AggregateMetadata parseAggregate(
+  public AggregateMetadata parseAggregate(
       AdminRow row,
       CqlIdentifier keyspaceId,
       Map<CqlIdentifier, UserDefinedType> userDefinedTypes) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/CassandraSchemaParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/CassandraSchemaParser.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata.schema.parsing;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.metadata.schema.AggregateMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.FunctionMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.FunctionSignature;
+import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.ViewMetadata;
+import com.datastax.oss.driver.api.core.type.UserDefinedType;
+import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.metadata.schema.DefaultKeyspaceMetadata;
+import com.datastax.oss.driver.internal.core.metadata.schema.queries.SchemaRows;
+import com.datastax.oss.driver.internal.core.metadata.schema.refresh.SchemaRefresh;
+import com.datastax.oss.driver.internal.core.util.NanoTime;
+import com.datastax.oss.driver.shaded.guava.common.base.MoreObjects;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import java.util.Map;
+import net.jcip.annotations.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default parser implementation for Cassandra.
+ *
+ * <p>For modularity, the code for each element row is split into separate classes (schema stuff is
+ * not on the hot path, so creating a few extra objects doesn't matter).
+ */
+@ThreadSafe
+public class CassandraSchemaParser implements SchemaParser {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CassandraSchemaParser.class);
+
+  private final SchemaRows rows;
+  private final UserDefinedTypeParser userDefinedTypeParser;
+  private final TableParser tableParser;
+  private final ViewParser viewParser;
+  private final FunctionParser functionParser;
+  private final AggregateParser aggregateParser;
+  private final String logPrefix;
+  private final long startTimeNs = System.nanoTime();
+
+  public CassandraSchemaParser(SchemaRows rows, InternalDriverContext context) {
+    this.rows = rows;
+    this.logPrefix = context.sessionName();
+
+    this.userDefinedTypeParser = new UserDefinedTypeParser(rows.dataTypeParser(), context);
+    this.tableParser = new TableParser(rows, context);
+    this.viewParser = new ViewParser(rows, context);
+    this.functionParser = new FunctionParser(rows.dataTypeParser(), context);
+    this.aggregateParser = new AggregateParser(rows.dataTypeParser(), context);
+  }
+
+  @Override
+  public SchemaRefresh parse() {
+    ImmutableMap.Builder<CqlIdentifier, KeyspaceMetadata> keyspacesBuilder = ImmutableMap.builder();
+    for (AdminRow row : rows.keyspaces()) {
+      KeyspaceMetadata keyspace = parseKeyspace(row);
+      keyspacesBuilder.put(keyspace.getName(), keyspace);
+    }
+    SchemaRefresh refresh = new SchemaRefresh(keyspacesBuilder.build());
+    LOG.debug("[{}] Schema parsing took {}", logPrefix, NanoTime.formatTimeSince(startTimeNs));
+    return refresh;
+  }
+
+  private KeyspaceMetadata parseKeyspace(AdminRow keyspaceRow) {
+
+    // Cassandra <= 2.2
+    // CREATE TABLE system.schema_keyspaces (
+    //     keyspace_name text PRIMARY KEY,
+    //     durable_writes boolean,
+    //     strategy_class text,
+    //     strategy_options text
+    // )
+    //
+    // Cassandra >= 3.0:
+    // CREATE TABLE system_schema.keyspaces (
+    //     keyspace_name text PRIMARY KEY,
+    //     durable_writes boolean,
+    //     replication frozen<map<text, text>>
+    // )
+    CqlIdentifier keyspaceId = CqlIdentifier.fromInternal(keyspaceRow.getString("keyspace_name"));
+    boolean durableWrites =
+        MoreObjects.firstNonNull(keyspaceRow.getBoolean("durable_writes"), false);
+
+    Map<String, String> replicationOptions;
+    if (keyspaceRow.contains("strategy_class")) {
+      String strategyClass = keyspaceRow.getString("strategy_class");
+      Map<String, String> strategyOptions =
+          SimpleJsonParser.parseStringMap(keyspaceRow.getString("strategy_options"));
+      replicationOptions =
+          ImmutableMap.<String, String>builder()
+              .putAll(strategyOptions)
+              .put("class", strategyClass)
+              .build();
+    } else {
+      replicationOptions = keyspaceRow.getMapOfStringToString("replication");
+    }
+
+    Map<CqlIdentifier, UserDefinedType> types = parseTypes(keyspaceId);
+
+    return new DefaultKeyspaceMetadata(
+        keyspaceId,
+        durableWrites,
+        replicationOptions,
+        types,
+        parseTables(keyspaceId, types),
+        parseViews(keyspaceId, types),
+        parseFunctions(keyspaceId, types),
+        parseAggregates(keyspaceId, types));
+  }
+
+  private Map<CqlIdentifier, UserDefinedType> parseTypes(CqlIdentifier keyspaceId) {
+    return userDefinedTypeParser.parse(rows.types().get(keyspaceId), keyspaceId);
+  }
+
+  private Map<CqlIdentifier, TableMetadata> parseTables(
+      CqlIdentifier keyspaceId, Map<CqlIdentifier, UserDefinedType> types) {
+    ImmutableMap.Builder<CqlIdentifier, TableMetadata> tablesBuilder = ImmutableMap.builder();
+    for (AdminRow tableRow : rows.tables().get(keyspaceId)) {
+      TableMetadata table = tableParser.parseTable(tableRow, keyspaceId, types);
+      if (table != null) {
+        tablesBuilder.put(table.getName(), table);
+      }
+    }
+    return tablesBuilder.build();
+  }
+
+  private Map<CqlIdentifier, ViewMetadata> parseViews(
+      CqlIdentifier keyspaceId, Map<CqlIdentifier, UserDefinedType> types) {
+    ImmutableMap.Builder<CqlIdentifier, ViewMetadata> viewsBuilder = ImmutableMap.builder();
+    for (AdminRow viewRow : rows.views().get(keyspaceId)) {
+      ViewMetadata view = viewParser.parseView(viewRow, keyspaceId, types);
+      if (view != null) {
+        viewsBuilder.put(view.getName(), view);
+      }
+    }
+    return viewsBuilder.build();
+  }
+
+  private Map<FunctionSignature, FunctionMetadata> parseFunctions(
+      CqlIdentifier keyspaceId, Map<CqlIdentifier, UserDefinedType> types) {
+    ImmutableMap.Builder<FunctionSignature, FunctionMetadata> functionsBuilder =
+        ImmutableMap.builder();
+    for (AdminRow functionRow : rows.functions().get(keyspaceId)) {
+      FunctionMetadata function = functionParser.parseFunction(functionRow, keyspaceId, types);
+      if (function != null) {
+        functionsBuilder.put(function.getSignature(), function);
+      }
+    }
+    return functionsBuilder.build();
+  }
+
+  private Map<FunctionSignature, AggregateMetadata> parseAggregates(
+      CqlIdentifier keyspaceId, Map<CqlIdentifier, UserDefinedType> types) {
+    ImmutableMap.Builder<FunctionSignature, AggregateMetadata> aggregatesBuilder =
+        ImmutableMap.builder();
+    for (AdminRow aggregateRow : rows.aggregates().get(keyspaceId)) {
+      AggregateMetadata aggregate = aggregateParser.parseAggregate(aggregateRow, keyspaceId, types);
+      if (aggregate != null) {
+        aggregatesBuilder.put(aggregate.getSignature(), aggregate);
+      }
+    }
+    return aggregatesBuilder.build();
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/DataTypeClassNameCompositeParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/DataTypeClassNameCompositeParser.java
@@ -65,11 +65,11 @@ public class DataTypeClassNameCompositeParser extends DataTypeClassNameParser {
     return new ParseResult(true, types, reversed, collections);
   }
 
-  static class ParseResult {
-    final boolean isComposite;
-    final List<DataType> types;
-    final List<Boolean> reversed;
-    final Map<String, DataType> collections;
+  public static class ParseResult {
+    public final boolean isComposite;
+    public final List<DataType> types;
+    public final List<Boolean> reversed;
+    public final Map<String, DataType> collections;
 
     private ParseResult(DataType type, boolean reversed) {
       this(

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/DataTypeParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/DataTypeParser.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 /** Parses data types from their string representation in schema tables. */
-interface DataTypeParser {
+public interface DataTypeParser {
 
   /**
    * @param userTypes the UDTs in the current keyspace, if we know them already. This is used to

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/DefaultSchemaParserFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/DefaultSchemaParserFactory.java
@@ -30,6 +30,6 @@ public class DefaultSchemaParserFactory implements SchemaParserFactory {
 
   @Override
   public SchemaParser newInstance(SchemaRows rows) {
-    return new SchemaParser(rows, context);
+    return new CassandraSchemaParser(rows, context);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/FunctionParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/FunctionParser.java
@@ -32,7 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-class FunctionParser {
+public class FunctionParser {
 
   private static final Logger LOG = LoggerFactory.getLogger(FunctionParser.class);
 
@@ -40,13 +40,13 @@ class FunctionParser {
   private final InternalDriverContext context;
   private final String logPrefix;
 
-  FunctionParser(DataTypeParser dataTypeParser, InternalDriverContext context) {
+  public FunctionParser(DataTypeParser dataTypeParser, InternalDriverContext context) {
     this.dataTypeParser = dataTypeParser;
     this.context = context;
     this.logPrefix = context.sessionName();
   }
 
-  FunctionMetadata parseFunction(
+  public FunctionMetadata parseFunction(
       AdminRow row,
       CqlIdentifier keyspaceId,
       Map<CqlIdentifier, UserDefinedType> userDefinedTypes) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/RelationParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/RelationParser.java
@@ -33,14 +33,11 @@ import net.jcip.annotations.ThreadSafe;
 public abstract class RelationParser {
 
   protected final SchemaRows rows;
-  protected final DataTypeParser dataTypeParser;
   protected final InternalDriverContext context;
   protected final String logPrefix;
 
-  protected RelationParser(
-      SchemaRows rows, DataTypeParser dataTypeParser, InternalDriverContext context) {
+  protected RelationParser(SchemaRows rows, InternalDriverContext context) {
     this.rows = rows;
-    this.dataTypeParser = dataTypeParser;
     this.context = context;
     this.logPrefix = context.sessionName();
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/SchemaParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/SchemaParser.java
@@ -15,151 +15,21 @@
  */
 package com.datastax.oss.driver.internal.core.metadata.schema.parsing;
 
-import com.datastax.oss.driver.api.core.CqlIdentifier;
-import com.datastax.oss.driver.api.core.metadata.schema.AggregateMetadata;
-import com.datastax.oss.driver.api.core.metadata.schema.FunctionMetadata;
-import com.datastax.oss.driver.api.core.metadata.schema.FunctionSignature;
-import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
-import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
-import com.datastax.oss.driver.api.core.metadata.schema.ViewMetadata;
-import com.datastax.oss.driver.api.core.type.UserDefinedType;
-import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
-import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
-import com.datastax.oss.driver.internal.core.metadata.schema.DefaultKeyspaceMetadata;
 import com.datastax.oss.driver.internal.core.metadata.schema.queries.SchemaRows;
 import com.datastax.oss.driver.internal.core.metadata.schema.refresh.SchemaRefresh;
-import com.datastax.oss.driver.internal.core.util.NanoTime;
-import com.datastax.oss.driver.shaded.guava.common.base.MoreObjects;
-import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
-import java.util.Map;
-import net.jcip.annotations.ThreadSafe;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The main entry point for system schema rows parsing.
  *
- * <p>For modularity, the code for each element row is split into separate classes (schema stuff is
- * not on the hot path, so creating a few extra objects doesn't matter).
+ * <p>Implementations must be thread-safe.
  */
-@ThreadSafe
-public class SchemaParser {
+public interface SchemaParser {
 
-  private static final Logger LOG = LoggerFactory.getLogger(SchemaParser.class);
-
-  private final SchemaRows rows;
-  private final UserDefinedTypeParser userDefinedTypeParser;
-  private final TableParser tableParser;
-  private final ViewParser viewParser;
-  private final FunctionParser functionParser;
-  private final AggregateParser aggregateParser;
-  private final String logPrefix;
-  private final long startTimeNs = System.nanoTime();
-
-  public SchemaParser(SchemaRows rows, InternalDriverContext context) {
-    this.rows = rows;
-    this.logPrefix = context.sessionName();
-
-    DataTypeParser dataTypeParser =
-        rows.isCassandraV3 ? new DataTypeCqlNameParser() : new DataTypeClassNameParser();
-
-    this.userDefinedTypeParser = new UserDefinedTypeParser(dataTypeParser, context);
-    this.tableParser = new TableParser(rows, dataTypeParser, context);
-    this.viewParser = new ViewParser(rows, dataTypeParser, context);
-    this.functionParser = new FunctionParser(dataTypeParser, context);
-    this.aggregateParser = new AggregateParser(dataTypeParser, context);
-  }
-
-  public SchemaRefresh parse() {
-    ImmutableMap.Builder<CqlIdentifier, KeyspaceMetadata> keyspacesBuilder = ImmutableMap.builder();
-    for (AdminRow row : rows.keyspaces) {
-      KeyspaceMetadata keyspace = parseKeyspace(row);
-      keyspacesBuilder.put(keyspace.getName(), keyspace);
-    }
-    SchemaRefresh refresh = new SchemaRefresh(keyspacesBuilder.build());
-    LOG.debug("[{}] Schema parsing took {}", logPrefix, NanoTime.formatTimeSince(startTimeNs));
-    return refresh;
-  }
-
-  protected KeyspaceMetadata parseKeyspace(AdminRow keyspaceRow) {
-
-    // Cassandra <= 2.2
-    // CREATE TABLE system.schema_keyspaces (
-    //     keyspace_name text PRIMARY KEY,
-    //     durable_writes boolean,
-    //     strategy_class text,
-    //     strategy_options text
-    // )
-    //
-    // Cassandra >= 3.0:
-    // CREATE TABLE system_schema.keyspaces (
-    //     keyspace_name text PRIMARY KEY,
-    //     durable_writes boolean,
-    //     replication frozen<map<text, text>>
-    // )
-    CqlIdentifier keyspaceId = CqlIdentifier.fromInternal(keyspaceRow.getString("keyspace_name"));
-    boolean durableWrites =
-        MoreObjects.firstNonNull(keyspaceRow.getBoolean("durable_writes"), false);
-
-    Map<String, String> replicationOptions;
-    if (keyspaceRow.contains("strategy_class")) {
-      String strategyClass = keyspaceRow.getString("strategy_class");
-      Map<String, String> strategyOptions =
-          SimpleJsonParser.parseStringMap(keyspaceRow.getString("strategy_options"));
-      replicationOptions =
-          ImmutableMap.<String, String>builder()
-              .putAll(strategyOptions)
-              .put("class", strategyClass)
-              .build();
-    } else {
-      replicationOptions = keyspaceRow.getMapOfStringToString("replication");
-    }
-
-    Map<CqlIdentifier, UserDefinedType> types =
-        userDefinedTypeParser.parse(rows.types.get(keyspaceId), keyspaceId);
-
-    ImmutableMap.Builder<CqlIdentifier, TableMetadata> tablesBuilder = ImmutableMap.builder();
-    for (AdminRow tableRow : rows.tables.get(keyspaceId)) {
-      TableMetadata table = tableParser.parseTable(tableRow, keyspaceId, types);
-      if (table != null) {
-        tablesBuilder.put(table.getName(), table);
-      }
-    }
-
-    ImmutableMap.Builder<CqlIdentifier, ViewMetadata> viewsBuilder = ImmutableMap.builder();
-    for (AdminRow viewRow : rows.views.get(keyspaceId)) {
-      ViewMetadata view = viewParser.parseView(viewRow, keyspaceId, types);
-      if (view != null) {
-        viewsBuilder.put(view.getName(), view);
-      }
-    }
-
-    ImmutableMap.Builder<FunctionSignature, FunctionMetadata> functionsBuilder =
-        ImmutableMap.builder();
-    for (AdminRow functionRow : rows.functions.get(keyspaceId)) {
-      FunctionMetadata function = functionParser.parseFunction(functionRow, keyspaceId, types);
-      if (function != null) {
-        functionsBuilder.put(function.getSignature(), function);
-      }
-    }
-
-    ImmutableMap.Builder<FunctionSignature, AggregateMetadata> aggregatesBuilder =
-        ImmutableMap.builder();
-    for (AdminRow aggregateRow : rows.aggregates.get(keyspaceId)) {
-      AggregateMetadata aggregate = aggregateParser.parseAggregate(aggregateRow, keyspaceId, types);
-      if (aggregate != null) {
-        aggregatesBuilder.put(aggregate.getSignature(), aggregate);
-      }
-    }
-
-    return new DefaultKeyspaceMetadata(
-        keyspaceId,
-        durableWrites,
-        replicationOptions,
-        types,
-        tablesBuilder.build(),
-        viewsBuilder.build(),
-        functionsBuilder.build(),
-        aggregatesBuilder.build());
-  }
+  /**
+   * Process the rows that this parser was initialized with, and creates a refresh that will be
+   * applied to the metadata.
+   *
+   * @see SchemaParserFactory#newInstance(SchemaRows)
+   */
+  SchemaRefresh parse();
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/SimpleJsonParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/SimpleJsonParser.java
@@ -36,7 +36,7 @@ import net.jcip.annotations.NotThreadSafe;
  * obviously not expose this publicly.
  */
 @NotThreadSafe
-class SimpleJsonParser {
+public class SimpleJsonParser {
 
   private final String input;
   private int idx;
@@ -45,7 +45,7 @@ class SimpleJsonParser {
     this.input = input;
   }
 
-  static List<String> parseStringList(String input) {
+  public static List<String> parseStringList(String input) {
     if (input == null || input.isEmpty()) {
       return Collections.emptyList();
     }
@@ -73,7 +73,7 @@ class SimpleJsonParser {
     }
   }
 
-  static Map<String, String> parseStringMap(String input) {
+  public static Map<String, String> parseStringMap(String input) {
     if (input == null || input.isEmpty()) {
       return Collections.emptyMap();
     }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/UserDefinedTypeParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/UserDefinedTypeParser.java
@@ -39,11 +39,11 @@ import java.util.Map;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
-class UserDefinedTypeParser {
+public class UserDefinedTypeParser {
   private final DataTypeParser dataTypeParser;
   private final InternalDriverContext context;
 
-  UserDefinedTypeParser(DataTypeParser dataTypeParser, InternalDriverContext context) {
+  public UserDefinedTypeParser(DataTypeParser dataTypeParser, InternalDriverContext context) {
     this.dataTypeParser = dataTypeParser;
     this.context = context;
   }
@@ -54,7 +54,7 @@ class UserDefinedTypeParser {
    * order to properly build the definitions, we need to do a topological sort of the rows first, so
    * that each type is parsed after its dependencies.
    */
-  Map<CqlIdentifier, UserDefinedType> parse(
+  public Map<CqlIdentifier, UserDefinedType> parse(
       Collection<AdminRow> typeRows, CqlIdentifier keyspaceId) {
     if (typeRows.isEmpty()) {
       return Collections.emptyMap();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/ViewParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/ViewParser.java
@@ -40,15 +40,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-class ViewParser extends RelationParser {
+public class ViewParser extends RelationParser {
 
   private static final Logger LOG = LoggerFactory.getLogger(ViewParser.class);
 
-  ViewParser(SchemaRows rows, DataTypeParser dataTypeParser, InternalDriverContext context) {
-    super(rows, dataTypeParser, context);
+  public ViewParser(SchemaRows rows, InternalDriverContext context) {
+    super(rows, context);
   }
 
-  ViewMetadata parseView(
+  public ViewMetadata parseView(
       AdminRow viewRow, CqlIdentifier keyspaceId, Map<CqlIdentifier, UserDefinedType> userTypes) {
     // Cassandra 3.0 (no views in earlier versions):
     // CREATE TABLE system_schema.views (
@@ -87,7 +87,7 @@ class ViewParser extends RelationParser {
 
     List<RawColumn> rawColumns =
         RawColumn.toRawColumns(
-            rows.columns.getOrDefault(keyspaceId, ImmutableMultimap.of()).get(viewId),
+            rows.columns().getOrDefault(keyspaceId, ImmutableMultimap.of()).get(viewId),
             keyspaceId,
             userTypes);
     if (rawColumns.isEmpty()) {
@@ -106,15 +106,15 @@ class ViewParser extends RelationParser {
         ImmutableMap.builder();
 
     for (RawColumn raw : rawColumns) {
-      DataType dataType = dataTypeParser.parse(keyspaceId, raw.dataType, userTypes, context);
+      DataType dataType = rows.dataTypeParser().parse(keyspaceId, raw.dataType, userTypes, context);
       ColumnMetadata column =
           new DefaultColumnMetadata(
-              keyspaceId, viewId, raw.name, dataType, raw.kind == RawColumn.Kind.STATIC);
+              keyspaceId, viewId, raw.name, dataType, raw.kind.equals(RawColumn.KIND_STATIC));
       switch (raw.kind) {
-        case PARTITION_KEY:
+        case RawColumn.KIND_PARTITION_KEY:
           partitionKeyBuilder.add(column);
           break;
-        case CLUSTERING_COLUMN:
+        case RawColumn.KIND_CLUSTERING_COLUMN:
           clusteringColumnsBuilder.put(
               column, raw.reversed ? ClusteringOrder.DESC : ClusteringOrder.ASC);
           break;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra21SchemaQueries.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra21SchemaQueries.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
-class Cassandra21SchemaQueries extends SchemaQueries {
+class Cassandra21SchemaQueries extends CassandraSchemaQueries {
   Cassandra21SchemaQueries(
       DriverChannel channel,
       CompletableFuture<Metadata> refreshFuture,

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra22SchemaQueries.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra22SchemaQueries.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
-class Cassandra22SchemaQueries extends SchemaQueries {
+class Cassandra22SchemaQueries extends CassandraSchemaQueries {
   Cassandra22SchemaQueries(
       DriverChannel channel,
       CompletableFuture<Metadata> refreshFuture,

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra3SchemaQueries.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra3SchemaQueries.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
-class Cassandra3SchemaQueries extends SchemaQueries {
+class Cassandra3SchemaQueries extends CassandraSchemaQueries {
   Cassandra3SchemaQueries(
       DriverChannel channel,
       CompletableFuture<Metadata> refreshFuture,

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/CassandraSchemaQueries.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/CassandraSchemaQueries.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata.schema.queries;
+
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
+import com.datastax.oss.driver.api.core.metadata.Metadata;
+import com.datastax.oss.driver.internal.core.adminrequest.AdminRequestHandler;
+import com.datastax.oss.driver.internal.core.adminrequest.AdminResult;
+import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
+import com.datastax.oss.driver.internal.core.channel.DriverChannel;
+import com.datastax.oss.driver.internal.core.util.NanoTime;
+import com.datastax.oss.driver.internal.core.util.concurrent.RunOrSchedule;
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import io.netty.util.concurrent.EventExecutor;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import net.jcip.annotations.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ThreadSafe
+public abstract class CassandraSchemaQueries implements SchemaQueries {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CassandraSchemaQueries.class);
+
+  private final DriverChannel channel;
+  private final EventExecutor adminExecutor;
+  private final boolean isCassandraV3;
+  private final String logPrefix;
+  private final Duration timeout;
+  private final int pageSize;
+  private final String whereClause;
+  // The future we return from execute, completes when all the queries are done.
+  private final CompletableFuture<SchemaRows> schemaRowsFuture = new CompletableFuture<>();
+  // A future that completes later, when the whole refresh is done. We just store it here to pass it
+  // down to the next step.
+  public final CompletableFuture<Metadata> refreshFuture;
+  private final long startTimeNs = System.nanoTime();
+
+  // All non-final fields are accessed exclusively on adminExecutor
+  private CassandraSchemaRows.Builder schemaRowsBuilder;
+  private int pendingQueries;
+
+  protected CassandraSchemaQueries(
+      DriverChannel channel,
+      boolean isCassandraV3,
+      CompletableFuture<Metadata> refreshFuture,
+      DriverConfigProfile config,
+      String logPrefix) {
+    this.channel = channel;
+    this.adminExecutor = channel.eventLoop();
+    this.isCassandraV3 = isCassandraV3;
+    this.refreshFuture = refreshFuture;
+    this.logPrefix = logPrefix;
+    this.timeout = config.getDuration(DefaultDriverOption.METADATA_SCHEMA_REQUEST_TIMEOUT);
+    this.pageSize = config.getInt(DefaultDriverOption.METADATA_SCHEMA_REQUEST_PAGE_SIZE);
+
+    List<String> refreshedKeyspaces =
+        config.getStringList(
+            DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES, Collections.emptyList());
+    this.whereClause = buildWhereClause(refreshedKeyspaces);
+  }
+
+  private static String buildWhereClause(List<String> refreshedKeyspaces) {
+    if (refreshedKeyspaces.isEmpty()) {
+      return "";
+    } else {
+      StringBuilder builder = new StringBuilder(" WHERE keyspace_name in (");
+      boolean first = true;
+      for (String keyspace : refreshedKeyspaces) {
+        if (first) {
+          first = false;
+        } else {
+          builder.append(",");
+        }
+        builder.append('\'').append(keyspace).append('\'');
+      }
+      return builder.append(")").toString();
+    }
+  }
+
+  protected abstract String selectKeyspacesQuery();
+
+  protected abstract String selectTablesQuery();
+
+  protected abstract Optional<String> selectViewsQuery();
+
+  protected abstract Optional<String> selectIndexesQuery();
+
+  protected abstract String selectColumnsQuery();
+
+  protected abstract String selectTypesQuery();
+
+  protected abstract Optional<String> selectFunctionsQuery();
+
+  protected abstract Optional<String> selectAggregatesQuery();
+
+  @Override
+  public CompletionStage<SchemaRows> execute() {
+    RunOrSchedule.on(adminExecutor, this::executeOnAdminExecutor);
+    return schemaRowsFuture;
+  }
+
+  private void executeOnAdminExecutor() {
+    assert adminExecutor.inEventLoop();
+
+    schemaRowsBuilder = new CassandraSchemaRows.Builder(isCassandraV3, refreshFuture, logPrefix);
+
+    query(selectKeyspacesQuery() + whereClause, schemaRowsBuilder::withKeyspaces);
+    query(selectTypesQuery() + whereClause, schemaRowsBuilder::withTypes);
+    query(selectTablesQuery() + whereClause, schemaRowsBuilder::withTables);
+    query(selectColumnsQuery() + whereClause, schemaRowsBuilder::withColumns);
+    selectIndexesQuery()
+        .ifPresent(select -> query(select + whereClause, schemaRowsBuilder::withIndexes));
+    selectViewsQuery()
+        .ifPresent(select -> query(select + whereClause, schemaRowsBuilder::withViews));
+    selectFunctionsQuery()
+        .ifPresent(select -> query(select + whereClause, schemaRowsBuilder::withFunctions));
+    selectAggregatesQuery()
+        .ifPresent(select -> query(select + whereClause, schemaRowsBuilder::withAggregates));
+  }
+
+  private void query(
+      String queryString,
+      Function<Iterable<AdminRow>, CassandraSchemaRows.Builder> builderUpdater) {
+    assert adminExecutor.inEventLoop();
+
+    pendingQueries += 1;
+    query(queryString)
+        .whenCompleteAsync(
+            (result, error) -> handleResult(result, error, builderUpdater), adminExecutor);
+  }
+
+  @VisibleForTesting
+  protected CompletionStage<AdminResult> query(String query) {
+    return AdminRequestHandler.query(channel, query, timeout, pageSize, logPrefix).start();
+  }
+
+  private void handleResult(
+      AdminResult result,
+      Throwable error,
+      Function<Iterable<AdminRow>, CassandraSchemaRows.Builder> builderUpdater) {
+    if (schemaRowsFuture.isDone()) { // Another query failed already, ignore
+      return;
+    }
+    if (error != null) {
+      // Any error fails the whole refresh
+      schemaRowsFuture.completeExceptionally(error);
+    } else {
+      // Store the rows of the current page in the builder
+      schemaRowsBuilder = builderUpdater.apply(result);
+      // Move to the next page, or complete if we're the last query
+      if (result.hasNextPage()) {
+        result
+            .nextPage()
+            .whenCompleteAsync(
+                (nextResult, nextError) -> handleResult(nextResult, nextError, builderUpdater),
+                adminExecutor);
+      } else {
+        pendingQueries -= 1;
+        if (pendingQueries == 0) {
+          LOG.debug(
+              "[{}] Schema queries took {}", logPrefix, NanoTime.formatTimeSince(startTimeNs));
+          schemaRowsFuture.complete(schemaRowsBuilder.build());
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/CassandraSchemaRows.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/CassandraSchemaRows.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata.schema.queries;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.metadata.Metadata;
+import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
+import com.datastax.oss.driver.internal.core.metadata.schema.parsing.DataTypeClassNameParser;
+import com.datastax.oss.driver.internal.core.metadata.schema.parsing.DataTypeCqlNameParser;
+import com.datastax.oss.driver.internal.core.metadata.schema.parsing.DataTypeParser;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableListMultimap;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMultimap;
+import com.datastax.oss.driver.shaded.guava.common.collect.Multimap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import net.jcip.annotations.Immutable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Immutable
+public class CassandraSchemaRows implements SchemaRows {
+
+  private final DataTypeParser dataTypeParser;
+  private final CompletableFuture<Metadata> refreshFuture;
+  private final List<AdminRow> keyspaces;
+  private final Multimap<CqlIdentifier, AdminRow> tables;
+  private final Multimap<CqlIdentifier, AdminRow> views;
+  private final Multimap<CqlIdentifier, AdminRow> types;
+  private final Multimap<CqlIdentifier, AdminRow> functions;
+  private final Multimap<CqlIdentifier, AdminRow> aggregates;
+  private final Map<CqlIdentifier, Multimap<CqlIdentifier, AdminRow>> columns;
+  private final Map<CqlIdentifier, Multimap<CqlIdentifier, AdminRow>> indexes;
+
+  private CassandraSchemaRows(
+      boolean isCassandraV3,
+      CompletableFuture<Metadata> refreshFuture,
+      List<AdminRow> keyspaces,
+      Multimap<CqlIdentifier, AdminRow> tables,
+      Multimap<CqlIdentifier, AdminRow> views,
+      Map<CqlIdentifier, Multimap<CqlIdentifier, AdminRow>> columns,
+      Map<CqlIdentifier, Multimap<CqlIdentifier, AdminRow>> indexes,
+      Multimap<CqlIdentifier, AdminRow> types,
+      Multimap<CqlIdentifier, AdminRow> functions,
+      Multimap<CqlIdentifier, AdminRow> aggregates) {
+    this.dataTypeParser =
+        isCassandraV3 ? new DataTypeCqlNameParser() : new DataTypeClassNameParser();
+    this.refreshFuture = refreshFuture;
+    this.keyspaces = keyspaces;
+    this.tables = tables;
+    this.views = views;
+    this.columns = columns;
+    this.indexes = indexes;
+    this.types = types;
+    this.functions = functions;
+    this.aggregates = aggregates;
+  }
+
+  @Override
+  public DataTypeParser dataTypeParser() {
+    return dataTypeParser;
+  }
+
+  @Override
+  public CompletableFuture<Metadata> refreshFuture() {
+    return refreshFuture;
+  }
+
+  @Override
+  public List<AdminRow> keyspaces() {
+    return keyspaces;
+  }
+
+  @Override
+  public Multimap<CqlIdentifier, AdminRow> tables() {
+    return tables;
+  }
+
+  @Override
+  public Multimap<CqlIdentifier, AdminRow> views() {
+    return views;
+  }
+
+  @Override
+  public Multimap<CqlIdentifier, AdminRow> types() {
+    return types;
+  }
+
+  @Override
+  public Multimap<CqlIdentifier, AdminRow> functions() {
+    return functions;
+  }
+
+  @Override
+  public Multimap<CqlIdentifier, AdminRow> aggregates() {
+    return aggregates;
+  }
+
+  @Override
+  public Map<CqlIdentifier, Multimap<CqlIdentifier, AdminRow>> columns() {
+    return columns;
+  }
+
+  @Override
+  public Map<CqlIdentifier, Multimap<CqlIdentifier, AdminRow>> indexes() {
+    return indexes;
+  }
+
+  public static class Builder {
+    private static final Logger LOG = LoggerFactory.getLogger(Builder.class);
+
+    private final boolean isCassandraV3;
+    private final CompletableFuture<Metadata> refreshFuture;
+    private final String tableNameColumn;
+    private final String logPrefix;
+    private final ImmutableList.Builder<AdminRow> keyspacesBuilder = ImmutableList.builder();
+    private final ImmutableMultimap.Builder<CqlIdentifier, AdminRow> tablesBuilder =
+        ImmutableListMultimap.builder();
+    private final ImmutableMultimap.Builder<CqlIdentifier, AdminRow> viewsBuilder =
+        ImmutableListMultimap.builder();
+    private final ImmutableMultimap.Builder<CqlIdentifier, AdminRow> typesBuilder =
+        ImmutableListMultimap.builder();
+    private final ImmutableMultimap.Builder<CqlIdentifier, AdminRow> functionsBuilder =
+        ImmutableListMultimap.builder();
+    private final ImmutableMultimap.Builder<CqlIdentifier, AdminRow> aggregatesBuilder =
+        ImmutableListMultimap.builder();
+    private final Map<CqlIdentifier, ImmutableMultimap.Builder<CqlIdentifier, AdminRow>>
+        columnsBuilders = new LinkedHashMap<>();
+    private final Map<CqlIdentifier, ImmutableMultimap.Builder<CqlIdentifier, AdminRow>>
+        indexesBuilders = new LinkedHashMap<>();
+
+    public Builder(
+        boolean isCassandraV3, CompletableFuture<Metadata> refreshFuture, String logPrefix) {
+      this.isCassandraV3 = isCassandraV3;
+      this.refreshFuture = refreshFuture;
+      this.logPrefix = logPrefix;
+      this.tableNameColumn = isCassandraV3 ? "table_name" : "columnfamily_name";
+    }
+
+    public Builder withKeyspaces(Iterable<AdminRow> rows) {
+      keyspacesBuilder.addAll(rows);
+      return this;
+    }
+
+    public Builder withTables(Iterable<AdminRow> rows) {
+      for (AdminRow row : rows) {
+        putByKeyspace(row, tablesBuilder);
+      }
+      return this;
+    }
+
+    public Builder withViews(Iterable<AdminRow> rows) {
+      for (AdminRow row : rows) {
+        putByKeyspace(row, viewsBuilder);
+      }
+      return this;
+    }
+
+    public Builder withTypes(Iterable<AdminRow> rows) {
+      for (AdminRow row : rows) {
+        putByKeyspace(row, typesBuilder);
+      }
+      return this;
+    }
+
+    public Builder withFunctions(Iterable<AdminRow> rows) {
+      for (AdminRow row : rows) {
+        putByKeyspace(row, functionsBuilder);
+      }
+      return this;
+    }
+
+    public Builder withAggregates(Iterable<AdminRow> rows) {
+      for (AdminRow row : rows) {
+        putByKeyspace(row, aggregatesBuilder);
+      }
+      return this;
+    }
+
+    public Builder withColumns(Iterable<AdminRow> rows) {
+      for (AdminRow row : rows) {
+        putByKeyspaceAndTable(row, columnsBuilders);
+      }
+      return this;
+    }
+
+    public Builder withIndexes(Iterable<AdminRow> rows) {
+      for (AdminRow row : rows) {
+        putByKeyspaceAndTable(row, indexesBuilders);
+      }
+      return this;
+    }
+
+    private void putByKeyspace(
+        AdminRow row, ImmutableMultimap.Builder<CqlIdentifier, AdminRow> builder) {
+      String keyspace = row.getString("keyspace_name");
+      if (keyspace == null) {
+        LOG.warn("[{}] Skipping system row with missing keyspace name", logPrefix);
+      } else {
+        builder.put(CqlIdentifier.fromInternal(keyspace), row);
+      }
+    }
+
+    private void putByKeyspaceAndTable(
+        AdminRow row,
+        Map<CqlIdentifier, ImmutableMultimap.Builder<CqlIdentifier, AdminRow>> builders) {
+      String keyspace = row.getString("keyspace_name");
+      String table = row.getString(tableNameColumn);
+      if (keyspace == null) {
+        LOG.warn("[{}] Skipping system row with missing keyspace name", logPrefix);
+      } else if (table == null) {
+        LOG.warn("[{}] Skipping system row with missing table name", logPrefix);
+      } else {
+        ImmutableMultimap.Builder<CqlIdentifier, AdminRow> builder =
+            builders.computeIfAbsent(
+                CqlIdentifier.fromInternal(keyspace), s -> ImmutableListMultimap.builder());
+        builder.put(CqlIdentifier.fromInternal(table), row);
+      }
+    }
+
+    public CassandraSchemaRows build() {
+      return new CassandraSchemaRows(
+          isCassandraV3,
+          refreshFuture,
+          keyspacesBuilder.build(),
+          tablesBuilder.build(),
+          viewsBuilder.build(),
+          build(columnsBuilders),
+          build(indexesBuilders),
+          typesBuilder.build(),
+          functionsBuilder.build(),
+          aggregatesBuilder.build());
+    }
+
+    private static <K1, K2, V> Map<K1, Multimap<K2, V>> build(
+        Map<K1, ImmutableMultimap.Builder<K2, V>> builders) {
+      ImmutableMap.Builder<K1, Multimap<K2, V>> builder = ImmutableMap.builder();
+      for (Map.Entry<K1, ImmutableMultimap.Builder<K2, V>> entry : builders.entrySet()) {
+        builder.put(entry.getKey(), entry.getValue().build());
+      }
+      return builder.build();
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/SchemaQueries.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/SchemaQueries.java
@@ -15,179 +15,21 @@
  */
 package com.datastax.oss.driver.internal.core.metadata.schema.queries;
 
-import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
-import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
-import com.datastax.oss.driver.api.core.metadata.Metadata;
-import com.datastax.oss.driver.internal.core.adminrequest.AdminRequestHandler;
-import com.datastax.oss.driver.internal.core.adminrequest.AdminResult;
-import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
-import com.datastax.oss.driver.internal.core.channel.DriverChannel;
-import com.datastax.oss.driver.internal.core.util.NanoTime;
-import com.datastax.oss.driver.internal.core.util.concurrent.RunOrSchedule;
-import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
-import io.netty.util.concurrent.EventExecutor;
-import java.time.Duration;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
-import net.jcip.annotations.ThreadSafe;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Handles the queries to system tables during a schema refresh.
+ * Manages the queries to system tables during a schema refresh.
  *
- * <p>Depending on the kind of refresh, there is a variable number of queries. They are all
- * asynchronous, and possibly paged. This class abstracts all the details and exposes a common
- * result type.
+ * <p>They are all asynchronous, and possibly paged. This class abstracts all the details and
+ * exposes a common result type.
+ *
+ * <p>Implementations must be thread-safe.
  */
-@ThreadSafe
-public abstract class SchemaQueries {
+public interface SchemaQueries {
 
-  private static final Logger LOG = LoggerFactory.getLogger(SchemaQueries.class);
-
-  private final DriverChannel channel;
-  private final EventExecutor adminExecutor;
-  private final boolean isCassandraV3;
-  private final String logPrefix;
-  private final Duration timeout;
-  private final int pageSize;
-  private final String whereClause;
-  // The future we return from execute, completes when all the queries are done.
-  private final CompletableFuture<SchemaRows> schemaRowsFuture = new CompletableFuture<>();
-  // A future that completes later, when the whole refresh is done. We just store it here to pass it
-  // down to the next step.
-  public final CompletableFuture<Metadata> refreshFuture;
-  private final long startTimeNs = System.nanoTime();
-
-  // All non-final fields are accessed exclusively on adminExecutor
-  private SchemaRows.Builder schemaRowsBuilder;
-  private int pendingQueries;
-
-  protected SchemaQueries(
-      DriverChannel channel,
-      boolean isCassandraV3,
-      CompletableFuture<Metadata> refreshFuture,
-      DriverConfigProfile config,
-      String logPrefix) {
-    this.channel = channel;
-    this.adminExecutor = channel.eventLoop();
-    this.isCassandraV3 = isCassandraV3;
-    this.refreshFuture = refreshFuture;
-    this.logPrefix = logPrefix;
-    this.timeout = config.getDuration(DefaultDriverOption.METADATA_SCHEMA_REQUEST_TIMEOUT);
-    this.pageSize = config.getInt(DefaultDriverOption.METADATA_SCHEMA_REQUEST_PAGE_SIZE);
-
-    List<String> refreshedKeyspaces =
-        config.getStringList(
-            DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES, Collections.emptyList());
-    this.whereClause = buildWhereClause(refreshedKeyspaces);
-  }
-
-  private static String buildWhereClause(List<String> refreshedKeyspaces) {
-    if (refreshedKeyspaces.isEmpty()) {
-      return "";
-    } else {
-      StringBuilder builder = new StringBuilder(" WHERE keyspace_name in (");
-      boolean first = true;
-      for (String keyspace : refreshedKeyspaces) {
-        if (first) {
-          first = false;
-        } else {
-          builder.append(",");
-        }
-        builder.append('\'').append(keyspace).append('\'');
-      }
-      return builder.append(")").toString();
-    }
-  }
-
-  protected abstract String selectKeyspacesQuery();
-
-  protected abstract String selectTablesQuery();
-
-  protected abstract Optional<String> selectViewsQuery();
-
-  protected abstract Optional<String> selectIndexesQuery();
-
-  protected abstract String selectColumnsQuery();
-
-  protected abstract String selectTypesQuery();
-
-  protected abstract Optional<String> selectFunctionsQuery();
-
-  protected abstract Optional<String> selectAggregatesQuery();
-
-  public CompletionStage<SchemaRows> execute() {
-    RunOrSchedule.on(adminExecutor, this::executeOnAdminExecutor);
-    return schemaRowsFuture;
-  }
-
-  private void executeOnAdminExecutor() {
-    assert adminExecutor.inEventLoop();
-
-    schemaRowsBuilder = new SchemaRows.Builder(isCassandraV3, refreshFuture, logPrefix);
-
-    query(selectKeyspacesQuery() + whereClause, schemaRowsBuilder::withKeyspaces);
-    query(selectTypesQuery() + whereClause, schemaRowsBuilder::withTypes);
-    query(selectTablesQuery() + whereClause, schemaRowsBuilder::withTables);
-    query(selectColumnsQuery() + whereClause, schemaRowsBuilder::withColumns);
-    selectIndexesQuery()
-        .ifPresent(select -> query(select + whereClause, schemaRowsBuilder::withIndexes));
-    selectViewsQuery()
-        .ifPresent(select -> query(select + whereClause, schemaRowsBuilder::withViews));
-    selectFunctionsQuery()
-        .ifPresent(select -> query(select + whereClause, schemaRowsBuilder::withFunctions));
-    selectAggregatesQuery()
-        .ifPresent(select -> query(select + whereClause, schemaRowsBuilder::withAggregates));
-  }
-
-  private void query(
-      String queryString, Function<Iterable<AdminRow>, SchemaRows.Builder> builderUpdater) {
-    assert adminExecutor.inEventLoop();
-
-    pendingQueries += 1;
-    query(queryString)
-        .whenCompleteAsync(
-            (result, error) -> handleResult(result, error, builderUpdater), adminExecutor);
-  }
-
-  @VisibleForTesting
-  protected CompletionStage<AdminResult> query(String query) {
-    return AdminRequestHandler.query(channel, query, timeout, pageSize, logPrefix).start();
-  }
-
-  private void handleResult(
-      AdminResult result,
-      Throwable error,
-      Function<Iterable<AdminRow>, SchemaRows.Builder> builderUpdater) {
-    if (schemaRowsFuture.isDone()) { // Another query failed already, ignore
-      return;
-    }
-    if (error != null) {
-      // Any error fails the whole refresh
-      schemaRowsFuture.completeExceptionally(error);
-    } else {
-      // Store the rows of the current page in the builder
-      schemaRowsBuilder = builderUpdater.apply(result);
-      // Move to the next page, or complete if we're the last query
-      if (result.hasNextPage()) {
-        result
-            .nextPage()
-            .whenCompleteAsync(
-                (nextResult, nextError) -> handleResult(nextResult, nextError, builderUpdater),
-                adminExecutor);
-      } else {
-        pendingQueries -= 1;
-        if (pendingQueries == 0) {
-          LOG.debug(
-              "[{}] Schema queries took {}", logPrefix, NanoTime.formatTimeSince(startTimeNs));
-          schemaRowsFuture.complete(schemaRowsBuilder.build());
-        }
-      }
-    }
-  }
+  /**
+   * Launch the queries asynchronously, returning a future that will complete when they have all
+   * succeeded.
+   */
+  CompletionStage<SchemaRows> execute();
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/refresh/SchemaRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/refresh/SchemaRefresh.java
@@ -49,7 +49,7 @@ public class SchemaRefresh implements MetadataRefresh {
       DefaultMetadata oldMetadata, boolean tokenMapEnabled, InternalDriverContext context) {
     ImmutableList.Builder<Object> events = ImmutableList.builder();
 
-    Map<CqlIdentifier, KeyspaceMetadata> oldKeyspaces = oldMetadata.getKeyspaces();
+    Map<CqlIdentifier, ? extends KeyspaceMetadata> oldKeyspaces = oldMetadata.getKeyspaces();
     for (CqlIdentifier removedKey : Sets.difference(oldKeyspaces.keySet(), newKeyspaces.keySet())) {
       events.add(KeyspaceChangeEvent.dropped(oldKeyspaces.get(removedKey)));
     }
@@ -132,8 +132,8 @@ public class SchemaRefresh implements MetadataRefresh {
   }
 
   private <K, V> void computeChildEvents(
-      Map<K, V> oldChildren,
-      Map<K, V> newChildren,
+      Map<K, ? extends V> oldChildren,
+      Map<K, ? extends V> newChildren,
       Function<V, Object> newDroppedEvent,
       Function<V, Object> newCreatedEvent,
       BiFunction<V, V, Object> newUpdatedEvent,
@@ -141,7 +141,7 @@ public class SchemaRefresh implements MetadataRefresh {
     for (K removedKey : Sets.difference(oldChildren.keySet(), newChildren.keySet())) {
       events.add(newDroppedEvent.apply(oldChildren.get(removedKey)));
     }
-    for (Map.Entry<K, V> entry : newChildren.entrySet()) {
+    for (Map.Entry<K, ? extends V> entry : newChildren.entrySet()) {
       K key = entry.getKey();
       V newChild = entry.getValue();
       V oldChild = oldChildren.get(key);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/DefaultTokenMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/DefaultTokenMap.java
@@ -49,7 +49,7 @@ public class DefaultTokenMap implements TokenMap {
 
   public static DefaultTokenMap build(
       @NonNull Collection<Node> nodes,
-      @NonNull Collection<KeyspaceMetadata> keyspaces,
+      @NonNull Collection<? extends KeyspaceMetadata> keyspaces,
       @NonNull TokenFactory tokenFactory,
       @NonNull ReplicationStrategyFactory replicationStrategyFactory,
       @NonNull String logPrefix) {
@@ -191,7 +191,7 @@ public class DefaultTokenMap implements TokenMap {
   /** Called when only the schema has changed. */
   public DefaultTokenMap refresh(
       @NonNull Collection<Node> nodes,
-      @NonNull Collection<KeyspaceMetadata> keyspaces,
+      @NonNull Collection<? extends KeyspaceMetadata> keyspaces,
       @NonNull ReplicationStrategyFactory replicationStrategyFactory) {
 
     Map<CqlIdentifier, Map<String, String>> newReplicationConfigs =
@@ -266,7 +266,7 @@ public class DefaultTokenMap implements TokenMap {
   }
 
   private static Map<CqlIdentifier, Map<String, String>> buildReplicationConfigs(
-      Collection<KeyspaceMetadata> keyspaces, String logPrefix) {
+      Collection<? extends KeyspaceMetadata> keyspaces, String logPrefix) {
     ImmutableMap.Builder<CqlIdentifier, Map<String, String>> builder = ImmutableMap.builder();
     for (KeyspaceMetadata keyspace : keyspaces) {
       builder.put(keyspace.getName(), keyspace.getReplication());

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/SessionWrapper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/SessionWrapper.java
@@ -74,13 +74,13 @@ public class SessionWrapper implements Session {
 
   @NonNull
   @Override
-  public CompletionStage<Metadata> setSchemaMetadataEnabled(@Nullable Boolean newValue) {
+  public CompletionStage<? extends Metadata> setSchemaMetadataEnabled(@Nullable Boolean newValue) {
     return delegate.setSchemaMetadataEnabled(newValue);
   }
 
   @NonNull
   @Override
-  public CompletionStage<Metadata> refreshSchemaAsync() {
+  public CompletionStage<? extends Metadata> refreshSchemaAsync() {
     return delegate.refreshSchemaAsync();
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyQueryPlanTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicyQueryPlanTest.java
@@ -63,7 +63,7 @@ public class DefaultLoadBalancingPolicyQueryPlanTest extends DefaultLoadBalancin
 
     Mockito.when(context.metadataManager()).thenReturn(metadataManager);
     Mockito.when(metadataManager.getMetadata()).thenReturn(metadata);
-    Mockito.when(metadata.getTokenMap()).thenReturn(Optional.of(tokenMap));
+    Mockito.when(metadata.getTokenMap()).thenAnswer(invocation -> Optional.of(this.tokenMap));
 
     // Use a subclass to disable shuffling, we just spy to make sure that the shuffling method was
     // called (makes tests easier)

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/AddNodeRefreshTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/AddNodeRefreshTest.java
@@ -23,6 +23,7 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import java.net.InetSocketAddress;
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.Before;
@@ -51,7 +52,8 @@ public class AddNodeRefreshTest {
   @Test
   public void should_add_new_node() {
     // Given
-    DefaultMetadata oldMetadata = new DefaultMetadata(ImmutableMap.of(ADDRESS1, node1));
+    DefaultMetadata oldMetadata =
+        new DefaultMetadata(ImmutableMap.of(ADDRESS1, node1), Collections.emptyMap(), null);
     UUID hostId = Uuids.random();
     UUID schemaVersion = Uuids.random();
     DefaultNodeInfo newNodeInfo =
@@ -81,7 +83,8 @@ public class AddNodeRefreshTest {
   @Test
   public void should_not_add_existing_node() {
     // Given
-    DefaultMetadata oldMetadata = new DefaultMetadata(ImmutableMap.of(ADDRESS1, node1));
+    DefaultMetadata oldMetadata =
+        new DefaultMetadata(ImmutableMap.of(ADDRESS1, node1), Collections.emptyMap(), null);
     DefaultNodeInfo newNodeInfo =
         DefaultNodeInfo.builder()
             .withConnectAddress(ADDRESS1)

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultMetadataTokenMapTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultMetadataTokenMapTest.java
@@ -26,6 +26,7 @@ import com.datastax.oss.driver.internal.core.metadata.token.Murmur3TokenFactory;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import java.net.InetSocketAddress;
+import java.util.Collections;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,13 +64,15 @@ public class DefaultMetadataTokenMapTest {
 
   @Test
   public void should_not_build_token_map_when_initializing_with_contact_points() {
-    DefaultMetadata contactPointsMetadata = new DefaultMetadata(ImmutableMap.of(ADDRESS1, NODE1));
+    DefaultMetadata contactPointsMetadata =
+        new DefaultMetadata(ImmutableMap.of(ADDRESS1, NODE1), Collections.emptyMap(), null);
     assertThat(contactPointsMetadata.getTokenMap()).isNotPresent();
   }
 
   @Test
   public void should_build_minimal_token_map_on_first_refresh() {
-    DefaultMetadata contactPointsMetadata = new DefaultMetadata(ImmutableMap.of(ADDRESS1, NODE1));
+    DefaultMetadata contactPointsMetadata =
+        new DefaultMetadata(ImmutableMap.of(ADDRESS1, NODE1), Collections.emptyMap(), null);
     DefaultMetadata firstRefreshMetadata =
         contactPointsMetadata.withNodes(
             ImmutableMap.of(ADDRESS1, NODE1), true, true, new Murmur3TokenFactory(), context);
@@ -78,7 +81,8 @@ public class DefaultMetadataTokenMapTest {
 
   @Test
   public void should_not_build_token_map_when_disabled() {
-    DefaultMetadata contactPointsMetadata = new DefaultMetadata(ImmutableMap.of(ADDRESS1, NODE1));
+    DefaultMetadata contactPointsMetadata =
+        new DefaultMetadata(ImmutableMap.of(ADDRESS1, NODE1), Collections.emptyMap(), null);
     DefaultMetadata firstRefreshMetadata =
         contactPointsMetadata.withNodes(
             ImmutableMap.of(ADDRESS1, NODE1), false, true, new Murmur3TokenFactory(), context);
@@ -87,7 +91,8 @@ public class DefaultMetadataTokenMapTest {
 
   @Test
   public void should_stay_empty_on_first_refresh_if_partitioner_missing() {
-    DefaultMetadata contactPointsMetadata = new DefaultMetadata(ImmutableMap.of(ADDRESS1, NODE1));
+    DefaultMetadata contactPointsMetadata =
+        new DefaultMetadata(ImmutableMap.of(ADDRESS1, NODE1), Collections.emptyMap(), null);
     DefaultMetadata firstRefreshMetadata =
         contactPointsMetadata.withNodes(
             ImmutableMap.of(ADDRESS1, NODE1), true, true, null, context);
@@ -96,7 +101,8 @@ public class DefaultMetadataTokenMapTest {
 
   @Test
   public void should_update_minimal_token_map_if_new_node_and_still_no_schema() {
-    DefaultMetadata contactPointsMetadata = new DefaultMetadata(ImmutableMap.of(ADDRESS1, NODE1));
+    DefaultMetadata contactPointsMetadata =
+        new DefaultMetadata(ImmutableMap.of(ADDRESS1, NODE1), Collections.emptyMap(), null);
     DefaultMetadata firstRefreshMetadata =
         contactPointsMetadata.withNodes(
             ImmutableMap.of(ADDRESS1, NODE1), true, true, new Murmur3TokenFactory(), context);
@@ -108,7 +114,8 @@ public class DefaultMetadataTokenMapTest {
 
   @Test
   public void should_update_token_map_when_schema_changes() {
-    DefaultMetadata contactPointsMetadata = new DefaultMetadata(ImmutableMap.of(ADDRESS1, NODE1));
+    DefaultMetadata contactPointsMetadata =
+        new DefaultMetadata(ImmutableMap.of(ADDRESS1, NODE1), Collections.emptyMap(), null);
     DefaultMetadata firstRefreshMetadata =
         contactPointsMetadata.withNodes(
             ImmutableMap.of(ADDRESS1, NODE1), true, true, new Murmur3TokenFactory(), context);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/FullNodeListRefreshTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/FullNodeListRefreshTest.java
@@ -23,6 +23,7 @@ import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import java.net.InetSocketAddress;
+import java.util.Collections;
 import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,7 +59,8 @@ public class FullNodeListRefreshTest {
   public void should_add_and_remove_nodes() {
     // Given
     DefaultMetadata oldMetadata =
-        new DefaultMetadata(ImmutableMap.of(ADDRESS1, node1, ADDRESS2, node2));
+        new DefaultMetadata(
+            ImmutableMap.of(ADDRESS1, node1, ADDRESS2, node2), Collections.emptyMap(), null);
     Iterable<NodeInfo> newInfos =
         ImmutableList.of(
             DefaultNodeInfo.builder().withConnectAddress(ADDRESS2).build(),
@@ -78,7 +80,8 @@ public class FullNodeListRefreshTest {
   public void should_update_existing_nodes() {
     // Given
     DefaultMetadata oldMetadata =
-        new DefaultMetadata(ImmutableMap.of(ADDRESS1, node1, ADDRESS2, node2));
+        new DefaultMetadata(
+            ImmutableMap.of(ADDRESS1, node1, ADDRESS2, node2), Collections.emptyMap(), null);
 
     UUID hostId1 = Uuids.random();
     UUID hostId2 = Uuids.random();

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/RemoveNodeRefreshTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/RemoveNodeRefreshTest.java
@@ -21,6 +21,7 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import java.net.InetSocketAddress;
+import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,7 +52,8 @@ public class RemoveNodeRefreshTest {
   public void should_remove_existing_node() {
     // Given
     DefaultMetadata oldMetadata =
-        new DefaultMetadata(ImmutableMap.of(ADDRESS1, node1, ADDRESS2, node2));
+        new DefaultMetadata(
+            ImmutableMap.of(ADDRESS1, node1, ADDRESS2, node2), Collections.emptyMap(), null);
     RemoveNodeRefresh refresh = new RemoveNodeRefresh(ADDRESS2);
 
     // When
@@ -65,7 +67,8 @@ public class RemoveNodeRefreshTest {
   @Test
   public void should_not_remove_nonexistent_node() {
     // Given
-    DefaultMetadata oldMetadata = new DefaultMetadata(ImmutableMap.of(ADDRESS1, node1));
+    DefaultMetadata oldMetadata =
+        new DefaultMetadata(ImmutableMap.of(ADDRESS1, node1), Collections.emptyMap(), null);
     RemoveNodeRefresh refresh = new RemoveNodeRefresh(ADDRESS2);
 
     // When

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/SchemaParserTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/SchemaParserTest.java
@@ -22,6 +22,7 @@ import com.datastax.oss.driver.api.core.metadata.schema.FunctionSignature;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.internal.core.metadata.MetadataRefresh;
+import com.datastax.oss.driver.internal.core.metadata.schema.queries.CassandraSchemaRows;
 import com.datastax.oss.driver.internal.core.metadata.schema.queries.SchemaRows;
 import com.datastax.oss.driver.internal.core.metadata.schema.refresh.SchemaRefresh;
 import com.datastax.oss.driver.internal.core.type.codec.registry.DefaultCodecRegistry;
@@ -135,10 +136,10 @@ public class SchemaParserTest extends SchemaParserTestBase {
     assertThat(ks2.getUserDefinedTypes()).hasSize(1).containsKey(CqlIdentifier.fromInternal("t2"));
   }
 
-  private MetadataRefresh parse(Consumer<SchemaRows.Builder> builderConfig) {
-    SchemaRows.Builder builder = new SchemaRows.Builder(true, null, "test");
+  private MetadataRefresh parse(Consumer<CassandraSchemaRows.Builder> builderConfig) {
+    CassandraSchemaRows.Builder builder = new CassandraSchemaRows.Builder(true, null, "test");
     builderConfig.accept(builder);
     SchemaRows rows = builder.build();
-    return new SchemaParser(rows, context).parse();
+    return new CassandraSchemaParser(rows, context).parse();
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/SchemaParserTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/SchemaParserTestBase.java
@@ -127,6 +127,8 @@ public abstract class SchemaParserTestBase {
   protected static AdminRow mockLegacyTableRow(String keyspace, String name, String comparator) {
     AdminRow row = Mockito.mock(AdminRow.class);
 
+    Mockito.when(row.contains("table_name")).thenReturn(false);
+
     Mockito.when(row.getString("keyspace_name")).thenReturn(keyspace);
     Mockito.when(row.getString("columnfamily_name")).thenReturn(name);
     Mockito.when(row.getBoolean("is_dense")).thenReturn(false);
@@ -184,6 +186,7 @@ public abstract class SchemaParserTestBase {
     AdminRow row = Mockito.mock(AdminRow.class);
 
     Mockito.when(row.contains("flags")).thenReturn(true);
+    Mockito.when(row.contains("table_name")).thenReturn(true);
 
     Mockito.when(row.getString("keyspace_name")).thenReturn(keyspace);
     Mockito.when(row.getString("table_name")).thenReturn(name);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/ViewParserTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/ViewParserTest.java
@@ -22,6 +22,7 @@ import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.ViewMetadata;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
+import com.datastax.oss.driver.internal.core.metadata.schema.queries.CassandraSchemaRows;
 import com.datastax.oss.driver.internal.core.metadata.schema.queries.SchemaRows;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import java.util.Collections;
@@ -44,7 +45,7 @@ public class ViewParserTest extends SchemaParserTestBase {
   @Test
   public void should_skip_when_no_column_rows() {
     SchemaRows rows = rows(VIEW_ROW_3_0, Collections.emptyList());
-    ViewParser parser = new ViewParser(rows, new DataTypeClassNameParser(), context);
+    ViewParser parser = new ViewParser(rows, context);
     ViewMetadata view = parser.parseView(VIEW_ROW_3_0, KEYSPACE_ID, Collections.emptyMap());
 
     assertThat(view).isNull();
@@ -53,7 +54,7 @@ public class ViewParserTest extends SchemaParserTestBase {
   @Test
   public void should_parse_view() {
     SchemaRows rows = rows(VIEW_ROW_3_0, COLUMN_ROWS_3_0);
-    ViewParser parser = new ViewParser(rows, new DataTypeCqlNameParser(), context);
+    ViewParser parser = new ViewParser(rows, context);
     ViewMetadata view = parser.parseView(VIEW_ROW_3_0, KEYSPACE_ID, Collections.emptyMap());
 
     assertThat(view.getKeyspace().asInternal()).isEqualTo("ks");
@@ -66,7 +67,7 @@ public class ViewParserTest extends SchemaParserTestBase {
     assertThat(pk0.getType()).isEqualTo(DataTypes.TEXT);
 
     assertThat(view.getClusteringColumns().entrySet()).hasSize(5);
-    Iterator<ColumnMetadata> clusteringColumnsIterator =
+    Iterator<? extends ColumnMetadata> clusteringColumnsIterator =
         view.getClusteringColumns().keySet().iterator();
     assertThat(clusteringColumnsIterator.next().getName().asInternal()).isEqualTo("score");
     assertThat(clusteringColumnsIterator.next().getName().asInternal()).isEqualTo("user");
@@ -85,7 +86,7 @@ public class ViewParserTest extends SchemaParserTestBase {
   }
 
   private SchemaRows rows(AdminRow viewRow, Iterable<AdminRow> columnRows) {
-    return new SchemaRows.Builder(true, null, "test")
+    return new CassandraSchemaRows.Builder(true, null, "test")
         .withViews(ImmutableList.of(viewRow))
         .withColumns(columnRows)
         .build();

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra21SchemaQueriesTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra21SchemaQueriesTest.java
@@ -75,27 +75,27 @@ public class Cassandra21SchemaQueriesTest extends SchemaQueriesTest {
         .isSuccess(
             rows -> {
               // Keyspace
-              assertThat(rows.keyspaces).hasSize(2);
-              assertThat(rows.keyspaces.get(0).getString("keyspace_name")).isEqualTo("ks1");
-              assertThat(rows.keyspaces.get(1).getString("keyspace_name")).isEqualTo("ks2");
+              assertThat(rows.keyspaces()).hasSize(2);
+              assertThat(rows.keyspaces().get(0).getString("keyspace_name")).isEqualTo("ks1");
+              assertThat(rows.keyspaces().get(1).getString("keyspace_name")).isEqualTo("ks2");
 
               // Types
-              assertThat(rows.types.keySet()).containsOnly(KS1_ID);
-              assertThat(rows.types.get(KS1_ID)).hasSize(1);
-              assertThat(rows.types.get(KS1_ID).iterator().next().getString("type_name"))
+              assertThat(rows.types().keySet()).containsOnly(KS1_ID);
+              assertThat(rows.types().get(KS1_ID)).hasSize(1);
+              assertThat(rows.types().get(KS1_ID).iterator().next().getString("type_name"))
                   .isEqualTo("type");
 
               // Tables
-              assertThat(rows.tables.keySet()).containsOnly(KS1_ID);
-              assertThat(rows.tables.get(KS1_ID)).hasSize(1);
-              assertThat(rows.tables.get(KS1_ID).iterator().next().getString("columnfamily_name"))
+              assertThat(rows.tables().keySet()).containsOnly(KS1_ID);
+              assertThat(rows.tables().get(KS1_ID)).hasSize(1);
+              assertThat(rows.tables().get(KS1_ID).iterator().next().getString("columnfamily_name"))
                   .isEqualTo("foo");
 
               // Rows
-              assertThat(rows.columns.keySet()).containsOnly(KS1_ID);
-              assertThat(rows.columns.get(KS1_ID).keySet()).containsOnly(FOO_ID);
+              assertThat(rows.columns().keySet()).containsOnly(KS1_ID);
+              assertThat(rows.columns().get(KS1_ID).keySet()).containsOnly(FOO_ID);
               assertThat(
-                      rows.columns
+                      rows.columns()
                           .get(KS1_ID)
                           .get(FOO_ID)
                           .iterator()
@@ -104,9 +104,9 @@ public class Cassandra21SchemaQueriesTest extends SchemaQueriesTest {
                   .isEqualTo("k");
 
               // No views, functions or aggregates in this version
-              assertThat(rows.views.keySet()).isEmpty();
-              assertThat(rows.functions.keySet()).isEmpty();
-              assertThat(rows.aggregates.keySet()).isEmpty();
+              assertThat(rows.views().keySet()).isEmpty();
+              assertThat(rows.functions().keySet()).isEmpty();
+              assertThat(rows.aggregates().keySet()).isEmpty();
             });
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra22SchemaQueriesTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra22SchemaQueriesTest.java
@@ -85,27 +85,27 @@ public class Cassandra22SchemaQueriesTest extends SchemaQueriesTest {
         .isSuccess(
             rows -> {
               // Keyspace
-              assertThat(rows.keyspaces).hasSize(2);
-              assertThat(rows.keyspaces.get(0).getString("keyspace_name")).isEqualTo("ks1");
-              assertThat(rows.keyspaces.get(1).getString("keyspace_name")).isEqualTo("ks2");
+              assertThat(rows.keyspaces()).hasSize(2);
+              assertThat(rows.keyspaces().get(0).getString("keyspace_name")).isEqualTo("ks1");
+              assertThat(rows.keyspaces().get(1).getString("keyspace_name")).isEqualTo("ks2");
 
               // Types
-              assertThat(rows.types.keySet()).containsOnly(KS1_ID);
-              assertThat(rows.types.get(KS1_ID)).hasSize(1);
-              assertThat(rows.types.get(KS1_ID).iterator().next().getString("type_name"))
+              assertThat(rows.types().keySet()).containsOnly(KS1_ID);
+              assertThat(rows.types().get(KS1_ID)).hasSize(1);
+              assertThat(rows.types().get(KS1_ID).iterator().next().getString("type_name"))
                   .isEqualTo("type");
 
               // Tables
-              assertThat(rows.tables.keySet()).containsOnly(KS1_ID);
-              assertThat(rows.tables.get(KS1_ID)).hasSize(1);
-              assertThat(rows.tables.get(KS1_ID).iterator().next().getString("columnfamily_name"))
+              assertThat(rows.tables().keySet()).containsOnly(KS1_ID);
+              assertThat(rows.tables().get(KS1_ID)).hasSize(1);
+              assertThat(rows.tables().get(KS1_ID).iterator().next().getString("columnfamily_name"))
                   .isEqualTo("foo");
 
               // Rows
-              assertThat(rows.columns.keySet()).containsOnly(KS1_ID);
-              assertThat(rows.columns.get(KS1_ID).keySet()).containsOnly(FOO_ID);
+              assertThat(rows.columns().keySet()).containsOnly(KS1_ID);
+              assertThat(rows.columns().get(KS1_ID).keySet()).containsOnly(FOO_ID);
               assertThat(
-                      rows.columns
+                      rows.columns()
                           .get(KS1_ID)
                           .get(FOO_ID)
                           .iterator()
@@ -114,19 +114,20 @@ public class Cassandra22SchemaQueriesTest extends SchemaQueriesTest {
                   .isEqualTo("k");
 
               // Functions
-              assertThat(rows.functions.keySet()).containsOnly(KS2_ID);
-              assertThat(rows.functions.get(KS2_ID)).hasSize(1);
-              assertThat(rows.functions.get(KS2_ID).iterator().next().getString("function_name"))
+              assertThat(rows.functions().keySet()).containsOnly(KS2_ID);
+              assertThat(rows.functions().get(KS2_ID)).hasSize(1);
+              assertThat(rows.functions().get(KS2_ID).iterator().next().getString("function_name"))
                   .isEqualTo("add");
 
               // Aggregates
-              assertThat(rows.aggregates.keySet()).containsOnly(KS2_ID);
-              assertThat(rows.aggregates.get(KS2_ID)).hasSize(1);
-              assertThat(rows.aggregates.get(KS2_ID).iterator().next().getString("aggregate_name"))
+              assertThat(rows.aggregates().keySet()).containsOnly(KS2_ID);
+              assertThat(rows.aggregates().get(KS2_ID)).hasSize(1);
+              assertThat(
+                      rows.aggregates().get(KS2_ID).iterator().next().getString("aggregate_name"))
                   .isEqualTo("add");
 
               // No views in this version
-              assertThat(rows.views.keySet()).isEmpty();
+              assertThat(rows.views().keySet()).isEmpty();
             });
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra3SchemaQueriesTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra3SchemaQueriesTest.java
@@ -115,27 +115,27 @@ public class Cassandra3SchemaQueriesTest extends SchemaQueriesTest {
         .isSuccess(
             rows -> {
               // Keyspace
-              assertThat(rows.keyspaces).hasSize(2);
-              assertThat(rows.keyspaces.get(0).getString("keyspace_name")).isEqualTo("ks1");
-              assertThat(rows.keyspaces.get(1).getString("keyspace_name")).isEqualTo("ks2");
+              assertThat(rows.keyspaces()).hasSize(2);
+              assertThat(rows.keyspaces().get(0).getString("keyspace_name")).isEqualTo("ks1");
+              assertThat(rows.keyspaces().get(1).getString("keyspace_name")).isEqualTo("ks2");
 
               // Types
-              assertThat(rows.types.keySet()).containsOnly(KS1_ID);
-              assertThat(rows.types.get(KS1_ID)).hasSize(1);
-              assertThat(rows.types.get(KS1_ID).iterator().next().getString("type_name"))
+              assertThat(rows.types().keySet()).containsOnly(KS1_ID);
+              assertThat(rows.types().get(KS1_ID)).hasSize(1);
+              assertThat(rows.types().get(KS1_ID).iterator().next().getString("type_name"))
                   .isEqualTo("type");
 
               // Tables
-              assertThat(rows.tables.keySet()).containsOnly(KS1_ID);
-              assertThat(rows.tables.get(KS1_ID)).hasSize(1);
-              assertThat(rows.tables.get(KS1_ID).iterator().next().getString("table_name"))
+              assertThat(rows.tables().keySet()).containsOnly(KS1_ID);
+              assertThat(rows.tables().get(KS1_ID)).hasSize(1);
+              assertThat(rows.tables().get(KS1_ID).iterator().next().getString("table_name"))
                   .isEqualTo("foo");
 
               // Columns
-              assertThat(rows.columns.keySet()).containsOnly(KS1_ID);
-              assertThat(rows.columns.get(KS1_ID).keySet()).containsOnly(FOO_ID);
+              assertThat(rows.columns().keySet()).containsOnly(KS1_ID);
+              assertThat(rows.columns().get(KS1_ID).keySet()).containsOnly(FOO_ID);
               assertThat(
-                      rows.columns
+                      rows.columns()
                           .get(KS1_ID)
                           .get(FOO_ID)
                           .iterator()
@@ -144,10 +144,10 @@ public class Cassandra3SchemaQueriesTest extends SchemaQueriesTest {
                   .isEqualTo("k");
 
               // Indexes
-              assertThat(rows.indexes.keySet()).containsOnly(KS1_ID);
-              assertThat(rows.indexes.get(KS1_ID).keySet()).containsOnly(FOO_ID);
+              assertThat(rows.indexes().keySet()).containsOnly(KS1_ID);
+              assertThat(rows.indexes().get(KS1_ID).keySet()).containsOnly(FOO_ID);
               assertThat(
-                      rows.indexes
+                      rows.indexes()
                           .get(KS1_ID)
                           .get(FOO_ID)
                           .iterator()
@@ -156,21 +156,22 @@ public class Cassandra3SchemaQueriesTest extends SchemaQueriesTest {
                   .isEqualTo("index");
 
               // Views
-              assertThat(rows.views.keySet()).containsOnly(KS2_ID);
-              assertThat(rows.views.get(KS2_ID)).hasSize(1);
-              assertThat(rows.views.get(KS2_ID).iterator().next().getString("view_name"))
+              assertThat(rows.views().keySet()).containsOnly(KS2_ID);
+              assertThat(rows.views().get(KS2_ID)).hasSize(1);
+              assertThat(rows.views().get(KS2_ID).iterator().next().getString("view_name"))
                   .isEqualTo("foo");
 
               // Functions
-              assertThat(rows.functions.keySet()).containsOnly(KS2_ID);
-              assertThat(rows.functions.get(KS2_ID)).hasSize(1);
-              assertThat(rows.functions.get(KS2_ID).iterator().next().getString("function_name"))
+              assertThat(rows.functions().keySet()).containsOnly(KS2_ID);
+              assertThat(rows.functions().get(KS2_ID)).hasSize(1);
+              assertThat(rows.functions().get(KS2_ID).iterator().next().getString("function_name"))
                   .isEqualTo("add");
 
               // Aggregates
-              assertThat(rows.aggregates.keySet()).containsOnly(KS2_ID);
-              assertThat(rows.aggregates.get(KS2_ID)).hasSize(1);
-              assertThat(rows.aggregates.get(KS2_ID).iterator().next().getString("aggregate_name"))
+              assertThat(rows.aggregates().keySet()).containsOnly(KS2_ID);
+              assertThat(rows.aggregates().get(KS2_ID)).hasSize(1);
+              assertThat(
+                      rows.aggregates().get(KS2_ID).iterator().next().getString("aggregate_name"))
                   .isEqualTo("add");
             });
   }
@@ -231,9 +232,9 @@ public class Cassandra3SchemaQueriesTest extends SchemaQueriesTest {
     assertThat(result)
         .isSuccess(
             rows -> {
-              assertThat(rows.columns.keySet()).containsOnly(KS1_ID);
-              assertThat(rows.columns.get(KS1_ID).keySet()).containsOnly(FOO_ID);
-              assertThat(rows.columns.get(KS1_ID).get(FOO_ID))
+              assertThat(rows.columns().keySet()).containsOnly(KS1_ID);
+              assertThat(rows.columns().get(KS1_ID).keySet()).containsOnly(FOO_ID);
+              assertThat(rows.columns().get(KS1_ID).get(FOO_ID))
                   .extracting(r -> r.getString("column_name"))
                   .containsExactly("k", "v");
             });
@@ -305,15 +306,15 @@ public class Cassandra3SchemaQueriesTest extends SchemaQueriesTest {
     assertThat(result)
         .isSuccess(
             rows -> {
-              assertThat(rows.tables.keySet()).containsOnly(KS_ID);
-              assertThat(rows.tables.get(KS_ID)).hasSize(1);
-              assertThat(rows.tables.get(KS_ID).iterator().next().getString("table_name"))
+              assertThat(rows.tables().keySet()).containsOnly(KS_ID);
+              assertThat(rows.tables().get(KS_ID)).hasSize(1);
+              assertThat(rows.tables().get(KS_ID).iterator().next().getString("table_name"))
                   .isEqualTo("foo");
 
-              assertThat(rows.columns.keySet()).containsOnly(KS_ID);
-              assertThat(rows.columns.get(KS_ID).keySet()).containsOnly(FOO_ID);
+              assertThat(rows.columns().keySet()).containsOnly(KS_ID);
+              assertThat(rows.columns().get(KS_ID).keySet()).containsOnly(FOO_ID);
               assertThat(
-                      rows.columns
+                      rows.columns()
                           .get(KS_ID)
                           .get(FOO_ID)
                           .iterator()

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/DescribeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/DescribeIT.java
@@ -88,7 +88,8 @@ public class DescribeIT {
     // connect session to this keyspace.
     session.execute(String.format("USE %s", keyspace.asCql(false)));
 
-    Optional<KeyspaceMetadata> originalKsMeta = session.getMetadata().getKeyspace(keyspace);
+    Optional<? extends KeyspaceMetadata> originalKsMeta =
+        session.getMetadata().getKeyspace(keyspace);
 
     // Usertype 'ztype' with two columns.  Given name to ensure that even though it has an
     // alphabetically later name, it shows up before other user types ('ctype') that depend on it.
@@ -199,7 +200,8 @@ public class DescribeIT {
     assertThat(originalKsMeta.get().getUserDefinedTypes()).isEmpty();
 
     // validate that the exported schema matches what was expected exactly.
-    Optional<KeyspaceMetadata> ks = sessionRule.session().getMetadata().getKeyspace(keyspace);
+    Optional<? extends KeyspaceMetadata> ks =
+        sessionRule.session().getMetadata().getKeyspace(keyspace);
     assertThat(ks.get().describeWithChildren(true).trim()).isEqualTo(expectedCql);
 
     // Also validate that when you create a Session with schema already created that the exported

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaChangesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaChangesIT.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
@@ -34,6 +35,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -138,7 +140,8 @@ public class SchemaChangesIT {
               .hasValueSatisfying(
                   k -> {
                     assertThat(k.getType()).isEqualTo(DataTypes.INT);
-                    assertThat(table.getPartitionKey()).containsExactly(k);
+                    Assertions.<ColumnMetadata>assertThat(table.getPartitionKey())
+                        .containsExactly(k);
                   });
           assertThat(table.getClusteringColumns()).isEmpty();
         },
@@ -418,7 +421,7 @@ public class SchemaChangesIT {
   private <T> void should_handle_creation(
       String beforeStatement,
       String createStatement,
-      Function<Metadata, Optional<T>> extract,
+      Function<Metadata, Optional<? extends T>> extract,
       Consumer<T> verifyMetadata,
       BiConsumer<SchemaChangeListener, T> verifyListener,
       CqlIdentifier... keyspaces) {
@@ -467,7 +470,7 @@ public class SchemaChangesIT {
   private <T> void should_handle_drop(
       Iterable<String> beforeStatements,
       String dropStatement,
-      Function<Metadata, Optional<T>> extract,
+      Function<Metadata, Optional<? extends T>> extract,
       BiConsumer<SchemaChangeListener, T> verifyListener,
       CqlIdentifier... keyspaces) {
 
@@ -510,7 +513,7 @@ public class SchemaChangesIT {
   private <T> void should_handle_update(
       Iterable<String> beforeStatements,
       String updateStatement,
-      Function<Metadata, Optional<T>> extract,
+      Function<Metadata, Optional<? extends T>> extract,
       Consumer<T> verifyNewMetadata,
       TriConsumer<SchemaChangeListener, T, T> verifyListener,
       CqlIdentifier... keyspaces) {
@@ -559,7 +562,7 @@ public class SchemaChangesIT {
       Iterable<String> beforeStatements,
       String dropStatement,
       String recreateStatement,
-      Function<Metadata, Optional<T>> extract,
+      Function<Metadata, Optional<? extends T>> extract,
       Consumer<T> verifyNewMetadata,
       TriConsumer<SchemaChangeListener, T, T> verifyListener,
       CqlIdentifier... keyspaces) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaIT.java
@@ -41,7 +41,7 @@ public class SchemaIT {
 
   @Test
   public void should_expose_system_and_test_keyspace() {
-    Map<CqlIdentifier, KeyspaceMetadata> keyspaces =
+    Map<CqlIdentifier, ? extends KeyspaceMetadata> keyspaces =
         sessionRule.session().getMetadata().getKeyspaces();
     assertThat(keyspaces)
         .containsKeys(


### PR DESCRIPTION
Motivation:

Custom extensions of the server might add new fields to schema system
tables, calling for dedicated classes, e.g. MyCustomKeyspaceMetadata.
If Metadata methods declare exact types, converting to those custom
types will require a cast.

Modifications:

Use bounded types for all Metadata methods, e.g.

Map<CqlIdentifier, ? extends KeyspaceMetadata> getKeyspaces();

Adapt internal classes so that custom schema parsing logic can be
plugged in more easily.

Result:

Custom extensions can now extend the interfaces to specialize the types:

interface MyCustomSession extends Session {
  MyCustomMetadata getMetadata();
}

interface MyCustomMetadata extends Metadata {
  Map<CqlIdentifier, ? extends MyCustomKeyspaceMetadata> getKeyspaces();
}

The client doesn't need to cast anymore.