### PR TITLE
JAVA-1903: Add WhiteListPolicy.ofHosts

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -11,6 +11,7 @@
 - [bug] JAVA-1924: StatementWrapper setters should return the wrapping statement.
 - [new feature] JAVA-1532: Add Codec support for Java 8's LocalDateTime and ZoneId.
 - [improvement] JAVA-1786: Use Google code formatter.
+- [new feature] JAVA-1903: Add WhiteListPolicy.fromHosts.
 
 Merged from 3.5.x:
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -11,7 +11,7 @@
 - [bug] JAVA-1924: StatementWrapper setters should return the wrapping statement.
 - [new feature] JAVA-1532: Add Codec support for Java 8's LocalDateTime and ZoneId.
 - [improvement] JAVA-1786: Use Google code formatter.
-- [new feature] JAVA-1903: Add WhiteListPolicy.fromHosts.
+- [new feature] JAVA-1903: Add WhiteListPolicy.ofHosts.
 
 Merged from 3.5.x:
 

--- a/driver-core/src/main/java/com/datastax/driver/core/policies/WhiteListPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/WhiteListPolicy.java
@@ -18,8 +18,13 @@ package com.datastax.driver.core.policies;
 import com.datastax.driver.core.Host;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * A load balancing policy wrapper that ensure that only hosts from a provided white list will ever
@@ -42,7 +47,7 @@ public class WhiteListPolicy extends HostFilterPolicy {
 
   /**
    * Creates a new policy that wraps the provided child policy but only "allows" hosts from the
-   * provided while list.
+   * provided white list.
    *
    * @param childPolicy the wrapped policy.
    * @param whiteList the white listed hosts. Only hosts from this list may get connected to
@@ -50,6 +55,14 @@ public class WhiteListPolicy extends HostFilterPolicy {
    */
   public WhiteListPolicy(LoadBalancingPolicy childPolicy, Collection<InetSocketAddress> whiteList) {
     super(childPolicy, buildPredicate(whiteList));
+  }
+
+  /**
+   * Private constructor solely for maintaining type from policy created by {@link
+   * #fromHosts(LoadBalancingPolicy, String...)}.
+   */
+  private WhiteListPolicy(LoadBalancingPolicy childPolicy, Predicate<Host> predicate) {
+    super(childPolicy, predicate);
   }
 
   private static Predicate<Host> buildPredicate(Collection<InetSocketAddress> whiteList) {
@@ -60,5 +73,52 @@ public class WhiteListPolicy extends HostFilterPolicy {
         return hosts.contains(host.getSocketAddress());
       }
     };
+  }
+
+  /**
+   * Creates a new policy with the given host names.
+   *
+   * <p>See {@link #fromHosts(LoadBalancingPolicy, String...)} for more details.
+   */
+  public static WhiteListPolicy fromHosts(
+      LoadBalancingPolicy childPolicy, Collection<String> hostnames) {
+    return fromHosts(childPolicy, hostnames.toArray(new String[0]));
+  }
+
+  /**
+   * Creates a new policy that wraps the provided child policy but only "allows" hosts having
+   * addresses that match those from the resolved input host names.
+   *
+   * <p>Note that all host names must be resolvable; if <em>any</em> of them cannot be resolved,
+   * this method will fail.
+   *
+   * @param childPolicy the wrapped policy.
+   * @param hostnames list of host names to resolve white listed addresses from.
+   * @throws IllegalArgumentException if any of the given {@code hostnames} could not be resolved.
+   * @throws NullPointerException If null was provided for a hostname.
+   * @throws SecurityException if a security manager is present and permission to resolve the host
+   *     name is denied.
+   */
+  public static WhiteListPolicy fromHosts(LoadBalancingPolicy childPolicy, String... hostnames) {
+    final Set<InetAddress> validAddresses = new HashSet<InetAddress>();
+    for (String hostname : hostnames) {
+      try {
+        // We explicitly check for nulls because InetAdress.getByName() will happily
+        // accept it and use localhost (while a null here almost likely mean a user error,
+        // not "connect to localhost")
+        if (hostname == null) throw new NullPointerException();
+        Collections.addAll(validAddresses, InetAddress.getAllByName(hostname));
+      } catch (UnknownHostException e) {
+        throw new IllegalArgumentException("Failed to resolve: " + hostname, e);
+      }
+    }
+    return new WhiteListPolicy(
+        childPolicy,
+        new Predicate<Host>() {
+          @Override
+          public boolean apply(Host host) {
+            return validAddresses.contains(host.getAddress());
+          }
+        });
   }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/WhiteListPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/WhiteListPolicyTest.java
