### PR TITLE
JAVA-1762: Improve shading and OSGi manifest generation

### DIFF
--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -16,7 +16,9 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -26,57 +28,112 @@
   </parent>
 
   <artifactId>java-driver-core-shaded</artifactId>
-  <packaging>bundle</packaging>
 
-  <name>DataStax Java driver for Apache Cassandra(R) - core with netty shaded</name>
+  <name>DataStax Java driver for Apache Cassandra(R) - core with shaded deps</name>
 
   <dependencies>
+    <!--
+    Declare a dependency to the core driver itself so that all its classes get included;
+    this dependency will be removed from the final pom by the shade plugin.
+    -->
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!--
+    Repeat all dependencies of the core driver *except* the ones that are going to be shaded,
+    so that they get included in the final pom (we don't use the "promoteTransitiveDependencies"
+    option of the shade plugin because it promotes all dependencies, even nested ones, to top level).
+    -->
+    <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>native-protocol</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-shaded-guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-ffi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-posix</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hdrhistogram</groupId>
+      <artifactId>HdrHistogram</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.stephenc.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
+
+  <!--
+  Generation of the shaded driver-core bundle during package phase:
+  1) shade plugin shades the driver and creates a shaded jar + source jar
+  2) dependency plugin unpacks the shaded jar to target/classes (and removes unwanted content)
+  3) bundle plugin analyzes shaded classes and generates the bundle manifest
+  4) assembly plugin re-creates the shaded jar by packing target/classes + manifest + shaded pom
+  -->
 
   <build>
     <plugins>
-      <!-- extract shaded manifest from core jar -->
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>unpack-manifest</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>unpack</goal>
-            </goals>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>com.datastax.oss</groupId>
-                  <artifactId>java-driver-core</artifactId>
-                  <version>${project.version}</version>
-                  <includes>META-INF-shaded/MANIFEST.MF</includes>
-                  <outputDirectory>${project.build.directory}</outputDirectory>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
+            <id>shade-core-dependencies</id>
             <phase>package</phase>
             <goals>
               <goal>shade</goal>
             </goals>
             <configuration>
+              <createSourcesJar>true</createSourcesJar>
+              <shadeSourcesContent>true</shadeSourcesContent>
               <artifactSet>
                 <includes>
+                  <!--
+                  Include:
+                  - The core driver itself; it is not relocated but needs to be included.
+                  - All the dependencies we want to shade & relocate: currently
+                    - all the Netty artifacts;
+                    - JCTools.
+                  -->
                   <include>com.datastax.oss:java-driver-core</include>
                   <include>io.netty:*</include>
+                  <include>org.jctools:*</include>
                 </includes>
               </artifactSet>
               <relocations>
@@ -84,39 +141,130 @@
                   <pattern>io.netty</pattern>
                   <shadedPattern>com.datastax.oss.driver.shaded.netty</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>org.jctools</pattern>
+                  <shadedPattern>com.datastax.oss.driver.shaded.jctools</shadedPattern>
+                </relocation>
               </relocations>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
