### PR TITLE
JAVA-2304: Avoid direct calls to ByteBuffer.array()

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.1.0 (in progress)
 
+- [bug] JAVA-2304: Avoid direct calls to ByteBuffer.array()
 - [new feature] JAVA-2078: Add object mapper
 - [improvement] JAVA-2297: Add a NettyOptions method to set socket options
 - [bug] JAVA-2280: Ignore peer rows with missing host id or RPC address

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/BoundStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/BoundStatement.java
@@ -66,11 +66,11 @@ public interface BoundStatement
     // - timestamp
 
     // prepared ID
-    size += PrimitiveSizes.sizeOfShortBytes(getPreparedStatement().getId().array());
+    size += PrimitiveSizes.sizeOfShortBytes(getPreparedStatement().getId());
 
     // result metadata ID
     if (getPreparedStatement().getResultMetadataId() != null) {
-      size += PrimitiveSizes.sizeOfShortBytes(getPreparedStatement().getResultMetadataId().array());
+      size += PrimitiveSizes.sizeOfShortBytes(getPreparedStatement().getResultMetadataId());
     }
 
     // parameters (always sent as positional values for bound statements)

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/Sizes.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/Sizes.java
@@ -128,7 +128,7 @@ public class Sizes {
     } else if (statement instanceof BoundStatement) {
       size +=
           PrimitiveSizes.sizeOfShortBytes(
-              ((BoundStatement) statement).getPreparedStatement().getId().array());
+              ((BoundStatement) statement).getPreparedStatement().getId());
       size += sizeOfBoundStatementValues(((BoundStatement) statement));
     }
     return size;

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <guava.version>25.1-jre</guava.version>
     <hdrhistogram.version>2.1.11</hdrhistogram.version>
     <metrics.version>4.0.5</metrics.version>
-    <native-protocol.version>1.4.4</native-protocol.version>
+    <native-protocol.version>1.4.5</native-protocol.version>
     <netty.version>4.1.34.Final</netty.version>
     <slf4j.version>1.7.26</slf4j.version>
     <!-- optional dependencies -->


### PR DESCRIPTION
Requires https://github.com/datastax/native-protocol/pull/27.