### PR TITLE
Fix flaky tests for JAVA-1950

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/WarningsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/WarningsTest.java
@@ -20,38 +20,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.datastax.driver.core.utils.CassandraVersion;
 import com.google.common.base.Strings;
 import java.util.List;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 @CCMConfig(config = {"batch_size_warn_threshold_in_kb:5"})
 @CassandraVersion("2.2.0")
 public class WarningsTest extends CCMTestsSupport {
 
-  private MemoryAppender logAppender;
-
   @Override
   public void onTestContextInitialized() {
     execute("CREATE TABLE foo(k int primary key, v text)");
   }
 
-  @Override
-  public void beforeTestClass(Object instance) throws Exception {
-    // create a MemoryAppender and add it
-    logAppender = new MemoryAppender();
-    logAppender.enableFor(LoggerFactory.getLogger(RequestHandler.class));
-    super.beforeTestClass(instance);
-  }
-
-  @Override
-  public void afterTestClass() throws Exception {
-    super.afterTestClass();
-    // remove the log appender
-    logAppender.disableFor(LoggerFactory.getLogger(RequestHandler.class));
-    logAppender = null;
-  }
-
   @Test(groups = "short")
-  public void should_expose_warnings_on_execution_info() {
+  public void should_expose_warnings_on_execution_info() throws Exception {
     // the default batch size warn threshold is 5 * 1024 bytes, but after CASSANDRA-10876 there must
     // be
     // multiple mutations in a batch to trigger this warning so the batch includes 2 different
@@ -63,28 +44,32 @@ public class WarningsTest extends CCMTestsSupport {
                 + "INSERT INTO foo (k, v) VALUES (2, '%s')\n"
                 + "APPLY BATCH",
             Strings.repeat("1", 2 * 1024), Strings.repeat("1", 3 * 1024));
-    ResultSet rs = session().execute(query);
-
-    List<String> warnings = rs.getExecutionInfo().getWarnings();
-    assertThat(warnings).hasSize(1);
-    // also assert that by default, the warning is logged and truncated to
-    // DEFAULT_MAX_QUERY_STRING_LENGTH
-    String log = logAppender.getNext();
-    assertThat(log).isNotNull();
-    assertThat(log).isNotEmpty();
-    assertThat(log)
-        .startsWith("Query '")
-        // query will only be logged up to QueryLogger.DEFAULT_MAX_QUERY_STRING_LENGTH characters
-        .contains(query.substring(0, QueryLogger.DEFAULT_MAX_QUERY_STRING_LENGTH))
-        .contains("' generated server side warning(s): ")
-        .contains(
-            String.format(
-                "Batch for [%s.foo] is of size 5152, exceeding specified threshold of 5120 by 32.",
-                keyspace));
+    MemoryAppender logAppender = new MemoryAppender();
+    logAppender.enableFor(RequestHandler.class);
+    try {
+      ResultSet rs = session().execute(query);
+      List<String> warnings = rs.getExecutionInfo().getWarnings();
+      assertThat(warnings).hasSize(1);
+      // also assert that by default, the warning is logged and truncated to
+      // DEFAULT_MAX_QUERY_STRING_LENGTH
+      String log = logAppender.waitAndGet(2000);
+      assertThat(log).isNotEmpty();
+      assertThat(log)
+          .startsWith("Query '")
+          // query will only be logged up to QueryLogger.DEFAULT_MAX_QUERY_STRING_LENGTH characters
+          .contains(query.substring(0, QueryLogger.DEFAULT_MAX_QUERY_STRING_LENGTH))
+          .contains("' generated server side warning(s): ")
+          .contains(
+              String.format(
+                  "Batch for [%s.foo] is of size 5152, exceeding specified threshold of 5120 by 32.",
+                  keyspace));
+    } finally {
+      logAppender.disableFor(RequestHandler.class);
+    }
   }
 
   @Test(groups = "short")
-  public void should_execute_query_and_log_server_side_warnings() {
+  public void should_execute_query_and_log_server_side_warnings() throws Exception {
     // Assert that logging of server-side query warnings is NOT disabled
     assertThat(Boolean.getBoolean(RequestHandler.DISABLE_QUERY_WARNING_LOGS)).isFalse();
 
@@ -93,29 +78,34 @@ public class WarningsTest extends CCMTestsSupport {
     final String query = "SELECT count(*) FROM foo;";
     SimpleStatement statement = new SimpleStatement(query);
     // When the query is executed
-    ResultSet rs = session().execute(statement);
-    // Then the result has 1 Row
-    Row row = rs.one();
-    assertThat(row).isNotNull();
-    // And there is a server side warning captured in the ResultSet's ExecutionInfo
-    ExecutionInfo ei = rs.getExecutionInfo();
-    List<String> warnings = ei.getWarnings();
-    assertThat(warnings).isNotEmpty();
-    assertThat(warnings.size()).isEqualTo(1);
-    assertThat(warnings.get(0)).isEqualTo("Aggregation query used without partition key");
-    // And the driver logged the server side warning
-    String log = logAppender.getNext();
-    assertThat(log).isNotNull();
-    assertThat(log).isNotEmpty();
-    assertThat(log)
-        .startsWith(
-            "Query '[0 bound values] "
-                + query
-                + "' generated server side warning(s): Aggregation query used without partition key");
+    MemoryAppender logAppender = new MemoryAppender();
+    logAppender.enableFor(RequestHandler.class);
+    try {
+      ResultSet rs = session().execute(statement);
+      // Then the result has 1 Row
+      Row row = rs.one();
+      assertThat(row).isNotNull();
+      // And there is a server side warning captured in the ResultSet's ExecutionInfo
+      ExecutionInfo ei = rs.getExecutionInfo();
+      List<String> warnings = ei.getWarnings();
+      assertThat(warnings).isNotEmpty();
+      assertThat(warnings.size()).isEqualTo(1);
+      assertThat(warnings.get(0)).isEqualTo("Aggregation query used without partition key");
+      // And the driver logged the server side warning
+      String log = logAppender.waitAndGet(2000);
+      assertThat(log).isNotEmpty();
+      assertThat(log)
+          .startsWith(
+              "Query '[0 bound values] "
+                  + query
+                  + "' generated server side warning(s): Aggregation query used without partition key");
+    } finally {
+      logAppender.disableFor(RequestHandler.class);
+    }
   }
 
   @Test(groups = "isolated")
-  public void should_execute_query_and_not_log_server_side_warnings() {
+  public void should_execute_query_and_not_log_server_side_warnings() throws Exception {
     // Get the system property value for disabling logging server side warnings
     final String disabledLogFlag =
         System.getProperty(RequestHandler.DISABLE_QUERY_WARNING_LOGS, "false");
@@ -128,19 +118,25 @@ public class WarningsTest extends CCMTestsSupport {
       // ExecutionInfo
       SimpleStatement statement = new SimpleStatement("SELECT count(*) FROM foo");
       // When the query is executed
-      ResultSet rs = session().execute(statement);
-      // Then the result has 1 Row
-      Row row = rs.one();
-      assertThat(row).isNotNull();
-      // And there is a server side warning captured in the ResultSet's ExecutionInfo
-      ExecutionInfo ei = rs.getExecutionInfo();
-      List<String> warnings = ei.getWarnings();
-      assertThat(warnings).isNotEmpty();
-      assertThat(warnings.size()).isEqualTo(1);
-      assertThat(warnings.get(0)).isEqualTo("Aggregation query used without partition key");
-      // And the driver did NOT log the server side warning
-      String log = logAppender.getNext();
-      assertThat(log).isNullOrEmpty();
+      MemoryAppender logAppender = new MemoryAppender();
+      logAppender.enableFor(RequestHandler.class);
+      try {
+        ResultSet rs = session().execute(statement);
+        // Then the result has 1 Row
+        Row row = rs.one();
+        assertThat(row).isNotNull();
+        // And there is a server side warning captured in the ResultSet's ExecutionInfo
+        ExecutionInfo ei = rs.getExecutionInfo();
+        List<String> warnings = ei.getWarnings();
+        assertThat(warnings).isNotEmpty();
+        assertThat(warnings.size()).isEqualTo(1);
+        assertThat(warnings.get(0)).isEqualTo("Aggregation query used without partition key");
+        // And the driver did NOT log the server side warning
+        String log = logAppender.waitAndGet(2000);
+        assertThat(log).isNullOrEmpty();
+      } finally {
+        logAppender.disableFor(RequestHandler.class);
+      }
     } finally {
       // reset the logging flag
       System.setProperty(RequestHandler.DISABLE_QUERY_WARNING_LOGS, disabledLogFlag);


### PR DESCRIPTION
This should fix 2 issues with these tests running on Jenkins. One issue is getting the log from the MemoryAppender too soon after the query has been executed can result in the log being empty (it hasn't been written to), thus failing the verification. The second issue is using a _global_ MemoryAppender for all of the tests can result in the logs of previous tests being pulled for verification.