### PR TITLE
JAVA-2272: Make DAO method return types pluggable

### DIFF
--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/CodeGeneratorFactory.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/CodeGeneratorFactory.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.mapper.annotations.Dao;
 import com.datastax.oss.driver.api.mapper.annotations.Entity;
 import com.datastax.oss.driver.api.mapper.annotations.Mapper;
 import com.datastax.oss.driver.internal.mapper.processor.dao.DaoImplementationSharedCode;
+import com.datastax.oss.driver.internal.mapper.processor.dao.DaoReturnTypeParser;
 import com.datastax.oss.driver.internal.mapper.processor.mapper.MapperImplementationSharedCode;
 import java.util.Map;
 import java.util.Optional;
@@ -80,4 +81,6 @@ public interface CodeGeneratorFactory {
       ExecutableElement methodElement,
       Map<Name, TypeElement> typeParameters,
       DaoImplementationSharedCode enclosingClass);
+
+  DaoReturnTypeParser getDaoReturnTypeParser();
 }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/DefaultCodeGeneratorFactory.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/DefaultCodeGeneratorFactory.java
@@ -31,9 +31,11 @@ import com.datastax.oss.driver.internal.mapper.processor.dao.DaoImplementationSh
 import com.datastax.oss.driver.internal.mapper.processor.dao.DaoInsertMethodGenerator;
 import com.datastax.oss.driver.internal.mapper.processor.dao.DaoQueryMethodGenerator;
 import com.datastax.oss.driver.internal.mapper.processor.dao.DaoQueryProviderMethodGenerator;
+import com.datastax.oss.driver.internal.mapper.processor.dao.DaoReturnTypeParser;
 import com.datastax.oss.driver.internal.mapper.processor.dao.DaoSelectMethodGenerator;
 import com.datastax.oss.driver.internal.mapper.processor.dao.DaoSetEntityMethodGenerator;
 import com.datastax.oss.driver.internal.mapper.processor.dao.DaoUpdateMethodGenerator;
+import com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeParser;
 import com.datastax.oss.driver.internal.mapper.processor.entity.EntityHelperGenerator;
 import com.datastax.oss.driver.internal.mapper.processor.mapper.MapperBuilderGenerator;
 import com.datastax.oss.driver.internal.mapper.processor.mapper.MapperDaoFactoryMethodGenerator;
@@ -49,9 +51,11 @@ import javax.lang.model.element.TypeElement;
 public class DefaultCodeGeneratorFactory implements CodeGeneratorFactory {
 
   private final ProcessorContext context;
+  private final DaoReturnTypeParser daoReturnTypeParser;
 
   public DefaultCodeGeneratorFactory(ProcessorContext context) {
     this.context = context;
+    this.daoReturnTypeParser = new DefaultDaoReturnTypeParser(context);
   }
 
   @Override
@@ -123,5 +127,10 @@ public class DefaultCodeGeneratorFactory implements CodeGeneratorFactory {
     } else {
       return Optional.empty();
     }
+  }
+
+  @Override
+  public DaoReturnTypeParser getDaoReturnTypeParser() {
+    return daoReturnTypeParser;
   }
 }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoGetEntityMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoGetEntityMethodGenerator.java
@@ -94,7 +94,7 @@ public class DaoGetEntityMethodGenerator extends DaoMethodGenerator {
     // Validate the return type. Make sure it matches the parameter type
     Transformation transformation = null;
     TypeMirror returnType = methodElement.getReturnType();
-    TypeElement entityElement = asEntityElement(returnType);
+    TypeElement entityElement = EntityUtils.asEntityElement(returnType, typeParameters);
     if (entityElement != null) {
       transformation = parameterIsGettable ? Transformation.NONE : Transformation.ONE;
     } else if (returnType.getKind() == TypeKind.DECLARED) {
@@ -111,7 +111,7 @@ public class DaoGetEntityMethodGenerator extends DaoMethodGenerator {
                   ResultSet.class.getSimpleName());
           return Optional.empty();
         }
-        entityElement = typeArgumentAsEntityElement(returnType);
+        entityElement = EntityUtils.typeArgumentAsEntityElement(returnType, typeParameters);
         transformation = Transformation.MAP;
       } else if (context.getClassUtils().isSame(element, MappedAsyncPagingIterable.class)) {
         if (!parameterIsAsyncResultSet) {
@@ -125,7 +125,7 @@ public class DaoGetEntityMethodGenerator extends DaoMethodGenerator {
                   AsyncResultSet.class.getSimpleName());
           return Optional.empty();
         }
-        entityElement = typeArgumentAsEntityElement(returnType);
+        entityElement = EntityUtils.typeArgumentAsEntityElement(returnType, typeParameters);
         transformation = Transformation.MAP;
       }
     }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoQueryProviderMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoQueryProviderMethodGenerator.java
