### PR TITLE
JAVA-2308: Add customWhereClause to Delete

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.2.0 (in progress)
 
+- [improvement] JAVA-2308: Add customWhereClause to `@Delete`
 - [improvement] JAVA-2247: PagingIterable implementations should implement spliterator()
 - [bug] JAVA-2312: Handle UDTs with names that clash with collection types
 - [improvement] JAVA-2307: Improve `@Select` and `@Delete` by not requiring full primary key

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InventoryITBase.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InventoryITBase.java
@@ -47,6 +47,9 @@ public abstract class InventoryITBase {
       new ProductSale(FLAMETHROWER.getId(), DATE_1, 1, Uuids.startOf(1561653130), 500.00, 2);
 
   protected static ProductSale FLAMETHROWER_SALE_4 =
+      new ProductSale(FLAMETHROWER.getId(), DATE_1, 1, Uuids.startOf(1561657504), 702.00, 3);
+
+  protected static ProductSale FLAMETHROWER_SALE_5 =
       new ProductSale(FLAMETHROWER.getId(), DATE_2, 1, Uuids.startOf(1561729530), 500.00, 23);
 
   protected static ProductSale MP3_DOWNLOAD_SALE_1 =

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectIT.java
@@ -81,6 +81,7 @@ public class SelectIT extends InventoryITBase {
     saleDao.save(FLAMETHROWER_SALE_2);
     saleDao.save(FLAMETHROWER_SALE_3);
     saleDao.save(FLAMETHROWER_SALE_4);
+    saleDao.save(FLAMETHROWER_SALE_5);
     saleDao.save(MP3_DOWNLOAD_SALE_1);
   }
 
@@ -133,21 +134,23 @@ public class SelectIT extends InventoryITBase {
         .containsOnly(
             FLAMETHROWER_SALE_1,
             FLAMETHROWER_SALE_3,
-            FLAMETHROWER_SALE_2,
             FLAMETHROWER_SALE_4,
+            FLAMETHROWER_SALE_2,
+            FLAMETHROWER_SALE_5,
             MP3_DOWNLOAD_SALE_1);
   }
 
   @Test
   public void should_select_by_partition_key() {
     assertThat(saleDao.salesByIdForDay(FLAMETHROWER.getId(), DATE_1).all())
-        .containsOnly(FLAMETHROWER_SALE_1, FLAMETHROWER_SALE_3, FLAMETHROWER_SALE_2);
+        .containsOnly(
+            FLAMETHROWER_SALE_1, FLAMETHROWER_SALE_3, FLAMETHROWER_SALE_2, FLAMETHROWER_SALE_4);
   }
 
   @Test
   public void should_select_by_partition_key_and_partial_clustering() {
     assertThat(saleDao.salesByIdForCustomer(FLAMETHROWER.getId(), DATE_1, 1).all())
-        .containsOnly(FLAMETHROWER_SALE_1, FLAMETHROWER_SALE_3);
+        .containsOnly(FLAMETHROWER_SALE_1, FLAMETHROWER_SALE_3, FLAMETHROWER_SALE_4);
   }
 
   @Test

--- a/manual/mapper/daos/delete/README.md
+++ b/manual/mapper/daos/delete/README.md
@@ -58,8 +58,19 @@ The method can operate on:
     void deleteByIdForTs(UUID productId, LocalDate day, long ts);
     ```
 
-An optional IF clause can be added to the generated query. It can contain placeholders, for which
-the method must have corresponding parameters (same name, and a compatible Java type):
+* a number of parameters matching the placeholder markers in `customWhereClause`, for which
+  the parameters match the name and compatible java type of the markers:
+
+    ```java
+    @Delete(
+        entityClass = ProductSale.class,
+        customWhereClause =
+            "id = :id and day = :day and customer_id = :customerId and ts >= :startTs and ts < :endTs")
+    ResultSet deleteInTimeRange(UUID id, String day, int customerId, UUID startTs, UUID endTs);
+    ```
+    
+An optional IF clause can be added to the generated query. Like `customWhereClause` it can contain 
+placeholders:
 
 ```java
 @Delete(entityClass = Product.class, customIfClause = "description = :expectedDescription")

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoDeleteMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoDeleteMethodGenerator.java
@@ -236,7 +236,7 @@ public class DaoDeleteMethodGenerator extends DaoMethodGenerator {
       nextParameterIndex = primaryKeyNames.size();
     }
 
-    // Bind any remaining parameters, assuming they are values for a custom IF clause
+    // Bind any remaining parameters, assuming they are values for a custom WHERE or IF clause
     if (nextParameterIndex < parameters.size()) {
       if (customIfClause.isEmpty() && customWhereClause.isEmpty()) {
         context

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityHelperDeleteByPrimaryKeyPartsMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityHelperDeleteByPrimaryKeyPartsMethodGenerator.java
@@ -58,14 +58,8 @@ public class EntityHelperDeleteByPrimaryKeyPartsMethodGenerator implements Metho
           "throw new $T($S)", MapperException.class, "parameterCount must be greater than 0");
       deleteByPrimaryKeyPartsBuilder.endControlFlow();
 
-      deleteByPrimaryKeyPartsBuilder
-          .addStatement("throwIfKeyspaceMissing()")
-          .addStatement(
-              "$1T deleteSelection = (keyspaceId == null)\n"
-                  + "? $2T.deleteFrom(tableId)\n"
-                  + ": $2T.deleteFrom(keyspaceId, tableId)",
-              DeleteSelection.class,
-              QueryBuilder.class);
+      deleteByPrimaryKeyPartsBuilder.addStatement(
+          "$1T deleteSelection = deleteStart()", DeleteSelection.class);
 
       deleteByPrimaryKeyPartsBuilder.addStatement(
           "$1T columnName = primaryKeys.get(0)", String.class);

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityHelperDeleteStartMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityHelperDeleteStartMethodGenerator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.mapper.processor.entity;
+
+import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
+import com.datastax.oss.driver.api.querybuilder.delete.DeleteSelection;
+import com.datastax.oss.driver.internal.mapper.processor.MethodGenerator;
+import com.datastax.oss.driver.internal.mapper.processor.ProcessorContext;
+import com.squareup.javapoet.MethodSpec;
+import java.util.Optional;
+import javax.lang.model.element.Modifier;
+
+public class EntityHelperDeleteStartMethodGenerator implements MethodGenerator {
+
+  private final EntityDefinition entityDefinition;
+
+  public EntityHelperDeleteStartMethodGenerator(
+      EntityDefinition entityDefinition,
+      EntityHelperGenerator enclosingClass,
+      ProcessorContext context) {
+    this.entityDefinition = entityDefinition;
+  }
+
+  @Override
+  public Optional<MethodSpec> generate() {
+    MethodSpec.Builder deleteStartBuilder =
+        MethodSpec.methodBuilder("deleteStart")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(DeleteSelection.class)
+            .addStatement("throwIfKeyspaceMissing()")
+            .addStatement(
+                "return (keyspaceId == null)\n"
+                    + "? $1T.deleteFrom(tableId)\n"
+                    + ": $1T.deleteFrom(keyspaceId, tableId)",
+                QueryBuilder.class);
+    return Optional.of(deleteStartBuilder.build());
+  }
+}

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityHelperGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityHelperGenerator.java
@@ -112,6 +112,7 @@ public class EntityHelperGenerator extends SingleFileCodeGenerator
             new EntityHelperSelectByPrimaryKeyPartsMethodGenerator(entityDefinition, this, context),
             new EntityHelperSelectByPrimaryKeyMethodGenerator(entityDefinition, this, context),
             new EntityHelperSelectStartMethodGenerator(entityDefinition, this, context),
+            new EntityHelperDeleteStartMethodGenerator(entityDefinition, this, context),
             new EntityHelperDeleteByPrimaryKeyPartsMethodGenerator(entityDefinition, this, context),
             new EntityHelperDeleteByPrimaryKeyMethodGenerator(entityDefinition, this, context),
             new EntityHelperUpdateStartMethodGenerator(entityDefinition, this, context),

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoDeleteMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoDeleteMethodGeneratorTest.java
@@ -76,8 +76,8 @@ public class DaoDeleteMethodGeneratorTest extends DaoMethodGeneratorTest {
       },
       {
         "Invalid parameter list: Delete methods that do not operate on an entity instance "
-            + "must match the primary key components in the exact order "
-            + "(expected primary key of Product: [java.util.UUID]). Mismatch at index 0: java.lang"
+            + "and lack a custom where clause must match the primary key components in the exact "
+            + "order (expected primary key of Product: [java.util.UUID]). Mismatch at index 0: java.lang"
             + ".Integer should be java.util.UUID",
         MethodSpec.methodBuilder("delete")
             .addAnnotation(
@@ -91,7 +91,7 @@ public class DaoDeleteMethodGeneratorTest extends DaoMethodGeneratorTest {
       },
       {
         "Invalid parameter list: Delete methods that do not operate on an entity instance "
-            + "must at least specify partition key components "
+            + "and lack a custom where clause must at least specify partition key components "
             + "(expected partition key of ProductSale: [java.util.UUID, java.lang.String])",
         MethodSpec.methodBuilder("delete")
             .addAnnotation(
@@ -116,12 +116,26 @@ public class DaoDeleteMethodGeneratorTest extends DaoMethodGeneratorTest {
       },
       {
         "Wrong number of parameters: Delete methods can only have additional parameters "
-            + "if they specify a custom IF clause",
+            + "if they specify a custom WHERE or IF clause",
         MethodSpec.methodBuilder("delete")
             .addAnnotation(Delete.class)
             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
             .addParameter(ENTITY_CLASS_NAME, "entity")
             .addParameter(Integer.class, "extra")
+            .build(),
+        ENTITY_SPEC
+      },
+      {
+        "Delete methods that have a custom where clause must not take an Entity (Product) as a "
+            + "parameter",
+        MethodSpec.methodBuilder("delete")
+            .addAnnotation(
+                AnnotationSpec.builder(Delete.class)
+                    .addMember("customWhereClause", "$S", "hello")
+                    .build())
+            .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+            .addParameter(ENTITY_CLASS_NAME, "entity")
+            .returns(Integer.class)
             .build(),
         ENTITY_SPEC
       },

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Delete.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Delete.java
@@ -129,10 +129,14 @@ public @interface Delete {
    * A hint to indicate the entity class, for cases where it can't be determined from the method's
    * signature.
    *
-   * <p>This is only needed if the method receives the primary key components as arguments:
+   * <p>This is only needed if the method receives the primary key components as arguments or uses a
+   * custom where clause:
    *
    * <pre>
    * &#64;Delete(entityClass = Product.class)
+   * void delete(UUID productId);
+   *
+   * &#64;Delete(entityClass = Product.class, customWhereClause="product_id = :productId")
    * void delete(UUID productId);
    * </pre>
    *
@@ -141,6 +145,21 @@ public @interface Delete {
    * proceed with the first one.
    */
   Class<?>[] entityClass() default {};
+
+  /**
+   * A custom WHERE clause for the DELETE query.
+   *
+   * <p>If this is not empty, it completely replaces the WHERE clause in the generated query. Note
+   * that the provided string <b>must not</b> contain the {@code WHERE} keyword and {@link
+   * #entityClass()} must be specified.
+   *
+   * <p>This clause can contain placeholders that will be bound with the method's parameters; see
+   * the top-level javadocs of this class for more explanations.
+   *
+   * <p>Also note that this can be used in conjunction with {@link #customIfClause()} or {@link
+   * #ifExists()}.
+   */
+  String customWhereClause() default "";
 
   /**
    * Whether to append an IF EXISTS clause at the end of the generated DELETE query.


### PR DESCRIPTION
For [JAVA-2308](https://datastax-oss.atlassian.net/browse/JAVA-2308)

---

Motivation:

CQL DELETE allows advanced capabilities for deleting a range of data
within a partition.  For example given a primary key of ((int k), int c),
one could perform the following:

DELETE FROM tbl WHERE k = 0 and c > 1 and c < 4

To support this capability in the mapper, customWhereClause should be
added to Delete in a similar way it is handled in the Select annotation.

Modifications:

Add customWhereClause to Delete annotation.

Update DaoDeleteMethodGenerator to handle customWhereClause.

Add EntityHelperDeleteStartMethodGenerator which adds a deleteStart
method, which is reused in
EntityHelperDeleteByPrimaryKeyPartsMethodGenerator and also used in the
code generation in DaoDeleteMethodGenerator

Result:

customWhereClause added to Delete.