### PR TITLE
JAVA-2249: Remove stripTrailingZeroBytes from OPPToken

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 3.7.2 (In progress)
+
+- [bug] JAVA-2249: Stop stripping trailing zeros in ByteOrderedTokens
+
 ### 3.7.1
 
 - [bug] JAVA-2174: Metadata.needsQuote should accept empty strings.

--- a/driver-core/src/main/java/com/datastax/driver/core/Token.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Token.java
@@ -418,7 +418,8 @@ public abstract class Token implements Comparable<Token> {
             start = toBigInteger(oppStartToken.value, significantBytes);
             end = toBigInteger(oppEndToken.value, significantBytes);
             range = end.subtract(start);
-            if (addedBytes == 4 || range.compareTo(bigNumberOfSplits) >= 0) break;
+            if (addedBytes == 4 || start.equals(end) || range.compareTo(bigNumberOfSplits) >= 0)
+              break;
             significantBytes += 1;
             addedBytes += 1;
           }
@@ -486,21 +487,7 @@ public abstract class Token implements Comparable<Token> {
 
     @VisibleForTesting
     OPPToken(ByteBuffer value) {
-      this.value = stripTrailingZeroBytes(value);
-    }
-
-    /** @return A new ByteBuffer from the input Buffer with any trailing 0-bytes stripped off. */
-    private static ByteBuffer stripTrailingZeroBytes(ByteBuffer b) {
-      byte result[] = Bytes.getArray(b);
-      int zeroIndex = result.length;
-      for (int i = result.length - 1; i > 0; i--) {
-        if (result[i] == 0) {
-          zeroIndex = i;
-        } else {
-          break;
-        }
-      }
-      return ByteBuffer.wrap(result, 0, zeroIndex);
+      this.value = value;
     }
 
     @Override

--- a/driver-core/src/test/java/com/datastax/driver/core/OPPTokenFactoryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/OPPTokenFactoryTest.java
@@ -46,20 +46,6 @@ public class OPPTokenFactoryTest {
   }
 
   @Test(groups = "unit")
-  public void should_strip_trailing_0_bytes() {
-    Token with0Bytes = token(ByteBuffer.wrap(new byte[] {4, 0, 0, 0}));
-    Token without0Bytes = token(ByteBuffer.wrap(new byte[] {4}));
-    Token fromStringWith0Bytes = factory.fromString("040000");
-
-    assertThat(with0Bytes).isEqualTo(without0Bytes).isEqualTo(fromStringWith0Bytes);
-
-    Token withMixed0Bytes = factory.fromString("0004000400");
-    Token withoutMixed0Bytes = factory.fromString("00040004");
-
-    assertThat(withMixed0Bytes).isEqualTo(withoutMixed0Bytes);
-  }
-
-  @Test(groups = "unit")
   public void should_split_range_that_wraps_around_the_ring() {
     for (int start = 1; start < 128; start++) {
       for (int end = start; end < start; end++) {

--- a/driver-core/src/test/java/com/datastax/driver/core/OPPTokenFactoryTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/OPPTokenFactoryTest.java
@@ -17,6 +17,7 @@ package com.datastax.driver.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.datastax.driver.core.utils.Bytes;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -43,6 +44,15 @@ public class OPPTokenFactoryTest {
     // range (which is the whole ring)
     List<Token> splits = factory.split(minToken, zero, 3);
     assertThat(splits).containsExactly(zero, zero);
+  }
+
+  @Test(groups = "unit")
+  public void should_split_range_where_start_as_int_equals_end_as_int() {
+    Token start = token(Bytes.fromHexString("0x11"));
+    Token end = token(Bytes.fromHexString("0x1100"));
+
+    List<Token> splits = factory.split(start, end, 3);
+    assertThat(splits).containsExactly(end, end);
   }
 
   @Test(groups = "unit")


### PR DESCRIPTION
Remove stripTrailingZeroBytes from OPPToken
 
See https://datastax-oss.atlassian.net/projects/JAVA/issues/JAVA-2249
 
Modifications:

- Remove code to strip trailing zero bytes upon creation of OPPToken
- Remove corresponding unit test
- Changed the condition for padding bytes in the split logic. In the [existing behavior](https://github.com/datastax/java-driver/blob/3.x/driver-core/src/main/java/com/datastax/driver/core/Token.java#L421), it looks like 4 bytes will always be added because the existing condition doesn't detect when `start.equals(end)`. Previously this went unnoticed because the 4 zero bytes would be stripped off. This came up in `OPPTokenFactoryTest.should_split_range_producing_empty_splits_near_ring_end()`