### PR TITLE
Allow for raw yaml to appended to config

### DIFF
--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
@@ -77,6 +77,11 @@ public class CustomCcmRule extends BaseCcmRule {
       return this;
     }
 
+    public Builder withDseConfiguration(String rawYaml) {
+      bridgeBuilder.withDseConfiguration(rawYaml);
+      return this;
+    }
+
     public Builder withDseWorkloads(String... workloads) {
       bridgeBuilder.withDseWorkloads(workloads);
       return this;


### PR DESCRIPTION
Ran into some test cases where It was necessary to insert nested yaml properties. 
This facilitates that. 