### PR TITLE
JAVA-2177: Don't exclude down nodes when initializing LBPs

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0 (in progress)
 
+- [bug] JAVA-2177: Don't exclude down nodes when initializing LBPs
 - [improvement] JAVA-2143: Rename Statement.setTimestamp() to setQueryTimestamp()
 - [improvement] JAVA-2165: Abstract node connection information
 - [improvement] JAVA-2090: Add support for additional_write_policy and read_repair table options

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapper.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
@@ -119,7 +118,7 @@ public class LoadBalancingPolicyWrapper implements AutoCloseable {
       MetadataManager metadataManager = context.getMetadataManager();
       Metadata metadata = metadataManager.getMetadata();
       for (LoadBalancingPolicy policy : policies) {
-        policy.init(excludeDownHosts(metadata), reporters.get(policy));
+        policy.init(metadata.getNodes(), reporters.get(policy));
       }
       if (stateRef.compareAndSet(State.DURING_INIT, State.RUNNING)) {
         eventFilter.markReady();
@@ -193,18 +192,6 @@ public class LoadBalancingPolicyWrapper implements AutoCloseable {
         }
         break;
     }
-  }
-
-  private static Map<UUID, Node> excludeDownHosts(Metadata metadata) {
-    ImmutableMap.Builder<UUID, Node> nodes = ImmutableMap.builder();
-    for (Map.Entry<UUID, Node> entry : metadata.getNodes().entrySet()) {
-      UUID id = entry.getKey();
-      Node node = entry.getValue();
-      if (node.getState() == NodeState.UP || node.getState() == NodeState.UNKNOWN) {
-        nodes.put(id, node);
-      }
-    }
-    return nodes.build();
   }
 
   @Override

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapperTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/LoadBalancingPolicyWrapperTest.java
@@ -146,7 +146,7 @@ public class LoadBalancingPolicyWrapperTest {
   }
 
   @Test
-  public void should_init_policies_with_up_or_unknown_nodes() {
+  public void should_init_policies_with_all_nodes() {
     // Given
     node1.state = NodeState.UP;
     node2.state = NodeState.UNKNOWN;
@@ -159,7 +159,7 @@ public class LoadBalancingPolicyWrapperTest {
     for (LoadBalancingPolicy policy : ImmutableList.of(policy1, policy2, policy3)) {
       verify(policy).init(initNodesCaptor.capture(), any(DistanceReporter.class));
       Map<UUID, Node> initNodes = initNodesCaptor.getValue();
-      assertThat(initNodes.values()).containsOnly(node1, node2);
+      assertThat(initNodes.values()).containsOnly(node1, node2, node3);
     }
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ConnectIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/ConnectIT.java
@@ -23,15 +23,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.api.testinfra.utils.ConditionChecker;
 import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.connection.ConstantReconnectionPolicy;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+import com.datastax.oss.simulacron.server.BoundCluster;
 import com.datastax.oss.simulacron.server.RejectScope;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -47,7 +54,7 @@ public class ConnectIT {
 
   @ClassRule
   public static SimulacronRule simulacronRule =
-      new SimulacronRule(ClusterSpec.builder().withNodes(1));
+      new SimulacronRule(ClusterSpec.builder().withNodes(2));
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
@@ -125,6 +132,40 @@ public class ConnectIT {
     checkThat(() -> simulacronRule.cluster().getConnections().getConnections().isEmpty())
         .before(1, SECONDS)
         .becomesTrue();
+  }
+
+  /**
+   * Test for JAVA-2177. This ensures that even if the first attempted contact point is unreachable,
+   * its distance is set to LOCAL and reconnections are scheduled.
+   */
+  @Test
+  public void should_mark_unreachable_contact_points_as_local_and_schedule_reconnections() {
+    // Reject connections only on one node
+    BoundCluster boundCluster = simulacronRule.cluster();
+    boundCluster.node(0).rejectConnections(0, RejectScope.STOP);
+
+    try (CqlSession session = SessionUtils.newSession(simulacronRule)) {
+      Map<UUID, Node> nodes = session.getMetadata().getNodes();
+      // Node states are updated asynchronously, so guard against race conditions
+      ConditionChecker.checkThat(
+              () -> {
+                // Before JAVA-2177, this would fail every other time because if the node was tried
+                // first for the initial connection, it was marked down and not passed to
+                // LBP.init(), and therefore stayed at distance IGNORED.
+                Node node0 = nodes.get(boundCluster.node(0).getHostId());
+                assertThat(node0.getState()).isEqualTo(NodeState.DOWN);
+                assertThat(node0.getDistance()).isEqualTo(NodeDistance.LOCAL);
+                assertThat(node0.getOpenConnections()).isEqualTo(0);
+                assertThat(node0.isReconnecting()).isTrue();
+
+                Node node1 = nodes.get(boundCluster.node(1).getHostId());
+                assertThat(node1.getState()).isEqualTo(NodeState.UP);
+                assertThat(node1.getDistance()).isEqualTo(NodeDistance.LOCAL);
+                assertThat(node1.getOpenConnections()).isEqualTo(2); // control + regular
+                assertThat(node1.isReconnecting()).isFalse();
+              })
+          .becomesTrue();
+    }
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Motivation:

In driver 4, the LBP "pushes" the distances to the driver, not the other
way around. So if we don't set the distance of a node in init(), it will
stay at IGNORED and the driver won't try to connect to it.
Therefore all nodes should be passed to init().

Modifications:

Don't filter the nodes in LoadBalancingPolicyWrapper.
Update the javadocs of LoadBalancingPolicy to explain the contract.
Update DefaultLoadBalancingPolicy to only add UP nodes to its live set.

Result:

Down nodes don't stay ignored anymore.