### PR TITLE
JAVA-2297: Set socket options from NettyOptions#afterBootstrapInitialized

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.1.0 (in progress)
 
+- [improvement] JAVA-2297: Add a NettyOptions method to set socket options
 - [bug] JAVA-2280: Ignore peer rows with missing host id or RPC address
 - [bug] JAVA-2264: Adjust HashedWheelTimer tick duration from 1 to 100 ms
 - [bug] JAVA-2260: Handle empty collections in PreparedStatement.bind(...)

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelFactory.java
@@ -39,7 +39,6 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.FixedRecvByteBufAllocator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -148,35 +147,6 @@ public class ChannelFactory {
             .option(ChannelOption.ALLOCATOR, nettyOptions.allocator())
             .handler(
                 initializer(endPoint, currentVersion, options, nodeMetricUpdater, resultFuture));
-
-    DriverExecutionProfile config = context.getConfig().getDefaultProfile();
-
-    boolean tcpNoDelay = config.getBoolean(DefaultDriverOption.SOCKET_TCP_NODELAY);
-    bootstrap = bootstrap.option(ChannelOption.TCP_NODELAY, tcpNoDelay);
-    if (config.isDefined(DefaultDriverOption.SOCKET_KEEP_ALIVE)) {
-      boolean keepAlive = config.getBoolean(DefaultDriverOption.SOCKET_KEEP_ALIVE);
-      bootstrap = bootstrap.option(ChannelOption.SO_KEEPALIVE, keepAlive);
-    }
-    if (config.isDefined(DefaultDriverOption.SOCKET_REUSE_ADDRESS)) {
-      boolean reuseAddress = config.getBoolean(DefaultDriverOption.SOCKET_REUSE_ADDRESS);
-      bootstrap = bootstrap.option(ChannelOption.SO_REUSEADDR, reuseAddress);
-    }
-    if (config.isDefined(DefaultDriverOption.SOCKET_LINGER_INTERVAL)) {
-      int lingerInterval = config.getInt(DefaultDriverOption.SOCKET_LINGER_INTERVAL);
-      bootstrap = bootstrap.option(ChannelOption.SO_LINGER, lingerInterval);
-    }
-    if (config.isDefined(DefaultDriverOption.SOCKET_RECEIVE_BUFFER_SIZE)) {
-      int receiveBufferSize = config.getInt(DefaultDriverOption.SOCKET_RECEIVE_BUFFER_SIZE);
-      bootstrap =
-          bootstrap
-              .option(ChannelOption.SO_RCVBUF, receiveBufferSize)
-              .option(
-                  ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(receiveBufferSize));
-    }
-    if (config.isDefined(DefaultDriverOption.SOCKET_SEND_BUFFER_SIZE)) {
-      int sendBufferSize = config.getInt(DefaultDriverOption.SOCKET_SEND_BUFFER_SIZE);
-      bootstrap = bootstrap.option(ChannelOption.SO_SNDBUF, sendBufferSize);
-    }
 
     nettyOptions.afterBootstrapInitialized(bootstrap);
 

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -1,5 +1,15 @@
 ## Upgrade guide
 
+### 4.1.0
+
+#### Internal API
+
+`NettyOptions#afterBootstrapInitialized` is now responsible for setting socket options on driver
+connections (see `advanced.socket` in the configuration). If you had written a custom `NettyOptions`
+for 4.0, you'll have to copy over -- and possibly adapt -- the contents of
+`DefaultNettyOptions#afterBootstrapInitialized` (if you didn't override `NettyOptions`, you don't
+have to change anything).
+
 ### 4.0.0
 
 Version 4 is major redesign of the internal architecture. As such, it is **not binary compatible**


### PR DESCRIPTION
Motivation:

Setting socket options on the bootstrap is currently hardcoded in
ChannelFactory. This can cause warnings if the transport is overridden
with an implementation that does not support some of these options (ex:
TCP_NODELAY for Unix domain sockets).

Modifications:

Move the code to NettyOptions#afterBootstrapInitialized.

Result:

Custom NettyOptions implementations can decide which socket options to
set. Note that they will now have to copy over the code from
DefaultNettyOptions to get the default behavior.