### PR TITLE
fix incorrect documentation about `get` method

### DIFF
--- a/manual/object_mapper/using/README.md
+++ b/manual/object_mapper/using/README.md
@@ -51,8 +51,8 @@ UUID userId = ...;
 User u = mapper.get(userId);
 ```
 
-`get`'s arguments must match the partition key components (number of
-arguments and their types).
+`get`'s arguments must match the primary key components (number of
+arguments, their types, and order).
 
 --------------
 


### PR DESCRIPTION
Documentation says about partition key, not primary key that is really used