### PR TITLE
JAVA-2029: Handle schema refresh failure after a DDL query

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-beta3 (in progress)
 
+- [bug] JAVA-2029: Handle schema refresh failure after a DDL query
 - [bug] JAVA-1947: Make schema parsing more lenient and allow missing system_virtual_schema
 - [bug] JAVA-2028: Use CQL form when parsing UDT types in system tables
 - [improvement] JAVA-1918: Document temporal types


### PR DESCRIPTION
This is a bit hard to cover with a test since there needs to be a bug in the schema refresh code, but while #1126 is still not merged, this can be reproduced manually by creating a table that uses a UDT with a case-sensitive name.