### PR TITLE
JAVA-2025: Include exception message in AbstractCollectionCodec.accepts(null)

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 3.7.0
+
+- [improvement] JAVA-2025: Include exception message in AbstractCollectionCodec.accepts(null).
+
+
 ### 3.6.0
 
 - [improvement] JAVA-1394: Add request-queue-depth metric.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### 3.7.0
+### 3.7.0 (In progress)
 
 - [improvement] JAVA-2025: Include exception message in AbstractCollectionCodec.accepts(null).
 

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
@@ -1850,7 +1850,7 @@ public abstract class TypeCodec<T> {
 
     @Override
     public boolean accepts(Object value) {
-      checkNotNull(javaType, "Parameter javaType cannot be null");
+      checkNotNull(value, "Parameter value cannot be null");
       if (getJavaType().getRawType().isAssignableFrom(value.getClass())) {
         // runtime type ok, now check element type
         Collection<?> coll = (Collection<?>) value;

--- a/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TypeCodec.java
@@ -1850,6 +1850,7 @@ public abstract class TypeCodec<T> {
 
     @Override
     public boolean accepts(Object value) {
+      checkNotNull(javaType, "Parameter javaType cannot be null");
       if (getJavaType().getRawType().isAssignableFrom(value.getClass())) {
         // runtime type ok, now check element type
         Collection<?> coll = (Collection<?>) value;


### PR DESCRIPTION
For [JAVA-2025](https://datastax-oss.atlassian.net/browse/JAVA-2025).

Improve AbstractCollectionCodec.accepts() to explicitly null check and
raise an NPE with a similar message to TypeCodec.accepts().