@@ -101,6 +101,74 @@ public class WhiteListPolicyTest {
   }
 
   /**
+   * Ensures that {@link WhiteListPolicy#fromHosts(LoadBalancingPolicy, String...)} throws an {@link
+   * IllegalArgumentException} if a name could not be resolved.
+   *
+   * @test_category load_balancing:white_list
+   */
+  @Test(groups = "unit", expectedExceptions = IllegalArgumentException.class)
+  public void should_throw_IAE_if_name_could_not_be_resolved() {
+    WhiteListPolicy.fromHosts(new RoundRobinPolicy(), "a.b.c.d.e.f.UNRESOLVEABLE");
+  }
+
+  /**
+   * Ensures that {@link WhiteListPolicy#fromHosts(LoadBalancingPolicy, String...)} throws a {@link
+   * NullPointerException} if a name provided is null.
+   *
+   * @test_category load_balancing:white_list
+   */
+  @Test(groups = "unit", expectedExceptions = NullPointerException.class)
+  public void should_throw_NPE_if_null_provided() {
+    WhiteListPolicy.fromHosts(new RoundRobinPolicy(), null, null);
+  }
+
+  /**
+   * Ensures that {@link WhiteListPolicy#fromHosts(LoadBalancingPolicy, String...)} appropriately
+   * choses hosts based on their resolved ip addresses.
+   *
+   * @test_category load_balancing:white_list
+   */
+  @Test(groups = "short")
+  public void should_only_query_hosts_in_white_list_from_hosts() throws Exception {
+    // given: a 5 node cluster with a WhiteListPolicy targeting nodes 1 and 4
+    ScassandraCluster sCluster = ScassandraCluster.builder().withNodes(5).build();
+
+    // In this case, we can't rely on DNS.  However, node 1 should be 127.0.0.1 which depending on
+    // /etc/hosts configuration is likely to resolve the name of the machine running the test.
+    WhiteListPolicy policy =
+        WhiteListPolicy.fromHosts(
+            new RoundRobinPolicy(),
+            sCluster.address(1).getHostName(),
+            sCluster.address(4).getHostName());
+
+    Cluster cluster =
+        Cluster.builder()
+            .addContactPoints(sCluster.address(1).getAddress())
+            .withPort(sCluster.getBinaryPort())
+            .withLoadBalancingPolicy(policy)
+            .withNettyOptions(nonQuietClusterCloseOptions)
+            .build();
+
+    try {
+      sCluster.init();
+
+      Session session = cluster.connect();
+      // when: a query is executed 50 times.
+      queryTracker.query(session, 50);
+
+      // then: only nodes 1 and 4 should have been queried.
+      queryTracker.assertQueried(sCluster, 1, 1, 25);
+      queryTracker.assertQueried(sCluster, 1, 2, 0);
+      queryTracker.assertQueried(sCluster, 1, 3, 0);
+      queryTracker.assertQueried(sCluster, 1, 4, 25);
+      queryTracker.assertQueried(sCluster, 1, 5, 0);
+    } finally {
+      cluster.close();
+      sCluster.stop();
+    }
+  }
+
+  /**
    * Validates that a {@link Cluster} cannot be initiated if using a {@link WhiteListPolicy} and
    * none of the specified contact point addresses are present in the white list.
    *

--- a/driver-core/src/test/java/com/datastax/driver/core/policies/WhiteListPolicyTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/policies/WhiteListPolicyTest.java
@@ -101,29 +101,29 @@ public class WhiteListPolicyTest {
   }
 
   /**
-   * Ensures that {@link WhiteListPolicy#fromHosts(LoadBalancingPolicy, String...)} throws an {@link
+   * Ensures that {@link WhiteListPolicy#ofHosts(LoadBalancingPolicy, String...)} throws an {@link
    * IllegalArgumentException} if a name could not be resolved.
    *
    * @test_category load_balancing:white_list
    */
   @Test(groups = "unit", expectedExceptions = IllegalArgumentException.class)
   public void should_throw_IAE_if_name_could_not_be_resolved() {
-    WhiteListPolicy.fromHosts(new RoundRobinPolicy(), "a.b.c.d.e.f.UNRESOLVEABLE");
+    WhiteListPolicy.ofHosts(new RoundRobinPolicy(), "a.b.c.d.e.f.UNRESOLVEABLE");
   }
 
   /**
-   * Ensures that {@link WhiteListPolicy#fromHosts(LoadBalancingPolicy, String...)} throws a {@link
+   * Ensures that {@link WhiteListPolicy#ofHosts(LoadBalancingPolicy, String...)} throws a {@link
    * NullPointerException} if a name provided is null.
    *
    * @test_category load_balancing:white_list
    */
   @Test(groups = "unit", expectedExceptions = NullPointerException.class)
   public void should_throw_NPE_if_null_provided() {
-    WhiteListPolicy.fromHosts(new RoundRobinPolicy(), null, null);
+    WhiteListPolicy.ofHosts(new RoundRobinPolicy(), null, null);
   }
 
   /**
-   * Ensures that {@link WhiteListPolicy#fromHosts(LoadBalancingPolicy, String...)} appropriately
+   * Ensures that {@link WhiteListPolicy#ofHosts(LoadBalancingPolicy, String...)} appropriately
    * choses hosts based on their resolved ip addresses.
    *
    * @test_category load_balancing:white_list
@@ -136,7 +136,7 @@ public class WhiteListPolicyTest {
     // In this case, we can't rely on DNS.  However, node 1 should be 127.0.0.1 which depending on
     // /etc/hosts configuration is likely to resolve the name of the machine running the test.
     WhiteListPolicy policy =
-        WhiteListPolicy.fromHosts(
+        WhiteListPolicy.ofHosts(
             new RoundRobinPolicy(),
             sCluster.address(1).getHostName(),
             sCluster.address(4).getHostName());


### PR DESCRIPTION
For [JAVA-1903](https://datastax-oss.atlassian.net/browse/JAVA-1903)

Motivation:

Similarly to Cluster.Builder.addContactPoints(String ...) it would be
convenient for WhiteListPolicy to support a similar mechanism of
providing hostnames to resolve IP addresses from to be considered
for host selection.

Modifications:

Add WhiteListPolicy.fromHosts to create a WhiteListPolicy that uses
DNS to resolve IP addresses to be considered.

Result:

WhiteListPolicy can now be created from hostname(s).