### PR TITLE
JAVA-1947: Make schema parsing more lenient and allow missing system_virtual_schema

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-beta3 (in progress)
 
+- [bug] JAVA-1947: Make schema parsing more lenient and allow missing system_virtual_schema
 - [bug] JAVA-2028: Use CQL form when parsing UDT types in system tables
 - [improvement] JAVA-1918: Document temporal types
 - [improvement] JAVA-1914: Optimize use of System.nanoTime in CqlRequestHandlerBase


### PR DESCRIPTION
The issue only happens with DDAC, which reports a `release_version` > 4 but is not a true C* 4 equivalent (no virtual tables). I've simply disabled the warning if the virtual schema keyspace is missing.

I also made schema parsing more lenient: failure to query a system table does not cancel the whole refresh anymore, we keep going with the data we have.