### PR TITLE
JAVA-1388: Add dynamic port discovery for system.peers_v2

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -17,6 +17,7 @@
 - [bug] JAVA-1928: Fix GuavaCompatibility for Guava 26.
 - [bug] JAVA-1935: Add null check in QueryConsistencyException.getHost.
 - [improvement] JAVA-1771: Send driver name and version in STARTUP message.
+- [improvement] JAVA-1388: Add dynamic port discovery for system.peers\_v2.
 
 Merged from 3.5.x:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -1686,11 +1686,15 @@ public class Cluster implements Closeable {
       return configuration.getPolicies().getReconnectionPolicy();
     }
 
+    InetSocketAddress translateAddress(InetSocketAddress address) {
+      InetSocketAddress translated =
+          configuration.getPolicies().getAddressTranslator().translate(address);
+      return translated == null ? address : translated;
+    }
+
     InetSocketAddress translateAddress(InetAddress address) {
       InetSocketAddress sa = new InetSocketAddress(address, connectionFactory.getPort());
-      InetSocketAddress translated =
-          configuration.getPolicies().getAddressTranslator().translate(sa);
-      return translated == null ? sa : translated;
+      return translateAddress(sa);
     }
 
     private Session newSession() {

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -773,10 +773,11 @@ public class Cluster implements Closeable {
 
     /**
      * Enables host port discovery using the system.peers_v2 table added in Cassandra 4.0 (via
-     * CASSANDRA-7544). This enables running multiple Cassandra
+     * CASSANDRA-7544). This enables running multiple Cassandra nodes on the same IP address with
+     * each having its own set of ports.
      *
      * <p>Use of this option only works for clusters running version Cassandra 4.0 or newer. Using
-     * it with an older version of Cassandra will likely cause initialization to fail.
+     * it with an older version of Cassandra will cause initialization to fail.
      *
      * <p>When using this option configuration provided via {@link #withPort(int)} is unused as
      * ports are resolved from Cassandra.

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -717,6 +717,7 @@ public class Cluster implements Closeable {
     private SSLOptions sslOptions = null;
     private boolean metricsEnabled = true;
     private boolean jmxEnabled = true;
+    private boolean allowHostPortDiscovery = false;
     private boolean allowBetaProtocolVersion = false;
     private boolean noCompact = false;
 
@@ -760,11 +761,30 @@ public class Cluster implements Closeable {
      *
      * <p>If not set through this method, the default port (9042) will be used instead.
      *
+     * <p>If {@link #allowHostPortDiscovery()} is used, this value is ignored.
+     *
      * @param port the port to set.
      * @return this Builder.
      */
     public Builder withPort(int port) {
       this.port = port;
+      return this;
+    }
+
+    /**
+     * Enables host port discovery using the system.peers_v2 table added in Cassandra 4.0 (via
+     * CASSANDRA-7544). This enables running multiple Cassandra
+     *
+     * <p>Use of this option only works for clusters running version Cassandra 4.0 or newer. Using
+     * it with an older version of Cassandra will likely cause initialization to fail.
+     *
+     * <p>When using this option configuration provided via {@link #withPort(int)} is unused as
+     * ports are resolved from Cassandra.
+     *
+     * @return this builder.
+     */
+    public Builder allowHostPortDiscovery() {
+      this.allowHostPortDiscovery = true;
       return this;
     }
 
@@ -1338,7 +1358,8 @@ public class Cluster implements Closeable {
                   maxSchemaAgreementWaitSeconds,
                   sslOptions,
                   authProvider,
-                  noCompact)
+                  noCompact,
+                  allowHostPortDiscovery)
               .setCompression(compression);
 
       MetricsOptions metricsOptions = new MetricsOptions(metricsEnabled, jmxEnabled);

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -717,7 +717,6 @@ public class Cluster implements Closeable {
     private SSLOptions sslOptions = null;
     private boolean metricsEnabled = true;
     private boolean jmxEnabled = true;
-    private boolean allowHostPortDiscovery = false;
     private boolean allowBetaProtocolVersion = false;
     private boolean noCompact = false;
 
@@ -761,31 +760,11 @@ public class Cluster implements Closeable {
      *
      * <p>If not set through this method, the default port (9042) will be used instead.
      *
-     * <p>If {@link #allowHostPortDiscovery()} is used, this value is ignored.
-     *
      * @param port the port to set.
      * @return this Builder.
      */
     public Builder withPort(int port) {
       this.port = port;
-      return this;
-    }
-
-    /**
-     * Enables host port discovery using the system.peers_v2 table added in Cassandra 4.0 (via
-     * CASSANDRA-7544). This enables running multiple Cassandra nodes on the same IP address with
-     * each having its own set of ports.
-     *
-     * <p>Use of this option only works for clusters running version Cassandra 4.0 or newer. Using
-     * it with an older version of Cassandra will cause initialization to fail.
-     *
-     * <p>When using this option configuration provided via {@link #withPort(int)} is unused as
-     * ports are resolved from Cassandra.
-     *
-     * @return this builder.
-     */
-    public Builder allowHostPortDiscovery() {
-      this.allowHostPortDiscovery = true;
       return this;
     }
 
@@ -1359,8 +1338,7 @@ public class Cluster implements Closeable {
                   maxSchemaAgreementWaitSeconds,
                   sslOptions,
                   authProvider,
-                  noCompact,
-                  allowHostPortDiscovery)
+                  noCompact)
               .setCompression(compression);
 
       MetricsOptions metricsOptions = new MetricsOptions(metricsEnabled, jmxEnabled);

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -703,8 +703,14 @@ class ControlConnection implements Connection.Owner {
 
             @Override
             public void onFailure(Throwable t) {
-              isPeersV2 = false;
-              MoreFutures.propagateFuture(peersFuture, selectPeersFuture(connection));
+              // downgrade to system.peers if we get an invalid query as this indicates
+              // the peers_v2 table does not exist.
+              if (t instanceof InvalidQueryException) {
+                isPeersV2 = false;
+                MoreFutures.propagateFuture(peersFuture, selectPeersFuture(connection));
+              } else {
+                peersFuture.setException(t);
+              }
             }
           });
       return peersFuture;

--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -28,7 +28,6 @@ import com.datastax.driver.core.utils.MoreFutures;
 import com.datastax.driver.core.utils.MoreObjects;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import java.net.InetAddress;
@@ -697,7 +696,7 @@ class ControlConnection implements Connection.Owner {
       connection.write(peersV2Future);
       final SettableFuture<ResultSet> peersFuture = SettableFuture.create();
       // if peers v2 query fails, query peers table instead.
-      Futures.addCallback(
+      GuavaCompatibility.INSTANCE.addCallback(
           peersV2Future,
           new FutureCallback<ResultSet>() {
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Host.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Host.java
@@ -44,12 +44,12 @@ public class Host {
   // We use that internally because
   // that's the 'peer' in the 'System.peers' table and avoids querying the full peers table in
   // ControlConnection.refreshNodeInfo.
-  private volatile InetAddress broadcastAddress;
+  private volatile InetSocketAddress broadcastAddress;
 
   // The listen_address as known by Cassandra.
   // This is usually the same as broadcast_address unless
   // specified otherwise in cassandra.yaml file.
-  private volatile InetAddress listenAddress;
+  private volatile InetSocketAddress listenAddress;
 
   private volatile UUID hostId;
 
@@ -118,11 +118,11 @@ public class Host {
     this.cassandraVersion = versionNumber;
   }
 
-  void setBroadcastAddress(InetAddress broadcastAddress) {
+  void setBroadcastAddress(InetSocketAddress broadcastAddress) {
     this.broadcastAddress = broadcastAddress;
   }
 
-  void setListenAddress(InetAddress listenAddress) {
+  void setListenAddress(InetSocketAddress listenAddress) {
     this.listenAddress = listenAddress;
   }
 
@@ -165,8 +165,10 @@ public class Host {
    * <p>This is a shortcut for {@code getSocketAddress().getAddress()}.
    *
    * @return the address.
+   * @deprecated
    * @see #getSocketAddress()
    */
+  @Deprecated
   public InetAddress getAddress() {
     return address.getAddress();
   }
@@ -194,12 +196,27 @@ public class Host {
   }
 
   /**
-   * Returns the node broadcast address (that is, the IP by which it should be contacted by other
-   * peers in the cluster), if known.
+   * @return the node broadcast address, if known. Otherwise {@code null}.
+   * @deprecated
+   * @see #getBroadcastSocketAddress()
+   * @see <a
+   *     href="https://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configCassandra_yaml_r.html">The
+   *     cassandra.yaml configuration file</a>
+   */
+  @Deprecated
+  public InetAddress getBroadcastAddress() {
+    return broadcastAddress != null ? broadcastAddress.getAddress() : null;
+  }
+
+  /**
+   * Returns the node broadcast address (that is, the address by which it should be contacted by
+   * other peers in the cluster), if known.
+   *
+   * <p>Note that the port of the returned address may be 0 if it could not be determined.
    *
    * <p>This corresponds to the {@code broadcast_address} cassandra.yaml file setting and is by
-   * default the same as {@link #getListenAddress()}, unless specified otherwise in cassandra.yaml.
-   * <em>This is NOT the address clients should use to contact this node</em>.
+   * default the same as {@link #getListenSocketAddress()}, unless specified otherwise in
+   * cassandra.yaml. <em>This is NOT the address clients should use to contact this node</em>.
    *
    * <p>This information is always available for peer hosts. For the control host, it's only
    * available if CASSANDRA-9436 is fixed on the server side (Cassandra versions >= 2.0.16, 2.1.6,
@@ -212,13 +229,28 @@ public class Host {
    *     href="https://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configCassandra_yaml_r.html">The
    *     cassandra.yaml configuration file</a>
    */
-  public InetAddress getBroadcastAddress() {
+  public InetSocketAddress getBroadcastSocketAddress() {
     return broadcastAddress;
   }
 
   /**
-   * Returns the node listen address (that is, the IP the node uses to contact other peers in the
-   * cluster), if known.
+   * @return the node listen address, if known. Otherwise {@code null}.
+   * @deprecated
+   * @see #getListenSocketAddress()
+   * @see <a
+   *     href="https://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configCassandra_yaml_r.html">The
+   *     cassandra.yaml configuration file</a>
+   */
+  @Deprecated
+  public InetAddress getListenAddress() {
+    return listenAddress != null ? listenAddress.getAddress() : null;
+  }
+
+  /**
+   * Returns the node listen address (that is, the address the node uses to contact other peers in
+   * the cluster), if known.
+   *
+   * <p>Note that the port of the returned address may be 0 if it could not be determined.
    *
    * <p>This corresponds to the {@code listen_address} cassandra.yaml file setting. <em>This is NOT
    * the address clients should use to contact this node</em>.
@@ -234,7 +266,7 @@ public class Host {
    *     href="https://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configCassandra_yaml_r.html">The
    *     cassandra.yaml configuration file</a>
    */
-  public InetAddress getListenAddress() {
+  public InetSocketAddress getListenSocketAddress() {
     return listenAddress;
   }
 

--- a/driver-core/src/main/java/com/datastax/driver/core/Host.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Host.java
@@ -232,13 +232,11 @@ public class Host {
 
   /**
    * @return the node listen address, if known. Otherwise {@code null}.
-   * @deprecated
    * @see #getListenSocketAddress()
    * @see <a
    *     href="https://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configCassandra_yaml_r.html">The
    *     cassandra.yaml configuration file</a>
    */
-  @Deprecated
   public InetAddress getListenAddress() {
     return listenAddress != null ? listenAddress.getAddress() : null;
   }

--- a/driver-core/src/main/java/com/datastax/driver/core/Host.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Host.java
@@ -165,10 +165,8 @@ public class Host {
    * <p>This is a shortcut for {@code getSocketAddress().getAddress()}.
    *
    * @return the address.
-   * @deprecated
    * @see #getSocketAddress()
    */
-  @Deprecated
   public InetAddress getAddress() {
     return address.getAddress();
   }
@@ -197,13 +195,11 @@ public class Host {
 
   /**
    * @return the node broadcast address, if known. Otherwise {@code null}.
-   * @deprecated
    * @see #getBroadcastSocketAddress()
    * @see <a
    *     href="https://docs.datastax.com/en/cassandra/2.1/cassandra/configuration/configCassandra_yaml_r.html">The
    *     cassandra.yaml configuration file</a>
    */
-  @Deprecated
   public InetAddress getBroadcastAddress() {
     return broadcastAddress != null ? broadcastAddress.getAddress() : null;
   }
@@ -212,7 +208,8 @@ public class Host {
    * Returns the node broadcast address (that is, the address by which it should be contacted by
    * other peers in the cluster), if known.
    *
-   * <p>Note that the port of the returned address may be 0 if it could not be determined.
+   * <p>Note that the port of the returned address will be 0 unless {@link
+   * Cluster.Builder#allowHostPortDiscovery() allowHostPortDiscovery} was used.
    *
    * <p>This corresponds to the {@code broadcast_address} cassandra.yaml file setting and is by
    * default the same as {@link #getListenSocketAddress()}, unless specified otherwise in
@@ -250,7 +247,8 @@ public class Host {
    * Returns the node listen address (that is, the address the node uses to contact other peers in
    * the cluster), if known.
    *
-   * <p>Note that the port of the returned address may be 0 if it could not be determined.
+   * <p>Note that the port of the returned address will be 0 unless {@link
+   * Cluster.Builder#allowHostPortDiscovery() allowHostPortDiscovery} was used.
    *
    * <p>This corresponds to the {@code listen_address} cassandra.yaml file setting. <em>This is NOT
    * the address clients should use to contact this node</em>.

--- a/driver-core/src/main/java/com/datastax/driver/core/Host.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Host.java
@@ -44,12 +44,12 @@ public class Host {
   // We use that internally because
   // that's the 'peer' in the 'System.peers' table and avoids querying the full peers table in
   // ControlConnection.refreshNodeInfo.
-  private volatile InetSocketAddress broadcastAddress;
+  private volatile InetSocketAddress broadcastSocketAddress;
 
   // The listen_address as known by Cassandra.
   // This is usually the same as broadcast_address unless
   // specified otherwise in cassandra.yaml file.
-  private volatile InetSocketAddress listenAddress;
+  private volatile InetSocketAddress listenSocketAddress;
 
   private volatile UUID hostId;
 
@@ -118,12 +118,12 @@ public class Host {
     this.cassandraVersion = versionNumber;
   }
 
-  void setBroadcastAddress(InetSocketAddress broadcastAddress) {
-    this.broadcastAddress = broadcastAddress;
+  void setBroadcastSocketAddress(InetSocketAddress broadcastAddress) {
+    this.broadcastSocketAddress = broadcastAddress;
   }
 
-  void setListenAddress(InetSocketAddress listenAddress) {
-    this.listenAddress = listenAddress;
+  void setListenSocketAddress(InetSocketAddress listenAddress) {
+    this.listenSocketAddress = listenAddress;
   }
 
   void setDseVersion(String dseVersion) {
@@ -194,6 +194,10 @@ public class Host {
   }
 
   /**
+   * Returns the node broadcast address, if known. Otherwise {@code null}.
+   *
+   * <p>This is a shortcut for {@code getBroadcastSocketAddress().getAddress()}.
+   *
    * @return the node broadcast address, if known. Otherwise {@code null}.
    * @see #getBroadcastSocketAddress()
    * @see <a
@@ -201,15 +205,15 @@ public class Host {
    *     cassandra.yaml configuration file</a>
    */
   public InetAddress getBroadcastAddress() {
-    return broadcastAddress != null ? broadcastAddress.getAddress() : null;
+    return broadcastSocketAddress != null ? broadcastSocketAddress.getAddress() : null;
   }
 
   /**
    * Returns the node broadcast address (that is, the address by which it should be contacted by
-   * other peers in the cluster), if known.
+   * other peers in the cluster), if known. Otherwise {@code null}.
    *
-   * <p>Note that the port of the returned address will be 0 unless {@link
-   * Cluster.Builder#allowHostPortDiscovery() allowHostPortDiscovery} was used.
+   * <p>Note that the port of the returned address will be 0 for versions of Cassandra older than
+   * 4.0.
    *
    * <p>This corresponds to the {@code broadcast_address} cassandra.yaml file setting and is by
    * default the same as {@link #getListenSocketAddress()}, unless specified otherwise in
@@ -227,10 +231,14 @@ public class Host {
    *     cassandra.yaml configuration file</a>
    */
   public InetSocketAddress getBroadcastSocketAddress() {
-    return broadcastAddress;
+    return broadcastSocketAddress;
   }
 
   /**
+   * Returns the node listen address, if known. Otherwise {@code null}.
+   *
+   * <p>This is a shortcut for {@code getListenSocketAddress().getAddress()}.
+   *
    * @return the node listen address, if known. Otherwise {@code null}.
    * @see #getListenSocketAddress()
    * @see <a
@@ -238,15 +246,15 @@ public class Host {
    *     cassandra.yaml configuration file</a>
    */
   public InetAddress getListenAddress() {
-    return listenAddress != null ? listenAddress.getAddress() : null;
+    return listenSocketAddress != null ? listenSocketAddress.getAddress() : null;
   }
 
   /**
    * Returns the node listen address (that is, the address the node uses to contact other peers in
-   * the cluster), if known.
+   * the cluster), if known. Otherwise {@code null}.
    *
-   * <p>Note that the port of the returned address will be 0 unless {@link
-   * Cluster.Builder#allowHostPortDiscovery() allowHostPortDiscovery} was used.
+   * <p>Note that the port of the returned address will be 0 for versions of Cassandra older than
+   * 4.0.
    *
    * <p>This corresponds to the {@code listen_address} cassandra.yaml file setting. <em>This is NOT
    * the address clients should use to contact this node</em>.
@@ -263,7 +271,7 @@ public class Host {
    *     cassandra.yaml configuration file</a>
    */
   public InetSocketAddress getListenSocketAddress() {
-    return listenAddress;
+    return listenSocketAddress;
   }
 
   /**

--- a/driver-core/src/main/java/com/datastax/driver/core/ProtocolOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ProtocolOptions.java
@@ -82,6 +82,7 @@ public class ProtocolOptions {
   private final AuthProvider authProvider;
 
   private final boolean noCompact;
+  private final boolean allowHostPortDiscovery;
 
   private volatile Compression compression = Compression.NONE;
 
@@ -144,12 +145,45 @@ public class ProtocolOptions {
       SSLOptions sslOptions,
       AuthProvider authProvider,
       boolean noCompact) {
+    this(
+        port,
+        protocolVersion,
+        maxSchemaAgreementWaitSeconds,
+        sslOptions,
+        authProvider,
+        noCompact,
+        false);
+  }
+
+  /**
+   * Creates a new {@code ProtocolOptions} instance using the provided port and SSL context.
+   *
+   * @param port the port to use for the binary protocol.
+   * @param protocolVersion the protocol version to use. This can be {@code null}, in which case the
+   *     version used will be the biggest version supported by the <em>first</em> node the driver
+   *     connects to. See {@link Cluster.Builder#withProtocolVersion} for more details.
+   * @param sslOptions the SSL options to use. Use {@code null} if SSL is not to be used.
+   * @param authProvider the {@code AuthProvider} to use for authentication against the Cassandra
+   *     nodes.
+   * @param noCompact whether or not to include the NO_COMPACT startup option.
+   * @param allowHostPortDiscovery whether or not to allow host port discovery via system.peers_v2
+   *     table.
+   */
+  public ProtocolOptions(
+      int port,
+      ProtocolVersion protocolVersion,
+      int maxSchemaAgreementWaitSeconds,
+      SSLOptions sslOptions,
+      AuthProvider authProvider,
+      boolean noCompact,
+      boolean allowHostPortDiscovery) {
     this.port = port;
     this.initialProtocolVersion = protocolVersion;
     this.maxSchemaAgreementWaitSeconds = maxSchemaAgreementWaitSeconds;
     this.sslOptions = sslOptions;
     this.authProvider = authProvider;
     this.noCompact = noCompact;
+    this.allowHostPortDiscovery = allowHostPortDiscovery;
   }
 
   void register(Cluster.Manager manager) {
@@ -246,5 +280,10 @@ public class ProtocolOptions {
   /** @return Whether or not to include the NO_COMPACT startup option. */
   public boolean isNoCompact() {
     return noCompact;
+  }
+
+  /** @return Whether or not host port discovery is allowed. */
+  public boolean isAllowHostPortDiscovery() {
+    return this.allowHostPortDiscovery;
   }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/ProtocolOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ProtocolOptions.java
@@ -82,7 +82,6 @@ public class ProtocolOptions {
   private final AuthProvider authProvider;
 
   private final boolean noCompact;
-  private final boolean allowHostPortDiscovery;
 
   private volatile Compression compression = Compression.NONE;
 
@@ -145,45 +144,12 @@ public class ProtocolOptions {
       SSLOptions sslOptions,
       AuthProvider authProvider,
       boolean noCompact) {
-    this(
-        port,
-        protocolVersion,
-        maxSchemaAgreementWaitSeconds,
-        sslOptions,
-        authProvider,
-        noCompact,
-        false);
-  }
-
-  /**
-   * Creates a new {@code ProtocolOptions} instance using the provided port and SSL context.
-   *
-   * @param port the port to use for the binary protocol.
-   * @param protocolVersion the protocol version to use. This can be {@code null}, in which case the
-   *     version used will be the biggest version supported by the <em>first</em> node the driver
-   *     connects to. See {@link Cluster.Builder#withProtocolVersion} for more details.
-   * @param sslOptions the SSL options to use. Use {@code null} if SSL is not to be used.
-   * @param authProvider the {@code AuthProvider} to use for authentication against the Cassandra
-   *     nodes.
-   * @param noCompact whether or not to include the NO_COMPACT startup option.
-   * @param allowHostPortDiscovery whether or not to allow host port discovery via system.peers_v2
-   *     table.
-   */
-  public ProtocolOptions(
-      int port,
-      ProtocolVersion protocolVersion,
-      int maxSchemaAgreementWaitSeconds,
-      SSLOptions sslOptions,
-      AuthProvider authProvider,
-      boolean noCompact,
-      boolean allowHostPortDiscovery) {
     this.port = port;
     this.initialProtocolVersion = protocolVersion;
     this.maxSchemaAgreementWaitSeconds = maxSchemaAgreementWaitSeconds;
     this.sslOptions = sslOptions;
     this.authProvider = authProvider;
     this.noCompact = noCompact;
-    this.allowHostPortDiscovery = allowHostPortDiscovery;
   }
 
   void register(Cluster.Manager manager) {
@@ -280,10 +246,5 @@ public class ProtocolOptions {
   /** @return Whether or not to include the NO_COMPACT startup option. */
   public boolean isNoCompact() {
     return noCompact;
-  }
-
-  /** @return Whether or not host port discovery is allowed. */
-  public boolean isAllowHostPortDiscovery() {
-    return this.allowHostPortDiscovery;
   }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/utils/MoreFutures.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/utils/MoreFutures.java
@@ -18,6 +18,7 @@ package com.datastax.driver.core.utils;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 
 /** Helpers to work with Guava's {@link ListenableFuture}. */
 public class MoreFutures {
@@ -38,5 +39,29 @@ public class MoreFutures {
     public void onSuccess(V result) {
       /* nothing */
     }
+  }
+
+  /**
+   * Configures a {@link SettableFuture} to propagate the result of a future.
+   *
+   * @param settable future to be propagated to
+   * @param future future to propagate
+   * @param <T>
+   */
+  public static <T> void propagateFuture(
+      final SettableFuture<T> settable, ListenableFuture<T> future) {
+    Futures.addCallback(
+        future,
+        new FutureCallback<T>() {
+          @Override
+          public void onSuccess(T result) {
+            settable.set(result);
+          }
+
+          @Override
+          public void onFailure(Throwable t) {
+            settable.setException(t);
+          }
+        });
   }
 }

--- a/driver-core/src/main/java/com/datastax/driver/core/utils/MoreFutures.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/utils/MoreFutures.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.driver.core.utils;
 
+import com.datastax.driver.core.GuavaCompatibility;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -50,7 +51,7 @@ public class MoreFutures {
    */
   public static <T> void propagateFuture(
       final SettableFuture<T> settable, ListenableFuture<T> future) {
-    Futures.addCallback(
+    GuavaCompatibility.INSTANCE.addCallback(
         future,
         new FutureCallback<T>() {
           @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeoutException;
 import org.scassandra.Scassandra;
 import org.scassandra.http.client.PrimingClient;
 import org.scassandra.http.client.PrimingRequest;
+import org.scassandra.http.client.Result;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -309,6 +310,13 @@ public class ClusterInitTest {
         PrimingRequest.queryBuilder()
             .withQuery("SELECT * FROM system.peers")
             .withThen(then().withRows(rows).withColumnTypes(ScassandraCluster.SELECT_PEERS))
+            .build());
+
+    // prime invalid for peers_v2 so peers table is used.
+    primingClient.prime(
+        PrimingRequest.queryBuilder()
+            .withQuery("SELECT * FROM system.peers_v2")
+            .withThen(then().withResult(Result.invalid))
             .build());
   }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/DataProviders.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DataProviders.java
@@ -62,4 +62,9 @@ public class DataProviders {
   public static Object[][] serialConsistencyLevels() {
     return new Object[][] {{ConsistencyLevel.SERIAL}, {ConsistencyLevel.LOCAL_SERIAL}};
   }
+
+  @DataProvider(name = "bool")
+  public static Object[][] bool() {
+    return new Object[][] {{true}, {false}};
+  }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/ExtendedPeerCheckDisabledTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ExtendedPeerCheckDisabledTest.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.driver.core;
 
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 public class ExtendedPeerCheckDisabledTest {
@@ -32,8 +33,12 @@ public class ExtendedPeerCheckDisabledTest {
       dataProvider = "disallowedNullColumnsInPeerData",
       dataProviderClass = ControlConnectionTest.class)
   @CCMConfig(createCcm = false)
-  public void should_use_peer_if_extended_peer_check_is_disabled(String columns) {
+  public void should_use_peer_if_extended_peer_check_is_disabled(
+      String columns, boolean allowHostPortDiscovery, boolean requiresExtendedPeerCheck) {
     System.setProperty("com.datastax.driver.EXTENDED_PEER_CHECK", "false");
-    ControlConnectionTest.run_with_null_peer_info(columns, true);
+    if (!requiresExtendedPeerCheck) {
+      throw new SkipException("Absence of column does not require extended peer check, skipping");
+    }
+    ControlConnectionTest.run_with_null_peer_info(columns, true, allowHostPortDiscovery);
   }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/ExtendedPeerCheckDisabledTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ExtendedPeerCheckDisabledTest.java
@@ -34,11 +34,11 @@ public class ExtendedPeerCheckDisabledTest {
       dataProviderClass = ControlConnectionTest.class)
   @CCMConfig(createCcm = false)
   public void should_use_peer_if_extended_peer_check_is_disabled(
-      String columns, boolean allowHostPortDiscovery, boolean requiresExtendedPeerCheck) {
+      String columns, boolean withPeersV2, boolean requiresExtendedPeerCheck) {
     System.setProperty("com.datastax.driver.EXTENDED_PEER_CHECK", "false");
     if (!requiresExtendedPeerCheck) {
       throw new SkipException("Absence of column does not require extended peer check, skipping");
     }
-    ControlConnectionTest.run_with_null_peer_info(columns, true, allowHostPortDiscovery);
+    ControlConnectionTest.run_with_null_peer_info(columns, true, withPeersV2);
   }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/HostAssert.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HostAssert.java
@@ -23,6 +23,7 @@ import com.datastax.driver.core.Host.State;
 import com.datastax.driver.core.Host.StateListener;
 import com.datastax.driver.core.policies.LoadBalancingPolicy;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -186,8 +187,18 @@ public class HostAssert extends AbstractAssert<HostAssert, Host> {
     return this;
   }
 
+  public HostAssert hasSocketAddress(InetSocketAddress address) {
+    assertThat(actual.getSocketAddress()).isNotNull().isEqualTo(address);
+    return this;
+  }
+
   public HostAssert hasListenAddress(InetAddress address) {
     assertThat(actual.getListenAddress()).isNotNull().isEqualTo(address);
+    return this;
+  }
+
+  public HostAssert hasListenSocketAddress(InetSocketAddress address) {
+    assertThat(actual.getListenSocketAddress()).isNotNull().isEqualTo(address);
     return this;
   }
 
@@ -196,13 +207,28 @@ public class HostAssert extends AbstractAssert<HostAssert, Host> {
     return this;
   }
 
+  public HostAssert hasNoListenSocketAddress() {
+    assertThat(actual.getListenSocketAddress()).isNull();
+    return this;
+  }
+
   public HostAssert hasBroadcastAddress(InetAddress address) {
     assertThat(actual.getBroadcastAddress()).isNotNull().isEqualTo(address);
     return this;
   }
 
+  public HostAssert hasBroadcastSocketAddress(InetSocketAddress address) {
+    assertThat(actual.getBroadcastSocketAddress()).isNotNull().isEqualTo(address);
+    return this;
+  }
+
   public HostAssert hasNoBroadcastAddress() {
     assertThat(actual.getBroadcastAddress()).isNull();
+    return this;
+  }
+
+  public HostAssert hasNoBroadcastSocketAddress() {
+    assertThat(actual.getBroadcastSocketAddress()).isNull();
     return this;
   }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/ScassandraCluster.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ScassandraCluster.java
@@ -484,6 +484,7 @@ public class ScassandraCluster {
           addPeerInfo(row, dc, n + 1, "graph", false);
           addPeerInfo(rowV2, dc, n + 1, "graph", false);
 
+          addPeerInfoIfExists(row, dc, n + 1, "listen_address");
           addPeerInfoIfExists(row, dc, n + 1, "dse_version");
           addPeerInfoIfExists(row, dc, n + 1, "workload");
 
@@ -601,6 +602,7 @@ public class ScassandraCluster {
     column("rack", TEXT),
     column("release_version", TEXT),
     column("tokens", set(TEXT)),
+    column("listen_address", INET),
     column("host_id", UUID),
     column("graph", BOOLEAN),
     column("schema_version", UUID)

--- a/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TokenIntegrationTest.java
@@ -306,12 +306,12 @@ public abstract class TokenIntegrationTest extends CCMTestsSupport {
       } else {
         // non-control hosts are populated from system.peers and their broadcast address should be
         // known
-        assertThat(host.getBroadcastAddress()).isNotNull();
+        assertThat(host.getBroadcastSocketAddress()).isNotNull();
         row =
             session()
                 .execute(
                     "select tokens from system.peers where peer = '"
-                        + host.getBroadcastAddress().getHostAddress()
+                        + host.getBroadcastSocketAddress().getAddress().getHostAddress()
                         + "'")
                 .one();
       }


### PR DESCRIPTION
For [JAVA-1388](https://datastax-oss.atlassian.net/browse/JAVA-1388).

Based on #1064 for now until that is merged.

I followed the approaches in #1000 where we query the peers_v2 table first, and if that fails, downgrade to the peers table and never query v2 again.  I just realized we should probably be more selective about downgrading based on the error returned by that (both here and on 4.x), as its reasonable to expect we can get other errors (like client timeouts) that don't necessitate downgrading to the peers table.

I updated `ScassandraCluster` to support multiple nodes per IP and added a test for this, and it seems to work well.   It would be nice to have tests against real cassandra nodes, which will require CCM changes, which may take me a little bit.  Also needs tests for the broadcast address changing / query of peers table for a single host that we currently have in `ControlConnectionTest` for the existing peers table.
