### PR TITLE
JAVA-2183: Enable materialized views when testing against Cassandra 4

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -16,6 +16,7 @@
 
 ### 4.0.0-rc1
 
+- [improvement] JAVA-2183: Enable materialized views when testing against Cassandra 4
 - [improvement] JAVA-2106: Log server side warnings returned from a query
 - [improvement] JAVA-2151: Drop "Dsl" suffix from query builder main classes
 - [new feature] JAVA-2144: Expose internal API to hook into the session lifecycle

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/DefaultLoadBalancingPolicy.java
@@ -141,11 +141,9 @@ public class DefaultLoadBalancingPolicy implements LoadBalancingPolicy {
     } else {
       ImmutableMap.Builder<Node, String> builder = ImmutableMap.builder();
       for (Node node : contactPoints) {
-        if (node != null) {
-          String datacenter = node.getDatacenter();
-          if (!Objects.equals(localDc, datacenter)) {
-            builder.put(node, (datacenter == null) ? "<null>" : datacenter);
-          }
+        String datacenter = node.getDatacenter();
+        if (!Objects.equals(localDc, datacenter)) {
+          builder.put(node, (datacenter == null) ? "<null>" : datacenter);
         }
       }
       ImmutableMap<Node, String> badContactPoints = builder.build();

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/DefaultCcmBridgeBuilderCustomizer.java
@@ -15,9 +15,14 @@
  */
 package com.datastax.oss.driver.api.testinfra.ccm;
 
+import com.datastax.oss.driver.api.core.Version;
+
 public class DefaultCcmBridgeBuilderCustomizer {
 
   public static CcmBridge.Builder configureBuilder(CcmBridge.Builder builder) {
+    if (!CcmBridge.DSE_ENABLEMENT && CcmBridge.VERSION.compareTo(Version.V4_0_0) >= 0) {
+      builder.withCassandraConfiguration("enable_materialized_views", true);
+    }
     return builder;
   }
 }


### PR DESCRIPTION
To test, run `DescribeIT` against a local checkout of the Cassandra trunk:
```
-Dccm.version=4.0.0 -Dccm.directory=/path/to/cassandra
```
Note that the test still fails after views are enabled ([JAVA-2184](https://datastax-oss.atlassian.net/browse/JAVA-2184)), but you can see that it's a different error.