-                  <resources>
-                    <resource>META-INF/MANIFEST.MF</resource>
-                    <resource>META-INF-shaded/MANIFEST.MF</resource>
-                    <resource>META-INF/maven/com.datastax.oss/java-driver-core/pom.xml</resource>
-                    <resource>META-INF/maven/com.datastax.oss/java-driver-core/pom.properties</resource>
-                    <resource>META-INF/maven/io.netty/netty-handler/pom.properties</resource>
-                    <resource>META-INF/maven/io.netty/netty-handler/pom.xml</resource>
-                    <resource>META-INF/maven/io.netty/netty-buffer/pom.properties</resource>
-                    <resource>META-INF/maven/io.netty/netty-buffer/pom.xml</resource>
-                    <resource>META-INF/maven/io.netty/netty-common/pom.properties</resource>
-                    <resource>META-INF/maven/io.netty/netty-common/pom.xml</resource>
-                    <resource>META-INF/maven/io.netty/netty-transport/pom.properties</resource>
-                    <resource>META-INF/maven/io.netty/netty-transport/pom.xml</resource>
-                    <resource>META-INF/maven/io.netty/netty-resolver/pom.properties</resource>
-                    <resource>META-INF/maven/io.netty/netty-resolver/pom.xml</resource>
-                    <resource>META-INF/maven/io.netty/netty-codec/pom.properties</resource>
-                    <resource>META-INF/maven/io.netty/netty-codec/pom.xml</resource>
-                    <!-- netty's shading of jctools does not remove its pom files -->
-                    <resource>META-INF/maven/org.jctools/jctools-core/pom.properties</resource>
-                    <resource>META-INF/maven/org.jctools/jctools-core/pom.xml</resource>
-                  </resources>
-                </transformer>
-                <!-- Pick up the alternate manifest that was extracted from the core module -->
-                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
-                  <resource>META-INF/MANIFEST.MF</resource>
-                  <file>${project.build.directory}/META-INF-shaded/MANIFEST.MF</file>
-                </transformer>
-              </transformers>
-              <!-- Keep the dependencies of driver-core -->
-              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>unpack-shaded-classes</id>
+            <phase>package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>com.datastax.oss</groupId>
+                  <artifactId>java-driver-core-shaded</artifactId>
+                  <version>${project.version}</version>
+                  <type>jar</type>
+                  <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+              <!--
+              Exclude leftovers from the shading phase (this could also be done with a
+              resource transformer by the shade plugin itself, but this way is more flexible).
+              -->
+              <excludes>
+                META-INF/maven/com.datastax.oss/java-driver-core/**,
+                META-INF/maven/io.netty/**,
+                META-INF/maven/org.jctools/**
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>generate-shaded-manifest</id>
+            <phase>package</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <instructions>
+                <Bundle-SymbolicName>com.datastax.oss.driver.core</Bundle-SymbolicName>
+                <!--
+                Allow importing code from other packages
+                (so reflection-based loading of policies works)
+                -->
+                <DynamicImport-Package>*</DynamicImport-Package>
+                <!--
+                Don't import the packages below because either:
+                1) they were shaded (except Guava which resides in a separate bundle); or
+                2) they aren't OSGi bundles, and the driver bundle can live without them; or
+                3) they are imported by shaded classes, but not used by the driver bundle.
+                -->
+                <Import-Package>
+                  !com.datastax.oss.driver.shaded.netty.*,
+                  !com.datastax.oss.driver.shaded.jctools.*,
+                  !jnr.*,
+                  !net.jcip.annotations.*,
+                  !edu.umd.cs.findbugs.annotations.*,
+                  !com.google.protobuf.*,
+                  !com.jcraft.jzlib.*,
+                  !com.ning.compress.*,
+                  !lzma.sdk.*,
+                  !net.jpountz.xxhash.*,
+                  !org.bouncycastle.*,
+                  !org.conscrypt.*,
+                  !org.apache.commons.logging.*,
+                  !org.apache.log4j.*,
+                  !org.apache.logging.log4j.*,
+                  !org.eclipse.jetty.*,
+                  !org.jboss.marshalling.*,
+                  !sun.misc.*,
+                  !sun.security.*,
+                  *
+                </Import-Package>
+                <!--
+                Export:
+                1) The driver's packages (API and internal);
+                2) All shaded packages, except Guava which resides in a separate bundle.
+                -->
+                <Export-Package>
+                  com.datastax.oss.driver.api.core.*,
+                  com.datastax.oss.driver.internal.core.*,
+                  com.datastax.oss.driver.shaded.netty.*,
+                  com.datastax.oss.driver.shaded.jctools.*
+                </Export-Package>
+              </instructions>
+              <rebuildBundle>true</rebuildBundle>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-final-shaded-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <archive>
+                <!-- this is the manifest generated by the bundle plugin -->
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+              </archive>
+              <descriptors>
+                <descriptor>src/assembly/shaded-jar.xml</descriptor>
+              </descriptors>
+              <!-- Replace the original artifact -->
+              <appendAssemblyId>false</appendAssemblyId>
             </configuration>
           </execution>
         </executions>

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -128,22 +128,16 @@
                   Include:
                   - The core driver itself; it is not relocated but needs to be included.
                   - All the dependencies we want to shade & relocate: currently
-                    - all the Netty artifacts;
-                    - JCTools.
+                    - all the Netty artifacts.
                   -->
                   <include>com.datastax.oss:java-driver-core</include>
                   <include>io.netty:*</include>
-                  <include>org.jctools:*</include>
                 </includes>
               </artifactSet>
               <relocations>
                 <relocation>
                   <pattern>io.netty</pattern>
                   <shadedPattern>com.datastax.oss.driver.shaded.netty</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.jctools</pattern>
-                  <shadedPattern>com.datastax.oss.driver.shaded.jctools</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>
@@ -176,7 +170,6 @@
               <excludes>
                 META-INF/maven/com.datastax.oss/java-driver-core/**,
                 META-INF/maven/io.netty/**,
-                META-INF/maven/org.jctools/**
               </excludes>
             </configuration>
           </execution>
@@ -209,7 +202,6 @@
                 -->
                 <Import-Package>
                   !com.datastax.oss.driver.shaded.netty.*,
-                  !com.datastax.oss.driver.shaded.jctools.*,
                   !jnr.*,
                   !net.jcip.annotations.*,
                   !edu.umd.cs.findbugs.annotations.*,
@@ -238,7 +230,6 @@
                   com.datastax.oss.driver.api.core.*,
                   com.datastax.oss.driver.internal.core.*,
                   com.datastax.oss.driver.shaded.netty.*,
-                  com.datastax.oss.driver.shaded.jctools.*
                 </Export-Package>
               </instructions>
               <rebuildBundle>true</rebuildBundle>

--- a/core-shaded/src/assembly/shaded-jar.xml
+++ b/core-shaded/src/assembly/shaded-jar.xml
@@ -1,0 +1,44 @@
+<!--
+
+    Copyright DataStax, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+  <id>shaded-jar</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <!--
+    Include everything from the shaded jar created with the shade plugin and
+    unpacked by the dependency plugin
+    -->
+    <fileSet>
+      <directory>${project.build.outputDirectory}</directory>
+      <outputDirectory/>
+    </fileSet>
+  </fileSets>
+  <!-- Include the transformed pom with shaded deps created by the shade plugin -->
+  <files>
+    <file>
+      <source>${project.basedir}/dependency-reduced-pom.xml</source>
+      <outputDirectory>META-INF/maven/com.datastax.oss/java-driver-core-shaded</outputDirectory>
+      <destName>pom.xml</destName>
+    </file>
+  </files>
+</assembly>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,9 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -25,6 +27,7 @@
   </parent>
 
   <artifactId>java-driver-core</artifactId>
+  <packaging>bundle</packaging>
 
   <name>DataStax Java driver for Apache Cassandra(R) - core</name>
 
@@ -143,22 +146,12 @@
     <plugins>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-          </archive>
-        </configuration>
         <executions>
           <execution>
             <id>test-jar</id>
             <goals>
               <goal>test-jar</goal>
             </goals>
-            <configuration>
-              <excludes>
-                <exclude>logback-test.xml</exclude>
-              </excludes>
-            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -173,114 +166,37 @@
           </properties>
         </configuration>
       </plugin>
-      <!--
-      We avoid packaging bundle because it does not play nicely with the shade plugin, see
-      https://stackoverflow.com/questions/31262032/maven-shade-plugin-and-custom-packaging-type
-      -->
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>com.datastax.oss.driver.core</Bundle-SymbolicName>
-          </instructions>
-          <!--
-          Prevent customized manifest entries from the project's maven-jar-plugin configuration from being read, see
-          http://apache-felix.18485.x6.nabble.com/how-lt-manifestLocation-gt-is-used-in-maven-bundle-plugin-td4835566.html
-          -->
-          <archive>
-            <forced>true</forced>
-          </archive>
-        </configuration>
+        <extensions>true</extensions>
         <executions>
           <execution>
-            <id>bundle-manifest</id>
-            <phase>process-classes</phase>
             <goals>
-              <goal>manifest</goal>
+              <goal>bundle</goal>
             </goals>
             <configuration>
-              <manifestLocation>${project.build.outputDirectory}/META-INF</manifestLocation>
               <instructions>
-                <!-- Allow importing code from other packages (so reflection-based loading of policies works) -->
+                <Bundle-SymbolicName>com.datastax.oss.driver.core</Bundle-SymbolicName>
+                <!--
+                Allow importing code from other packages
+                (so reflection-based loading of policies works)
+                -->
                 <DynamicImport-Package>*</DynamicImport-Package>
-                <!-- Don't include JNR packages since some JNR modules are not OSGi bundles,
-                     jcip because its not an OSGi bundle, jctools because its shaded.
-                     Import sun.misc as jctools does this. -->
+                <!--
+                Don't include the packages below because they aren't OSGi bundles,
+                and the driver can live without them.
+                -->
                 <Import-Package>
-                  !net.jcip.annotations,!jnr.*,!org.jctools.*,sun.misc;resolution:=optional,*
-                </Import-Package>
-                <!-- Explicitly declare shaded jctools packages since this isn't covered by shade plugin -->
-                <Export-Package>
-                  com.datastax.oss.driver.*.core.*,
-                  com.datastax.oss.driver.shaded.jctools.util;version="${project.version}";uses:="sun.misc",
-                  com.datastax.oss.driver.shaded.jctools.queues;version="${project.version}";uses:="com.datastax.oss.driver.shaded.jctools.queues.spec",
-                  com.datastax.oss.driver.shaded.jctools.queues.spec;version="${project.version}",
-                  com.datastax.oss.driver.shaded.jctools.queues.atomic;version="${project.version}";uses:="com.datastax.oss.driver.shaded.jctools.queues,com.datastax.oss.driver.shaded.jctools.queues.spec",
-                  com.datastax.oss.driver.shaded.jctools.maps;version="${project.version}"
-                </Export-Package>
-              </instructions>
-            </configuration>
-          </execution>
-          <!-- Alternate execution to generate the manifest to be used by the java-driver-core-shaded module -->
-          <execution>
-            <id>bundle-manifest-shaded</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-            <configuration>
-              <manifestLocation>${project.build.directory}/classes/META-INF-shaded</manifestLocation>
-              <instructions>
-                <Bundle-Name>DataStax Java driver for Apache Cassandra(R) - core netty shaded</Bundle-Name>
-                <DynamicImport-Package>*</DynamicImport-Package>
-                <!-- Don't include netty since it will be shaded, import javax.security.cert as needed by netty ssl -->
-                <Import-Package>
-                  !net.jcip.annotations,!jnr.*,!org.jctools.*,sun.misc;resolution:=optional,!io.netty.*,javax.security.cert,*
+                  !net.jcip.annotations.*,
+                  !edu.umd.cs.findbugs.annotations.*,
+                  !jnr.*,
+                  *
                 </Import-Package>
                 <Export-Package>
-                  com.datastax.oss.driver.*.core.*,
-                  com.datastax.oss.driver.shaded.jctools.util;version="${project.version}";uses:="sun.misc",
-                  com.datastax.oss.driver.shaded.jctools.queues;version="${project.version}";uses:="com.datastax.oss.driver.shaded.jctools.queues.spec",
-                  com.datastax.oss.driver.shaded.jctools.queues.spec;version="${project.version}",
-                  com.datastax.oss.driver.shaded.jctools.queues.atomic;version="${project.version}";uses:="com.datastax.oss.driver.shaded.jctools.queues,com.datastax.oss.driver.shaded.jctools.queues.spec",
-                  com.datastax.oss.driver.shaded.jctools.maps;version="${project.version}"
+                  com.datastax.oss.driver.*.core.*
                 </Export-Package>
               </instructions>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <!-- shade jctools -->
-      <plugin>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <artifactSet>
-                <includes>
-                  <include>org.jctools:jctools-core</include>
-                </includes>
-              </artifactSet>
-              <relocations>
-                <relocation>
-                  <pattern>org.jctools</pattern>
-                  <shadedPattern>com.datastax.oss.driver.shaded.jctools</shadedPattern>
-                </relocation>
-              </relocations>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
-                  <resources>
-                    <resource>META-INF/maven/org.jctools/jctools-core/pom.properties</resource>
-                    <resource>META-INF/maven/org.jctools/jctools-core/pom.xml</resource>
-                  </resources>
-                </transformer>
-              </transformers>
-              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
             </configuration>
           </execution>
         </executions>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -78,10 +78,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jctools</groupId>
-      <artifactId>jctools-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
     </dependency>

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DefaultWriteCoalescer.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DefaultWriteCoalescer.java
@@ -26,11 +26,11 @@ import java.util.HashSet;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import net.jcip.annotations.ThreadSafe;
-import org.jctools.queues.atomic.MpscLinkedAtomicQueue;
 
 /**
  * Default write coalescing strategy.
@@ -55,9 +55,8 @@ public class DefaultWriteCoalescer implements WriteCoalescer {
 
   public DefaultWriteCoalescer(DriverContext context) {
     DriverExecutionProfile config = context.getConfig().getDefaultProfile();
-    this.maxRunsWithNoWork = config.getInt(DefaultDriverOption.COALESCER_MAX_RUNS);
-    this.rescheduleIntervalNanos =
-        config.getDuration(DefaultDriverOption.COALESCER_INTERVAL).toNanos();
+    maxRunsWithNoWork = config.getInt(DefaultDriverOption.COALESCER_MAX_RUNS);
+    rescheduleIntervalNanos = config.getDuration(DefaultDriverOption.COALESCER_INTERVAL).toNanos();
   }
 
   @Override
@@ -77,7 +76,7 @@ public class DefaultWriteCoalescer implements WriteCoalescer {
     private final EventLoop eventLoop;
 
     // These variables are accessed both from client threads and the event loop
-    private final Queue<Write> writes = new MpscLinkedAtomicQueue<>();
+    private final Queue<Write> writes = new ConcurrentLinkedQueue<>();
     private final AtomicBoolean running = new AtomicBoolean();
 
     // These variables are accessed only from runOnEventLoop, they don't need to be thread-safe

--- a/core/src/main/resources/com/datastax/oss/driver/Driver.properties
+++ b/core/src/main/resources/com/datastax/oss/driver/Driver.properties
@@ -20,4 +20,4 @@
 driver.groupId=${project.groupId}
 driver.artifactId=${project.artifactId}
 driver.version=${project.version}
-driver.name=${project.parent.name}
+driver.name=DataStax Java driver for Apache Cassandra(R)

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -15,7 +15,9 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -132,6 +134,7 @@
             <project.version>${project.version}</project.version>
             <assertj.version>${assertj.version}</assertj.version>
             <config.version>${config.version}</config.version>
+            <jctools.version>${jctools.version}</jctools.version>
             <commons-exec.version>${commons-exec.version}</commons-exec.version>
             <guava.version>${guava.version}</guava.version>
             <hdrhistogram.version>${hdrhistogram.version}</hdrhistogram.version>
@@ -156,6 +159,7 @@
             <project.version>${project.version}</project.version>
             <assertj.version>${assertj.version}</assertj.version>
             <config.version>${config.version}</config.version>
+            <jctools.version>${jctools.version}</jctools.version>
             <commons-exec.version>${commons-exec.version}</commons-exec.version>
             <guava.version>${guava.version}</guava.version>
             <hdrhistogram.version>${hdrhistogram.version}</hdrhistogram.version>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -134,7 +134,6 @@
             <project.version>${project.version}</project.version>
             <assertj.version>${assertj.version}</assertj.version>
             <config.version>${config.version}</config.version>
-            <jctools.version>${jctools.version}</jctools.version>
             <commons-exec.version>${commons-exec.version}</commons-exec.version>
             <guava.version>${guava.version}</guava.version>
             <hdrhistogram.version>${hdrhistogram.version}</hdrhistogram.version>
@@ -159,7 +158,6 @@
             <project.version>${project.version}</project.version>
             <assertj.version>${assertj.version}</assertj.version>
             <config.version>${config.version}</config.version>
-            <jctools.version>${jctools.version}</jctools.version>
             <commons-exec.version>${commons-exec.version}</commons-exec.version>
             <guava.version>${guava.version}</guava.version>
             <hdrhistogram.version>${hdrhistogram.version}</hdrhistogram.version>

--- a/integration-tests/src/test/java/com/datastax/oss/driver/osgi/BundleOptions.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/osgi/BundleOptions.java
@@ -29,6 +29,9 @@ import org.ops4j.pax.exam.util.PathUtils;
 public class BundleOptions {
 
   public static CompositeOption baseOptions() {
+    // Note: the bundles below include Netty and JCTools; these bundles are not required by
+    // the shaded core driver bundle, but they need to be present in all cases because
+    // the test-infra bundle requires the (non-shaded) Netty bundle.
     return () ->
         options(
             nettyBundles(),
@@ -38,6 +41,7 @@ public class BundleOptions {
             mavenBundle("org.slf4j", "slf4j-api", getVersion("slf4j.version")),
             mavenBundle("org.hdrhistogram", "HdrHistogram", getVersion("hdrhistogram.version")),
             mavenBundle("com.typesafe", "config", getVersion("config.version")),
+            mavenBundle("org.jctools", "jctools-core", getVersion("jctools.version")),
             mavenBundle(
                 "com.datastax.oss", "native-protocol", getVersion("native-protocol.version")),
             logbackBundles(),

--- a/integration-tests/src/test/java/com/datastax/oss/driver/osgi/BundleOptions.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/osgi/BundleOptions.java
@@ -29,7 +29,7 @@ import org.ops4j.pax.exam.util.PathUtils;
 public class BundleOptions {
 
   public static CompositeOption baseOptions() {
-    // Note: the bundles below include Netty and JCTools; these bundles are not required by
+    // Note: the bundles below include Netty; these bundles are not required by
     // the shaded core driver bundle, but they need to be present in all cases because
     // the test-infra bundle requires the (non-shaded) Netty bundle.
     return () ->
@@ -41,7 +41,6 @@ public class BundleOptions {
             mavenBundle("org.slf4j", "slf4j-api", getVersion("slf4j.version")),
             mavenBundle("org.hdrhistogram", "HdrHistogram", getVersion("hdrhistogram.version")),
             mavenBundle("com.typesafe", "config", getVersion("config.version")),
-            mavenBundle("org.jctools", "jctools-core", getVersion("jctools.version")),
             mavenBundle(
                 "com.datastax.oss", "native-protocol", getVersion("native-protocol.version")),
             logbackBundles(),

--- a/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiBaseIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiBaseIT.java
@@ -16,11 +16,7 @@
 package com.datastax.oss.driver.osgi;
 
 import static com.datastax.oss.driver.api.querybuilder.QueryBuilderDsl.selectFrom;
-import static com.datastax.oss.driver.osgi.BundleOptions.baseOptions;
-import static com.datastax.oss.driver.osgi.BundleOptions.driverCoreBundle;
-import static com.datastax.oss.driver.osgi.BundleOptions.driverQueryBuilderBundle;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.ops4j.pax.exam.CoreOptions.options;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;
@@ -29,15 +25,11 @@ import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
-import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.categories.IsolatedTests;
-import com.google.common.collect.ObjectArrays;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.ops4j.pax.exam.Configuration;
-import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
@@ -54,31 +46,17 @@ public abstract class OsgiBaseIT {
 
   @ClassRule public static CustomCcmRule ccmRule = CustomCcmRule.builder().withNodes(1).build();
 
-  /** @return Additional options that should be used in OSGi environment configuration. */
-  public abstract Option[] additionalOptions();
-
-  @Configuration
-  public Option[] config() {
-    return ObjectArrays.concat(
-        options(driverCoreBundle(), driverQueryBuilderBundle(), baseOptions()),
-        additionalOptions(),
-        Option.class);
-  }
-
   /** @return config loader to be used to create session. */
