### PR TITLE
JAVA-1942: Adapt type with CodecRegistry's associated AttachmentPoint

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-beta2 (in progress)
 
+- [bug] JAVA-1942: Adapt type with CodecRegistry's associated AttachmentPoint
 - [bug] JAVA-1938: Make CassandraSchemaQueries classes public
 - [improvement] JAVA-1925: Rename context getters
 - [improvement] JAVA-1544: Check API compatibility with Revapi

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
@@ -395,7 +395,7 @@ public class DefaultDriverContext implements InternalDriverContext {
 
   protected CodecRegistry buildCodecRegistry(String logPrefix, List<TypeCodec<?>> codecs) {
     TypeCodec<?>[] array = new TypeCodec<?>[codecs.size()];
-    return new DefaultCodecRegistry(logPrefix, codecs.toArray(array));
+    return new DefaultCodecRegistry(logPrefix, this, codecs.toArray(array));
   }
 
   protected SchemaQueriesFactory buildSchemaQueriesFactory() {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/DefaultCodecRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/DefaultCodecRegistry.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.type.codec.registry;
 
 import com.datastax.oss.driver.api.core.DriverExecutionException;
+import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
 import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
@@ -46,6 +47,8 @@ public class DefaultCodecRegistry extends CachingCodecRegistry {
 
   private final LoadingCache<CacheKey, TypeCodec<?>> cache;
 
+  private final AttachmentPoint attachmentPoint;
+
   /**
    * Creates a new instance, with some amount of control over the cache behavior.
    *
@@ -60,10 +63,12 @@ public class DefaultCodecRegistry extends CachingCodecRegistry {
       BiFunction<CacheKey, TypeCodec<?>, Integer> cacheWeigher,
       int maximumCacheWeight,
       BiConsumer<CacheKey, TypeCodec<?>> cacheRemovalListener,
+      AttachmentPoint attachmentPoint,
       TypeCodec<?>[] primitiveCodecs,
       TypeCodec<?>[] userCodecs) {
 
-    super(logPrefix, primitiveCodecs, userCodecs);
+    super(logPrefix, attachmentPoint, primitiveCodecs, userCodecs);
+    this.attachmentPoint = attachmentPoint;
     CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
     if (initialCacheCapacity > 0) {
       cacheBuilder.initialCapacity(initialCacheCapacity);
@@ -93,12 +98,20 @@ public class DefaultCodecRegistry extends CachingCodecRegistry {
   }
 
   public DefaultCodecRegistry(String logPrefix, TypeCodec<?>... userCodecs) {
-    this(logPrefix, CodecRegistryConstants.PRIMITIVE_CODECS, userCodecs);
+    this(logPrefix, AttachmentPoint.NONE, userCodecs);
   }
 
   public DefaultCodecRegistry(
-      String logPrefix, TypeCodec<?>[] primitiveCodecs, TypeCodec<?>... userCodecs) {
-    this(logPrefix, 0, null, 0, null, primitiveCodecs, userCodecs);
+      String logPrefix, AttachmentPoint attachmentPoint, TypeCodec<?>... userCodecs) {
+    this(logPrefix, CodecRegistryConstants.PRIMITIVE_CODECS, attachmentPoint, userCodecs);
+  }
+
+  public DefaultCodecRegistry(
+      String logPrefix,
+      TypeCodec<?>[] primitiveCodecs,
+      AttachmentPoint attachmentPoint,
+      TypeCodec<?>... userCodecs) {
+    this(logPrefix, 0, null, 0, null, attachmentPoint, primitiveCodecs, userCodecs);
   }
 
   @Override

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BoundStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BoundStatementIT.java
@@ -72,7 +72,7 @@ public class BoundStatementIT {
 
   @ClassRule public static CcmRule ccm = CcmRule.getInstance();
 
-  private static boolean atLeastV4 = ccm.getHighestProtocolVersion().getCode() >= 4;
+  private static boolean atLeastV4 = SessionUtils.getMaxProtocolVersion().getCode() >= 4;
 
   @ClassRule
   public static SessionRule<CqlSession> sessionRule =

--- a/test-infra/revapi.json
+++ b/test-infra/revapi.json
@@ -14,6 +14,41 @@
           ]
         }
       }
-    }
+    },
+    "ignore": [
+      {
+        "code": "java.method.removed",
+        "old": "method com.datastax.oss.driver.api.core.ProtocolVersion com.datastax.oss.driver.api.testinfra.CassandraResourceRule::getHighestProtocolVersion()",
+        "package": "com.datastax.oss.driver.api.testinfra",
+        "classQualifiedName": "com.datastax.oss.driver.api.testinfra.CassandraResourceRule",
+        "classSimpleName": "CassandraResourceRule",
+        "methodName": "getHighestProtocolVersion",
+        "oldArchive": "com.datastax.oss:java-driver-test-infra:jar:4.0.0-beta1",
+        "elementKind": "method",
+        "justification": "replaced by SessionUtils.getMaxProtocolVersion"
+      },
+      {
+        "code": "java.method.removed",
+        "old": "method com.datastax.oss.driver.api.core.ProtocolVersion com.datastax.oss.driver.api.testinfra.ccm.BaseCcmRule::getHighestProtocolVersion()",
+        "package": "com.datastax.oss.driver.api.testinfra.ccm",
+        "classQualifiedName": "com.datastax.oss.driver.api.testinfra.ccm.BaseCcmRule",
+        "classSimpleName": "BaseCcmRule",
+        "methodName": "getHighestProtocolVersion",
+        "oldArchive": "com.datastax.oss:java-driver-test-infra:jar:4.0.0-beta1",
+        "elementKind": "method",
+        "justification": "replaced by SessionUtils.getMaxProtocolVersion"
+      },
+      {
+        "code": "java.method.removed",
+        "old": "method com.datastax.oss.driver.api.core.ProtocolVersion com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule::getHighestProtocolVersion()",
+        "package": "com.datastax.oss.driver.api.testinfra.simulacron",
+        "classQualifiedName": "com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule",
+        "classSimpleName": "SimulacronRule",
+        "methodName": "getHighestProtocolVersion",
+        "oldArchive": "com.datastax.oss:java-driver-test-infra:jar:4.0.0-beta1",
+        "elementKind": "method",
+        "justification": "replaced by SessionUtils.getMaxProtocolVersion"
+      }
+    ]
   }
 }

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/CassandraResourceRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/CassandraResourceRule.java
@@ -15,7 +15,6 @@
  */
 package com.datastax.oss.driver.api.testinfra;
 
-import com.datastax.oss.driver.api.core.ProtocolVersion;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.Set;
@@ -43,7 +42,4 @@ public abstract class CassandraResourceRule extends ExternalResource {
   public Set<InetSocketAddress> getContactPoints() {
     return Collections.singleton(new InetSocketAddress("127.0.0.1", 9042));
   }
-
-  /** @return The highest protocol version supported by this resource. */
-  public abstract ProtocolVersion getHighestProtocolVersion();
 }

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
@@ -15,8 +15,6 @@
  */
 package com.datastax.oss.driver.api.testinfra.ccm;
 
-import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
-import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.Version;
 import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
 import com.datastax.oss.driver.api.testinfra.CassandraResourceRule;
@@ -137,14 +135,5 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
 
   public Optional<Version> getDseVersion() {
     return ccmBridge.getDseVersion();
-  }
-
-  @Override
-  public ProtocolVersion getHighestProtocolVersion() {
-    if (ccmBridge.getCassandraVersion().compareTo(Version.V2_2_0) >= 0) {
-      return DefaultProtocolVersion.V4;
-    } else {
-      return DefaultProtocolVersion.V3;
-    }
   }
 }

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
@@ -161,11 +161,15 @@ public class CcmBridge implements AutoCloseable {
     this.dseWorkloads = dseWorkloads;
   }
 
-  public Optional<Version> getDseVersion() {
+  public static Optional<Version> getGlobalDseVersion() {
     return DSE_ENABLEMENT ? Optional.of(VERSION) : Optional.empty();
   }
 
-  public Version getCassandraVersion() {
+  public Optional<Version> getDseVersion() {
+    return getGlobalDseVersion();
+  }
+
+  public static Version getGlobalCassandraVersion() {
     if (!DSE_ENABLEMENT) {
       return VERSION;
     } else {
@@ -180,6 +184,10 @@ public class CcmBridge implements AutoCloseable {
         return V2_1_19;
       }
     }
+  }
+
+  public Version getCassandraVersion() {
+    return getGlobalCassandraVersion();
   }
 
   public void create() {

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/simulacron/SimulacronRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/simulacron/SimulacronRule.java
@@ -15,8 +15,6 @@
  */
 package com.datastax.oss.driver.api.testinfra.simulacron;
 
-import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
-import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.testinfra.CassandraResourceRule;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
 import com.datastax.oss.simulacron.server.BoundCluster;
@@ -81,10 +79,5 @@ public class SimulacronRule extends CassandraResourceRule {
         .stream()
         .map(BoundNode::inetSocketAddress)
         .collect(Collectors.toSet());
-  }
-
-  @Override
-  public ProtocolVersion getHighestProtocolVersion() {
-    return DefaultProtocolVersion.V4;
   }
 }


### PR DESCRIPTION
For [JAVA-1942](https://datastax-oss.atlassian.net/browse/JAVA-1942).

Motivation:

To ensure tuples and udts are decoded using the codec registry and
protocol version associated with the current Session, adapt any
incoming TupleValue / UdtValue's type to the AttachmentPoint of
the session when creating their associated codecs.

Modifications:

Update CachingCodecRegistry constructor to accept AttachmentPoint
to be associated with this registry.  Update DefaultDriverContext
to pass itself as the AttachmentPoint.

Update CachingCodecRegistry.createCodec methods to adapt types
to the AttachmentPoint.

Update DataTypeIT to create an AttachmentPoint based on the expected
ProtocolVersion to be used by the Session.

Introduce SessionUtils.getMaxProtocolVersion, which replaces
CassandraResourceRule.getHighestProtocolVersion.

Result:

Session's protocol version and codec registry are ensured to be
factored in when deserializing UDTs and Tuples.