### PR TITLE
JAVA2193: Fix flaky tests in ExecutionInfoWarningsIT

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.1 (in progress)
 
+- [bug] JAVA-2193: Fix flaky tests in ExecutionInfoWarningsIT
 - [improvement] JAVA-2197: Skip deployment of examples and integration tests to Maven central
 
 ### 4.0.0

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -228,25 +228,10 @@
           <skip>true</skip>
         </configuration>
       </plugin>
-      <plugin>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <configuration>
-          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-        </configuration>
-      </plugin>
+      <!--
+        Don't disable the install or deploy plugins as downstream projects may rely on running
+        these integration tests as well.
+      -->
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Fixes issues with the tests failing against some versions of Cassandra, in particular the Batch warn threshold size (so the batch does need to be over 64Kb to trigger the warning log), and the log assertions, as the format of the log is a little different in the different versions of Cassandra.