### PR TITLE
JAVA-2143: Rename Statement.setTimestamp() to setQueryTimestamp()

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.0 (in progress)
 
+- [improvement] JAVA-2143: Rename Statement.setTimestamp() to setQueryTimestamp()
 - [improvement] JAVA-2165: Abstract node connection information
 - [improvement] JAVA-2090: Add support for additional_write_policy and read_repair table options
 - [improvement] JAVA-2164: Rename statement builder methods to setXxx

--- a/core/revapi.json
+++ b/core/revapi.json
@@ -234,6 +234,26 @@
         "new": "parameter javax.net.ssl.SSLEngine com.datastax.oss.driver.api.core.ssl.SslEngineFactory::newSslEngine(===com.datastax.oss.driver.api.core.metadata.EndPoint===)",
         "oldArchive": "com.datastax.oss:java-driver-core:jar:4.0.0-rc1",
         "justification": "JAVA-2165: Abstract node connection information"
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method long com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>>::getQueryTimestamp()",
+        "justification": "JAVA-2143: Rename Statement.setTimestamp() to setQueryTimestamp()"
+      },
+      {
+        "code": "java.method.removed",
+        "old": "method long com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>>::getTimestamp()",
+        "justification": "JAVA-2143: Rename Statement.setTimestamp() to setQueryTimestamp()"
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method SelfT com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>>::setQueryTimestamp(long)",
+        "justification": "JAVA-2143: Rename Statement.setTimestamp() to setQueryTimestamp()"
+      },
+      {
+        "code": "java.method.removed",
+        "old": "method SelfT com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>>::setTimestamp(long)",
+        "justification": "JAVA-2143: Rename Statement.setTimestamp() to setQueryTimestamp()"
       }
     ]
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/CqlSession.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/CqlSession.java
@@ -114,9 +114,9 @@ public interface CqlSession extends Session {
    *       null}), or {@code simpleStatement.getRoutingKeyspace()};
    *   <li>on the other hand, the following attributes are <b>not</b> propagated:
    *       <ul>
