### PR TITLE
Make Statement.ASYNC and PrepareRequest.ASYNC of type CompletionStage<? extends X>

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/PrepareRequest.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/PrepareRequest.java
@@ -61,8 +61,8 @@ public interface PrepareRequest extends Request {
    * of the driver's built-in helper methods (such as {@link
    * CqlSession#prepareAsync(SimpleStatement)}.
    */
-  GenericType<CompletionStage<PreparedStatement>> ASYNC =
-      new GenericType<CompletionStage<PreparedStatement>>() {};
+  GenericType<CompletionStage<? extends PreparedStatement>> ASYNC =
+      new GenericType<CompletionStage<? extends PreparedStatement>>() {};
 
   /** The CQL query to prepare. */
   @NonNull

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/Statement.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/Statement.java
@@ -63,8 +63,8 @@ public interface Statement<SelfT extends Statement<SelfT>> extends Request {
    * Session#execute(Request, GenericType)}), but CQL statements will generally be run with one of
    * the driver's built-in helper methods (such as {@link CqlSession#executeAsync(Statement)}).
    */
-  GenericType<CompletionStage<AsyncResultSet>> ASYNC =
-      new GenericType<CompletionStage<AsyncResultSet>>() {};
+  GenericType<CompletionStage<? extends AsyncResultSet>> ASYNC =
+      new GenericType<CompletionStage<? extends AsyncResultSet>>() {};
 
   /**
    * Sets the name of the execution profile that will be used for this statement.

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareAsyncHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareAsyncHandler.java
@@ -28,7 +28,7 @@ import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
 public class CqlPrepareAsyncHandler extends CqlPrepareHandlerBase
-    implements RequestHandler<PrepareRequest, CompletionStage<PreparedStatement>> {
+    implements RequestHandler<PrepareRequest, CompletionStage<? extends PreparedStatement>> {
 
   CqlPrepareAsyncHandler(
       PrepareRequest request,
@@ -40,7 +40,7 @@ public class CqlPrepareAsyncHandler extends CqlPrepareHandlerBase
   }
 
   @Override
-  public CompletableFuture<PreparedStatement> handle() {
+  public CompletableFuture<? extends PreparedStatement> handle() {
     return result;
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareAsyncProcessor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareAsyncProcessor.java
@@ -30,7 +30,7 @@ import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
 public class CqlPrepareAsyncProcessor
-    implements RequestProcessor<PrepareRequest, CompletionStage<PreparedStatement>> {
+    implements RequestProcessor<PrepareRequest, CompletionStage<? extends PreparedStatement>> {
 
   private final ConcurrentMap<ByteBuffer, DefaultPreparedStatement> preparedStatementsCache;
 
@@ -45,7 +45,7 @@ public class CqlPrepareAsyncProcessor
   }
 
   @Override
-  public RequestHandler<PrepareRequest, CompletionStage<PreparedStatement>> newHandler(
+  public RequestHandler<PrepareRequest, CompletionStage<? extends PreparedStatement>> newHandler(
       PrepareRequest request,
       DefaultSession session,
       InternalDriverContext context,

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestAsyncHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestAsyncHandler.java
@@ -25,7 +25,7 @@ import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
 public class CqlRequestAsyncHandler extends CqlRequestHandlerBase
-    implements RequestHandler<Statement<?>, CompletionStage<AsyncResultSet>> {
+    implements RequestHandler<Statement<?>, CompletionStage<? extends AsyncResultSet>> {
 
   CqlRequestAsyncHandler(
       Statement<?> statement,
@@ -36,7 +36,7 @@ public class CqlRequestAsyncHandler extends CqlRequestHandlerBase
   }
 
   @Override
-  public CompletionStage<AsyncResultSet> handle() {
+  public CompletionStage<? extends AsyncResultSet> handle() {
     return result;
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestAsyncProcessor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestAsyncProcessor.java
@@ -28,7 +28,7 @@ import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
 public class CqlRequestAsyncProcessor
-    implements RequestProcessor<Statement<?>, CompletionStage<AsyncResultSet>> {
+    implements RequestProcessor<Statement<?>, CompletionStage<? extends AsyncResultSet>> {
 
   @Override
   public boolean canProcess(Request request, GenericType<?> resultType) {
@@ -36,7 +36,7 @@ public class CqlRequestAsyncProcessor
   }
 
   @Override
-  public RequestHandler<Statement<?>, CompletionStage<AsyncResultSet>> newHandler(
+  public RequestHandler<Statement<?>, CompletionStage<? extends AsyncResultSet>> newHandler(
       Statement<?> request,
       DefaultSession session,
       InternalDriverContext context,

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandlerTest.java
@@ -66,7 +66,7 @@ public class CqlPrepareHandlerTest {
   @Mock private Node node2;
   @Mock private Node node3;
 
-  private ConcurrentMap<ByteBuffer, DefaultPreparedStatement> preparedStatementsCache =
+  private final ConcurrentMap<ByteBuffer, DefaultPreparedStatement> preparedStatementsCache =
       new ConcurrentHashMap<>();
   private final Map<String, ByteBuffer> payload =
       ImmutableMap.of("key1", ByteBuffer.wrap(new byte[] {1, 2, 3, 4}));
@@ -88,7 +88,7 @@ public class CqlPrepareHandlerTest {
 
     try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
 
-      CompletionStage<PreparedStatement> prepareFuture =
+      CompletionStage<? extends PreparedStatement> prepareFuture =
           new CqlPrepareAsyncHandler(
                   PREPARE_REQUEST,
                   preparedStatementsCache,
@@ -129,7 +129,7 @@ public class CqlPrepareHandlerTest {
       DriverExecutionProfile config = harness.getContext().getConfig().getDefaultProfile();
       Mockito.when(config.getBoolean(DefaultDriverOption.PREPARE_ON_ALL_NODES)).thenReturn(false);
 
-      CompletionStage<PreparedStatement> prepareFuture =
+      CompletionStage<? extends PreparedStatement> prepareFuture =
           new CqlPrepareAsyncHandler(
                   PREPARE_REQUEST,
                   preparedStatementsCache,
@@ -164,7 +164,7 @@ public class CqlPrepareHandlerTest {
 
     try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
 
-      CompletionStage<PreparedStatement> prepareFuture =
+      CompletionStage<? extends PreparedStatement> prepareFuture =
           new CqlPrepareAsyncHandler(
                   PREPARE_REQUEST,
                   preparedStatementsCache,
@@ -198,7 +198,7 @@ public class CqlPrepareHandlerTest {
 
     try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
 
-      CompletionStage<PreparedStatement> prepareFuture =
+      CompletionStage<? extends PreparedStatement> prepareFuture =
           new CqlPrepareAsyncHandler(
                   PREPARE_REQUEST,
                   preparedStatementsCache,
@@ -242,7 +242,7 @@ public class CqlPrepareHandlerTest {
                   .onErrorResponse(eq(PREPARE_REQUEST), any(OverloadedException.class), eq(0)))
           .thenReturn(RetryDecision.RETRY_NEXT);
 
-      CompletionStage<PreparedStatement> prepareFuture =
+      CompletionStage<? extends PreparedStatement> prepareFuture =
           new CqlPrepareAsyncHandler(
                   PREPARE_REQUEST,
                   preparedStatementsCache,
@@ -281,7 +281,7 @@ public class CqlPrepareHandlerTest {
                   .onErrorResponse(eq(PREPARE_REQUEST), any(OverloadedException.class), eq(0)))
           .thenReturn(RetryDecision.RETHROW);
 
-      CompletionStage<PreparedStatement> prepareFuture =
+      CompletionStage<? extends PreparedStatement> prepareFuture =
           new CqlPrepareAsyncHandler(
                   PREPARE_REQUEST,
                   preparedStatementsCache,
@@ -321,7 +321,7 @@ public class CqlPrepareHandlerTest {
                   eq(PREPARE_REQUEST), any(OverloadedException.class), eq(0)))
           .thenReturn(RetryDecision.IGNORE);
 
-      CompletionStage<PreparedStatement> prepareFuture =
+      CompletionStage<? extends PreparedStatement> prepareFuture =
           new CqlPrepareAsyncHandler(
                   PREPARE_REQUEST,
                   preparedStatementsCache,
@@ -358,7 +358,7 @@ public class CqlPrepareHandlerTest {
     try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
       DriverExecutionProfile config = harness.getContext().getConfig().getDefaultProfile();
       Mockito.when(config.getBoolean(DefaultDriverOption.PREPARE_ON_ALL_NODES)).thenReturn(false);
-      CompletionStage<PreparedStatement> prepareFuture =
+      CompletionStage<? extends PreparedStatement> prepareFuture =
           new CqlPrepareAsyncHandler(
                   prepareRequest,
                   preparedStatementsCache,
@@ -389,7 +389,7 @@ public class CqlPrepareHandlerTest {
     try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
       DriverExecutionProfile config = harness.getContext().getConfig().getDefaultProfile();
       Mockito.when(config.getBoolean(DefaultDriverOption.PREPARE_ON_ALL_NODES)).thenReturn(true);
-      CompletionStage<PreparedStatement> prepareFuture =
+      CompletionStage<? extends PreparedStatement> prepareFuture =
           new CqlPrepareAsyncHandler(
                   prepareRequest,
                   preparedStatementsCache,

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerRetryTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerRetryTest.java
@@ -71,7 +71,7 @@ public class CqlRequestHandlerRetryTest extends CqlRequestHandlerTestBase {
             .withResponse(node2, defaultFrameOf(singleRow()))
             .build()) {
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
 
@@ -111,7 +111,7 @@ public class CqlRequestHandlerRetryTest extends CqlRequestHandlerTestBase {
                 defaultFrameOf(new Error(ProtocolConstants.ErrorCode.INVALID, "mock message")))
             .build()) {
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
 
@@ -152,7 +152,7 @@ public class CqlRequestHandlerRetryTest extends CqlRequestHandlerTestBase {
       failureScenario.mockRetryPolicyDecision(
           harness.getContext().getRetryPolicy(anyString()), RetryDecision.RETRY_NEXT);
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
 
@@ -203,7 +203,7 @@ public class CqlRequestHandlerRetryTest extends CqlRequestHandlerTestBase {
       failureScenario.mockRetryPolicyDecision(
           harness.getContext().getRetryPolicy(anyString()), RetryDecision.RETRY_SAME);
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
 
@@ -253,7 +253,7 @@ public class CqlRequestHandlerRetryTest extends CqlRequestHandlerTestBase {
       failureScenario.mockRetryPolicyDecision(
           harness.getContext().getRetryPolicy(anyString()), RetryDecision.IGNORE);
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
 
@@ -302,7 +302,7 @@ public class CqlRequestHandlerRetryTest extends CqlRequestHandlerTestBase {
       failureScenario.mockRetryPolicyDecision(
           harness.getContext().getRetryPolicy(anyString()), RetryDecision.RETHROW);
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
 
@@ -350,7 +350,7 @@ public class CqlRequestHandlerRetryTest extends CqlRequestHandlerTestBase {
             harness.getContext().getRetryPolicy(anyString()), RetryDecision.RETHROW);
       }
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerSpeculativeExecutionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerSpeculativeExecutionTest.java
@@ -153,7 +153,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
 
       CqlRequestAsyncHandler requestHandler =
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test");
-      CompletionStage<AsyncResultSet> resultSetFuture = requestHandler.handle();
+      CompletionStage<? extends AsyncResultSet> resultSetFuture = requestHandler.handle();
       node1Behavior.verifyWrite();
       node1Behavior.setWriteSuccess();
 
@@ -209,7 +209,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
                   any(Node.class), eq(null), eq(statement), eq(1)))
           .thenReturn(firstExecutionDelay);
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
 
@@ -240,7 +240,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
                   any(Node.class), eq(null), eq(statement), eq(1)))
           .thenReturn(firstExecutionDelay);
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
       node1Behavior.verifyWrite();
@@ -293,7 +293,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
                   any(Node.class), eq(null), eq(statement), eq(1)))
           .thenReturn(firstExecutionDelay);
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
       node1Behavior.verifyWrite();
@@ -349,7 +349,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
                   any(Node.class), eq(null), eq(statement), eq(1)))
           .thenReturn(firstExecutionDelay);
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
       node1Behavior.verifyWrite();
@@ -398,7 +398,7 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
               speculativeExecutionPolicy.nextExecution(
                   any(Node.class), eq(null), eq(statement), eq(1)))
           .thenReturn(firstExecutionDelay);
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(statement, harness.getSession(), harness.getContext(), "test")
               .handle();
       node1Behavior.verifyWrite();

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTest.java
@@ -55,7 +55,7 @@ public class CqlRequestHandlerTest extends CqlRequestHandlerTestBase {
             .withResponse(node1, defaultFrameOf(singleRow()))
             .build()) {
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(
                   UNDEFINED_IDEMPOTENCE_STATEMENT,
                   harness.getSession(),
@@ -89,7 +89,7 @@ public class CqlRequestHandlerTest extends CqlRequestHandlerTestBase {
             // Mock no responses => this will produce an empty query plan
             .build()) {
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(
                   UNDEFINED_IDEMPOTENCE_STATEMENT,
                   harness.getSession(),
@@ -110,7 +110,7 @@ public class CqlRequestHandlerTest extends CqlRequestHandlerTestBase {
 
     try (RequestHandlerTestHarness harness = harnessBuilder.build()) {
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(
                   UNDEFINED_IDEMPOTENCE_STATEMENT,
                   harness.getSession(),
@@ -142,7 +142,7 @@ public class CqlRequestHandlerTest extends CqlRequestHandlerTestBase {
             .withResponse(node1, defaultFrameOf(new SetKeyspace("newKeyspace")))
             .build()) {
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(
                   UNDEFINED_IDEMPOTENCE_STATEMENT,
                   harness.getSession(),
@@ -185,7 +185,7 @@ public class CqlRequestHandlerTest extends CqlRequestHandlerTestBase {
           mockId, new RepreparePayload(mockId, "mock query", null, Collections.emptyMap()));
       Mockito.when(harness.getSession().getRepreparePayloads()).thenReturn(repreparePayloads);
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(
                   boundStatement, harness.getSession(), harness.getContext(), "test")
               .handle();

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTrackerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTrackerTest.java
@@ -49,7 +49,7 @@ public class CqlRequestHandlerTrackerTest extends CqlRequestHandlerTestBase {
       RequestTracker requestTracker = Mockito.mock(RequestTracker.class);
       Mockito.when(harness.getContext().getRequestTracker()).thenReturn(requestTracker);
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(
                   UNDEFINED_IDEMPOTENCE_STATEMENT,
                   harness.getSession(),
@@ -99,7 +99,7 @@ public class CqlRequestHandlerTrackerTest extends CqlRequestHandlerTestBase {
       RequestTracker requestTracker = spy(new NoopRequestTracker(harness.getContext()));
       Mockito.when(harness.getContext().getRequestTracker()).thenReturn(requestTracker);
 
-      CompletionStage<AsyncResultSet> resultSetFuture =
+      CompletionStage<? extends AsyncResultSet> resultSetFuture =
           new CqlRequestAsyncHandler(
                   UNDEFINED_IDEMPOTENCE_STATEMENT,
                   harness.getSession(),

--- a/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/GuavaRequestAsyncProcessor.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/GuavaRequestAsyncProcessor.java
@@ -33,16 +33,16 @@ import java.util.concurrent.CompletionStage;
  * @param <U> The type of responses enclosed in the future response.
  */
 public class GuavaRequestAsyncProcessor<T extends Request, U>
-    implements RequestProcessor<T, ListenableFuture<U>> {
+    implements RequestProcessor<T, ListenableFuture<? extends U>> {
 
-  private final RequestProcessor<T, CompletionStage<U>> subProcessor;
+  private final RequestProcessor<T, CompletionStage<? extends U>> subProcessor;
 
   private final GenericType resultType;
 
   private final Class<?> requestClass;
 
   GuavaRequestAsyncProcessor(
-      RequestProcessor<T, CompletionStage<U>> subProcessor,
+      RequestProcessor<T, CompletionStage<? extends U>> subProcessor,
       Class<?> requestClass,
       GenericType resultType) {
     this.subProcessor = subProcessor;
@@ -56,22 +56,22 @@ public class GuavaRequestAsyncProcessor<T extends Request, U>
   }
 
   @Override
-  public RequestHandler<T, ListenableFuture<U>> newHandler(
+  public RequestHandler<T, ListenableFuture<? extends U>> newHandler(
       T request, DefaultSession session, InternalDriverContext context, String sessionLogPrefix) {
     return new GuavaRequestHandler(
         subProcessor.newHandler(request, session, context, sessionLogPrefix));
   }
 
-  class GuavaRequestHandler implements RequestHandler<T, ListenableFuture<U>> {
+  class GuavaRequestHandler implements RequestHandler<T, ListenableFuture<? extends U>> {
 
-    private final RequestHandler<T, CompletionStage<U>> subHandler;
+    private final RequestHandler<T, CompletionStage<? extends U>> subHandler;
 
-    GuavaRequestHandler(RequestHandler<T, CompletionStage<U>> subHandler) {
+    GuavaRequestHandler(RequestHandler<T, CompletionStage<? extends U>> subHandler) {
       this.subHandler = subHandler;
     }
 
     @Override
-    public ListenableFuture<U> handle() {
+    public ListenableFuture<? extends U> handle() {
       // convert CompletionStage to ListenableFuture by adding a whenComplete listener that sets the
       // listenable future's result.
       SettableFuture<U> future = SettableFuture.create();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/KeyRequestProcessor.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/KeyRequestProcessor.java
@@ -59,22 +59,24 @@ public class KeyRequestProcessor implements RequestProcessor<KeyRequest, Integer
     SimpleStatement statement =
         SimpleStatement.newInstance(
             "select v1 from test where k = ? and v0 = ?", RequestProcessorIT.KEY, request.getKey());
-    RequestHandler<Statement<?>, CompletionStage<AsyncResultSet>> subHandler =
+    RequestHandler<Statement<?>, CompletionStage<? extends AsyncResultSet>> subHandler =
         subProcessor.newHandler(statement, session, context, sessionLogPrefix);
     return new KeyRequestHandler(subHandler);
   }
 
   static class KeyRequestHandler implements RequestHandler<KeyRequest, Integer> {
 
-    private final RequestHandler<Statement<?>, CompletionStage<AsyncResultSet>> subHandler;
+    private final RequestHandler<Statement<?>, CompletionStage<? extends AsyncResultSet>>
+        subHandler;
 
-    KeyRequestHandler(RequestHandler<Statement<?>, CompletionStage<AsyncResultSet>> subHandler) {
+    KeyRequestHandler(
+        RequestHandler<Statement<?>, CompletionStage<? extends AsyncResultSet>> subHandler) {
       this.subHandler = subHandler;
     }
 
     @Override
     public Integer handle() {
-      CompletionStage<AsyncResultSet> future = subHandler.handle();
+      CompletionStage<? extends AsyncResultSet> future = subHandler.handle();
       AsyncResultSet result = CompletableFutures.getUninterruptibly(future);
       // If not exactly 1 rows were found, return Integer.MIN_VALUE, otherwise return the value.
       if (result.remaining() != 1) {


### PR DESCRIPTION
Since we already agreed that all `executeAsync` methods return a `CompletionStage<? extends ResultT>`, it makes sense to also have `Statement.ASYNC` be of type `CompletionStage<? extends AsyncResultSet>` and `PrepareRequest.ASYNC` of type `CompletionStage<? extends PreparedStatement>`