### PR TITLE
 JAVA-1939: Exclude logback-test.xml files from test jars

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -154,6 +154,11 @@
             <goals>
               <goal>test-jar</goal>
             </goals>
+            <configuration>
+              <excludes>
+                <exclude>logback-test.xml</exclude>
+              </excludes>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -115,6 +115,11 @@
             <goals>
               <goal>test-jar</goal>
             </goals>
+            <configuration>
+              <excludes>
+                <exclude>logback-test.xml</exclude>
+              </excludes>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/integration-tests/src/test/java/com/datastax/oss/driver/internal/core/retry/DefaultRetryPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/internal/core/retry/DefaultRetryPolicyIT.java
@@ -58,6 +58,7 @@ import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.util.Arrays;
 import java.util.Map;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -111,6 +112,7 @@ public class DefaultRetryPolicyIT {
     simulacron.cluster().clearPrimes(true);
   }
 
+  @After
   public void teardown() {
     logger.detachAppender(appender);
     logger.setLevel(oldLevel);

--- a/integration-tests/src/test/resources/logback-test.xml
+++ b/integration-tests/src/test/resources/logback-test.xml
@@ -24,5 +24,5 @@
   <root level="ERROR">
     <appender-ref ref="STDOUT"/>
   </root>
-  <logger name="com.datastax.oss.driver" level="${driverLevel:-WARN}"/>
+  <logger name="com.datastax.oss.driver" level="${driverLevel:-ERROR}"/>
 </configuration>


### PR DESCRIPTION
Note: the 3 commits in this PR should not be squashed together.