### PR TITLE
Java2063 Normalize authentication error logging.

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,10 +4,10 @@
 
 ### 4.0.0-rc1 (in progress)
 
+- [bug] JAVA-2063: Normalize authentication logging
 - [improvement] JAVA-2067: Publish javadocs JAR for the shaded module
 - [improvement] JAVA-2103: Expose partitioner name in TokenMap API
 - [documentation] JAVA-2075: Document preference for LZ4 over Snappy
-- [bug] JAVA-2063: Normalize authentication logging
 
 ### 4.0.0-beta3
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -7,6 +7,7 @@
 - [improvement] JAVA-2067: Publish javadocs JAR for the shaded module
 - [improvement] JAVA-2103: Expose partitioner name in TokenMap API
 - [documentation] JAVA-2075: Document preference for LZ4 over Snappy
+- [bug] JAVA-2063: Normalize authentication logging
 
 ### 4.0.0-beta3
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -276,7 +276,11 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
             },
             error -> {
               if (isAuthFailure(error)) {
-                Loggers.warnWithException(LOG, "[{}] Authentication error", logPrefix, error);
+                Loggers.warnWithException(
+                    LOG,
+                    "[{}] Authentication errors encountered on all contact points. Please check our authentication configuration.",
+                    logPrefix,
+                    error);
               }
               if (reconnectOnFailure && !closeWasCalled) {
                 reconnection.start();
@@ -337,11 +341,16 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
                       if (closeWasCalled || initFuture.isCancelled()) {
                         onSuccess.run(); // abort, we don't really care about the result
                       } else {
-                        LOG.debug(
-                            "[{}] Error connecting to {}, trying next node",
-                            logPrefix,
-                            node,
-                            error);
+                        if (error instanceof AuthenticationException) {
+                          Loggers.warnWithException(
+                              LOG, "[{}] Authentication error", logPrefix, error);
+                        } else {
+                          LOG.debug(
+                              "[{}] Error connecting to {}, trying next node",
+                              logPrefix,
+                              node,
+                              error);
+                        }
                         Map<Node, Throwable> newErrors =
                             (errors == null) ? new LinkedHashMap<>() : errors;
                         newErrors.put(node, error);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -278,7 +278,7 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
               if (isAuthFailure(error)) {
                 Loggers.warnWithException(
                     LOG,
-                    "[{}] Authentication errors encountered on all contact points. Please check our authentication configuration.",
+                    "[{}] Authentication errors encountered on all contact points. Please check your authentication configuration.",
                     logPrefix,
                     error);
               }
@@ -519,6 +519,9 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
     boolean authFailure = true;
     if (error instanceof AllNodesFailedException) {
       Collection<Throwable> errors = ((AllNodesFailedException) error).getErrors().values();
+      if (errors.size() == 0) {
+        return false;
+      }
       for (Throwable nodeError : errors) {
         if (!(nodeError instanceof AuthenticationException)) {
           authFailure = false;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -351,7 +351,11 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
                               .getDefaultProfile()
                               .getBoolean(DefaultDriverOption.CONNECTION_WARN_INIT_ERROR)) {
                             Loggers.warnWithException(
-                                LOG, "[{}]  Error while opening new channel", logPrefix, error);
+                                LOG,
+                                "[{}] Error connecting to {}, trying next node",
+                                logPrefix,
+                                node,
+                                error);
                           } else {
                             LOG.debug(
                                 "[{}] Error connecting to {}, trying next node",

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
@@ -19,6 +19,9 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 
 import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfig;
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.connection.ReconnectionPolicy;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.internal.core.addresstranslation.PassThroughAddressTranslator;
@@ -67,6 +70,8 @@ abstract class ControlConnectionTestBase {
   @Mock protected LoadBalancingPolicyWrapper loadBalancingPolicyWrapper;
   @Mock protected MetadataManager metadataManager;
   @Mock protected MetricsFactory metricsFactory;
+  @Mock protected DriverConfig config;
+  @Mock protected DriverExecutionProfile defaultProfile;
 
   protected AddressTranslator addressTranslator;
   protected DefaultNode node1;
@@ -115,6 +120,10 @@ abstract class ControlConnectionTestBase {
 
     addressTranslator = Mockito.spy(new PassThroughAddressTranslator(context));
     Mockito.when(context.getAddressTranslator()).thenReturn(addressTranslator);
+    Mockito.when(context.getConfig()).thenReturn(config);
+    Mockito.when(config.getDefaultProfile()).thenReturn(defaultProfile);
+    Mockito.when(defaultProfile.getBoolean(DefaultDriverOption.CONNECTION_WARN_INIT_ERROR))
+        .thenReturn(false);
 
     controlConnection = new ControlConnection(context);
   }


### PR DESCRIPTION
This brings control connection Authentication logging inline with the channel pool authentication logging. They are both logged at warn.