### PR TITLE
JAVA-1943: Fail fast in execute() when the session is closed

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-beta3 (in progress)
 
+- [improvement] JAVA-1943: Fail fast in execute() when the session is closed
 - [improvement] JAVA-2056: Reduce HashedWheelTimer tick duration
 - [bug] JAVA-2057: Do not create pool when SUGGEST\_UP topology event received
 - [improvement] JAVA-2049: Add shorthand method to SessionBuilder to specify local DC

--- a/core/src/main/java/com/datastax/oss/driver/api/core/AsyncAutoCloseable.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/AsyncAutoCloseable.java
@@ -36,6 +36,15 @@ public interface AsyncAutoCloseable extends AutoCloseable {
   CompletionStage<Void> closeFuture();
 
   /**
+   * Whether shutdown has completed.
+   *
+   * <p>This is a shortcut for {@code closeFuture().toCompletableFuture().isDone()}.
+   */
+  default boolean isClosed() {
+    return closeFuture().toCompletableFuture().isDone();
+  }
+
+  /**
    * Initiates an orderly shutdown: no new requests are accepted, but all pending requests are
    * allowed to complete normally.
    *

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultNettyOptions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultNettyOptions.java
@@ -132,8 +132,7 @@ public class DefaultNettyOptions implements NettyOptions {
             ioShutdownQuietPeriod, ioShutdownTimeout, ioShutdownUnit));
     DefaultPromise<Void> closeFuture = new DefaultPromise<>(GlobalEventExecutor.INSTANCE);
     combiner.finish(closeFuture);
-    // stop the timer as well
-    timer.stop();
+    closeFuture.addListener(f -> timer.stop());
     return closeFuture;
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareAsyncProcessor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareAsyncProcessor.java
@@ -23,6 +23,7 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.session.DefaultSession;
 import com.datastax.oss.driver.internal.core.session.RequestHandler;
 import com.datastax.oss.driver.internal.core.session.RequestProcessor;
+import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentMap;
@@ -52,5 +53,10 @@ public class CqlPrepareAsyncProcessor
       String sessionLogPrefix) {
     return new CqlPrepareAsyncHandler(
         request, preparedStatementsCache, session, context, sessionLogPrefix);
+  }
+
+  @Override
+  public CompletionStage<PreparedStatement> newFailure(RuntimeException error) {
+    return CompletableFutures.failedFuture(error);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareSyncProcessor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareSyncProcessor.java
@@ -52,4 +52,9 @@ public class CqlPrepareSyncProcessor
     return new CqlPrepareSyncHandler(
         request, preparedStatementsCache, session, context, sessionLogPrefix);
   }
+
+  @Override
+  public PreparedStatement newFailure(RuntimeException error) {
+    throw error;
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestAsyncProcessor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestAsyncProcessor.java
@@ -23,6 +23,7 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.session.DefaultSession;
 import com.datastax.oss.driver.internal.core.session.RequestHandler;
 import com.datastax.oss.driver.internal.core.session.RequestProcessor;
+import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import java.util.concurrent.CompletionStage;
 import net.jcip.annotations.ThreadSafe;
 
@@ -42,5 +43,10 @@ public class CqlRequestAsyncProcessor
       InternalDriverContext context,
       String sessionLogPrefix) {
     return new CqlRequestAsyncHandler(request, session, context, sessionLogPrefix);
+  }
+
+  @Override
+  public CompletionStage<AsyncResultSet> newFailure(RuntimeException error) {
+    return CompletableFutures.failedFuture(error);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerBase.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerBase.java
@@ -212,16 +212,25 @@ public abstract class CqlRequestHandlerBase implements Throttled {
 
   private Timeout scheduleTimeout(Duration timeoutDuration) {
     if (timeoutDuration.toNanos() > 0) {
-      return this.timer.newTimeout(
-          (Timeout timeout1) -> {
-            setFinalError(
-                new DriverTimeoutException("Query timed out after " + timeoutDuration), null, -1);
-          },
-          timeoutDuration.toNanos(),
-          TimeUnit.NANOSECONDS);
-    } else {
-      return null;
+      try {
+        return this.timer.newTimeout(
+            (Timeout timeout1) ->
+                setFinalError(
+                    new DriverTimeoutException("Query timed out after " + timeoutDuration),
+                    null,
+                    -1),
+            timeoutDuration.toNanos(),
+            TimeUnit.NANOSECONDS);
+      } catch (IllegalStateException e) {
+        // If we raced with session shutdown the timer might be closed already, rethrow with a more
+        // explicit message
+        result.completeExceptionally(
+            ("cannot be started once stopped".equals(e.getMessage()))
+                ? new IllegalStateException("Session is closed")
+                : e);
+      }
     }
+    return null;
   }
 
   /**
@@ -479,36 +488,10 @@ public abstract class CqlRequestHandlerBase implements Throttled {
           inFlightCallbacks.add(this);
           if (scheduleNextExecution && isIdempotent) {
             int nextExecution = execution + 1;
-            // Note that `node` is the first node of the execution, it might not be the "slow" one
-            // if there were retries, but in practice retries are rare.
             long nextDelay =
                 speculativeExecutionPolicy.nextExecution(node, keyspace, statement, nextExecution);
             if (nextDelay >= 0) {
-              LOG.trace(
-                  "[{}] Scheduling speculative execution {} in {} ms",
-                  logPrefix,
-                  nextExecution,
-                  nextDelay);
-              scheduledExecutions.add(
-                  timer.newTimeout(
-                      (Timeout timeout1) -> {
-                        if (!result.isDone()) {
-                          LOG.trace(
-                              "[{}] Starting speculative execution {}",
-                              CqlRequestHandlerBase.this.logPrefix,
-                              nextExecution);
-                          activeExecutionsCount.incrementAndGet();
-                          startedSpeculativeExecutionsCount.incrementAndGet();
-                          ((DefaultNode) node)
-                              .getMetricUpdater()
-                              .incrementCounter(
-                                  DefaultNodeMetric.SPECULATIVE_EXECUTIONS,
-                                  executionProfile.getName());
-                          sendRequest(null, queryPlan, nextExecution, 0, true);
-                        }
-                      },
-                      nextDelay,
-                      TimeUnit.MILLISECONDS));
+              scheduleSpeculativeExecution(nextExecution, nextDelay);
             } else {
               LOG.trace(
                   "[{}] Speculative execution policy returned {}, no next execution",
@@ -516,6 +499,41 @@ public abstract class CqlRequestHandlerBase implements Throttled {
                   nextDelay);
             }
           }
+        }
+      }
+    }
+
+    private void scheduleSpeculativeExecution(int index, long delay) {
+      LOG.trace("[{}] Scheduling speculative execution {} in {} ms", logPrefix, index, delay);
+      try {
+        scheduledExecutions.add(
+            timer.newTimeout(
+                (Timeout timeout1) -> {
+                  if (!result.isDone()) {
+                    LOG.trace(
+                        "[{}] Starting speculative execution {}",
+                        CqlRequestHandlerBase.this.logPrefix,
+                        index);
+                    activeExecutionsCount.incrementAndGet();
+                    startedSpeculativeExecutionsCount.incrementAndGet();
+                    // Note that `node` is the first node of the execution, it might not be the
+                    // "slow"
+                    // one if there were retries, but in practice retries are rare.
+                    ((DefaultNode) node)
+                        .getMetricUpdater()
+                        .incrementCounter(
+                            DefaultNodeMetric.SPECULATIVE_EXECUTIONS, executionProfile.getName());
+                    sendRequest(null, queryPlan, index, 0, true);
+                  }
+                },
+                delay,
+                TimeUnit.MILLISECONDS));
+      } catch (IllegalStateException e) {
+        // If we're racing with session shutdown, the timer might be stopped already. We don't want
+        // to schedule more executions anyway, so swallow the error.
+        if (!"cannot be started once stopped".equals(e.getMessage())) {
+          Loggers.warnWithException(
+              LOG, "[{}] Error while scheduling speculative execution", logPrefix, e);
         }
       }
     }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestSyncProcessor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestSyncProcessor.java
@@ -41,4 +41,9 @@ public class CqlRequestSyncProcessor implements RequestProcessor<Statement<?>, R
       String sessionLogPrefix) {
     return new CqlRequestSyncHandler(request, session, context, sessionLogPrefix);
   }
+
+  @Override
+  public ResultSet newFailure(RuntimeException error) {
+    throw error;
+  }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
@@ -199,10 +199,11 @@ public class DefaultSession implements CqlSession {
   @Override
   public <RequestT extends Request, ResultT> ResultT execute(
       @NonNull RequestT request, @NonNull GenericType<ResultT> resultType) {
-    return processorRegistry
-        .processorFor(request, resultType)
-        .newHandler(request, this, context, logPrefix)
-        .handle();
+    RequestProcessor<RequestT, ResultT> processor =
+        processorRegistry.processorFor(request, resultType);
+    return isClosed()
+        ? processor.newFailure(new IllegalStateException("Session is closed"))
+        : processor.newHandler(request, this, context, logPrefix).handle();
   }
 
   @Nullable

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/RequestProcessor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/RequestProcessor.java
@@ -46,4 +46,7 @@ public interface RequestProcessor<RequestT extends Request, ResultT> {
       DefaultSession session,
       InternalDriverContext context,
       String sessionLogPrefix);
+
+  /** Builds a failed result to directly report the given error. */
+  ResultT newFailure(RuntimeException error);
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/session/ShutdownIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/session/ShutdownIT.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.session;
+
+import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.noRows;
+import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.NoNodeAvailableException;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.connection.ClosedConnectionException;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(ParallelizableTests.class)
+public class ShutdownIT {
+
+  @ClassRule
+  public static SimulacronRule simulacronRule =
+      new SimulacronRule(ClusterSpec.builder().withNodes(1));
+
+  private static final String QUERY_STRING = "select * from foo";
+
+  @Test
+  public void should_fail_requests_when_session_is_closed() throws Exception {
+    // Given
+    // Prime with a bit of delay to increase the chance that a query will be aborted in flight when
+    // we force-close the session
+    simulacronRule
+        .cluster()
+        .prime(when(QUERY_STRING).then(noRows()).delay(20, TimeUnit.MILLISECONDS));
+    CqlSession session = SessionUtils.newSession(simulacronRule);
+
+    // When
+    // Max out the in-flight requests on the connection (from a separate thread pool to get a bit of
+    // contention), then force-close the session abruptly.
+    Set<String> unexpectedErrors = new ConcurrentSkipListSet<>();
+    ExecutorService requestExecutor = Executors.newFixedThreadPool(4);
+    int maxConcurrentRequests =
+        session
+            .getContext()
+            .getConfig()
+            .getDefaultProfile()
+            .getInt(DefaultDriverOption.CONNECTION_MAX_REQUESTS);
+    Semaphore semaphore = new Semaphore(maxConcurrentRequests);
+    CountDownLatch gotSessionClosedError = new CountDownLatch(1);
+    for (int i = 0; i < 4; i++) {
+      requestExecutor.execute(
+          () -> {
+            try {
+              while (!Thread.currentThread().isInterrupted()) {
+                semaphore.acquire();
+                session
+                    .executeAsync(QUERY_STRING)
+                    .whenComplete(
+                        (ignoredResult, error) -> {
+                          semaphore.release();
+                          // Three things can happen:
+                          // - DefaultSession.execute() detects that it's closed and fails the
+                          //   request immediately
+                          // - the request was in flight and gets aborted when its channel is
+                          //   force-closed => ClosedConnectionException
+                          // - the request races with the shutdown: it gets past execute() but by
+                          //   the time it tries to acquire a channel the pool was closed
+                          //   => NoNodeAvailableException
+                          if (error instanceof IllegalStateException
+                              && "Session is closed".equals(error.getMessage())) {
+                            gotSessionClosedError.countDown();
+                          } else if (error != null
+                              && !(error instanceof ClosedConnectionException
+                                  || error instanceof NoNodeAvailableException)) {
+                            unexpectedErrors.add(error.toString());
+                          }
+                        });
+              }
+            } catch (InterruptedException e) {
+              // return
+            }
+          });
+    }
+    TimeUnit.MILLISECONDS.sleep(100);
+    session.forceCloseAsync();
+    assertThat(gotSessionClosedError.await(1, TimeUnit.SECONDS))
+        .as("Expected to get the 'Session is closed' error shortly after shutting down")
+        .isTrue();
+    requestExecutor.shutdownNow();
+
+    // Then
+    assertThat(unexpectedErrors).isEmpty();
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/GuavaRequestAsyncProcessor.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/GuavaRequestAsyncProcessor.java
@@ -21,6 +21,7 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.session.DefaultSession;
 import com.datastax.oss.driver.internal.core.session.RequestHandler;
 import com.datastax.oss.driver.internal.core.session.RequestProcessor;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import java.util.concurrent.CompletionStage;
@@ -87,5 +88,10 @@ public class GuavaRequestAsyncProcessor<T extends Request, U>
               });
       return future;
     }
+  }
+
+  @Override
+  public ListenableFuture<U> newFailure(RuntimeException error) {
+    return Futures.immediateFailedFuture(error);
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/KeyRequestProcessor.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/KeyRequestProcessor.java
@@ -84,4 +84,9 @@ public class KeyRequestProcessor implements RequestProcessor<KeyRequest, Integer
       }
     }
   }
+
+  @Override
+  public Integer newFailure(RuntimeException error) {
+    throw error;
+  }
 }


### PR DESCRIPTION
As mentioned on the JIRA ticket, this can still race if the session is stopped while another thread is still executing requests. Requests might fail with `NoNodeAvailableException` if they hit closed pools. The point is more to signal obvious errors where the user is trying to use a closed session.

I think making this completely thread-safe would be prohibitive in terms of performance, and is not that useful in practice. In a typical webapp, you would probably not shut down abruptly, but rather redirect all incoming HTTP traffic to another node or a maintenance page first, and then only close the session in a second step.