### PR TITLE
JAVA-2014: Schedule timeouts on a separate Timer

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-beta3 (in progress)
 
+- [improvement] JAVA-2014: Schedule timeouts on a separate Timer
 - [bug] JAVA-2029: Handle schema refresh failure after a DDL query
 - [bug] JAVA-1947: Make schema parsing more lenient and allow missing system_virtual_schema
 - [bug] JAVA-2028: Use CQL form when parsing UDT types in system tables

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -168,6 +168,9 @@ public enum DefaultDriverOption implements DriverOption {
   COALESCER_INTERVAL("advanced.coalescer.reschedule-interval"),
 
   RESOLVE_CONTACT_POINTS("advanced.resolve-contact-points"),
+
+  NETTY_TIMER_TICK_DURATION("advanced.netty.timer.tick-duration"),
+  NETTY_TIMER_TICKS_PER_WHEEL("advanced.netty.timer.ticks-per-wheel"),
   ;
 
   private final String path;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/NettyOptions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/NettyOptions.java
@@ -20,6 +20,7 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
+import io.netty.util.Timer;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.Future;
 
@@ -80,4 +81,12 @@ public interface NettyOptions {
    * groups.
    */
   Future<Void> onClose();
+
+  /**
+   * The Timer on which non-I/O events should be scheduled. This must always return the same
+   * instance. This timer should be used for things like request timeout events and scheduling
+   * speculative executions. Under high load, scheduling these non-I/O events on a separate, lower
+   * resolution timer will allow for higher overall I/O throughput.
+   */
+  Timer getTimer();
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1369,6 +1369,30 @@ datastax-java-driver {
 
       shutdown {quiet-period = 2, timeout = 15, unit = SECONDS}
     }
+    # The timer used for scheduling request timeouts and speculative executions
+    timer {
+      # The timer tick duration
+      # This is the how frequent the timer should wake-up to check for timed out tasks.
+      # Lower resolution (i.e. longer durations) will leave more CPU cycles for running I/O
+      # operations at the cost of precision of exactly when a request timeout will expire or a
+      # speculative execution will run. Higher resolution (i.e. shorter durations) will result in
+      # more precise request timeouts and speculative execution scheduling, but at the cost of CPU
+      # cycles taken from I/O operations, which could lead to lower overall I/O throughput.
+      #
+      # Required: yes
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
+      tick-duration = 100 milliseconds
+
+      # Number of ticks in a Timer wheel. The underlying implementation uses Netty's
+      # HashedWheelTimer, which uses hashes to arrange the timeouts. This effectively controls the
+      # size of the timer wheel.
+      #
+      # Required: yes
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
+      ticks-per-wheel = 512
+    }
   }
 
   # The component that coalesces writes on the connections.

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerSpeculativeExecutionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerSpeculativeExecutionTest.java
@@ -30,7 +30,7 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
 import com.datastax.oss.driver.api.core.servererrors.BootstrappingException;
 import com.datastax.oss.driver.api.core.specex.SpeculativeExecutionPolicy;
-import com.datastax.oss.driver.internal.core.util.concurrent.ScheduledTaskCapturingEventLoop;
+import com.datastax.oss.driver.internal.core.util.concurrent.CapturingTimer.CapturedTimeout;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
 import com.datastax.oss.protocol.internal.response.Error;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
@@ -59,8 +59,8 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
 
       node1Behavior.verifyWrite();
 
-      harness.nextScheduledTask(); // Discard the timeout task
-      assertThat(harness.nextScheduledTask()).isNull();
+      assertThat(harness.nextScheduledTimeout()).isNotNull(); // Discard the timeout task
+      assertThat(harness.nextScheduledTimeout()).isNull();
 
       Mockito.verifyNoMoreInteractions(speculativeExecutionPolicy);
       Mockito.verifyNoMoreInteractions(nodeMetricUpdater1);
@@ -70,7 +70,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
   @Test
   @UseDataProvider("idempotentConfig")
   public void should_schedule_speculative_executions(
-      boolean defaultIdempotence, SimpleStatement statement) {
+      boolean defaultIdempotence, SimpleStatement statement) throws Exception {
     RequestHandlerTestHarness.Builder harnessBuilder =
         RequestHandlerTestHarness.builder().withDefaultIdempotence(defaultIdempotence);
     PoolBehavior node1Behavior = harnessBuilder.customBehavior(node1);
@@ -101,26 +101,24 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
       node1Behavior.verifyWrite();
       node1Behavior.setWriteSuccess();
 
-      harness.nextScheduledTask(); // Discard the timeout task
+      harness.nextScheduledTimeout(); // Discard the timeout task
 
-      ScheduledTaskCapturingEventLoop.CapturedTask<?> firstExecutionTask =
-          harness.nextScheduledTask();
-      assertThat(firstExecutionTask.getInitialDelay(TimeUnit.MILLISECONDS))
+      CapturedTimeout speculativeExecution1 = harness.nextScheduledTimeout();
+      assertThat(speculativeExecution1.getDelay(TimeUnit.MILLISECONDS))
           .isEqualTo(firstExecutionDelay);
       Mockito.verifyNoMoreInteractions(nodeMetricUpdater1);
-      firstExecutionTask.run();
+      speculativeExecution1.task().run(speculativeExecution1);
       Mockito.verify(nodeMetricUpdater1)
           .incrementCounter(
               DefaultNodeMetric.SPECULATIVE_EXECUTIONS, DriverExecutionProfile.DEFAULT_NAME);
       node2Behavior.verifyWrite();
       node2Behavior.setWriteSuccess();
 
-      ScheduledTaskCapturingEventLoop.CapturedTask<?> secondExecutionTask =
-          harness.nextScheduledTask();
-      assertThat(secondExecutionTask.getInitialDelay(TimeUnit.MILLISECONDS))
+      CapturedTimeout speculativeExecution2 = harness.nextScheduledTimeout();
+      assertThat(speculativeExecution2.getDelay(TimeUnit.MILLISECONDS))
           .isEqualTo(secondExecutionDelay);
       Mockito.verifyNoMoreInteractions(nodeMetricUpdater2);
-      secondExecutionTask.run();
+      speculativeExecution2.task().run(speculativeExecution2);
       Mockito.verify(nodeMetricUpdater2)
           .incrementCounter(
               DefaultNodeMetric.SPECULATIVE_EXECUTIONS, DriverExecutionProfile.DEFAULT_NAME);
@@ -128,7 +126,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
       node3Behavior.setWriteSuccess();
 
       // No more scheduled tasks since the policy returns 0 on the third call.
-      assertThat(harness.nextScheduledTask()).isNull();
+      assertThat(harness.nextScheduledTimeout()).isNull();
 
       // Note that we don't need to complete any response, the test is just about checking that
       // executions are started.
@@ -138,7 +136,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
   @Test
   @UseDataProvider("idempotentConfig")
   public void should_not_start_execution_if_result_complete(
-      boolean defaultIdempotence, SimpleStatement statement) {
+      boolean defaultIdempotence, SimpleStatement statement) throws Exception {
     RequestHandlerTestHarness.Builder harnessBuilder =
         RequestHandlerTestHarness.builder().withDefaultIdempotence(defaultIdempotence);
     PoolBehavior node1Behavior = harnessBuilder.customBehavior(node1);
@@ -153,18 +151,17 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
                   any(Node.class), eq(null), eq(statement), eq(1)))
           .thenReturn(firstExecutionDelay);
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
-          new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
-              .handle();
+      CqlRequestAsyncHandler requestHandler =
+          new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test");
+      CompletionStage<AsyncResultSet> resultSetFuture = requestHandler.handle();
       node1Behavior.verifyWrite();
       node1Behavior.setWriteSuccess();
 
-      ScheduledTaskCapturingEventLoop.CapturedTask<?> timeoutFuture = harness.nextScheduledTask();
+      harness.nextScheduledTimeout(); // Discard the timeout task
 
       // Check that the first execution was scheduled but don't run it yet
-      ScheduledTaskCapturingEventLoop.CapturedTask<?> firstExecutionTask =
-          harness.nextScheduledTask();
-      assertThat(firstExecutionTask.getInitialDelay(TimeUnit.MILLISECONDS))
+      CapturedTimeout speculativeExecution1 = harness.nextScheduledTimeout();
+      assertThat(speculativeExecution1.getDelay(TimeUnit.MILLISECONDS))
           .isEqualTo(firstExecutionDelay);
 
       // Complete the request from the initial execution
@@ -177,11 +174,11 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
       // Travis CI build). When that happens, the speculative execution is not recorded yet when
       // cancelScheduledTasks runs.
       // So check the timeout future instead, since it's cancelled in the same method.
-      assertThat(timeoutFuture.isCancelled()).isTrue();
+      assertThat(requestHandler.scheduledTimeout.isCancelled()).isTrue();
 
       // The fact that we missed the speculative execution is not a problem; even if it starts, it
       // will eventually find out that the result is already complete and cancel itself:
-      firstExecutionTask.run();
+      speculativeExecution1.task().run(speculativeExecution1);
       node2Behavior.verifyNoWrite();
 
       Mockito.verify(nodeMetricUpdater1)
@@ -216,7 +213,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
 
-      harness.nextScheduledTask(); // Discard the timeout task
+      harness.nextScheduledTimeout(); // Discard the timeout task
 
       assertThatStage(resultSetFuture)
           .isFailed(error -> assertThat(error).isInstanceOf(NoNodeAvailableException.class));
@@ -226,7 +223,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
   @Test
   @UseDataProvider("idempotentConfig")
   public void should_fail_if_no_more_nodes_and_initial_execution_is_last(
-      boolean defaultIdempotence, SimpleStatement statement) {
+      boolean defaultIdempotence, SimpleStatement statement) throws Exception {
     RequestHandlerTestHarness.Builder harnessBuilder =
         RequestHandlerTestHarness.builder().withDefaultIdempotence(defaultIdempotence);
     PoolBehavior node1Behavior = harnessBuilder.customBehavior(node1);
@@ -250,16 +247,16 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
       node1Behavior.setWriteSuccess();
       // do not simulate a response from node1 yet
 
-      harness.nextScheduledTask(); // Discard the timeout task
+      harness.nextScheduledTimeout(); // Discard the timeout task
 
       // Run the next scheduled task to start the speculative execution. node2 will reply with a
       // BOOTSTRAPPING error, causing a RETRY_NEXT; but the query plan is now empty so the
       // speculative execution stops.
-      ScheduledTaskCapturingEventLoop.CapturedTask<?> firstExecutionTask =
-          harness.nextScheduledTask();
-      assertThat(firstExecutionTask.getInitialDelay(TimeUnit.MILLISECONDS))
+      // next scheduled timeout should be the first speculative execution. Get it and run it.
+      CapturedTimeout speculativeExecution1 = harness.nextScheduledTimeout();
+      assertThat(speculativeExecution1.getDelay(TimeUnit.MILLISECONDS))
           .isEqualTo(firstExecutionDelay);
-      firstExecutionTask.run();
+      speculativeExecution1.task().run(speculativeExecution1);
 
       // node1 now replies with the same response, that triggers a RETRY_NEXT
       node1Behavior.setResponseSuccess(
@@ -281,7 +278,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
   @Test
   @UseDataProvider("idempotentConfig")
   public void should_fail_if_no_more_nodes_and_speculative_execution_is_last(
-      boolean defaultIdempotence, SimpleStatement statement) {
+      boolean defaultIdempotence, SimpleStatement statement) throws Exception {
     RequestHandlerTestHarness.Builder harnessBuilder =
         RequestHandlerTestHarness.builder().withDefaultIdempotence(defaultIdempotence);
     PoolBehavior node1Behavior = harnessBuilder.customBehavior(node1);
@@ -303,14 +300,13 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
       node1Behavior.setWriteSuccess();
       // do not simulate a response from node1 yet
 
-      harness.nextScheduledTask(); // Discard the timeout task
+      harness.nextScheduledTimeout(); // Discard the timeout task
 
-      // Run the next scheduled task to start the speculative execution.
-      ScheduledTaskCapturingEventLoop.CapturedTask<?> firstExecutionTask =
-          harness.nextScheduledTask();
-      assertThat(firstExecutionTask.getInitialDelay(TimeUnit.MILLISECONDS))
+      // next scheduled timeout should be the first speculative execution. Get it and run it.
+      CapturedTimeout speculativeExecution1 = harness.nextScheduledTimeout();
+      assertThat(speculativeExecution1.getDelay(TimeUnit.MILLISECONDS))
           .isEqualTo(firstExecutionDelay);
-      firstExecutionTask.run();
+      speculativeExecution1.task().run(speculativeExecution1);
 
       // node1 now replies with a BOOTSTRAPPING error that triggers a RETRY_NEXT
       // but the query plan is empty so the initial execution stops
@@ -337,7 +333,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
   @Test
   @UseDataProvider("idempotentConfig")
   public void should_retry_in_speculative_executions(
-      boolean defaultIdempotence, SimpleStatement statement) {
+      boolean defaultIdempotence, SimpleStatement statement) throws Exception {
     RequestHandlerTestHarness.Builder harnessBuilder =
         RequestHandlerTestHarness.builder().withDefaultIdempotence(defaultIdempotence);
     PoolBehavior node1Behavior = harnessBuilder.customBehavior(node1);
@@ -361,13 +357,14 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
       // do not simulate a response from node1. The request will stay hanging for the rest of this
       // test
 
-      harness.nextScheduledTask(); // Discard the timeout task
+      harness.nextScheduledTimeout(); // Discard the timeout task
 
-      ScheduledTaskCapturingEventLoop.CapturedTask<?> firstExecutionTask =
-          harness.nextScheduledTask();
-      assertThat(firstExecutionTask.getInitialDelay(TimeUnit.MILLISECONDS))
+      // next scheduled timeout should be the first speculative execution. Get it and run it.
+      CapturedTimeout speculativeExecution1 = harness.nextScheduledTimeout();
+      assertThat(speculativeExecution1.getDelay(TimeUnit.MILLISECONDS))
           .isEqualTo(firstExecutionDelay);
-      firstExecutionTask.run();
+      speculativeExecution1.task().run(speculativeExecution1);
+
       node2Behavior.verifyWrite();
       node2Behavior.setWriteSuccess();
 
@@ -386,7 +383,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
   @Test
   @UseDataProvider("idempotentConfig")
   public void should_stop_retrying_other_executions_if_result_complete(
-      boolean defaultIdempotence, SimpleStatement statement) {
+      boolean defaultIdempotence, SimpleStatement statement) throws Exception {
     RequestHandlerTestHarness.Builder harnessBuilder =
         RequestHandlerTestHarness.builder().withDefaultIdempotence(defaultIdempotence);
     PoolBehavior node1Behavior = harnessBuilder.customBehavior(node1);
@@ -401,20 +398,20 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
               speculativeExecutionPolicy.nextExecution(
                   any(Node.class), eq(null), eq(statement), eq(1)))
           .thenReturn(firstExecutionDelay);
-
       CompletionStage<AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
       node1Behavior.verifyWrite();
       node1Behavior.setWriteSuccess();
 
-      harness.nextScheduledTask(); // Discard the timeout task
+      harness.nextScheduledTimeout(); // Discard the timeout task
 
-      ScheduledTaskCapturingEventLoop.CapturedTask<?> firstExecutionTask =
-          harness.nextScheduledTask();
-      assertThat(firstExecutionTask.getInitialDelay(TimeUnit.MILLISECONDS))
+      // next scheduled timeout should be the first speculative execution. Get it and run it.
+      CapturedTimeout speculativeExecution1 = harness.nextScheduledTimeout();
+      assertThat(speculativeExecution1.getDelay(TimeUnit.MILLISECONDS))
           .isEqualTo(firstExecutionDelay);
-      firstExecutionTask.run();
+      speculativeExecution1.task().run(speculativeExecution1);
+
       node2Behavior.verifyWrite();
       node2Behavior.setWriteSuccess();
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/util/concurrent/CapturingTimer.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/util/concurrent/CapturingTimer.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.datastax.oss.driver.internal.core.util.concurrent;
+
+import static org.assertj.core.api.Assertions.fail;
+
+import io.netty.util.Timeout;
+import io.netty.util.Timer;
+import io.netty.util.TimerTask;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Implementation of Netty's {@link io.netty.util.Timer Timer} interface to capture scheduled {@link
+ * io.netty.util.Timeout Timeouts} instead of running them, so they can be run manually in tests.
+ */
+public class CapturingTimer implements Timer {
+
+  private final ArrayBlockingQueue<CapturedTimeout> timeoutQueue = new ArrayBlockingQueue<>(16);
+
+  @Override
+  public Timeout newTimeout(TimerTask task, long delay, TimeUnit unit) {
+    // delay and unit are not needed as the Timeout's TimerTask will be run manually
+    CapturedTimeout timeout = new CapturedTimeout(task, this, delay, unit);
+    // add the timeout to the queue
+    timeoutQueue.add(timeout);
+    return timeout;
+  }
+
+  /**
+   * Retrieves the next scheduled Timeout. In tests, this will usually be a request timeout or a
+   * speculative execution. Tests will need be able to predict the ordering as it is not easy to
+   * tell from the returned Timeout itself.
+   */
+  public CapturedTimeout getNextTimeout() {
+    try {
+      return timeoutQueue.poll(100, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException ie) {
+      fail("Unexpected interruption", ie);
+      throw new AssertionError();
+    }
+  }
+
+  @Override
+  public Set<Timeout> stop() {
+    if (timeoutQueue.isEmpty()) {
+      return Collections.emptySet();
+    }
+    Set<Timeout> timeoutsRemaining = new HashSet<>(timeoutQueue.size());
+    for (Timeout t : timeoutQueue) {
+      if (t != null) {
+        t.cancel();
+        timeoutsRemaining.add(t);
+      }
+    }
+    return timeoutsRemaining;
+  }
+
+  /**
+   * Implementation of Netty's {@link io.netty.util.Timeout Timeout} interface. It is just a simple
+   * class that keeps track of the {@link io.netty.util.TimerTask TimerTask} and the {@link
+   * io.netty.util.Timer Timer} implementation that should only be used in tests. The intended use
+   * is to call the {@link io.netty.util.TimerTask#run(io.netty.util.Timeout) run()} method on the
+   * TimerTask when you want to execute the task (so you don't have to depend on a real timer).
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * // get the next timeout from the timer
+   * Timeout t = timer.getNextTimeout();
+   * // run the TimerTask associated with the timeout
+   * t.task.run(t);
+   * }</pre>
+   */
+  public static class CapturedTimeout implements Timeout {
+
+    private final TimerTask task;
+    private final CapturingTimer timer;
+    private final long delay;
+    private final TimeUnit unit;
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+    private CapturedTimeout(TimerTask task, CapturingTimer timer, long delay, TimeUnit unit) {
+      this.task = task;
+      this.timer = timer;
+      this.delay = delay;
+      this.unit = unit;
+    }
+
+    @Override
+    public Timer timer() {
+      return timer;
+    }
+
+    @Override
+    public TimerTask task() {
+      return task;
+    }
+
+    public long getDelay(TimeUnit targetUnit) {
+      return targetUnit.convert(delay, unit);
+    }
+
+    @Override
+    public boolean isExpired() {
+      return false;
+    }
+
+    @Override
+    public boolean isCancelled() {
+      return cancelled.get();
+    }
+
+    @Override
+    public boolean cancel() {
+      return cancelled.compareAndSet(false, true);
+    }
+  }
+}


### PR DESCRIPTION
Motivation:

Scheduling request timeouts and speculative executions on the
main I/O event loop seems to lower overall I/O throughput under
load. Moving those events off of the main I/O event loop will
allow the driver to achieve higher overall throughput.

Modifications:

Add a Netty HashedWheelTimer to the NettyOptions and use that
Timer for scheduling request timeouts and speculative executions.
Also, add configuration parameters for controlling the Timer
tick duration (resolution) and wheel size.

Result:

In Cassandra stress tests, offloading the timeouts and speculative
executions onto a separate timer yields about a 10% increase in
I/O throughput.