### PR TITLE
JAVA-2017: Slightly optimize conversion methods on the hot path

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-beta3 (in progress)
 
+- [improvement] JAVA-2017: Slightly optimize conversion methods on the hot path
 - [improvement] JAVA-2010: Make dependencies to annotations required again
 - [improvement] JAVA-1978: Add a config option to keep contact points unresolved
 - [bug] JAVA-2000: Fix ConcurrentModificationException during channel shutdown

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/ConsistencyLevelRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/ConsistencyLevelRegistry.java
@@ -25,9 +25,9 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
  */
 public interface ConsistencyLevelRegistry {
 
-  ConsistencyLevel fromCode(int code);
+  ConsistencyLevel codeToLevel(int code);
 
-  ConsistencyLevel fromName(String name);
+  int nameToCode(String name);
 
   /** @return all the values known to this driver instance. */
   Iterable<ConsistencyLevel> getValues();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultConsistencyLevelRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultConsistencyLevelRegistry.java
@@ -18,26 +18,36 @@ package com.datastax.oss.driver.internal.core;
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
 public class DefaultConsistencyLevelRegistry implements ConsistencyLevelRegistry {
 
-  private static final ImmutableList<ConsistencyLevel> values =
+  private static final ImmutableList<ConsistencyLevel> VALUES =
       ImmutableList.<ConsistencyLevel>builder().add(DefaultConsistencyLevel.values()).build();
+  private static final ImmutableMap<String, Integer> NAME_TO_CODE;
+
+  static {
+    ImmutableMap.Builder<String, Integer> nameToCodeBuilder = ImmutableMap.builder();
+    for (DefaultConsistencyLevel consistencyLevel : DefaultConsistencyLevel.values()) {
+      nameToCodeBuilder.put(consistencyLevel.name(), consistencyLevel.getProtocolCode());
+    }
+    NAME_TO_CODE = nameToCodeBuilder.build();
+  }
 
   @Override
-  public ConsistencyLevel fromCode(int code) {
+  public ConsistencyLevel codeToLevel(int code) {
     return DefaultConsistencyLevel.fromCode(code);
   }
 
   @Override
-  public ConsistencyLevel fromName(String name) {
-    return DefaultConsistencyLevel.valueOf(name);
+  public int nameToCode(String name) {
+    return NAME_TO_CODE.get(name);
   }
 
   @Override
   public Iterable<ConsistencyLevel> getValues() {
-    return values;
+    return VALUES;
   }
 }


### PR DESCRIPTION
Nothing spectacular, I've benchmarked locally and they should save at best a few nanoseconds per request.
I'm not sure if that's significant, but they shouldn't hurt either.