-  public DriverConfigLoader configLoader() {
-    return SessionUtils.configLoaderBuilder().build();
-  }
+  protected abstract DriverConfigLoader configLoader();
 
   /**
    * A very simple test that ensures a session can be established and a query made when running in
    * an OSGi container.
    */
   @Test
-  @SuppressWarnings("unchecked")
   public void should_connect_and_query() {
     SessionBuilder<CqlSessionBuilder, CqlSession> builder =
-        SessionUtils.baseBuilder()
+        CqlSession.builder()
             .addContactPoints(ccmRule.getContactPoints())
             // use the driver's ClassLoader instead of the OSGI application thread's.
             .withClassLoader(CqlSession.class.getClassLoader())

--- a/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiCustomLoadBalancingPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiCustomLoadBalancingPolicyIT.java
@@ -15,10 +15,16 @@
  */
 package com.datastax.oss.driver.osgi;
 
+import static com.datastax.oss.driver.osgi.BundleOptions.baseOptions;
+import static com.datastax.oss.driver.osgi.BundleOptions.driverCoreBundle;
+import static com.datastax.oss.driver.osgi.BundleOptions.driverQueryBuilderBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.testinfra.loadbalancing.SortingLoadBalancingPolicy;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 
 /**
@@ -27,13 +33,14 @@ import org.ops4j.pax.exam.Option;
  * DynamicImport-Package: *</code>.
  */
 public class OsgiCustomLoadBalancingPolicyIT extends OsgiBaseIT {
-  @Override
-  public Option[] additionalOptions() {
-    return new Option[0];
+
+  @Configuration
+  public Option[] config() {
+    return options(driverCoreBundle(), driverQueryBuilderBundle(), baseOptions());
   }
 
   @Override
-  public DriverConfigLoader configLoader() {
+  protected DriverConfigLoader configLoader() {
     return SessionUtils.configLoaderBuilder()
         .withClass(
             DefaultDriverOption.LOAD_BALANCING_POLICY_CLASS, SortingLoadBalancingPolicy.class)

--- a/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiIT.java
@@ -15,12 +15,25 @@
  */
 package com.datastax.oss.driver.osgi;
 
+import static com.datastax.oss.driver.osgi.BundleOptions.baseOptions;
+import static com.datastax.oss.driver.osgi.BundleOptions.driverCoreBundle;
+import static com.datastax.oss.driver.osgi.BundleOptions.driverQueryBuilderBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 
 public class OsgiIT extends OsgiBaseIT {
 
+  @Configuration
+  public Option[] config() {
+    return options(driverCoreBundle(), driverQueryBuilderBundle(), baseOptions());
+  }
+
   @Override
-  public Option[] additionalOptions() {
-    return new Option[0];
+  protected DriverConfigLoader configLoader() {
+    return SessionUtils.configLoaderBuilder().build();
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiLz4IT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiLz4IT.java
@@ -15,23 +15,27 @@
  */
 package com.datastax.oss.driver.osgi;
 
+import static com.datastax.oss.driver.osgi.BundleOptions.baseOptions;
+import static com.datastax.oss.driver.osgi.BundleOptions.driverCoreBundle;
+import static com.datastax.oss.driver.osgi.BundleOptions.driverQueryBuilderBundle;
 import static com.datastax.oss.driver.osgi.BundleOptions.lz4Bundle;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 
 public class OsgiLz4IT extends OsgiBaseIT {
 
-  @Override
-  public Option[] additionalOptions() {
-    return options(lz4Bundle());
+  @Configuration
+  public Option[] config() {
+    return options(lz4Bundle(), driverCoreBundle(), driverQueryBuilderBundle(), baseOptions());
   }
 
   @Override
-  public DriverConfigLoader configLoader() {
+  protected DriverConfigLoader configLoader() {
     return SessionUtils.configLoaderBuilder()
         .withString(DefaultDriverOption.PROTOCOL_COMPRESSION, "lz4")
         .build();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiShadedIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiShadedIT.java
@@ -20,23 +20,20 @@ import static com.datastax.oss.driver.osgi.BundleOptions.driverCoreShadedBundle;
 import static com.datastax.oss.driver.osgi.BundleOptions.driverQueryBuilderBundle;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
-import com.google.common.collect.ObjectArrays;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 
 public class OsgiShadedIT extends OsgiBaseIT {
 
-  @Override
   @Configuration
   public Option[] config() {
-    return ObjectArrays.concat(
-        options(driverCoreShadedBundle(), driverQueryBuilderBundle(), baseOptions()),
-        additionalOptions(),
-        Option.class);
+    return options(driverCoreShadedBundle(), driverQueryBuilderBundle(), baseOptions());
   }
 
   @Override
-  public Option[] additionalOptions() {
-    return new Option[0];
+  protected DriverConfigLoader configLoader() {
+    return SessionUtils.configLoaderBuilder().build();
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiSnappyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/osgi/OsgiSnappyIT.java
@@ -15,23 +15,27 @@
  */
 package com.datastax.oss.driver.osgi;
 
+import static com.datastax.oss.driver.osgi.BundleOptions.baseOptions;
+import static com.datastax.oss.driver.osgi.BundleOptions.driverCoreBundle;
+import static com.datastax.oss.driver.osgi.BundleOptions.driverQueryBuilderBundle;
 import static com.datastax.oss.driver.osgi.BundleOptions.snappyBundle;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 
 public class OsgiSnappyIT extends OsgiBaseIT {
 
-  @Override
-  public Option[] additionalOptions() {
-    return options(snappyBundle());
+  @Configuration
+  public Option[] config() {
+    return options(snappyBundle(), driverCoreBundle(), driverQueryBuilderBundle(), baseOptions());
   }
 
   @Override
-  public DriverConfigLoader configLoader() {
+  protected DriverConfigLoader configLoader() {
     return SessionUtils.configLoaderBuilder()
         .withString(DefaultDriverOption.PROTOCOL_COMPRESSION, "snappy")
         .build();

--- a/integration-tests/src/test/resources/logback-test.xml
+++ b/integration-tests/src/test/resources/logback-test.xml
@@ -25,4 +25,6 @@
     <appender-ref ref="STDOUT"/>
   </root>
   <logger name="com.datastax.oss.driver" level="${driverLevel:-ERROR}"/>
+  <!-- Set this logger to DEBUG to help debugging OSGi tests -->
+  <logger name="org.ops4j" level="ERROR"/>
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <config.version>1.3.3</config.version>
     <guava.version>25.1-jre</guava.version>
     <hdrhistogram.version>2.1.10</hdrhistogram.version>
+    <jctools.version>2.1.2</jctools.version>
     <metrics.version>4.0.2</metrics.version>
     <native-protocol.version>1.4.3</native-protocol.version>
     <netty.version>4.1.27.Final</netty.version>
@@ -137,7 +138,7 @@
       <dependency>
         <groupId>org.jctools</groupId>
         <artifactId>jctools-core</artifactId>
-        <version>2.1.2</version>
+        <version>${jctools.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.stephenc.jcip</groupId>
@@ -197,7 +198,7 @@
       <dependency>
         <groupId>org.apache.felix</groupId>
         <artifactId>org.apache.felix.framework</artifactId>
-        <version>5.6.10</version>
+        <version>6.0.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -229,7 +230,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
@@ -289,7 +290,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.5.1</version>
         </plugin>
         <plugin>
           <groupId>org.revapi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
     <config.version>1.3.3</config.version>
     <guava.version>25.1-jre</guava.version>
     <hdrhistogram.version>2.1.10</hdrhistogram.version>
-    <jctools.version>2.1.2</jctools.version>
     <metrics.version>4.0.2</metrics.version>
     <native-protocol.version>1.4.3</native-protocol.version>
     <netty.version>4.1.27.Final</netty.version>
@@ -134,11 +133,6 @@
         <groupId>org.hdrhistogram</groupId>
         <artifactId>HdrHistogram</artifactId>
         <version>${hdrhistogram.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jctools</groupId>
-        <artifactId>jctools-core</artifactId>
-        <version>${jctools.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.stephenc.jcip</groupId>
@@ -483,7 +477,7 @@ limitations under the License.]]>
                 <!-- API types do not leak internal types -->
                 <additionalparam>-preventleak</additionalparam>
                 <additionalparam>com.datastax.oss.driver.internal</additionalparam>
-                <!-- Shaded dependencies (Guava, JCTools) -->
+                <!-- Shaded dependencies (Guava, Netty, etc.) -->
                 <additionalparam>-preventleak</additionalparam>
                 <additionalparam>com.datastax.oss.driver.shaded</additionalparam>
                 <!--

--- a/test-infra/pom.xml
+++ b/test-infra/pom.xml
@@ -66,9 +66,13 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>com.datastax.oss.driver.testinfra</Bundle-SymbolicName>
-            <!-- TODO: Only needed to use TestConfigLoader in integration-tests, remove this when we have
-                 a programmatic solution in core -->
-            <Export-Package>com.datastax.oss.driver.*.testinfra.*,com.datastax.oss.driver.assertions,com.datastax.oss.driver.categories</Export-Package>
+            <!-- allow SessionUtils to instantiate sessions by reflection -->
+            <DynamicImport-Package>*</DynamicImport-Package>
+            <Export-Package>
+              com.datastax.oss.driver.*.testinfra.*,
+              com.datastax.oss.driver.assertions,
+              com.datastax.oss.driver.categories
+            </Export-Package>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
Summary of changes:

* In module core there is no more shading.
  * The shading of jctools is IMO unnecessary, since it is an OSGi-ready bundle.
  * The generation of the shaded manifest is now done inside core-shaded.
* In module core-shaded, the procedure to generate the shaded classes and the shaded bundle is as follows:
  1. Shade the classes, generate a first shaded jar;
  2. Unpack the shaded jar;
  3. Generate the manifest based on the unpacked shaded classes;
  4. Repack the shaded jar.

Producing the shaded manifest based on shaded classes is IMO more accurate since BND analyzes the actual content of the shaded jar to generate the manifest (whereas previously we made it generate a shaded manifest based on non-shaded classes in module core).

And a note about Guava: I'm still doubtful about the necessity of shading Guava differently (i.e. outside the driver). With the changes in this PR the shading of dependencies is clearly isolated in dedicated modules. I don't see why we couldn't do the same for Guava as we do for Netty. But as agreed, I didn't touch Guava within this PR.