### PR TITLE
JAVA-2255: Add annotation to indicate a property is transient

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/TransientIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/TransientIT.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.mapper;
+
+import static com.datastax.oss.driver.assertions.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.mapper.annotations.Dao;
+import com.datastax.oss.driver.api.mapper.annotations.DaoFactory;
+import com.datastax.oss.driver.api.mapper.annotations.DaoKeyspace;
+import com.datastax.oss.driver.api.mapper.annotations.DaoTable;
+import com.datastax.oss.driver.api.mapper.annotations.Entity;
+import com.datastax.oss.driver.api.mapper.annotations.Insert;
+import com.datastax.oss.driver.api.mapper.annotations.Mapper;
+import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
+import com.datastax.oss.driver.api.mapper.annotations.Select;
+import com.datastax.oss.driver.api.mapper.annotations.Transient;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+@Category(ParallelizableTests.class)
+public class TransientIT {
+
+  private static CcmRule ccm = CcmRule.getInstance();
+
+  private static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccm).build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccm).around(sessionRule);
+
+  private static TestMapper mapper;
+
+  private static final AtomicInteger keyProvider = new AtomicInteger(0);
+
+  @BeforeClass
+  public static void setup() {
+    CqlSession session = sessionRule.session();
+
+    session.execute(
+        SimpleStatement.builder("CREATE TABLE entity(id int primary key, v int)")
+            .setExecutionProfile(sessionRule.slowProfile())
+            .build());
+
+    mapper = new TransientIT_TestMapperBuilder(session).build();
+  }
+
+  @Test
+  public void should_ignore_field_with_transient_annotated_field() {
+    EntityWithTransientAnnotatedFieldDao dao =
+        mapper.entityWithTransientAnnotatedFieldDao(
+            sessionRule.keyspace(), CqlIdentifier.fromCql("entity"));
+
+    int key = keyProvider.incrementAndGet();
+    EntityWithTransientAnnotatedField entity = new EntityWithTransientAnnotatedField(key, 1, 7);
+    dao.save(entity);
+
+    EntityWithTransientAnnotatedField retrievedEntity = dao.findById(key);
+    assertThat(retrievedEntity.getId()).isEqualTo(key);
+    assertThat(retrievedEntity.getV()).isEqualTo(1);
+    // column should not have been set since field was @Transient-annotated
+    assertThat(retrievedEntity.getNotAColumn()).isNull();
+  }
+
+  @Test
+  public void should_ignore_field_with_transient_annotated_getter() {
+    EntityWithTransientAnnotatedGetterDao dao =
+        mapper.entityWithTransientAnnotatedGetterDao(
+            sessionRule.keyspace(), CqlIdentifier.fromCql("entity"));
+
+    int key = keyProvider.incrementAndGet();
+    EntityWithTransientAnnotatedGetter entity = new EntityWithTransientAnnotatedGetter(key, 1, 7);
+    dao.save(entity);
+
+    EntityWithTransientAnnotatedGetter retrievedEntity = dao.findById(key);
+    assertThat(retrievedEntity.getId()).isEqualTo(key);
+    assertThat(retrievedEntity.getV()).isEqualTo(1);
+    // column should not have been set since field was @Transient-annotated
+    assertThat(retrievedEntity.getNotAColumn()).isNull();
+  }
+
+  @Test
+  public void should_ignore_field_with_transient_keyword() {
+    EntityWithTransientKeywordDao dao =
+        mapper.entityWithTransientKeywordDao(
+            sessionRule.keyspace(), CqlIdentifier.fromCql("entity"));
+
+    int key = keyProvider.incrementAndGet();
+    EntityWithTransientKeyword entity = new EntityWithTransientKeyword(key, 1, 7);
+    dao.save(entity);
+
+    EntityWithTransientKeyword retrievedEntity = dao.findById(key);
+    assertThat(retrievedEntity.getId()).isEqualTo(key);
+    assertThat(retrievedEntity.getV()).isEqualTo(1);
+    // column should not have been set since field was @Transient-annotated
+    assertThat(retrievedEntity.getNotAColumn()).isNull();
+  }
+
+  @Entity
+  public static class EntityWithTransientAnnotatedField {
+
+    @PartitionKey private int id;
+
+    private int v;
+
+    @Transient private Integer notAColumn;
+
+    public EntityWithTransientAnnotatedField() {}
+
+    public EntityWithTransientAnnotatedField(int id, int v, Integer notAColumn) {
+      this.id = id;
+      this.v = v;
+      this.notAColumn = notAColumn;
+    }
+
+    public int getId() {
+      return id;
+    }
+
+    public void setId(int id) {
+      this.id = id;
+    }
+
+    public int getV() {
+      return v;
+    }
+
+    public void setV(int v) {
+      this.v = v;
+    }
+
+    public Integer getNotAColumn() {
+      return notAColumn;
+    }
+
+    public void setNotAColumn(Integer notAColumn) {
+      this.notAColumn = notAColumn;
+    }
+  }
+
+  @Entity
+  public static class EntityWithTransientAnnotatedGetter {
+
+    @PartitionKey private int id;
+
+    private int v;
+
+    private Integer notAColumn;
+
+    public EntityWithTransientAnnotatedGetter() {}
+
+    public EntityWithTransientAnnotatedGetter(int id, int v, Integer notAColumn) {
+      this.id = id;
+      this.v = v;
+      this.notAColumn = notAColumn;
+    }
+
+    public int getId() {
+      return id;
+    }
+
+    public void setId(int id) {
+      this.id = id;
+    }
+
+    public int getV() {
+      return v;
+    }
+
+    public void setV(int v) {
+      this.v = v;
+    }
+
+    @Transient
+    public Integer getNotAColumn() {
+      return notAColumn;
+    }
+
+    public void setNotAColumn(Integer notAColumn) {
+      this.notAColumn = notAColumn;
+    }
+  }
+
+  @Entity
+  public static class EntityWithTransientKeyword {
+
+    @PartitionKey private int id;
+
+    private int v;
+
+    private transient Integer notAColumn;
+
+    public EntityWithTransientKeyword() {}
+
+    public EntityWithTransientKeyword(int id, int v, Integer notAColumn) {
+      this.id = id;
+      this.v = v;
+      this.notAColumn = notAColumn;
+    }
+
+    public int getId() {
+      return id;
+    }
+
+    public void setId(int id) {
+      this.id = id;
+    }
+
+    public int getV() {
+      return v;
+    }
+
+    public void setV(int v) {
+      this.v = v;
+    }
+
+    public Integer getNotAColumn() {
+      return notAColumn;
+    }
+
+    public void setNotAColumn(Integer notAColumn) {
+      this.notAColumn = notAColumn;
+    }
+  }
+
+  @Dao
+  public interface EntityWithTransientAnnotatedFieldDao {
+    @Select
+    EntityWithTransientAnnotatedField findById(int id);
+
+    @Insert
+    void save(EntityWithTransientAnnotatedField entity);
+  }
+
+  @Dao
+  public interface EntityWithTransientAnnotatedGetterDao {
+    @Select
+    EntityWithTransientAnnotatedGetter findById(int id);
+
+    @Insert
+    void save(EntityWithTransientAnnotatedGetter entity);
+  }
+
+  @Dao
+  public interface EntityWithTransientKeywordDao {
+    @Select
+    EntityWithTransientKeyword findById(int id);
+
+    @Insert
+    void save(EntityWithTransientKeyword entity);
+  }
+
+  @Mapper
+  public interface TestMapper {
+    @DaoFactory
+    EntityWithTransientAnnotatedFieldDao entityWithTransientAnnotatedFieldDao(
+        @DaoKeyspace CqlIdentifier keyspace, @DaoTable CqlIdentifier table);
+
+    @DaoFactory
+    EntityWithTransientAnnotatedGetterDao entityWithTransientAnnotatedGetterDao(
+        @DaoKeyspace CqlIdentifier keyspace, @DaoTable CqlIdentifier table);
+
+    @DaoFactory
+    EntityWithTransientKeywordDao entityWithTransientKeywordDao(
+        @DaoKeyspace CqlIdentifier keyspace, @DaoTable CqlIdentifier table);
+  }
+}

