### PR TITLE
JAVA-2300: Add support for additional return types in Insert methods

### DIFF
--- a/manual/mapper/daos/insert/README.md
+++ b/manual/mapper/daos/insert/README.md
@@ -50,6 +50,23 @@ The method can return:
     @Insert(ifNotExists = true)
     Optional<Product> insertIfNotExists(Product product);
     ```
+
+* a `boolean` or `Boolean`, which will be mapped to [ResultSet#wasApplied()]. This is intended for
+  IF EXISTS queries:
+
+    ```java
+    /** @return true if the product did not exist */
+    @Insert(ifNotExists = true)
+    boolean saveIfNotExists(Product product);
+    ```
+    
+* a [ResultSet]. This is intended for cases where you intend to inspect data associated with the
+  result, such as [ResultSet#getExecutionInfo()]:
+  
+    ```java
+    @Insert
+    ResultSet save(Product product);
+    ```
     
 * a [CompletionStage] or [CompletableFuture] of any of the above. The mapper will execute the query
   asynchronously.
@@ -75,8 +92,13 @@ If a table was specified when creating the DAO, then the generated query targets
 Otherwise, it uses the default table name for the entity (which is determined by the name of the
 entity class and the [naming strategy](../../entities/#naming-strategy)).
 
-[default keyspace]: https://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withKeyspace-com.datastax.oss.driver.api.core.CqlIdentifier-
-[@Insert]:          https://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/Insert.html
+[default keyspace]:             https://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withKeyspace-com.datastax.oss.driver.api.core.CqlIdentifier-
+[@Insert]:                      https://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/mapper/annotations/Insert.html
+[ResultSet]:                    https://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/core/cql/ResultSet.html
+[ResultSet#wasApplied()]:       https://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/core/cql/ResultSet.html#wasApplied--
+[ResultSet#getExecutionInfo()]: https://docs.datastax.com/en/drivers/java/4.0/com/datastax/oss/driver/api/core/cql/ResultSet.html#getExecutionInfo--
+
+
 
 [CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
 [CompletableFuture]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html

--- a/manual/mapper/daos/insert/README.md
+++ b/manual/mapper/daos/insert/README.md
@@ -52,7 +52,7 @@ The method can return:
     ```
 
 * a `boolean` or `Boolean`, which will be mapped to [ResultSet#wasApplied()]. This is intended for
-  IF EXISTS queries:
+  IF NOT EXISTS queries:
 
     ```java
     /** @return true if the product did not exist */

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoInsertMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoInsertMethodGenerator.java
@@ -15,11 +15,15 @@
  */
 package com.datastax.oss.driver.internal.mapper.processor.dao;
 
+import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.BOOLEAN;
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.ENTITY;
+import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.FUTURE_OF_ASYNC_RESULT_SET;
+import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.FUTURE_OF_BOOLEAN;
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.FUTURE_OF_ENTITY;
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.FUTURE_OF_OPTIONAL_ENTITY;
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.FUTURE_OF_VOID;
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.OPTIONAL_ENTITY;
+import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.RESULT_SET;
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.VOID;
 
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
@@ -57,7 +61,16 @@ public class DaoInsertMethodGenerator extends DaoMethodGenerator {
 
   protected Set<DaoReturnTypeKind> getSupportedReturnTypes() {
     return ImmutableSet.of(
-        VOID, FUTURE_OF_VOID, ENTITY, FUTURE_OF_ENTITY, OPTIONAL_ENTITY, FUTURE_OF_OPTIONAL_ENTITY);
+        VOID,
+        FUTURE_OF_VOID,
+        ENTITY,
+        FUTURE_OF_ENTITY,
+        OPTIONAL_ENTITY,
+        FUTURE_OF_OPTIONAL_ENTITY,
+        BOOLEAN,
+        FUTURE_OF_BOOLEAN,
+        RESULT_SET,
+        FUTURE_OF_ASYNC_RESULT_SET);
   }
 
   @Override

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoInsertMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoInsertMethodGeneratorTest.java
@@ -56,8 +56,8 @@ public class DaoInsertMethodGeneratorTest extends DaoMethodGeneratorTest {
             .build(),
       },
       {
-        "Invalid return type: Insert methods must return one of [VOID, FUTURE_OF_VOID, ENTITY, "
-            + "FUTURE_OF_ENTITY, OPTIONAL_ENTITY, FUTURE_OF_OPTIONAL_ENTITY]",
+        "Insert methods must return one of [VOID, FUTURE_OF_VOID, ENTITY, FUTURE_OF_ENTITY, "
+            + "OPTIONAL_ENTITY, FUTURE_OF_OPTIONAL_ENTITY, BOOLEAN, FUTURE_OF_BOOLEAN, RESULT_SET, FUTURE_OF_ASYNC_RESULT_SET]",
         MethodSpec.methodBuilder("insert")
             .addAnnotation(Insert.class)
             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Insert.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Insert.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.api.mapper.annotations;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
 import com.datastax.oss.driver.api.mapper.entity.saving.NullSavingStrategy;
@@ -77,6 +78,18 @@ import java.util.function.UnaryOperator;
  *       <pre>
  * &#64;Insert(ifNotExists = true)
  * Optional&lt;Product&gt; insertIfNotExists(Product product);
+ *       </pre>
+ *   <li>a {@code boolean} or {@link Boolean}, which will be mapped to {@link
+ *       ResultSet#wasApplied()}. This is intended for IF NOT EXISTS queries:
+ *       <pre>
+ * &#64;Insert(ifNotExists = true)
+ * boolean saveIfNotExists(Product product);
+ *       </pre>
+ *   <li>a {@link ResultSet}. This is intended for cases where you intend to inspect data associated
+ *       with the result, such as {@link ResultSet#getExecutionInfo()}.
+ *       <pre>
+ * &#64;Insert
+ * ResultSet save(Product product);
  *       </pre>
  *   <li>a {@link CompletionStage} or {@link CompletableFuture} of any of the above. The mapper will
  *       execute the query asynchronously.


### PR DESCRIPTION
For [JAVA-2300](https://datastax-oss.atlassian.net/browse/JAVA-2300)

---

Motivation:

`@Insert`-annotated DAO methods do not currently support the capability
of returning `boolean` or `ResultSet` return types.  These are useful to
determine whether or not LWT operations were applied and also to have
access to useful data associated with `ResultSet`, such as
`ExecutionInfo`.

Modifications:

Update `DaoInsertMethodGenerator.getSupportedReturnTypes()` to include
`BOOLEAN`, `FUTURE_OF_BOOLEAN`, `RESULT_SET`, and
`FUTURE_OF_RESULT_SET`.

Result:

`@Insert` methods can now return `boolean` and `ResultSet`-based types.