### PR TITLE
JAVA-1927 fix issue with unused native port

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
@@ -319,7 +319,7 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
       return null;
     }
     Integer row_port = row.getInteger("native_port");
-    if (row_port == null) {
+    if (row_port == null || row_port == 0) {
       row_port = port;
     }
     return addressTranslator.translate(new InetSocketAddress(nativeAddress, row_port));

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
@@ -318,10 +318,10 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
     if (nativeAddress == null) {
       return null;
     }
-    Integer row_port = row.getInteger("native_port");
-    if (row_port == null || row_port == 0) {
-      row_port = port;
+    Integer rowPort = row.getInteger("native_port");
+    if (rowPort == null || rowPort == 0) {
+      rowPort = port;
     }
-    return addressTranslator.translate(new InetSocketAddress(nativeAddress, row_port));
+    return addressTranslator.translate(new InetSocketAddress(nativeAddress, rowPort));
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.servererrors.InvalidQueryException;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminRequestHandler;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminResult;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
@@ -166,7 +167,7 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
 
     peersV2Query.whenComplete(
         (r, t) -> {
-          if (t != null) {
+          if (t instanceof InvalidQueryException) {
             // The query to system.peers_v2 failed, we should not attempt this query in the
             // future.
             this.isSchemaV2 = false;
@@ -317,7 +318,10 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
     if (nativeAddress == null) {
       return null;
     }
-    int row_port = port;
+    Integer row_port = row.getInteger("native_port");
+    if (row_port == null) {
+      row_port = port;
+    }
     return addressTranslator.translate(new InetSocketAddress(nativeAddress, row_port));
   }
 }


### PR DESCRIPTION
Two things here,
1. Native port is now honored not just in the metadata but also when the the connections are actually made.
2. We only fall back to system_peers when the v2 query errors with an InvalidQueryException