### PR TITLE
JAVA-2260: Handle empty collections in PreparedStatement.bind(...)

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.1.0 (in progress)
 
+- [bug] JAVA-2260: Handle empty collections in PreparedStatement.bind(...)
 - [improvement] JAVA-2278: Pass the request's log prefix to RequestTracker
 - [bug] JAVA-2253: Don't strip trailing zeros in ByteOrderedToken
 - [improvement] JAVA-2207: Add bulk value assignment to QueryBuilder Insert

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/codec/registry/CodecRegistry.java
@@ -161,6 +161,9 @@ public interface CodecRegistry {
    * {@code ArrayList<String>}, it should be possible to encode it with a codec that accepts a
    * {@code List<String>}.
    *
+   * <p>Note that, if {@code value} is an empty collection, this method may return a codec that
+   * won't accept {@code JavaTypeT}; but it will encode {@code value} correctly.
+   *
    * @throws CodecNotFoundException if there is no such codec.
    */
   @NonNull

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/DefaultCodecRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/DefaultCodecRegistry.java
@@ -27,6 +27,7 @@ import com.datastax.oss.driver.shaded.guava.common.cache.RemovalListener;
 import com.datastax.oss.driver.shaded.guava.common.util.concurrent.ExecutionError;
 import com.datastax.oss.driver.shaded.guava.common.util.concurrent.UncheckedExecutionException;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -55,13 +56,13 @@ public class DefaultCodecRegistry extends CachingCodecRegistry {
    * eviction is that useful anyway.
    */
   public DefaultCodecRegistry(
-      String logPrefix,
+      @NonNull String logPrefix,
       int initialCacheCapacity,
-      BiFunction<CacheKey, TypeCodec<?>, Integer> cacheWeigher,
+      @Nullable BiFunction<CacheKey, TypeCodec<?>, Integer> cacheWeigher,
       int maximumCacheWeight,
-      BiConsumer<CacheKey, TypeCodec<?>> cacheRemovalListener,
-      TypeCodec<?>[] primitiveCodecs,
-      TypeCodec<?>[] userCodecs) {
+      @Nullable BiConsumer<CacheKey, TypeCodec<?>> cacheRemovalListener,
+      @NonNull TypeCodec<?>[] primitiveCodecs,
+      @NonNull TypeCodec<?>[] userCodecs) {
 
     super(logPrefix, primitiveCodecs, userCodecs);
     CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
@@ -92,18 +93,20 @@ public class DefaultCodecRegistry extends CachingCodecRegistry {
     }
   }
 
-  public DefaultCodecRegistry(String logPrefix, TypeCodec<?>... userCodecs) {
+  public DefaultCodecRegistry(@NonNull String logPrefix, @NonNull TypeCodec<?>... userCodecs) {
     this(logPrefix, CodecRegistryConstants.PRIMITIVE_CODECS, userCodecs);
   }
 
   public DefaultCodecRegistry(
-      String logPrefix, TypeCodec<?>[] primitiveCodecs, TypeCodec<?>... userCodecs) {
+      @NonNull String logPrefix,
+      @NonNull TypeCodec<?>[] primitiveCodecs,
+      @NonNull TypeCodec<?>... userCodecs) {
     this(logPrefix, 0, null, 0, null, primitiveCodecs, userCodecs);
   }
 
   @Override
   protected TypeCodec<?> getCachedCodec(
-      DataType cqlType, GenericType<?> javaType, boolean isJavaCovariant) {
+      @Nullable DataType cqlType, @Nullable GenericType<?> javaType, boolean isJavaCovariant) {
     LOG.trace("[{}] Checking cache", logPrefix);
     try {
       return cache.getUnchecked(new CacheKey(cqlType, javaType, isJavaCovariant));
@@ -126,7 +129,8 @@ public class DefaultCodecRegistry extends CachingCodecRegistry {
     public final GenericType<?> javaType;
     public final boolean isJavaCovariant;
 
-    public CacheKey(DataType cqlType, GenericType<?> javaType, boolean isJavaCovariant) {
+    public CacheKey(
+        @Nullable DataType cqlType, @Nullable GenericType<?> javaType, boolean isJavaCovariant) {
       this.javaType = javaType;
       this.cqlType = cqlType;
       this.isJavaCovariant = isJavaCovariant;


### PR DESCRIPTION
Motivation:

`preparedStatement.bind(new HashSet<>())` fails with a
CodecNotFoundException.

This is because the codec registry defaults to Set<Boolean> when it
tries to infer the type of the value (this works fine for lookups by
Java type only, because all empty collections are encoded in the same
way, so any collection codec will do -- but here we happen to also know
the CQL type, and it doesn't match).

Modifications:

Special-case empty collections at the beginning of codecFor(CqlType,
value): simply look up a collection codec for an arbitrary element type.

Result:

We return a codec that can encode the provided value.
Note that it doesn't accept the CQL type, nor the declared Java type of
the value, but the contract of the method doesn't say that it should.