### PR TITLE
JAVA-1960: Ensure type parameters have meaningful names

### DIFF
--- a/core/revapi.json
+++ b/core/revapi.json
@@ -514,7 +514,7 @@
       },
       {
         "code": "java.method.addedToInterface",
-        "new": "method T com.datastax.oss.driver.api.core.cql.Statement<T extends com.datastax.oss.driver.api.core.cql.Statement<T extends com.datastax.oss.driver.api.core.cql.Statement<T>>>::setNode(com.datastax.oss.driver.api.core.metadata.Node)",
+        "new": "method SelfT com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>>::setNode(com.datastax.oss.driver.api.core.metadata.Node)",
         "package": "com.datastax.oss.driver.api.core.cql",
         "classQualifiedName": "com.datastax.oss.driver.api.core.cql.Statement",
         "classSimpleName": "Statement",

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/BatchableStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/BatchableStatement.java
@@ -18,6 +18,7 @@ package com.datastax.oss.driver.api.core.cql;
 /**
  * A statement that can be added to a CQL batch.
  *
- * @param <T> the "self type" used for covariant returns in subtypes.
+ * @param <SelfT> the "self type" used for covariant returns in subtypes.
  */
-public interface BatchableStatement<T extends BatchableStatement<T>> extends Statement<T> {}
+public interface BatchableStatement<SelfT extends BatchableStatement<SelfT>>
+    extends Statement<SelfT> {}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/Bindable.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/Bindable.java
@@ -25,8 +25,8 @@ import com.datastax.oss.protocol.internal.ProtocolConstants;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /** A data container with the ability to unset values. */
-public interface Bindable<T extends Bindable<T>>
-    extends GettableById, GettableByName, SettableById<T>, SettableByName<T> {
+public interface Bindable<SelfT extends Bindable<SelfT>>
+    extends GettableById, GettableByName, SettableById<SelfT>, SettableByName<SelfT> {
   /**
    * Whether the {@code i}th value has been set.
    *
@@ -70,7 +70,7 @@ public interface Bindable<T extends Bindable<T>>
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T unset(int i) {
+  default SelfT unset(int i) {
     return setBytesUnsafe(i, ProtocolConstants.UNSET_VALUE);
   }
 
@@ -81,7 +81,7 @@ public interface Bindable<T extends Bindable<T>>
    * @throws IndexOutOfBoundsException if the id is invalid.
    */
   @NonNull
-  default T unset(@NonNull CqlIdentifier id) {
+  default SelfT unset(@NonNull CqlIdentifier id) {
     return setBytesUnsafe(id, ProtocolConstants.UNSET_VALUE);
   }
 
@@ -92,7 +92,7 @@ public interface Bindable<T extends Bindable<T>>
    * @throws IndexOutOfBoundsException if the name is invalid.
    */
   @NonNull
-  default T unset(@NonNull String name) {
+  default SelfT unset(@NonNull String name) {
     return setBytesUnsafe(name, ProtocolConstants.UNSET_VALUE);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/Statement.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/Statement.java
@@ -41,9 +41,9 @@ import java.util.concurrent.CompletionStage;
 /**
  * A request to execute a CQL query.
  *
- * @param <T> the "self type" used for covariant returns in subtypes.
+ * @param <SelfT> the "self type" used for covariant returns in subtypes.
  */
-public interface Statement<T extends Statement<T>> extends Request {
+public interface Statement<SelfT extends Statement<SelfT>> extends Request {
   // Implementation note: "CqlRequest" would be a better name, but we keep "Statement" to match
   // previous driver versions.
 
@@ -76,7 +76,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    * method. However custom implementations may choose to be mutable and return the same instance.
    */
   @NonNull
-  T setExecutionProfileName(@Nullable String newConfigProfileName);
+  SelfT setExecutionProfileName(@Nullable String newConfigProfileName);
 
   /**
    * Sets the execution profile to use for this statement.
@@ -85,7 +85,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    * method. However custom implementations may choose to be mutable and return the same instance.
    */
   @NonNull
-  T setExecutionProfile(@Nullable DriverExecutionProfile newProfile);
+  SelfT setExecutionProfile(@Nullable DriverExecutionProfile newProfile);
 
   /**
    * Sets the keyspace to use for token-aware routing.
@@ -95,7 +95,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    * @param newRoutingKeyspace The keyspace to use, or {@code null} to disable token-aware routing.
    */
   @NonNull
-  T setRoutingKeyspace(@Nullable CqlIdentifier newRoutingKeyspace);
+  SelfT setRoutingKeyspace(@Nullable CqlIdentifier newRoutingKeyspace);
 
   /**
    * Sets the {@link Node} that should handle this query.
@@ -119,7 +119,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    *     delegate to the configured load balancing policy.
    */
   @NonNull
-  T setNode(@Nullable Node node);
+  SelfT setNode(@Nullable Node node);
 
   /**
    * Shortcut for {@link #setRoutingKeyspace(CqlIdentifier)
@@ -129,7 +129,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    *     routing.
    */
   @NonNull
-  default T setRoutingKeyspace(@Nullable String newRoutingKeyspaceName) {
+  default SelfT setRoutingKeyspace(@Nullable String newRoutingKeyspaceName) {
     return setRoutingKeyspace(
         newRoutingKeyspaceName == null ? null : CqlIdentifier.fromCql(newRoutingKeyspaceName));
   }
@@ -142,7 +142,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    * @param newRoutingKey The routing key to use, or {@code null} to disable token-aware routing.
    */
   @NonNull
-  T setRoutingKey(@Nullable ByteBuffer newRoutingKey);
+  SelfT setRoutingKey(@Nullable ByteBuffer newRoutingKey);
 
   /**
    * Sets the key to use for token-aware routing, when the partition key has multiple components.
@@ -152,7 +152,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    * can be {@code null}.
    */
   @NonNull
-  default T setRoutingKey(@NonNull ByteBuffer... newRoutingKeyComponents) {
+  default SelfT setRoutingKey(@NonNull ByteBuffer... newRoutingKeyComponents) {
     return setRoutingKey(RoutingKey.compose(newRoutingKeyComponents));
   }
 
@@ -165,7 +165,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    *     routing.
    */
   @NonNull
-  T setRoutingToken(@Nullable Token newRoutingToken);
+  SelfT setRoutingToken(@Nullable Token newRoutingToken);
 
   /**
    * Sets the custom payload to use for execution.
@@ -179,7 +179,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    * it's never modified after being set on the statement).
    */
   @NonNull
-  T setCustomPayload(@NonNull Map<String, ByteBuffer> newCustomPayload);
+  SelfT setCustomPayload(@NonNull Map<String, ByteBuffer> newCustomPayload);
 
   /**
    * Sets the idempotence to use for execution.
@@ -191,7 +191,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    *     use the default idempotence defined in the configuration.
    */
   @NonNull
-  T setIdempotent(@Nullable Boolean newIdempotence);
+  SelfT setIdempotent(@Nullable Boolean newIdempotence);
 
   /**
    * Sets tracing for execution.
@@ -200,7 +200,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    * method. However custom implementations may choose to be mutable and return the same instance.
    */
   @NonNull
-  T setTracing(boolean newTracing);
+  SelfT setTracing(boolean newTracing);
 
   /**
    * Returns the query timestamp, in microseconds, to send with the statement.
@@ -224,7 +224,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    * @see TimestampGenerator
    */
   @NonNull
-  T setTimestamp(long newTimestamp);
+  SelfT setTimestamp(long newTimestamp);
 
   /**
    * Sets how long to wait for this request to complete. This is a global limit on the duration of a
@@ -235,7 +235,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    * @see DefaultDriverOption#REQUEST_TIMEOUT
    */
   @NonNull
-  T setTimeout(@Nullable Duration newTimeout);
+  SelfT setTimeout(@Nullable Duration newTimeout);
 
   /**
    * Returns the paging state to send with the statement, or {@code null} if this statement has no
@@ -265,7 +265,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    * if you do so, you must override {@link #copy(ByteBuffer)}.
    */
   @NonNull
-  T setPagingState(@Nullable ByteBuffer newPagingState);
+  SelfT setPagingState(@Nullable ByteBuffer newPagingState);
 
   /**
    * Returns the page size to use for the statement.
@@ -285,7 +285,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    * @see DefaultDriverOption#REQUEST_PAGE_SIZE
    */
   @NonNull
-  T setPageSize(int newPageSize);
+  SelfT setPageSize(int newPageSize);
 
   /**
    * Returns the {@link ConsistencyLevel} to use for the statement.
@@ -304,7 +304,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    *     defined in the configuration.
    * @see DefaultDriverOption#REQUEST_CONSISTENCY
    */
-  T setConsistencyLevel(@Nullable ConsistencyLevel newConsistencyLevel);
+  SelfT setConsistencyLevel(@Nullable ConsistencyLevel newConsistencyLevel);
 
   /**
    * Returns the serial {@link ConsistencyLevel} to use for the statement.
@@ -324,7 +324,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    * @see DefaultDriverOption#REQUEST_SERIAL_CONSISTENCY
    */
   @NonNull
-  T setSerialConsistencyLevel(@Nullable ConsistencyLevel newSerialConsistencyLevel);
+  SelfT setSerialConsistencyLevel(@Nullable ConsistencyLevel newSerialConsistencyLevel);
 
   /** Whether tracing information should be recorded for this statement. */
   boolean isTracing();
@@ -351,7 +351,7 @@ public interface Statement<T extends Statement<T>> extends Request {
    * your own mutable implementation, make sure it returns a different instance.
    */
   @NonNull
-  default T copy(@Nullable ByteBuffer newPagingState) {
+  default SelfT copy(@Nullable ByteBuffer newPagingState) {
     return setPagingState(newPagingState);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/StatementBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/StatementBuilder.java
@@ -36,10 +36,11 @@ import net.jcip.annotations.NotThreadSafe;
  * @see PreparedStatement#boundStatementBuilder(Object...)
  */
 @NotThreadSafe
-public abstract class StatementBuilder<T extends StatementBuilder<T, S>, S extends Statement<S>> {
+public abstract class StatementBuilder<
+    SelfT extends StatementBuilder<SelfT, StatementT>, StatementT extends Statement<StatementT>> {
 
   @SuppressWarnings("unchecked")
-  private final T self = (T) this;
+  private final SelfT self = (SelfT) this;
 
   @Nullable protected String executionProfileName;
   @Nullable protected DriverExecutionProfile executionProfile;
@@ -61,7 +62,7 @@ public abstract class StatementBuilder<T extends StatementBuilder<T, S>, S exten
     // nothing to do
   }
 
-  protected StatementBuilder(S template) {
+  protected StatementBuilder(StatementT template) {
     this.executionProfileName = template.getExecutionProfileName();
     this.executionProfile = template.getExecutionProfile();
     this.routingKeyspace = template.getRoutingKeyspace();
@@ -85,14 +86,14 @@ public abstract class StatementBuilder<T extends StatementBuilder<T, S>, S exten
 
   /** @see Statement#setExecutionProfileName(String) */
   @NonNull
-  public T withExecutionProfileName(@Nullable String executionProfileName) {
+  public SelfT withExecutionProfileName(@Nullable String executionProfileName) {
     this.executionProfileName = executionProfileName;
     return self;
   }
 
   /** @see Statement#setExecutionProfile(DriverExecutionProfile) */
   @NonNull
-  public T withExecutionProfile(@Nullable DriverExecutionProfile executionProfile) {
+  public SelfT withExecutionProfile(@Nullable DriverExecutionProfile executionProfile) {
     this.executionProfile = executionProfile;
     this.executionProfileName = null;
     return self;
@@ -100,7 +101,7 @@ public abstract class StatementBuilder<T extends StatementBuilder<T, S>, S exten
 
   /** @see Statement#setRoutingKeyspace(CqlIdentifier) */
   @NonNull
-  public T withRoutingKeyspace(@Nullable CqlIdentifier routingKeyspace) {
+  public SelfT withRoutingKeyspace(@Nullable CqlIdentifier routingKeyspace) {
     this.routingKeyspace = routingKeyspace;
     return self;
   }
@@ -110,28 +111,28 @@ public abstract class StatementBuilder<T extends StatementBuilder<T, S>, S exten
    * withRoutingKeyspace(CqlIdentifier.fromCql(routingKeyspaceName))}.
    */
   @NonNull
-  public T withRoutingKeyspace(@Nullable String routingKeyspaceName) {
+  public SelfT withRoutingKeyspace(@Nullable String routingKeyspaceName) {
     return withRoutingKeyspace(
         routingKeyspaceName == null ? null : CqlIdentifier.fromCql(routingKeyspaceName));
   }
 
   /** @see Statement#setRoutingKey(ByteBuffer) */
   @NonNull
-  public T withRoutingKey(@Nullable ByteBuffer routingKey) {
+  public SelfT withRoutingKey(@Nullable ByteBuffer routingKey) {
     this.routingKey = routingKey;
     return self;
   }
 
   /** @see Statement#setRoutingToken(Token) */
   @NonNull
-  public T withRoutingToken(@Nullable Token routingToken) {
+  public SelfT withRoutingToken(@Nullable Token routingToken) {
     this.routingToken = routingToken;
     return self;
   }
 
   /** @see Statement#setCustomPayload(Map) */
   @NonNull
-  public T addCustomPayload(@NonNull String key, @Nullable ByteBuffer value) {
+  public SelfT addCustomPayload(@NonNull String key, @Nullable ByteBuffer value) {
     if (customPayloadBuilder == null) {
       customPayloadBuilder = NullAllowingImmutableMap.builder();
     }
@@ -141,69 +142,69 @@ public abstract class StatementBuilder<T extends StatementBuilder<T, S>, S exten
 
   /** @see Statement#setCustomPayload(Map) */
   @NonNull
-  public T clearCustomPayload() {
+  public SelfT clearCustomPayload() {
     customPayloadBuilder = null;
     return self;
   }
 
   /** @see Statement#setIdempotent(Boolean) */
   @NonNull
-  public T withIdempotence(@Nullable Boolean idempotent) {
+  public SelfT withIdempotence(@Nullable Boolean idempotent) {
     this.idempotent = idempotent;
     return self;
   }
 
   /** @see Statement#setTracing(boolean) */
   @NonNull
-  public T withTracing() {
+  public SelfT withTracing() {
     this.tracing = true;
     return self;
   }
 
   /** @see Statement#setTimestamp(long) */
   @NonNull
-  public T withTimestamp(long timestamp) {
+  public SelfT withTimestamp(long timestamp) {
     this.timestamp = timestamp;
     return self;
   }
 
   /** @see Statement#setPagingState(ByteBuffer) */
   @NonNull
-  public T withPagingState(@Nullable ByteBuffer pagingState) {
+  public SelfT withPagingState(@Nullable ByteBuffer pagingState) {
     this.pagingState = pagingState;
     return self;
   }
 
   /** @see Statement#setPageSize(int) */
   @NonNull
-  public T withPageSize(int pageSize) {
+  public SelfT withPageSize(int pageSize) {
     this.pageSize = pageSize;
     return self;
   }
 
   /** @see Statement#setConsistencyLevel(ConsistencyLevel) */
   @NonNull
-  public T withConsistencyLevel(@Nullable ConsistencyLevel consistencyLevel) {
+  public SelfT withConsistencyLevel(@Nullable ConsistencyLevel consistencyLevel) {
     this.consistencyLevel = consistencyLevel;
     return self;
   }
 
   /** @see Statement#setSerialConsistencyLevel(ConsistencyLevel) */
   @NonNull
-  public T withSerialConsistencyLevel(@Nullable ConsistencyLevel serialConsistencyLevel) {
+  public SelfT withSerialConsistencyLevel(@Nullable ConsistencyLevel serialConsistencyLevel) {
     this.serialConsistencyLevel = serialConsistencyLevel;
     return self;
   }
 
   /** @see Statement#setTimeout(Duration) */
   @NonNull
-  public T withTimeout(@Nullable Duration timeout) {
+  public SelfT withTimeout(@Nullable Duration timeout) {
     this.timeout = timeout;
     return self;
   }
 
   /** @see Statement#setNode(Node) */
-  public T withNode(@Nullable Node node) {
+  public SelfT withNode(@Nullable Node node) {
     this.node = node;
     return self;
   }
@@ -216,5 +217,5 @@ public abstract class StatementBuilder<T extends StatementBuilder<T, S>, S exten
   }
 
   @NonNull
-  public abstract S build();
+  public abstract StatementT build();
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableById.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableById.java
@@ -96,7 +96,7 @@ public interface GettableById extends GettableByIndex, AccessibleById {
    * @throws IllegalArgumentException if the id is invalid.
    */
   @Nullable
-  default <T> T get(@NonNull CqlIdentifier id, @NonNull TypeCodec<T> codec) {
+  default <ValueT> ValueT get(@NonNull CqlIdentifier id, @NonNull TypeCodec<ValueT> codec) {
     return get(firstIndexOf(id), codec);
   }
 
@@ -118,7 +118,7 @@ public interface GettableById extends GettableByIndex, AccessibleById {
    * @throws CodecNotFoundException if no codec can perform the conversion.
    */
   @Nullable
-  default <T> T get(@NonNull CqlIdentifier id, @NonNull GenericType<T> targetType) {
+  default <ValueT> ValueT get(@NonNull CqlIdentifier id, @NonNull GenericType<ValueT> targetType) {
     return get(firstIndexOf(id), targetType);
   }
 
@@ -139,7 +139,7 @@ public interface GettableById extends GettableByIndex, AccessibleById {
    * @throws CodecNotFoundException if no codec can perform the conversion.
    */
   @Nullable
-  default <T> T get(@NonNull CqlIdentifier id, @NonNull Class<T> targetClass) {
+  default <ValueT> ValueT get(@NonNull CqlIdentifier id, @NonNull Class<ValueT> targetClass) {
     return get(firstIndexOf(id), targetClass);
   }
 
@@ -551,7 +551,8 @@ public interface GettableById extends GettableByIndex, AccessibleById {
    * @throws IllegalArgumentException if the id is invalid.
    */
   @Nullable
-  default <T> List<T> getList(@NonNull CqlIdentifier id, @NonNull Class<T> elementsClass) {
+  default <ElementT> List<ElementT> getList(
+      @NonNull CqlIdentifier id, @NonNull Class<ElementT> elementsClass) {
     return getList(firstIndexOf(id), elementsClass);
   }
 
@@ -576,7 +577,8 @@ public interface GettableById extends GettableByIndex, AccessibleById {
    * @throws IllegalArgumentException if the id is invalid.
    */
   @Nullable
-  default <T> Set<T> getSet(@NonNull CqlIdentifier id, @NonNull Class<T> elementsClass) {
+  default <ElementT> Set<ElementT> getSet(
+      @NonNull CqlIdentifier id, @NonNull Class<ElementT> elementsClass) {
     return getSet(firstIndexOf(id), elementsClass);
   }
 
@@ -601,8 +603,8 @@ public interface GettableById extends GettableByIndex, AccessibleById {
    * @throws IllegalArgumentException if the id is invalid.
    */
   @Nullable
-  default <K, V> Map<K, V> getMap(
-      @NonNull CqlIdentifier id, @NonNull Class<K> keyClass, @NonNull Class<V> valueClass) {
+  default <KeyT, ValueT> Map<KeyT, ValueT> getMap(
+      @NonNull CqlIdentifier id, @NonNull Class<KeyT> keyClass, @NonNull Class<ValueT> valueClass) {
     return getMap(firstIndexOf(id), keyClass, valueClass);
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByIndex.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByIndex.java
@@ -86,7 +86,7 @@ public interface GettableByIndex extends AccessibleByIndex {
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @Nullable
-  default <T> T get(int i, TypeCodec<T> codec) {
+  default <ValueT> ValueT get(int i, TypeCodec<ValueT> codec) {
     return codec.decode(getBytesUnsafe(i), protocolVersion());
   }
 
@@ -102,9 +102,9 @@ public interface GettableByIndex extends AccessibleByIndex {
    * @throws CodecNotFoundException if no codec can perform the conversion.
    */
   @Nullable
-  default <T> T get(int i, GenericType<T> targetType) {
+  default <ValueT> ValueT get(int i, GenericType<ValueT> targetType) {
     DataType cqlType = getType(i);
-    TypeCodec<T> codec = codecRegistry().codecFor(cqlType, targetType);
+    TypeCodec<ValueT> codec = codecRegistry().codecFor(cqlType, targetType);
     return get(i, codec);
   }
 
@@ -119,11 +119,11 @@ public interface GettableByIndex extends AccessibleByIndex {
    * @throws CodecNotFoundException if no codec can perform the conversion.
    */
   @Nullable
-  default <T> T get(int i, Class<T> targetClass) {
+  default <ValueT> ValueT get(int i, Class<ValueT> targetClass) {
     // This is duplicated from the GenericType variant, because we want to give the codec registry
     // a chance to process the unwrapped class directly, if it can do so in a more efficient way.
     DataType cqlType = getType(i);
-    TypeCodec<T> codec = codecRegistry().codecFor(cqlType, targetClass);
+    TypeCodec<ValueT> codec = codecRegistry().codecFor(cqlType, targetClass);
     return get(i, codec);
   }
 
@@ -473,7 +473,7 @@ public interface GettableByIndex extends AccessibleByIndex {
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @Nullable
-  default <T> List<T> getList(int i, @NonNull Class<T> elementsClass) {
+  default <ElementT> List<ElementT> getList(int i, @NonNull Class<ElementT> elementsClass) {
     return get(i, GenericType.listOf(elementsClass));
   }
 
@@ -492,7 +492,7 @@ public interface GettableByIndex extends AccessibleByIndex {
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @Nullable
-  default <T> Set<T> getSet(int i, @NonNull Class<T> elementsClass) {
+  default <ElementT> Set<ElementT> getSet(int i, @NonNull Class<ElementT> elementsClass) {
     return get(i, GenericType.setOf(elementsClass));
   }
 
@@ -511,7 +511,8 @@ public interface GettableByIndex extends AccessibleByIndex {
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @Nullable
-  default <K, V> Map<K, V> getMap(int i, @NonNull Class<K> keyClass, @NonNull Class<V> valueClass) {
+  default <KeyT, ValueT> Map<KeyT, ValueT> getMap(
+      int i, @NonNull Class<KeyT> keyClass, @NonNull Class<ValueT> valueClass) {
     return get(i, GenericType.mapOf(keyClass, valueClass));
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByName.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByName.java
@@ -95,7 +95,7 @@ public interface GettableByName extends GettableByIndex, AccessibleByName {
    * @throws IllegalArgumentException if the name is invalid.
    */
   @Nullable
-  default <T> T get(@NonNull String name, @NonNull TypeCodec<T> codec) {
+  default <ValueT> ValueT get(@NonNull String name, @NonNull TypeCodec<ValueT> codec) {
     return get(firstIndexOf(name), codec);
   }
 
@@ -118,7 +118,7 @@ public interface GettableByName extends GettableByIndex, AccessibleByName {
    * @throws CodecNotFoundException if no codec can perform the conversion.
    */
   @Nullable
-  default <T> T get(@NonNull String name, @NonNull GenericType<T> targetType) {
+  default <ValueT> ValueT get(@NonNull String name, @NonNull GenericType<ValueT> targetType) {
     return get(firstIndexOf(name), targetType);
   }
 
@@ -140,7 +140,7 @@ public interface GettableByName extends GettableByIndex, AccessibleByName {
    * @throws CodecNotFoundException if no codec can perform the conversion.
    */
   @Nullable
-  default <T> T get(@NonNull String name, @NonNull Class<T> targetClass) {
+  default <ValueT> ValueT get(@NonNull String name, @NonNull Class<ValueT> targetClass) {
     return get(firstIndexOf(name), targetClass);
   }
 
@@ -547,7 +547,8 @@ public interface GettableByName extends GettableByIndex, AccessibleByName {
    * @throws IllegalArgumentException if the name is invalid.
    */
   @Nullable
-  default <T> List<T> getList(@NonNull String name, @NonNull Class<T> elementsClass) {
+  default <ElementT> List<ElementT> getList(
+      @NonNull String name, @NonNull Class<ElementT> elementsClass) {
     return getList(firstIndexOf(name), elementsClass);
   }
 
@@ -572,7 +573,8 @@ public interface GettableByName extends GettableByIndex, AccessibleByName {
    * @throws IllegalArgumentException if the name is invalid.
    */
   @Nullable
-  default <T> Set<T> getSet(@NonNull String name, @NonNull Class<T> elementsClass) {
+  default <ElementT> Set<ElementT> getSet(
+      @NonNull String name, @NonNull Class<ElementT> elementsClass) {
     return getSet(firstIndexOf(name), elementsClass);
   }
 
@@ -597,8 +599,8 @@ public interface GettableByName extends GettableByIndex, AccessibleByName {
    * @throws IllegalArgumentException if the name is invalid.
    */
   @Nullable
-  default <K, V> Map<K, V> getMap(
-      @NonNull String name, @NonNull Class<K> keyClass, @NonNull Class<V> valueClass) {
+  default <KeyT, ValueT> Map<KeyT, ValueT> getMap(
+      @NonNull String name, @NonNull Class<KeyT> keyClass, @NonNull Class<ValueT> valueClass) {
     return getMap(firstIndexOf(name), keyClass, valueClass);
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableById.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableById.java
@@ -36,8 +36,8 @@ import java.util.Set;
 import java.util.UUID;
 
 /** A data structure that provides methods to set its values via a CQL identifier. */
-public interface SettableById<T extends SettableById<T>>
-    extends SettableByIndex<T>, AccessibleById {
+public interface SettableById<SelfT extends SettableById<SelfT>>
+    extends SettableByIndex<SelfT>, AccessibleById {
 
   /**
    * Sets the raw binary representation of the value for the first occurrence of {@code id}.
@@ -56,7 +56,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setBytesUnsafe(@NonNull CqlIdentifier id, @Nullable ByteBuffer v) {
+  default SelfT setBytesUnsafe(@NonNull CqlIdentifier id, @Nullable ByteBuffer v) {
     return setBytesUnsafe(firstIndexOf(id), v);
   }
 
@@ -75,7 +75,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setToNull(@NonNull CqlIdentifier id) {
+  default SelfT setToNull(@NonNull CqlIdentifier id) {
     return setToNull(firstIndexOf(id));
   }
 
@@ -96,7 +96,8 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default <V> T set(@NonNull CqlIdentifier id, @Nullable V v, @NonNull TypeCodec<V> codec) {
+  default <ValueT> SelfT set(
+      @NonNull CqlIdentifier id, @Nullable ValueT v, @NonNull TypeCodec<ValueT> codec) {
     return set(firstIndexOf(id), v, codec);
   }
 
@@ -115,7 +116,8 @@ public interface SettableById<T extends SettableById<T>>
    * @throws CodecNotFoundException if no codec can perform the conversion.
    */
   @NonNull
-  default <V> T set(@NonNull CqlIdentifier id, @Nullable V v, @NonNull GenericType<V> targetType) {
+  default <ValueT> SelfT set(
+      @NonNull CqlIdentifier id, @Nullable ValueT v, @NonNull GenericType<ValueT> targetType) {
     return set(firstIndexOf(id), v, targetType);
   }
 
@@ -133,7 +135,8 @@ public interface SettableById<T extends SettableById<T>>
    * @throws CodecNotFoundException if no codec can perform the conversion.
    */
   @NonNull
-  default <V> T set(@NonNull CqlIdentifier id, @Nullable V v, @NonNull Class<V> targetClass) {
+  default <ValueT> SelfT set(
+      @NonNull CqlIdentifier id, @Nullable ValueT v, @NonNull Class<ValueT> targetClass) {
     return set(firstIndexOf(id), v, targetClass);
   }
 
@@ -151,7 +154,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setBoolean(@NonNull CqlIdentifier id, boolean v) {
+  default SelfT setBoolean(@NonNull CqlIdentifier id, boolean v) {
     return setBoolean(firstIndexOf(id), v);
   }
 
@@ -169,7 +172,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setByte(@NonNull CqlIdentifier id, byte v) {
+  default SelfT setByte(@NonNull CqlIdentifier id, byte v) {
     return setByte(firstIndexOf(id), v);
   }
 
@@ -187,7 +190,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setDouble(@NonNull CqlIdentifier id, double v) {
+  default SelfT setDouble(@NonNull CqlIdentifier id, double v) {
     return setDouble(firstIndexOf(id), v);
   }
 
@@ -205,7 +208,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setFloat(@NonNull CqlIdentifier id, float v) {
+  default SelfT setFloat(@NonNull CqlIdentifier id, float v) {
     return setFloat(firstIndexOf(id), v);
   }
 
@@ -223,7 +226,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setInt(@NonNull CqlIdentifier id, int v) {
+  default SelfT setInt(@NonNull CqlIdentifier id, int v) {
     return setInt(firstIndexOf(id), v);
   }
 
@@ -241,7 +244,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setLong(@NonNull CqlIdentifier id, long v) {
+  default SelfT setLong(@NonNull CqlIdentifier id, long v) {
     return setLong(firstIndexOf(id), v);
   }
 
@@ -259,7 +262,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setShort(@NonNull CqlIdentifier id, short v) {
+  default SelfT setShort(@NonNull CqlIdentifier id, short v) {
     return setShort(firstIndexOf(id), v);
   }
 
@@ -274,7 +277,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setInstant(@NonNull CqlIdentifier id, @Nullable Instant v) {
+  default SelfT setInstant(@NonNull CqlIdentifier id, @Nullable Instant v) {
     return setInstant(firstIndexOf(id), v);
   }
 
@@ -289,7 +292,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setLocalDate(@NonNull CqlIdentifier id, @Nullable LocalDate v) {
+  default SelfT setLocalDate(@NonNull CqlIdentifier id, @Nullable LocalDate v) {
     return setLocalDate(firstIndexOf(id), v);
   }
 
@@ -304,7 +307,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setLocalTime(@NonNull CqlIdentifier id, @Nullable LocalTime v) {
+  default SelfT setLocalTime(@NonNull CqlIdentifier id, @Nullable LocalTime v) {
     return setLocalTime(firstIndexOf(id), v);
   }
 
@@ -319,7 +322,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setByteBuffer(@NonNull CqlIdentifier id, @Nullable ByteBuffer v) {
+  default SelfT setByteBuffer(@NonNull CqlIdentifier id, @Nullable ByteBuffer v) {
     return setByteBuffer(firstIndexOf(id), v);
   }
 
@@ -334,7 +337,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setString(@NonNull CqlIdentifier id, @Nullable String v) {
+  default SelfT setString(@NonNull CqlIdentifier id, @Nullable String v) {
     return setString(firstIndexOf(id), v);
   }
 
@@ -349,7 +352,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setBigInteger(@NonNull CqlIdentifier id, @Nullable BigInteger v) {
+  default SelfT setBigInteger(@NonNull CqlIdentifier id, @Nullable BigInteger v) {
     return setBigInteger(firstIndexOf(id), v);
   }
 
@@ -364,7 +367,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setBigDecimal(@NonNull CqlIdentifier id, @Nullable BigDecimal v) {
+  default SelfT setBigDecimal(@NonNull CqlIdentifier id, @Nullable BigDecimal v) {
     return setBigDecimal(firstIndexOf(id), v);
   }
 
@@ -379,7 +382,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setUuid(@NonNull CqlIdentifier id, @Nullable UUID v) {
+  default SelfT setUuid(@NonNull CqlIdentifier id, @Nullable UUID v) {
     return setUuid(firstIndexOf(id), v);
   }
 
@@ -394,7 +397,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setInetAddress(@NonNull CqlIdentifier id, @Nullable InetAddress v) {
+  default SelfT setInetAddress(@NonNull CqlIdentifier id, @Nullable InetAddress v) {
     return setInetAddress(firstIndexOf(id), v);
   }
 
@@ -409,7 +412,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setCqlDuration(@NonNull CqlIdentifier id, @Nullable CqlDuration v) {
+  default SelfT setCqlDuration(@NonNull CqlIdentifier id, @Nullable CqlDuration v) {
     return setCqlDuration(firstIndexOf(id), v);
   }
 
@@ -426,7 +429,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the index is invalid.
    */
   @NonNull
-  default T setToken(@NonNull CqlIdentifier id, @NonNull Token v) {
+  default SelfT setToken(@NonNull CqlIdentifier id, @NonNull Token v) {
     return setToken(firstIndexOf(id), v);
   }
 
@@ -444,8 +447,10 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default <V> T setList(
-      @NonNull CqlIdentifier id, @Nullable List<V> v, @NonNull Class<V> elementsClass) {
+  default <ElementT> SelfT setList(
+      @NonNull CqlIdentifier id,
+      @Nullable List<ElementT> v,
+      @NonNull Class<ElementT> elementsClass) {
     return setList(firstIndexOf(id), v, elementsClass);
   }
 
@@ -463,8 +468,10 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default <V> T setSet(
-      @NonNull CqlIdentifier id, @Nullable Set<V> v, @NonNull Class<V> elementsClass) {
+  default <ElementT> SelfT setSet(
+      @NonNull CqlIdentifier id,
+      @Nullable Set<ElementT> v,
+      @NonNull Class<ElementT> elementsClass) {
     return setSet(firstIndexOf(id), v, elementsClass);
   }
 
@@ -482,11 +489,11 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default <K, V> T setMap(
+  default <KeyT, ValueT> SelfT setMap(
       @NonNull CqlIdentifier id,
-      @Nullable Map<K, V> v,
-      @NonNull Class<K> keyClass,
-      @NonNull Class<V> valueClass) {
+      @Nullable Map<KeyT, ValueT> v,
+      @NonNull Class<KeyT> keyClass,
+      @NonNull Class<ValueT> valueClass) {
     return setMap(firstIndexOf(id), v, keyClass, valueClass);
   }
 
@@ -501,7 +508,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setUdtValue(@NonNull CqlIdentifier id, @Nullable UdtValue v) {
+  default SelfT setUdtValue(@NonNull CqlIdentifier id, @Nullable UdtValue v) {
     return setUdtValue(firstIndexOf(id), v);
   }
 
@@ -516,7 +523,7 @@ public interface SettableById<T extends SettableById<T>>
    * @throws IllegalArgumentException if the id is invalid.
    */
   @NonNull
-  default T setTupleValue(@NonNull CqlIdentifier id, @Nullable TupleValue v) {
+  default SelfT setTupleValue(@NonNull CqlIdentifier id, @Nullable TupleValue v) {
     return setTupleValue(firstIndexOf(id), v);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableByIndex.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableByIndex.java
@@ -45,7 +45,7 @@ import java.util.Set;
 import java.util.UUID;
 
 /** A data structure that provides methods to set its values via an integer index. */
-public interface SettableByIndex<T extends SettableByIndex<T>> extends AccessibleByIndex {
+public interface SettableByIndex<SelfT extends SettableByIndex<SelfT>> extends AccessibleByIndex {
 
   /**
    * Sets the raw binary representation of the {@code i}th value.
@@ -61,7 +61,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  T setBytesUnsafe(int i, @Nullable ByteBuffer v);
+  SelfT setBytesUnsafe(int i, @Nullable ByteBuffer v);
 
   /**
    * Sets the {@code i}th value to CQL {@code NULL}.
@@ -69,7 +69,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setToNull(int i) {
+  default SelfT setToNull(int i) {
     return setBytesUnsafe(i, null);
   }
 
@@ -86,7 +86,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default <V> T set(int i, @Nullable V v, @NonNull TypeCodec<V> codec) {
+  default <ValueT> SelfT set(int i, @Nullable ValueT v, @NonNull TypeCodec<ValueT> codec) {
     return setBytesUnsafe(i, codec.encode(v, protocolVersion()));
   }
 
@@ -102,9 +102,9 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws CodecNotFoundException if no codec can perform the conversion.
    */
   @NonNull
-  default <V> T set(int i, @Nullable V v, @NonNull GenericType<V> targetType) {
+  default <ValueT> SelfT set(int i, @Nullable ValueT v, @NonNull GenericType<ValueT> targetType) {
     DataType cqlType = getType(i);
-    TypeCodec<V> codec = codecRegistry().codecFor(cqlType, targetType);
+    TypeCodec<ValueT> codec = codecRegistry().codecFor(cqlType, targetType);
     return set(i, v, codec);
   }
 
@@ -119,11 +119,11 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws CodecNotFoundException if no codec can perform the conversion.
    */
   @NonNull
-  default <V> T set(int i, @Nullable V v, @NonNull Class<V> targetClass) {
+  default <ValueT> SelfT set(int i, @Nullable ValueT v, @NonNull Class<ValueT> targetClass) {
     // This is duplicated from the GenericType variant, because we want to give the codec registry
     // a chance to process the unwrapped class directly, if it can do so in a more efficient way.
     DataType cqlType = getType(i);
-    TypeCodec<V> codec = codecRegistry().codecFor(cqlType, targetClass);
+    TypeCodec<ValueT> codec = codecRegistry().codecFor(cqlType, targetClass);
     return set(i, v, codec);
   }
 
@@ -138,7 +138,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setBoolean(int i, boolean v) {
+  default SelfT setBoolean(int i, boolean v) {
     DataType cqlType = getType(i);
     TypeCodec<Boolean> codec = codecRegistry().codecFor(cqlType, Boolean.class);
     return (codec instanceof PrimitiveBooleanCodec)
@@ -157,7 +157,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setByte(int i, byte v) {
+  default SelfT setByte(int i, byte v) {
     DataType cqlType = getType(i);
     TypeCodec<Byte> codec = codecRegistry().codecFor(cqlType, Byte.class);
     return (codec instanceof PrimitiveByteCodec)
@@ -176,7 +176,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setDouble(int i, double v) {
+  default SelfT setDouble(int i, double v) {
     DataType cqlType = getType(i);
     TypeCodec<Double> codec = codecRegistry().codecFor(cqlType, Double.class);
     return (codec instanceof PrimitiveDoubleCodec)
@@ -195,7 +195,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setFloat(int i, float v) {
+  default SelfT setFloat(int i, float v) {
     DataType cqlType = getType(i);
     TypeCodec<Float> codec = codecRegistry().codecFor(cqlType, Float.class);
     return (codec instanceof PrimitiveFloatCodec)
@@ -214,7 +214,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setInt(int i, int v) {
+  default SelfT setInt(int i, int v) {
     DataType cqlType = getType(i);
     TypeCodec<Integer> codec = codecRegistry().codecFor(cqlType, Integer.class);
     return (codec instanceof PrimitiveIntCodec)
@@ -233,7 +233,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setLong(int i, long v) {
+  default SelfT setLong(int i, long v) {
     DataType cqlType = getType(i);
     TypeCodec<Long> codec = codecRegistry().codecFor(cqlType, Long.class);
     return (codec instanceof PrimitiveLongCodec)
@@ -252,7 +252,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setShort(int i, short v) {
+  default SelfT setShort(int i, short v) {
     DataType cqlType = getType(i);
     TypeCodec<Short> codec = codecRegistry().codecFor(cqlType, Short.class);
     return (codec instanceof PrimitiveShortCodec)
@@ -268,7 +268,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setInstant(int i, @Nullable Instant v) {
+  default SelfT setInstant(int i, @Nullable Instant v) {
     return set(i, v, Instant.class);
   }
 
@@ -280,7 +280,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setLocalDate(int i, @Nullable LocalDate v) {
+  default SelfT setLocalDate(int i, @Nullable LocalDate v) {
     return set(i, v, LocalDate.class);
   }
 
@@ -292,7 +292,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setLocalTime(int i, @Nullable LocalTime v) {
+  default SelfT setLocalTime(int i, @Nullable LocalTime v) {
     return set(i, v, LocalTime.class);
   }
 
@@ -304,7 +304,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setByteBuffer(int i, @Nullable ByteBuffer v) {
+  default SelfT setByteBuffer(int i, @Nullable ByteBuffer v) {
     return set(i, v, ByteBuffer.class);
   }
 
@@ -316,7 +316,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setString(int i, @Nullable String v) {
+  default SelfT setString(int i, @Nullable String v) {
     return set(i, v, String.class);
   }
 
@@ -328,7 +328,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setBigInteger(int i, @Nullable BigInteger v) {
+  default SelfT setBigInteger(int i, @Nullable BigInteger v) {
     return set(i, v, BigInteger.class);
   }
 
@@ -340,7 +340,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setBigDecimal(int i, @Nullable BigDecimal v) {
+  default SelfT setBigDecimal(int i, @Nullable BigDecimal v) {
     return set(i, v, BigDecimal.class);
   }
 
@@ -352,7 +352,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setUuid(int i, @Nullable UUID v) {
+  default SelfT setUuid(int i, @Nullable UUID v) {
     return set(i, v, UUID.class);
   }
 
@@ -364,7 +364,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setInetAddress(int i, @Nullable InetAddress v) {
+  default SelfT setInetAddress(int i, @Nullable InetAddress v) {
     return set(i, v, InetAddress.class);
   }
 
@@ -376,7 +376,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setCqlDuration(int i, @Nullable CqlDuration v) {
+  default SelfT setCqlDuration(int i, @Nullable CqlDuration v) {
     return set(i, v, CqlDuration.class);
   }
 
@@ -390,7 +390,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setToken(int i, @NonNull Token v) {
+  default SelfT setToken(int i, @NonNull Token v) {
     // Simply enumerate all known implementations. This goes against the concept of TokenFactory,
     // but injecting the factory here is too much of a hassle.
     // The only issue is if someone uses a custom partitioner, but this is highly unlikely, and even
@@ -417,7 +417,8 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default <V> T setList(int i, @Nullable List<V> v, @NonNull Class<V> elementsClass) {
+  default <ElementT> SelfT setList(
+      int i, @Nullable List<ElementT> v, @NonNull Class<ElementT> elementsClass) {
     return set(i, v, GenericType.listOf(elementsClass));
   }
 
@@ -432,7 +433,8 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default <V> T setSet(int i, @Nullable Set<V> v, @NonNull Class<V> elementsClass) {
+  default <ElementT> SelfT setSet(
+      int i, @Nullable Set<ElementT> v, @NonNull Class<ElementT> elementsClass) {
     return set(i, v, GenericType.setOf(elementsClass));
   }
 
@@ -447,8 +449,11 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default <K, V> T setMap(
-      int i, @Nullable Map<K, V> v, @NonNull Class<K> keyClass, @NonNull Class<V> valueClass) {
+  default <KeyT, ValueT> SelfT setMap(
+      int i,
+      @Nullable Map<KeyT, ValueT> v,
+      @NonNull Class<KeyT> keyClass,
+      @NonNull Class<ValueT> valueClass) {
     return set(i, v, GenericType.mapOf(keyClass, valueClass));
   }
 
@@ -460,7 +465,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setUdtValue(int i, @Nullable UdtValue v) {
+  default SelfT setUdtValue(int i, @Nullable UdtValue v) {
     return set(i, v, UdtValue.class);
   }
 
@@ -472,7 +477,7 @@ public interface SettableByIndex<T extends SettableByIndex<T>> extends Accessibl
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @NonNull
-  default T setTupleValue(int i, @Nullable TupleValue v) {
+  default SelfT setTupleValue(int i, @Nullable TupleValue v) {
     return set(i, v, TupleValue.class);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableByName.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableByName.java
@@ -35,8 +35,8 @@ import java.util.Set;
 import java.util.UUID;
 
 /** A data structure that provides methods to set its values via a name. */
-public interface SettableByName<T extends SettableByName<T>>
-    extends SettableByIndex<T>, AccessibleByName {
+public interface SettableByName<SelfT extends SettableByName<SelfT>>
+    extends SettableByIndex<SelfT>, AccessibleByName {
 
   /**
    * Sets the raw binary representation of the value for the first occurrence of {@code name}.
@@ -55,7 +55,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setBytesUnsafe(@NonNull String name, @Nullable ByteBuffer v) {
+  default SelfT setBytesUnsafe(@NonNull String name, @Nullable ByteBuffer v) {
     return setBytesUnsafe(firstIndexOf(name), v);
   }
 
@@ -74,7 +74,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setToNull(@NonNull String name) {
+  default SelfT setToNull(@NonNull String name) {
     return setToNull(firstIndexOf(name));
   }
 
@@ -95,7 +95,8 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default <V> T set(@NonNull String name, @Nullable V v, @NonNull TypeCodec<V> codec) {
+  default <ValueT> SelfT set(
+      @NonNull String name, @Nullable ValueT v, @NonNull TypeCodec<ValueT> codec) {
     return set(firstIndexOf(name), v, codec);
   }
 
@@ -114,7 +115,8 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws CodecNotFoundException if no codec can perform the conversion.
    */
   @NonNull
-  default <V> T set(@NonNull String name, @Nullable V v, @NonNull GenericType<V> targetType) {
+  default <ValueT> SelfT set(
+      @NonNull String name, @Nullable ValueT v, @NonNull GenericType<ValueT> targetType) {
     return set(firstIndexOf(name), v, targetType);
   }
 
@@ -133,7 +135,8 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws CodecNotFoundException if no codec can perform the conversion.
    */
   @NonNull
-  default <V> T set(@NonNull String name, @Nullable V v, @NonNull Class<V> targetClass) {
+  default <ValueT> SelfT set(
+      @NonNull String name, @Nullable ValueT v, @NonNull Class<ValueT> targetClass) {
     return set(firstIndexOf(name), v, targetClass);
   }
 
@@ -151,7 +154,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setBoolean(@NonNull String name, boolean v) {
+  default SelfT setBoolean(@NonNull String name, boolean v) {
     return setBoolean(firstIndexOf(name), v);
   }
 
@@ -169,7 +172,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setByte(@NonNull String name, byte v) {
+  default SelfT setByte(@NonNull String name, byte v) {
     return setByte(firstIndexOf(name), v);
   }
 
@@ -187,7 +190,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setDouble(@NonNull String name, double v) {
+  default SelfT setDouble(@NonNull String name, double v) {
     return setDouble(firstIndexOf(name), v);
   }
 
@@ -205,7 +208,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setFloat(@NonNull String name, float v) {
+  default SelfT setFloat(@NonNull String name, float v) {
     return setFloat(firstIndexOf(name), v);
   }
 
@@ -223,7 +226,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setInt(@NonNull String name, int v) {
+  default SelfT setInt(@NonNull String name, int v) {
     return setInt(firstIndexOf(name), v);
   }
 
@@ -241,7 +244,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setLong(@NonNull String name, long v) {
+  default SelfT setLong(@NonNull String name, long v) {
     return setLong(firstIndexOf(name), v);
   }
 
@@ -259,7 +262,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setShort(@NonNull String name, short v) {
+  default SelfT setShort(@NonNull String name, short v) {
     return setShort(firstIndexOf(name), v);
   }
 
@@ -274,7 +277,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setInstant(@NonNull String name, @Nullable Instant v) {
+  default SelfT setInstant(@NonNull String name, @Nullable Instant v) {
     return setInstant(firstIndexOf(name), v);
   }
 
@@ -289,7 +292,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setLocalDate(@NonNull String name, @Nullable LocalDate v) {
+  default SelfT setLocalDate(@NonNull String name, @Nullable LocalDate v) {
     return setLocalDate(firstIndexOf(name), v);
   }
 
@@ -304,7 +307,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setLocalTime(@NonNull String name, @Nullable LocalTime v) {
+  default SelfT setLocalTime(@NonNull String name, @Nullable LocalTime v) {
     return setLocalTime(firstIndexOf(name), v);
   }
 
@@ -319,7 +322,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setByteBuffer(@NonNull String name, @Nullable ByteBuffer v) {
+  default SelfT setByteBuffer(@NonNull String name, @Nullable ByteBuffer v) {
     return setByteBuffer(firstIndexOf(name), v);
   }
 
@@ -334,7 +337,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setString(@NonNull String name, @Nullable String v) {
+  default SelfT setString(@NonNull String name, @Nullable String v) {
     return setString(firstIndexOf(name), v);
   }
 
@@ -349,7 +352,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setBigInteger(@NonNull String name, @Nullable BigInteger v) {
+  default SelfT setBigInteger(@NonNull String name, @Nullable BigInteger v) {
     return setBigInteger(firstIndexOf(name), v);
   }
 
@@ -364,7 +367,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setBigDecimal(@NonNull String name, @Nullable BigDecimal v) {
+  default SelfT setBigDecimal(@NonNull String name, @Nullable BigDecimal v) {
     return setBigDecimal(firstIndexOf(name), v);
   }
 
@@ -379,7 +382,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setUuid(@NonNull String name, @Nullable UUID v) {
+  default SelfT setUuid(@NonNull String name, @Nullable UUID v) {
     return setUuid(firstIndexOf(name), v);
   }
 
@@ -394,7 +397,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setInetAddress(@NonNull String name, @Nullable InetAddress v) {
+  default SelfT setInetAddress(@NonNull String name, @Nullable InetAddress v) {
     return setInetAddress(firstIndexOf(name), v);
   }
 
@@ -409,7 +412,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setCqlDuration(@NonNull String name, @Nullable CqlDuration v) {
+  default SelfT setCqlDuration(@NonNull String name, @Nullable CqlDuration v) {
     return setCqlDuration(firstIndexOf(name), v);
   }
 
@@ -426,7 +429,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setToken(@NonNull String name, @NonNull Token v) {
+  default SelfT setToken(@NonNull String name, @NonNull Token v) {
     return setToken(firstIndexOf(name), v);
   }
 
@@ -444,8 +447,8 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default <V> T setList(
-      @NonNull String name, @Nullable List<V> v, @NonNull Class<V> elementsClass) {
+  default <ElementT> SelfT setList(
+      @NonNull String name, @Nullable List<ElementT> v, @NonNull Class<ElementT> elementsClass) {
     return setList(firstIndexOf(name), v, elementsClass);
   }
 
@@ -463,7 +466,8 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default <V> T setSet(@NonNull String name, @Nullable Set<V> v, @NonNull Class<V> elementsClass) {
+  default <ElementT> SelfT setSet(
+      @NonNull String name, @Nullable Set<ElementT> v, @NonNull Class<ElementT> elementsClass) {
     return setSet(firstIndexOf(name), v, elementsClass);
   }
 
@@ -481,11 +485,11 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default <K, V> T setMap(
+  default <KeyT, ValueT> SelfT setMap(
       @NonNull String name,
-      @Nullable Map<K, V> v,
-      @NonNull Class<K> keyClass,
-      @NonNull Class<V> valueClass) {
+      @Nullable Map<KeyT, ValueT> v,
+      @NonNull Class<KeyT> keyClass,
+      @NonNull Class<ValueT> valueClass) {
     return setMap(firstIndexOf(name), v, keyClass, valueClass);
   }
 
@@ -501,7 +505,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setUdtValue(@NonNull String name, @Nullable UdtValue v) {
+  default SelfT setUdtValue(@NonNull String name, @Nullable UdtValue v) {
     return setUdtValue(firstIndexOf(name), v);
   }
 
@@ -516,7 +520,7 @@ public interface SettableByName<T extends SettableByName<T>>
    * @throws IllegalArgumentException if the name is invalid.
    */
   @NonNull
-  default T setTupleValue(@NonNull String name, @Nullable TupleValue v) {
+  default SelfT setTupleValue(@NonNull String name, @Nullable TupleValue v) {
     return setTupleValue(firstIndexOf(name), v);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/codec/TypeCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/codec/TypeCodec.java
@@ -58,10 +58,10 @@ import java.nio.ByteBuffer;
  *       buffers prior to reading them.
  * </ol>
  */
-public interface TypeCodec<T> {
+public interface TypeCodec<JavaTypeT> {
 
   @NonNull
-  GenericType<T> getJavaType();
+  GenericType<JavaTypeT> getJavaType();
 
   @NonNull
   DataType getCqlType();
@@ -109,7 +109,7 @@ public interface TypeCodec<T> {
    * subtype</em> of the Java type that it has been created for. This is so because codec lookups by
    * arbitrary Java objects only make sense when attempting to encode, never when attempting to
    * decode, and indeed the {@linkplain #encode(Object, ProtocolVersion) encode} method is covariant
-   * with {@code T}.
+   * with {@code JavaTypeT}.
    *
    * <p>It can only handle non-parameterized types; codecs handling parameterized types, such as
    * collection types, must override this method and perform some sort of "manual" inspection of the
@@ -145,7 +145,7 @@ public interface TypeCodec<T> {
    * </ul>
    */
   @Nullable
-  ByteBuffer encode(@Nullable T value, @NonNull ProtocolVersion protocolVersion);
+  ByteBuffer encode(@Nullable JavaTypeT value, @NonNull ProtocolVersion protocolVersion);
 
   /**
    * Decodes a value from the binary format of the CQL type handled by this codec.
@@ -167,7 +167,7 @@ public interface TypeCodec<T> {
    * </ul>
    */
   @Nullable
-  T decode(@Nullable ByteBuffer bytes, @NonNull ProtocolVersion protocolVersion);
+  JavaTypeT decode(@Nullable ByteBuffer bytes, @NonNull ProtocolVersion protocolVersion);
 
   /**
    * Formats the given value as a valid CQL literal according to the CQL type handled by this codec.
@@ -191,7 +191,7 @@ public interface TypeCodec<T> {
    * constant string (for example "XxxCodec.format not implemented").
    */
   @NonNull
-  String format(@Nullable T value);
+  String format(@Nullable JavaTypeT value);
 
   /**
    * Parse the given CQL literal into an instance of the Java type handled by this codec.
@@ -210,5 +210,5 @@ public interface TypeCodec<T> {
    * {@code null}.
    */
   @Nullable
-  T parse(@Nullable String value);
+  JavaTypeT parse(@Nullable String value);
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistry.java
@@ -63,7 +63,8 @@ public interface CodecRegistry {
    * @throws CodecNotFoundException if there is no such codec.
    */
   @NonNull
-  <T> TypeCodec<T> codecFor(@NonNull DataType cqlType, @NonNull GenericType<T> javaType);
+  <JavaTypeT> TypeCodec<JavaTypeT> codecFor(
+      @NonNull DataType cqlType, @NonNull GenericType<JavaTypeT> javaType);
 
   /**
    * Shortcut for {@link #codecFor(DataType, GenericType) codecFor(cqlType,
@@ -75,7 +76,8 @@ public interface CodecRegistry {
    * @throws CodecNotFoundException if there is no such codec.
    */
   @NonNull
-  default <T> TypeCodec<T> codecFor(@NonNull DataType cqlType, @NonNull Class<T> javaType) {
+  default <JavaTypeT> TypeCodec<JavaTypeT> codecFor(
+      @NonNull DataType cqlType, @NonNull Class<JavaTypeT> javaType) {
     return codecFor(cqlType, GenericType.of(javaType));
   }
 
@@ -93,7 +95,7 @@ public interface CodecRegistry {
    * @throws CodecNotFoundException if there is no such codec.
    */
   @NonNull
-  <T> TypeCodec<T> codecFor(@NonNull DataType cqlType);
+  <JavaTypeT> TypeCodec<JavaTypeT> codecFor(@NonNull DataType cqlType);
 
   /**
    * Returns a codec to convert the given Java type to the CQL type deemed most appropriate to
@@ -110,7 +112,7 @@ public interface CodecRegistry {
    * @throws CodecNotFoundException if there is no such codec.
    */
   @NonNull
-  <T> TypeCodec<T> codecFor(@NonNull GenericType<T> javaType);
+  <JavaTypeT> TypeCodec<JavaTypeT> codecFor(@NonNull GenericType<JavaTypeT> javaType);
 
   /**
    * Shortcut for {@link #codecFor(GenericType) codecFor(GenericType.of(javaType))}.
@@ -121,7 +123,7 @@ public interface CodecRegistry {
    * @throws CodecNotFoundException if there is no such codec.
    */
   @NonNull
-  default <T> TypeCodec<T> codecFor(@NonNull Class<T> javaType) {
+  default <JavaTypeT> TypeCodec<JavaTypeT> codecFor(@NonNull Class<JavaTypeT> javaType) {
     return codecFor(GenericType.of(javaType));
   }
 
@@ -142,7 +144,7 @@ public interface CodecRegistry {
    * @throws CodecNotFoundException if there is no such codec.
    */
   @NonNull
-  <T> TypeCodec<T> codecFor(@NonNull DataType cqlType, @NonNull T value);
+  <JavaTypeT> TypeCodec<JavaTypeT> codecFor(@NonNull DataType cqlType, @NonNull JavaTypeT value);
 
   /**
    * Returns a codec to convert the given Java object to the CQL type deemed most appropriate to
@@ -162,5 +164,5 @@ public interface CodecRegistry {
    * @throws CodecNotFoundException if there is no such codec.
    */
   @NonNull
-  <T> TypeCodec<T> codecFor(@NonNull T value);
+  <JavaTypeT> TypeCodec<JavaTypeT> codecFor(@NonNull JavaTypeT value);
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/EventBus.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/EventBus.java
@@ -55,7 +55,7 @@ public class EventBus {
    *
    * @return a key that is needed to unregister later.
    */
-  public <T> Object register(Class<T> eventClass, Consumer<T> listener) {
+  public <EventT> Object register(Class<EventT> eventClass, Consumer<EventT> listener) {
     LOG.debug("[{}] Registering {} for {}", logPrefix, listener, eventClass);
     listeners.put(eventClass, listener);
     // The reason for the key mechanism is that this will often be used with method references,
@@ -69,7 +69,7 @@ public class EventBus {
    *
    * @param key the key that was returned by {@link #register(Class, Consumer)}
    */
-  public <T> boolean unregister(Object key, Class<T> eventClass) {
+  public <EventT> boolean unregister(Object key, Class<EventT> eventClass) {
     LOG.debug("[{}] Unregistering {} for {}", logPrefix, key, eventClass);
     return listeners.remove(eventClass, key);
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistry.java
@@ -89,13 +89,14 @@ public abstract class CachingCodecRegistry implements CodecRegistry {
 
   @NonNull
   @Override
-  public <T> TypeCodec<T> codecFor(@NonNull DataType cqlType, @NonNull GenericType<T> javaType) {
+  public <JavaTypeT> TypeCodec<JavaTypeT> codecFor(
+      @NonNull DataType cqlType, @NonNull GenericType<JavaTypeT> javaType) {
     return codecFor(cqlType, javaType, false);
   }
 
   // Not exposed publicly, (isJavaCovariant=true) is only used for internal recursion
-  protected <T> TypeCodec<T> codecFor(
-      DataType cqlType, GenericType<T> javaType, boolean isJavaCovariant) {
+  protected <JavaTypeT> TypeCodec<JavaTypeT> codecFor(
+      DataType cqlType, GenericType<JavaTypeT> javaType, boolean isJavaCovariant) {
     LOG.trace("[{}] Looking up codec for {} <-> {}", logPrefix, cqlType, javaType);
     TypeCodec<?> primitiveCodec = primitiveCodecsByCode.get(cqlType.getProtocolCode());
     if (primitiveCodec != null && matches(primitiveCodec, javaType, isJavaCovariant)) {
@@ -113,7 +114,8 @@ public abstract class CachingCodecRegistry implements CodecRegistry {
 
   @NonNull
   @Override
-  public <T> TypeCodec<T> codecFor(@NonNull DataType cqlType, @NonNull Class<T> javaType) {
+  public <JavaTypeT> TypeCodec<JavaTypeT> codecFor(
+      @NonNull DataType cqlType, @NonNull Class<JavaTypeT> javaType) {
     LOG.trace("[{}] Looking up codec for {} <-> {}", logPrefix, cqlType, javaType);
     TypeCodec<?> primitiveCodec = primitiveCodecsByCode.get(cqlType.getProtocolCode());
     if (primitiveCodec != null && primitiveCodec.getJavaType().__getToken().getType() == javaType) {
@@ -131,7 +133,7 @@ public abstract class CachingCodecRegistry implements CodecRegistry {
 
   @NonNull
   @Override
-  public <T> TypeCodec<T> codecFor(@NonNull DataType cqlType) {
+  public <JavaTypeT> TypeCodec<JavaTypeT> codecFor(@NonNull DataType cqlType) {
     LOG.trace("[{}] Looking up codec for CQL type {}", logPrefix, cqlType);
     TypeCodec<?> primitiveCodec = primitiveCodecsByCode.get(cqlType.getProtocolCode());
     if (primitiveCodec != null) {
@@ -149,7 +151,8 @@ public abstract class CachingCodecRegistry implements CodecRegistry {
 
   @NonNull
   @Override
-  public <T> TypeCodec<T> codecFor(@NonNull DataType cqlType, @NonNull T value) {
+  public <JavaTypeT> TypeCodec<JavaTypeT> codecFor(
+      @NonNull DataType cqlType, @NonNull JavaTypeT value) {
     Preconditions.checkNotNull(cqlType);
     Preconditions.checkNotNull(value);
     LOG.trace("[{}] Looking up codec for CQL type {} and object {}", logPrefix, cqlType, value);
@@ -179,7 +182,7 @@ public abstract class CachingCodecRegistry implements CodecRegistry {
 
   @NonNull
   @Override
-  public <T> TypeCodec<T> codecFor(@NonNull T value) {
+  public <JavaTypeT> TypeCodec<JavaTypeT> codecFor(@NonNull JavaTypeT value) {
     Preconditions.checkNotNull(value);
     LOG.trace("[{}] Looking up codec for object {}", logPrefix, value);
 
@@ -209,12 +212,13 @@ public abstract class CachingCodecRegistry implements CodecRegistry {
 
   @NonNull
   @Override
-  public <T> TypeCodec<T> codecFor(@NonNull GenericType<T> javaType) {
+  public <JavaTypeT> TypeCodec<JavaTypeT> codecFor(@NonNull GenericType<JavaTypeT> javaType) {
     return codecFor(javaType, false);
   }
 
   // Not exposed publicly, (isJavaCovariant=true) is only used for internal recursion
-  protected <T> TypeCodec<T> codecFor(GenericType<T> javaType, boolean isJavaCovariant) {
+  protected <JavaTypeT> TypeCodec<JavaTypeT> codecFor(
+      GenericType<JavaTypeT> javaType, boolean isJavaCovariant) {
     LOG.trace(
         "[{}] Looking up codec for Java type {} (covariant = {})",
         logPrefix,
@@ -403,9 +407,10 @@ public abstract class CachingCodecRegistry implements CodecRegistry {
   }
 
   // We call this after validating the types, so we know the cast will never fail.
-  private static <T, U> TypeCodec<T> uncheckedCast(TypeCodec<U> codec) {
+  private static <DeclaredT, RuntimeT> TypeCodec<DeclaredT> uncheckedCast(
+      TypeCodec<RuntimeT> codec) {
     @SuppressWarnings("unchecked")
-    TypeCodec<T> result = (TypeCodec<T>) codec;
+    TypeCodec<DeclaredT> result = (TypeCodec<DeclaredT>) codec;
     return result;
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/ArrayUtils.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/ArrayUtils.java
@@ -20,9 +20,9 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class ArrayUtils {
 
-  public static <T> void swap(@NonNull T[] elements, int i, int j) {
+  public static <ElementT> void swap(@NonNull ElementT[] elements, int i, int j) {
     if (i != j) {
-      T tmp = elements[i];
+      ElementT tmp = elements[i];
       elements[i] = elements[j];
       elements[j] = tmp;
     }
@@ -32,7 +32,8 @@ public class ArrayUtils {
    * Moves an element towards the beginning of the array, shifting all the intermediary elements to
    * the right (no-op if {@code targetIndex >= sourceIndex}).
    */
-  public static <T> void bubbleUp(@NonNull T[] elements, int sourceIndex, int targetIndex) {
+  public static <ElementT> void bubbleUp(
+      @NonNull ElementT[] elements, int sourceIndex, int targetIndex) {
     for (int i = sourceIndex; i > targetIndex; i--) {
       swap(elements, i, i - 1);
     }
@@ -42,7 +43,8 @@ public class ArrayUtils {
    * Moves an element towards the end of the array, shifting all the intermediary elements to the
    * left (no-op if {@code targetIndex <= sourceIndex}).
    */
-  public static <T> void bubbleDown(@NonNull T[] elements, int sourceIndex, int targetIndex) {
+  public static <ElementT> void bubbleDown(
+      @NonNull ElementT[] elements, int sourceIndex, int targetIndex) {
     for (int i = sourceIndex; i < targetIndex; i++) {
       swap(elements, i, i + 1);
     }
@@ -57,7 +59,7 @@ public class ArrayUtils {
    *     href="https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm">Modern
    *     Fisher-Yates shuffle</a>
    */
-  public static <T> void shuffleHead(@NonNull T[] elements, int n) {
+  public static <ElementT> void shuffleHead(@NonNull ElementT[] elements, int n) {
     shuffleHead(elements, n, ThreadLocalRandom.current());
   }
 
@@ -72,8 +74,8 @@ public class ArrayUtils {
    *     href="https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm">Modern
    *     Fisher-Yates shuffle</a>
    */
-  public static <T> void shuffleHead(
-      @NonNull T[] elements, int n, @NonNull ThreadLocalRandom random) {
+  public static <ElementT> void shuffleHead(
+      @NonNull ElementT[] elements, int n, @NonNull ThreadLocalRandom random) {
     if (n > elements.length) {
       throw new ArrayIndexOutOfBoundsException(
           String.format(
@@ -88,7 +90,8 @@ public class ArrayUtils {
   }
 
   /** Rotates the elements in the specified range by the specified amount (round-robin). */
-  public static <T> void rotate(@NonNull T[] elements, int startIndex, int length, int amount) {
+  public static <ElementT> void rotate(
+      @NonNull ElementT[] elements, int startIndex, int length, int amount) {
     if (length >= 2) {
       amount = amount % length;
       // Repeatedly shift by 1. This is not the most time-efficient but the array will typically be

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/CountingIterator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/CountingIterator.java
@@ -25,7 +25,7 @@ import net.jcip.annotations.NotThreadSafe;
  * elements get returned.
  */
 @NotThreadSafe
-public abstract class CountingIterator<T> implements Iterator<T> {
+public abstract class CountingIterator<ElementT> implements Iterator<ElementT> {
 
   protected int remaining;
 
@@ -64,11 +64,11 @@ public abstract class CountingIterator<T> implements Iterator<T> {
   }
 
   private State state = State.NOT_READY;
-  private T next;
+  private ElementT next;
 
-  protected abstract T computeNext();
+  protected abstract ElementT computeNext();
 
-  protected final T endOfData() {
+  protected final ElementT endOfData() {
     state = State.DONE;
     return null;
   }
@@ -97,19 +97,19 @@ public abstract class CountingIterator<T> implements Iterator<T> {
   }
 
   @Override
-  public final T next() {
+  public final ElementT next() {
     if (!hasNext()) {
       throw new NoSuchElementException();
     }
     state = State.NOT_READY;
-    T result = next;
+    ElementT result = next;
     next = null;
     // Added to original Guava code: decrement counter when we return an element
     remaining -= 1;
     return result;
   }
 
-  public final T peek() {
+  public final ElementT peek() {
     if (!hasNext()) {
       throw new NoSuchElementException();
     }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/DirectedGraph.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/DirectedGraph.java
@@ -31,26 +31,26 @@ import net.jcip.annotations.NotThreadSafe;
 
 /** A basic directed graph implementation to perform topological sorts. */
 @NotThreadSafe
-public class DirectedGraph<V> {
+public class DirectedGraph<VertexT> {
 
   // We need to keep track of the predecessor count. For simplicity, use a map to store it
   // alongside the vertices.
-  private final Map<V, Integer> vertices;
-  private final Multimap<V, V> adjacencyList;
+  private final Map<VertexT, Integer> vertices;
+  private final Multimap<VertexT, VertexT> adjacencyList;
   private boolean wasSorted;
 
-  public DirectedGraph(Collection<V> vertices) {
+  public DirectedGraph(Collection<VertexT> vertices) {
     this.vertices = Maps.newLinkedHashMapWithExpectedSize(vertices.size());
     this.adjacencyList = LinkedHashMultimap.create();
 
-    for (V vertex : vertices) {
+    for (VertexT vertex : vertices) {
       this.vertices.put(vertex, 0);
     }
   }
 
   @VisibleForTesting
   @SafeVarargs
-  DirectedGraph(V... vertices) {
+  DirectedGraph(VertexT... vertices) {
     this(Arrays.asList(vertices));
   }
 
@@ -58,30 +58,30 @@ public class DirectedGraph<V> {
    * this assumes that {@code from} and {@code to} were part of the vertices passed to the
    * constructor
    */
-  public void addEdge(V from, V to) {
+  public void addEdge(VertexT from, VertexT to) {
     Preconditions.checkArgument(vertices.containsKey(from) && vertices.containsKey(to));
     adjacencyList.put(from, to);
     vertices.put(to, vertices.get(to) + 1);
   }
 
   /** one-time use only, calling this multiple times on the same graph won't work */
-  public List<V> topologicalSort() {
+  public List<VertexT> topologicalSort() {
     Preconditions.checkState(!wasSorted);
     wasSorted = true;
 
-    Queue<V> queue = new ArrayDeque<>();
+    Queue<VertexT> queue = new ArrayDeque<>();
 
-    for (Map.Entry<V, Integer> entry : vertices.entrySet()) {
+    for (Map.Entry<VertexT, Integer> entry : vertices.entrySet()) {
       if (entry.getValue() == 0) {
         queue.add(entry.getKey());
       }
     }
 
-    List<V> result = Lists.newArrayList();
+    List<VertexT> result = Lists.newArrayList();
     while (!queue.isEmpty()) {
-      V vertex = queue.remove();
+      VertexT vertex = queue.remove();
       result.add(vertex);
-      for (V successor : adjacencyList.get(vertex)) {
+      for (VertexT successor : adjacencyList.get(vertex)) {
         if (decrementAndGetCount(successor) == 0) {
           queue.add(successor);
         }
@@ -95,7 +95,7 @@ public class DirectedGraph<V> {
     return result;
   }
 
-  private int decrementAndGetCount(V vertex) {
+  private int decrementAndGetCount(VertexT vertex) {
     Integer count = vertices.get(vertex);
     count = count - 1;
     vertices.put(vertex, count);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/Reflection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/Reflection.java
@@ -83,10 +83,10 @@ public class Reflection {
    * @return the new instance, or empty if {@code classNameOption} is not defined in the
    *     configuration.
    */
-  public static <T> Optional<T> buildFromConfig(
+  public static <ComponentT> Optional<ComponentT> buildFromConfig(
       InternalDriverContext context,
       DriverOption classNameOption,
-      Class<T> expectedSuperType,
+      Class<ComponentT> expectedSuperType,
       String... defaultPackages) {
     return buildFromConfig(context, null, classNameOption, expectedSuperType, defaultPackages);
   }
@@ -119,10 +119,10 @@ public class Reflection {
    * @return the policy instances by profile name. If multiple profiles share the same
    *     configuration, a single instance will be shared by all their entries.
    */
-  public static <T> Map<String, T> buildFromConfigProfiles(
+  public static <ComponentT> Map<String, ComponentT> buildFromConfigProfiles(
       InternalDriverContext context,
       DriverOption rootOption,
-      Class<T> expectedSuperType,
+      Class<ComponentT> expectedSuperType,
       String... defaultPackages) {
 
     // Find out how many distinct configurations we have
@@ -133,11 +133,11 @@ public class Reflection {
     }
 
     // Instantiate each distinct configuration, and associate it with the corresponding profiles
-    ImmutableMap.Builder<String, T> result = ImmutableMap.builder();
+    ImmutableMap.Builder<String, ComponentT> result = ImmutableMap.builder();
     for (Collection<String> profiles : profilesByConfig.asMap().values()) {
       // Since all profiles use the same config, we can use any of them
       String profileName = profiles.iterator().next();
-      T policy =
+      ComponentT policy =
           buildFromConfig(
                   context, profileName, classOption(rootOption), expectedSuperType, defaultPackages)
               .orElseThrow(
@@ -158,11 +158,11 @@ public class Reflection {
    *     one-arg constructor. If not null, this is a per-profile policy, look for a two-arg
    *     constructor.
    */
-  public static <T> Optional<T> buildFromConfig(
+  public static <ComponentT> Optional<ComponentT> buildFromConfig(
       InternalDriverContext context,
       String profileName,
       DriverOption classNameOption,
-      Class<T> expectedSuperType,
+      Class<ComponentT> expectedSuperType,
       String... defaultPackages) {
 
     DriverExecutionProfile config =
@@ -205,7 +205,7 @@ public class Reflection {
         configPath,
         expectedSuperType.getName());
 
-    Constructor<? extends T> constructor;
+    Constructor<? extends ComponentT> constructor;
     Class<?>[] argumentTypes =
         (profileName == null)
             ? new Class<?>[] {DriverContext.class}
@@ -221,7 +221,7 @@ public class Reflection {
     }
     try {
       @SuppressWarnings("JavaReflectionInvocation")
-      T instance =
+      ComponentT instance =
           (profileName == null)
               ? constructor.newInstance(context)
               : constructor.newInstance(context, profileName);

--- a/query-builder/src/main/java/com/datastax/oss/driver/internal/querybuilder/DefaultLiteral.java
+++ b/query-builder/src/main/java/com/datastax/oss/driver/internal/querybuilder/DefaultLiteral.java
@@ -25,18 +25,18 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import net.jcip.annotations.Immutable;
 
 @Immutable
-public class DefaultLiteral<T> implements Literal {
+public class DefaultLiteral<ValueT> implements Literal {
 
-  private final T value;
-  private final TypeCodec<T> codec;
+  private final ValueT value;
+  private final TypeCodec<ValueT> codec;
   private final CqlIdentifier alias;
 
-  public DefaultLiteral(@Nullable T value, @Nullable TypeCodec<T> codec) {
+  public DefaultLiteral(@Nullable ValueT value, @Nullable TypeCodec<ValueT> codec) {
     this(value, codec, null);
   }
 
   public DefaultLiteral(
-      @Nullable T value, @Nullable TypeCodec<T> codec, @Nullable CqlIdentifier alias) {
+      @Nullable ValueT value, @Nullable TypeCodec<ValueT> codec, @Nullable CqlIdentifier alias) {
     Preconditions.checkArgument(
         value == null || codec != null, "Must provide a codec if the value is not null");
     this.value = value;
@@ -68,12 +68,12 @@ public class DefaultLiteral<T> implements Literal {
   }
 
   @Nullable
-  public T getValue() {
+  public ValueT getValue() {
     return value;
   }
 
   @Nullable
-  public TypeCodec<T> getCodec() {
+  public TypeCodec<ValueT> getCodec() {
     return codec;
   }
 


### PR DESCRIPTION
Trivial change, no runtime impacts (no changelog entry for that reason), but I think it really helps.
I've kept single-letter names for cases where the type is truly abstract (e.g. `GenericType`) and/or simple one-liners.