### PR TITLE
JAVA-1857: Add Statement.setHost

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -3,6 +3,7 @@
 ### 3.6.0 (In progress)
 
 - [improvement] JAVA-1394: Add request-queue-depth metric.
+- [improvement] JAVA-1857: Add Statement.setHost.
 
 Merged from 3.5.x:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Statement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Statement.java
@@ -635,7 +635,7 @@ public abstract class Statement {
      * </ol>
      * <p/>
      * Configuring a specific host causes the configured {@link LoadBalancingPolicy} to
-     * be completely bypassed.  However, if the load balancing policy dictates that the host is at
+     * be completely bypassed. However, if the load balancing policy dictates that the host is at
      * distance {@link HostDistance#IGNORED} or there is no active connectivity to the host, the
      * request will fail with a {@link NoHostAvailableException}.
      *

--- a/driver-core/src/main/java/com/datastax/driver/core/Statement.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Statement.java
@@ -15,8 +15,10 @@
  */
 package com.datastax.driver.core;
 
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.datastax.driver.core.exceptions.PagingStateException;
 import com.datastax.driver.core.exceptions.UnsupportedProtocolVersionException;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
 import com.datastax.driver.core.policies.RetryPolicy;
 import com.datastax.driver.core.querybuilder.BuiltStatement;
 import com.google.common.base.Preconditions;
@@ -70,6 +72,7 @@ public abstract class Statement {
     private volatile ByteBuffer pagingState;
     protected volatile Boolean idempotent;
     private volatile Map<String, ByteBuffer> outgoingPayload;
+    private volatile Host host;
 
     // We don't want to expose the constructor, because the code relies on this being only sub-classed by RegularStatement, BoundStatement and BatchStatement
     Statement() {
@@ -609,5 +612,39 @@ public abstract class Statement {
             }
         }
         return (hasNullIdempotentStatements) ? null : true;
+    }
+
+    /**
+     * @return The host configured on this statement, or null if none is configured.
+     * @see #setHost(Host)
+     */
+    public Host getHost() {
+        return host;
+    }
+
+    /**
+     * Sets the {@link Host} that should handle this query.
+     * <p/>
+     * In the general case, use of this method is <em>heavily discouraged</em> and should only be
+     * used in the following cases:
+     * <ol>
+     * <li>Querying node-local tables, such as tables in the {@code system} and
+     * {@code system_views} keyspaces.</li>
+     * <li>Applying a series of schema changes, where it may be advantageous to execute schema
+     * changes in sequence on the same node.</li>
+     * </ol>
+     * <p/>
+     * Configuring a specific host causes the configured {@link LoadBalancingPolicy} to
+     * be completely bypassed.  However, if the load balancing policy dictates that the host is at
+     * distance {@link HostDistance#IGNORED} or there is no active connectivity to the host, the
+     * request will fail with a {@link NoHostAvailableException}.
+     *
+     * @param host The host that should be used to handle executions of this statement or null
+     *             to delegate to the configured load balancing policy.
+     * @return this {@code Statement} object.
+     */
+    public Statement setHost(Host host) {
+        this.host = host;
+        return this;
     }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/StatementWrapper.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/StatementWrapper.java
@@ -210,4 +210,15 @@ public abstract class StatementWrapper extends Statement {
     public int requestSizeInBytes(ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
         return wrapped.requestSizeInBytes(protocolVersion, codecRegistry);
     }
+
+    @Override
+    public Host getHost() {
+        return wrapped.getHost();
+    }
+
+    @Override
+    public Statement setHost(Host host) {
+        wrapped.setHost(host);
+        return this;
+    }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/HostTargetingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostTargetingTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.datastax.driver.core;
 
 import static com.datastax.driver.core.Assertions.assertThat;

--- a/driver-core/src/test/java/com/datastax/driver/core/HostTargetingTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostTargetingTest.java
@@ -1,0 +1,126 @@
+package com.datastax.driver.core;
+
+import static com.datastax.driver.core.Assertions.assertThat;
+import static com.datastax.driver.core.TestUtils.nonQuietClusterCloseOptions;
+import static org.scassandra.http.client.PrimingRequest.then;
+import static org.testng.Assert.fail;
+
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import com.datastax.driver.core.exceptions.UnavailableException;
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
+import com.datastax.driver.core.policies.HostFilterPolicy;
+import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.google.common.base.Predicate;
+import org.mockito.Mockito;
+import org.scassandra.http.client.PrimingRequest;
+import org.scassandra.http.client.Result;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class HostTargetingTest {
+
+    private ScassandraCluster sCluster;
+    private Cluster cluster;
+    private Session session;
+    // Allow connecting to all hosts except for the 4th one.
+    private LoadBalancingPolicy lbSpy = Mockito.spy(new HostFilterPolicy(
+            DCAwareRoundRobinPolicy.builder().build(), new Predicate<Host>() {
+        @Override
+        public boolean apply(Host host) {
+            return !host.getAddress().getHostAddress().endsWith("4");
+        }
+    }));
+
+    @BeforeMethod(groups = "short")
+    public void setUp() {
+        sCluster = ScassandraCluster.builder().withNodes(4).build();
+        sCluster.init();
+
+        cluster = Cluster.builder()
+                .addContactPoints(sCluster.address(1).getAddress())
+                .withPort(sCluster.getBinaryPort())
+                .withLoadBalancingPolicy(lbSpy)
+                .withNettyOptions(nonQuietClusterCloseOptions)
+                .build();
+        session = cluster.connect();
+
+        // Reset invocations before entering test.
+        Mockito.reset(lbSpy);
+    }
+
+    @AfterMethod(groups = "short")
+    public void tearDown() {
+        cluster.close();
+        sCluster.stop();
+    }
+
+    private void verifyNoLbpInteractions() {
+        // load balancing policy should have been skipped completely as host was set.
+        Mockito.verify(lbSpy, Mockito.times(0))
+                .newQueryPlan(Mockito.any(String.class), Mockito.any(Statement.class));
+    }
+
+    @Test(groups = "short")
+    public void should_use_host_on_statement() {
+        for (int i = 0; i < 10; i++) {
+            int hostIndex = i % 3 + 1;
+            Host host = TestUtils.findHost(cluster, hostIndex);
+
+            // given a statement with host explicitly set.
+            Statement statement = new SimpleStatement("select * system.local").setHost(host);
+
+            // when statement is executed
+            ResultSet result = session.execute(statement);
+
+            // then the query should have been sent to the configured host.
+            assertThat(result.getExecutionInfo().getQueriedHost()).isSameAs(host);
+
+            verifyNoLbpInteractions();
+        }
+    }
+
+    @Test(groups = "short")
+    public void should_fail_if_host_fails_query() {
+        String query = "mock";
+        sCluster.node(1).primingClient().prime(PrimingRequest.queryBuilder()
+                .withQuery(query)
+                .withThen(then().withResult(Result.unavailable)).build());
+
+        // given a statement with a host configured to fail the given query.
+        Host host1 = TestUtils.findHost(cluster, 1);
+        Statement statement = new SimpleStatement(query).setHost(host1);
+
+        try {
+            // when statement is executed an error should be raised.
+            session.execute(statement);
+            fail("Query should have failed");
+        } catch (NoHostAvailableException e) {
+            // then the request should fail with a NHAE and no host was tried.
+            assertThat(e.getErrors()).hasSize(1);
+            assertThat(e.getErrors().values().iterator().next())
+                    .isInstanceOf(UnavailableException.class);
+        } finally {
+            verifyNoLbpInteractions();
+        }
+
+    }
+
+    @Test(groups = "short")
+    public void should_fail_if_host_is_not_connected() {
+        // given a statement with host explicitly set that for which we have no active pool.
+        Host host4 = TestUtils.findHost(cluster, 4);
+        Statement statement = new SimpleStatement("select * system.local").setHost(host4);
+
+        try {
+            // when statement is executed
+            session.execute(statement);
+            fail("Query should have failed");
+        } catch (NoHostAvailableException e) {
+            // then the request should fail with a NHAE and no host was tried.
+            assertThat(e.getErrors()).isEmpty();
+        } finally {
+            verifyNoLbpInteractions();
+        }
+    }
+}


### PR DESCRIPTION
For [JAVA-1857](https://datastax-oss.atlassian.net/browse/JAVA-1857).

Motivation:

With the introduction of system views in Apache C* 4.0
(CASSANDRA-7622) there is a need for the capability to
set a target node when executing queries.

This feature should be avoided in the general case and
only used in exceptional cases such as this.

Modifications:

Add Statement.setHost(Host).

Update RequestHandler to bypass the configured load balancing policy
and instead create a single host query plan targeting the configured
host if set.

Result:

Driver now offers capability of host targeting via Statement.setHost.