### PR TITLE
Fix wrong type signature in custom codecs documentation

### DIFF
--- a/manual/core/custom_codecs/README.md
+++ b/manual/core/custom_codecs/README.md
@@ -105,7 +105,7 @@ session.execute(
 
 Custom codecs are used not only for their base type, but also recursively in collections, tuples and
 UDTs. For example, once your `int <-> String` codec is registered, you can also read a CQL
-`list<int>` as a Java `List<Integer>`:
+`list<int>` as a Java `List<String>`:
 
 ```java
 // cqlsh:ks> desc table test3;


### PR DESCRIPTION
The documentation states the following:
```
For example, once your `int <-> String` codec is registered, you can also read a CQL
`list<int>` as a Java `List<Integer>`:
```

Since we convert from `int <-> String` you've probably meant we can now convert from `list<int> <-> List<String>`.