### PR TITLE
Make ProtocolFeature an interface

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/ProtocolVersion.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/ProtocolVersion.java
@@ -43,8 +43,8 @@ public interface ProtocolVersion {
   /**
    * Whether the protocol version is in a beta status.
    *
-   * <p>Beta versions are intended for Cassandra development. They should be used in a regular
-   * application, beta features may break at any point.
+   * <p>Beta versions are intended for Cassandra development. They should not be used in a regular
+   * application, as beta features may break at any point.
    */
   boolean isBeta();
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/CassandraProtocolVersionRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/CassandraProtocolVersionRegistry.java
@@ -170,13 +170,12 @@ public class CassandraProtocolVersionRegistry implements ProtocolVersionRegistry
 
   @Override
   public boolean supports(ProtocolVersion version, ProtocolFeature feature) {
-    switch (feature) {
-      case UNSET_BOUND_VALUES:
-        return version.getCode() >= 4;
-      case PER_REQUEST_KEYSPACE:
-        return version.getCode() >= 5;
-      default:
-        throw new IllegalArgumentException("Unhandled protocol feature: " + feature);
+    if (DefaultProtocolFeature.UNSET_BOUND_VALUES.equals(feature)) {
+      return version.getCode() >= 4;
+    } else if (DefaultProtocolFeature.PER_REQUEST_KEYSPACE.equals(feature)) {
+      return version.getCode() >= 5;
+    } else {
+      throw new IllegalArgumentException("Unhandled protocol feature: " + feature);
     }
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultProtocolFeature.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultProtocolFeature.java
@@ -15,17 +15,25 @@
  */
 package com.datastax.oss.driver.internal.core;
 
-import com.datastax.oss.driver.api.core.ProtocolVersion;
-
 /**
- * A marker interface for features of the native protocol that are only supported by specific
- * {@linkplain ProtocolVersion versions}.
+ * Features that are commonly supported by most Apache Cassandra protocol versions.
  *
- * <p>The only reason to model this as an interface (as opposed to an enum type) is to accommodate
- * for custom protocol extensions. If you're connecting to a standard Apache Cassandra cluster, all
- * {@code ProtocolFeature}s are {@link DefaultProtocolFeature} instances.
- *
- * @see ProtocolVersionRegistry#supports(ProtocolVersion, ProtocolFeature)
- * @see DefaultProtocolFeature
+ * @see com.datastax.oss.driver.api.core.DefaultProtocolVersion
  */
-public interface ProtocolFeature {}
+public enum DefaultProtocolFeature implements ProtocolFeature {
+
+  /**
+   * The ability to leave variables unset in prepared statements.
+   *
+   * @see <a href="https://issues.apache.org/jira/browse/CASSANDRA-7304">CASSANDRA-7304</a>
+   */
+  UNSET_BOUND_VALUES,
+
+  /**
+   * The ability to override the keyspace on a per-request basis.
+   *
+   * @see <a href="https://issues.apache.org/jira/browse/CASSANDRA-10145">CASSANDRA-10145</a>
+   */
+  PER_REQUEST_KEYSPACE,
+  ;
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
@@ -53,7 +53,7 @@ import com.datastax.oss.driver.api.core.servererrors.WriteFailureException;
 import com.datastax.oss.driver.api.core.servererrors.WriteTimeoutException;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
-import com.datastax.oss.driver.internal.core.ProtocolFeature;
+import com.datastax.oss.driver.internal.core.DefaultProtocolFeature;
 import com.datastax.oss.driver.internal.core.ProtocolVersionRegistry;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metadata.token.ByteOrderedToken;
@@ -128,7 +128,7 @@ public class Conversions {
             "Can't have both positional and named values in a statement.");
       }
       if (keyspace != null
-          && !registry.supports(protocolVersion, ProtocolFeature.PER_REQUEST_KEYSPACE)) {
+          && !registry.supports(protocolVersion, DefaultProtocolFeature.PER_REQUEST_KEYSPACE)) {
         throw new IllegalArgumentException(
             "Can't use per-request keyspace with protocol " + protocolVersion);
       }
@@ -146,7 +146,7 @@ public class Conversions {
       return new Query(simpleStatement.getQuery(), queryOptions);
     } else if (statement instanceof BoundStatement) {
       BoundStatement boundStatement = (BoundStatement) statement;
-      if (!registry.supports(protocolVersion, ProtocolFeature.UNSET_BOUND_VALUES)) {
+      if (!registry.supports(protocolVersion, DefaultProtocolFeature.UNSET_BOUND_VALUES)) {
         ensureAllSet(boundStatement);
       }
       boolean skipMetadata =
@@ -171,11 +171,11 @@ public class Conversions {
           queryOptions);
     } else if (statement instanceof BatchStatement) {
       BatchStatement batchStatement = (BatchStatement) statement;
-      if (!registry.supports(protocolVersion, ProtocolFeature.UNSET_BOUND_VALUES)) {
+      if (!registry.supports(protocolVersion, DefaultProtocolFeature.UNSET_BOUND_VALUES)) {
         ensureAllSet(batchStatement);
       }
       if (keyspace != null
-          && !registry.supports(protocolVersion, ProtocolFeature.PER_REQUEST_KEYSPACE)) {
+          && !registry.supports(protocolVersion, DefaultProtocolFeature.PER_REQUEST_KEYSPACE)) {
         throw new IllegalArgumentException(
             "Can't use per-request keyspace with protocol " + protocolVersion);
       }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandlerBase.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandlerBase.java
@@ -36,7 +36,7 @@ import com.datastax.oss.driver.api.core.servererrors.ProtocolError;
 import com.datastax.oss.driver.api.core.servererrors.QueryValidationException;
 import com.datastax.oss.driver.api.core.session.throttling.RequestThrottler;
 import com.datastax.oss.driver.api.core.session.throttling.Throttled;
-import com.datastax.oss.driver.internal.core.ProtocolFeature;
+import com.datastax.oss.driver.internal.core.DefaultProtocolFeature;
 import com.datastax.oss.driver.internal.core.ProtocolVersionRegistry;
 import com.datastax.oss.driver.internal.core.adminrequest.ThrottledAdminRequestHandler;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
@@ -149,7 +149,7 @@ public abstract class CqlPrepareHandlerBase implements Throttled {
     ProtocolVersionRegistry registry = context.getProtocolVersionRegistry();
     CqlIdentifier keyspace = request.getKeyspace();
     if (keyspace != null
-        && !registry.supports(protocolVersion, ProtocolFeature.PER_REQUEST_KEYSPACE)) {
+        && !registry.supports(protocolVersion, DefaultProtocolFeature.PER_REQUEST_KEYSPACE)) {
       throw new IllegalArgumentException(
           "Can't use per-request keyspace with protocol " + protocolVersion);
     }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BoundStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BoundStatementIT.java
@@ -36,7 +36,7 @@ import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
 import com.datastax.oss.driver.categories.ParallelizableTests;
-import com.datastax.oss.driver.internal.core.ProtocolFeature;
+import com.datastax.oss.driver.internal.core.DefaultProtocolFeature;
 import com.datastax.oss.driver.internal.core.ProtocolVersionRegistry;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.type.codec.CqlIntToStringCodec;
@@ -499,6 +499,6 @@ public class BoundStatementIT {
     InternalDriverContext context = (InternalDriverContext) session.getContext();
     ProtocolVersionRegistry protocolVersionRegistry = context.getProtocolVersionRegistry();
     return protocolVersionRegistry.supports(
-        context.getProtocolVersion(), ProtocolFeature.PER_REQUEST_KEYSPACE);
+        context.getProtocolVersion(), DefaultProtocolFeature.PER_REQUEST_KEYSPACE);
   }
 }


### PR DESCRIPTION
Motivation:

ProtocolFeature is currently an enum and as such is not extensible;
if custom protocol extensions need to support proprietary features,
such features cannot be modeled as a ProtocolFeature instance.

Modification:

Make ProtocolFeature an interface, create enum DefaultProtocolFeature.

Result:

ProtocolFeature can now be implemented by other classes.