### PR TITLE
JAVA-2056: Reduce HashedWheelTimer tick duration

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-beta3 (in progress)
 
+- [improvement] JAVA-2056: Reduce HashedWheelTimer tick duration
 - [bug] JAVA-2057: Do not create pool when SUGGEST\_UP topology event received
 - [improvement] JAVA-2049: Add shorthand method to SessionBuilder to specify local DC
 - [bug] JAVA-2037: Fix NPE when preparing statement with no bound variables

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1385,7 +1385,7 @@ datastax-java-driver {
       # Required: yes
       # Modifiable at runtime: no
       # Overridable in a profile: no
-      tick-duration = 100 milliseconds
+      tick-duration = 1 millisecond
 
       # Number of ticks in a Timer wheel. The underlying implementation uses Netty's
       # HashedWheelTimer, which uses hashes to arrange the timeouts. This effectively controls the
@@ -1394,7 +1394,7 @@ datastax-java-driver {
       # Required: yes
       # Modifiable at runtime: no
       # Overridable in a profile: no
-      ticks-per-wheel = 512
+      ticks-per-wheel = 2048
     }
   }
 


### PR DESCRIPTION
Motivation:
Timeouts and speculative executions are scheduled on the
same HashedWheelTimer, which has a default tick duration
of 100ms. This can be too imprecise for speculative executions.
Lowering the tick duration to 1ms does not affect performance,
but does allow for more precision for scheduling speculative
executions.

Modifications:
Reduce the default timer tick duration to 1ms (from 100ms)
and increase the default wheel size to 2048 (from 512).