### PR TITLE
Updated RequestHandler to handle read failures

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Metrics.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metrics.java
@@ -353,6 +353,7 @@ public class Metrics {
         private final Counter authenticationErrors = registry.counter("authentication-errors");
 
         private final Counter writeTimeouts = registry.counter("write-timeouts");
+        private final Counter readFailures = registry.counter("read-failures");
         private final Counter readTimeouts = registry.counter("read-timeouts");
         private final Counter unavailables = registry.counter("unavailables");
         private final Counter clientTimeouts = registry.counter("client-timeouts");
@@ -361,6 +362,7 @@ public class Metrics {
 
         private final Counter retries = registry.counter("retries");
         private final Counter retriesOnWriteTimeout = registry.counter("retries-on-write-timeout");
+        private final Counter retriesOnReadFailure = registry.counter("retries-on-read-failure");
         private final Counter retriesOnReadTimeout = registry.counter("retries-on-read-timeout");
         private final Counter retriesOnUnavailable = registry.counter("retries-on-unavailable");
         private final Counter retriesOnClientTimeout = registry.counter("retries-on-client-timeout");
@@ -369,6 +371,7 @@ public class Metrics {
 
         private final Counter ignores = registry.counter("ignores");
         private final Counter ignoresOnWriteTimeout = registry.counter("ignores-on-write-timeout");
+        private final Counter ignoresOnReadFailure = registry.counter("ignores-on-read-failure");
         private final Counter ignoresOnReadTimeout = registry.counter("ignores-on-read-timeout");
         private final Counter ignoresOnUnavailable = registry.counter("ignores-on-unavailable");
         private final Counter ignoresOnClientTimeout = registry.counter("ignores-on-client-timeout");
@@ -411,6 +414,16 @@ public class Metrics {
          */
         public Counter getWriteTimeouts() {
             return writeTimeouts;
+        }
+
+        /**
+         * Returns the number of read requests that returned a timeout (independently of the final
+         * decision taken by the {@link com.datastax.driver.core.policies.RetryPolicy}).
+         *
+         * @return the number of read timeout.
+         */
+        public Counter getReadFailures() {
+            return readFailures;
         }
 
         /**
@@ -464,6 +477,17 @@ public class Metrics {
          */
         public Counter getRetries() {
             return retries;
+        }
+
+        /**
+         * Returns the number of times a request was retried due to the {@link
+         * com.datastax.driver.core.policies.RetryPolicy}, after a read failure.
+         *
+         * @return the number of times a request was retried due to the {@link
+         *     com.datastax.driver.core.policies.RetryPolicy}, after a read failure.
+         */
+        public Counter getRetriesOnReadFailure() {
+            return retriesOnReadFailure;
         }
 
         /**
@@ -554,6 +578,17 @@ public class Metrics {
          */
         public Counter getIgnores() {
             return ignores;
+        }
+
+        /**
+         * Returns the number of times a request was ignored due to the {@link
+         * com.datastax.driver.core.policies.RetryPolicy}, after a read failure.
+         *
+         * @return the number of times a request was ignored due to the {@link
+         *     com.datastax.driver.core.policies.RetryPolicy}, after a read failure.
+         */
+        public Counter getIgnoresOnReadFailure() {
+            return ignoresOnReadFailure;
         }
 
         /**


### PR DESCRIPTION
Using the spark cassandra connector, I kept getting errors like the one I pasted below, despite a generous retry policy. I traced them back to this repo, which immediately throws for any READ_FAILURE exceptions. I believe this change fixes it, but please check.

```
java.io.IOException: Exception during execution of SELECT (omitted): Cassandra failure during read query at consistency QUORUM (2 responses were required but only 1 replica responded, 1 failed)
	at com.datastax.spark.connector.rdd.CassandraTableScanRDD.com$datastax$spark$connector$rdd$CassandraTableScanRDD$$fetchTokenRange(CassandraTableScanRDD.scala:350)
	at com.datastax.spark.connector.rdd.CassandraTableScanRDD$$anonfun$17.apply(CassandraTableScanRDD.scala:367)
	at com.datastax.spark.connector.rdd.CassandraTableScanRDD$$anonfun$17.apply(CassandraTableScanRDD.scala:367)
	at scala.collection.Iterator$$anon$12.nextCur(Iterator.scala:434)
	at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:440)
	at com.datastax.spark.connector.util.CountingIterator.hasNext(CountingIterator.scala:12)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage4.processNext(Unknown Source)
	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
	at org.apache.spark.sql.execution.WholeStageCodegenExec$$anonfun$10$$anon$1.hasNext(WholeStageCodegenExec.scala:614)
	at org.apache.spark.sql.execution.SparkPlan$$anonfun$2.apply(SparkPlan.scala:253)
	at org.apache.spark.sql.execution.SparkPlan$$anonfun$2.apply(SparkPlan.scala:247)
	at org.apache.spark.rdd.RDD$$anonfun$mapPartitionsInternal$1$$anonfun$apply$25.apply(RDD.scala:830)
	at org.apache.spark.rdd.RDD$$anonfun$mapPartitionsInternal$1$$anonfun$apply$25.apply(RDD.scala:830)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:38)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:87)
	at org.apache.spark.scheduler.Task.run(Task.scala:109)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:345)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: com.datastax.driver.core.exceptions.ReadFailureException: Cassandra failure during read query at consistency QUORUM (2 responses were required but only 1 replica responded, 1 failed)
	at com.datastax.driver.core.exceptions.ReadFailureException.copy(ReadFailureException.java:85)
	at com.datastax.driver.core.exceptions.ReadFailureException.copy(ReadFailureException.java:27)
	at com.datastax.driver.core.DriverThrowables.propagateCause(DriverThrowables.java:37)
	at com.datastax.driver.core.DefaultResultSetFuture.getUninterruptibly(DefaultResultSetFuture.java:245)
	at com.datastax.driver.core.AbstractSession.execute(AbstractSession.java:68)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.datastax.spark.connector.cql.SessionProxy.invoke(SessionProxy.scala:37)
	at com.sun.proxy.$Proxy19.execute(Unknown Source)
	at com.datastax.spark.connector.cql.DefaultScanner.scan(Scanner.scala:34)
	at com.datastax.spark.connector.rdd.CassandraTableScanRDD.com$datastax$spark$connector$rdd$CassandraTableScanRDD$$fetchTokenRange(CassandraTableScanRDD.scala:342)
```