### PR TITLE
Allow ControlConnection to initialize if reconnectOnFailure is false

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -39,7 +39,6 @@ import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.driver.internal.core.util.concurrent.Reconnection;
 import com.datastax.oss.driver.internal.core.util.concurrent.RunOrSchedule;
 import com.datastax.oss.driver.internal.core.util.concurrent.UncaughtExceptions;
-import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.protocol.internal.Message;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
@@ -116,9 +115,6 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
       boolean listenToClusterEvents,
       boolean reconnectOnFailure,
       boolean useInitialReconnectionSchedule) {
-    Preconditions.checkArgument(
-        reconnectOnFailure || !useInitialReconnectionSchedule,
-        "Can't set useInitialReconnectionSchedule if reconnectOnFailure is false");
     RunOrSchedule.on(
         adminExecutor,
         () ->


### PR DESCRIPTION
Since JAVA-2077, initialization of the ControllConnection in `DefaultTopologyMonitor` will fail if `advanced.reconnect-on-init` is set to `false`, which is the default in reference.conf/application.conf. This is because the connection is always initialized with `useInitialReconnectionSchedule` set to true.

There is a precondition check that fails the ControlConnection initialization only when `reconnectOnFailure` (set from `advanced.reconnect-on-init` in the configuration) is `false` and `useInitialReconnectionSchedule` is true. All other combinations pass the precondition. However, the documentation in `ControlConnection.init()` suggests that `useInitialReconnectionSchedule` will simply be ignored if `reconnectOnFailure` is `false`.

In this PR, I have 2 proposed solutions:
1) Change the precondition check to a simple warning log (so the initialization does not fail)
2) Change DefaultTopologyMonitor to only set `useInitialReconnectionSchedule` to `true` if  `reconnectOnFailure` is `true`