### PR TITLE
JAVA-1941: Override toString for all schema metadata types

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/schema/FunctionSignature.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/schema/FunctionSignature.java
@@ -95,4 +95,19 @@ public class FunctionSignature {
   public int hashCode() {
     return Objects.hash(name, parameterTypes);
   }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder(name.asInternal()).append('(');
+    boolean first = true;
+    for (DataType type : parameterTypes) {
+      if (first) {
+        first = false;
+      } else {
+        builder.append(", ");
+      }
+      builder.append(type.asCql(true, true));
+    }
+    return builder.append(')').toString();
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultAggregateMetadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultAggregateMetadata.java
@@ -149,4 +149,15 @@ public class DefaultAggregateMetadata implements AggregateMetadata {
         stateFuncSignature,
         stateType);
   }
+
+  @Override
+  public String toString() {
+    return "DefaultAggregateMetadata@"
+        + Integer.toHexString(hashCode())
+        + "("
+        + keyspace.asInternal()
+        + "."
+        + signature
+        + ")";
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultColumnMetadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultColumnMetadata.java
@@ -92,4 +92,19 @@ public class DefaultColumnMetadata implements ColumnMetadata {
   public int hashCode() {
     return Objects.hash(keyspace, parent, name, dataType, isStatic);
   }
+
+  @Override
+  public String toString() {
+    return "DefaultColumnMetadata@"
+        + Integer.toHexString(hashCode())
+        + "("
+        + keyspace.asInternal()
+        + "."
+        + parent.asInternal()
+        + "."
+        + name.asInternal()
+        + " "
+        + dataType.asCql(true, false)
+        + ")";
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultFunctionMetadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultFunctionMetadata.java
@@ -122,4 +122,15 @@ public class DefaultFunctionMetadata implements FunctionMetadata {
     return Objects.hash(
         keyspace, signature, parameterNames, body, calledOnNullInput, language, returnType);
   }
+
+  @Override
+  public String toString() {
+    return "DefaultFunctionMetadata@"
+        + Integer.toHexString(hashCode())
+        + "("
+        + keyspace.asInternal()
+        + "."
+        + signature
+        + ")";
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultIndexMetadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultIndexMetadata.java
@@ -105,4 +105,17 @@ public class DefaultIndexMetadata implements IndexMetadata {
   public int hashCode() {
     return Objects.hash(keyspace, table, name, kind, target, options);
   }
+
+  @Override
+  public String toString() {
+    return "DefaultIndexMetadata@"
+        + Integer.toHexString(hashCode())
+        + "("
+        + keyspace.asInternal()
+        + "."
+        + table.asInternal()
+        + "."
+        + name.asInternal()
+        + ")";
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultKeyspaceMetadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultKeyspaceMetadata.java
@@ -138,4 +138,13 @@ public class DefaultKeyspaceMetadata implements KeyspaceMetadata {
     return Objects.hash(
         name, durableWrites, replication, types, tables, views, functions, aggregates);
   }
+
+  @Override
+  public String toString() {
+    return "DefaultKeyspaceMetadata@"
+        + Integer.toHexString(hashCode())
+        + "("
+        + name.asInternal()
+        + ")";
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultTableMetadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultTableMetadata.java
@@ -22,7 +22,11 @@ import com.datastax.oss.driver.api.core.metadata.schema.IndexMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 import net.jcip.annotations.Immutable;
 
 @Immutable
@@ -144,5 +148,16 @@ public class DefaultTableMetadata implements TableMetadata {
   public int hashCode() {
     return Objects.hash(
         keyspace, name, id, compactStorage, partitionKey, clusteringColumns, columns, indexes);
+  }
+
+  @Override
+  public String toString() {
+    return "DefaultTableMetadata@"
+        + Integer.toHexString(hashCode())
+        + "("
+        + keyspace.asInternal()
+        + "."
+        + name.asInternal()
+        + ")";
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultViewMetadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/DefaultViewMetadata.java
@@ -161,4 +161,15 @@ public class DefaultViewMetadata implements ViewMetadata {
         columns,
         options);
   }
+
+  @Override
+  public String toString() {
+    return "DefaultViewMetadata@"
+        + Integer.toHexString(hashCode())
+        + "("
+        + keyspace.asInternal()
+        + "."
+        + name.asInternal()
+        + ")";
+  }
 }


### PR DESCRIPTION
No changelog since this has very little user impact (mainly logs).

I don't think we should put every piece of information in the toString representation: if you need to compare individual fields between two instances, you should probably write tests / do some proper debugging.

So I went with the uniquely identifying fields for each type, along with the hash code for a quick indication of whether two instances are equal.