### PR TITLE
JAVA-2057: Do not create pool when SUGGEST_UP topology event received

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,7 +4,7 @@
 
 ### 4.0.0-beta3 (in progress)
 
-- [bug] JAVA-2057: Ignore SUGGEST\_UP TopologyEvent if pool is pending
+- [bug] JAVA-2057: Do not create pool when SUGGEST\_UP topology event received
 - [improvement] JAVA-2049: Add shorthand method to SessionBuilder to specify local DC
 - [bug] JAVA-2037: Fix NPE when preparing statement with no bound variables
 - [improvement] JAVA-2014: Schedule timeouts on a separate Timer

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-beta3 (in progress)
 
+- [bug] JAVA-2057: Ignore SUGGEST\_UP TopologyEvent if pool is pending
 - [improvement] JAVA-2049: Add shorthand method to SessionBuilder to specify local DC
 - [bug] JAVA-2037: Fix NPE when preparing statement with no bound variables
 - [improvement] JAVA-2014: Schedule timeouts on a separate Timer

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/PoolManager.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/PoolManager.java
@@ -338,9 +338,17 @@ public class PoolManager implements AsyncAutoCloseable {
       if (event.type == TopologyEvent.Type.SUGGEST_UP) {
         Node node = context.getMetadataManager().getMetadata().getNodes().get(event.address);
         if (node.getDistance() != NodeDistance.IGNORED) {
-          LOG.debug(
-              "[{}] Received a SUGGEST_UP event for {}, reconnecting pool now", logPrefix, node);
-          createOrReconnectPool(node);
+          if (pending.containsKey(node)) {
+            LOG.debug(
+                "[{}] Received a SUGGEST_UP event for {} while pool was already initializing, "
+                    + "ignoring",
+                logPrefix,
+                node);
+          } else {
+            LOG.debug(
+                "[{}] Received a SUGGEST_UP event for {}, reconnecting pool now", logPrefix, node);
+            createOrReconnectPool(node);
+          }
         }
       }
     }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/PoolManager.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/PoolManager.java
@@ -338,16 +338,11 @@ public class PoolManager implements AsyncAutoCloseable {
       if (event.type == TopologyEvent.Type.SUGGEST_UP) {
         Node node = context.getMetadataManager().getMetadata().getNodes().get(event.address);
         if (node.getDistance() != NodeDistance.IGNORED) {
-          if (pending.containsKey(node)) {
-            LOG.debug(
-                "[{}] Received a SUGGEST_UP event for {} while pool was already initializing, "
-                    + "ignoring",
-                logPrefix,
-                node);
-          } else {
-            LOG.debug(
-                "[{}] Received a SUGGEST_UP event for {}, reconnecting pool now", logPrefix, node);
-            createOrReconnectPool(node);
+          LOG.debug(
+              "[{}] Received a SUGGEST_UP event for {}, reconnecting pool now", logPrefix, node);
+          ChannelPool pool = pools.get(node);
+          if (pool != null) {
+            pool.reconnectNow();
           }
         }
       }


### PR DESCRIPTION
For [JAVA-2057](https://datastax-oss.atlassian.net/browse/JAVA-2057).

This should fix an issue I noticed on our CI servers, were occasionally after forcing a node down I observed that there were still some open connections.   I have CI running repeatedly against #1147, which has this fix, so assuming that continues to run well we should consider merging this.  Lets wait overnight to see how things go.

Old description (see 41dec29 for actual change)

Motivation:

There is a small window where a NEW_NODE event may be sent over the
control connection while a pool is initializing.  This is more likely to
happen in testing, where a cluster is brought up and the driver connects
to it immediately.

In this case, the driver would erroneously create another pool, which
would create additional connections.  The first pool created between
the currently initializing one and the new one being created would be
untracked with its connections remanining open even after the Session is
closed.

Modifications:

Akin to the logic in processDistanceEvent and processStateEvent, only
invoke createOrReconnectPool in onTopologyEvent when there is not an
initializing pool future present in the pending map.

Result:

createOrReconnectPool is no longer invoked in onTopologyEvent if there
is a pending initialization for that node.