### PR TITLE
JAVA-2066: Array index range error when fetching routing keys on bound statements

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-beta3 (in progress)
 
+- [bug] JAVA-2066: Array index range error when fetching routing keys on bound statements
 - [documentation] JAVA-2061: Add section to upgrade guide about updated type mappings
 - [improvement] JAVA-2038: Add jitter to delays between reconnection attempts
 - [improvement] JAVA-2053: Cache results of session.prepare()

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
@@ -335,7 +335,8 @@ public class DefaultBoundStatement implements BoundStatement {
         ByteBuffer[] components = new ByteBuffer[indices.size()];
         for(int i = 0; i< components.length; i++){
           ByteBuffer value;
-          if (!isSet(indices.get(i)) || (value = getBytesUnsafe(indices.get(i))) == null) {
+          int index = indices.get(i);
+          if (!isSet(index) || (value = getBytesUnsafe(index)) == null) {
             return null;
           } else {
             components[i] = value;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
@@ -333,12 +333,12 @@ public class DefaultBoundStatement implements BoundStatement {
         return getBytesUnsafe(indices.get(0));
       } else {
         ByteBuffer[] components = new ByteBuffer[indices.size()];
-        for (Integer index : indices) {
+        for(int i = 0; i< components.length; i++){
           ByteBuffer value;
-          if (!isSet(index) || (value = getBytesUnsafe(index)) == null) {
+          if (!isSet(indices.get(i)) || (value = getBytesUnsafe(indices.get(i))) == null) {
             return null;
           } else {
-            components[index] = value;
+            components[i] = value;
           }
         }
         return RoutingKey.compose(components);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
@@ -333,7 +333,7 @@ public class DefaultBoundStatement implements BoundStatement {
         return getBytesUnsafe(indices.get(0));
       } else {
         ByteBuffer[] components = new ByteBuffer[indices.size()];
-        for(int i = 0; i< components.length; i++){
+        for (int i = 0; i < components.length; i++) {
           ByteBuffer value;
           int index = indices.get(i);
           if (!isSet(index) || (value = getBytesUnsafe(index)) == null) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BoundStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BoundStatementIT.java
@@ -75,11 +75,11 @@ public class BoundStatementIT {
   @ClassRule
   public static SimulacronRule simulacron = new SimulacronRule(ClusterSpec.builder().withNodes(1));
 
-  private static final CcmRule ccm = CcmRule.getInstance();
+  private static CcmRule ccm = CcmRule.getInstance();
 
   private static final boolean atLeastV4 = ccm.getHighestProtocolVersion().getCode() >= 4;
 
-  private static final SessionRule<CqlSession> sessionRule =
+  private static SessionRule<CqlSession> sessionRule =
       SessionRule.builder(ccm)
           .withConfigLoader(
               SessionUtils.configLoaderBuilder()


### PR DESCRIPTION
I think this will solve the problem. We need to add some tests specifically of unordered partition keys still