### PR TITLE
JAVA-2037: Prepared statements without bound variables should not throw NPE

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-beta3 (in progress)
 
+- [bug] JAVA-2037: Fix NPE when preparing statement with no bound variables
 - [improvement] JAVA-2014: Schedule timeouts on a separate Timer
 - [bug] JAVA-2029: Handle schema refresh failure after a DDL query
 - [bug] JAVA-1947: Make schema parsing more lenient and allow missing system_virtual_schema

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
@@ -362,7 +362,7 @@ public class Conversions {
         ByteBuffer.wrap(response.preparedQueryId).asReadOnlyBuffer(),
         request.getQuery(),
         toColumnDefinitions(response.variablesMetadata, context),
-        Ints.asList(response.variablesMetadata.pkIndices),
+        asList(response.variablesMetadata.pkIndices),
         (response.resultMetadataId == null)
             ? null
             : ByteBuffer.wrap(response.resultMetadataId).asReadOnlyBuffer(),
@@ -394,6 +394,14 @@ public class Conversions {
       values[i++] = new DefaultColumnDefinition(columnSpec, context);
     }
     return DefaultColumnDefinitions.valueOf(ImmutableList.copyOf(values));
+  }
+
+  public static List<Integer> asList(int[] pkIndices) {
+    if (pkIndices == null || pkIndices.length == 0) {
+      return Collections.emptyList();
+    } else {
+      return Ints.asList(pkIndices);
+    }
   }
 
   public static CoordinatorException toThrowable(


### PR DESCRIPTION
Our internal CI builds are failing due to this.