### PR TITLE
JAVA-2264: HashedWheelTimer tick duration should be >= 10 ms on Windows

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.1.0 (in progress)
 
+- [bug] JAVA-2264: Adjust HashedWheelTimer tick duration from 1 to 100 ms
 - [bug] JAVA-2260: Handle empty collections in PreparedStatement.bind(...)
 - [improvement] JAVA-2278: Pass the request's log prefix to RequestTracker
 - [bug] JAVA-2253: Don't strip trailing zeros in ByteOrderedToken

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -88,6 +88,11 @@ datastax-java-driver {
     # For any serious deployment, we recommend that you use separate configuration profiles for DDL
     # and DML; you can then set the DML timeout much lower (down to a few milliseconds if needed).
     #
+    # Note that, because timeouts are scheduled on the driver's timer thread, the duration specified
+    # here must be greater than the timer tick duration defined by the
+    # advanced.netty.timer.tick-duration setting (see below). If that is not the case, timeouts will
+    # not be triggered as timely as desired.
+    #
     # Required: yes
     # Modifiable at runtime: yes, the new value will be used for requests issued after the change.
     # Overridable in a profile: yes
@@ -359,8 +364,15 @@ datastax-java-driver {
 
     # The delay between each execution. 0 is allowed, and will result in all executions being sent
     # simultaneously when the request starts.
+    #
     # Note that sub-millisecond precision is not supported, any excess precision information will be
     # dropped; in particular, delays of less than 1 millisecond are equivalent to 0.
+    #
+    # Also note that, because speculative executions are scheduled on the driver's timer thread,
+    # the duration specified here must be greater than the timer tick duration defined by the
+    # advanced.netty.timer.tick-duration setting (see below). If that is not the case, speculative
+    # executions will not be triggered as timely as desired.
+    #
     # This must be positive or 0.
     // delay = 100 milliseconds
   }
@@ -1400,18 +1412,29 @@ datastax-java-driver {
     # By default, this thread is named after the session name and "-timer-0", for example
     # "s0-timer-0".
     timer {
-      # The timer tick duration
-      # This is the how frequent the timer should wake-up to check for timed out tasks.
-      # Lower resolution (i.e. longer durations) will leave more CPU cycles for running I/O
-      # operations at the cost of precision of exactly when a request timeout will expire or a
+      # The timer tick duration.
+      # This is how frequent the timer should wake up to check for timed-out tasks or speculative
+      # executions. Lower resolution (i.e. longer durations) will leave more CPU cycles for running
+      # I/O operations at the cost of precision of exactly when a request timeout will expire or a
       # speculative execution will run. Higher resolution (i.e. shorter durations) will result in
       # more precise request timeouts and speculative execution scheduling, but at the cost of CPU
       # cycles taken from I/O operations, which could lead to lower overall I/O throughput.
       #
+      # The default value is 100 milliseconds, which is a comfortable value for most use cases.
+      # However if you are using more agressive timeouts or speculative execution delays, then you
+      # should lower the timer tick duration as well, so that its value is always equal to or lesser
+      # than the timeout duration and/or speculative execution delay you intend to use.
+      #
+      # Note for Windows users: avoid setting this to aggressive values, that is, anything under 100
+      # milliseconds; doing so is known to cause extreme CPU usage. Also, the tick duration must be
+      # a multiple of 10 under Windows; if that is not the case, it will be automatically rounded
+      # down to the nearest multiple of 10 (e.g. 99 milliseconds will be rounded down to 90
+      # milliseconds).
+      #
       # Required: yes
       # Modifiable at runtime: no
       # Overridable in a profile: no
-      tick-duration = 1 millisecond
+      tick-duration = 100 milliseconds
 
       # Number of ticks in a Timer wheel. The underlying implementation uses Netty's
       # HashedWheelTimer, which uses hashes to arrange the timeouts. This effectively controls the


### PR DESCRIPTION
Not sure how to test this other than manually verifying CPU usage.