### PR TITLE
JAVA-2038 Add jitter to delays between reconnection attempts

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-beta3 (in progress)
 
+- [improvement] JAVA-2038: Add jitter to delays between reconnection attempts
 - [improvement] JAVA-2053: Cache results of session.prepare()
 - [improvement] JAVA-2058: Make programmatic config reloading part of the public API
 - [improvement] JAVA-1943: Fail fast in execute() when the session is closed

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/connection/ExponentialReconnectionPolicyTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/connection/ExponentialReconnectionPolicyTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfig;
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.connection.ReconnectionPolicy;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+public class ExponentialReconnectionPolicyTest {
+
+  @Mock private DriverContext driverContext;
+  @Mock private DriverConfig driverConfig;
+  @Mock private DriverExecutionProfile profile;
+  private final long baseDelay = 1000L;
+  private final long maxDelay = 60000L;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    Mockito.when(driverConfig.getDefaultProfile()).thenReturn(profile);
+    Mockito.when(driverContext.getConfig()).thenReturn(driverConfig);
+    Mockito.when(profile.getDuration(DefaultDriverOption.RECONNECTION_BASE_DELAY))
+        .thenReturn(Duration.of(baseDelay, ChronoUnit.MILLIS));
+    Mockito.when(profile.getDuration(DefaultDriverOption.RECONNECTION_MAX_DELAY))
+        .thenReturn(Duration.of(maxDelay, ChronoUnit.MILLIS));
+  }
+
+  @Test
+  public void should_generate_exponential_delay_with_jitter() throws Exception {
+    ExponentialReconnectionPolicy policy = new ExponentialReconnectionPolicy(driverContext);
+    ReconnectionPolicy.ReconnectionSchedule schedule = policy.newControlConnectionSchedule();
+    // generate a number of delays and make sure they are all within the base/max values range
+    for (int i = 0; i < 128; ++i) {
+      // compute the min and max delays based on attempt count (i)
+      long exponentialDelay = Math.min(baseDelay * (1L << i), maxDelay);
+      // min will be 85% of the pure exponential delay (with a floor of baseDelay)
+      long minJitterDelay = Math.min(baseDelay, (exponentialDelay * 85) / 100);
+      // max will be 115% of the pure exponential delay (with a ceiling of maxDelay)
+      long maxJitterDelay = Math.max(maxDelay, (exponentialDelay * 115) / 100);
+      long delay = schedule.nextDelay().toMillis();
+      assertThat(delay).isBetween(minJitterDelay, maxJitterDelay);
+    }
+  }
+}


### PR DESCRIPTION
Add random jitter to the reconnect delays for cases when there are multiple clients trying to reconnect at the same time. The implementation adds between -15% to 15% jitter to the pure exponential back-off.