### PR TITLE
JAVA-1889: Upgrade dependencies to the latest minor versions

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-beta1 (in progress)
 
+- [improvement] JAVA-1889: Upgrade dependencies to the latest minor versions
 - [improvement] JAVA-1819: Propagate more attributes to bound statements
 - [improvement] JAVA-1897: Improve extensibility of schema metadata classes
 - [improvement] JAVA-1437: Enable SSL hostname validation by default

--- a/core/src/test/java/com/datastax/oss/driver/Assertions.java
+++ b/core/src/test/java/com/datastax/oss/driver/Assertions.java
@@ -40,7 +40,11 @@ public class Assertions extends org.assertj.core.api.Assertions {
     return new NettyFutureAssert<>(actual);
   }
 
-  public static <V> CompletionStageAssert<V> assertThat(CompletionStage<V> actual) {
+  /**
+   * Use a different name because this clashes with AssertJ's built-in one. Our implementation is a
+   * bit more flexible for checking completion values and errors.
+   */
+  public static <V> CompletionStageAssert<V> assertThatStage(CompletionStage<V> actual) {
     return new CompletionStageAssert<>(actual);
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryAvailableIdsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryAvailableIdsTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.channel;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.timeout;
 
@@ -64,7 +65,7 @@ public class ChannelFactoryAvailableIdsTest extends ChannelFactoryTestBase {
     completeSimpleChannelInit();
 
     // Then
-    assertThat(channelFuture)
+    assertThatStage(channelFuture)
         .isSuccess(
             channel -> {
               assertThat(channel.getAvailableIds()).isEqualTo(128);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryClusterNameTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryClusterNameTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.channel;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 
 import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
@@ -45,7 +46,7 @@ public class ChannelFactoryClusterNameTest extends ChannelFactoryTestBase {
     writeInboundFrame(readOutboundFrame(), TestResponses.clusterNameResponse("mockClusterName"));
 
     // Then
-    assertThat(channelFuture).isSuccess();
+    assertThatStage(channelFuture).isSuccess();
     assertThat(factory.clusterName).isEqualTo("mockClusterName");
   }
 
@@ -64,7 +65,7 @@ public class ChannelFactoryClusterNameTest extends ChannelFactoryTestBase {
     // open a first connection that will define the cluster name
     writeInboundFrame(readOutboundFrame(), new Ready());
     writeInboundFrame(readOutboundFrame(), TestResponses.clusterNameResponse("mockClusterName"));
-    assertThat(channelFuture).isSuccess();
+    assertThatStage(channelFuture).isSuccess();
     // open a second connection that returns the same cluster name
     channelFuture =
         factory.connect(
@@ -73,7 +74,7 @@ public class ChannelFactoryClusterNameTest extends ChannelFactoryTestBase {
     writeInboundFrame(readOutboundFrame(), TestResponses.clusterNameResponse("mockClusterName"));
 
     // Then
-    assertThat(channelFuture).isSuccess();
+    assertThatStage(channelFuture).isSuccess();
 
     // When
     // open a third connection that returns a different cluster name
@@ -84,7 +85,7 @@ public class ChannelFactoryClusterNameTest extends ChannelFactoryTestBase {
     writeInboundFrame(readOutboundFrame(), TestResponses.clusterNameResponse("wrongClusterName"));
 
     // Then
-    assertThat(channelFuture)
+    assertThatStage(channelFuture)
         .isFailed(
             e ->
                 assertThat(e)

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryProtocolNegotiationTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryProtocolNegotiationTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.channel;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 
 import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
 import com.datastax.oss.driver.api.core.UnsupportedProtocolVersionException;
@@ -53,7 +54,7 @@ public class ChannelFactoryProtocolNegotiationTest extends ChannelFactoryTestBas
     completeSimpleChannelInit();
 
     // Then
-    assertThat(channelFuture)
+    assertThatStage(channelFuture)
         .isSuccess(channel -> assertThat(channel.getClusterName()).isEqualTo("mockClusterName"));
     assertThat(factory.protocolVersion).isEqualTo(DefaultProtocolVersion.V4);
   }
@@ -81,7 +82,7 @@ public class ChannelFactoryProtocolNegotiationTest extends ChannelFactoryTestBas
         requestFrame, new Error(errorCode, "Invalid or unsupported protocol version"));
 
     // Then
-    assertThat(channelFuture)
+    assertThatStage(channelFuture)
         .isFailed(
             e -> {
               assertThat(e)
@@ -113,7 +114,7 @@ public class ChannelFactoryProtocolNegotiationTest extends ChannelFactoryTestBas
     writeInboundFrame(requestFrame, TestResponses.clusterNameResponse("mockClusterName"));
 
     // Then
-    assertThat(channelFuture)
+    assertThatStage(channelFuture)
         .isSuccess(channel -> assertThat(channel.getClusterName()).isEqualTo("mockClusterName"));
     assertThat(factory.protocolVersion).isEqualTo(DefaultProtocolVersion.V4);
   }
@@ -148,7 +149,7 @@ public class ChannelFactoryProtocolNegotiationTest extends ChannelFactoryTestBas
 
     requestFrame = readOutboundFrame();
     writeInboundFrame(requestFrame, TestResponses.clusterNameResponse("mockClusterName"));
-    assertThat(channelFuture)
+    assertThatStage(channelFuture)
         .isSuccess(channel -> assertThat(channel.getClusterName()).isEqualTo("mockClusterName"));
     assertThat(factory.protocolVersion).isEqualTo(DefaultProtocolVersion.V3);
   }
@@ -185,7 +186,7 @@ public class ChannelFactoryProtocolNegotiationTest extends ChannelFactoryTestBas
         requestFrame, new Error(errorCode, "Invalid or unsupported protocol version"));
 
     // Then
-    assertThat(channelFuture)
+    assertThatStage(channelFuture)
         .isFailed(
             e -> {
               assertThat(e)

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/MockChannelFactoryHelper.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/MockChannelFactoryHelper.java
@@ -117,7 +117,7 @@ public class MockChannelFactoryHelper {
         MultimapBuilder.hashKeys().arrayListValues().build();
 
     public Builder(ChannelFactory channelFactory) {
-      assertThat(MockUtil.isMock(channelFactory)).isTrue().as("expected a mock");
+      assertThat(MockUtil.isMock(channelFactory)).as("expected a mock").isTrue();
       Mockito.verifyZeroInteractions(channelFactory);
       this.channelFactory = channelFactory;
     }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.control;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 
@@ -44,7 +45,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     CompletionStage<Void> closeFuture = controlConnection.forceCloseAsync();
 
     // Then
-    assertThat(closeFuture).isSuccess();
+    assertThatStage(closeFuture).isSuccess();
   }
 
   @Test
@@ -60,7 +61,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     waitForPendingAdminTasks();
 
     // Then
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     assertThat(controlConnection.channel()).isEqualTo(channel1);
     Mockito.verify(eventBus).fire(ChannelEvent.channelOpened(node1));
 
@@ -80,7 +81,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     CompletionStage<Void> initFuture2 = controlConnection.init(false, false);
 
     // Then
-    assertThat(initFuture1).isEqualTo(initFuture2);
+    assertThatStage(initFuture1).isEqualTo(initFuture2);
 
     factoryHelper.verifyNoMoreCalls();
   }
@@ -102,7 +103,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     waitForPendingAdminTasks();
 
     // Then
-    assertThat(initFuture)
+    assertThatStage(initFuture)
         .isSuccess(v -> assertThat(controlConnection.channel()).isEqualTo(channel2));
     Mockito.verify(eventBus).fire(ChannelEvent.controlConnectionFailed(node1));
     Mockito.verify(eventBus).fire(ChannelEvent.channelOpened(node2));
@@ -128,7 +129,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     waitForPendingAdminTasks();
 
     // Then
-    assertThat(initFuture).isFailed();
+    assertThatStage(initFuture).isFailed();
     Mockito.verify(eventBus).fire(ChannelEvent.controlConnectionFailed(node1));
     Mockito.verify(eventBus).fire(ChannelEvent.controlConnectionFailed(node2));
     // no reconnections at init
@@ -154,7 +155,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     factoryHelper.waitForCall(node1);
 
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     assertThat(controlConnection.channel()).isEqualTo(channel1);
     Mockito.verify(eventBus).fire(ChannelEvent.channelOpened(node1));
 
@@ -193,7 +194,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     factoryHelper.waitForCall(node1);
 
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     assertThat(controlConnection.channel()).isEqualTo(channel1);
     Mockito.verify(eventBus).fire(ChannelEvent.channelOpened(node1));
 
@@ -241,7 +242,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     factoryHelper.waitForCall(node1);
 
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     assertThat(controlConnection.channel()).isEqualTo(channel1);
     Mockito.verify(eventBus).fire(ChannelEvent.channelOpened(node1));
 
@@ -285,7 +286,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     factoryHelper.waitForCall(node1);
 
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     assertThat(controlConnection.channel()).isEqualTo(channel1);
     Mockito.verify(eventBus).fire(ChannelEvent.channelOpened(node1));
 
@@ -342,7 +343,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     factoryHelper.waitForCall(node1);
 
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     assertThat(controlConnection.channel()).isEqualTo(channel1);
     Mockito.verify(eventBus).fire(ChannelEvent.channelOpened(node1));
 
@@ -385,7 +386,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
     factoryHelper.waitForCall(node1);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     assertThat(controlConnection.channel()).isEqualTo(channel1);
     Mockito.verify(eventBus).fire(ChannelEvent.channelOpened(node1));
 
@@ -423,7 +424,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
     factoryHelper.waitForCall(node1);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     assertThat(controlConnection.channel()).isEqualTo(channel1);
     Mockito.verify(eventBus).fire(ChannelEvent.channelOpened(node1));
 
@@ -461,9 +462,9 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
     factoryHelper.waitForCall(node1);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     CompletionStage<Void> closeFuture = controlConnection.forceCloseAsync();
-    assertThat(closeFuture).isSuccess();
+    assertThatStage(closeFuture).isSuccess();
 
     // When
     controlConnection.reconnectNow();
@@ -485,14 +486,14 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
     factoryHelper.waitForCall(node1);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
 
     // When
     CompletionStage<Void> closeFuture = controlConnection.forceCloseAsync();
     waitForPendingAdminTasks();
 
     // Then
-    assertThat(closeFuture).isSuccess();
+    assertThatStage(closeFuture).isSuccess();
     Mockito.verify(channel1).forceClose();
 
     factoryHelper.verifyNoMoreCalls();
@@ -516,7 +517,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
     factoryHelper.waitForCall(node1);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     assertThat(controlConnection.channel()).isEqualTo(channel1);
     Mockito.verify(eventBus).fire(ChannelEvent.channelOpened(node1));
 
@@ -563,7 +564,7 @@ public class ControlConnectionTest extends ControlConnectionTestBase {
     CompletionStage<Void> initFuture = controlConnection.init(false, false);
     factoryHelper.waitForCall(node1);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     assertThat(controlConnection.channel()).isEqualTo(channel1);
     Mockito.verify(eventBus).fire(ChannelEvent.channelOpened(node1));
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
@@ -33,6 +33,7 @@ import com.datastax.oss.driver.internal.core.metadata.LoadBalancingPolicyWrapper
 import com.datastax.oss.driver.internal.core.metadata.MetadataManager;
 import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
 import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
+import io.netty.channel.Channel;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.EventLoop;
@@ -136,25 +137,27 @@ abstract class ControlConnectionTestBase {
   }
 
   protected DriverChannel newMockDriverChannel(int id) {
-    DriverChannel channel = Mockito.mock(DriverChannel.class);
+    DriverChannel driverChannel = Mockito.mock(DriverChannel.class);
+    Channel channel = Mockito.mock(Channel.class);
     EventLoop adminExecutor = adminEventLoopGroup.next();
-    DefaultChannelPromise closeFuture = new DefaultChannelPromise(null, adminExecutor);
-    Mockito.when(channel.close())
+    DefaultChannelPromise closeFuture = new DefaultChannelPromise(channel, adminExecutor);
+    Mockito.when(driverChannel.close())
         .thenAnswer(
             i -> {
               closeFuture.trySuccess(null);
               return closeFuture;
             });
-    Mockito.when(channel.forceClose())
+    Mockito.when(driverChannel.forceClose())
         .thenAnswer(
             i -> {
               closeFuture.trySuccess(null);
               return closeFuture;
             });
-    Mockito.when(channel.closeFuture()).thenReturn(closeFuture);
-    Mockito.when(channel.toString()).thenReturn("channel" + id);
-    Mockito.when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0." + id, 9042));
-    return channel;
+    Mockito.when(driverChannel.closeFuture()).thenReturn(closeFuture);
+    Mockito.when(driverChannel.toString()).thenReturn("channel" + id);
+    Mockito.when(driverChannel.remoteAddress())
+        .thenReturn(new InetSocketAddress("127.0.0." + id, 9042));
+    return driverChannel;
   }
 
   // Wait for all the tasks on the admin executor to complete.

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandlerTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.cql;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -101,7 +102,7 @@ public class CqlPrepareHandlerTest {
       node1Behavior.setResponseSuccess(defaultFrameOf(simplePrepared()));
 
       // The future waits for the reprepare attempt on other nodes, so it's not done yet.
-      assertThat(prepareFuture).isNotDone();
+      assertThatStage(prepareFuture).isNotDone();
 
       // Should now reprepare on the remaining nodes:
       node2Behavior.verifyWrite();
@@ -112,7 +113,7 @@ public class CqlPrepareHandlerTest {
       node3Behavior.setWriteSuccess();
       node3Behavior.setResponseSuccess(defaultFrameOf(simplePrepared()));
 
-      assertThat(prepareFuture).isSuccess(CqlPrepareHandlerTest::assertMatchesSimplePrepared);
+      assertThatStage(prepareFuture).isSuccess(CqlPrepareHandlerTest::assertMatchesSimplePrepared);
     }
   }
 
@@ -142,7 +143,7 @@ public class CqlPrepareHandlerTest {
       node1Behavior.setResponseSuccess(defaultFrameOf(simplePrepared()));
 
       // The future should complete immediately:
-      assertThat(prepareFuture).isSuccess();
+      assertThatStage(prepareFuture).isSuccess();
 
       // And the other nodes should not be contacted:
       node2Behavior.verifyNoWrite();
@@ -178,7 +179,7 @@ public class CqlPrepareHandlerTest {
 
       // When the statement already existed, we don't prepare on other nodes, so the future should
       // complete immediately.
-      assertThat(prepareFuture)
+      assertThatStage(prepareFuture)
           .isSuccess(
               preparedStatement -> assertThat(preparedStatement).isSameAs(mockExistingStatement));
 
@@ -206,7 +207,7 @@ public class CqlPrepareHandlerTest {
                   "test")
               .handle();
 
-      assertThat(prepareFuture).isNotDone();
+      assertThatStage(prepareFuture).isNotDone();
 
       // Other nodes fail, the future should still succeed when all done
       node2Behavior.verifyWrite();
@@ -217,7 +218,7 @@ public class CqlPrepareHandlerTest {
       node3Behavior.verifyWrite();
       node3Behavior.setWriteFailure(new RuntimeException("mock error"));
 
-      assertThat(prepareFuture).isSuccess(CqlPrepareHandlerTest::assertMatchesSimplePrepared);
+      assertThatStage(prepareFuture).isSuccess(CqlPrepareHandlerTest::assertMatchesSimplePrepared);
     }
   }
 
@@ -251,12 +252,12 @@ public class CqlPrepareHandlerTest {
               .handle();
 
       // Success on node2, reprepare on node3
-      assertThat(prepareFuture).isNotDone();
+      assertThatStage(prepareFuture).isNotDone();
       node3Behavior.verifyWrite();
       node3Behavior.setWriteSuccess();
       node3Behavior.setResponseSuccess(defaultFrameOf(simplePrepared()));
 
-      assertThat(prepareFuture).isSuccess(CqlPrepareHandlerTest::assertMatchesSimplePrepared);
+      assertThatStage(prepareFuture).isSuccess(CqlPrepareHandlerTest::assertMatchesSimplePrepared);
     }
   }
 
@@ -290,7 +291,7 @@ public class CqlPrepareHandlerTest {
               .handle();
 
       // Success on node2, reprepare on node3
-      assertThat(prepareFuture)
+      assertThatStage(prepareFuture)
           .isFailed(
               error -> {
                 assertThat(error).isInstanceOf(OverloadedException.class);
@@ -330,7 +331,7 @@ public class CqlPrepareHandlerTest {
               .handle();
 
       // Success on node2, reprepare on node3
-      assertThat(prepareFuture)
+      assertThatStage(prepareFuture)
           .isFailed(
               error -> {
                 assertThat(error)
@@ -369,7 +370,7 @@ public class CqlPrepareHandlerTest {
           .write(any(Prepare.class), anyBoolean(), eq(payload), any(ResponseCallback.class));
       node2Behavior.verifyNoWrite();
       node3Behavior.verifyNoWrite();
-      assertThat(prepareFuture).isSuccess(CqlPrepareHandlerTest::assertMatchesSimplePrepared);
+      assertThatStage(prepareFuture).isSuccess(CqlPrepareHandlerTest::assertMatchesSimplePrepared);
     }
   }
 
@@ -402,7 +403,7 @@ public class CqlPrepareHandlerTest {
           .write(any(Prepare.class), anyBoolean(), eq(payload), any(ResponseCallback.class));
       Mockito.verify(node3Behavior.channel)
           .write(any(Prepare.class), anyBoolean(), eq(payload), any(ResponseCallback.class));
-      assertThat(prepareFuture).isSuccess(CqlPrepareHandlerTest::assertMatchesSimplePrepared);
+      assertThatStage(prepareFuture).isSuccess(CqlPrepareHandlerTest::assertMatchesSimplePrepared);
     }
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerRetryTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerRetryTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.cql;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -74,7 +75,7 @@ public class CqlRequestHandlerRetryTest extends CqlRequestHandlerTestBase {
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
 
-      assertThat(resultSetFuture)
+      assertThatStage(resultSetFuture)
           .isSuccess(
               resultSet -> {
                 Iterator<Row> rows = resultSet.currentPage().iterator();
@@ -114,7 +115,7 @@ public class CqlRequestHandlerRetryTest extends CqlRequestHandlerTestBase {
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
 
-      assertThat(resultSetFuture)
+      assertThatStage(resultSetFuture)
           .isFailed(
               error -> {
                 assertThat(error)
@@ -153,7 +154,7 @@ public class CqlRequestHandlerRetryTest extends CqlRequestHandlerTestBase {
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
 
-      assertThat(resultSetFuture)
+      assertThatStage(resultSetFuture)
           .isSuccess(
               resultSet -> {
                 Iterator<Row> rows = resultSet.currentPage().iterator();
@@ -201,7 +202,7 @@ public class CqlRequestHandlerRetryTest extends CqlRequestHandlerTestBase {
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
 
-      assertThat(resultSetFuture)
+      assertThatStage(resultSetFuture)
           .isSuccess(
               resultSet -> {
                 Iterator<Row> rows = resultSet.currentPage().iterator();
@@ -248,7 +249,7 @@ public class CqlRequestHandlerRetryTest extends CqlRequestHandlerTestBase {
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
 
-      assertThat(resultSetFuture)
+      assertThatStage(resultSetFuture)
           .isSuccess(
               resultSet -> {
                 Iterator<Row> rows = resultSet.currentPage().iterator();
@@ -294,7 +295,7 @@ public class CqlRequestHandlerRetryTest extends CqlRequestHandlerTestBase {
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
 
-      assertThat(resultSetFuture)
+      assertThatStage(resultSetFuture)
           .isFailed(
               error -> {
                 assertThat(error).isInstanceOf(failureScenario.expectedExceptionClass);
@@ -340,7 +341,7 @@ public class CqlRequestHandlerRetryTest extends CqlRequestHandlerTestBase {
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
 
-      assertThat(resultSetFuture)
+      assertThatStage(resultSetFuture)
           .isFailed(
               error -> {
                 assertThat(error).isInstanceOf(failureScenario.expectedExceptionClass);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerSpeculativeExecutionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerSpeculativeExecutionTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.cql;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -168,7 +169,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
 
       // Complete the request from the initial execution
       node1Behavior.setResponseSuccess(defaultFrameOf(singleRow()));
-      assertThat(resultSetFuture).isSuccess();
+      assertThatStage(resultSetFuture).isSuccess();
 
       // Pending speculative executions should have been cancelled. However we don't check
       // firstExecutionTask directly because the request handler's onResponse can sometimes be
@@ -215,7 +216,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
 
       harness.nextScheduledTask(); // Discard the timeout task
 
-      assertThat(resultSetFuture)
+      assertThatStage(resultSetFuture)
           .isFailed(error -> assertThat(error).isInstanceOf(NoNodeAvailableException.class));
     }
   }
@@ -263,7 +264,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
           defaultFrameOf(new Error(ProtocolConstants.ErrorCode.IS_BOOTSTRAPPING, "mock message")));
 
       // But again the query plan is empty so that should fail the request
-      assertThat(resultSetFuture)
+      assertThatStage(resultSetFuture)
           .isFailed(
               error -> {
                 assertThat(error).isInstanceOf(AllNodesFailedException.class);
@@ -319,7 +320,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
       node2Behavior.setResponseSuccess(
           defaultFrameOf(new Error(ProtocolConstants.ErrorCode.IS_BOOTSTRAPPING, "mock message")));
 
-      assertThat(resultSetFuture)
+      assertThatStage(resultSetFuture)
           .isFailed(
               error -> {
                 assertThat(error).isInstanceOf(AllNodesFailedException.class);
@@ -373,7 +374,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
           defaultFrameOf(new Error(ProtocolConstants.ErrorCode.IS_BOOTSTRAPPING, "mock message")));
 
       // The second execution should move to node3 and complete the request
-      assertThat(resultSetFuture).isSuccess();
+      assertThatStage(resultSetFuture).isSuccess();
 
       // The request to node1 was still in flight, it should have been cancelled
       node1Behavior.verifyCancellation();
@@ -417,7 +418,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
 
       // Complete the request from the initial execution
       node1Behavior.setResponseSuccess(defaultFrameOf(singleRow()));
-      assertThat(resultSetFuture).isSuccess();
+      assertThatStage(resultSetFuture).isSuccess();
 
       // node2 replies with a response that would trigger a RETRY_NEXT if the request was still
       // running

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.cql;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.DriverTimeoutException;
@@ -62,7 +63,7 @@ public class CqlRequestHandlerTest extends CqlRequestHandlerTestBase {
                   "test")
               .handle();
 
-      assertThat(resultSetFuture)
+      assertThatStage(resultSetFuture)
           .isSuccess(
               resultSet -> {
                 Iterator<Row> rows = resultSet.currentPage().iterator();
@@ -96,7 +97,7 @@ public class CqlRequestHandlerTest extends CqlRequestHandlerTestBase {
                   "test")
               .handle();
 
-      assertThat(resultSetFuture)
+      assertThatStage(resultSetFuture)
           .isFailed(error -> assertThat(error).isInstanceOf(NoNodeAvailableException.class));
     }
   }
@@ -129,7 +130,7 @@ public class CqlRequestHandlerTest extends CqlRequestHandlerTestBase {
           .isEqualTo(configuredTimeout.toNanos());
       scheduledTask.run();
 
-      assertThat(resultSetFuture)
+      assertThatStage(resultSetFuture)
           .isFailed(t -> assertThat(t).isInstanceOf(DriverTimeoutException.class));
     }
   }
@@ -149,7 +150,7 @@ public class CqlRequestHandlerTest extends CqlRequestHandlerTestBase {
                   "test")
               .handle();
 
-      assertThat(resultSetFuture)
+      assertThatStage(resultSetFuture)
           .isSuccess(
               resultSet ->
                   Mockito.verify(harness.getSession())
@@ -199,7 +200,7 @@ public class CqlRequestHandlerTest extends CqlRequestHandlerTestBase {
           defaultFrameOf(new Unprepared("mock message", mockId.array())));
 
       // Should now re-prepare, re-execute and succeed.
-      assertThat(resultSetFuture).isSuccess();
+      assertThatStage(resultSetFuture).isSuccess();
     }
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/DefaultAsyncResultSetTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/DefaultAsyncResultSetTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.cql;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
@@ -96,7 +97,7 @@ public class DefaultAsyncResultSetTest {
     // Then
     Mockito.verify(statement).copy(mockPagingState);
     Mockito.verify(session).executeAsync(mockNextStatement);
-    assertThat(nextPageFuture).isEqualTo(mockResultFuture);
+    assertThatStage(nextPageFuture).isEqualTo(mockResultFuture);
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/QueryTraceFetcherTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/QueryTraceFetcherTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.cql;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
@@ -129,7 +130,7 @@ public class QueryTraceFetcherTest {
     assertEventsQuery(statement);
     Mockito.verifyNoMoreInteractions(session);
 
-    assertThat(traceFuture)
+    assertThatStage(traceFuture)
         .isSuccess(
             trace -> {
               assertThat(trace.getTracingId()).isEqualTo(TRACING_ID);
@@ -181,7 +182,7 @@ public class QueryTraceFetcherTest {
     assertThat(statements.get(2).getPagingState()).isEqualTo(PAGING_STATE);
     Mockito.verifyNoMoreInteractions(session);
 
-    assertThat(traceFuture).isSuccess(trace -> assertThat(trace.getEvents()).hasSize(2));
+    assertThatStage(traceFuture).isSuccess(trace -> assertThat(trace.getEvents()).hasSize(2));
   }
 
   @Test
@@ -205,7 +206,7 @@ public class QueryTraceFetcherTest {
     assertEventsQuery(statements.get(2));
     Mockito.verifyNoMoreInteractions(session);
 
-    assertThat(traceFuture)
+    assertThatStage(traceFuture)
         .isSuccess(
             trace -> {
               assertThat(trace.getTracingId()).isEqualTo(TRACING_ID);
@@ -248,7 +249,7 @@ public class QueryTraceFetcherTest {
     assertSessionQuery(statement);
     Mockito.verifyNoMoreInteractions(session);
 
-    assertThat(traceFuture).isFailed(error -> assertThat(error).isSameAs(mockError));
+    assertThatStage(traceFuture).isFailed(error -> assertThat(error).isSameAs(mockError));
   }
 
   @Test
@@ -271,7 +272,7 @@ public class QueryTraceFetcherTest {
       assertSessionQuery(statements.get(i));
     }
 
-    assertThat(traceFuture)
+    assertThatStage(traceFuture)
         .isFailed(
             error ->
                 assertThat(error.getMessage())

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitorTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.metadata;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
@@ -110,7 +111,7 @@ public class DefaultTopologyMonitorTest {
     CompletionStage<Optional<NodeInfo>> futureInfo = topologyMonitor.refreshNode(node1);
 
     // Then
-    assertThat(futureInfo).isSuccess(maybeInfo -> assertThat(maybeInfo.isPresent()).isFalse());
+    assertThatStage(futureInfo).isSuccess(maybeInfo -> assertThat(maybeInfo.isPresent()).isFalse());
   }
 
   @Test
@@ -128,7 +129,7 @@ public class DefaultTopologyMonitorTest {
     CompletionStage<Optional<NodeInfo>> futureInfo = topologyMonitor.refreshNode(node2);
 
     // Then
-    assertThat(futureInfo)
+    assertThatStage(futureInfo)
         .isSuccess(
             maybeInfo -> {
               assertThat(maybeInfo.isPresent()).isTrue();
@@ -152,7 +153,7 @@ public class DefaultTopologyMonitorTest {
     CompletionStage<Optional<NodeInfo>> futureInfo = topologyMonitor.refreshNode(node2);
 
     // Then
-    assertThat(futureInfo)
+    assertThatStage(futureInfo)
         .isSuccess(
             maybeInfo -> {
               assertThat(maybeInfo.isPresent()).isTrue();
@@ -176,7 +177,7 @@ public class DefaultTopologyMonitorTest {
     CompletionStage<Optional<NodeInfo>> futureInfo = topologyMonitor.refreshNode(node2);
 
     // Then
-    assertThat(futureInfo)
+    assertThatStage(futureInfo)
         .isSuccess(
             maybeInfo -> {
               assertThat(maybeInfo.isPresent()).isTrue();
@@ -208,7 +209,7 @@ public class DefaultTopologyMonitorTest {
     CompletionStage<Optional<NodeInfo>> futureInfo = topologyMonitor.refreshNode(node2);
 
     // Then
-    assertThat(futureInfo)
+    assertThatStage(futureInfo)
         .isSuccess(
             maybeInfo -> {
               assertThat(maybeInfo.isPresent()).isTrue();
@@ -240,7 +241,7 @@ public class DefaultTopologyMonitorTest {
     CompletionStage<Optional<NodeInfo>> futureInfo = topologyMonitor.getNewNodeInfo(ADDRESS1);
 
     // Then
-    assertThat(futureInfo)
+    assertThatStage(futureInfo)
         .isSuccess(
             maybeInfo -> {
               assertThat(maybeInfo.isPresent()).isTrue();
@@ -276,7 +277,7 @@ public class DefaultTopologyMonitorTest {
     CompletionStage<Optional<NodeInfo>> futureInfo = topologyMonitor.getNewNodeInfo(ADDRESS1);
 
     // Then
-    assertThat(futureInfo)
+    assertThatStage(futureInfo)
         .isSuccess(
             maybeInfo -> {
               assertThat(maybeInfo.isPresent()).isTrue();
@@ -316,7 +317,7 @@ public class DefaultTopologyMonitorTest {
     CompletionStage<Iterable<NodeInfo>> futureInfos = topologyMonitor.refreshNodeList();
 
     // Then
-    assertThat(futureInfos)
+    assertThatStage(futureInfos)
         .isSuccess(
             infos -> {
               Iterator<NodeInfo> iterator = infos.iterator();
@@ -343,7 +344,7 @@ public class DefaultTopologyMonitorTest {
     CompletionStage<Iterable<NodeInfo>> futureInfos = topologyMonitor.refreshNodeList();
 
     // Then
-    assertThat(futureInfos)
+    assertThatStage(futureInfos)
         .isFailed(error -> assertThat(error).isInstanceOf(IllegalStateException.class));
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/MetadataManagerTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.metadata;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.timeout;
 
@@ -110,7 +111,7 @@ public class MetadataManagerTest {
     waitForPendingAdminTasks();
 
     // Then
-    assertThat(addContactPointsFuture).isSuccess();
+    assertThatStage(addContactPointsFuture).isSuccess();
     assertThat(metadataManager.refreshes).hasSize(1);
     InitContactPointsRefresh refresh =
         ((InitContactPointsRefresh) metadataManager.refreshes.get(0));
@@ -125,7 +126,7 @@ public class MetadataManagerTest {
     waitForPendingAdminTasks();
 
     // Then
-    assertThat(addContactPointsFuture).isSuccess();
+    assertThatStage(addContactPointsFuture).isSuccess();
     assertThat(metadataManager.refreshes).hasSize(1);
     InitContactPointsRefresh refresh =
         ((InitContactPointsRefresh) metadataManager.refreshes.get(0));
@@ -146,7 +147,7 @@ public class MetadataManagerTest {
     waitForPendingAdminTasks();
 
     // Then
-    assertThat(refreshNodesFuture).isSuccess();
+    assertThatStage(refreshNodesFuture).isSuccess();
     assertThat(metadataManager.refreshes).hasSize(1);
     FullNodeListRefresh refresh = (FullNodeListRefresh) metadataManager.refreshes.get(0);
     assertThat(refresh.nodeInfos).containsExactlyInAnyOrder(info1, info2);
@@ -166,7 +167,7 @@ public class MetadataManagerTest {
 
     // Then
     // the info should have been copied to the node
-    assertThat(refreshNodeFuture).isSuccess();
+    assertThatStage(refreshNodeFuture).isSuccess();
     Mockito.verify(info, timeout(500)).getDatacenter();
     assertThat(node.getDatacenter()).isEqualTo("dc1");
   }
@@ -182,7 +183,7 @@ public class MetadataManagerTest {
     CompletionStage<Void> refreshNodeFuture = metadataManager.refreshNode(node);
 
     // Then
-    assertThat(refreshNodeFuture).isSuccess();
+    assertThatStage(refreshNodeFuture).isSuccess();
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/SchemaAgreementCheckerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/SchemaAgreementCheckerTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.metadata;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
@@ -119,7 +120,7 @@ public class SchemaAgreementCheckerTest {
     CompletionStage<Boolean> future = checker.run();
 
     // Then
-    assertThat(future).isSuccess(b -> assertThat(b).isFalse());
+    assertThatStage(future).isSuccess(b -> assertThat(b).isFalse());
   }
 
   @Test
@@ -137,7 +138,7 @@ public class SchemaAgreementCheckerTest {
     CompletionStage<Boolean> future = checker.run();
 
     // Then
-    assertThat(future).isSuccess(b -> assertThat(b).isTrue());
+    assertThatStage(future).isSuccess(b -> assertThat(b).isTrue());
   }
 
   @Test
@@ -156,7 +157,7 @@ public class SchemaAgreementCheckerTest {
     CompletionStage<Boolean> future = checker.run();
 
     // Then
-    assertThat(future).isSuccess(b -> assertThat(b).isTrue());
+    assertThatStage(future).isSuccess(b -> assertThat(b).isTrue());
     Mockito.verify(addressTranslator).translate(ADDRESS2);
   }
 
@@ -177,7 +178,7 @@ public class SchemaAgreementCheckerTest {
     CompletionStage<Boolean> future = checker.run();
 
     // Then
-    assertThat(future).isSuccess(b -> assertThat(b).isTrue());
+    assertThatStage(future).isSuccess(b -> assertThat(b).isTrue());
     Mockito.verify(addressTranslator).translate(ADDRESS2);
   }
 
@@ -197,7 +198,7 @@ public class SchemaAgreementCheckerTest {
     CompletionStage<Boolean> future = checker.run();
 
     // Then
-    assertThat(future).isSuccess(b -> assertThat(b).isTrue());
+    assertThatStage(future).isSuccess(b -> assertThat(b).isTrue());
     Mockito.verify(addressTranslator, never()).translate(ADDRESS2);
   }
 
@@ -220,7 +221,7 @@ public class SchemaAgreementCheckerTest {
     CompletionStage<Boolean> future = checker.run();
 
     // Then
-    assertThat(future).isSuccess(b -> assertThat(b).isTrue());
+    assertThatStage(future).isSuccess(b -> assertThat(b).isTrue());
     Mockito.verify(addressTranslator).translate(ADDRESS2);
   }
 
@@ -249,7 +250,7 @@ public class SchemaAgreementCheckerTest {
     CompletionStage<Boolean> future = checker.run();
 
     // Then
-    assertThat(future).isSuccess(b -> assertThat(b).isTrue());
+    assertThatStage(future).isSuccess(b -> assertThat(b).isTrue());
   }
 
   @Test
@@ -271,7 +272,7 @@ public class SchemaAgreementCheckerTest {
     CompletionStage<Boolean> future = checker.run();
 
     // Then
-    assertThat(future).isSuccess(b -> assertThat(b).isFalse());
+    assertThatStage(future).isSuccess(b -> assertThat(b).isFalse());
   }
 
   /** Extend to mock the query execution logic. */

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra21SchemaQueriesTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra21SchemaQueriesTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.metadata.schema.queries;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
@@ -71,7 +72,7 @@ public class Cassandra21SchemaQueriesTest extends SchemaQueriesTest {
 
     channel.runPendingTasks();
 
-    assertThat(result)
+    assertThatStage(result)
         .isSuccess(
             rows -> {
               // Keyspace

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra22SchemaQueriesTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra22SchemaQueriesTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.metadata.schema.queries;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
@@ -81,7 +82,7 @@ public class Cassandra22SchemaQueriesTest extends SchemaQueriesTest {
 
     channel.runPendingTasks();
 
-    assertThat(result)
+    assertThatStage(result)
         .isSuccess(
             rows -> {
               // Keyspace

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra3SchemaQueriesTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra3SchemaQueriesTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.metadata.schema.queries;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigProfile;
@@ -111,7 +112,7 @@ public class Cassandra3SchemaQueriesTest extends SchemaQueriesTest {
 
     channel.runPendingTasks();
 
-    assertThat(result)
+    assertThatStage(result)
         .isSuccess(
             rows -> {
               // Keyspace
@@ -229,7 +230,7 @@ public class Cassandra3SchemaQueriesTest extends SchemaQueriesTest {
 
     channel.runPendingTasks();
 
-    assertThat(result)
+    assertThatStage(result)
         .isSuccess(
             rows -> {
               assertThat(rows.columns().keySet()).containsOnly(KS1_ID);
@@ -303,7 +304,7 @@ public class Cassandra3SchemaQueriesTest extends SchemaQueriesTest {
 
     channel.runPendingTasks();
 
-    assertThat(result)
+    assertThatStage(result)
         .isSuccess(
             rows -> {
               assertThat(rows.tables().keySet()).containsOnly(KS_ID);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolInitTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolInitTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.pool;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
@@ -58,7 +59,7 @@ public class ChannelPoolInitTest extends ChannelPoolTestBase {
     factoryHelper.waitForCalls(node, 3);
     waitForPendingAdminTasks();
 
-    assertThat(poolFuture)
+    assertThatStage(poolFuture)
         .isSuccess(pool -> assertThat(pool.channels).containsOnly(channel1, channel2, channel3));
     Mockito.verify(eventBus, times(3)).fire(ChannelEvent.channelOpened(node));
 
@@ -83,7 +84,7 @@ public class ChannelPoolInitTest extends ChannelPoolTestBase {
     factoryHelper.waitForCalls(node, 3);
     waitForPendingAdminTasks();
 
-    assertThat(poolFuture).isSuccess(pool -> assertThat(pool.channels).isEmpty());
+    assertThatStage(poolFuture).isSuccess(pool -> assertThat(pool.channels).isEmpty());
     Mockito.verify(eventBus, never()).fire(ChannelEvent.channelOpened(node));
     Mockito.verify(nodeMetricUpdater, times(3))
         .incrementCounter(DefaultNodeMetric.CONNECTION_INIT_ERRORS, null);
@@ -108,7 +109,7 @@ public class ChannelPoolInitTest extends ChannelPoolTestBase {
 
     factoryHelper.waitForCalls(node, 3);
     waitForPendingAdminTasks();
-    assertThat(poolFuture)
+    assertThatStage(poolFuture)
         .isSuccess(
             pool -> {
               assertThat(pool.isInvalidKeyspace()).isTrue();
@@ -171,7 +172,7 @@ public class ChannelPoolInitTest extends ChannelPoolTestBase {
     factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
 
-    assertThat(poolFuture).isSuccess();
+    assertThatStage(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     assertThat(pool.channels).containsOnly(channel1);
     inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(node));

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolKeyspaceTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolKeyspaceTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.pool;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
@@ -50,7 +51,7 @@ public class ChannelPoolKeyspaceTest extends ChannelPoolTestBase {
     factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
 
-    assertThat(poolFuture).isSuccess();
+    assertThatStage(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     assertThat(pool.channels).containsOnly(channel1, channel2);
 
@@ -61,7 +62,7 @@ public class ChannelPoolKeyspaceTest extends ChannelPoolTestBase {
     Mockito.verify(channel1).setKeyspace(newKeyspace);
     Mockito.verify(channel2).setKeyspace(newKeyspace);
 
-    assertThat(setKeyspaceFuture).isSuccess();
+    assertThatStage(setKeyspaceFuture).isSuccess();
 
     factoryHelper.verifyNoMoreCalls();
   }
@@ -93,7 +94,7 @@ public class ChannelPoolKeyspaceTest extends ChannelPoolTestBase {
     factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
 
-    assertThat(poolFuture).isSuccess();
+    assertThatStage(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
 
     // Check that reconnection has kicked in, but do not complete it yet
@@ -105,7 +106,7 @@ public class ChannelPoolKeyspaceTest extends ChannelPoolTestBase {
     CqlIdentifier newKeyspace = CqlIdentifier.fromCql("new_keyspace");
     CompletionStage<Void> setKeyspaceFuture = pool.setKeyspace(newKeyspace);
     waitForPendingAdminTasks();
-    assertThat(setKeyspaceFuture).isSuccess();
+    assertThatStage(setKeyspaceFuture).isSuccess();
 
     // Now let the two channels succeed to complete the reconnection
     channel1Future.complete(channel1);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolReconnectTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolReconnectTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.pool;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -63,7 +64,7 @@ public class ChannelPoolReconnectTest extends ChannelPoolTestBase {
     factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
 
-    assertThat(poolFuture).isSuccess();
+    assertThatStage(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     assertThat(pool.channels).containsOnly(channel1, channel2);
     inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
@@ -115,7 +116,7 @@ public class ChannelPoolReconnectTest extends ChannelPoolTestBase {
     factoryHelper.waitForCalls(node, 2);
     waitForPendingAdminTasks();
 
-    assertThat(poolFuture).isSuccess();
+    assertThatStage(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     assertThat(pool.channels).containsOnly(channel1, channel2);
     inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
@@ -165,7 +166,7 @@ public class ChannelPoolReconnectTest extends ChannelPoolTestBase {
         ChannelPool.init(node, null, NodeDistance.LOCAL, context, "test");
     factoryHelper.waitForCalls(node, 1);
     waitForPendingAdminTasks();
-    assertThat(poolFuture).isSuccess();
+    assertThatStage(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     inOrder.verify(eventBus, times(1)).fire(ChannelEvent.channelOpened(node));
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolResizeTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolResizeTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.pool;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
@@ -60,7 +61,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     factoryHelper.waitForCalls(node, 4);
     waitForPendingAdminTasks();
 
-    assertThat(poolFuture).isSuccess();
+    assertThatStage(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     assertThat(pool.channels).containsOnly(channel1, channel2, channel3, channel4);
     inOrder.verify(eventBus, times(4)).fire(ChannelEvent.channelOpened(node));
@@ -110,7 +111,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     waitForPendingAdminTasks();
 
     inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
-    assertThat(poolFuture).isSuccess();
+    assertThatStage(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     assertThat(pool.channels).containsOnly(channel1, channel2);
 
@@ -169,7 +170,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     waitForPendingAdminTasks();
     inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
 
-    assertThat(poolFuture).isSuccess();
+    assertThatStage(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     assertThat(pool.channels).containsOnly(channel1, channel2);
 
@@ -226,7 +227,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     waitForPendingAdminTasks();
     inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(node));
 
-    assertThat(poolFuture).isSuccess();
+    assertThatStage(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     assertThat(pool.channels).containsOnly(channel1);
 
@@ -294,7 +295,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     waitForPendingAdminTasks();
     inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
 
-    assertThat(poolFuture).isSuccess();
+    assertThatStage(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     assertThat(pool.channels).containsOnly(channel1, channel2);
 
@@ -352,7 +353,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     waitForPendingAdminTasks();
     inOrder.verify(eventBus).fire(ChannelEvent.channelOpened(node));
 
-    assertThat(poolFuture).isSuccess();
+    assertThatStage(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     assertThat(pool.channels).containsOnly(channel1);
 
@@ -416,7 +417,7 @@ public class ChannelPoolResizeTest extends ChannelPoolTestBase {
     waitForPendingAdminTasks();
     inOrder.verify(eventBus, times(2)).fire(ChannelEvent.channelOpened(node));
 
-    assertThat(poolFuture).isSuccess();
+    assertThatStage(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     assertThat(pool.channels).containsOnly(channel1, channel2);
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolShutdownTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolShutdownTest.java
@@ -15,7 +15,7 @@
  */
 package com.datastax.oss.driver.internal.core.pool;
 
-import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
@@ -64,7 +64,7 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
     waitForPendingAdminTasks();
     inOrder.verify(eventBus, times(3)).fire(ChannelEvent.channelOpened(node));
 
-    assertThat(poolFuture).isSuccess();
+    assertThatStage(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
 
     // Simulate graceful shutdown on channel3
@@ -101,7 +101,7 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
     ((ChannelPromise) channel2.closeFuture()).setSuccess();
     ((ChannelPromise) channel3.closeFuture()).setSuccess();
 
-    assertThat(closeFuture).isSuccess();
+    assertThatStage(closeFuture).isSuccess();
 
     factoryHelper.verifyNoMoreCalls();
   }
@@ -135,7 +135,7 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
     factoryHelper.waitForCalls(node, 3);
     waitForPendingAdminTasks();
 
-    assertThat(poolFuture).isSuccess();
+    assertThatStage(poolFuture).isSuccess();
     ChannelPool pool = poolFuture.toCompletableFuture().get();
     inOrder.verify(eventBus, times(3)).fire(ChannelEvent.channelOpened(node));
 
@@ -173,7 +173,7 @@ public class ChannelPoolShutdownTest extends ChannelPoolTestBase {
     ((ChannelPromise) channel2.closeFuture()).setSuccess();
     ((ChannelPromise) channel3.closeFuture()).setSuccess();
 
-    assertThat(closeFuture).isSuccess();
+    assertThatStage(closeFuture).isSuccess();
 
     factoryHelper.verifyNoMoreCalls();
   }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelPoolTestBase.java
@@ -31,6 +31,7 @@ import com.datastax.oss.driver.internal.core.context.NettyOptions;
 import com.datastax.oss.driver.internal.core.metadata.DefaultNode;
 import com.datastax.oss.driver.internal.core.metrics.NodeMetricUpdater;
 import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
+import io.netty.channel.Channel;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.EventLoop;
@@ -93,18 +94,19 @@ abstract class ChannelPoolTestBase {
   }
 
   DriverChannel newMockDriverChannel(int id) {
-    DriverChannel channel = Mockito.mock(DriverChannel.class);
+    DriverChannel driverChannel = Mockito.mock(DriverChannel.class);
     EventLoop adminExecutor = adminEventLoopGroup.next();
-    DefaultChannelPromise closeFuture = new DefaultChannelPromise(null, adminExecutor);
-    DefaultChannelPromise closeStartedFuture = new DefaultChannelPromise(null, adminExecutor);
-    Mockito.when(channel.close()).thenReturn(closeFuture);
-    Mockito.when(channel.forceClose()).thenReturn(closeFuture);
-    Mockito.when(channel.closeFuture()).thenReturn(closeFuture);
-    Mockito.when(channel.closeStartedFuture()).thenReturn(closeStartedFuture);
-    Mockito.when(channel.setKeyspace(any(CqlIdentifier.class)))
+    Channel channel = Mockito.mock(Channel.class);
+    DefaultChannelPromise closeFuture = new DefaultChannelPromise(channel, adminExecutor);
+    DefaultChannelPromise closeStartedFuture = new DefaultChannelPromise(channel, adminExecutor);
+    Mockito.when(driverChannel.close()).thenReturn(closeFuture);
+    Mockito.when(driverChannel.forceClose()).thenReturn(closeFuture);
+    Mockito.when(driverChannel.closeFuture()).thenReturn(closeFuture);
+    Mockito.when(driverChannel.closeStartedFuture()).thenReturn(closeStartedFuture);
+    Mockito.when(driverChannel.setKeyspace(any(CqlIdentifier.class)))
         .thenReturn(adminExecutor.newSucceededFuture(null));
-    Mockito.when(channel.toString()).thenReturn("channel" + id);
-    return channel;
+    Mockito.when(driverChannel.toString()).thenReturn("channel" + id);
+    return driverChannel;
   }
 
   // Wait for all the tasks on the pool's admin executor to complete.

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/DefaultSessionPoolsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/DefaultSessionPoolsTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.session;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -218,14 +219,14 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.REMOTE);
     waitForPendingAdminTasks();
 
-    assertThat(initFuture).isNotDone();
+    assertThatStage(initFuture).isNotDone();
 
     pool1Future.complete(pool1);
     pool2Future.complete(pool2);
     pool3Future.complete(pool3);
     waitForPendingAdminTasks();
 
-    assertThat(initFuture)
+    assertThatStage(initFuture)
         .isSuccess(
             session ->
                 assertThat(((DefaultSession) session).getPools())
@@ -250,7 +251,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node1, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture)
+    assertThatStage(initFuture)
         .isSuccess(
             session ->
                 assertThat(((DefaultSession) session).getPools()).containsValues(pool1, pool3));
@@ -274,7 +275,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node1, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture)
+    assertThatStage(initFuture)
         .isSuccess(
             session ->
                 assertThat(((DefaultSession) session).getPools()).containsValues(pool1, pool3));
@@ -302,7 +303,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
 
-    assertThat(initFuture).isNotDone();
+    assertThatStage(initFuture).isNotDone();
 
     // Distance changes while init still pending
     eventBus.fire(new DistanceEvent(NodeDistance.REMOTE, node2));
@@ -314,7 +315,7 @@ public class DefaultSessionPoolsTest {
 
     Mockito.verify(pool2).resize(NodeDistance.REMOTE);
 
-    assertThat(initFuture)
+    assertThatStage(initFuture)
         .isSuccess(
             session ->
                 assertThat(((DefaultSession) session).getPools())
@@ -343,7 +344,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
 
-    assertThat(initFuture).isNotDone();
+    assertThatStage(initFuture).isNotDone();
 
     // Distance changes while init still pending
     eventBus.fire(new DistanceEvent(NodeDistance.IGNORED, node2));
@@ -355,7 +356,7 @@ public class DefaultSessionPoolsTest {
 
     Mockito.verify(pool2).closeAsync();
 
-    assertThat(initFuture)
+    assertThatStage(initFuture)
         .isSuccess(
             session ->
                 assertThat(((DefaultSession) session).getPools()).containsValues(pool1, pool3));
@@ -383,7 +384,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
 
-    assertThat(initFuture).isNotDone();
+    assertThatStage(initFuture).isNotDone();
 
     // Forced down while init still pending
     eventBus.fire(NodeStateEvent.changed(NodeState.UP, NodeState.FORCED_DOWN, node2));
@@ -395,7 +396,7 @@ public class DefaultSessionPoolsTest {
 
     Mockito.verify(pool2).closeAsync();
 
-    assertThat(initFuture)
+    assertThatStage(initFuture)
         .isSuccess(
             session ->
                 assertThat(((DefaultSession) session).getPools()).containsValues(pool1, pool3));
@@ -419,7 +420,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node2, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
 
     eventBus.fire(new DistanceEvent(NodeDistance.REMOTE, node2));
     Mockito.verify(pool2, timeout(500)).resize(NodeDistance.REMOTE);
@@ -443,7 +444,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node2, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
 
     eventBus.fire(new DistanceEvent(NodeDistance.IGNORED, node2));
     Mockito.verify(pool2, timeout(500)).closeAsync();
@@ -470,7 +471,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node2, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
 
     eventBus.fire(new DistanceEvent(NodeDistance.IGNORED, node2));
     Mockito.verify(pool2, timeout(100)).closeAsync();
@@ -505,7 +506,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node1, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     Session session = CompletableFutures.getCompleted(initFuture.toCompletableFuture());
     assertThat(((DefaultSession) session).getPools()).containsValues(pool1, pool3);
 
@@ -534,7 +535,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node2, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
 
     eventBus.fire(NodeStateEvent.changed(NodeState.UP, NodeState.FORCED_DOWN, node2));
     Mockito.verify(pool2, timeout(500)).closeAsync();
@@ -564,7 +565,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node1, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     Session session = CompletableFutures.getCompleted(initFuture.toCompletableFuture());
     assertThat(((DefaultSession) session).getPools()).containsValues(pool1, pool3);
 
@@ -594,7 +595,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node1, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     Session session = CompletableFutures.getCompleted(initFuture.toCompletableFuture());
     assertThat(((DefaultSession) session).getPools()).containsValues(pool1, pool3);
 
@@ -626,7 +627,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node1, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     Session session = CompletableFutures.getCompleted(initFuture.toCompletableFuture());
     assertThat(((DefaultSession) session).getPools()).containsValues(pool1, pool3);
 
@@ -669,7 +670,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node1, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     Session session = CompletableFutures.getCompleted(initFuture.toCompletableFuture());
     assertThat(((DefaultSession) session).getPools()).containsValues(pool1, pool3);
 
@@ -712,7 +713,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node1, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     Session session = CompletableFutures.getCompleted(initFuture.toCompletableFuture());
     assertThat(((DefaultSession) session).getPools()).containsValues(pool1, pool3);
 
@@ -751,12 +752,12 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node2, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     Session session = CompletableFutures.getCompleted(initFuture.toCompletableFuture());
 
     CompletionStage<Void> closeFuture = session.closeAsync();
     waitForPendingAdminTasks();
-    assertThat(closeFuture).isSuccess();
+    assertThatStage(closeFuture).isSuccess();
 
     Mockito.verify(pool1).closeAsync();
     Mockito.verify(pool2).closeAsync();
@@ -781,12 +782,12 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node2, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     Session session = CompletableFutures.getCompleted(initFuture.toCompletableFuture());
 
     CompletionStage<Void> closeFuture = session.forceCloseAsync();
     waitForPendingAdminTasks();
-    assertThat(closeFuture).isSuccess();
+    assertThatStage(closeFuture).isSuccess();
 
     Mockito.verify(pool1).forceCloseAsync();
     Mockito.verify(pool2).forceCloseAsync();
@@ -815,7 +816,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node1, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     Session session = CompletableFutures.getCompleted(initFuture.toCompletableFuture());
     assertThat(((DefaultSession) session).getPools()).containsValues(pool1, pool3);
 
@@ -826,7 +827,7 @@ public class DefaultSessionPoolsTest {
     // but the session gets closed before pool init completes
     CompletionStage<Void> closeFuture = session.closeAsync();
     waitForPendingAdminTasks();
-    assertThat(closeFuture).isSuccess();
+    assertThatStage(closeFuture).isSuccess();
 
     // now pool init completes
     pool2Future.complete(pool2);
@@ -854,7 +855,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node2, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     Session session = CompletableFutures.getCompleted(initFuture.toCompletableFuture());
 
     CqlIdentifier newKeyspace = CqlIdentifier.fromInternal("newKeyspace");
@@ -888,7 +889,7 @@ public class DefaultSessionPoolsTest {
     factoryHelper.waitForCall(node1, KEYSPACE, NodeDistance.LOCAL);
     factoryHelper.waitForCall(node3, KEYSPACE, NodeDistance.LOCAL);
     waitForPendingAdminTasks();
-    assertThat(initFuture).isSuccess();
+    assertThatStage(initFuture).isSuccess();
     DefaultSession session =
         (DefaultSession) CompletableFutures.getCompleted(initFuture.toCompletableFuture());
     assertThat(session.getPools()).containsValues(pool1, pool3);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/MockChannelPoolFactoryHelper.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/MockChannelPoolFactoryHelper.java
@@ -119,7 +119,7 @@ public class MockChannelPoolFactoryHelper {
         MultimapBuilder.hashKeys().arrayListValues().build();
 
     private Builder(ChannelPoolFactory channelPoolFactory) {
-      assertThat(MockUtil.isMock(channelPoolFactory)).isTrue().as("expected a mock");
+      assertThat(MockUtil.isMock(channelPoolFactory)).as("expected a mock").isTrue();
       Mockito.verifyZeroInteractions(channelPoolFactory);
       this.channelPoolFactory = channelPoolFactory;
     }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUpTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/ReprepareOnUpTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.session;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 
 import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
@@ -106,7 +107,7 @@ public class ReprepareOnUpTest {
     reprepareOnUp.start();
 
     // Then
-    assertThat(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
+    assertThatStage(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
   }
 
   @Test
@@ -120,7 +121,7 @@ public class ReprepareOnUpTest {
     reprepareOnUp.start();
 
     // Then
-    assertThat(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
+    assertThatStage(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
   }
 
   @Test
@@ -144,7 +145,7 @@ public class ReprepareOnUpTest {
       adminQuery.resultFuture.complete(null);
     }
 
-    assertThat(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
+    assertThatStage(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
   }
 
   @Test
@@ -170,7 +171,7 @@ public class ReprepareOnUpTest {
       adminQuery.resultFuture.complete(null);
     }
 
-    assertThat(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
+    assertThatStage(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
   }
 
   @Test
@@ -192,7 +193,7 @@ public class ReprepareOnUpTest {
       adminQuery.resultFuture.complete(null);
     }
 
-    assertThat(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
+    assertThatStage(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
   }
 
   @Test
@@ -218,7 +219,7 @@ public class ReprepareOnUpTest {
       adminQuery.resultFuture.complete(null);
     }
 
-    assertThat(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
+    assertThatStage(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
   }
 
   @Test
@@ -261,7 +262,7 @@ public class ReprepareOnUpTest {
       adminQuery.resultFuture.complete(null);
     }
 
-    assertThat(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
+    assertThatStage(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
   }
 
   @Test
@@ -303,7 +304,7 @@ public class ReprepareOnUpTest {
       adminQuery.resultFuture.complete(null);
     }
 
-    assertThat(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
+    assertThatStage(done).isSuccess(v -> assertThat(reprepareOnUp.queries).isEmpty());
   }
 
   private Map<ByteBuffer, RepreparePayload> getMockPayloads(char... values) {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/throttling/ConcurrencyLimitingRequestThrottlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/throttling/ConcurrencyLimitingRequestThrottlerTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.session.throttling;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 
 import com.datastax.oss.driver.api.core.RequestThrottlingException;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
@@ -65,7 +66,7 @@ public class ConcurrencyLimitingRequestThrottlerTest {
     throttler.register(request);
 
     // Then
-    assertThat(request.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
+    assertThatStage(request.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
     assertThat(throttler.getConcurrentRequests()).isEqualTo(1);
     assertThat(throttler.getQueue()).isEmpty();
   }
@@ -91,7 +92,7 @@ public class ConcurrencyLimitingRequestThrottlerTest {
     // Given
     MockThrottled first = new MockThrottled();
     throttler.register(first);
-    assertThat(first.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
+    assertThatStage(first.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
     for (int i = 0; i < 4; i++) { // fill to capacity
       throttler.register(new MockThrottled());
     }
@@ -106,7 +107,7 @@ public class ConcurrencyLimitingRequestThrottlerTest {
     throttler.register(incoming);
 
     // Then
-    assertThat(incoming.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
+    assertThatStage(incoming.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
     assertThat(throttler.getConcurrentRequests()).isEqualTo(5);
     assertThat(throttler.getQueue()).isEmpty();
   }
@@ -125,7 +126,7 @@ public class ConcurrencyLimitingRequestThrottlerTest {
     throttler.register(incoming);
 
     // Then
-    assertThat(incoming.started).isNotDone();
+    assertThatStage(incoming.started).isNotDone();
     assertThat(throttler.getConcurrentRequests()).isEqualTo(5);
     assertThat(throttler.getQueue()).containsExactly(incoming);
   }
@@ -150,20 +151,20 @@ public class ConcurrencyLimitingRequestThrottlerTest {
     // Given
     MockThrottled first = new MockThrottled();
     throttler.register(first);
-    assertThat(first.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
+    assertThatStage(first.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
     for (int i = 0; i < 4; i++) {
       throttler.register(new MockThrottled());
     }
 
     MockThrottled incoming = new MockThrottled();
     throttler.register(incoming);
-    assertThat(incoming.started).isNotDone();
+    assertThatStage(incoming.started).isNotDone();
 
     // When
     completeCallback.accept(first);
 
     // Then
-    assertThat(incoming.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isTrue());
+    assertThatStage(incoming.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isTrue());
     assertThat(throttler.getConcurrentRequests()).isEqualTo(5);
     assertThat(throttler.getQueue()).isEmpty();
   }
@@ -182,7 +183,7 @@ public class ConcurrencyLimitingRequestThrottlerTest {
     throttler.register(incoming);
 
     // Then
-    assertThat(incoming.started)
+    assertThatStage(incoming.started)
         .isFailed(error -> assertThat(error).isInstanceOf(RequestThrottlingException.class));
   }
 
@@ -201,7 +202,7 @@ public class ConcurrencyLimitingRequestThrottlerTest {
     throttler.signalTimeout(queued1);
 
     // Then
-    assertThat(queued2.started).isNotDone();
+    assertThatStage(queued2.started).isNotDone();
     assertThat(throttler.getConcurrentRequests()).isEqualTo(5);
     assertThat(throttler.getQueue()).hasSize(1);
   }
@@ -216,7 +217,7 @@ public class ConcurrencyLimitingRequestThrottlerTest {
     for (int i = 0; i < 10; i++) {
       MockThrottled request = new MockThrottled();
       throttler.register(request);
-      assertThat(request.started).isNotDone();
+      assertThatStage(request.started).isNotDone();
       enqueued.add(request);
     }
 
@@ -225,7 +226,7 @@ public class ConcurrencyLimitingRequestThrottlerTest {
 
     // Then
     for (MockThrottled request : enqueued) {
-      assertThat(request.started)
+      assertThatStage(request.started)
           .isFailed(error -> assertThat(error).isInstanceOf(RequestThrottlingException.class));
     }
 
@@ -234,7 +235,7 @@ public class ConcurrencyLimitingRequestThrottlerTest {
     throttler.register(request);
 
     // Then
-    assertThat(request.started)
+    assertThatStage(request.started)
         .isFailed(error -> assertThat(error).isInstanceOf(RequestThrottlingException.class));
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/throttling/RateLimitingRequestThrottlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/throttling/RateLimitingRequestThrottlerTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.session.throttling;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 
 import com.datastax.oss.driver.api.core.RequestThrottlingException;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
@@ -94,7 +95,7 @@ public class RateLimitingRequestThrottlerTest {
     throttler.register(request);
 
     // Then
-    assertThat(request.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
+    assertThatStage(request.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
     assertThat(throttler.getStoredPermits()).isEqualTo(4);
     assertThat(throttler.getQueue()).isEmpty();
   }
@@ -113,7 +114,7 @@ public class RateLimitingRequestThrottlerTest {
     throttler.register(request);
 
     // Then
-    assertThat(request.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
+    assertThatStage(request.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isFalse());
     assertThat(throttler.getStoredPermits()).isEqualTo(0);
     assertThat(throttler.getQueue()).isEmpty();
   }
@@ -132,7 +133,7 @@ public class RateLimitingRequestThrottlerTest {
     throttler.register(request);
 
     // Then
-    assertThat(request.started).isNotDone();
+    assertThatStage(request.started).isNotDone();
     assertThat(throttler.getStoredPermits()).isEqualTo(0);
     assertThat(throttler.getQueue()).containsExactly(request);
 
@@ -156,7 +157,7 @@ public class RateLimitingRequestThrottlerTest {
     throttler.register(request);
 
     // Then
-    assertThat(request.started)
+    assertThatStage(request.started)
         .isFailed(error -> assertThat(error).isInstanceOf(RequestThrottlingException.class));
   }
 
@@ -175,7 +176,7 @@ public class RateLimitingRequestThrottlerTest {
     throttler.signalTimeout(queued1);
 
     // Then
-    assertThat(queued2.started).isNotDone();
+    assertThatStage(queued2.started).isNotDone();
     assertThat(throttler.getStoredPermits()).isEqualTo(0);
     assertThat(throttler.getQueue()).containsExactly(queued2);
   }
@@ -189,10 +190,10 @@ public class RateLimitingRequestThrottlerTest {
 
     MockThrottled queued1 = new MockThrottled();
     throttler.register(queued1);
-    assertThat(queued1.started).isNotDone();
+    assertThatStage(queued1.started).isNotDone();
     MockThrottled queued2 = new MockThrottled();
     throttler.register(queued2);
-    assertThat(queued2.started).isNotDone();
+    assertThatStage(queued2.started).isNotDone();
     assertThat(throttler.getStoredPermits()).isEqualTo(0);
     assertThat(throttler.getQueue()).hasSize(2);
 
@@ -217,8 +218,8 @@ public class RateLimitingRequestThrottlerTest {
     task.run();
 
     // Then
-    assertThat(queued1.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isTrue());
-    assertThat(queued2.started).isNotDone();
+    assertThatStage(queued1.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isTrue());
+    assertThatStage(queued2.started).isNotDone();
     assertThat(throttler.getStoredPermits()).isEqualTo(0);
     assertThat(throttler.getQueue()).containsExactly(queued2);
     // task reschedules itself since it did not empty the queue
@@ -231,7 +232,7 @@ public class RateLimitingRequestThrottlerTest {
     task.run();
 
     // Then
-    assertThat(queued2.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isTrue());
+    assertThatStage(queued2.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isTrue());
     assertThat(throttler.getStoredPermits()).isEqualTo(0);
     assertThat(throttler.getQueue()).isEmpty();
     assertThat(adminExecutor.nextTask()).isNull();
@@ -273,14 +274,14 @@ public class RateLimitingRequestThrottlerTest {
     // Then
     MockThrottled queued = new MockThrottled();
     throttler.register(queued);
-    assertThat(queued.started).isNotDone();
+    assertThatStage(queued.started).isNotDone();
 
     // When
     clock.add(ONE_HUNDRED_MILLISECONDS);
     adminExecutor.nextTask().run();
 
     // Then
-    assertThat(queued.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isTrue());
+    assertThatStage(queued.started).isSuccess(wasDelayed -> assertThat(wasDelayed).isTrue());
   }
 
   @Test
@@ -293,7 +294,7 @@ public class RateLimitingRequestThrottlerTest {
     for (int i = 0; i < 10; i++) {
       MockThrottled request = new MockThrottled();
       throttler.register(request);
-      assertThat(request.started).isNotDone();
+      assertThatStage(request.started).isNotDone();
       enqueued.add(request);
     }
 
@@ -302,7 +303,7 @@ public class RateLimitingRequestThrottlerTest {
 
     // Then
     for (MockThrottled request : enqueued) {
-      assertThat(request.started)
+      assertThatStage(request.started)
           .isFailed(error -> assertThat(error).isInstanceOf(RequestThrottlingException.class));
     }
 
@@ -311,7 +312,7 @@ public class RateLimitingRequestThrottlerTest {
     throttler.register(request);
 
     // Then
-    assertThat(request.started)
+    assertThatStage(request.started)
         .isFailed(error -> assertThat(error).isInstanceOf(RequestThrottlingException.class));
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/time/ThreadLocalTimestampGeneratorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/time/ThreadLocalTimestampGeneratorTest.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.time;
 
 import static com.datastax.oss.driver.Assertions.assertThat;
+import static com.datastax.oss.driver.Assertions.assertThatStage;
 import static com.datastax.oss.driver.Assertions.fail;
 
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
@@ -70,7 +71,7 @@ public class ThreadLocalTimestampGeneratorTest extends MonotonicTimestampGenerat
 
     assertThat(futures).hasSize(testThreadsCount);
     for (CompletionStage<Void> future : futures) {
-      assertThat(future).isSuccess();
+      assertThatStage(future).isSuccess();
     }
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/CodecTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/CodecTestBase.java
@@ -26,7 +26,7 @@ public class CodecTestBase<T> {
   protected TypeCodec<T> codec;
 
   protected String encode(T t, ProtocolVersion protocolVersion) {
-    assertThat(codec).isNotNull().as("Must set codec before calling this method");
+    assertThat(codec).as("Must set codec before calling this method").isNotNull();
     ByteBuffer bytes = codec.encode(t, protocolVersion);
     return (bytes == null) ? null : Bytes.toHexString(bytes);
   }
@@ -36,7 +36,7 @@ public class CodecTestBase<T> {
   }
 
   protected T decode(String hexString, ProtocolVersion protocolVersion) {
-    assertThat(codec).isNotNull().as("Must set codec before calling this method");
+    assertThat(codec).as("Must set codec before calling this method").isNotNull();
     ByteBuffer bytes = (hexString == null) ? null : Bytes.fromHexString(hexString);
     // Decode twice, to assert that decode leaves the input buffer in its original state
     codec.decode(bytes, protocolVersion);
@@ -48,12 +48,12 @@ public class CodecTestBase<T> {
   }
 
   protected String format(T t) {
-    assertThat(codec).isNotNull().as("Must set codec before calling this method");
+    assertThat(codec).as("Must set codec before calling this method").isNotNull();
     return codec.format(t);
   }
 
   protected T parse(String s) {
-    assertThat(codec).isNotNull().as("Must set codec before calling this method");
+    assertThat(codec).as("Must set codec before calling this method").isNotNull();
     return codec.parse(s);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -46,23 +46,23 @@
     <format.validateOnly>true</format.validateOnly>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <config.version>1.3.1</config.version>
+    <config.version>1.3.3</config.version>
     <guava.version>25.1-jre</guava.version>
     <hdrhistogram.version>2.1.10</hdrhistogram.version>
     <metrics.version>4.0.2</metrics.version>
     <native-protocol.version>1.4.3-SNAPSHOT</native-protocol.version>
-    <netty.version>4.1.9.Final</netty.version>
+    <netty.version>4.1.26.Final</netty.version>
     <slf4j.version>1.7.25</slf4j.version>
     <!-- optional dependencies -->
-    <snappy.version>1.1.2.6</snappy.version>
+    <snappy.version>1.1.7.2</snappy.version>
     <lz4.version>1.4.1</lz4.version>
     <!-- test dependencies -->
-    <assertj.version>3.6.2</assertj.version>
+    <assertj.version>3.10.0</assertj.version>
     <commons-exec.version>1.3</commons-exec.version>
     <jackson.version>2.9.5</jackson.version>
     <junit.version>4.12</junit.version>
     <logback.version>1.2.3</logback.version>
-    <pax-exam.version>4.11.0</pax-exam.version>
+    <pax-exam.version>4.12.0</pax-exam.version>
     <simulacron.version>0.8.3</simulacron.version>
   </properties>
 
@@ -107,7 +107,7 @@
       <dependency>
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-ffi</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.8</version>
       </dependency>
       <dependency>
         <groupId>org.xerial.snappy</groupId>
@@ -122,7 +122,7 @@
       <dependency>
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-posix</artifactId>
-        <version>3.0.27</version>
+        <version>3.0.46</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
@@ -147,7 +147,7 @@
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
-        <version>3.1.3</version>
+        <version>3.1.5</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -157,7 +157,7 @@
       <dependency>
         <groupId>com.tngtech.java</groupId>
         <artifactId>junit-dataprovider</artifactId>
-        <version>1.12.0</version>
+        <version>1.13.1</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
@@ -167,7 +167,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>2.7.19</version>
+        <version>2.19.0</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss.simulacron</groupId>


### PR DESCRIPTION
Pretty straightforward, just a name clash with a new AssertJ assertion, and an added null check in a Netty method where we passed `null` in our tests (passing a plain mock instead works).