### PR TITLE
JAVA-2070: Call onRemove instead of onDown when rack and/or DC information changes for a host

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ControlConnection.java
@@ -671,7 +671,7 @@ class ControlConnection implements Connection.Owner {
     // policy.
     // For that, we remove and re-add the node against the policy. Not the most elegant, and assumes
     // that the policy will update correctly, but in practice this should work.
-    if (!isInitialConnection) cluster.loadBalancingPolicy().onDown(host);
+    if (!isInitialConnection) cluster.loadBalancingPolicy().onRemove(host);
     host.setLocationInfo(datacenter, rack);
     if (!isInitialConnection) cluster.loadBalancingPolicy().onAdd(host);
   }


### PR DESCRIPTION
LoadBalancingPolicy.java defines a pair of consistent methods onAdd/onRemove and onUp/onDown. I guess a ControlConnection.java is broke this contract.