### PR TITLE
Bump dropwizard-metrics

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -50,6 +50,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jmx</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/driver-core/src/main/java/com/datastax/driver/core/Metrics.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Metrics.java
@@ -17,10 +17,10 @@ package com.datastax.driver.core;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
-import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.codahale.metrics.jmx.JmxReporter;
 import com.datastax.driver.core.policies.SpeculativeExecutionPolicy;
 import java.util.HashSet;
 import java.util.Set;

--- a/driver-tests/osgi/pom.xml
+++ b/driver-tests/osgi/pom.xml
@@ -67,6 +67,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jmx</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <guava.version>19.0</guava.version>
         <netty.version>4.0.56.Final</netty.version>
         <netty-tcnative.version>2.0.7.Final</netty-tcnative.version>
-        <metrics.version>3.2.2</metrics.version>
+        <metrics.version>4.0.2</metrics.version>
         <snappy.version>1.1.2.6</snappy.version>
         <lz4.version>1.4.1</lz4.version>
         <hdr.version>2.1.10</hdr.version>
@@ -140,6 +140,12 @@
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-jmx</artifactId>
                 <version>${metrics.version}</version>
             </dependency>
 


### PR DESCRIPTION
The cassandra driver uses dropwizard metrics. The dropwizard-metrics modules have been updated since a long time, and is now causing conflicts where this driver is used in combination with the dropwizard framework.. 
The conflict lies in a change made in dropwizard-metrics, causing `JmxReporter` to be moved to it's own maven module. It's package name also got updated.

Hopefully this shouldn't be a breaking change for anyone.
