### PR TITLE
JAVA-2286: Improve error reporting when entity has no properties

### DIFF
--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/DefaultEntityFactory.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/DefaultEntityFactory.java
@@ -186,6 +186,15 @@ public class DefaultEntityFactory implements EntityFactory {
       }
     }
 
+    if (encounteredPropertyNames.isEmpty()) {
+      context
+          .getMessager()
+          .error(
+              classElement,
+              "@%s-annotated class must have at least one property defined.",
+              Entity.class.getSimpleName());
+    }
+
     String entityName = Introspector.decapitalize(classElement.getSimpleName().toString());
     String defaultKeyspace = classElement.getAnnotation(Entity.class).defaultKeyspace();
 

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityPropertyAnnotationsTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityPropertyAnnotationsTest.java
@@ -307,6 +307,19 @@ public class EntityPropertyAnnotationsTest extends MapperProcessorTest {
                     .build())
             .build(),
       },
+      {
+        "@Entity-annotated class must have at least one property defined.",
+        TypeSpec.classBuilder(ClassName.get("test", "Product"))
+            .addAnnotation(Entity.class)
+            .addField(FieldSpec.builder(UUID.class, "id", Modifier.PRIVATE).build())
+            .addMethod(
+                MethodSpec.methodBuilder("getId")
+                    .returns(UUID.class)
+                    .addModifiers(Modifier.PUBLIC)
+                    .addStatement("return id")
+                    .build())
+            .build(),
+      },
     };
   }
 }


### PR DESCRIPTION
For [JAVA-2286](https://datastax-oss.atlassian.net/browse/JAVA-2286)

---

Motivation:

Currently if an Entity-annotated class lacks any properties, code
generation produces code that doesn't compile because no properties are
specified using QueryBuilder.

To rectify this, preemptively check to see if an Entity lacks properties
when generating its definition.

Modifications:

Update DefaultEntityFactory.getDefinition to generate an error if no
properties are specified on an Entity-annotated class.

Result:

A more appropriate compiler error is now generated informing the user
that their Entity-annotated class lacks properties.