### PR TITLE
JAVA-2119: Add PagingIterable abstraction as a supertype of ResultSet

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0-rc1 (in progress)
 
+- [improvement] JAVA-2119: Add PagingIterable abstraction as a supertype of ResultSet
 - [bug] JAVA-2063: Normalize authentication logging
 - [documentation] JAVA-2034: Add performance recommendations in the manual
 - [improvement] JAVA-2077: Allow reconnection policy to detect first connection attempt

--- a/core/src/main/java/com/datastax/oss/driver/api/core/AsyncPagingIterable.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/AsyncPagingIterable.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core;
+
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
+import com.datastax.oss.driver.internal.core.AsyncPagingIterableWrapper;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Iterator;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+/**
+ * An iterable of elements which are fetched asynchronously by the driver, possibly in multiple
+ * requests.
+ */
+public interface AsyncPagingIterable<ElementT> {
+
+  /** Metadata about the columns returned by the CQL request that was used to build this result. */
+  @NonNull
+  ColumnDefinitions getColumnDefinitions();
+
+  /** Returns {@linkplain ExecutionInfo information about the execution} of this page of results. */
+  @NonNull
+  ExecutionInfo getExecutionInfo();
+
+  /** How many rows are left before the current page is exhausted. */
+  int remaining();
+
+  /**
+   * The elements in the current page. To keep iterating beyond that, use {@link #hasMorePages()}
+   * and {@link #fetchNextPage()}.
+   *
+   * <p>Note that this method always returns the same object, and that that object can only be
+   * iterated once: elements are "consumed" as they are read.
+   */
+  @NonNull
+  Iterable<ElementT> currentPage();
+
+  /**
+   * Returns the next element, or {@code null} if the results are exhausted.
+   *
+   * <p>This is convenient for queries that are known to return exactly one element, for example
+   * count queries.
+   */
+  @Nullable
+  default ElementT one() {
+    Iterator<ElementT> iterator = currentPage().iterator();
+    return iterator.hasNext() ? iterator.next() : null;
+  }
+
+  /**
+   * Whether there are more pages of results. If so, call {@link #fetchNextPage()} to fetch the next
+   * one asynchronously.
+   */
+  boolean hasMorePages();
+
+  /**
+   * Fetch the next page of results asynchronously.
+   *
+   * @throws IllegalStateException if there are no more pages. Use {@link #hasMorePages()} to check
+   *     if you can call this method.
+   */
+  @NonNull
+  CompletionStage<? extends AsyncPagingIterable<ElementT>> fetchNextPage()
+      throws IllegalStateException;
+
+  /**
+   * If the query that produced this result was a CQL conditional update, indicate whether it was
+   * successfully applied.
+   *
+   * <p>For consistency, this method always returns {@code true} for non-conditional queries
+   * (although there is no reason to call the method in that case). This is also the case for
+   * conditional DDL statements ({@code CREATE KEYSPACE... IF NOT EXISTS}, {@code CREATE TABLE... IF
+   * NOT EXISTS}), for which Cassandra doesn't return an {@code [applied]} column.
+   *
+   * <p>Note that, for versions of Cassandra strictly lower than 2.1.0-rc2, a server-side bug (<a
+   * href="https://issues.apache.org/jira/browse/CASSANDRA-7337">CASSANDRA-7337</a>) causes this
+   * method to always return {@code true} for batches containing conditional queries.
+   */
+  boolean wasApplied();
+
+  /**
+   * Creates a new instance by transforming each element of this iterable with the provided
+   * function.
+   *
+   * <p>Note that both instances share the same underlying data: consuming elements from the
+   * transformed iterable will also consume them from this object, and vice-versa.
+   */
+  default <TargetT> AsyncPagingIterable<TargetT> map(
+      Function<? super ElementT, ? extends TargetT> elementMapper) {
+    return new AsyncPagingIterableWrapper<>(this, elementMapper);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/PagingIterable.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/PagingIterable.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core;
+
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.internal.core.PagingIterableWrapper;
+import com.datastax.oss.driver.shaded.guava.common.collect.Iterables;
+import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * An iterable of elements which are fetched synchronously by the driver, possibly in multiple
+ * requests.
+ *
+ * <p>It uses asynchronous calls internally, but blocks on the results in order to provide a
+ * synchronous API to its clients. If the query is paged, only the first page will be fetched
+ * initially, and iteration will trigger background fetches of the next pages when necessary.
+ *
+ * <p>Note that this object can only be iterated once: elements are "consumed" as they are read,
+ * subsequent calls to {@code iterator()} will return the same iterator instance.
+ *
+ * <p>Implementations of this type are <b>not thread-safe</b>. They can only be iterated by the
+ * thread that invoked {@code session.execute}.
+ *
+ * <p>This is a generalization of {@link ResultSet}, replacing rows by an arbitrary element type.
+ */
+public interface PagingIterable<ElementT> extends Iterable<ElementT> {
+
+  /** Metadata about the columns returned by the CQL request that was used to build this result. */
+  @NonNull
+  ColumnDefinitions getColumnDefinitions();
+
+  /**
+   * The execution information for the last query performed for this iterable.
+   *
+   * <p>This is a shortcut for:
+   *
+   * <pre>
+   * getExecutionInfos().get(getExecutionInfos().size() - 1)
+   * </pre>
+   *
+   * @see #getExecutionInfos()
+   */
+  @NonNull
+  default ExecutionInfo getExecutionInfo() {
+    List<ExecutionInfo> infos = getExecutionInfos();
+    return infos.get(infos.size() - 1);
+  }
+
+  /**
+   * The execution information for all the queries that have been performed so far to assemble this
+   * iterable.
+   *
+   * <p>This will have multiple elements if the query is paged, since the driver performs blocking
+   * background queries to fetch additional pages transparently as the result set is being iterated.
+   */
+  @NonNull
+  List<ExecutionInfo> getExecutionInfos();
+
+  /**
+   * Returns the next element, or {@code null} if the iterable is exhausted.
+   *
+   * <p>This is convenient for queries that are known to return exactly one row, for example count
+   * queries.
+   */
+  @Nullable
+  default ElementT one() {
+    Iterator<ElementT> iterator = iterator();
+    return iterator.hasNext() ? iterator.next() : null;
+  }
+
+  /**
+   * Returns all the remaining elements as a list; <b>not recommended for queries that return a
+   * large number of elements</b>.
+   *
+   * <p>Contrary to {@link #iterator()} or successive calls to {@link #one()}, this method forces
+   * fetching the <b>full contents</b> at once; in particular, this means that a large number of
+   * background queries might have to be run, and that all the data will be held in memory locally.
+   * Therefore it is crucial to only call this method for queries that are known to return a
+   * reasonable number of results.
+   */
+  @NonNull
+  default List<ElementT> all() {
+    if (!iterator().hasNext()) {
+      return Collections.emptyList();
+    }
+    // We can't know the actual size in advance since more pages could be fetched, but we can at
+    // least allocate for what we already have.
+    List<ElementT> result = Lists.newArrayListWithExpectedSize(getAvailableWithoutFetching());
+    Iterables.addAll(result, this);
+    return result;
+  }
+
+  /**
+   * Whether all pages have been fetched from the database.
+   *
+   * <p>If this is {@code false}, it means that more blocking background queries will be triggered
+   * as iteration continues.
+   */
+  boolean isFullyFetched();
+
+  /**
+   * The number of elements that can be returned from this result set before a blocking background
+   * query needs to be performed to retrieve more results. In other words, this is the number of
+   * elements remaining in the current page.
+   *
+   * <p>This is useful if you use the paging state to pause the iteration and resume it later: after
+   * you've retrieved the state ({@link ExecutionInfo#getPagingState()
+   * getExecutionInfo().getPagingState()}), call this method and iterate the remaining elements;
+   * that way you're not leaving a gap between the last element and the position you'll restart from
+   * when you reinject the state in a new query.
+   */
+  int getAvailableWithoutFetching();
+
+  /**
+   * If the query that produced this result was a CQL conditional update, indicate whether it was
+   * successfully applied.
+   *
+   * <p>For consistency, this method always returns {@code true} for non-conditional queries
+   * (although there is no reason to call the method in that case). This is also the case for
+   * conditional DDL statements ({@code CREATE KEYSPACE... IF NOT EXISTS}, {@code CREATE TABLE... IF
+   * NOT EXISTS}), for which Cassandra doesn't return an {@code [applied]} column.
+   *
+   * <p>Note that, for versions of Cassandra strictly lower than 2.1.0-rc2, a server-side bug (<a
+   * href="https://issues.apache.org/jira/browse/CASSANDRA-7337">CASSANDRA-7337</a>) causes this
+   * method to always return {@code true} for batches containing conditional queries.
+   */
+  boolean wasApplied();
+
+  /**
+   * Creates a new instance by transforming each element of this iterable with the provided
+   * function.
+   *
+   * <p>Note that both instances share the same underlying data: consuming elements from the
+   * transformed iterable will also consume them from this object, and vice-versa.
+   */
+  default <TargetElementT> PagingIterable<TargetElementT> map(
+      Function<? super ElementT, ? extends TargetElementT> elementMapper) {
+    return new PagingIterableWrapper<>(this, elementMapper);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/AsyncResultSet.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/AsyncResultSet.java
@@ -15,10 +15,9 @@
  */
 package com.datastax.oss.driver.api.core.cql;
 
+import com.datastax.oss.driver.api.core.AsyncPagingIterable;
 import com.datastax.oss.driver.api.core.CqlSession;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
-import java.util.Iterator;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -27,59 +26,16 @@ import java.util.concurrent.CompletionStage;
  * @see CqlSession#executeAsync(Statement)
  * @see CqlSession#executeAsync(String)
  */
-public interface AsyncResultSet {
+public interface AsyncResultSet extends AsyncPagingIterable<Row> {
 
-  /** Returns metadata about the {@linkplain ColumnDefinitions columns} contained in this row. */
+  // overridden to use a covariant return type:
   @NonNull
-  ColumnDefinitions getColumnDefinitions();
-
-  /** Returns {@linkplain ExecutionInfo information about the execution} of this page of results. */
-  @NonNull
-  ExecutionInfo getExecutionInfo();
-
-  /** How many rows are left before the current page is exhausted. */
-  int remaining();
-
-  /**
-   * The rows in the current page. To keep iterating beyond that, use {@link #hasMorePages()} and
-   * {@link #fetchNextPage()}.
-   *
-   * <p>Note that this method always returns the same object, and that that object can only be
-   * iterated once: rows are "consumed" as they are read.
-   */
-  @NonNull
-  Iterable<Row> currentPage();
-
-  /**
-   * Returns the next row, or {@code null} if the result set is exhausted.
-   *
-   * <p>This is convenient for queries that are known to return exactly one row, for example count
-   * queries.
-   */
-  @Nullable
-  default Row one() {
-    Iterator<Row> iterator = currentPage().iterator();
-    return iterator.hasNext() ? iterator.next() : null;
-  }
-
-  /**
-   * Whether there are more pages of results. If so, call {@link #fetchNextPage()} to fetch the next
-   * one asynchronously.
-   */
-  boolean hasMorePages();
-
-  /**
-   * Fetch the next page of results asynchronously.
-   *
-   * @throws IllegalStateException if there are no more pages. Use {@link #hasMorePages()} to check
-   *     if you can call this method.
-   */
-  @NonNull
+  @Override
   CompletionStage<? extends AsyncResultSet> fetchNextPage() throws IllegalStateException;
 
+  // overridden to amend the javadocs:
   /**
-   * If the query that produced this result was a conditional update, indicate whether it was
-   * successfully applied.
+   * {@inheritDoc}
    *
    * <p>This is equivalent to calling:
    *
@@ -88,15 +44,7 @@ public interface AsyncResultSet {
    * </pre>
    *
    * Except that this method peeks at the next row without consuming it.
-   *
-   * <p>For consistency, this method always returns {@code true} for non-conditional queries
-   * (although there is no reason to call the method in that case). This is also the case for
-   * conditional DDL statements ({@code CREATE KEYSPACE... IF NOT EXISTS}, {@code CREATE TABLE... IF
-   * NOT EXISTS}), for which Cassandra doesn't return an {@code [applied]} column.
-   *
-   * <p>Note that, for versions of Cassandra strictly lower than 2.1.0-rc2, a server-side bug (<a
-   * href="https://issues.apache.org/jira/browse/CASSANDRA-7337">CASSANDRA-7337</a>) causes this
-   * method to always return {@code true} for batches containing conditional queries.
    */
+  @Override
   boolean wasApplied();
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/ResultSet.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/ResultSet.java
@@ -16,122 +16,23 @@
 package com.datastax.oss.driver.api.core.cql;
 
 import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.shaded.guava.common.collect.Iterables;
-import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
+import com.datastax.oss.driver.api.core.PagingIterable;
 
 /**
  * The result of a synchronous CQL query.
  *
- * <p>It uses {@link AsyncResultSet asynchronous calls} internally, but blocks on the results in
- * order to provide a synchronous API to its clients. If the query is paged, only the first page
- * will be fetched initially, and iteration will trigger background fetches of the next pages when
- * necessary.
- *
- * <p>Note that this object can only be iterated once: rows are "consumed" as they are read,
- * subsequent calls to {@code iterator()} will the same iterator instance.
- *
- * <p>Implementations of this type are <b>not</b> thread-safe. They can only be iterated by the
+ * <p>See {@link PagingIterable} for a few generic explanations about the behavior of this object;
+ * in particular, implementations are <b>not thread-safe</b>. They can only be iterated by the
  * thread that invoked {@code session.execute}.
  *
  * @see CqlSession#execute(Statement)
  * @see CqlSession#execute(String)
  */
-public interface ResultSet extends Iterable<Row> {
+public interface ResultSet extends PagingIterable<Row> {
 
-  /** @return the column definitions contained in this result set. */
-  @NonNull
-  ColumnDefinitions getColumnDefinitions();
-
+  // overridden to amend the javadocs:
   /**
-   * The execution information for the last query performed for this result set.
-   *
-   * <p>This is a shortcut for:
-   *
-   * <pre>
-   * getExecutionInfos().get(getExecutionInfos().size() - 1)
-   * </pre>
-   *
-   * @see #getExecutionInfos()
-   */
-  @NonNull
-  default ExecutionInfo getExecutionInfo() {
-    List<ExecutionInfo> infos = getExecutionInfos();
-    return infos.get(infos.size() - 1);
-  }
-
-  /**
-   * The execution information for all the queries that have been performed so far to assemble this
-   * result set.
-   *
-   * <p>This will have multiple elements if the query is paged, since the driver performs blocking
-   * background queries to fetch additional pages transparently as the result set is being iterated.
-   */
-  @NonNull
-  List<ExecutionInfo> getExecutionInfos();
-
-  /**
-   * Returns the next row, or {@code null} if the result set is exhausted.
-   *
-   * <p>This is convenient for queries that are known to return exactly one row, for example count
-   * queries.
-   */
-  @Nullable
-  default Row one() {
-    Iterator<Row> iterator = iterator();
-    return iterator.hasNext() ? iterator.next() : null;
-  }
-
-  /**
-   * Returns all the remaining rows as a list; <b>not recommended for queries that return a large
-   * number of rows</b>.
-   *
-   * <p>Contrary to {@link #iterator()} or successive calls to {@link #one()}, this method forces
-   * fetching the <b>full contents</b> of the result set at once; in particular, this means that a
-   * large number of background queries might have to be run, and that all the data will be held in
-   * memory locally. Therefore it is crucial to only call this method for queries that are known to
-   * return a reasonable number of results.
-   */
-  @NonNull
-  default List<Row> all() {
-    if (!iterator().hasNext()) {
-      return Collections.emptyList();
-    }
-    // We can't know the actual size in advance since more pages could be fetched, but we can at
-    // least allocate for what we already have.
-    List<Row> result = Lists.newArrayListWithExpectedSize(getAvailableWithoutFetching());
-    Iterables.addAll(result, this);
-    return result;
-  }
-
-  /**
-   * Whether all pages have been fetched from the database.
-   *
-   * <p>If this is {@code false}, it means that more blocking background queries will be triggered
-   * as iteration continues.
-   */
-  boolean isFullyFetched();
-
-  /**
-   * The number of rows that can be returned from this result set before a blocking background query
-   * needs to be performed to retrieve more results. In other words, this is the number of rows
-   * remaining in the current page.
-   *
-   * <p>This is useful if you use the paging state to pause the iteration and resume it later: after
-   * you've retrieved the state ({@link ExecutionInfo#getPagingState()
-   * getExecutionInfo().getPagingState()}), call this method and iterate the remaining rows; that
-   * way you're not leaving a gap between the last row and the position you'll restart from when you
-   * reinject the state in a new query.
-   */
-  int getAvailableWithoutFetching();
-
-  /**
-   * If the query that produced this result was a conditional update, indicate whether it was
-   * successfully applied.
+   * {@inheritDoc}
    *
    * <p>This is equivalent to calling:
    *
@@ -140,15 +41,7 @@ public interface ResultSet extends Iterable<Row> {
    * </pre>
    *
    * Except that this method peeks at the next row without consuming it.
-   *
-   * <p>For consistency, this method always returns {@code true} for non-conditional queries
-   * (although there is no reason to call the method in that case). This is also the case for
-   * conditional DDL statements ({@code CREATE KEYSPACE... IF NOT EXISTS}, {@code CREATE TABLE... IF
-   * NOT EXISTS}), for which Cassandra doesn't return an {@code [applied]} column.
-   *
-   * <p>Note that, for versions of Cassandra strictly lower than 2.1.0-rc2, a server-side bug (<a
-   * href="https://issues.apache.org/jira/browse/CASSANDRA-7337">CASSANDRA-7337</a>) causes this
-   * method to always return {@code true} for batches containing conditional queries.
    */
+  @Override
   boolean wasApplied();
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/AsyncPagingIterableWrapper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/AsyncPagingIterableWrapper.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core;
+
+import com.datastax.oss.driver.api.core.AsyncPagingIterable;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
+import com.datastax.oss.driver.shaded.guava.common.collect.AbstractIterator;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Iterator;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+public class AsyncPagingIterableWrapper<SourceT, TargetT> implements AsyncPagingIterable<TargetT> {
+
+  private final AsyncPagingIterable<SourceT> source;
+  private final Function<? super SourceT, ? extends TargetT> elementMapper;
+
+  private final Iterable<TargetT> currentPage;
+
+  public AsyncPagingIterableWrapper(
+      AsyncPagingIterable<SourceT> source,
+      Function<? super SourceT, ? extends TargetT> elementMapper) {
+    this.source = source;
+    this.elementMapper = elementMapper;
+
+    Iterator<SourceT> sourceIterator = source.currentPage().iterator();
+    Iterator<TargetT> iterator =
+        new AbstractIterator<TargetT>() {
+          @Override
+          protected TargetT computeNext() {
+            return (sourceIterator.hasNext())
+                ? elementMapper.apply(sourceIterator.next())
+                : endOfData();
+          }
+        };
+    this.currentPage = () -> iterator;
+  }
+
+  @NonNull
+  @Override
+  public ColumnDefinitions getColumnDefinitions() {
+    return source.getColumnDefinitions();
+  }
+
+  @NonNull
+  @Override
+  public ExecutionInfo getExecutionInfo() {
+    return source.getExecutionInfo();
+  }
+
+  @Override
+  public int remaining() {
+    return source.remaining();
+  }
+
+  @NonNull
+  @Override
+  public Iterable<TargetT> currentPage() {
+    return currentPage;
+  }
+
+  @Override
+  public boolean hasMorePages() {
+    return source.hasMorePages();
+  }
+
+  @NonNull
+  @Override
+  public CompletionStage<? extends AsyncPagingIterable<TargetT>> fetchNextPage()
+      throws IllegalStateException {
+    return source
+        .fetchNextPage()
+        .thenApply(
+            nextSource ->
+                new AsyncPagingIterableWrapper<SourceT, TargetT>(nextSource, elementMapper));
+  }
+
+  @Override
+  public boolean wasApplied() {
+    return source.wasApplied();
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/PagingIterableWrapper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/PagingIterableWrapper.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core;
+
+import com.datastax.oss.driver.api.core.PagingIterable;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
+import com.datastax.oss.driver.shaded.guava.common.collect.AbstractIterator;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+
+public class PagingIterableWrapper<SourceT, TargetT> implements PagingIterable<TargetT> {
+
+  private final PagingIterable<SourceT> source;
+  private final Iterator<TargetT> iterator;
+
+  public PagingIterableWrapper(
+      PagingIterable<SourceT> source, Function<? super SourceT, ? extends TargetT> elementMapper) {
+    this.source = source;
+    Iterator<SourceT> sourceIterator = source.iterator();
+    this.iterator =
+        new AbstractIterator<TargetT>() {
+          @Override
+          protected TargetT computeNext() {
+            return (sourceIterator.hasNext())
+                ? elementMapper.apply(sourceIterator.next())
+                : endOfData();
+          }
+        };
+  }
+
+  @NonNull
+  @Override
+  public ColumnDefinitions getColumnDefinitions() {
+    return source.getColumnDefinitions();
+  }
+
+  @NonNull
+  @Override
+  public List<ExecutionInfo> getExecutionInfos() {
+    return source.getExecutionInfos();
+  }
+
+  @Override
+  public boolean isFullyFetched() {
+    return source.isFullyFetched();
+  }
+
+  @Override
+  public int getAvailableWithoutFetching() {
+    return source.getAvailableWithoutFetching();
+  }
+
+  @Override
+  public boolean wasApplied() {
+    return source.wasApplied();
+  }
+
+  @Override
+  public Iterator<TargetT> iterator() {
+    return iterator;
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/AsyncPagingIterableWrapperTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/AsyncPagingIterableWrapperTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.AsyncPagingIterable;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
+import com.datastax.oss.driver.api.core.cql.Statement;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.cql.DefaultAsyncResultSet;
+import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+public class AsyncPagingIterableWrapperTest {
+
+  @Mock private ColumnDefinitions columnDefinitions;
+  @Mock private Statement<?> statement;
+  @Mock private CqlSession session;
+  @Mock private InternalDriverContext context;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+
+    // One single column "i" of type int:
+    Mockito.when(columnDefinitions.contains("i")).thenReturn(true);
+    ColumnDefinition iDefinition = Mockito.mock(ColumnDefinition.class);
+    Mockito.when(iDefinition.getType()).thenReturn(DataTypes.INT);
+    Mockito.when(columnDefinitions.get("i")).thenReturn(iDefinition);
+    Mockito.when(columnDefinitions.firstIndexOf("i")).thenReturn(0);
+    Mockito.when(columnDefinitions.get(0)).thenReturn(iDefinition);
+
+    Mockito.when(context.getCodecRegistry()).thenReturn(CodecRegistry.DEFAULT);
+    Mockito.when(context.getProtocolVersion()).thenReturn(DefaultProtocolVersion.DEFAULT);
+  }
+
+  @Test
+  public void should_wrap_result_set() throws Exception {
+    // Given
+    // two pages of data:
+    ExecutionInfo executionInfo1 = mockExecutionInfo();
+    DefaultAsyncResultSet resultSet1 =
+        new DefaultAsyncResultSet(
+            columnDefinitions, executionInfo1, mockData(0, 5), session, context);
+    DefaultAsyncResultSet resultSet2 =
+        new DefaultAsyncResultSet(
+            columnDefinitions, mockExecutionInfo(), mockData(5, 10), session, context);
+    // chain them together:
+    ByteBuffer mockPagingState = ByteBuffer.allocate(0);
+    Mockito.when(executionInfo1.getPagingState()).thenReturn(mockPagingState);
+    Statement<?> mockNextStatement = Mockito.mock(Statement.class);
+    Mockito.when(((Statement) statement).copy(mockPagingState)).thenReturn(mockNextStatement);
+    Mockito.when(session.executeAsync(mockNextStatement))
+        .thenAnswer(invocation -> CompletableFuture.completedFuture(resultSet2));
+
+    // When
+    AsyncPagingIterable<Integer> iterable1 = resultSet1.map(row -> row.getInt("i"));
+
+    // Then
+    for (int i = 0; i < 5; i++) {
+      assertThat(iterable1.one()).isEqualTo(i);
+      assertThat(iterable1.remaining()).isEqualTo(resultSet1.remaining()).isEqualTo(4 - i);
+    }
+    assertThat(iterable1.hasMorePages()).isTrue();
+
+    AsyncPagingIterable<Integer> iterable2 = iterable1.fetchNextPage().toCompletableFuture().get();
+    for (int i = 5; i < 10; i++) {
+      assertThat(iterable2.one()).isEqualTo(i);
+      assertThat(iterable2.remaining()).isEqualTo(resultSet2.remaining()).isEqualTo(9 - i);
+    }
+    assertThat(iterable2.hasMorePages()).isFalse();
+  }
+
+  /** Checks that consuming from the wrapper consumes from the source, and vice-versa. */
+  @Test
+  public void should_share_iteration_progress_with_wrapped_result_set() {
+    // Given
+    DefaultAsyncResultSet resultSet =
+        new DefaultAsyncResultSet(
+            columnDefinitions, mockExecutionInfo(), mockData(0, 10), session, context);
+
+    // When
+    AsyncPagingIterable<Integer> iterable = resultSet.map(row -> row.getInt("i"));
+
+    // Then
+    // Consume alternatively from the source and mapped iterable, and check that they stay in sync
+    for (int i = 0; i < 10; i++) {
+      Object element = (i % 2 == 0 ? resultSet : iterable).one();
+      assertThat(element).isNotNull();
+      assertThat(iterable.remaining()).isEqualTo(resultSet.remaining()).isEqualTo(9 - i);
+    }
+    assertThat(resultSet.hasMorePages()).isFalse();
+    assertThat(iterable.hasMorePages()).isFalse();
+  }
+
+  private ExecutionInfo mockExecutionInfo() {
+    ExecutionInfo executionInfo = Mockito.mock(ExecutionInfo.class);
+    Mockito.when(executionInfo.getStatement()).thenAnswer(invocation -> statement);
+    return executionInfo;
+  }
+
+  private Queue<List<ByteBuffer>> mockData(int start, int end) {
+    Queue<List<ByteBuffer>> data = new ArrayDeque<>();
+    for (int i = start; i < end; i++) {
+      data.add(Lists.newArrayList(TypeCodecs.INT.encode(i, DefaultProtocolVersion.DEFAULT)));
+    }
+    return data;
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/PagingIterableWrapperTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/PagingIterableWrapperTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.PagingIterable;
+import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.internal.core.cql.ResultSetTestBase;
+import com.datastax.oss.driver.internal.core.cql.ResultSets;
+import java.util.Iterator;
+import org.junit.Test;
+
+public class PagingIterableWrapperTest extends ResultSetTestBase {
+
+  @Test
+  public void should_wrap_result_set() {
+    // Given
+    AsyncResultSet page1 = mockPage(true, 0, 1, 2);
+    AsyncResultSet page2 = mockPage(true, 3, 4, 5);
+    AsyncResultSet page3 = mockPage(false, 6, 7, 8);
+
+    complete(page1.fetchNextPage(), page2);
+    complete(page2.fetchNextPage(), page3);
+
+    // When
+    PagingIterable<Integer> iterable = ResultSets.newInstance(page1).map(row -> row.getInt(0));
+
+    // Then
+    assertThat(iterable.getExecutionInfo()).isSameAs(page1.getExecutionInfo());
+    assertThat(iterable.getExecutionInfos()).containsExactly(page1.getExecutionInfo());
+
+    Iterator<Integer> iterator = iterable.iterator();
+
+    assertThat(iterator.next()).isEqualTo(0);
+    assertThat(iterator.next()).isEqualTo(1);
+    assertThat(iterator.next()).isEqualTo(2);
+
+    assertThat(iterator.hasNext()).isTrue();
+    // This should have triggered the fetch of page2
+    assertThat(iterable.getExecutionInfo()).isEqualTo(page2.getExecutionInfo());
+    assertThat(iterable.getExecutionInfos())
+        .containsExactly(page1.getExecutionInfo(), page2.getExecutionInfo());
+
+    assertThat(iterator.next()).isEqualTo(3);
+    assertThat(iterator.next()).isEqualTo(4);
+    assertThat(iterator.next()).isEqualTo(5);
+
+    assertThat(iterator.hasNext()).isTrue();
+    // This should have triggered the fetch of page3
+    assertThat(iterable.getExecutionInfo()).isEqualTo(page3.getExecutionInfo());
+    assertThat(iterable.getExecutionInfos())
+        .containsExactly(
+            page1.getExecutionInfo(), page2.getExecutionInfo(), page3.getExecutionInfo());
+
+    assertThat(iterator.next()).isEqualTo(6);
+    assertThat(iterator.next()).isEqualTo(7);
+    assertThat(iterator.next()).isEqualTo(8);
+  }
+
+  /** Checks that consuming from the wrapper consumes from the source, and vice-versa. */
+  @Test
+  public void should_share_iteration_progress_with_wrapped_result_set() {
+    // Given
+    AsyncResultSet page1 = mockPage(true, 0, 1, 2);
+    AsyncResultSet page2 = mockPage(true, 3, 4, 5);
+    AsyncResultSet page3 = mockPage(false, 6, 7, 8);
+
+    complete(page1.fetchNextPage(), page2);
+    complete(page2.fetchNextPage(), page3);
+
+    // When
+    ResultSet resultSet = ResultSets.newInstance(page1);
+    PagingIterable<Integer> iterable = resultSet.map(row -> row.getInt(0));
+
+    // Then
+    Iterator<Row> sourceIterator = resultSet.iterator();
+    Iterator<Integer> mappedIterator = iterable.iterator();
+
+    assertThat(mappedIterator.next()).isEqualTo(0);
+    assertNextRow(sourceIterator, 1);
+    assertThat(mappedIterator.next()).isEqualTo(2);
+    assertNextRow(sourceIterator, 3);
+    assertThat(mappedIterator.next()).isEqualTo(4);
+    assertNextRow(sourceIterator, 5);
+    assertThat(mappedIterator.next()).isEqualTo(6);
+    assertNextRow(sourceIterator, 7);
+    assertThat(mappedIterator.next()).isEqualTo(8);
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/ResultSetTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/ResultSetTestBase.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.cql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.internal.core.util.CountingIterator;
+import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.mockito.Mockito;
+
+public abstract class ResultSetTestBase {
+
+  /** Mocks an async result set where column 0 has type INT, with rows with the provided data. */
+  protected AsyncResultSet mockPage(boolean nextPage, Integer... data) {
+    AsyncResultSet page = Mockito.mock(AsyncResultSet.class);
+
+    ColumnDefinitions columnDefinitions = Mockito.mock(ColumnDefinitions.class);
+    Mockito.when(page.getColumnDefinitions()).thenReturn(columnDefinitions);
+
+    ExecutionInfo executionInfo = Mockito.mock(ExecutionInfo.class);
+    Mockito.when(page.getExecutionInfo()).thenReturn(executionInfo);
+
+    if (nextPage) {
+      Mockito.when(page.hasMorePages()).thenReturn(true);
+      Mockito.when(page.fetchNextPage()).thenReturn(Mockito.spy(new CompletableFuture<>()));
+    } else {
+      Mockito.when(page.hasMorePages()).thenReturn(false);
+      Mockito.when(page.fetchNextPage()).thenThrow(new IllegalStateException());
+    }
+
+    // Emulate DefaultAsyncResultSet's internals (this is a bit sketchy, maybe it would be better
+    // to use real DefaultAsyncResultSet instances)
+    Queue<Integer> queue = Lists.newLinkedList(Arrays.asList(data));
+    CountingIterator<Row> iterator =
+        new CountingIterator<Row>(queue.size()) {
+          @Override
+          protected Row computeNext() {
+            Integer index = queue.poll();
+            return (index == null) ? endOfData() : mockRow(index);
+          }
+        };
+    Mockito.when(page.currentPage()).thenReturn(() -> iterator);
+    Mockito.when(page.remaining()).thenAnswer(invocation -> iterator.remaining());
+
+    return page;
+  }
+
+  private Row mockRow(int index) {
+    Row row = Mockito.mock(Row.class);
+    Mockito.when(row.getInt(0)).thenReturn(index);
+    return row;
+  }
+
+  protected static void complete(
+      CompletionStage<? extends AsyncResultSet> stage, AsyncResultSet result) {
+    @SuppressWarnings("unchecked")
+    CompletableFuture<AsyncResultSet> future = (CompletableFuture<AsyncResultSet>) stage;
+    future.complete(result);
+  }
+
+  protected void assertNextRow(Iterator<Row> iterator, int expectedValue) {
+    assertThat(iterator.hasNext()).isTrue();
+    Row row = iterator.next();
+    assertThat(row.getInt(0)).isEqualTo(expectedValue);
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/ResultSetsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/ResultSetsTest.java
@@ -18,21 +18,12 @@ package com.datastax.oss.driver.internal.core.cql;
 import static com.datastax.oss.driver.Assertions.assertThat;
 
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
-import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
-import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
-import com.datastax.oss.driver.internal.core.util.CountingIterator;
-import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
-import java.util.Arrays;
 import java.util.Iterator;
-import java.util.Queue;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-public class ResultSetsTest {
+public class ResultSetsTest extends ResultSetTestBase {
 
   @Test
   public void should_create_result_set_from_single_page() {
@@ -102,58 +93,5 @@ public class ResultSetsTest {
     assertNextRow(iterator, 6);
     assertNextRow(iterator, 7);
     assertNextRow(iterator, 8);
-  }
-
-  private void assertNextRow(Iterator<Row> iterator, int expectedValue) {
-    assertThat(iterator.hasNext()).isTrue();
-    Row row0 = iterator.next();
-    assertThat(row0.getInt(0)).isEqualTo(expectedValue);
-  }
-
-  private AsyncResultSet mockPage(boolean nextPage, Integer... data) {
-    AsyncResultSet page = Mockito.mock(AsyncResultSet.class);
-
-    ColumnDefinitions columnDefinitions = Mockito.mock(ColumnDefinitions.class);
-    Mockito.when(page.getColumnDefinitions()).thenReturn(columnDefinitions);
-
-    ExecutionInfo executionInfo = Mockito.mock(ExecutionInfo.class);
-    Mockito.when(page.getExecutionInfo()).thenReturn(executionInfo);
-
-    if (nextPage) {
-      Mockito.when(page.hasMorePages()).thenReturn(true);
-      Mockito.when(page.fetchNextPage()).thenReturn(Mockito.spy(new CompletableFuture<>()));
-    } else {
-      Mockito.when(page.hasMorePages()).thenReturn(false);
-      Mockito.when(page.fetchNextPage()).thenThrow(new IllegalStateException());
-    }
-
-    // Emulate DefaultAsyncResultSet's internals (this is a bit sketchy, maybe it would be better
-    // to use real DefaultAsyncResultSet instances)
-    Queue<Integer> queue = Lists.newLinkedList(Arrays.asList(data));
-    CountingIterator<Row> iterator =
-        new CountingIterator<Row>(queue.size()) {
-          @Override
-          protected Row computeNext() {
-            Integer index = queue.poll();
-            return (index == null) ? endOfData() : mockRow(index);
-          }
-        };
-    Mockito.when(page.currentPage()).thenReturn(() -> iterator);
-    Mockito.when(page.remaining()).thenAnswer(invocation -> iterator.remaining());
-
-    return page;
-  }
-
-  private Row mockRow(int index) {
-    Row row = Mockito.mock(Row.class);
-    Mockito.when(row.getInt(0)).thenReturn(index);
-    return row;
-  }
-
-  private static void complete(
-      CompletionStage<? extends AsyncResultSet> stage, AsyncResultSet result) {
-    @SuppressWarnings("unchecked")
-    CompletableFuture<AsyncResultSet> future = (CompletableFuture<AsyncResultSet>) stage;
-    future.complete(result);
   }
 }


### PR DESCRIPTION
Contrary to our expectations, this doesn't seem to break backward compatibility.