### PR TITLE
JAVA-1437: Enable SSL hostname validation by default

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-beta1 (in progress)
 
+- [improvement] JAVA-1437: Enable SSL hostname validation by default
 - [improvement] JAVA-1879: Duplicate basic.request options as Request/Statement attributes
 - [improvement] JAVA-1870: Use sensible defaults in RequestLogger if config options are missing
 - [improvement] JAVA-1877: Use a separate reconnection schedule for the control connection

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/ssl/DefaultSslEngineFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/ssl/DefaultSslEngineFactory.java
@@ -80,7 +80,7 @@ public class DefaultSslEngineFactory implements SslEngineFactory {
       this.cipherSuites = null;
     }
     this.requireHostnameValidation =
-        config.getBoolean(DefaultDriverOption.SSL_HOSTNAME_VALIDATION, false);
+        config.getBoolean(DefaultDriverOption.SSL_HOSTNAME_VALIDATION, true);
   }
 
   @NonNull

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -407,8 +407,8 @@ datastax-java-driver {
     // cipher-suites = [ "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA" ]
 
     # Whether or not to require validation that the hostname of the server certificate's common
-    # name matches the hostname of the server being connected to.
-    hostname-validation = false
+    # name matches the hostname of the server being connected to. If not set, defaults to true.
+    // hostname-validation = true
 
     # The locations and passwords used to access truststore and keystore contents.
     # These properties are optional. If either truststore-path or keystore-path are specified,

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ssl/DefaultSslEngineFactoryIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ssl/DefaultSslEngineFactoryIT.java
@@ -33,6 +33,7 @@ public class DefaultSslEngineFactoryIT {
         SessionUtils.newSession(
             ccm,
             "advanced.ssl-engine-factory.class = DefaultSslEngineFactory",
+            "advanced.ssl-engine-factory.hostname-validation = false",
             "advanced.ssl-engine-factory.truststore-path = "
                 + CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_FILE.getAbsolutePath(),
             "advanced.ssl-engine-factory.truststore-password = "
@@ -49,7 +50,6 @@ public class DefaultSslEngineFactoryIT {
         SessionUtils.newSession(
             ccm,
             "advanced.ssl-engine-factory.class = DefaultSslEngineFactory",
-            "advanced.ssl-engine-factory.hostname-validation = true",
             "advanced.ssl-engine-factory.truststore-path = "
                 + CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_FILE.getAbsolutePath(),
             "advanced.ssl-engine-factory.truststore-password = "
@@ -62,7 +62,9 @@ public class DefaultSslEngineFactoryIT {
   public void should_not_connect_if_truststore_not_provided() {
     try (CqlSession session =
         SessionUtils.newSession(
-            ccm, "advanced.ssl-engine-factory.class = DefaultSslEngineFactory")) {
+            ccm,
+            "advanced.ssl-engine-factory.class = DefaultSslEngineFactory",
+            "advanced.ssl-engine-factory.hostname-validation = false")) {
       session.execute("select * from system.local");
     }
   }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ssl/DefaultSslEngineFactoryPropertyBasedIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ssl/DefaultSslEngineFactoryPropertyBasedIT.java
@@ -27,7 +27,7 @@ import org.junit.experimental.categories.Category;
 @Category(IsolatedTests.class)
 public class DefaultSslEngineFactoryPropertyBasedIT {
 
-  @ClassRule public static CustomCcmRule ccm = CustomCcmRule.builder().withSsl().build();
+  @ClassRule public static CustomCcmRule ccm = CustomCcmRule.builder().withSslLocalhostCn().build();
 
   @Test
   public void should_connect_with_ssl() {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ssl/DefaultSslEngineFactoryPropertyBasedWithClientAuthIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ssl/DefaultSslEngineFactoryPropertyBasedWithClientAuthIT.java
@@ -41,7 +41,9 @@ public class DefaultSslEngineFactoryPropertyBasedWithClientAuthIT {
         "javax.net.ssl.trustStorePassword", CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_PASSWORD);
     try (CqlSession session =
         SessionUtils.newSession(
-            ccm, "advanced.ssl-engine-factory.class = DefaultSslEngineFactory")) {
+            ccm,
+            "advanced.ssl-engine-factory.class = DefaultSslEngineFactory",
+            "advanced.ssl-engine-factory.hostname-validation = false")) {
       session.execute("select * from system.local");
     }
   }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ssl/DefaultSslEngineFactoryWithClientAuthIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ssl/DefaultSslEngineFactoryWithClientAuthIT.java
@@ -33,6 +33,7 @@ public class DefaultSslEngineFactoryWithClientAuthIT {
         SessionUtils.newSession(
             ccm,
             "advanced.ssl-engine-factory.class = DefaultSslEngineFactory",
+            "advanced.ssl-engine-factory.hostname-validation = false",
             "advanced.ssl-engine-factory.keystore-path = "
                 + CcmBridge.DEFAULT_CLIENT_KEYSTORE_FILE.getAbsolutePath(),
             "advanced.ssl-engine-factory.keystore-password = "
@@ -51,6 +52,7 @@ public class DefaultSslEngineFactoryWithClientAuthIT {
         SessionUtils.newSession(
             ccm,
             "advanced.ssl-engine-factory.class = DefaultSslEngineFactory",
+            "advanced.ssl-engine-factory.hostname-validation = false",
             "advanced.ssl-engine-factory.truststore-path = "
                 + CcmBridge.DEFAULT_CLIENT_TRUSTSTORE_FILE.getAbsolutePath(),
             "advanced.ssl-engine-factory.truststore-password = "

--- a/manual/core/ssl/README.md
+++ b/manual/core/ssl/README.md
@@ -84,8 +84,8 @@ datastax-java-driver {
     // cipher-suites = [ "TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA" ]
 
     # Whether or not to require validation that the hostname of the server certificate's common
-    # name matches the hostname of the server being connected to.
-    hostname-validation = false
+    # name matches the hostname of the server being connected to. If not set, defaults to true.
+    // hostname-validation = true
 
     # The locations and passwords used to access truststore and keystore contents.
     # These properties are optional. If either truststore-path or keystore-path are specified,


### PR DESCRIPTION
For [JAVA-1437](https://datastax-oss.atlassian.net/browse/JAVA-1437).

Motivation:

When SSL is enabled, the driver should also enable validation of
certificate common names against server hostname by default. The
reasoning is that it seems logical to perform more validation than
less by default when the user enables SSL.

Modifications:

Change advanced.ssl-engine-factory.hostname-validation default to true.

Update manual and tests to reflect this change.

Result:

When DefaultSslEngineFactory is configured, hostname validation is
enabled by default.  The user may adjust the configuration to
explicitly disable hostname validation.