### PR TITLE
JAVA-1544: Check API compatibility with Revapi

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-beta2 (in progress)
 
+- [improvement] JAVA-1544: Check API compatibility with Revapi
 
 ### 4.0.0-beta1
 

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -121,6 +121,13 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/core/revapi.json
+++ b/core/revapi.json
@@ -1,0 +1,16 @@
+// Configures Revapi (https://revapi.org/getting-started.html) to check API compatibility between
+// successive driver versions.
+{
+  "revapi": {
+    "java": {
+      "filter": {
+        "packages": {
+          "regex": true,
+          "include": [
+            "com\\.datastax\\.oss\\.driver\\.api\\..*"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -90,6 +90,13 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -216,6 +216,13 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,18 @@
           <artifactId>maven-bundle-plugin</artifactId>
           <version>3.5.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.revapi</groupId>
+          <artifactId>revapi-maven-plugin</artifactId>
+          <version>0.10.4</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.revapi</groupId>
+              <artifactId>revapi-java</artifactId>
+              <version>0.18.0</version>
+            </dependency>
+          </dependencies>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -541,6 +553,23 @@ limitations under the License.]]>
             <supportedProjectType>pom</supportedProjectType>
           </supportedProjectTypes>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <analysisConfigurationFiles>
+                <!-- Present at the root of each module that doesn't skip this goal -->
+                <analysisConfigurationFile>revapi.json</analysisConfigurationFile>
+              </analysisConfigurationFiles>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/query-builder/revapi.json
+++ b/query-builder/revapi.json
@@ -1,0 +1,16 @@
+// Configures Revapi (https://revapi.org/getting-started.html) to check API compatibility between
+// successive driver versions.
+{
+  "revapi": {
+    "java": {
+      "filter": {
+        "packages": {
+          "regex": true,
+          "include": [
+            "com\\.datastax\\.oss\\.driver\\.api\\..*"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/test-infra/revapi.json
+++ b/test-infra/revapi.json
@@ -1,0 +1,16 @@
+// Configures Revapi (https://revapi.org/getting-started.html) to check API compatibility between
+// successive driver versions.
+{
+  "revapi": {
+    "java": {
+      "filter": {
+        "packages": {
+          "regex": true,
+          "include": [
+            "com\\.datastax\\.oss\\.driver\\.api\\..*"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
To test:
```
mvn verify -DskipTests -DskipITs | tee revapi.log 2>&1
```
Right now it compares beta1 to alpha3, so there are still a lot of breaking changes and the build fails. Things will get more interesting once we release beta1, I think we want to start tracking API changes right then, even though they're still allowed between betas.

Note: the plugin requires Maven >= 3.2.5

TODO
- [x] test again when we have a beta1 release