### PR TITLE
JAVA-1938: Make CassandraSchemaQueries classes public

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-beta2 (in progress)
 
+- [bug] JAVA-1938: Make CassandraSchemaQueries classes public
 - [improvement] JAVA-1925: Rename context getters
 - [improvement] JAVA-1544: Check API compatibility with Revapi
 - [new feature] JAVA-1900: Add support for virtual tables

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra21SchemaQueries.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra21SchemaQueries.java
@@ -23,8 +23,8 @@ import java.util.concurrent.CompletableFuture;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
-class Cassandra21SchemaQueries extends CassandraSchemaQueries {
-  Cassandra21SchemaQueries(
+public class Cassandra21SchemaQueries extends CassandraSchemaQueries {
+  public Cassandra21SchemaQueries(
       DriverChannel channel,
       CompletableFuture<Metadata> refreshFuture,
       DriverExecutionProfile config,

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra22SchemaQueries.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra22SchemaQueries.java
@@ -23,8 +23,8 @@ import java.util.concurrent.CompletableFuture;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
-class Cassandra22SchemaQueries extends CassandraSchemaQueries {
-  Cassandra22SchemaQueries(
+public class Cassandra22SchemaQueries extends CassandraSchemaQueries {
+  public Cassandra22SchemaQueries(
       DriverChannel channel,
       CompletableFuture<Metadata> refreshFuture,
       DriverExecutionProfile config,

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra3SchemaQueries.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra3SchemaQueries.java
@@ -23,8 +23,8 @@ import java.util.concurrent.CompletableFuture;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
-class Cassandra3SchemaQueries extends CassandraSchemaQueries {
-  Cassandra3SchemaQueries(
+public class Cassandra3SchemaQueries extends CassandraSchemaQueries {
+  public Cassandra3SchemaQueries(
       DriverChannel channel,
       CompletableFuture<Metadata> refreshFuture,
       DriverExecutionProfile config,

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra4SchemaQueries.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra4SchemaQueries.java
@@ -23,8 +23,8 @@ import java.util.concurrent.CompletableFuture;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
-class Cassandra4SchemaQueries extends Cassandra3SchemaQueries {
-  Cassandra4SchemaQueries(
+public class Cassandra4SchemaQueries extends Cassandra3SchemaQueries {
+  public Cassandra4SchemaQueries(
       DriverChannel channel,
       CompletableFuture<Metadata> refreshFuture,
       DriverExecutionProfile config,


### PR DESCRIPTION
For [JAVA-1938](https://datastax-oss.atlassian.net/browse/JAVA-1938)