### PR TITLE
 Log query warnings before setting the final result

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -225,7 +225,6 @@ class RequestHandler {
                 execution.retryConsistencyLevel,
                 response.getCustomPayload());
       }
-      callback.onSet(connection, response, info, statement, System.nanoTime() - startTime);
       // if the response from the server has warnings, they'll be set on the ExecutionInfo. Log them
       // here, unless they've been disabled.
       if (response.warnings != null
@@ -234,6 +233,7 @@ class RequestHandler {
           && logger.isWarnEnabled()) {
         logServerWarnings(response.warnings);
       }
+      callback.onSet(connection, response, info, statement, System.nanoTime() - startTime);
     } catch (Exception e) {
       callback.onException(
           connection,

--- a/driver-core/src/test/java/com/datastax/driver/core/WarningsTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/WarningsTest.java
@@ -34,8 +34,7 @@ public class WarningsTest extends CCMTestsSupport {
   @CassandraVersion("2.2.0")
   public void should_expose_warnings_on_execution_info() throws Exception {
     // the default batch size warn threshold is 5 * 1024 bytes, but after CASSANDRA-10876 there must
-    // be
-    // multiple mutations in a batch to trigger this warning so the batch includes 2 different
+    // be multiple mutations in a batch to trigger this warning so the batch includes 2 different
     // inserts.
     final String query =
         String.format(
@@ -61,7 +60,8 @@ public class WarningsTest extends CCMTestsSupport {
           .contains(query.substring(0, QueryLogger.DEFAULT_MAX_QUERY_STRING_LENGTH))
           .contains("' generated server side warning(s): ")
           .contains("Batch")
-          .contains(String.format("for [%s.foo] is of size", keyspace))
+          .contains(keyspace + ".foo")
+          .contains(" is of size")
           .contains(", exceeding specified threshold");
     } finally {
       logAppender.disableFor(RequestHandler.class);


### PR DESCRIPTION
The commits in this PR should not be squashed together.

Motivation:

Currently the callback result is set _before_ the query warnings are
logged. As a consequence, client code dependent on the callback's
completion may get executed before the warnings are logged.

Modification:

Set the callback result after the query warnings are logged.

Result:

Client code is guaranteed to be executed after the query warnings are
logged.