--- a/manual/mapper/entities/README.md
+++ b/manual/mapper/entities/README.md
@@ -169,11 +169,34 @@ by the mapper.  In this case, simply annotate these properties with [@Transient]
 private int notAColumn;
 ```
 
-[@ClusteringColumn]: http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/ClusteringColumn.html
-[@CqlName]:          http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/CqlName.html
-[@Entity]:           http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/Entity.html
-[NameConverter]:     http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/entity/naming/NameConverter.html
-[NamingConvention]:  http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/entity/naming/NamingConvention.html
-[@NamingStrategy]:   http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/NamingStrategy.html
-[@PartitionKey]:     http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/PartitionKey.html
-[@Transient]:        http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/Transient.html
+In addition, one may specify transient property names at the entity level by leveraging the
+[@TransientProperties] annotation:
+
+```java
+@TransientProperties({"notAColumn", "x"})
+@Entity
+public class Product {
+  @PartitionKey private UUID id;
+  private String description;
+  // these columns are not included because their names are specified in @TransientProperties
+  private int notAColumn;
+  private int x;
+}
+```
+
+Finally, any field including the `transient` keyword modifier will also be considered transient,
+i.e.:
+
+```java
+private transient int notAColumn;
+```
+
+[@ClusteringColumn]:    http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/ClusteringColumn.html
+[@CqlName]:             http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/CqlName.html
+[@Entity]:              http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/Entity.html
+[NameConverter]:        http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/entity/naming/NameConverter.html
+[NamingConvention]:     http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/entity/naming/NamingConvention.html
+[@NamingStrategy]:      http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/NamingStrategy.html
+[@PartitionKey]:        http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/PartitionKey.html
+[@Transient]:           http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/Transient.html
+[@TransientProperties]: http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/Transient.html

--- a/manual/mapper/entities/README.md
+++ b/manual/mapper/entities/README.md
@@ -159,6 +159,16 @@ private int day;
 This information is used by some of the DAO method annotations; for example,
 [@Select](../daos/select/)'s default behavior is to generate a selection by primary key.
 
+#### Transient properties
+
+In some cases, one may opt to exclude properties defined on an entity from being considered
+by the mapper.  In this case, simply annotate these properties with [@Transient]:
+
+```java
+@Transient
+private int notAColumn;
+```
+
 [@ClusteringColumn]: http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/ClusteringColumn.html
 [@CqlName]:          http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/CqlName.html
 [@Entity]:           http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/Entity.html
@@ -166,3 +176,4 @@ This information is used by some of the DAO method annotations; for example,
 [NamingConvention]:  http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/entity/naming/NamingConvention.html
 [@NamingStrategy]:   http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/NamingStrategy.html
 [@PartitionKey]:     http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/PartitionKey.html
+[@Transient]:        http://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/Transient.html

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/DefaultEntityFactory.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/DefaultEntityFactory.java
@@ -25,9 +25,13 @@ import com.datastax.oss.driver.api.mapper.entity.naming.NamingConvention;
 import com.datastax.oss.driver.internal.mapper.processor.ProcessorContext;
 import com.datastax.oss.driver.internal.mapper.processor.util.generation.PropertyType;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
+import com.datastax.oss.driver.shaded.guava.common.collect.Maps;
 import com.datastax.oss.driver.shaded.guava.common.collect.Sets;
 import com.squareup.javapoet.ClassName;
 import java.beans.Introspector;
+import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +53,17 @@ import javax.lang.model.type.TypeMirror;
 public class DefaultEntityFactory implements EntityFactory {
 
   private final ProcessorContext context;
+
+  // property annotations of which only 1 is allowed on a property
+  private static final Set<Class<? extends Annotation>> EXCLUSIVE_PROPERTY_ANNOTATIONS =
+      ImmutableSet.of(ClusteringColumn.class, PartitionKey.class, Transient.class);
+
+  // all valid property annotations to scan for.
+  private static final Set<Class<? extends Annotation>> PROPERTY_ANNOTATIONS =
+      ImmutableSet.<Class<? extends Annotation>>builder()
+          .addAll(EXCLUSIVE_PROPERTY_ANNOTATIONS)
+          .add(CqlName.class)
+          .build();
 
   public DefaultEntityFactory(ProcessorContext context) {
     this.context = context;
@@ -90,25 +105,19 @@ public class DefaultEntityFactory implements EntityFactory {
       }
       VariableElement field = findField(classElement, propertyName, typeMirror);
 
-      int partitionKeyIndex = getPartitionKeyIndex(getMethod, field);
-      int clusteringColumnIndex = getClusteringColumnIndex(getMethod, field, partitionKeyIndex);
-
-      if (isTransient(
-          propertyName,
-          transientProperties,
-          classElement,
-          getMethod,
-          field,
-          partitionKeyIndex,
-          clusteringColumnIndex)) {
+      Map<Class<? extends Annotation>, Annotation> propertyAnnotations =
+          scanPropertyAnnotations(getMethod, field);
+      if (isTransient(propertyAnnotations, propertyName, transientProperties, getMethod, field)) {
         continue;
       }
 
+      int partitionKeyIndex = getPartitionKeyIndex(propertyAnnotations);
+      int clusteringColumnIndex = getClusteringColumnIndex(propertyAnnotations);
       PropertyType propertyType = PropertyType.parse(typeMirror, context);
       PropertyDefinition property =
           new DefaultPropertyDefinition(
               propertyName,
-              getCustomCqlName(getMethod, field),
+              getCustomCqlName(propertyAnnotations),
               getMethodName,
               setMethodName,
               propertyType,
@@ -197,77 +206,20 @@ public class DefaultEntityFactory implements EntityFactory {
     return null;
   }
 
-  private Optional<String> getCustomCqlName(ExecutableElement getMethod, VariableElement field) {
-    CqlName getterAnnotation = getMethod.getAnnotation(CqlName.class);
-    CqlName fieldAnnotation = (field == null) ? null : field.getAnnotation(CqlName.class);
-    if (getterAnnotation != null) {
-      if (fieldAnnotation != null) {
-        context
-            .getMessager()
-            .warn(
-                field,
-                "@%s should be used either on the field or the getter, but not both. "
-                    + "The annotation on this field will be ignored.",
-                CqlName.class.getSimpleName());
-      }
-      return Optional.of(getterAnnotation.value());
-    } else if (fieldAnnotation != null) {
-      return Optional.of(fieldAnnotation.value());
-    } else {
-      return Optional.empty();
-    }
+  private Optional<String> getCustomCqlName(
+      Map<Class<? extends Annotation>, Annotation> annotations) {
+    CqlName cqlName = (CqlName) annotations.get(CqlName.class);
+    return cqlName != null ? Optional.of(cqlName.value()) : Optional.empty();
   }
 
-  private int getPartitionKeyIndex(ExecutableElement getMethod, VariableElement field) {
-    PartitionKey getterAnnotation = getMethod.getAnnotation(PartitionKey.class);
-    PartitionKey fieldAnnotation = (field == null) ? null : field.getAnnotation(PartitionKey.class);
-
-    if (getterAnnotation != null) {
-      if (fieldAnnotation != null) {
-        context
-            .getMessager()
-            .warn(
-                field,
-                "@%s should be used either on the field or the getter, but not both. "
-                    + "The annotation on this field will be ignored.",
-                PartitionKey.class.getSimpleName());
-      }
-      return getterAnnotation.value();
-    } else if (fieldAnnotation != null) {
-      return fieldAnnotation.value();
-    } else {
-      return -1;
-    }
+  private int getPartitionKeyIndex(Map<Class<? extends Annotation>, Annotation> annotations) {
+    PartitionKey partitionKey = (PartitionKey) annotations.get(PartitionKey.class);
+    return partitionKey != null ? partitionKey.value() : -1;
   }
 
-  private int getClusteringColumnIndex(
-      ExecutableElement getMethod, VariableElement field, int partitionKeyIndex) {
-    ClusteringColumn getterAnnotation = getMethod.getAnnotation(ClusteringColumn.class);
-    ClusteringColumn fieldAnnotation =
-        (field == null) ? null : field.getAnnotation(ClusteringColumn.class);
-
-    if (getterAnnotation != null) {
-      if (partitionKeyIndex >= 0) {
-        reportMultipleAnnotationError(getMethod, PartitionKey.class, ClusteringColumn.class);
-        return -1;
-      } else if (fieldAnnotation != null) {
-        context
-            .getMessager()
-            .warn(
-                field,
-                "@%s should be used either on the field or the getter, but not both. "
-                    + "The annotation on this field will be ignored.",
-                ClusteringColumn.class.getSimpleName());
-      }
-      return getterAnnotation.value();
-    } else if (fieldAnnotation != null) {
-      if (partitionKeyIndex >= 0) {
-        reportMultipleAnnotationError(field, PartitionKey.class, ClusteringColumn.class);
-      }
-      return fieldAnnotation.value();
-    } else {
-      return -1;
-    }
+  private int getClusteringColumnIndex(Map<Class<? extends Annotation>, Annotation> annotations) {
+    ClusteringColumn clusteringColumn = (ClusteringColumn) annotations.get(ClusteringColumn.class);
+    return clusteringColumn != null ? clusteringColumn.value() : -1;
   }
 
   private CqlNameGenerator buildCqlNameGenerator(TypeElement classElement) {
@@ -354,60 +306,34 @@ public class DefaultEntityFactory implements EntityFactory {
   }
 
   private boolean isTransient(
+      Map<Class<? extends Annotation>, Annotation> annotations,
       String propertyName,
       Set<String> transientProperties,
-      TypeElement classElement,
       ExecutableElement getMethod,
-      VariableElement field,
-      int partitionKeyIndex,
-      int clusteringColumnIndex) {
+      VariableElement field) {
 
-    // check if property is present in @TransientProperties
-    Class<?> otherAnnotationClass =
-        partitionKeyIndex >= 0
-            ? PartitionKey.class
-            : clusteringColumnIndex >= 0 ? ClusteringColumn.class : null;
-    if (transientProperties.contains(propertyName)) {
-      if (otherAnnotationClass != null) {
-        context
-            .getMessager()
-            .error(
-                classElement,
-                "Properties included in @%s can't be annotated with @%s.",
-                TransientProperties.class.getSimpleName(),
-                otherAnnotationClass.getSimpleName());
-      }
-      return true;
+    Transient transientAnnotation = (Transient) annotations.get(Transient.class);
+    // check if property name is included in @TransientProperties
+    // -or- if property is annotated with @Transient
+    // -or- if field has transient keyword modifier
+    boolean isTransient =
+        transientProperties.contains(propertyName)
+            || transientAnnotation != null
+            || field != null && field.getModifiers().contains(Modifier.TRANSIENT);
+
+    // if annotations contains an exclusive annotation that isn't transient, raise
+    // an error here.
+    Class<? extends Annotation> exclusiveAnnotation = getExclusiveAnnotation(annotations);
+    if (isTransient && transientAnnotation == null && exclusiveAnnotation != null) {
+      Element element = field != null ? field : getMethod;
+      context
+          .getMessager()
+          .error(
+              element,
+              "Property that is considered transient cannot be annotated with @%s.",
+              exclusiveAnnotation.getSimpleName());
     }
 
-    // check if property is annotated with @Transient
-    Transient getterAnnotation = getMethod.getAnnotation(Transient.class);
-    boolean isTransient;
-    Element transientElement = getMethod;
-    isTransient = getterAnnotation != null;
-
-    if (!isTransient && field != null) {
-      transientElement = null;
-      if (field.getModifiers().contains(Modifier.TRANSIENT)) {
-        isTransient = true;
-        if (otherAnnotationClass != null) {
-          context
-              .getMessager()
-              .error(
-                  field,
-                  "Field with transient keyword modifier can't be annotated with @%s.",
-                  otherAnnotationClass.getSimpleName());
-        }
-      } else if (field.getAnnotation(Transient.class) != null) {
-        isTransient = true;
-        transientElement = field;
-      }
-    }
-
-    // report if property has both @Transient annotation and another annotation.
-    if (transientElement != null && otherAnnotationClass != null) {
-      reportMultipleAnnotationError(transientElement, Transient.class, otherAnnotationClass);
-    }
     return isTransient;
   }
 
@@ -419,13 +345,85 @@ public class DefaultEntityFactory implements EntityFactory {
         : Collections.emptySet();
   }
 
-  private void reportMultipleAnnotationError(Element element, Class<?> a0, Class<?> a1) {
-    context
-        .getMessager()
-        .error(
-            element,
-            "Properties can't be annotated with both @%s and @%s.",
-            a0.getSimpleName(),
-            a1.getSimpleName());
+  private void reportMultipleAnnotationError(
+      Element element, Class<? extends Annotation> a0, Class<? extends Annotation> a1) {
+    if (a0 == a1) {
+      context
+          .getMessager()
+          .warn(
+              element,
+              "@%s should be used either on the field or the getter, but not both. "
+                  + "The annotation on this field will be ignored.",
+              a0.getSimpleName());
+    } else {
+      context
+          .getMessager()
+          .error(
+              element,
+              "Properties can't be annotated with both @%s and @%s.",
+              a0.getSimpleName(),
+              a1.getSimpleName());
+    }
+  }
+
+  private Map<Class<? extends Annotation>, Annotation> scanPropertyAnnotations(
+      ExecutableElement getMethod, VariableElement field) {
+    Map<Class<? extends Annotation>, Annotation> annotations = Maps.newHashMap();
+
+    // scan methods first as they should take precedence.
+    scanMethodAnnotations(getMethod, annotations, null);
+    if (field != null) {
+      scanFieldAnnotations(field, annotations, getExclusiveAnnotation(annotations));
+    }
+
+    return ImmutableMap.copyOf(annotations);
+  }
+
+  private Class<? extends Annotation> getExclusiveAnnotation(
+      Map<Class<? extends Annotation>, Annotation> annotations) {
+    for (Class<? extends Annotation> annotationClass : annotations.keySet()) {
+      if (EXCLUSIVE_PROPERTY_ANNOTATIONS.contains(annotationClass)) {
+        return annotationClass;
+      }
+    }
+    return null;
+  }
+
+  private void scanFieldAnnotations(
+      VariableElement field,
+      Map<Class<? extends Annotation>, Annotation> annotations,
+      Class<? extends Annotation> exclusiveAnnotation) {
+    for (Class<? extends Annotation> annotationClass : PROPERTY_ANNOTATIONS) {
+      Annotation annotation = field.getAnnotation(annotationClass);
+      if (annotation != null) {
+        if (EXCLUSIVE_PROPERTY_ANNOTATIONS.contains(annotationClass)) {
+          if (exclusiveAnnotation == null) {
+            exclusiveAnnotation = annotationClass;
+          } else {
+            reportMultipleAnnotationError(field, exclusiveAnnotation, annotationClass);
+          }
+        }
+        annotations.put(annotationClass, annotation);
+      }
+    }
+  }
+
+  private void scanMethodAnnotations(
+      ExecutableElement getMethod,
+      Map<Class<? extends Annotation>, Annotation> annotations,
+      Class<? extends Annotation> exclusiveAnnotation) {
+    for (Class<? extends Annotation> annotationClass : PROPERTY_ANNOTATIONS) {
+      Annotation annotation = getMethod.getAnnotation(annotationClass);
+      if (annotation != null) {
+        if (EXCLUSIVE_PROPERTY_ANNOTATIONS.contains(annotationClass)) {
+          if (exclusiveAnnotation == null) {
+            exclusiveAnnotation = annotationClass;
+          } else {
+            reportMultipleAnnotationError(getMethod, exclusiveAnnotation, annotationClass);
+          }
+        }
+        annotations.put(annotationClass, annotation);
+      }
+    }
   }
 }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/DefaultEntityFactory.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/DefaultEntityFactory.java
@@ -319,7 +319,7 @@ public class DefaultEntityFactory implements EntityFactory {
     boolean isTransient =
         transientProperties.contains(propertyName)
             || transientAnnotation != null
-            || field != null && field.getModifiers().contains(Modifier.TRANSIENT);
+            || (field != null && field.getModifiers().contains(Modifier.TRANSIENT));
 
     // if annotations contains an exclusive annotation that isn't transient, raise
     // an error here.

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityPropertyAnnotationsTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityPropertyAnnotationsTest.java
@@ -105,7 +105,7 @@ public class EntityPropertyAnnotationsTest extends MapperProcessorTest {
   public static Object[][] entitiesWithErrors() {
     return new Object[][] {
       {
-        "Properties can't be annotated with both @PartitionKey and @ClusteringColumn.",
+        "Properties can't be annotated with both @ClusteringColumn and @PartitionKey.",
         TypeSpec.classBuilder(ClassName.get("test", "Product"))
             .addAnnotation(Entity.class)
             .addField(
@@ -128,7 +128,7 @@ public class EntityPropertyAnnotationsTest extends MapperProcessorTest {
             .build(),
       },
       {
-        "Properties can't be annotated with both @PartitionKey and @ClusteringColumn.",
+        "Properties can't be annotated with both @ClusteringColumn and @PartitionKey.",
         TypeSpec.classBuilder(ClassName.get("test", "Product"))
             .addAnnotation(Entity.class)
             .addField(

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityPropertyAnnotationsTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityPropertyAnnotationsTest.java
@@ -18,6 +18,7 @@ package com.datastax.oss.driver.internal.mapper.processor.entity;
 import com.datastax.oss.driver.api.mapper.annotations.ClusteringColumn;
 import com.datastax.oss.driver.api.mapper.annotations.Entity;
 import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
+import com.datastax.oss.driver.api.mapper.annotations.Transient;
 import com.datastax.oss.driver.internal.mapper.processor.MapperProcessorTest;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
@@ -233,6 +234,52 @@ public class EntityPropertyAnnotationsTest extends MapperProcessorTest {
                     .addParameter(UUID.class, "id2")
                     .addModifiers(Modifier.PUBLIC)
                     .addStatement("this.id2 = id2")
+                    .build())
+            .build(),
+      },
+      {
+        "Properties can't be annotated with both @ClusteringColumn and @Transient.",
+        TypeSpec.classBuilder(ClassName.get("test", "Product"))
+            .addAnnotation(Entity.class)
+            .addField(
+                FieldSpec.builder(UUID.class, "id", Modifier.PRIVATE)
+                    .addAnnotation(ClusteringColumn.class)
+                    .addAnnotation(Transient.class)
+                    .build())
+            .addMethod(
+                MethodSpec.methodBuilder("getId")
+                    .returns(UUID.class)
+                    .addModifiers(Modifier.PUBLIC)
+                    .addStatement("return id")
+                    .build())
+            .addMethod(
+                MethodSpec.methodBuilder("setId")
+                    .addParameter(UUID.class, "id")
+                    .addModifiers(Modifier.PUBLIC)
+                    .addStatement("this.id = id")
+                    .build())
+            .build(),
+      },
+      {
+        "Property that is considered transient cannot be annotated with @PartitionKey.",
+        TypeSpec.classBuilder(ClassName.get("test", "Product"))
+            .addAnnotation(Entity.class)
+            .addField(
+                FieldSpec.builder(UUID.class, "id", Modifier.PRIVATE)
+                    .addModifiers(Modifier.TRANSIENT)
+                    .addAnnotation(PartitionKey.class)
+                    .build())
+            .addMethod(
+                MethodSpec.methodBuilder("getId")
+                    .returns(UUID.class)
+                    .addModifiers(Modifier.PUBLIC)
+                    .addStatement("return id")
+                    .build())
+            .addMethod(
+                MethodSpec.methodBuilder("setId")
+                    .addParameter(UUID.class, "id")
+                    .addModifiers(Modifier.PUBLIC)
+                    .addStatement("this.id = id")
                     .build())
             .build(),
       },

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Transient.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Transient.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.mapper.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates the field or getter of an {@link Entity} property, to indicate that it will not be
+ * mapped to any column (neither during reads nor writes).
+ *
+ * <p>Example:
+ *
+ * <pre>
+ * &#64;Transient private int notAColumn;
+ * </pre>
+ *
+ * This information is used by the mapper processor to exclude the property from generated queries.
+ *
+ * <p>Please note that {@code Transient} takes precedence over {@link PartitionKey} and {@link
+ * ClusteringColumn} annotations.
+ */
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.CLASS)
+public @interface Transient {}

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/TransientProperties.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/TransientProperties.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.mapper.annotations;
+
+/**
+ * Annotates an {@link Entity} to indicate which properties should be considered 'transient',
+ * meaning that they should not be mapped to any column (neither during reads nor writes).
+ *
+ * <p>Example:
+ *
+ * <pre>
+ * &#64;TransientProperties({"notAColumn", "x"})
+ * &#64;Entity
+ * public class Product {
+ *   &#64;PartitionKey private UUID id;
+ *   private String description;
+ *   // these columns are not included because their names are specified in &#64;TransientProperties
+ *   private int notAColumn;
+ *   private int x;
+ *   ...
+ * }
+ * </pre>
+ *
+ * <p>This annotation is an alternative to using the {@link Transient} annotation on a field or
+ * getter. It is useful in cases where this annotation may be specified on a parent class where
+ * implementing classes will share a common configuration without needing to explicitly annotate
+ * each property with a {@link Transient} annotation.
+ */
+public @interface TransientProperties {
+
+  /** Specifies a list of property names that should be considered transient. */
+  String[] value() default {};
+}


### PR DESCRIPTION
For [JAVA-2255](https://datastax-oss.atlassian.net/browse/JAVA-2255)

---

Motivation:

It is sometimes desirable for properties of an entity to not be
considered by an object mapper.

Modifications:

Introduced a `@Transient` annotation that when applied to a field or
getter, causes the mapper to not include this field for generated
queries.

In addition, if a field includes the 'transient' keyword, it is also not
considered.

Result:

properties including a `@Transient` annotation or having a field with
transient keyword will not be considered by the mapper.