### PR TITLE
JAVA-2253: Don't strip trailing zeros in ByteOrderedToken

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.1.0 (in progress)
 
+- [bug] JAVA-2253: Don't strip trailing zeros in ByteOrderedToken
 - [improvement] JAVA-2207: Add bulk value assignment to QueryBuilder Insert
 - [bug] JAVA-2234: Handle terminated executor when the session is closed twice
 - [documentation] JAVA-2220: Emphasize that query builder is now a separate artifact in root README

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/ByteOrderedToken.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/ByteOrderedToken.java
@@ -29,10 +29,11 @@ public class ByteOrderedToken implements Token {
 
   private final ByteBuffer value;
 
-  public ByteOrderedToken(ByteBuffer value) {
-    this.value = stripTrailingZeroBytes(value);
+  public ByteOrderedToken(@NonNull ByteBuffer value) {
+    this.value = ByteBuffer.wrap(Bytes.getArray(value)).asReadOnlyBuffer();
   }
 
+  @NonNull
   public ByteBuffer getValue() {
     return value;
   }
@@ -65,18 +66,5 @@ public class ByteOrderedToken implements Token {
   @Override
   public String toString() {
     return "ByteOrderedToken(" + Bytes.toHexString(value) + ")";
-  }
-
-  private static ByteBuffer stripTrailingZeroBytes(ByteBuffer b) {
-    byte result[] = Bytes.getArray(b);
-    int zeroIndex = result.length;
-    for (int i = result.length - 1; i > 0; i--) {
-      if (result[i] == 0) {
-        zeroIndex = i;
-      } else {
-        break;
-      }
-    }
-    return ByteBuffer.wrap(result, 0, zeroIndex);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/ByteOrderedTokenRange.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/ByteOrderedTokenRange.java
@@ -67,7 +67,7 @@ public class ByteOrderedTokenRange extends TokenRangeBase {
         start = toBigInteger(startToken.getValue(), significantBytes);
         end = toBigInteger(endToken.getValue(), significantBytes);
         range = end.subtract(start);
-        if (addedBytes == 4 || range.compareTo(bigNumberOfSplits) >= 0) {
+        if (addedBytes == 4 || start.equals(end) || range.compareTo(bigNumberOfSplits) >= 0) {
           break;
         }
         significantBytes += 1;

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/token/ByteOrderedTokenRangeTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/token/ByteOrderedTokenRangeTest.java
@@ -41,6 +41,16 @@ public class ByteOrderedTokenRangeTest {
   }
 
   @Test
+  public void should_split_range_when_padding_produces_same_token() {
+    // To compute the ranges, we pad with trailing zeroes until the range is big enough for the
+    // number of splits.
+    // But in this case padding produces the same token 0x1100, so adding more zeroes wouldn't help.
+    assertThat(range("0x11", "0x1100").splitEvenly(3))
+        .containsExactly(
+            range("0x11", "0x1100"), range("0x1100", "0x1100"), range("0x1100", "0x1100"));
+  }
+
+  @Test
   public void should_split_range_that_wraps_around_the_ring() {
     assertThat(range("0x0d", "0x0a").splitEvenly(2))
         .containsExactly(range("0x0d", "0x8c"), range("0x8c", "0x0a"));


### PR DESCRIPTION
This commit also creates a defensive copy of the token's ByteBuffer
in order to guarantee its immutability.