### PR TITLE
JAVA-2113: Generate SetEntity DAO methods

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -39,7 +39,6 @@ import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.driver.internal.core.util.concurrent.Reconnection;
 import com.datastax.oss.driver.internal.core.util.concurrent.RunOrSchedule;
 import com.datastax.oss.driver.internal.core.util.concurrent.UncaughtExceptions;
-import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.protocol.internal.Message;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
@@ -116,9 +115,6 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
       boolean listenToClusterEvents,
       boolean reconnectOnFailure,
       boolean useInitialReconnectionSchedule) {
-    Preconditions.checkArgument(
-        reconnectOnFailure || !useInitialReconnectionSchedule,
-        "Can't set useInitialReconnectionSchedule if reconnectOnFailure is false");
     RunOrSchedule.on(
         adminExecutor,
         () ->

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SetEntityIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SetEntityIT.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.mapper;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.data.UdtValue;
+import com.datastax.oss.driver.api.core.type.UserDefinedType;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.driver.mapper.model.inventory.InventoryFixtures;
+import com.datastax.oss.driver.mapper.model.inventory.InventoryMapper;
+import com.datastax.oss.driver.mapper.model.inventory.InventoryMapperBuilder;
+import com.datastax.oss.driver.mapper.model.inventory.ProductDao;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+@Category(ParallelizableTests.class)
+public class SetEntityIT {
+
+  private static CcmRule ccm = CcmRule.getInstance();
+
+  private static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccm).build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccm).around(sessionRule);
+
+  private static ProductDao productDao;
+
+  @BeforeClass
+  public static void setup() {
+    CqlSession session = sessionRule.session();
+
+    for (String query : InventoryFixtures.createStatements()) {
+      session.execute(
+          SimpleStatement.builder(query).withExecutionProfile(sessionRule.slowProfile()).build());
+    }
+
+    InventoryMapper inventoryMapper = new InventoryMapperBuilder(session).build();
+    productDao = inventoryMapper.productDao(sessionRule.keyspace());
+  }
+
+  @Test
+  public void should_set_entity_on_bound_statement() {
+    // Given
+    CqlSession session = sessionRule.session();
+    PreparedStatement preparedStatement =
+        session.prepare("INSERT INTO product (id, description, dimensions) VALUES (?, ?, ?)");
+    BoundStatement boundStatement = preparedStatement.bind();
+
+    // When
+    boundStatement = productDao.set(InventoryFixtures.FLAMETHROWER.entity, boundStatement);
+
+    // Then
+    InventoryFixtures.FLAMETHROWER.assertMatches(boundStatement);
+  }
+
+  @Test
+  public void should_set_entity_on_bound_statement_builder() {
+    // Given
+    CqlSession session = sessionRule.session();
+    PreparedStatement preparedStatement =
+        session.prepare("INSERT INTO product (id, description, dimensions) VALUES (?, ?, ?)");
+    BoundStatementBuilder builder = preparedStatement.boundStatementBuilder();
+
+    // When
+    productDao.set(builder, InventoryFixtures.FLAMETHROWER.entity);
+    BoundStatement boundStatement = builder.build();
+
+    // Then
+    InventoryFixtures.FLAMETHROWER.assertMatches(boundStatement);
+  }
+
+  @Test
+  public void should_set_entity_on_udt_value() {
+    // Given
+    CqlSession session = sessionRule.session();
+    UserDefinedType udtType =
+        session
+            .getMetadata()
+            .getKeyspace(sessionRule.keyspace())
+            .orElseThrow(AssertionError::new)
+            .getUserDefinedType("dimensions")
+            .orElseThrow(AssertionError::new);
+    UdtValue udtValue = udtType.newValue();
+
+    // When
+    productDao.set(InventoryFixtures.SAMPLE_DIMENSIONS.entity, udtValue);
+
+    // Then
+    InventoryFixtures.SAMPLE_DIMENSIONS.assertMatches(udtValue);
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/model/EntityFixture.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/model/EntityFixture.java
@@ -13,14 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datastax.oss.driver.api.mapper.entity;
+package com.datastax.oss.driver.mapper.model;
 
 import com.datastax.oss.driver.api.core.data.GettableByName;
-import com.datastax.oss.driver.api.core.data.SettableByName;
 
-public interface EntityHelper<EntityT> {
+/**
+ * Provides a sample of an entity and means to check that it's correctly mapped to a driver data
+ * structure.
+ */
+public abstract class EntityFixture<EntityT> {
 
-  <SettableT extends SettableByName<SettableT>> SettableT set(EntityT entity, SettableT target);
+  public final EntityT entity;
 
-  EntityT get(GettableByName source);
+  protected EntityFixture(EntityT entity) {
+    this.entity = entity;
+  }
+
+  public abstract void assertMatches(GettableByName data);
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/model/inventory/Dimensions.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/model/inventory/Dimensions.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.mapper.model.inventory;
+
+import com.datastax.oss.driver.api.mapper.annotations.Entity;
+
+@Entity
+public class Dimensions {
+
+  private int length;
+  private int width;
+  private int height;
+
+  public Dimensions() {}
+
+  public Dimensions(int length, int width, int height) {
+    this.length = length;
+    this.width = width;
+    this.height = height;
+  }
+
+  public int getLength() {
+    return length;
+  }
+
+  public void setLength(int length) {
+    this.length = length;
+  }
+
+  public int getWidth() {
+    return width;
+  }
+
+  public void setWidth(int width) {
+    this.width = width;
+  }
+
+  public int getHeight() {
+    return height;
+  }
+
+  public void setHeight(int height) {
+    this.height = height;
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/model/inventory/InventoryFixtures.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/model/inventory/InventoryFixtures.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.mapper.model.inventory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.data.GettableByName;
+import com.datastax.oss.driver.api.core.data.UdtValue;
+import com.datastax.oss.driver.mapper.model.EntityFixture;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import java.util.List;
+import java.util.UUID;
+
+public class InventoryFixtures {
+  public static List<String> createStatements() {
+    return ImmutableList.of(
+        "CREATE TYPE dimensions(length int, width int, height int)",
+        "CREATE TABLE product(id uuid PRIMARY KEY, description text, dimensions dimensions)");
+  }
+
+  public static EntityFixture<Product> FLAMETHROWER =
+      new EntityFixture<Product>(
+          new Product(UUID.randomUUID(), "Flamethrower", new Dimensions(30, 10, 8))) {
+
+        @Override
+        public void assertMatches(GettableByName data) {
+          assertThat(data.getUuid("id")).isEqualTo(entity.getId());
+          assertThat(data.getString("description")).isEqualTo(entity.getDescription());
+          UdtValue udtValue = data.getUdtValue("dimensions");
+          assertThat(udtValue.getType().getName().asInternal()).isEqualTo("dimensions");
+          assertThat(udtValue.getInt("length")).isEqualTo(entity.getDimensions().getLength());
+          assertThat(udtValue.getInt("width")).isEqualTo(entity.getDimensions().getWidth());
+          assertThat(udtValue.getInt("height")).isEqualTo(entity.getDimensions().getHeight());
+        }
+      };
+
+  public static EntityFixture<Dimensions> SAMPLE_DIMENSIONS =
+      new EntityFixture<Dimensions>(new Dimensions(30, 10, 8)) {
+        @Override
+        public void assertMatches(GettableByName data) {
+          assertThat(data.getInt("length")).isEqualTo(entity.getLength());
+          assertThat(data.getInt("width")).isEqualTo(entity.getWidth());
+          assertThat(data.getInt("height")).isEqualTo(entity.getHeight());
+        }
+      };
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/model/inventory/InventoryMapper.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/model/inventory/InventoryMapper.java
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datastax.oss.driver.api.mapper.entity;
+package com.datastax.oss.driver.mapper.model.inventory;
 
-import com.datastax.oss.driver.api.core.data.GettableByName;
-import com.datastax.oss.driver.api.core.data.SettableByName;
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.mapper.annotations.DaoKeyspace;
+import com.datastax.oss.driver.api.mapper.annotations.Mapper;
 
-public interface EntityHelper<EntityT> {
-
-  <SettableT extends SettableByName<SettableT>> SettableT set(EntityT entity, SettableT target);
-
-  EntityT get(GettableByName source);
+@Mapper
+public interface InventoryMapper {
+  ProductDao productDao(@DaoKeyspace CqlIdentifier keyspace);
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/model/inventory/InventorySchema.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/model/inventory/InventorySchema.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datastax.oss.driver.api.mapper.entity;
+package com.datastax.oss.driver.mapper.model.inventory;
 
-import com.datastax.oss.driver.api.core.data.GettableByName;
-import com.datastax.oss.driver.api.core.data.SettableByName;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import java.util.List;
 
-public interface EntityHelper<EntityT> {
-
-  <SettableT extends SettableByName<SettableT>> SettableT set(EntityT entity, SettableT target);
-
-  EntityT get(GettableByName source);
+public class InventorySchema {
+  public static List<String> createStatements() {
+    return ImmutableList.of(
+        "CREATE TYPE dimensions(length int, width int, height int)",
+        "CREATE TABLE product(id uuid PRIMARY KEY, description text, dimensions dimensions)");
+  }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/model/inventory/Product.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/model/inventory/Product.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.mapper.model.inventory;
+
+import com.datastax.oss.driver.api.mapper.annotations.Entity;
+import java.util.UUID;
+
+@Entity
+public class Product {
+
+  private UUID id;
+  private String description;
+  private Dimensions dimensions;
+
+  public Product() {}
+
+  public Product(UUID id, String description, Dimensions dimensions) {
+    this.id = id;
+    this.description = description;
+    this.dimensions = dimensions;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(UUID id) {
+    this.id = id;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public Dimensions getDimensions() {
+    return dimensions;
+  }
+
+  public void setDimensions(Dimensions dimensions) {
+    this.dimensions = dimensions;
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/model/inventory/ProductDao.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/model/inventory/ProductDao.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.mapper.model.inventory;
+
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
+import com.datastax.oss.driver.api.core.data.UdtValue;
+import com.datastax.oss.driver.api.mapper.annotations.Dao;
+import com.datastax.oss.driver.api.mapper.annotations.SetEntity;
+
+@Dao
+public interface ProductDao {
+
+  @SetEntity
+  BoundStatement set(Product product, BoundStatement boundStatement);
+
+  @SetEntity
+  void set(BoundStatementBuilder builder, Product product);
+
+  @SetEntity
+  void set(Dimensions dimensions, UdtValue udtValue);
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/model/package-info.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/model/package-info.java
@@ -13,14 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datastax.oss.driver.api.mapper.entity;
-
-import com.datastax.oss.driver.api.core.data.GettableByName;
-import com.datastax.oss.driver.api.core.data.SettableByName;
-
-public interface EntityHelper<EntityT> {
-
-  <SettableT extends SettableByName<SettableT>> SettableT set(EntityT entity, SettableT target);
-
-  EntityT get(GettableByName source);
-}
+/** Sample data models for object mapper tests. */
+package com.datastax.oss.driver.mapper.model;

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/MethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/MethodGenerator.java
@@ -13,14 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datastax.oss.driver.api.mapper.entity;
+package com.datastax.oss.driver.internal.mapper.processor;
 
-import com.datastax.oss.driver.api.core.data.GettableByName;
-import com.datastax.oss.driver.api.core.data.SettableByName;
+import com.squareup.javapoet.MethodSpec;
 
-public interface EntityHelper<EntityT> {
-
-  <SettableT extends SettableByName<SettableT>> SettableT set(EntityT entity, SettableT target);
-
-  EntityT get(GettableByName source);
+/** A component that generates a single method. */
+public interface MethodGenerator {
+  MethodSpec.Builder generate();
 }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoImplementationGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoImplementationGenerator.java
@@ -15,19 +15,32 @@
  */
 package com.datastax.oss.driver.internal.mapper.processor.dao;
 
+import com.datastax.oss.driver.api.mapper.annotations.SetEntity;
+import com.datastax.oss.driver.api.mapper.entity.EntityHelper;
 import com.datastax.oss.driver.internal.core.util.concurrent.BlockingOperation;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.driver.internal.mapper.MapperContext;
 import com.datastax.oss.driver.internal.mapper.processor.GeneratedNames;
 import com.datastax.oss.driver.internal.mapper.processor.ProcessorContext;
 import com.datastax.oss.driver.internal.mapper.processor.SingleFileCodeGenerator;
+import com.datastax.oss.driver.internal.mapper.processor.SkipGenerationException;
+import com.datastax.oss.driver.internal.mapper.processor.util.NameIndex;
 import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
+import java.beans.Introspector;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 
@@ -35,11 +48,32 @@ public class DaoImplementationGenerator extends SingleFileCodeGenerator {
 
   private final TypeElement interfaceElement;
   private final ClassName implementationName;
+  private final NameIndex nameIndex = new NameIndex();
+  private final Map<ClassName, String> entityHelperFields = new HashMap<>();
 
   public DaoImplementationGenerator(TypeElement interfaceElement, ProcessorContext context) {
     super(context);
     this.interfaceElement = interfaceElement;
     implementationName = GeneratedNames.daoImplementation(interfaceElement);
+  }
+
+  /**
+   * Requests the generation of a field holding the {@link EntityHelper} that was generated for the
+   * given entity class, along with the initialization code in the constructor.
+   *
+   * <p>If this is called multiple times, only a single field will be created.
+   *
+   * @return the name of the field.
+   */
+  String addEntityHelperField(TypeElement entityClass) {
+    ClassName helperClass = GeneratedNames.entityHelper(entityClass);
+    return entityHelperFields.computeIfAbsent(
+        helperClass,
+        k -> {
+          String baseName =
+              Introspector.decapitalize(entityClass.getSimpleName().toString()) + "Helper";
+          return nameIndex.uniqueField(baseName);
+        });
   }
 
   @Override
@@ -50,6 +84,20 @@ public class DaoImplementationGenerator extends SingleFileCodeGenerator {
   @Override
   protected JavaFile.Builder getContents() {
 
+    List<MethodSpec.Builder> methods = new ArrayList<>();
+    for (Element child : interfaceElement.getEnclosedElements()) {
+      try {
+        if (child.getKind() == ElementKind.METHOD) {
+          ExecutableElement methodElement = (ExecutableElement) child;
+          if (methodElement.getAnnotation(SetEntity.class) != null) {
+            methods.add(new DaoSetEntityMethodGenerator(methodElement, this, context).generate());
+          }
+          // TODO handle other annotations
+        }
+      } catch (SkipGenerationException ignored) {
+      }
+    }
+
     TypeSpec.Builder classBuilder =
         TypeSpec.classBuilder(implementationName)
             .addJavadoc(JAVADOC_GENERATED_WARNING)
@@ -59,26 +107,9 @@ public class DaoImplementationGenerator extends SingleFileCodeGenerator {
                 FieldSpec.builder(MapperContext.class, "context", Modifier.PRIVATE, Modifier.FINAL)
                     .build());
 
-    MethodSpec.Builder initAsyncBuilder =
-        MethodSpec.methodBuilder("initAsync")
-            .returns(
-                ParameterizedTypeName.get(
-                    ClassName.get(CompletableFuture.class), ClassName.get(interfaceElement)))
-            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-            .addParameter(MapperContext.class, "context")
-            .addStatement(
-                "return $T.completedFuture(new $T(context))",
-                CompletableFuture.class,
-                implementationName);
+    MethodSpec.Builder initAsyncBuilder = getInitAsyncContents();
 
-    MethodSpec.Builder initBuilder =
-        MethodSpec.methodBuilder("init")
-            .returns(ClassName.get(interfaceElement))
-            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-            .addParameter(MapperContext.class, "context")
-            .addStatement("$T.checkNotDriverThread()", BlockingOperation.class)
-            .addStatement(
-                "return $T.getUninterruptibly(initAsync(context))", CompletableFutures.class);
+    MethodSpec.Builder initBuilder = getInitContents();
 
     MethodSpec.Builder constructorBuilder =
         MethodSpec.constructorBuilder()
@@ -86,10 +117,83 @@ public class DaoImplementationGenerator extends SingleFileCodeGenerator {
             .addParameter(MapperContext.class, "context")
             .addStatement("this.context = context");
 
+    // For each entity helper that was requested by a method generator, create a field for it and
+    // add a constructor parameter for it (the instance gets created in initAsync).
+    for (Map.Entry<ClassName, String> entry : entityHelperFields.entrySet()) {
+      ClassName fieldTypeName = entry.getKey();
+      String fieldName = entry.getValue();
+
+      classBuilder.addField(
+          FieldSpec.builder(fieldTypeName, fieldName, Modifier.PRIVATE, Modifier.FINAL).build());
+      constructorBuilder
+          .addParameter(fieldTypeName, fieldName)
+          .addStatement("this.$1L = $1L", fieldName);
+    }
+
     classBuilder.addMethod(initAsyncBuilder.build());
     classBuilder.addMethod(initBuilder.build());
     classBuilder.addMethod(constructorBuilder.build());
 
+    for (MethodSpec.Builder method : methods) {
+      classBuilder.addMethod(method.build());
+    }
+
     return JavaFile.builder(implementationName.packageName(), classBuilder.build());
+  }
+
+  /**
+   * Generates the DAO's initAsync() builder: this is the entry point, that the main mapper will use
+   * to build instances.
+   *
+   * <p>In this method we want to instantiate any entity helper or prepared statement that will be
+   * needed by methods of the DAO. Then we call the DAO's private constructor, passing that
+   * information.
+   */
+  private MethodSpec.Builder getInitAsyncContents() {
+    MethodSpec.Builder initAsyncBuilder =
+        MethodSpec.methodBuilder("initAsync")
+            .returns(
+                ParameterizedTypeName.get(
+                    ClassName.get(CompletableFuture.class), ClassName.get(interfaceElement)))
+            .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+            .addParameter(MapperContext.class, "context");
+
+    // Start a constructor call: we build it dynamically because the number of parameters depends on
+    // the entity helpers and prepared statements below.
+    CodeBlock.Builder newDaoStatement = CodeBlock.builder();
+    newDaoStatement.add("$[$1T dao = new $1T(context", implementationName);
+
+    // For each entity helper that was requested by a method generator:
+    // - create an instance
+    // - add it as a parameter to the constructor call
+    // Example:
+    // User_Helper userHelper = new User_Helper(context);
+    // Address_Helper addressHelper = new Address_Helper(context);
+    // UserDao_Impl dao = new UserDao_Impl(context,
+    //     userHelper,
+    //     addressHelper);
+    for (Map.Entry<ClassName, String> entry : entityHelperFields.entrySet()) {
+      ClassName fieldTypeName = entry.getKey();
+      String fieldName = entry.getValue();
+      initAsyncBuilder.addStatement("$1T $2L = new $1T(context)", fieldTypeName, fieldName);
+      newDaoStatement.add(",\n$L", fieldName);
+    }
+    newDaoStatement.add(")$];\n");
+
+    // Finally emit the complete constructor call, and wrap the result in a future
+    // TODO this will change once we also create prepared statements in this method
+    initAsyncBuilder.addCode(newDaoStatement.build());
+    initAsyncBuilder.addStatement("return $T.completedFuture(dao)", CompletableFuture.class);
+    return initAsyncBuilder;
+  }
+
+  /** Generates the DAO's init() method: it's a simple synchronous wrapper of initAsync(). */
+  private MethodSpec.Builder getInitContents() {
+    return MethodSpec.methodBuilder("init")
+        .returns(ClassName.get(interfaceElement))
+        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+        .addParameter(MapperContext.class, "context")
+        .addStatement("$T.checkNotDriverThread()", BlockingOperation.class)
+        .addStatement("return $T.getUninterruptibly(initAsync(context))", CompletableFutures.class);
   }
 }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoSetEntityMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoSetEntityMethodGenerator.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.mapper.processor.dao;
+
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.mapper.annotations.Entity;
+import com.datastax.oss.driver.api.mapper.annotations.SetEntity;
+import com.datastax.oss.driver.internal.mapper.processor.MethodGenerator;
+import com.datastax.oss.driver.internal.mapper.processor.ProcessorContext;
+import com.datastax.oss.driver.internal.mapper.processor.SkipGenerationException;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.MethodSpec;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+public class DaoSetEntityMethodGenerator implements MethodGenerator {
+
+  private final ExecutableElement methodElement;
+  private final DaoImplementationGenerator daoImplementationGenerator;
+  private final String entityParameterName;
+  private final TypeElement entityElement;
+  private final String targetParameterName;
+  private final boolean isVoid;
+
+  public DaoSetEntityMethodGenerator(
+      ExecutableElement methodElement,
+      DaoImplementationGenerator daoImplementationGenerator,
+      ProcessorContext context) {
+    this.methodElement = methodElement;
+    this.daoImplementationGenerator = daoImplementationGenerator;
+    // We're expecting a method where one parameter is an annotated entity, and the other a
+    // SettableByName or subtype. It can either be void or return the SettableByName.
+    if (methodElement.getParameters().size() != 2) {
+      context
+          .getMessager()
+          .error(
+              methodElement,
+              "%s methods must have two parameters",
+              SetEntity.class.getSimpleName());
+      throw new SkipGenerationException();
+    }
+    String tmpEntity = null;
+    TypeElement tmpEntityElement = null;
+    String tmpTarget = null;
+    TypeMirror targetParameterType = null;
+    for (VariableElement parameterElement : methodElement.getParameters()) {
+      TypeMirror parameterType = parameterElement.asType();
+      if (context.getClassUtils().implementsSettableByName(parameterType)) {
+        tmpTarget = parameterElement.getSimpleName().toString();
+        targetParameterType = parameterElement.asType();
+      } else if (parameterType.getKind() == TypeKind.DECLARED) {
+        Element parameterTypeElement = ((DeclaredType) parameterType).asElement();
+        if (parameterTypeElement.getKind() == ElementKind.CLASS
+            && parameterTypeElement.getAnnotation(Entity.class) != null) {
+          tmpEntity = parameterElement.getSimpleName().toString();
+          tmpEntityElement = ((TypeElement) parameterTypeElement);
+        }
+      }
+    }
+    if (tmpEntity == null || tmpTarget == null) {
+      context
+          .getMessager()
+          .error(
+              methodElement,
+              "Could not match parameters, expected a SettableByName "
+                  + "and an annotated entity (in any order)");
+      throw new SkipGenerationException();
+    }
+    this.entityParameterName = tmpEntity;
+    this.entityElement = tmpEntityElement;
+    this.targetParameterName = tmpTarget;
+    TypeMirror returnType = methodElement.getReturnType();
+    this.isVoid = returnType.getKind() == TypeKind.VOID;
+    if (isVoid) {
+      if (context.getClassUtils().isSame(targetParameterType, BoundStatement.class)) {
+        context
+            .getMessager()
+            .warn(
+                methodElement,
+                "BoundStatement is immutable, "
+                    + "this method will not modify '%s' in place. "
+                    + "It should probably return BoundStatement rather than void",
+                targetParameterName);
+      }
+    } else if (!context.getTypeUtils().isSameType(returnType, targetParameterType)) {
+      context
+          .getMessager()
+          .error(
+              methodElement,
+              "Invalid return type, should be the same as '%s' (%s)",
+              targetParameterName,
+              targetParameterType);
+    }
+  }
+
+  @Override
+  public MethodSpec.Builder generate() {
+    String helperFieldName = daoImplementationGenerator.addEntityHelperField(entityElement);
+
+    MethodSpec.Builder overridingMethodBuilder =
+        MethodSpec.methodBuilder(methodElement.getSimpleName().toString())
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(ClassName.get(methodElement.getReturnType()));
+    for (VariableElement parameterElement : methodElement.getParameters()) {
+      overridingMethodBuilder.addParameter(
+          ClassName.get(parameterElement.asType()), parameterElement.getSimpleName().toString());
+    }
+    // Forward to the base injector in the helper:
+    overridingMethodBuilder.addStatement(
+        "$L$L.set($L, $L)",
+        isVoid ? "" : "return ",
+        helperFieldName,
+        entityParameterName,
+        targetParameterName);
+
+    return overridingMethodBuilder;
+  }
+}

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityHelperGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityHelperGenerator.java
@@ -93,8 +93,8 @@ public class EntityHelperGenerator extends SingleFileCodeGenerator {
 
     List<PartialClassGenerator> methodGenerators =
         ImmutableList.of(
-            new EntityHelperInjectGenerator(entityDefinition, this, context),
-            new EntityHelperExtractGenerator(entityDefinition, this, context));
+            new EntityHelperSetMethodGenerator(entityDefinition, this, context),
+            new EntityHelperGetMethodGenerator(entityDefinition, this, context));
 
     TypeSpec.Builder classContents =
         TypeSpec.classBuilder(helperName)

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityHelperGetMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityHelperGetMethodGenerator.java
@@ -24,11 +24,11 @@ import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.TypeSpec;
 import javax.lang.model.element.Modifier;
 
-public class EntityHelperExtractGenerator implements PartialClassGenerator {
+public class EntityHelperGetMethodGenerator implements PartialClassGenerator {
 
   private final EntityDefinition entityDefinition;
 
-  public EntityHelperExtractGenerator(
+  public EntityHelperGetMethodGenerator(
       EntityDefinition entityDefinition,
       EntityHelperGenerator enclosingClass,
       ProcessorContext context) {
@@ -39,7 +39,7 @@ public class EntityHelperExtractGenerator implements PartialClassGenerator {
   public void addMembers(TypeSpec.Builder classBuilder) {
 
     MethodSpec.Builder extractBuilder =
-        MethodSpec.methodBuilder("extract")
+        MethodSpec.methodBuilder("get")
             .addAnnotation(Override.class)
             .addModifiers(Modifier.PUBLIC)
             .addParameter(

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/util/Classes.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/util/Classes.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.driver.internal.mapper.processor.util;
 
+import com.datastax.oss.driver.api.core.data.SettableByName;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
@@ -33,9 +34,14 @@ public class Classes {
   private final Types typeUtils;
   private final Elements elementUtils;
 
+  private final TypeMirror settableByNameType;
+
   public Classes(Types typeUtils, Elements elementUtils) {
     this.typeUtils = typeUtils;
     this.elementUtils = elementUtils;
+
+    this.settableByNameType =
+        typeUtils.erasure(elementUtils.getTypeElement(SettableByName.class.getName()).asType());
   }
 
   /** Whether an element is the {@link TypeElement} for the given class. */
@@ -51,5 +57,9 @@ public class Classes {
    */
   public boolean isSame(TypeMirror mirror, Class<?> javaClass) {
     return typeUtils.isSameType(mirror, elementUtils.getTypeElement(javaClass.getName()).asType());
+  }
+
+  public boolean implementsSettableByName(TypeMirror mirror) {
+    return typeUtils.isAssignable(mirror, settableByNameType);
   }
 }

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/SetEntity.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/SetEntity.java
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datastax.oss.driver.api.mapper.entity;
+package com.datastax.oss.driver.api.mapper.annotations;
 
-import com.datastax.oss.driver.api.core.data.GettableByName;
-import com.datastax.oss.driver.api.core.data.SettableByName;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-public interface EntityHelper<EntityT> {
-
-  <SettableT extends SettableByName<SettableT>> SettableT set(EntityT entity, SettableT target);
-
-  EntityT get(GettableByName source);
-}
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.CLASS)
+public @interface SetEntity {}


### PR DESCRIPTION
Now that the base injection logic is handled by `EntityHelper`, this ticket is very simple: the DAO just needs to create an instance of the helper (cached in a field), and delegate to its `inject` method.

Sample code to test:
```java
@Entity
class User { ... }

@Dao
public interface UserDao {
  @EntityInjector
  void inject(User user, BoundStatement boundStatement);
}
```
(I'm aware that automatic tests are lacking so far, it's on my todo list)