### PR TITLE
fix: Clause implements Serializable to suport using from an Apache Beam pipline

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Clause.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/querybuilder/Clause.java
@@ -17,9 +17,11 @@ package com.datastax.driver.core.querybuilder;
 
 import com.datastax.driver.core.CodecRegistry;
 import com.google.common.collect.Lists;
+
+import java.io.Serializable;
 import java.util.List;
 
-public abstract class Clause extends Utils.Appendeable {
+public abstract class Clause extends Utils.Appendeable implements Serializable {
 
   abstract String name();
 


### PR DESCRIPTION
I'd like to create a BEAM PR for the following:
https://github.com/srfrnk/beam/commit/583c77cb7c04176aeba0e97e17bc0fe0752e401c

However it has will require this PR for the driver to first propagate.