### PR TITLE
JAVA-2214: Fix flaky RequestLoggerIT test

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.0.1 (in progress)
 
+- [bug] JAVA-2214: Fix flaky RequestLoggerIT test
 - [bug] JAVA-2203: Handle unresolved addresses in DefaultEndPoint
 - [bug] JAVA-2210: Add ability to set TTL for modification queries
 - [improvement] JAVA-2212: Add truncate to QueryBuilder 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/DefaultSessionPoolsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/DefaultSessionPoolsTest.java
@@ -952,7 +952,7 @@ public class DefaultSessionPoolsTest {
     // This works because the event loop group is single-threaded
     Future<?> f = adminEventLoopGroup.schedule(() -> null, 5, TimeUnit.NANOSECONDS);
     try {
-      Uninterruptibles.getUninterruptibly(f, 100, TimeUnit.MILLISECONDS);
+      Uninterruptibles.getUninterruptibly(f, 250, TimeUnit.MILLISECONDS);
     } catch (ExecutionException e) {
       fail("unexpected error", e.getCause());
     } catch (TimeoutException e) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/context/LifecycleListenerIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/context/LifecycleListenerIT.java
@@ -75,7 +75,7 @@ public class LifecycleListenerIT {
       simulacronRule.cluster().acceptConnections();
     }
     assertThat(listener.ready).isFalse();
-    assertThat(listener.closed).isTrue();
+    ConditionChecker.checkThat(() -> listener.closed).before(1, SECONDS).becomesTrue();
   }
 
   private CqlSession newSession(TestLifecycleListener listener) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/querybuilder/JsonInsertIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/querybuilder/JsonInsertIT.java
@@ -28,6 +28,7 @@ import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import com.datastax.oss.driver.api.core.type.codec.CodecNotFoundException;
+import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
@@ -46,6 +47,7 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 @Category(ParallelizableTests.class)
+@CassandraRequirement(min = "2.2", description = "JSON support in Cassandra was added in 2.2")
 public class JsonInsertIT {
   private static final CcmRule ccmRule = CcmRule.getInstance();
   private static final JacksonJsonCodec<User> JACKSON_JSON_CODEC =


### PR DESCRIPTION
Also fixes a couple other test failures:
* Ensure JSON Insert tests are run against Cassandra 2.2+
* Ensure LifecycleListenerIT tests allow listener to close before asserting it is closed.
* Allow adminEventLoopGroup more time to complete admin tasks for DefaultSessionPoolsTest