### PR TITLE
JAVA-2306: Clear security tokens from memory immediately after use

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.2.0 (in progress)
 
+- [improvement] JAVA-2306: Clear security tokens from memory immediately after use
 - [improvement] JAVA-2320: Expose more attributes on mapper Select for individual query clauses
 - [bug] JAVA-2332: Destroy connection pool when a node gets removed
 - [bug] JAVA-2324: Add support for primitive shorts in mapper

--- a/core/src/main/java/com/datastax/oss/driver/api/core/auth/Authenticator.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/auth/Authenticator.java
@@ -57,7 +57,11 @@ public interface Authenticator {
    * Obtain an initial response token for initializing the SASL handshake.
    *
    * @return a completion stage that will complete with the initial response to send to the server
-   *     (which may be {@code null}).
+   *     (which may be {@code null}). Note that, if the returned byte buffer is writable, the driver
+   *     will <b>clear its contents</b> immediately after use (to avoid keeping sensitive
+   *     information in memory); do not reuse the same buffer across multiple invocations.
+   *     Alternatively, if the contents are not sensitive, you can make the buffer {@linkplain
+   *     ByteBuffer#asReadOnlyBuffer() read-only} and safely reuse it.
    */
   @NonNull
   CompletionStage<ByteBuffer> initialResponse();
@@ -68,7 +72,11 @@ public interface Authenticator {
    *
    * @param challenge the server's SASL challenge.
    * @return a completion stage that will complete with the updated SASL token (which may be null to
-   *     indicate the client requires no further action).
+   *     indicate the client requires no further action). Note that, if the returned byte buffer is
+   *     writable, the driver will <b>clear its contents</b> immediately after use (to avoid keeping
+   *     sensitive information in memory); do not reuse the same buffer across multiple invocations.
+   *     Alternatively, if the contents are not sensitive, you can make the buffer {@linkplain
+   *     ByteBuffer#asReadOnlyBuffer() read-only} and safely reuse it.
    */
   @NonNull
   CompletionStage<ByteBuffer> evaluateChallenge(@Nullable ByteBuffer challenge);

--- a/core/src/main/java/com/datastax/oss/driver/api/core/auth/SyncAuthenticator.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/auth/SyncAuthenticator.java
@@ -35,7 +35,11 @@ public interface SyncAuthenticator extends Authenticator {
    * <p>{@link #initialResponse()} calls this and wraps the result in an immediately completed
    * future.
    *
-   * @return The initial response to send to the server (which may be {@code null}).
+   * @return The initial response to send to the server (which may be {@code null}). Note that, if
+   *     the returned byte buffer is writable, the driver will <b>clear its contents</b> immediately
+   *     after use (to avoid keeping sensitive information in memory); do not reuse the same buffer
+   *     across multiple invocations. Alternatively, if the contents are not sensitive, you can make
+   *     the buffer {@linkplain ByteBuffer#asReadOnlyBuffer() read-only} and safely reuse it.
    */
   @Nullable
   ByteBuffer initialResponseSync();
@@ -48,7 +52,11 @@ public interface SyncAuthenticator extends Authenticator {
    *
    * @param challenge the server's SASL challenge; may be {@code null}.
    * @return The updated SASL token (which may be {@code null} to indicate the client requires no
-   *     further action).
+   *     further action). Note that, if the returned byte buffer is writable, the driver will
+   *     <b>clear its contents</b> immediately after use (to avoid keeping sensitive information in
+   *     memory); do not reuse the same buffer across multiple invocations. Alternatively, if the
+   *     contents are not sensitive, you can make the buffer {@linkplain
+   *     ByteBuffer#asReadOnlyBuffer() read-only} and safely reuse it.
    */
   @Nullable
   ByteBuffer evaluateChallengeSync(@Nullable ByteBuffer challenge);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/auth/PlainTextAuthProviderBase.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/auth/PlainTextAuthProviderBase.java
@@ -149,7 +149,7 @@ public abstract class PlainTextAuthProviderBase implements AuthProvider {
     @Override
     @Nullable
     public ByteBuffer initialResponseSync() {
-      return initialToken.duplicate();
+      return initialToken;
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <guava.version>25.1-jre</guava.version>
     <hdrhistogram.version>2.1.11</hdrhistogram.version>
     <metrics.version>4.0.5</metrics.version>
-    <native-protocol.version>1.4.5</native-protocol.version>
+    <native-protocol.version>1.4.6-SNAPSHOT</native-protocol.version>
     <netty.version>4.1.34.Final</netty.version>
     <slf4j.version>1.7.26</slf4j.version>
     <!-- optional dependencies -->


### PR DESCRIPTION
Most of the changes are in the native protocol (datastax/native-protocol#28), this merely upgrades the dependency and adds a few javadocs.