### PR TITLE
Test fixes for 4.0.0-beta3

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverConfigValidationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverConfigValidationIT.java
@@ -60,7 +60,7 @@ public class DriverConfigValidationIT {
               assertThat(error).isInstanceOf(DriverExecutionException.class);
               assertThat(error.getCause())
                   .isInstanceOf(IllegalArgumentException.class)
-                  .hasMessage(
+                  .hasMessageContaining(
                       "Can't find class AClassThatDoesNotExist "
                           + "(specified by "
                           + option.getPath()

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverExecutionProfileIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverExecutionProfileIT.java
@@ -78,6 +78,7 @@ public class DriverExecutionProfileIT {
   public void should_use_profile_request_timeout() {
     DriverConfigLoader loader =
         SessionUtils.configLoaderBuilder()
+            .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(2))
             .withProfile(
                 "olap",
                 DefaultDriverConfigLoaderBuilder.profileBuilder()
@@ -89,7 +90,7 @@ public class DriverExecutionProfileIT {
       // configure query with delay of 4 seconds.
       simulacron.cluster().prime(when(query).then(noRows()).delay(4, TimeUnit.SECONDS));
 
-      // Execute query without profile, should timeout with default (2s).
+      // Execute query without profile, should timeout with default session timeout (2s).
       try {
         session.execute(query);
         fail("Should have timed out");

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverExecutionProfileReloadIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverExecutionProfileReloadIT.java
@@ -53,7 +53,9 @@ public class DriverExecutionProfileReloadIT {
         new DefaultDriverConfigLoader(
             () ->
                 ConfigFactory.parseString(
-                        "basic.config-reload-interval = 2s\n" + configSource.get())
+                        "basic.config-reload-interval = 0\n"
+                            + "basic.request.timeout = 2s\n"
+                            + configSource.get())
                     .withFallback(DEFAULT_CONFIG_SUPPLIER.get()));
     try (CqlSession session =
         (CqlSession)
@@ -63,7 +65,7 @@ public class DriverExecutionProfileReloadIT {
                 .build()) {
       simulacron.cluster().prime(when(query).then(noRows()).delay(4, TimeUnit.SECONDS));
 
-      // Expect timeout since default timeout is 2s
+      // Expect timeout since default session timeout is 2s
       try {
         session.execute(query);
         fail("DriverTimeoutException expected");
@@ -88,7 +90,10 @@ public class DriverExecutionProfileReloadIT {
     DefaultDriverConfigLoader loader =
         new DefaultDriverConfigLoader(
             () ->
-                ConfigFactory.parseString("basic.config-reload-interval = 0\n" + configSource.get())
+                ConfigFactory.parseString(
+                        "basic.config-reload-interval = 0\n"
+                            + "basic.request.timeout = 2s\n"
+                            + configSource.get())
                     .withFallback(DEFAULT_CONFIG_SUPPLIER.get()));
     try (CqlSession session =
         (CqlSession)
@@ -98,7 +103,7 @@ public class DriverExecutionProfileReloadIT {
                 .build()) {
       simulacron.cluster().prime(when(query).then(noRows()).delay(4, TimeUnit.SECONDS));
 
-      // Expect timeout since default timeout is 2s
+      // Expect timeout since default session timeout is 2s
       try {
         session.execute(query);
         fail("DriverTimeoutException expected");
@@ -144,7 +149,7 @@ public class DriverExecutionProfileReloadIT {
       }
 
       // Bump up request timeout to 10 seconds on profile and wait for config to reload.
-      configSource.set("profiles.slow.basic.request.timeout = 2s");
+      configSource.set("profiles.slow.basic.request.timeout = 10s");
       waitForConfigChange(session, 3, TimeUnit.SECONDS);
 
       // Execute again, should expect to fail again because doesn't allow to dynamically define

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverExecutionProfileReloadIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/config/DriverExecutionProfileReloadIT.java
@@ -53,7 +53,7 @@ public class DriverExecutionProfileReloadIT {
         new DefaultDriverConfigLoader(
             () ->
                 ConfigFactory.parseString(
-                        "basic.config-reload-interval = 0\n"
+                        "basic.config-reload-interval = 2s\n"
                             + "basic.request.timeout = 2s\n"
                             + configSource.get())
                     .withFallback(DEFAULT_CONFIG_SUPPLIER.get()));

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/loadbalancing/PerProfileLoadBalancingPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/loadbalancing/PerProfileLoadBalancingPolicyIT.java
@@ -31,7 +31,6 @@ import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
 import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoaderBuilder;
-import com.datastax.oss.driver.internal.core.loadbalancing.DefaultLoadBalancingPolicy;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -88,13 +87,10 @@ public class PerProfileLoadBalancingPolicyIT {
         .hasSize(3)
         .containsKeys(DriverExecutionProfile.DEFAULT_NAME, "profile1", "profile2");
 
-    DefaultLoadBalancingPolicy defaultPolicy =
-        (DefaultLoadBalancingPolicy)
-            context.getLoadBalancingPolicy(DriverExecutionProfile.DEFAULT_NAME);
-    DefaultLoadBalancingPolicy policy1 =
-        (DefaultLoadBalancingPolicy) context.getLoadBalancingPolicy("profile1");
-    DefaultLoadBalancingPolicy policy2 =
-        (DefaultLoadBalancingPolicy) context.getLoadBalancingPolicy("profile2");
+    LoadBalancingPolicy defaultPolicy =
+        context.getLoadBalancingPolicy(DriverExecutionProfile.DEFAULT_NAME);
+    LoadBalancingPolicy policy1 = context.getLoadBalancingPolicy("profile1");
+    LoadBalancingPolicy policy2 = context.getLoadBalancingPolicy("profile2");
 
     assertThat(defaultPolicy).isSameAs(policy2).isNotSameAs(policy1);
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/session/ShutdownIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/session/ShutdownIT.java
@@ -105,7 +105,7 @@ public class ShutdownIT {
                             assertThat(anfe.getErrors()).hasSize(1);
                             error = anfe.getErrors().values().iterator().next();
                             if (!(error instanceof IllegalStateException)
-                                && !"Driver channel is closing".equals(error.getMessage())) {
+                                && !error.getMessage().endsWith("is closing")) {
                               unexpectedErrors.add(error.toString());
                             }
                           }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/session/ShutdownIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/session/ShutdownIT.java
@@ -97,7 +97,7 @@ public class ShutdownIT {
                             gotSessionClosedError.countDown();
                           } else if (error instanceof AllNodesFailedException) {
                             AllNodesFailedException anfe = (AllNodesFailedException) error;
-                            // if there were 0 errors, its a NoNodeAvailabeException which is
+                            // if there were 0 errors, its a NoNodeAvailableException which is
                             // acceptable.
                             if (anfe.getErrors().size() > 0) {
                               assertThat(anfe.getErrors()).hasSize(1);


### PR DESCRIPTION
These changes are mostly for testing against DSE using the dse driver, as there were some assumptions that aren't necessarily true upstream.

There is also an ancillary change in`DropwizardSessionMetricUpdater` to use `gauge` instead of `register`.