### PR TITLE
JAVA-1612: Include netty-common jar in binary tarball

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -9,6 +9,7 @@
 - [bug] JAVA-2070: Call onRemove instead of onDown when rack and/or DC information changes for a host.
 - [improvement] JAVA-1256: Log parameters of BuiltStatement in QueryLogger.
 - [documentation] JAVA-2074: Document preference for LZ4 over Snappy.
+- [bug] JAVA-1612: Include netty-common jar in binary tarball.
 
 
 ### 3.6.0

--- a/driver-dist/src/assembly/binary-tarball.xml
+++ b/driver-dist/src/assembly/binary-tarball.xml
@@ -45,7 +45,6 @@
                             <!-- platform-dependent -->
                             <exclude>io.netty:netty-transport-native-epoll:*</exclude>
                         </excludes>
-                        <useTransitiveFiltering>true</useTransitiveFiltering>
                     </dependencySet>
                 </dependencySets>
             </binaries>


### PR DESCRIPTION
Motivation:

Users of the binary tarball noticed that the netty-common dependency was
missing, via a NoClassDefFoundError for io.netty.util.Timer.

This was caused by netty-common being excluded as it is a transitive
dependency of netty-transport-epoll.  While it is also a transitive
dependency of included jars, the maven-assembly-plugin still excludes
it.

Modifications:

Remove the use of useTransitiveFiltering in the dependencySet.  This is
ok as netty-transport-epoll dependencies are depended on by the driver jar
already.

Result:

netty-common jar is now included in the lib directory of the binary
tarball.

----

This took quite a bit of investigation, but I think this is the best solution available.  The alternative would be to list `netty-common` as an explicit dependency of `driver-core`.  Removing `useTransitiveFiltering` for core does the trick, and shouldn't be an issue as long as `netty-transport-epoll` does not add a platform specific dependency which seems very unlikely.