### PR TITLE
JAVA-2247: PagingIterable implementations should implement spliterator()

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.2.0 (in progress)
 
+- [improvement] JAVA-2247: PagingIterable implementations should implement spliterator()
 - [bug] JAVA-2312: Handle UDTs with names that clash with collection types
 - [improvement] JAVA-2307: Improve `@Select` and `@Delete` by not requiring full primary key
 - [improvement] JAVA-2315: Improve extensibility of session builder

--- a/core/revapi.json
+++ b/core/revapi.json
@@ -4766,6 +4766,34 @@
         "code": "java.field.removed",
         "old": "field com.datastax.oss.driver.api.core.session.SessionBuilder<SelfT extends com.datastax.oss.driver.api.core.session.SessionBuilder, SessionT>.typeCodecs",
         "justification": "JAVA-2315: Improve extensibility of session builder"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method <TargetElementT> com.datastax.oss.driver.api.core.PagingIterable<TargetElementT> com.datastax.oss.driver.api.core.PagingIterable<ElementT>::map(java.util.function.Function<? super ElementT, ? extends TargetElementT>)",
+        "new": "method <TargetElementT> com.datastax.oss.driver.api.core.PagingIterable<TargetElementT> com.datastax.oss.driver.api.core.PagingIterable<ElementT>::map(java.util.function.Function<? super ElementT, ? extends TargetElementT>)",
+        "annotation": "@edu.umd.cs.findbugs.annotations.NonNull",
+        "justification": "PagingIterable.map() should have been annotated with @NonNull"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method <TargetElementT> com.datastax.oss.driver.api.core.PagingIterable<TargetElementT> com.datastax.oss.driver.api.core.PagingIterable<ElementT>::map(java.util.function.Function<? super ElementT, ? extends TargetElementT>) @ com.datastax.oss.driver.api.core.cql.ResultSet",
+        "new": "method <TargetElementT> com.datastax.oss.driver.api.core.PagingIterable<TargetElementT> com.datastax.oss.driver.api.core.PagingIterable<ElementT>::map(java.util.function.Function<? super ElementT, ? extends TargetElementT>) @ com.datastax.oss.driver.api.core.cql.ResultSet",
+        "annotation": "@edu.umd.cs.findbugs.annotations.NonNull",
+        "justification": "PagingIterable.map() should have been annotated with @NonNull"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method java.util.Spliterator<T> java.lang.Iterable<T>::spliterator() @ com.datastax.oss.driver.api.core.PagingIterable<ElementT>",
+        "new": "method java.util.Spliterator<ElementT> com.datastax.oss.driver.api.core.PagingIterable<ElementT>::spliterator()",
+        "annotation": "@edu.umd.cs.findbugs.annotations.NonNull",
+        "justification": "JAVA-2247: PagingIterable implementations should implement spliterator()"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method java.util.Spliterator<T> java.lang.Iterable<T>::spliterator() @ com.datastax.oss.driver.api.core.cql.ResultSet",
+        "new": "method java.util.Spliterator<ElementT> com.datastax.oss.driver.api.core.PagingIterable<ElementT>::spliterator() @ com.datastax.oss.driver.api.core.cql.ResultSet",
+        "annotation": "@edu.umd.cs.findbugs.annotations.NonNull",
+        "justification": "JAVA-2247: PagingIterable implementations should implement spliterator()"
       }
     ]
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/PagingIterableWrapper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/PagingIterableWrapper.java
@@ -48,7 +48,7 @@ public class PagingIterableWrapper<SourceT, TargetT> implements PagingIterable<T
   /**
    * Creates a {@link PagingIterableWrapper} for the given source. If {@code sized} is {@code true},
    * spliterators for this iterable will report {@link Spliterator#SIZED} and {@link
-   * Spliterator#SIZED} and their estimated size will be {@link #getAvailableWithoutFetching()}.
+   * Spliterator#SUBSIZED} and their estimated size will be {@link #getAvailableWithoutFetching()}.
    *
    * @param source The source to wrap.
    * @param elementMapper The element mapper.

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/PagingIterableWrapper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/PagingIterableWrapper.java
@@ -18,20 +18,48 @@ package com.datastax.oss.driver.internal.core;
 import com.datastax.oss.driver.api.core.PagingIterable;
 import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
+import com.datastax.oss.driver.internal.core.cql.PagingIterableSpliterator;
 import com.datastax.oss.driver.shaded.guava.common.collect.AbstractIterator;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
 import java.util.function.Function;
 
 public class PagingIterableWrapper<SourceT, TargetT> implements PagingIterable<TargetT> {
 
   private final PagingIterable<SourceT> source;
+  private final boolean sized;
   private final Iterator<TargetT> iterator;
 
+  /**
+   * Creates a {@link PagingIterableWrapper} for the given source, with unknown size. Spliterators
+   * for this iterable will never report {@link Spliterator#SIZED}.
+   *
+   * @param source The source to wrap.
+   * @param elementMapper The element mapper.
+   */
   public PagingIterableWrapper(
-      PagingIterable<SourceT> source, Function<? super SourceT, ? extends TargetT> elementMapper) {
+      @NonNull PagingIterable<SourceT> source,
+      @NonNull Function<? super SourceT, ? extends TargetT> elementMapper) {
+    this(source, elementMapper, false);
+  }
+
+  /**
+   * Creates a {@link PagingIterableWrapper} for the given source. If {@code size} is {@code true},
+   * spliterators for this iterable will report {@link Spliterator#SIZED} and {@link
+   * Spliterator#SIZED} and their estimated size will be {@link #getAvailableWithoutFetching()}.
+   *
+   * @param source The source to wrap.
+   * @param elementMapper The element mapper.
+   * @param sized Whether this iterable has a known size or not.
+   */
+  public PagingIterableWrapper(
+      @NonNull PagingIterable<SourceT> source,
+      @NonNull Function<? super SourceT, ? extends TargetT> elementMapper,
+      boolean sized) {
     this.source = source;
+    this.sized = sized;
     Iterator<SourceT> sourceIterator = source.iterator();
     this.iterator =
         new AbstractIterator<TargetT>() {
@@ -71,8 +99,26 @@ public class PagingIterableWrapper<SourceT, TargetT> implements PagingIterable<T
     return source.wasApplied();
   }
 
+  @NonNull
   @Override
   public Iterator<TargetT> iterator() {
     return iterator;
+  }
+
+  @NonNull
+  @Override
+  public Spliterator<TargetT> spliterator() {
+    PagingIterableSpliterator.Builder<TargetT> builder = PagingIterableSpliterator.builder(this);
+    if (sized) {
+      builder.withEstimatedSize(getAvailableWithoutFetching());
+    }
+    return builder.build();
+  }
+
+  @NonNull
+  @Override
+  public <NewTargetT> PagingIterable<NewTargetT> map(
+      Function<? super TargetT, ? extends NewTargetT> elementMapper) {
+    return new PagingIterableWrapper<>(this, elementMapper, sized);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/PagingIterableWrapper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/PagingIterableWrapper.java
@@ -46,7 +46,7 @@ public class PagingIterableWrapper<SourceT, TargetT> implements PagingIterable<T
   }
 
   /**
-   * Creates a {@link PagingIterableWrapper} for the given source. If {@code size} is {@code true},
+   * Creates a {@link PagingIterableWrapper} for the given source. If {@code sized} is {@code true},
    * spliterators for this iterable will report {@link Spliterator#SIZED} and {@link
    * Spliterator#SIZED} and their estimated size will be {@link #getAvailableWithoutFetching()}.
    *

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/PagingIterableSpliterator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/PagingIterableSpliterator.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.cql;
+
+import com.datastax.oss.driver.api.core.PagingIterable;
+import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import net.jcip.annotations.NotThreadSafe;
+
+/**
+ * A Spliterator for {@link PagingIterable} instances that splits the stream in chunks of equal
+ * size.
+ *
+ * @param <ElementT> The element type of the underlying stream.
+ */
+@NotThreadSafe
+public class PagingIterableSpliterator<ElementT> implements Spliterator<ElementT> {
+
+  /**
+   * Creates a new {@link Builder} for {@link PagingIterableSpliterator} instances.
+   *
+   * @param iterable The {@link PagingIterable} to create a spliterator for.
+   * @param <ElementT> The iterable's element type
+   * @return a new {@link Builder}.
+   */
+  @NonNull
+  public static <ElementT> Builder<ElementT> builder(@NonNull PagingIterable<ElementT> iterable) {
+    return new Builder<>(iterable);
+  }
+
+  /** The default chunk size for {@link PagingIterableSpliterator}. */
+  public static final int DEFAULT_CHUNK_SIZE = 128;
+
+  private final PagingIterable<ElementT> iterable;
+  private long estimatedSize;
+  private final int chunkSize;
+  private final int characteristics;
+
+  /**
+   * Creates a new {@link PagingIterableSpliterator} for the given iterable, with unknown size and
+   * default chunk size ({@value #DEFAULT_CHUNK_SIZE}).
+   *
+   * @param iterable The {@link PagingIterable} to create a spliterator for.
+   */
+  public PagingIterableSpliterator(@NonNull PagingIterable<ElementT> iterable) {
+    this(iterable, Long.MAX_VALUE, DEFAULT_CHUNK_SIZE);
+  }
+
+  private PagingIterableSpliterator(
+      @NonNull PagingIterable<ElementT> iterable, long estimatedSize, int chunkSize) {
+    this.iterable = Objects.requireNonNull(iterable, "iterable cannot be null");
+    this.estimatedSize = estimatedSize;
+    this.chunkSize = chunkSize;
+    if (estimatedSize < Long.MAX_VALUE) {
+      characteristics =
+          Spliterator.ORDERED
+              | Spliterator.IMMUTABLE
+              | Spliterator.NONNULL
+              | Spliterator.SIZED
+              | Spliterator.SUBSIZED;
+    } else {
+      characteristics = Spliterator.ORDERED | Spliterator.IMMUTABLE | Spliterator.NONNULL;
+    }
+  }
+
+  @Override
+  public boolean tryAdvance(Consumer<? super ElementT> action) {
+    Objects.requireNonNull(action, "action cannot be null");
+    ElementT row = iterable.one();
+    if (row == null) {
+      return false;
+    }
+    action.accept(row);
+    return true;
+  }
+
+  @Override
+  @Nullable
+  public Spliterator<ElementT> trySplit() {
+    if (estimatedSize != Long.MAX_VALUE && estimatedSize <= chunkSize) {
+      // There is not point in splitting if the number of remaining elements is below the chunk size
+      return null;
+    }
+    ElementT row = iterable.one();
+    if (row == null) {
+      return null;
+    }
+    Object[] array = new Object[chunkSize];
+    int i = 0;
+    do {
+      array[i++] = row;
+      if (i < chunkSize) {
+        row = iterable.one();
+      } else {
+        break;
+      }
+    } while (row != null);
+    if (estimatedSize != Long.MAX_VALUE) {
+      estimatedSize -= i;
+    }
+    // Splits will also report SIZED and SUBSIZED as well.
+    return Spliterators.spliterator(array, 0, i, characteristics());
+  }
+
+  @Override
+  public void forEachRemaining(Consumer<? super ElementT> action) {
+    iterable.iterator().forEachRemaining(action);
+  }
+
+  @Override
+  public long estimateSize() {
+    return estimatedSize;
+  }
+
+  @Override
+  public int characteristics() {
+    return characteristics;
+  }
+
+  public static class Builder<ElementT> {
+
+    private final PagingIterable<ElementT> iterable;
+    private long estimatedSize = Long.MAX_VALUE;
+    private int chunkSize = DEFAULT_CHUNK_SIZE;
+
+    Builder(@NonNull PagingIterable<ElementT> iterable) {
+      this.iterable = iterable;
+    }
+
+    @NonNull
+    public Builder<ElementT> withEstimatedSize(long estimatedSize) {
+      Preconditions.checkArgument(estimatedSize > 0, "estimatedSize must be > 0");
+      this.estimatedSize = estimatedSize;
+      return this;
+    }
+
+    @NonNull
+    public Builder<ElementT> withChunkSize(int chunkSize) {
+      Preconditions.checkArgument(chunkSize > 0, "chunkSize must be > 0");
+      this.chunkSize = chunkSize;
+      return this;
+    }
+
+    @NonNull
+    public PagingIterableSpliterator<ElementT> build() {
+      return new PagingIterableSpliterator<>(iterable, estimatedSize, chunkSize);
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/PagingIterableSpliterator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/PagingIterableSpliterator.java
@@ -34,13 +34,6 @@ import net.jcip.annotations.NotThreadSafe;
 @NotThreadSafe
 public class PagingIterableSpliterator<ElementT> implements Spliterator<ElementT> {
 
-  /**
-   * Creates a new {@link Builder} for {@link PagingIterableSpliterator} instances.
-   *
-   * @param iterable The {@link PagingIterable} to create a spliterator for.
-   * @param <ElementT> The iterable's element type
-   * @return a new {@link Builder}.
-   */
   @NonNull
   public static <ElementT> Builder<ElementT> builder(@NonNull PagingIterable<ElementT> iterable) {
     return new Builder<>(iterable);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/PagingIterableSpliteratorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/PagingIterableSpliteratorTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.cql;
+
+import static java.util.stream.StreamSupport.stream;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.PagingIterable;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
+import com.datastax.oss.driver.internal.core.cql.PagingIterableSpliterator.Builder;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(DataProviderRunner.class)
+public class PagingIterableSpliteratorTest {
+
+  @Test
+  @UseDataProvider("splitsWithEstimatedSize")
+  public void should_split_with_estimated_size(
+      int size, int chunkSize, List<Integer> expectedLeft, List<Integer> expectedRight) {
+    // given
+    Builder<Integer> builder =
+        PagingIterableSpliterator.builder(iterableOfSize(size))
+            .withEstimatedSize(size)
+            .withChunkSize(chunkSize);
+    // when
+    PagingIterableSpliterator<Integer> right = builder.build();
+    Spliterator<Integer> left = right.trySplit();
+    // then
+    assertThat(right.characteristics())
+        .isEqualTo(
+            Spliterator.ORDERED
+                | Spliterator.IMMUTABLE
+                | Spliterator.NONNULL
+                | Spliterator.SIZED
+                | Spliterator.SUBSIZED);
+    assertThat(right.estimateSize()).isEqualTo(expectedRight.size());
+    assertThat(right.getExactSizeIfKnown()).isEqualTo(expectedRight.size());
+    TestConsumer rightConsumer = new TestConsumer();
+    right.forEachRemaining(rightConsumer);
+    assertThat(rightConsumer.items).containsExactlyElementsOf(expectedRight);
+    if (expectedLeft.isEmpty()) {
+      assertThat(left).isNull();
+    } else {
+      assertThat(left.characteristics())
+          .isEqualTo(
+              Spliterator.ORDERED
+                  | Spliterator.IMMUTABLE
+                  | Spliterator.NONNULL
+                  | Spliterator.SIZED
+                  | Spliterator.SUBSIZED);
+      assertThat(left.estimateSize()).isEqualTo(expectedLeft.size());
+      assertThat(left.getExactSizeIfKnown()).isEqualTo(expectedLeft.size());
+      TestConsumer leftConsumer = new TestConsumer();
+      left.forEachRemaining(leftConsumer);
+      assertThat(leftConsumer.items).containsExactlyElementsOf(expectedLeft);
+    }
+  }
+
+  @DataProvider
+  public static Iterable<?> splitsWithEstimatedSize() {
+    List<List<Object>> arguments = new ArrayList<>();
+    arguments.add(Lists.newArrayList(1, 1, ImmutableList.of(), ImmutableList.of(0)));
+    arguments.add(Lists.newArrayList(1, 2, ImmutableList.of(), ImmutableList.of(0)));
+    arguments.add(Lists.newArrayList(2, 1, ImmutableList.of(0), ImmutableList.of(1)));
+    arguments.add(
+        Lists.newArrayList(
+            10, 1, ImmutableList.of(0), ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9)));
+    arguments.add(
+        Lists.newArrayList(
+            10, 5, ImmutableList.of(0, 1, 2, 3, 4), ImmutableList.of(5, 6, 7, 8, 9)));
+    arguments.add(
+        Lists.newArrayList(
+            10, 9, ImmutableList.of(0, 1, 2, 3, 4, 5, 6, 7, 8), ImmutableList.of(9)));
+    arguments.add(
+        Lists.newArrayList(
+            10, 10, ImmutableList.of(), ImmutableList.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)));
+    return arguments;
+  }
+
+  @Test
+  @UseDataProvider("splitsWithUnknownSize")
+  public void should_split_with_unknown_size(
+      int size, int chunkSize, List<Integer> expectedLeft, List<Integer> expectedRight) {
+    // given
+    Builder<Integer> builder =
+        PagingIterableSpliterator.builder(iterableOfSize(size)).withChunkSize(chunkSize);
+    // when
+    PagingIterableSpliterator<Integer> right = builder.build();
+    Spliterator<Integer> left = right.trySplit();
+    // then
+    assertThat(right.characteristics())
+        .isEqualTo(Spliterator.ORDERED | Spliterator.IMMUTABLE | Spliterator.NONNULL);
+    assertThat(right.estimateSize()).isEqualTo(Long.MAX_VALUE);
+    assertThat(right.getExactSizeIfKnown()).isEqualTo(-1);
+    TestConsumer rightConsumer = new TestConsumer();
+    right.forEachRemaining(rightConsumer);
+    assertThat(rightConsumer.items).containsExactlyElementsOf(expectedRight);
+    if (expectedLeft.isEmpty()) {
+      assertThat(left).isNull();
+    } else {
+      // left side will also be SIZED and SUBSIZED
+      assertThat(left.characteristics())
+          .isEqualTo(
+              Spliterator.ORDERED
+                  | Spliterator.IMMUTABLE
+                  | Spliterator.NONNULL
+                  | Spliterator.SIZED
+                  | Spliterator.SUBSIZED);
+      assertThat(left.estimateSize()).isEqualTo(expectedLeft.size());
+      assertThat(left.getExactSizeIfKnown()).isEqualTo(expectedLeft.size());
+      TestConsumer leftConsumer = new TestConsumer();
+      left.forEachRemaining(leftConsumer);
+      assertThat(leftConsumer.items).containsExactlyElementsOf(expectedLeft);
+    }
+  }
+
+  @DataProvider
+  public static Iterable<?> splitsWithUnknownSize() {
+    List<List<Object>> arguments = new ArrayList<>();
+    arguments.add(Lists.newArrayList(1, 1, ImmutableList.of(0), ImmutableList.of()));
+    arguments.add(Lists.newArrayList(1, 2, ImmutableList.of(0), ImmutableList.of()));
+    arguments.add(Lists.newArrayList(2, 1, ImmutableList.of(0), ImmutableList.of(1)));
+    arguments.add(
+        Lists.newArrayList(
+            10, 1, ImmutableList.of(0), ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9)));
+    arguments.add(
+        Lists.newArrayList(
+            10, 5, ImmutableList.of(0, 1, 2, 3, 4), ImmutableList.of(5, 6, 7, 8, 9)));
+    arguments.add(
+        Lists.newArrayList(
+            10, 9, ImmutableList.of(0, 1, 2, 3, 4, 5, 6, 7, 8), ImmutableList.of(9)));
+    arguments.add(
+        Lists.newArrayList(
+            10, 10, ImmutableList.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), ImmutableList.of()));
+    return arguments;
+  }
+
+  @Test
+  public void should_consume_with_tryAdvance() {
+    // given
+    PagingIterableSpliterator<Integer> spliterator =
+        new PagingIterableSpliterator<>(iterableOfSize(10));
+    TestConsumer action = new TestConsumer();
+    // when
+    for (int i = 0; i < 20; i++) {
+      spliterator.tryAdvance(action);
+    }
+    // then
+    assertThat(action.items).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+  }
+
+  @Test
+  public void should_consume_with_forEachRemaining() {
+    // given
+    PagingIterableSpliterator<Integer> spliterator =
+        new PagingIterableSpliterator<>(iterableOfSize(10));
+    TestConsumer action = new TestConsumer();
+    // when
+    spliterator.forEachRemaining(action);
+    // then
+    assertThat(action.items).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+  }
+
+  @Test
+  @UseDataProvider("streams")
+  public void should_consume_stream(int size, int chunkSize, boolean parallel) {
+    // given
+    PagingIterableSpliterator<Integer> spliterator =
+        PagingIterableSpliterator.builder(iterableOfSize(size))
+            .withEstimatedSize(size)
+            .withChunkSize(chunkSize)
+            .build();
+    // when
+    long count = stream(spliterator, parallel).count();
+    // then
+    assertThat(count).isEqualTo(size);
+  }
+
+  @DataProvider
+  public static Iterable<?> streams() {
+    List<List<Object>> arguments = new ArrayList<>();
+    arguments.add(Lists.newArrayList(10_000, 5_000, false));
+    arguments.add(Lists.newArrayList(10_000, 1_000, false));
+    arguments.add(Lists.newArrayList(10_000, 9_999, false));
+    arguments.add(Lists.newArrayList(10_000, 1, false));
+    arguments.add(Lists.newArrayList(10_000, 5_000, true));
+    arguments.add(Lists.newArrayList(10_000, 1_000, true));
+    arguments.add(Lists.newArrayList(10_000, 9_999, true));
+    arguments.add(Lists.newArrayList(10_000, 1, true));
+    return arguments;
+  }
+
+  private static MockPagingIterable<Integer> iterableOfSize(int size) {
+    return new MockPagingIterable<>(
+        IntStream.range(0, size).boxed().collect(Collectors.toList()).iterator());
+  }
+
+  private static class MockPagingIterable<T> implements PagingIterable<T> {
+
+    private final Iterator<T> iterator;
+
+    private MockPagingIterable(Iterator<T> iterator) {
+      this.iterator = iterator;
+    }
+
+    @NonNull
+    @Override
+    public Iterator<T> iterator() {
+      return iterator;
+    }
+
+    @Override
+    public boolean isFullyFetched() {
+      return !iterator.hasNext();
+    }
+
+    @NonNull
+    @Override
+    public ColumnDefinitions getColumnDefinitions() {
+      throw new UnsupportedOperationException("irrelevant");
+    }
+
+    @NonNull
+    @Override
+    public List<ExecutionInfo> getExecutionInfos() {
+      throw new UnsupportedOperationException("irrelevant");
+    }
+
+    @Override
+    public int getAvailableWithoutFetching() {
+      throw new UnsupportedOperationException("irrelevant");
+    }
+
+    @Override
+    public boolean wasApplied() {
+      throw new UnsupportedOperationException("irrelevant");
+    }
+  }
+
+  private static class TestConsumer implements Consumer<Integer> {
+
+    private final List<Integer> items = new ArrayList<>();
+
+    @Override
+    public void accept(Integer integer) {
+      items.add(integer);
+    }
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/PagingIterableSpliteratorIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/api/core/cql/PagingIterableSpliteratorIT.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.cql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.driver.shaded.guava.common.collect.Lists;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.stream.StreamSupport;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+
+@RunWith(DataProviderRunner.class)
+@Category(ParallelizableTests.class)
+public class PagingIterableSpliteratorIT {
+
+  private static CcmRule ccm = CcmRule.getInstance();
+
+  private static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccm).build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccm).around(sessionRule);
+
+  @BeforeClass
+  public static void setupSchema() {
+    sessionRule
+        .session()
+        .execute(
+            SimpleStatement.builder(
+                    "CREATE TABLE IF NOT EXISTS test (k0 int, k1 int, v int, PRIMARY KEY(k0, k1))")
+                .setExecutionProfile(sessionRule.slowProfile())
+                .build());
+    PreparedStatement prepared =
+        sessionRule.session().prepare("INSERT INTO test (k0, k1, v) VALUES (?, ?, ?)");
+    for (int i = 0; i < 20_000; i += 1_000) {
+      BatchStatementBuilder batch = BatchStatement.builder(DefaultBatchType.UNLOGGED);
+      for (int j = 0; j < 1_000; j++) {
+        int n = i + j;
+        batch.addStatement(prepared.bind(0, n, n));
+      }
+      sessionRule.session().execute(batch.setExecutionProfile(sessionRule.slowProfile()).build());
+    }
+  }
+
+  @Test
+  @UseDataProvider("pageSizes")
+  public void should_consume_spliterator(int pageSize, boolean parallel) throws Exception {
+    CqlSession session = sessionRule.session();
+    DriverExecutionProfile profile =
+        session
+            .getContext()
+            .getConfig()
+            .getDefaultProfile()
+            .withInt(DefaultDriverOption.REQUEST_PAGE_SIZE, pageSize);
+    ResultSet result =
+        session.execute(
+            SimpleStatement.newInstance("SELECT v FROM test where k0 = 0")
+                .setExecutionProfile(profile));
+    Spliterator<Row> spliterator = result.spliterator();
+    if (pageSize > 20_000) {
+      // if the page size is greater than the result set size,
+      // we create a SinglePageResultSet with known spliterator size
+      assertThat(spliterator.estimateSize()).isEqualTo(20_000);
+      assertThat(spliterator.getExactSizeIfKnown()).isEqualTo(20_000);
+      assertThat(spliterator.characteristics())
+          .isEqualTo(
+              Spliterator.ORDERED
+                  | Spliterator.IMMUTABLE
+                  | Spliterator.NONNULL
+                  | Spliterator.SIZED
+                  | Spliterator.SUBSIZED);
+    } else {
+      assertThat(spliterator.estimateSize()).isEqualTo(Long.MAX_VALUE);
+      assertThat(spliterator.getExactSizeIfKnown()).isEqualTo(-1);
+      assertThat(spliterator.characteristics())
+          .isEqualTo(Spliterator.ORDERED | Spliterator.IMMUTABLE | Spliterator.NONNULL);
+    }
+    long count = StreamSupport.stream(spliterator, parallel).count();
+    assertThat(count).isEqualTo(20_000L);
+  }
+
+  @DataProvider
+  public static Iterable<?> pageSizes() {
+    List<List<Object>> arguments = new ArrayList<>();
+    arguments.add(Lists.newArrayList(30_000, false));
+    arguments.add(Lists.newArrayList(20_000, false));
+    arguments.add(Lists.newArrayList(10_000, false));
+    arguments.add(Lists.newArrayList(5_000, false));
+    arguments.add(Lists.newArrayList(500, false));
+    arguments.add(Lists.newArrayList(9_999, false));
+    arguments.add(Lists.newArrayList(10_001, false));
+    arguments.add(Lists.newArrayList(5, false));
+    arguments.add(Lists.newArrayList(19_995, false));
+    arguments.add(Lists.newArrayList(30_000, true));
+    arguments.add(Lists.newArrayList(20_000, true));
+    arguments.add(Lists.newArrayList(10_000, true));
+    arguments.add(Lists.newArrayList(5_000, true));
+    arguments.add(Lists.newArrayList(500, true));
+    arguments.add(Lists.newArrayList(9_999, true));
+    arguments.add(Lists.newArrayList(10_001, true));
+    arguments.add(Lists.newArrayList(5, true));
+    arguments.add(Lists.newArrayList(19_995, true));
+    return arguments;
+  }
+}


### PR DESCRIPTION
I ran this [small benchmark](https://gist.github.com/adutra/7d6c15a403867c4e6f2d052249ecbc46), adapted from [here](https://www.airpair.com/java/posts/parallel-processing-of-io-based-data-with-java-streams), and that gave me the below results:

```
Start processing JDK stream
          Cores: 8
       CPU time: 70.60 s
      Real time: 18.00 s
CPU utilization: 49.01%

Start processing fixed-batch stream
          Cores: 8
       CPU time: 86.84 s
      Real time: 10.93 s
CPU utilization: 99.29%
```
So it does seem to improve things, specially in the case of parallel computation.