-   *         <li>{@link Statement#getTimestamp() boundStatement.getTimestamp()} will be set to
-   *             {@link Long#MIN_VALUE}, meaning that the value will be assigned by the session's
-   *             timestamp generator.
+   *         <li>{@link Statement#getQueryTimestamp() boundStatement.getQueryTimestamp()} will be
+   *             set to {@link Long#MIN_VALUE}, meaning that the value will be assigned by the
+   *             session's timestamp generator.
    *         <li>{@link Statement#getNode() boundStatement.getNode()} will always be {@code null}.
    *       </ul>
    * </ul>

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/BatchStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/BatchStatement.java
@@ -243,7 +243,7 @@ public interface BatchStatement extends Statement<BatchStatement>, Iterable<Batc
 
     // timestamp
     if (!(context.getTimestampGenerator() instanceof ServerSideTimestampGenerator)
-        || getTimestamp() != Long.MIN_VALUE) {
+        || getQueryTimestamp() != Long.MIN_VALUE) {
 
       size += PrimitiveSizes.LONG;
     }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/BoundStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/BoundStatement.java
@@ -86,7 +86,7 @@ public interface BoundStatement
 
     // timestamp
     if (!(context.getTimestampGenerator() instanceof ServerSideTimestampGenerator)
-        || getTimestamp() != Long.MIN_VALUE) {
+        || getQueryTimestamp() != Long.MIN_VALUE) {
       size += PrimitiveSizes.LONG;
     }
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/SimpleStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/SimpleStatement.java
@@ -285,7 +285,7 @@ public interface SimpleStatement extends BatchableStatement<SimpleStatement> {
 
     // timestamp
     if (!(context.getTimestampGenerator() instanceof ServerSideTimestampGenerator)
-        || getTimestamp() != Long.MIN_VALUE) {
+        || getQueryTimestamp() != Long.MIN_VALUE) {
       size += PrimitiveSizes.LONG;
     }
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/Statement.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/Statement.java
@@ -210,7 +210,7 @@ public interface Statement<SelfT extends Statement<SelfT>> extends Request {
    *
    * @see TimestampGenerator
    */
-  long getTimestamp();
+  long getQueryTimestamp();
 
   /**
    * Sets the query timestamp, in microseconds, to send with the statement.
@@ -224,7 +224,7 @@ public interface Statement<SelfT extends Statement<SelfT>> extends Request {
    * @see TimestampGenerator
    */
   @NonNull
-  SelfT setTimestamp(long newTimestamp);
+  SelfT setQueryTimestamp(long newTimestamp);
 
   /**
    * Sets how long to wait for this request to complete. This is a global limit on the duration of a

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/StatementBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/StatementBuilder.java
@@ -75,7 +75,7 @@ public abstract class StatementBuilder<
     }
     this.idempotent = template.isIdempotent();
     this.tracing = template.isTracing();
-    this.timestamp = template.getTimestamp();
+    this.timestamp = template.getQueryTimestamp();
     this.pagingState = template.getPagingState();
     this.pageSize = template.getPageSize();
     this.consistencyLevel = template.getConsistencyLevel();
@@ -161,9 +161,9 @@ public abstract class StatementBuilder<
     return self;
   }
 
-  /** @see Statement#setTimestamp(long) */
+  /** @see Statement#setQueryTimestamp(long) */
   @NonNull
-  public SelfT setTimestamp(long timestamp) {
+  public SelfT setQueryTimestamp(long timestamp) {
     this.timestamp = timestamp;
     return self;
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
@@ -131,7 +131,7 @@ public class Conversions {
             ? consistencyLevelRegistry.nameToCode(
                 config.getString(DefaultDriverOption.REQUEST_SERIAL_CONSISTENCY))
             : serialConsistency.getProtocolCode();
-    long timestamp = statement.getTimestamp();
+    long timestamp = statement.getQueryTimestamp();
     if (timestamp == Long.MIN_VALUE) {
       timestamp = context.getTimestampGenerator().next();
     }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBatchStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBatchStatement.java
@@ -678,13 +678,13 @@ public class DefaultBatchStatement implements BatchStatement {
   }
 
   @Override
-  public long getTimestamp() {
+  public long getQueryTimestamp() {
     return timestamp;
   }
 
   @NonNull
   @Override
-  public BatchStatement setTimestamp(long newTimestamp) {
+  public BatchStatement setQueryTimestamp(long newTimestamp) {
     return new DefaultBatchStatement(
         batchType,
         statements,

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
@@ -499,13 +499,13 @@ public class DefaultBoundStatement implements BoundStatement {
   }
 
   @Override
-  public long getTimestamp() {
+  public long getQueryTimestamp() {
     return timestamp;
   }
 
   @NonNull
   @Override
-  public BoundStatement setTimestamp(long newTimestamp) {
+  public BoundStatement setQueryTimestamp(long newTimestamp) {
     return new DefaultBoundStatement(
         preparedStatement,
         variableDefinitions,

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultSimpleStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultSimpleStatement.java
@@ -504,13 +504,13 @@ public class DefaultSimpleStatement implements SimpleStatement {
   }
 
   @Override
-  public long getTimestamp() {
+  public long getQueryTimestamp() {
     return timestamp;
   }
 
   @NonNull
   @Override
-  public SimpleStatement setTimestamp(long newTimestamp) {
+  public SimpleStatement setQueryTimestamp(long newTimestamp) {
     return new DefaultSimpleStatement(
         query,
         positionalValues,

--- a/faq/README.md
+++ b/faq/README.md
@@ -57,3 +57,10 @@ higher latencies.
 We therefore urge users to carefully choose upfront the consistency level that works best for their
 use cases. If there is a legitimate reason to downgrade and retry, that should be handled by the
 application code.
+
+### I want to set a date on a bound statement, where did `setTimestamp()` go?
+
+The driver now uses Java 8's improved date and time API. CQL type `timestamp` is mapped to
+`java.time.Instant`, and the corresponding getter and setter are `getInstant` and `setInstant`.
+
+See [Temporal types](../manual/core/temporal_types/) for more details.

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BoundStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/BoundStatementIT.java
@@ -441,7 +441,7 @@ public class BoundStatementIT {
             .setRoutingKeyspace(mockRoutingKeyspace)
             .setRoutingKey(mockRoutingKey)
             .setRoutingToken(mockRoutingToken)
-            .setTimestamp(42)
+            .setQueryTimestamp(42)
             .setIdempotence(true)
             .setTracing()
             .setTimeout(mockTimeout)
@@ -483,7 +483,7 @@ public class BoundStatementIT {
       // Bound statements do not support per-query keyspaces, so this is not set
       assertThat(boundStatement.getKeyspace()).isNull();
       // Should not be propagated
-      assertThat(boundStatement.getTimestamp()).isEqualTo(Long.MIN_VALUE);
+      assertThat(boundStatement.getQueryTimestamp()).isEqualTo(Long.MIN_VALUE);
     }
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/SimpleStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/SimpleStatementIT.java
@@ -175,7 +175,7 @@ public class SimpleStatementIT {
     SimpleStatement insert =
         SimpleStatement.builder("INSERT INTO test2 (k, v) values (?, ?)")
             .addPositionalValues(name.getMethodName(), 0)
-            .setTimestamp(timestamp)
+            .setQueryTimestamp(timestamp)
             .build();
 
     sessionRule.session().execute(insert);

--- a/manual/core/query_timestamps/README.md
+++ b/manual/core/query_timestamps/README.md
@@ -145,7 +145,7 @@ Finally, you can assign a timestamp to a statement directly from application cod
 ```java
 Statement statement =
     SimpleStatement.builder("UPDATE users SET email = 'x@y.com' where id = 1")
-        .setTimestamp(1432815430948040L)
+        .setQueryTimestamp(1432815430948040L)
         .build();
 session.execute(statement);
 ```

--- a/manual/core/statements/prepared/README.md
+++ b/manual/core/statements/prepared/README.md
@@ -161,7 +161,7 @@ BoundStatement bound =
       .setString(0, "324378")
       .setString(1, "LCD screen")
       .setExecutionProfileName("oltp")
-      .setTimestamp(123456789L)
+      .setQueryTimestamp(123456789L)
       .build();
 ```
 


### PR DESCRIPTION
I opted for `queryTimestamp`.
`writeTime` was another suggestion, but I thought it was too disconnected from `TimestampGenerator`, and I didn't want to rename that.