### PR TITLE
getMetadata() is a member of Cluster, not Session

### DIFF
--- a/manual/udts/README.md
+++ b/manual/udts/README.md
@@ -61,7 +61,7 @@ various ways to get it:
 * from the driver's [schema metadata](../metadata/#schema-metadata):
 
     ```java
-    UserType udt = session.getMetadata().getKeyspace("ks").getUserType("type1");
+    UserType udt = session.getCluster().getMetadata().getKeyspace("ks").getUserType("type1");
     ```
 
 * from another UDT value:


### PR DESCRIPTION
There's one ".getCluster()" call missing at a location in the documentation