### PR TITLE
JAVA-2326: Reduce memory allocations during queries execution

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,7 +1,7 @@
 ## Changelog
 
 ### 3.7.2 (In progress)
-
+- [improvement] JAVA-2326: Avoid String allocations required only for trace in RequestHandler
 - [bug] JAVA-2249: Stop stripping trailing zeros in ByteOrderedTokens.
 - [bug] JAVA-1492: Don't immediately reuse busy connections for another request.
 - [bug] JAVA-2198: Handle UDTs with names that clash with collection types.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,7 +2,7 @@
 
 ### 3.7.3 (In progress)
 
-- [improvement] JAVA-2326: Avoid String allocations required only for trace in RequestHandler
+- [improvement] JAVA-2326: Reduce memory allocations in Flusher.run, RequestHandler and flags decoding logic
 
 
 ### 3.7.2

--- a/driver-core/src/main/java/com/datastax/driver/core/Connection.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Connection.java
@@ -731,7 +731,8 @@ class Connection {
       throw new ConnectionException(address, "Connection has been closed");
     }
 
-    logger.trace("{}, stream {}, writing request {}", this, request.getStreamId(), request);
+    if (logger.isTraceEnabled())
+      logger.trace("{}, stream {}, writing request {}", this, request.getStreamId(), request);
     writer.incrementAndGet();
 
     if (DISABLE_COALESCING) {
@@ -787,8 +788,9 @@ class Connection {
                   }
                 });
         } else {
-          logger.trace(
-              "{}, stream {}, request sent successfully", Connection.this, request.getStreamId());
+          if (logger.isTraceEnabled())
+            logger.trace(
+                "{}, stream {}, request sent successfully", Connection.this, request.getStreamId());
         }
       }
     };
@@ -1103,11 +1105,11 @@ class Connection {
         }
       }
 
-      // Always flush what we have (don't artificially delay to try to coalesce more messages)
-      for (Channel channel : channels) channel.flush();
-      channels.clear();
-
       if (doneWork) {
+        // Always flush what we have (don't artificially delay to try to coalesce more messages)
+        for (Channel channel : channels) channel.flush();
+        channels.clear();
+
         runsWithNoWork = 0;
       } else {
         // either reschedule or cancel

--- a/driver-core/src/main/java/com/datastax/driver/core/Frame.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Frame.java
@@ -179,9 +179,10 @@ class Frame {
       WARNING,
       USE_BETA;
 
+      private static final Flag[] values = Flag.values();
+
       static EnumSet<Flag> deserialize(int flags) {
         EnumSet<Flag> set = EnumSet.noneOf(Flag.class);
-        Flag[] values = Flag.values();
         for (int n = 0; n < 8; n++) {
           if ((flags & (1 << n)) != 0) set.add(values[n]);
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/Responses.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Responses.java
@@ -393,9 +393,10 @@ class Responses {
           NO_METADATA,
           METADATA_CHANGED;
 
+          private static final Flag[] values = Flag.values();
+
           static EnumSet<Flag> deserialize(int flags) {
             EnumSet<Flag> set = EnumSet.noneOf(Flag.class);
-            Flag[] values = Flag.values();
             for (int n = 0; n < values.length; n++) {
               if ((flags & (1 << n)) != 0) set.add(values[n]);
             }


### PR DESCRIPTION
Fields "id" are evaluated for each request and allocate extra objects in heap but actually needed only for tracing. The values can be calculated lazy.