### PR TITLE
JAVA-1995: Use rule chains to enforce JUnit rule order

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ConnectKeyspaceIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ConnectKeyspaceIT.java
@@ -27,12 +27,16 @@ import com.datastax.oss.driver.categories.ParallelizableTests;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 public class ConnectKeyspaceIT {
-  @ClassRule public static CcmRule ccm = CcmRule.getInstance();
+  private static CcmRule ccm = CcmRule.getInstance();
 
-  @ClassRule public static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccm).build();
+  private static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccm).build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccm).around(sessionRule);
 
   @Test
   public void should_connect_to_existing_keyspace() {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/compression/DirectCompressionIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/compression/DirectCompressionIT.java
@@ -34,20 +34,23 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 public class DirectCompressionIT {
 
-  @ClassRule public static CcmRule ccmRule = CcmRule.getInstance();
+  private static CcmRule ccmRule = CcmRule.getInstance();
 
-  @ClassRule
-  public static SessionRule<CqlSession> schemaSessionRule =
+  private static SessionRule<CqlSession> schemaSessionRule =
       SessionRule.builder(ccmRule)
           .withConfigLoader(
               SessionUtils.configLoaderBuilder()
                   .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
                   .build())
           .build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccmRule).around(schemaSessionRule);
 
   @BeforeClass
   public static void setup() {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/compression/HeapCompressionIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/compression/HeapCompressionIT.java
@@ -34,6 +34,8 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 @Category(IsolatedTests.class)
 public class HeapCompressionIT {
@@ -43,16 +45,17 @@ public class HeapCompressionIT {
     System.setProperty("io.netty.noUnsafe", "true");
   }
 
-  @ClassRule public static CustomCcmRule ccmRule = CustomCcmRule.builder().build();
+  private static CustomCcmRule ccmRule = CustomCcmRule.builder().build();
 
-  @ClassRule
-  public static SessionRule<CqlSession> schemaSessionRule =
+  private static SessionRule<CqlSession> schemaSessionRule =
       SessionRule.builder(ccmRule)
           .withConfigLoader(
               SessionUtils.configLoaderBuilder()
                   .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
                   .build())
           .build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccmRule).around(schemaSessionRule);
 
   @BeforeClass
   public static void setup() {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/connection/ChannelSocketOptionsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/connection/ChannelSocketOptionsIT.java
@@ -43,12 +43,13 @@ import io.netty.channel.socket.SocketChannelConfig;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 public class ChannelSocketOptionsIT {
 
-  public static @ClassRule SimulacronRule simulacron =
-      new SimulacronRule(ClusterSpec.builder().withNodes(1));
+  private static SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(1));
 
   private static DriverConfigLoader loader =
       SessionUtils.configLoaderBuilder()
@@ -60,9 +61,10 @@ public class ChannelSocketOptionsIT {
           .withInt(DefaultDriverOption.SOCKET_SEND_BUFFER_SIZE, 123456)
           .build();
 
-  @ClassRule
-  public static SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(simulacron).withConfigLoader(loader).build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(simulacron).around(sessionRule);
 
   @Test
   public void should_report_socket_options() {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/connection/FrameLengthIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/connection/FrameLengthIT.java
@@ -46,11 +46,12 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 public class FrameLengthIT {
-  public static @ClassRule SimulacronRule simulacron =
-      new SimulacronRule(ClusterSpec.builder().withNodes(1));
+  private static SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(1));
 
   private static DriverConfigLoader loader =
       SessionUtils.configLoaderBuilder()
@@ -60,9 +61,10 @@ public class FrameLengthIT {
           .withBytes(DefaultDriverOption.PROTOCOL_MAX_FRAME_LENGTH, "100 kilobytes")
           .build();
 
-  @ClassRule
-  public static SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(simulacron).withConfigLoader(loader).build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(simulacron).around(sessionRule);
 
   private static final SimpleStatement LARGE_QUERY =
       SimpleStatement.newInstance("select * from foo").setIdempotent(true);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/AsyncResultSetIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/AsyncResultSetIT.java
@@ -31,6 +31,8 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 public class AsyncResultSetIT {
@@ -40,16 +42,17 @@ public class AsyncResultSetIT {
   private static final String PARTITION_KEY1 = "part";
   private static final String PARTITION_KEY2 = "part2";
 
-  @ClassRule public static CcmRule ccm = CcmRule.getInstance();
+  private static CcmRule ccm = CcmRule.getInstance();
 
-  @ClassRule
-  public static SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(ccm)
           .withConfigLoader(
               SessionUtils.configLoaderBuilder()
                   .withInt(DefaultDriverOption.REQUEST_PAGE_SIZE, PAGE_SIZE)
                   .build())
           .build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccm).around(sessionRule);
 
   @BeforeClass
   public static void setupSchema() {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BatchStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BatchStatementIT.java
@@ -32,14 +32,18 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 public class BatchStatementIT {
 
-  @Rule public CcmRule ccm = CcmRule.getInstance();
+  private CcmRule ccm = CcmRule.getInstance();
 
-  @Rule public SessionRule<CqlSession> sessionRule = SessionRule.builder(ccm).build();
+  private SessionRule<CqlSession> sessionRule = SessionRule.builder(ccm).build();
+
+  @Rule public TestRule chain = RuleChain.outerRule(ccm).around(sessionRule);
 
   @Rule public TestName name = new TestName();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BoundStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BoundStatementIT.java
@@ -64,7 +64,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 public class BoundStatementIT {
@@ -72,18 +74,19 @@ public class BoundStatementIT {
   @ClassRule
   public static SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(1));
 
-  @ClassRule public static CcmRule ccm = CcmRule.getInstance();
+  private static CcmRule ccm = CcmRule.getInstance();
 
   private static final boolean atLeastV4 = ccm.getHighestProtocolVersion().getCode() >= 4;
 
-  @ClassRule
-  public static SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(ccm)
           .withConfigLoader(
               SessionUtils.configLoaderBuilder()
                   .withInt(DefaultDriverOption.REQUEST_PAGE_SIZE, 20)
                   .build())
           .build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccm).around(sessionRule);
 
   @Rule public TestName name = new TestName();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/PerRequestKeyspaceIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/PerRequestKeyspaceIT.java
@@ -30,7 +30,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
 
 /**
  * Note: at the time of writing, this test exercises features of an unreleased Cassandra version. To
@@ -43,9 +45,11 @@ import org.junit.rules.TestName;
 @Category(ParallelizableTests.class)
 public class PerRequestKeyspaceIT {
 
-  @Rule public CcmRule ccmRule = CcmRule.getInstance();
+  private CcmRule ccmRule = CcmRule.getInstance();
 
-  @Rule public SessionRule<CqlSession> sessionRule = SessionRule.builder(ccmRule).build();
+  private SessionRule<CqlSession> sessionRule = SessionRule.builder(ccmRule).build();
+
+  @Rule public TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
 
   @Rule public ExpectedException thrown = ExpectedException.none();
   @Rule public TestName nameRule = new TestName();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/PreparedStatementInvalidationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/PreparedStatementInvalidationIT.java
@@ -39,6 +39,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 /**
  * Note: at the time of writing, some of these tests exercises features of an unreleased Cassandra
@@ -51,10 +53,9 @@ import org.junit.rules.ExpectedException;
 @Category(ParallelizableTests.class)
 public class PreparedStatementInvalidationIT {
 
-  @Rule public CcmRule ccmRule = CcmRule.getInstance();
+  private CcmRule ccmRule = CcmRule.getInstance();
 
-  @Rule
-  public SessionRule<CqlSession> sessionRule =
+  private SessionRule<CqlSession> sessionRule =
       SessionRule.builder(ccmRule)
           .withConfigLoader(
               SessionUtils.configLoaderBuilder()
@@ -62,6 +63,8 @@ public class PreparedStatementInvalidationIT {
                   .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
                   .build())
           .build();
+
+  @Rule public TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/QueryTraceIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/QueryTraceIT.java
@@ -29,14 +29,17 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 public class QueryTraceIT {
 
-  @ClassRule public static CcmRule ccmRule = CcmRule.getInstance();
+  private static CcmRule ccmRule = CcmRule.getInstance();
 
-  @ClassRule
-  public static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccmRule).build();
+  private static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccmRule).build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/SimpleStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/SimpleStatementIT.java
@@ -47,18 +47,18 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 public class SimpleStatementIT {
 
-  @ClassRule public static CcmRule ccm = CcmRule.getInstance();
+  private static CcmRule ccm = CcmRule.getInstance();
 
-  @ClassRule
-  public static SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(1));
+  private static SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(1));
 
-  @ClassRule
-  public static SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(ccm)
           .withConfigLoader(
               SessionUtils.configLoaderBuilder()
@@ -66,9 +66,14 @@ public class SimpleStatementIT {
                   .build())
           .build();
 
-  @ClassRule
-  public static SessionRule<CqlSession> simulacronSessionRule =
+  private static SessionRule<CqlSession> simulacronSessionRule =
       SessionRule.builder(simulacron).build();
+
+  @ClassRule public static TestRule ccmChain = RuleChain.outerRule(ccm).around(sessionRule);
+
+  @ClassRule
+  public static TestRule simulacronChain =
+      RuleChain.outerRule(simulacron).around(simulacronSessionRule);
 
   @Rule public TestName name = new TestName();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/data/DataTypeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/data/DataTypeIT.java
@@ -74,15 +74,19 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 
 @Category(ParallelizableTests.class)
 @RunWith(DataProviderRunner.class)
 public class DataTypeIT {
-  @ClassRule public static CcmRule ccm = CcmRule.getInstance();
+  private static CcmRule ccm = CcmRule.getInstance();
 
-  @ClassRule public static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccm).build();
+  private static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccm).build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccm).around(sessionRule);
 
   @Rule public TestName name = new TestName();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/loadbalancing/DefaultLoadBalancingPolicyIT.java
@@ -49,15 +49,16 @@ import java.util.Set;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 public class DefaultLoadBalancingPolicyIT {
 
   private static final String LOCAL_DC = "dc1";
 
-  @ClassRule public static CustomCcmRule ccmRule = CustomCcmRule.builder().withNodes(4, 1).build();
+  private static CustomCcmRule ccmRule = CustomCcmRule.builder().withNodes(4, 1).build();
 
-  @ClassRule
-  public static SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(ccmRule)
           .withKeyspace(false)
           .withConfigLoader(
@@ -65,6 +66,8 @@ public class DefaultLoadBalancingPolicyIT {
                   .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
                   .build())
           .build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
 
   @BeforeClass
   public static void setup() {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/loadbalancing/NodeTargetingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/loadbalancing/NodeTargetingIT.java
@@ -41,13 +41,17 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 public class NodeTargetingIT {
 
-  @Rule public SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(5));
+  private SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(5));
 
-  @Rule public SessionRule<CqlSession> sessionRule = SessionRule.builder(simulacron).build();
+  private SessionRule<CqlSession> sessionRule = SessionRule.builder(simulacron).build();
+
+  @Rule public TestRule chain = RuleChain.outerRule(simulacron).around(sessionRule);
 
   @Before
   public void clear() {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/loadbalancing/PerProfileLoadBalancingPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/loadbalancing/PerProfileLoadBalancingPolicyIT.java
@@ -38,16 +38,18 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 public class PerProfileLoadBalancingPolicyIT {
 
   // 3 2-node DCs
-  public static @ClassRule SimulacronRule simulacron =
+  private static SimulacronRule simulacron =
       new SimulacronRule(ClusterSpec.builder().withNodes(2, 2, 2));
 
   // default lb policy should consider dc1 local, profile1 dc3, profile2 empty.
-  public static @ClassRule SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(simulacron)
           .withConfigLoader(
               SessionUtils.configLoaderBuilder()
@@ -64,6 +66,8 @@ public class PerProfileLoadBalancingPolicyIT {
                           .build())
                   .build())
           .build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(simulacron).around(sessionRule);
 
   private static String QUERY_STRING = "select * from foo";
   private static final SimpleStatement QUERY = SimpleStatement.newInstance(QUERY_STRING);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/ByteOrderedTokenIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/ByteOrderedTokenIT.java
@@ -24,15 +24,15 @@ import com.datastax.oss.driver.internal.core.metadata.token.ByteOrderedToken;
 import java.time.Duration;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 public class ByteOrderedTokenIT extends TokenITBase {
 
-  @ClassRule
-  public static CustomCcmRule ccmRule =
+  private static CustomCcmRule ccmRule =
       CustomCcmRule.builder().withNodes(3).withCreateOption("-p ByteOrderedPartitioner").build();
 
-  @ClassRule
-  public static SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(ccmRule)
           .withKeyspace(false)
           .withConfigLoader(
@@ -40,6 +40,8 @@ public class ByteOrderedTokenIT extends TokenITBase {
                   .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
                   .build())
           .build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
 
   public ByteOrderedTokenIT() {
     super(ByteOrderedToken.class, false);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/ByteOrderedTokenVnodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/ByteOrderedTokenVnodesIT.java
@@ -24,19 +24,19 @@ import com.datastax.oss.driver.internal.core.metadata.token.ByteOrderedToken;
 import java.time.Duration;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 public class ByteOrderedTokenVnodesIT extends TokenITBase {
 
-  @ClassRule
-  public static CustomCcmRule ccmRule =
+  private static CustomCcmRule ccmRule =
       CustomCcmRule.builder()
           .withNodes(3)
           .withCreateOption("-p ByteOrderedPartitioner")
           .withCreateOption("--vnodes")
           .build();
 
-  @ClassRule
-  public static SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(ccmRule)
           .withKeyspace(false)
           .withConfigLoader(
@@ -44,6 +44,8 @@ public class ByteOrderedTokenVnodesIT extends TokenITBase {
                   .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
                   .build())
           .build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
 
   public ByteOrderedTokenVnodesIT() {
     super(ByteOrderedToken.class, true);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/DescribeIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/DescribeIT.java
@@ -38,6 +38,8 @@ import java.util.Optional;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,11 +48,10 @@ public class DescribeIT {
 
   private static final Logger logger = LoggerFactory.getLogger(DescribeIT.class);
 
-  @ClassRule public static CcmRule ccmRule = CcmRule.getInstance();
+  private static CcmRule ccmRule = CcmRule.getInstance();
 
   // disable debouncer to speed up test.
-  @ClassRule
-  public static SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(ccmRule)
           .withKeyspace(false)
           .withConfigLoader(
@@ -59,6 +60,8 @@ public class DescribeIT {
                   .withDuration(DefaultDriverOption.METADATA_SCHEMA_WINDOW, Duration.ofSeconds(0))
                   .build())
           .build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
 
   /**
    * Creates a keyspace using a variety of features and ensures {@link

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/Murmur3TokenIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/Murmur3TokenIT.java
@@ -24,13 +24,14 @@ import com.datastax.oss.driver.internal.core.metadata.token.Murmur3Token;
 import java.time.Duration;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 public class Murmur3TokenIT extends TokenITBase {
 
-  @ClassRule public static CustomCcmRule ccmRule = CustomCcmRule.builder().withNodes(3).build();
+  private static CustomCcmRule ccmRule = CustomCcmRule.builder().withNodes(3).build();
 
-  @ClassRule
-  public static SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(ccmRule)
           .withKeyspace(false)
           .withConfigLoader(
@@ -38,6 +39,8 @@ public class Murmur3TokenIT extends TokenITBase {
                   .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
                   .build())
           .build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
 
   public Murmur3TokenIT() {
     super(Murmur3Token.class, false);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/Murmur3TokenVnodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/Murmur3TokenVnodesIT.java
@@ -24,15 +24,15 @@ import com.datastax.oss.driver.internal.core.metadata.token.Murmur3Token;
 import java.time.Duration;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 public class Murmur3TokenVnodesIT extends TokenITBase {
 
-  @ClassRule
-  public static CustomCcmRule ccmRule =
+  private static CustomCcmRule ccmRule =
       CustomCcmRule.builder().withNodes(3).withCreateOption("--vnodes").build();
 
-  @ClassRule
-  public static SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(ccmRule)
           .withKeyspace(false)
           .withConfigLoader(
@@ -40,6 +40,8 @@ public class Murmur3TokenVnodesIT extends TokenITBase {
                   .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
                   .build())
           .build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
 
   public Murmur3TokenVnodesIT() {
     super(Murmur3Token.class, true);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/NodeMetadataIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/NodeMetadataIT.java
@@ -29,16 +29,19 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metadata.TopologyEvent;
 import java.util.Collection;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 public class NodeMetadataIT {
 
-  @ClassRule public static CcmRule ccmRule = CcmRule.getInstance();
+  private static CcmRule ccmRule = CcmRule.getInstance();
 
-  @Rule public SessionRule<CqlSession> sessionRule = SessionRule.builder(ccmRule).build();
+  private static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccmRule).build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
 
   @Test
   public void should_expose_node_metadata() {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/NodeStateIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/NodeStateIT.java
@@ -64,6 +64,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -75,12 +77,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class NodeStateIT {
 
-  public @Rule SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(2));
+  private SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(2));
 
   private NodeStateListener nodeStateListener = Mockito.mock(NodeStateListener.class);
   private InOrder inOrder;
 
-  public @Rule SessionRule<CqlSession> sessionRule =
+  private SessionRule<CqlSession> sessionRule =
       SessionRule.builder(simulacron)
           .withConfigLoader(
               SessionUtils.configLoaderBuilder()
@@ -92,6 +94,8 @@ public class NodeStateIT {
                   .build())
           .withNodeStateListener(nodeStateListener)
           .build();
+
+  @Rule public TestRule chain = RuleChain.outerRule(simulacron).around(sessionRule);
 
   private @Captor ArgumentCaptor<DefaultNode> nodeCaptor;
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/RandomTokenIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/RandomTokenIT.java
@@ -24,15 +24,15 @@ import com.datastax.oss.driver.internal.core.metadata.token.RandomToken;
 import java.time.Duration;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 public class RandomTokenIT extends TokenITBase {
 
-  @ClassRule
-  public static CustomCcmRule ccmRule =
+  private static CustomCcmRule ccmRule =
       CustomCcmRule.builder().withNodes(3).withCreateOption("-p RandomPartitioner").build();
 
-  @ClassRule
-  public static SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(ccmRule)
           .withKeyspace(false)
           .withConfigLoader(
@@ -40,6 +40,8 @@ public class RandomTokenIT extends TokenITBase {
                   .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
                   .build())
           .build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
 
   public RandomTokenIT() {
     super(RandomToken.class, false);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/RandomTokenVnodesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/RandomTokenVnodesIT.java
@@ -24,19 +24,19 @@ import com.datastax.oss.driver.internal.core.metadata.token.RandomToken;
 import java.time.Duration;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 public class RandomTokenVnodesIT extends TokenITBase {
 
-  @ClassRule
-  public static CustomCcmRule ccmRule =
+  private static CustomCcmRule ccmRule =
       CustomCcmRule.builder()
           .withNodes(3)
           .withCreateOption("-p RandomPartitioner")
           .withCreateOption("--vnodes")
           .build();
 
-  @ClassRule
-  public static SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(ccmRule)
           .withKeyspace(false)
           .withConfigLoader(
@@ -44,6 +44,8 @@ public class RandomTokenVnodesIT extends TokenITBase {
                   .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
                   .build())
           .build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
 
   public RandomTokenVnodesIT() {
     super(RandomToken.class, true);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaChangesIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaChangesIT.java
@@ -43,16 +43,17 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 import org.mockito.Mockito;
 
 @Category(ParallelizableTests.class)
 public class SchemaChangesIT {
 
-  @Rule public CcmRule ccmRule = CcmRule.getInstance();
+  private CcmRule ccmRule = CcmRule.getInstance();
 
   // A client that we only use to set up the tests
-  @Rule
-  public SessionRule<CqlSession> adminSessionRule =
+  private SessionRule<CqlSession> adminSessionRule =
       SessionRule.builder(ccmRule)
           .withConfigLoader(
               SessionUtils.configLoaderBuilder()
@@ -60,6 +61,8 @@ public class SchemaChangesIT {
                   .withDuration(DefaultDriverOption.METADATA_SCHEMA_WINDOW, Duration.ofSeconds(0))
                   .build())
           .build();
+
+  @Rule public TestRule chain = RuleChain.outerRule(ccmRule).around(adminSessionRule);
 
   @Before
   public void setup() {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/metadata/SchemaIT.java
@@ -38,13 +38,17 @@ import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 public class SchemaIT {
 
-  @Rule public CcmRule ccmRule = CcmRule.getInstance();
+  private CcmRule ccmRule = CcmRule.getInstance();
 
-  @Rule public SessionRule<CqlSession> sessionRule = SessionRule.builder(ccmRule).build();
+  private SessionRule<CqlSession> sessionRule = SessionRule.builder(ccmRule).build();
+
+  @Rule public TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
 
   @Test
   public void should_expose_system_and_test_keyspace() {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/retry/PerProfileRetryPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/retry/PerProfileRetryPolicyIT.java
@@ -49,15 +49,16 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 public class PerProfileRetryPolicyIT {
 
   // Shared across all tests methods.
-  public static @ClassRule SimulacronRule simulacron =
-      new SimulacronRule(ClusterSpec.builder().withNodes(2));
+  private static SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(2));
 
-  public static @ClassRule SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(simulacron)
           .withConfigLoader(
               SessionUtils.configLoaderBuilder()
@@ -77,6 +78,8 @@ public class PerProfileRetryPolicyIT {
                           .build())
                   .build())
           .build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(simulacron).around(sessionRule);
 
   private static String QUERY_STRING = "select * from foo";
   private static final SimpleStatement QUERY = SimpleStatement.newInstance(QUERY_STRING);

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/session/ExceptionIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/session/ExceptionIT.java
@@ -41,15 +41,15 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 public class ExceptionIT {
 
-  @ClassRule
-  public static SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(2));
+  private static SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(2));
 
-  @ClassRule
-  public static SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(simulacron)
           .withConfigLoader(
               SessionUtils.configLoaderBuilder()
@@ -59,6 +59,8 @@ public class ExceptionIT {
                   .withClass(DefaultDriverOption.RETRY_POLICY_CLASS, DefaultRetryPolicy.class)
                   .build())
           .build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(simulacron).around(sessionRule);
 
   private static String QUERY_STRING = "select * from foo";
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/session/RequestProcessorIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/session/RequestProcessorIT.java
@@ -41,6 +41,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 /**
  * A suite of tests for exercising registration of custom {@link
@@ -63,9 +65,11 @@ import org.junit.rules.ExpectedException;
 @Category(ParallelizableTests.class)
 public class RequestProcessorIT {
 
-  @ClassRule public static CcmRule ccm = CcmRule.getInstance();
+  private static CcmRule ccm = CcmRule.getInstance();
 
-  @ClassRule public static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccm).build();
+  private static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccm).build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccm).around(sessionRule);
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistryIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistryIT.java
@@ -51,14 +51,18 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
 public class CodecRegistryIT {
 
-  @ClassRule public static CcmRule ccm = CcmRule.getInstance();
+  private static CcmRule ccm = CcmRule.getInstance();
 
-  @ClassRule public static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccm).build();
+  private static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccm).build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccm).around(sessionRule);
 
   @Rule public TestName name = new TestName();
 

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/CassandraResourceRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/CassandraResourceRule.java
@@ -16,18 +16,26 @@
 package com.datastax.oss.driver.api.testinfra;
 
 import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.Set;
 import org.junit.rules.ExternalResource;
+import org.junit.rules.RuleChain;
 
 /**
- * An {@link ExternalResource} which provides a {@link #setUp()} method for initializing the
- * resource externally (instead of making users use rule chains) and a {@link #getContactPoints()}
- * for accessing the contact points of the cassandra cluster.
+ * An {@link ExternalResource} which provides a {@link #getContactPoints()} for accessing the
+ * contact points of the cassandra cluster.
  */
 public abstract class CassandraResourceRule extends ExternalResource {
 
+  /**
+   * @deprecated this method is preserved for backward compatibility only. The correct way to ensure
+   *     that a {@code CassandraResourceRule} gets initialized before a {@link SessionRule} is to
+   *     wrap them into a {@link RuleChain}. Therefore there is no need to force the initialization
+   *     of a {@code CassandraResourceRule} explicitly anymore.
+   */
+  @Deprecated
   public synchronized void setUp() {
     try {
       this.before();

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionRule.java
@@ -16,7 +16,6 @@
 package com.datastax.oss.driver.api.testinfra.session;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
-import com.datastax.oss.driver.api.core.NoNodeAvailableException;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
@@ -95,9 +94,6 @@ public class SessionRule<SessionT extends Session> extends ExternalResource {
 
   @Override
   protected void before() {
-    // ensure resource is initialized before initializing the session.
-    cassandraResource.setUp();
-
     session =
         SessionUtils.newSession(
             cassandraResource, null, nodeStateListener, schemaChangeListener, null, configLoader);
@@ -113,13 +109,7 @@ public class SessionRule<SessionT extends Session> extends ExternalResource {
   @Override
   protected void after() {
     if (keyspace != null) {
-      try {
-        SessionUtils.dropKeyspace(session, keyspace, slowProfile);
-      } catch (NoNodeAvailableException e) {
-        // Rule ordering is not deterministic, so the cassandraResource might have shut down
-        // already. Dropping the keyspace is not critical since we're throwing the cluster away, so
-        // just ignore.
-      }
+      SessionUtils.dropKeyspace(session, keyspace, slowProfile);
     }
     session.close();
   }


### PR DESCRIPTION
No changelog entry because this does not impact production code.

Summary of changes: take a look at `SessionRule` and `CassandraResourceRule`, then it's the same change in every integration test.