### PR TITLE
JAVA-2315: Improve extensibility of session builder

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.2.0 (in progress)
 
+- [improvement] JAVA-2315: Improve extensibility of session builder
 
 ### 4.1.0
 

--- a/core/revapi.json
+++ b/core/revapi.json
@@ -4756,6 +4756,16 @@
         "new": "method java.util.UUID com.datastax.oss.driver.api.core.metadata.Node::getHostId()",
         "annotation": "@edu.umd.cs.findbugs.annotations.Nullable",
         "justification": "Node.getHostId() should have been annotated with @NonNull"
+      },
+      {
+        "code": "java.field.removed",
+        "old": "field com.datastax.oss.driver.api.core.session.SessionBuilder<SelfT extends com.datastax.oss.driver.api.core.session.SessionBuilder, SessionT>.requestTracker",
+        "justification": "JAVA-2315: Improve extensibility of session builder"
+      },
+      {
+        "code": "java.field.removed",
+        "old": "field com.datastax.oss.driver.api.core.session.SessionBuilder<SelfT extends com.datastax.oss.driver.api.core.session.SessionBuilder, SessionT>.typeCodecs",
+        "justification": "JAVA-2315: Improve extensibility of session builder"
       }
     ]
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/ProgrammaticArguments.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/ProgrammaticArguments.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.session;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
+import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
+import com.datastax.oss.driver.api.core.tracker.RequestTracker;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * The arguments that can be set programmatically when building a session.
+ *
+ * <p>This is mostly for internal use, you only need to deal with this directly if you write custom
+ * {@link SessionBuilder} subclasses.
+ */
+public class ProgrammaticArguments {
+
+  @NonNull
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  private final List<TypeCodec<?>> typeCodecs;
+  private final NodeStateListener nodeStateListener;
+  private final SchemaChangeListener schemaChangeListener;
+  private final RequestTracker requestTracker;
+  private final Map<String, String> localDatacenters;
+  private final Map<String, Predicate<Node>> nodeFilters;
+  private final ClassLoader classLoader;
+
+  private ProgrammaticArguments(
+      @NonNull List<TypeCodec<?>> typeCodecs,
+      @Nullable NodeStateListener nodeStateListener,
+      @Nullable SchemaChangeListener schemaChangeListener,
+      @Nullable RequestTracker requestTracker,
+      @NonNull Map<String, String> localDatacenters,
+      @NonNull Map<String, Predicate<Node>> nodeFilters,
+      @Nullable ClassLoader classLoader) {
+    this.typeCodecs = typeCodecs;
+    this.nodeStateListener = nodeStateListener;
+    this.schemaChangeListener = schemaChangeListener;
+    this.requestTracker = requestTracker;
+    this.localDatacenters = localDatacenters;
+    this.nodeFilters = nodeFilters;
+    this.classLoader = classLoader;
+  }
+
+  @NonNull
+  public List<TypeCodec<?>> getTypeCodecs() {
+    return typeCodecs;
+  }
+
+  @Nullable
+  public NodeStateListener getNodeStateListener() {
+    return nodeStateListener;
+  }
+
+  @Nullable
+  public SchemaChangeListener getSchemaChangeListener() {
+    return schemaChangeListener;
+  }
+
+  @Nullable
+  public RequestTracker getRequestTracker() {
+    return requestTracker;
+  }
+
+  @NonNull
+  public Map<String, String> getLocalDatacenters() {
+    return localDatacenters;
+  }
+
+  @NonNull
+  public Map<String, Predicate<Node>> getNodeFilters() {
+    return nodeFilters;
+  }
+
+  @Nullable
+  public ClassLoader getClassLoader() {
+    return classLoader;
+  }
+
+  public static class Builder {
+
+    private ImmutableList.Builder<TypeCodec<?>> typeCodecsBuilder = ImmutableList.builder();
+    private NodeStateListener nodeStateListener;
+    private SchemaChangeListener schemaChangeListener;
+    private RequestTracker requestTracker;
+    private ImmutableMap.Builder<String, String> localDatacentersBuilder = ImmutableMap.builder();
+    private ImmutableMap.Builder<String, Predicate<Node>> nodeFiltersBuilder =
+        ImmutableMap.builder();
+    private ClassLoader classLoader;
+
+    @NonNull
+    public Builder addTypeCodecs(@NonNull TypeCodec<?>... typeCodecs) {
+      this.typeCodecsBuilder.add(typeCodecs);
+      return this;
+    }
+
+    @NonNull
+    public Builder withNodeStateListener(@Nullable NodeStateListener nodeStateListener) {
+      this.nodeStateListener = nodeStateListener;
+      return this;
+    }
+
+    @NonNull
+    public Builder withSchemaChangeListener(@Nullable SchemaChangeListener schemaChangeListener) {
+      this.schemaChangeListener = schemaChangeListener;
+      return this;
+    }
+
+    @NonNull
+    public Builder withRequestTracker(@Nullable RequestTracker requestTracker) {
+      this.requestTracker = requestTracker;
+      return this;
+    }
+
+    @NonNull
+    public Builder withLocalDatacenter(
+        @NonNull String profileName, @NonNull String localDatacenter) {
+      this.localDatacentersBuilder.put(profileName, localDatacenter);
+      return this;
+    }
+
+    @NonNull
+    public Builder withLocalDatacenters(Map<String, String> localDatacenters) {
+      for (Map.Entry<String, String> entry : localDatacenters.entrySet()) {
+        this.localDatacentersBuilder.put(entry.getKey(), entry.getValue());
+      }
+      return this;
+    }
+
+    @NonNull
+    public Builder withNodeFilter(
+        @NonNull String profileName, @NonNull Predicate<Node> nodeFilter) {
+      this.nodeFiltersBuilder.put(profileName, nodeFilter);
+      return this;
+    }
+
+    @NonNull
+    public Builder withNodeFilters(Map<String, Predicate<Node>> nodeFilters) {
+      for (Map.Entry<String, Predicate<Node>> entry : nodeFilters.entrySet()) {
+        this.nodeFiltersBuilder.put(entry.getKey(), entry.getValue());
+      }
+      return this;
+    }
+
+    @NonNull
+    public Builder withClassLoader(@Nullable ClassLoader classLoader) {
+      this.classLoader = classLoader;
+      return this;
+    }
+
+    @NonNull
+    public ProgrammaticArguments build() {
+      return new ProgrammaticArguments(
+          typeCodecsBuilder.build(),
+          nodeStateListener,
+          schemaChangeListener,
+          requestTracker,
+          localDatacentersBuilder.build(),
+          nodeFiltersBuilder.build(),
+          classLoader);
+    }
+  }
+}


### PR DESCRIPTION
Motivation:

Every time we add a new programmatic argument to the session builder,
there is a breaking change on SessionBuilder#buildContext.

This extends to DefaultDriverContext's constructor (even though
DefaultDriverContext is an internal class, it would be wise to be
conservative about its API, because plugging something through a custom
context subclass is one of the most basic "advanced" extensions).

Modifications:

Create a new class ProgrammaticArguments to wrap the arguments to
buildContext. Also pass it to the context constructor.

Preserve backward compatibility with the previous signatures.

Result:

We can now add new arguments to ProgrammaticArguments, which is not a
breaking change.