### PR TITLE
Avoid full cluster scans in Connection.checkClusterName

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -382,7 +382,9 @@ class Connection {
 
     DefaultResultSetFuture clusterNameFuture =
         new DefaultResultSetFuture(
-            null, protocolVersion, new Requests.Query("select cluster_name from system.local"));
+            null,
+            protocolVersion,
+            new Requests.Query("select cluster_name from system.local where key = 'local'"));
     try {
       write(clusterNameFuture);
       return GuavaCompatibility.INSTANCE.transformAsync(


### PR DESCRIPTION
Select without a partition key results in full cluster
scan that can hurt the performance of the cluster.
There is an easy solution to the problem by just
using a 'local' partition key for the query.

Signed-off-by: Piotr Jastrzebski <piotr@scylladb.com>