@@ -108,7 +108,7 @@ public class DaoQueryProviderMethodGenerator extends DaoMethodGenerator {
         List<ClassName> result = new ArrayList<>(values.size());
         for (AnnotationValue value : values) {
           TypeMirror entityMirror = (TypeMirror) value.getValue();
-          TypeElement entityElement = asEntityElement(entityMirror);
+          TypeElement entityElement = EntityUtils.asEntityElement(entityMirror, typeParameters);
           if (entityElement == null) {
             context
                 .getMessager()

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoReturnType.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoReturnType.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.mapper.processor.dao;
+
+import javax.lang.model.element.TypeElement;
+
+/** Holds information about the return type of a DAO method. */
+public class DaoReturnType {
+
+  public static final DaoReturnType VOID = new DaoReturnType(DefaultDaoReturnTypeKind.VOID);
+  public static final DaoReturnType BOOLEAN = new DaoReturnType(DefaultDaoReturnTypeKind.BOOLEAN);
+  public static final DaoReturnType LONG = new DaoReturnType(DefaultDaoReturnTypeKind.LONG);
+  public static final DaoReturnType ROW = new DaoReturnType(DefaultDaoReturnTypeKind.ROW);
+  public static final DaoReturnType RESULT_SET =
+      new DaoReturnType(DefaultDaoReturnTypeKind.RESULT_SET);
+  public static final DaoReturnType FUTURE_OF_VOID =
+      new DaoReturnType(DefaultDaoReturnTypeKind.FUTURE_OF_VOID);
+  public static final DaoReturnType FUTURE_OF_BOOLEAN =
+      new DaoReturnType(DefaultDaoReturnTypeKind.FUTURE_OF_BOOLEAN);
+  public static final DaoReturnType FUTURE_OF_LONG =
+      new DaoReturnType(DefaultDaoReturnTypeKind.FUTURE_OF_LONG);
+  public static final DaoReturnType FUTURE_OF_ROW =
+      new DaoReturnType(DefaultDaoReturnTypeKind.FUTURE_OF_ROW);
+  public static final DaoReturnType FUTURE_OF_ASYNC_RESULT_SET =
+      new DaoReturnType(DefaultDaoReturnTypeKind.FUTURE_OF_ASYNC_RESULT_SET);
+  public static final DaoReturnType UNSUPPORTED =
+      new DaoReturnType(DefaultDaoReturnTypeKind.UNSUPPORTED);
+
+  private final DaoReturnTypeKind kind;
+  private final TypeElement entityElement;
+
+  public DaoReturnType(DaoReturnTypeKind kind, TypeElement entityElement) {
+    this.kind = kind;
+    this.entityElement = entityElement;
+  }
+
+  public DaoReturnType(DaoReturnTypeKind kind) {
+    this(kind, null);
+  }
+
+  public DaoReturnTypeKind getKind() {
+    return kind;
+  }
+
+  /**
+   * If the type is parameterized by an entity-annotated class, return that entity.
+   *
+   * <p>For example {@code CompletionStage<Product>} => {@code Product}.
+   */
+  public TypeElement getEntityElement() {
+    return entityElement;
+  }
+}

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoReturnTypeKind.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoReturnTypeKind.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.mapper.processor.dao;
+
+import com.squareup.javapoet.CodeBlock;
+
+/**
+ * A "kind" of return type of a DAO method.
+ *
+ * <p>This represents a category of types that will be produced with the same pattern in the
+ * generated code. For example, "future of entity" is a kind that encompasses {@code
+ * CompletableFuture<Product>}, {@code CompletionStage<User>}, etc.
+ */
+public interface DaoReturnTypeKind {
+
+  /**
+   * Generates the code to execute a given statement (accessible through a local variable named
+   * {@code boundStatement}), and convert the result set into this kind.
+   *
+   * @param methodBuilder the method to add the code to.
+   * @param helperFieldName the name of the helper for entity conversions (might not get used for
+   *     certain kinds, in that case it's ok to pass null).
+   */
+  void addExecuteStatement(CodeBlock.Builder methodBuilder, String helperFieldName);
+
+  /**
+   * Generates a try-catch around the given code block, to translate unchecked exceptions into a
+   * result consistent with this kind.
+   *
+   * <p>For example, for futures, we want to generate this:
+   *
+   * <pre>
+   * CompletionStage&lt;Product&gt; findByIdAsync() {
+   *   try {
+   *     ... // innerBlock
+   *   } catch (Throwable t) {
+   *     return CompletableFutures.failedFuture(t);
+   *   }
+   * }
+   * </pre>
+   *
+   * <p>For some kinds, it's fine to let unchecked exceptions bubble up and no try-catch is
+   * necessary; in this case, this method can return {@code innerBlock} unchanged.
+   */
+  CodeBlock wrapWithErrorHandling(CodeBlock innerBlock);
+
+  /** A short description suitable for error messages. */
+  String getDescription();
+}

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoReturnTypeParser.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoReturnTypeParser.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.mapper.processor.dao;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Map;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+
+public interface DaoReturnTypeParser {
+  @NonNull
+  DaoReturnType parse(
+      @NonNull TypeMirror returnTypeMirror, @NonNull Map<Name, TypeElement> typeParameters);
+}

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoSetEntityMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoSetEntityMethodGenerator.java
@@ -71,7 +71,8 @@ public class DaoSetEntityMethodGenerator extends DaoMethodGenerator {
         targetParameterType = parameterElement.asType();
       } else if (parameterType.getKind() == TypeKind.DECLARED
           || parameterType.getKind() == TypeKind.TYPEVAR) {
-        TypeElement parameterTypeElement = asEntityElement(parameterType);
+        TypeElement parameterTypeElement =
+            EntityUtils.asEntityElement(parameterType, typeParameters);
         if (parameterTypeElement != null) {
           entityParameterName = parameterElement.getSimpleName().toString();
           entityElement = parameterTypeElement;

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DefaultDaoReturnTypeParser.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DefaultDaoReturnTypeParser.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.mapper.processor.dao;
+
+import com.datastax.oss.driver.api.core.MappedAsyncPagingIterable;
+import com.datastax.oss.driver.api.core.PagingIterable;
+import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.internal.mapper.processor.ProcessorContext;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+
+public class DefaultDaoReturnTypeParser implements DaoReturnTypeParser {
+
+  /**
+   * The return types that can be inferred directly from {@link TypeMirror#getKind()} (void and
+   * primitives).
+   */
+  protected static final Map<TypeKind, DaoReturnType> DEFAULT_TYPE_KIND_MATCHES =
+      ImmutableMap.<TypeKind, DaoReturnType>builder()
+          .put(TypeKind.VOID, DaoReturnType.VOID)
+          .put(TypeKind.BOOLEAN, DaoReturnType.BOOLEAN)
+          .put(TypeKind.LONG, DaoReturnType.LONG)
+          .build();
+
+  /** The return types that correspond directly to a non-generic Java class. */
+  protected static final Map<Class<?>, DaoReturnType> DEFAULT_CLASS_MATCHES =
+      ImmutableMap.<Class<?>, DaoReturnType>builder()
+          .put(Boolean.class, DaoReturnType.BOOLEAN)
+          .put(Long.class, DaoReturnType.LONG)
+          .put(Row.class, DaoReturnType.ROW)
+          .put(ResultSet.class, DaoReturnType.RESULT_SET)
+          .build();
+
+  /**
+   * The return types that correspond to a generic class with a single type parameter that is an
+   * entity class.
+   */
+  protected static final Map<Class<?>, DaoReturnTypeKind> DEFAULT_ENTITY_CONTAINER_MATCHES =
+      ImmutableMap.<Class<?>, DaoReturnTypeKind>builder()
+          .put(Optional.class, DefaultDaoReturnTypeKind.OPTIONAL_ENTITY)
+          .put(CompletionStage.class, DefaultDaoReturnTypeKind.FUTURE_OF_ENTITY)
+          .put(CompletableFuture.class, DefaultDaoReturnTypeKind.FUTURE_OF_ENTITY)
+          .put(PagingIterable.class, DefaultDaoReturnTypeKind.PAGING_ITERABLE)
+          .build();
+
+  /** The return types that correspond to a future of a non-generic Java class. */
+  protected static final Map<Class<?>, DaoReturnType> DEFAULT_FUTURE_OF_CLASS_MATCHES =
+      ImmutableMap.<Class<?>, DaoReturnType>builder()
+          .put(Void.class, DaoReturnType.FUTURE_OF_VOID)
+          .put(Boolean.class, DaoReturnType.FUTURE_OF_BOOLEAN)
+          .put(Long.class, DaoReturnType.FUTURE_OF_LONG)
+          .put(Row.class, DaoReturnType.FUTURE_OF_ROW)
+          .put(AsyncResultSet.class, DaoReturnType.FUTURE_OF_ASYNC_RESULT_SET)
+          .build();
+
+  /**
+   * The return types that correspond to a future of a generic class with a single type parameter
+   * that is an entity class.
+   */
+  protected static final Map<Class<?>, DaoReturnTypeKind>
+      DEFAULT_FUTURE_OF_ENTITY_CONTAINER_MATCHES =
+          ImmutableMap.<Class<?>, DaoReturnTypeKind>builder()
+              .put(Optional.class, DefaultDaoReturnTypeKind.FUTURE_OF_OPTIONAL_ENTITY)
+              .put(
+                  MappedAsyncPagingIterable.class,
+                  DefaultDaoReturnTypeKind.FUTURE_OF_ASYNC_PAGING_ITERABLE)
+              .build();
+
+  protected final ProcessorContext context;
+  private final Map<TypeKind, DaoReturnType> typeKindMatches;
+  private final Map<Class<?>, DaoReturnType> classMatches;
+  private final Map<Class<?>, DaoReturnTypeKind> entityContainerMatches;
+  private final Map<Class<?>, DaoReturnType> futureOfClassMatches;
+  private final Map<Class<?>, DaoReturnTypeKind> futureOfEntityContainerMatches;
+
+  public DefaultDaoReturnTypeParser(ProcessorContext context) {
+    this(
+        context,
+        DEFAULT_TYPE_KIND_MATCHES,
+        DEFAULT_CLASS_MATCHES,
+        DEFAULT_ENTITY_CONTAINER_MATCHES,
+        DEFAULT_FUTURE_OF_CLASS_MATCHES,
+        DEFAULT_FUTURE_OF_ENTITY_CONTAINER_MATCHES);
+  }
+
+  protected DefaultDaoReturnTypeParser(
+      ProcessorContext context,
+      Map<TypeKind, DaoReturnType> typeKindMatches,
+      Map<Class<?>, DaoReturnType> classMatches,
+      Map<Class<?>, DaoReturnTypeKind> entityContainerMatches,
+      Map<Class<?>, DaoReturnType> futureOfClassMatches,
+      Map<Class<?>, DaoReturnTypeKind> futureOfEntityContainerMatches) {
+    this.context = context;
+    this.typeKindMatches = typeKindMatches;
+    this.classMatches = classMatches;
+    this.entityContainerMatches = entityContainerMatches;
+    this.futureOfClassMatches = futureOfClassMatches;
+    this.futureOfEntityContainerMatches = futureOfEntityContainerMatches;
+  }
+
+  @NonNull
+  @Override
+  public DaoReturnType parse(
+      @NonNull TypeMirror returnTypeMirror, @NonNull Map<Name, TypeElement> typeParameters) {
+
+    // void or a primitive?
+    DaoReturnType match = typeKindMatches.get(returnTypeMirror.getKind());
+    if (match != null) {
+      return match;
+    }
+
+    if (returnTypeMirror.getKind() == TypeKind.DECLARED) {
+
+      // entity class? e.g. Product
+      TypeElement entityElement;
+      if ((entityElement = EntityUtils.asEntityElement(returnTypeMirror, typeParameters)) != null) {
+        return new DaoReturnType(DefaultDaoReturnTypeKind.ENTITY, entityElement);
+      }
+
+      // simple class? e.g. Boolean
+      DeclaredType declaredReturnType = (DeclaredType) returnTypeMirror;
+      for (Map.Entry<Class<?>, DaoReturnType> entry : classMatches.entrySet()) {
+        Class<?> simpleClass = entry.getKey();
+        if (context.getClassUtils().isSame(declaredReturnType, simpleClass)) {
+          return entry.getValue();
+        }
+      }
+
+      // entity container? e.g. Optional<Product>
+      if (declaredReturnType.getTypeArguments().size() == 1
+          && (entityElement =
+                  EntityUtils.typeArgumentAsEntityElement(returnTypeMirror, typeParameters))
+              != null) {
+        Element returnElement = declaredReturnType.asElement();
+        for (Map.Entry<Class<?>, DaoReturnTypeKind> entry : entityContainerMatches.entrySet()) {
+          Class<?> containerClass = entry.getKey();
+          if (context.getClassUtils().isSame(returnElement, containerClass)) {
+            return new DaoReturnType(entry.getValue(), entityElement);
+          }
+        }
+      }
+
+      if (context.getClassUtils().isFuture(declaredReturnType)) {
+        TypeMirror typeArgumentMirror = declaredReturnType.getTypeArguments().get(0);
+
+        // future of a simple class? e.g. CompletableFuture<Boolean>
+        for (Map.Entry<Class<?>, DaoReturnType> entry : futureOfClassMatches.entrySet()) {
+          Class<?> simpleClassArgument = entry.getKey();
+          if (context.getClassUtils().isSame(typeArgumentMirror, simpleClassArgument)) {
+            return entry.getValue();
+          }
+        }
+
+        // Note that futures of entities (e.g. CompletionStage<Product>) are already covered by the
+        // "entity container" check above
+
+        // future of entity container? e.g. CompletionStage<Optional<Product>>
+        if (typeArgumentMirror.getKind() == TypeKind.DECLARED) {
+          DeclaredType declaredTypeArgument = (DeclaredType) typeArgumentMirror;
+          if (declaredTypeArgument.getTypeArguments().size() == 1
+              && (entityElement =
+                      EntityUtils.typeArgumentAsEntityElement(typeArgumentMirror, typeParameters))
+                  != null) {
+            Element typeArgumentElement = declaredTypeArgument.asElement();
+            for (Map.Entry<Class<?>, DaoReturnTypeKind> entry :
+                futureOfEntityContainerMatches.entrySet()) {
+              Class<?> containerClass = entry.getKey();
+              if (context.getClassUtils().isSame(typeArgumentElement, containerClass)) {
+                return new DaoReturnType(entry.getValue(), entityElement);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if (returnTypeMirror.getKind() == TypeKind.TYPEVAR) {
+
+      // entity class? e.g. Product
+      TypeElement entityElement;
+      if ((entityElement = EntityUtils.asEntityElement(returnTypeMirror, typeParameters)) != null) {
+        return new DaoReturnType(DefaultDaoReturnTypeKind.ENTITY, entityElement);
+      }
+
+      // simple class? e.g. Boolean
+      TypeVariable typeVariable = ((TypeVariable) returnTypeMirror);
+      Name name = typeVariable.asElement().getSimpleName();
+      TypeElement element = typeParameters.get(name);
+      if (element != null) {
+        for (Map.Entry<Class<?>, DaoReturnType> entry : classMatches.entrySet()) {
+          Class<?> simpleClass = entry.getKey();
+          if (context.getClassUtils().isSame(element, simpleClass)) {
+            return entry.getValue();
+          }
+        }
+      }
+
+      // DAO parameterization by more complex types (futures, containers...) is not supported
+    }
+
+    return DaoReturnType.UNSUPPORTED;
+  }
+}

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/EntityUtils.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/EntityUtils.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.mapper.processor.dao;
+
+import com.datastax.oss.driver.api.mapper.annotations.Entity;
+import java.util.Map;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+
+public class EntityUtils {
+
+  /**
+   * If the type of this parameter is an {@link Entity}-annotated class, return that class's
+   * element, otherwise {@code null}.
+   */
+  public static TypeElement asEntityElement(
+      VariableElement parameter, Map<Name, TypeElement> typeParameters) {
+    return asEntityElement(parameter.asType(), typeParameters);
+  }
+
+  /**
+   * If this mirror's first type argument is an {@link Entity}-annotated class, return that class's
+   * element, otherwise {@code null}.
+   *
+   * <p>This method will fail if the mirror does not reference a generic type, the caller is
+   * responsible to perform that check beforehand.
+   */
+  public static TypeElement typeArgumentAsEntityElement(
+      TypeMirror mirror, Map<Name, TypeElement> typeParameters) {
+    DeclaredType declaredType = (DeclaredType) mirror;
+    assert !declaredType.getTypeArguments().isEmpty();
+    return asEntityElement(declaredType.getTypeArguments().get(0), typeParameters);
+  }
+
+  /**
+   * If this mirror is an {@link Entity}-annotated class, return that class's element, otherwise
+   * {@code null}.
+   */
+  public static TypeElement asEntityElement(
+      TypeMirror mirror, Map<Name, TypeElement> typeParameters) {
+    Element element;
+    if (mirror.getKind() == TypeKind.TYPEVAR) {
+      // extract concrete implementation for type variable.
+      TypeVariable typeVariable = ((TypeVariable) mirror);
+      Name name = typeVariable.asElement().getSimpleName();
+      element = typeParameters.get(name);
+      if (element == null) {
+        return null;
+      }
+    } else if (mirror.getKind() == TypeKind.DECLARED) {
+      element = ((DeclaredType) mirror).asElement();
+    } else {
+      return null;
+    }
+    if (element.getKind() != ElementKind.CLASS) {
+      return null;
+    }
+    TypeElement typeElement = (TypeElement) element;
+    if (typeElement.getAnnotation(Entity.class) == null) {
+      return null;
+    }
+    return typeElement;
+  }
+}

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityHelperSetMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityHelperSetMethodGenerator.java
@@ -67,17 +67,18 @@ public class EntityHelperSetMethodGenerator implements MethodGenerator {
                 ParameterSpec.builder(NullSavingStrategy.class, "nullSavingStrategy").build())
             .returns(settableT);
 
+    CodeBlock.Builder injectBodyBuilder = CodeBlock.builder();
     for (PropertyDefinition property : entityDefinition.getAllColumns()) {
       GeneratedCodePatterns.setValue(
           property.getCqlName(),
           property.getType(),
           CodeBlock.of("entity.$L()", property.getGetterName()),
           "target",
-          injectBuilder,
+          injectBodyBuilder,
           enclosingClass,
           true);
     }
-    injectBuilder.addCode("\n").addStatement("return target");
-    return Optional.of(injectBuilder.build());
+    injectBodyBuilder.add("\n").addStatement("return target");
+    return Optional.of(injectBuilder.addCode(injectBodyBuilder.build()).build());
   }
 }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/util/generation/GeneratedCodePatterns.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/util/generation/GeneratedCodePatterns.java
@@ -133,7 +133,7 @@ public class GeneratedCodePatterns {
    */
   public static void bindParameters(
       List<? extends VariableElement> parameters,
-      MethodSpec.Builder methodBuilder,
+      CodeBlock.Builder methodBuilder,
       BindableHandlingSharedCode enclosingClass,
       ProcessorContext context,
       boolean useNullSavingStrategy) {
@@ -150,7 +150,7 @@ public class GeneratedCodePatterns {
   public static void bindParameters(
       List<? extends VariableElement> parameters,
       List<CodeBlock> bindMarkerNames,
-      MethodSpec.Builder methodBuilder,
+      CodeBlock.Builder methodBuilder,
       BindableHandlingSharedCode enclosingClass,
       ProcessorContext context,
       boolean useNullSavingStrategy) {
@@ -204,7 +204,7 @@ public class GeneratedCodePatterns {
       PropertyType type,
       CodeBlock valueExtractor,
       String targetName,
-      MethodSpec.Builder methodBuilder,
+      CodeBlock.Builder methodBuilder,
       BindableHandlingSharedCode enclosingClass) {
     setValue(cqlName, type, valueExtractor, targetName, methodBuilder, enclosingClass, false);
   }
@@ -214,10 +214,10 @@ public class GeneratedCodePatterns {
       PropertyType type,
       CodeBlock valueExtractor,
       String targetName,
-      MethodSpec.Builder methodBuilder,
+      CodeBlock.Builder methodBuilder,
       BindableHandlingSharedCode enclosingClass,
       boolean useNullSavingStrategy) {
-    methodBuilder.addCode("\n");
+    methodBuilder.add("\n");
 
     if (type instanceof PropertyType.Simple) {
       TypeName typeName = ((PropertyType.Simple) type).typeName;
@@ -321,8 +321,8 @@ public class GeneratedCodePatterns {
           enclosingClass);
 
       methodBuilder
-          .addCode(udtTypesBuilder.build())
-          .addCode(conversionCodeBuilder.build())
+          .add(udtTypesBuilder.build())
+          .add(conversionCodeBuilder.build())
           .addStatement(
               "$1L = $1L.set($2L, $3L, $4L)",
               targetName,
@@ -347,7 +347,7 @@ public class GeneratedCodePatterns {
       CodeBlock cqlName,
       CodeBlock valueExtractor,
       String targetName,
-      MethodSpec.Builder methodBuilder,
+      CodeBlock.Builder methodBuilder,
       TypeName typeName,
       BindableHandlingSharedCode enclosingClass,
       boolean useNullSavingStrategy) {
@@ -367,7 +367,7 @@ public class GeneratedCodePatterns {
       CodeBlock cqlName,
       CodeBlock valueExtractor,
       String targetName,
-      MethodSpec.Builder methodBuilder,
+      CodeBlock.Builder methodBuilder,
       TypeName typeName,
       boolean useNullSavingStrategy) {
 
@@ -385,7 +385,7 @@ public class GeneratedCodePatterns {
    */
   private static void generateSetWithNullSavingStrategy(
       CodeBlock valueExtractor,
-      MethodSpec.Builder methodBuilder,
+      CodeBlock.Builder methodBuilder,
       CodeBlock nonNullStatement,
       boolean useNullSavingStrategy) {
     if (useNullSavingStrategy) {
@@ -403,7 +403,7 @@ public class GeneratedCodePatterns {
   }
 
   /**
-   * Shortcut for {@link #setValue(CodeBlock, PropertyType, CodeBlock, String, MethodSpec.Builder,
+   * Shortcut for {@link #setValue(CodeBlock, PropertyType, CodeBlock, String, CodeBlock.Builder,
    * BindableHandlingSharedCode)} when the cqlName is a string known at compile time.
    */
   public static void setValue(
@@ -411,7 +411,7 @@ public class GeneratedCodePatterns {
       PropertyType type,
       CodeBlock valueExtractor,
       String targetName,
-      MethodSpec.Builder methodBuilder,
+      CodeBlock.Builder methodBuilder,
       BindableHandlingSharedCode enclosingClass,
       boolean useNullSavingStrategy) {
     setValue(

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoDeleteMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoDeleteMethodGeneratorTest.java
@@ -81,8 +81,8 @@ public class DaoDeleteMethodGeneratorTest extends DaoMethodGeneratorTest {
             .build(),
       },
       {
-        "Invalid return type: Delete methods must return void, boolean or a result set, "
-            + "or a CompletableFuture/CompletionStage of Void, Boolean or AsyncResultSet",
+        "Delete methods must return one of [VOID, FUTURE_OF_VOID, BOOLEAN, FUTURE_OF_BOOLEAN, "
+            + "RESULT_SET, FUTURE_OF_ASYNC_RESULT_SET]",
         MethodSpec.methodBuilder("delete")
             .addAnnotation(Delete.class)
             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoInsertMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoInsertMethodGeneratorTest.java
@@ -56,8 +56,8 @@ public class DaoInsertMethodGeneratorTest extends DaoMethodGeneratorTest {
             .build(),
       },
       {
-        "Invalid return type: Insert methods must return either void or the entity class "
-            + "(possibly wrapped in a CompletionStage/CompletableFuture)",
+        "Invalid return type: Insert methods must return one of [VOID, FUTURE_OF_VOID, ENTITY, "
+            + "FUTURE_OF_ENTITY, OPTIONAL_ENTITY, FUTURE_OF_OPTIONAL_ENTITY]",
         MethodSpec.methodBuilder("insert")
             .addAnnotation(Insert.class)
             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoQueryMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoQueryMethodGeneratorTest.java
@@ -41,9 +41,11 @@ public class DaoQueryMethodGeneratorTest extends DaoMethodGeneratorTest {
     // Not many error cases to cover, the return type/parameters are pretty open
     return new Object[][] {
       {
-        "Invalid return type: Query methods must return void, boolean, Integer, Row, an entity "
-            + "class, a result set, a mapped iterable, or a CompletionStage/CompletableFuture "
-            + "of any of the above",
+        "Invalid return type: Query methods must return one of [VOID, BOOLEAN, LONG, ROW, "
+            + "ENTITY, OPTIONAL_ENTITY, RESULT_SET, PAGING_ITERABLE, FUTURE_OF_VOID, "
+            + "FUTURE_OF_BOOLEAN, FUTURE_OF_LONG, FUTURE_OF_ROW, FUTURE_OF_ENTITY, "
+            + "FUTURE_OF_OPTIONAL_ENTITY, FUTURE_OF_ASYNC_RESULT_SET, "
+            + "FUTURE_OF_ASYNC_PAGING_ITERABLE]",
         MethodSpec.methodBuilder("select")
             .addAnnotation(
                 AnnotationSpec.builder(Query.class)

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoSelectMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoSelectMethodGeneratorTest.java
@@ -41,9 +41,9 @@ public class DaoSelectMethodGeneratorTest extends DaoMethodGeneratorTest {
   public static Object[][] invalidSignatures() {
     return new Object[][] {
       {
-        "Invalid return type: Select methods must return an Entity-annotated class, or a "
-            + "CompletionStage, CompletableFuture, PagingIterable or "
-            + "CompletionStage/CompletableFuture<MappedAsyncPagingIterable> thereof",
+        "Invalid return type: Select methods must return one of [ENTITY, OPTIONAL_ENTITY, "
+            + "FUTURE_OF_ENTITY, FUTURE_OF_OPTIONAL_ENTITY, PAGING_ITERABLE, "
+            + "FUTURE_OF_ASYNC_PAGING_ITERABLE]",
         MethodSpec.methodBuilder("select")
             .addAnnotation(Select.class)
             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
@@ -51,9 +51,9 @@ public class DaoSelectMethodGeneratorTest extends DaoMethodGeneratorTest {
             .build(),
       },
       {
-        "Invalid return type: Select methods must return an Entity-annotated class, or a "
-            + "CompletionStage, CompletableFuture, PagingIterable or "
-            + "CompletionStage/CompletableFuture<MappedAsyncPagingIterable> thereof",
+        "Invalid return type: Select methods must return one of [ENTITY, OPTIONAL_ENTITY, "
+            + "FUTURE_OF_ENTITY, FUTURE_OF_OPTIONAL_ENTITY, PAGING_ITERABLE, "
+            + "FUTURE_OF_ASYNC_PAGING_ITERABLE]",
         MethodSpec.methodBuilder("select")
             .addAnnotation(Select.class)
             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoUpdateMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoUpdateMethodGeneratorTest.java
@@ -65,7 +65,8 @@ public class DaoUpdateMethodGeneratorTest extends DaoMethodGeneratorTest {
             .build(),
       },
       {
-        "Invalid return type: Update methods must return either void, ResultSet or boolean (possibly wrapped in a CompletionStage/CompletableFuture)",
+        "Invalid return type: Update methods must return one of [VOID, FUTURE_OF_VOID, "
+            + "RESULT_SET, FUTURE_OF_ASYNC_RESULT_SET, BOOLEAN, FUTURE_OF_BOOLEAN]",
         MethodSpec.methodBuilder("update")
             .addAnnotation(UPDATE_ANNOTATION)
             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)


### PR DESCRIPTION
Motivation:

We want to allow some degree of extensibility in the mapper. In
particular, it would be nice if a custom mapper extension could handle
new result types for DAO methods (e.g. `@Select`), without having to
rewrite the whole method generator.

Modifications:

Extract a superinterface DaoReturnTypeKind from the current enum.
Introduce a pluggable DaoReturnTypeParser in CodeGeneratorFactory.
Modify DAO method generators, so that the set of supported return type
kinds can be customized by overriding a method.

Result:

To support new return types, downstream projects will:
- write their own implementation of DaoReturnTypeKind (most likely as
  another enum)
- write their own DaoReturnTypeParser implementation
- extend the default method generators to override
  getSupportedReturnTypes()
- write their own CodeGeneratorFactory to return all those custom
  elements.

TODO:
- [x] try to make parser more extensible
- [x] try to factor result checking code in `DaoMethodGenerator`