### PR TITLE
Mapper uses Session to allow for pluggable request proccessors (e.g. GuavaSession etc)

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/mapper/CarITBase.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/mapper/CarITBase.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.example.guava.mapper;
+
+import com.datastax.oss.driver.api.mapper.annotations.Entity;
+import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+public abstract class CarITBase {
+  protected static GuavaSessionGetEntityIT.Car SAAB93 =
+      new GuavaSessionGetEntityIT.Car(UUID.randomUUID(), "SAAB", "9-3", 1999);
+  protected static GuavaSessionGetEntityIT.Car SAAB900 =
+      new GuavaSessionGetEntityIT.Car(UUID.randomUUID(), "SAAB", "900", 1993);
+
+  protected static List<String> createStatements(CcmRule ccmRule) {
+    ImmutableList.Builder<String> builder =
+        ImmutableList.<String>builder()
+            .add("CREATE TABLE car(id uuid PRIMARY KEY, make text, model test, year int)");
+
+    return builder.build();
+  }
+
+  @Entity
+  public static class Car {
+
+    @PartitionKey private UUID id;
+    private String make;
+    private String model;
+    private Integer year;
+
+    public Car() {}
+
+    public Car(UUID id, String make, String model, Integer year) {
+      this.id = id;
+      this.make = make;
+      this.model = model;
+      this.year = year;
+    }
+
+    public UUID getId() {
+      return id;
+    }
+
+    public void setId(UUID id) {
+      this.id = id;
+    }
+
+    public String getMake() {
+      return make;
+    }
+
+    public void setMake(String make) {
+      this.make = make;
+    }
+
+    public String getModel() {
+      return model;
+    }
+
+    public void setModel(String model) {
+      this.model = model;
+    }
+
+    public Integer getYear() {
+      return year;
+    }
+
+    public void setYear(Integer year) {
+      this.year = year;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      Car car = (Car) o;
+      return Objects.equals(id, car.id)
+          && Objects.equals(make, car.make)
+          && Objects.equals(model, car.model)
+          && Objects.equals(year, car.year);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id, make, model, year);
+    }
+
+    @Override
+    public String toString() {
+      return "Car{"
+          + "id="
+          + id
+          + ", make='"
+          + make
+          + '\''
+          + ", model='"
+          + model
+          + '\''
+          + ", year="
+          + year
+          + '}';
+    }
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/mapper/GuavaSessionGetEntityIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/mapper/GuavaSessionGetEntityIT.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.example.guava.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.MappedAsyncPagingIterable;
+import com.datastax.oss.driver.api.core.PagingIterable;
+import com.datastax.oss.driver.api.core.cql.*;
+import com.datastax.oss.driver.api.mapper.annotations.*;
+import com.datastax.oss.driver.api.mapper.entity.saving.NullSavingStrategy;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.driver.example.guava.api.GuavaSession;
+import com.datastax.oss.driver.example.guava.api.GuavaSessionUtils;
+import com.datastax.oss.driver.shaded.guava.common.collect.Sets;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+@Category(ParallelizableTests.class)
+public class GuavaSessionGetEntityIT extends CarITBase {
+
+  private static CcmRule ccm = CcmRule.getInstance();
+
+  private static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccm).build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccm).around(sessionRule);
+
+  private static CarDao dao;
+
+  private static GuavaSession newSession(CqlIdentifier keyspace) {
+    return GuavaSessionUtils.builder()
+        .addContactEndPoints(ccm.getContactPoints())
+        .withKeyspace(keyspace)
+        .build();
+  }
+
+  @BeforeClass
+  public static void setup() {
+    GuavaSession session = newSession(sessionRule.keyspace());
+
+    for (String query : createStatements(ccm)) {
+      try {
+        session
+            .executeAsync(
+                SimpleStatement.builder(query)
+                    .setExecutionProfile(sessionRule.slowProfile())
+                    .build())
+            .get();
+      } catch (Exception e) {
+        // shouldn't time out
+      }
+    }
+
+    CarMapper carMapper = new GuavaSessionGetEntityIT_CarMapperBuilder(session).build();
+    dao = carMapper.carDao(sessionRule.keyspace());
+
+    dao.save(SAAB93);
+    dao.save(SAAB900);
+  }
+
+  @Test
+  public void should_get_entity_from_row() {
+    GuavaSession session = newSession(sessionRule.keyspace());
+    ResultSet rs =
+        session.execute(
+            SimpleStatement.newInstance("SELECT * FROM car WHERE id = ?", SAAB93.getId()),
+            Statement.SYNC);
+    Row row = rs.one();
+    assertThat(row).isNotNull();
+
+    Car car = dao.get(row);
+    assertThat(car).isEqualTo(SAAB93);
+  }
+
+  @Test
+  public void should_get_entity_from_first_row_of_result_set() {
+    GuavaSession session = newSession(sessionRule.keyspace());
+    ResultSet rs =
+        session.execute(SimpleStatement.newInstance("SELECT * FROM car"), Statement.SYNC);
+
+    Car car = dao.getOne(rs);
+    // The order depends on the IDs, which are generated dynamically. This is good enough:
+    assertThat(car.equals(SAAB93) || car.equals(SAAB900)).isTrue();
+  }
+
+  @Test
+  public void should_get_entity_from_first_row_of_async_result_set() throws Exception {
+    GuavaSession session = newSession(sessionRule.keyspace());
+    AsyncResultSet rs = session.executeAsync("SELECT * FROM car").get();
+
+    Car car = dao.getOne(rs);
+    // The order depends on the IDs, which are generated dynamically. This is good enough:
+    assertThat(car.equals(SAAB93) || car.equals(SAAB900)).isTrue();
+  }
+
+  @Test
+  public void should_get_iterable_from_result_set() {
+    GuavaSession session = newSession(sessionRule.keyspace());
+    ResultSet rs =
+        session.execute(SimpleStatement.newInstance("SELECT * FROM car"), Statement.SYNC);
+    PagingIterable<Car> cars = dao.get(rs);
+    assertThat(Sets.newHashSet(cars)).containsOnly(SAAB93, SAAB900);
+  }
+
+  @Test
+  public void should_get_async_iterable_from_async_result_set() throws Exception {
+    GuavaSession session = newSession(sessionRule.keyspace());
+    AsyncResultSet rs = session.executeAsync("SELECT * FROM car").get();
+    MappedAsyncPagingIterable<Car> cars = dao.get(rs);
+    assertThat(Sets.newHashSet(cars.currentPage())).containsOnly(SAAB93, SAAB900);
+    assertThat(cars.hasMorePages()).isFalse();
+  }
+
+  @Mapper
+  public interface CarMapper {
+    @DaoFactory
+    CarDao carDao(@DaoKeyspace CqlIdentifier keyspace);
+  }
+
+  @Dao
+  @DefaultNullSavingStrategy(NullSavingStrategy.SET_TO_NULL)
+  public interface CarDao {
+    @GetEntity
+    Car get(Row row);
+
+    @GetEntity
+    PagingIterable<Car> get(ResultSet resultSet);
+
+    @GetEntity
+    MappedAsyncPagingIterable<Car> get(AsyncResultSet resultSet);
+
+    @GetEntity
+    Car getOne(ResultSet resultSet);
+
+    @GetEntity
+    Car getOne(AsyncResultSet resultSet);
+
+    @Insert
+    void save(Car car);
+  }
+}

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/mapper/MapperBuilderGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/mapper/MapperBuilderGenerator.java
@@ -15,7 +15,7 @@
  */
 package com.datastax.oss.driver.internal.mapper.processor.mapper;
 
-import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.mapper.MapperBuilder;
 import com.datastax.oss.driver.internal.mapper.DefaultMapperContext;
 import com.datastax.oss.driver.internal.mapper.processor.GeneratedNames;
@@ -45,8 +45,8 @@ public class MapperBuilderGenerator extends SingleFileCodeGenerator {
     return builderName;
   }
 
-  protected Class<? extends CqlSession> getSessionClass() {
-    return CqlSession.class;
+  protected Class<? extends Session> getSessionClass() {
+    return Session.class;
   }
 
   @Override

--- a/mapper-runtime/revapi.json
+++ b/mapper-runtime/revapi.json
@@ -17,6 +17,38 @@
           ]
         }
       }
-    }
+    },
+    "ignore": [
+      {
+        "code": "java.field.typeChanged",
+        "old": "field com.datastax.oss.driver.api.mapper.MapperBuilder<MapperT>.session",
+        "new": "field com.datastax.oss.driver.api.mapper.MapperBuilder<MapperT>.session",
+        "justification": "Downcast to Session to support pluggable RequestProcessors (e.g. GuavaSession etc)."
+      },
+      {
+        "code": "java.method.parameterTypeChanged",
+        "old": "parameter void com.datastax.oss.driver.api.mapper.MapperBuilder<MapperT>::<init>(===com.datastax.oss.driver.api.core.CqlSession===)",
+        "new": "parameter void com.datastax.oss.driver.api.mapper.MapperBuilder<MapperT>::<init>(===com.datastax.oss.driver.api.core.session.Session===)",
+        "justification": "Downcast to Session to support pluggable RequestProcessors (e.g. GuavaSession etc)."
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method com.datastax.oss.driver.api.core.CqlSession com.datastax.oss.driver.api.mapper.MapperContext::getSession()",
+        "new": "method com.datastax.oss.driver.api.core.session.Session com.datastax.oss.driver.api.mapper.MapperContext::getSession()",
+        "justification": "Downcast to Session to support pluggable RequestProcessors (e.g. GuavaSession etc)."
+      },
+      {
+        "code": "java.method.parameterTypeChanged",
+        "old": "parameter void com.datastax.oss.driver.internal.mapper.DefaultMapperContext::<init>(===com.datastax.oss.driver.api.core.CqlSession===, java.util.Map<java.lang.Object, java.lang.Object>)",
+        "new": "parameter void com.datastax.oss.driver.internal.mapper.DefaultMapperContext::<init>(===com.datastax.oss.driver.api.core.session.Session===, java.util.Map<java.lang.Object, java.lang.Object>)",
+        "justification": "Downcast to Session to support pluggable RequestProcessors (e.g. GuavaSession etc)."
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method com.datastax.oss.driver.api.core.CqlSession com.datastax.oss.driver.internal.mapper.DefaultMapperContext::getSession()",
+        "new": "method com.datastax.oss.driver.api.core.session.Session com.datastax.oss.driver.internal.mapper.DefaultMapperContext::getSession()",
+        "justification": "Downcast to Session to support pluggable RequestProcessors (e.g. GuavaSession etc)."
+      }
+    ]
   }
 }

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/MapperBuilder.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/MapperBuilder.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.api.mapper;
 
 import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.mapper.annotations.Mapper;
 import com.datastax.oss.driver.api.mapper.annotations.QueryProvider;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -31,10 +32,10 @@ import java.util.Map;
  */
 public abstract class MapperBuilder<MapperT> {
 
-  protected final CqlSession session;
+  protected final Session session;
   protected Map<Object, Object> customState;
 
-  protected MapperBuilder(CqlSession session) {
+  protected MapperBuilder(Session session) {
     this.session = session;
     this.customState = new HashMap<>();
   }
@@ -44,8 +45,8 @@ public abstract class MapperBuilder<MapperT> {
    *
    * <p>This is intended mainly for {@link QueryProvider} methods: since provider classes are
    * instantiated directly by the generated mapper code, they have no way to access non-static state
-   * from the rest of your application. This method allows you to pass that state while building the
-   * mapper, and access it later at runtime.
+   * from the rest of your application. This method allows you to psass that state while building
+   * the mapper, and access it later at runtime.
    *
    * <p>Note that this state will be accessed concurrently, it should be thread-safe.
    */

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/MapperContext.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/MapperContext.java
@@ -16,7 +16,7 @@
 package com.datastax.oss.driver.api.mapper;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
-import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.mapper.entity.naming.NameConverter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -29,7 +29,7 @@ import java.util.Map;
 public interface MapperContext {
 
   @NonNull
-  CqlSession getSession();
+  Session getSession();
 
   /**
    * If this context belongs to a DAO that was built with a keyspace-parameterized mapper method,

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/internal/mapper/DaoBase.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/internal/mapper/DaoBase.java
@@ -19,13 +19,7 @@ import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.MappedAsyncPagingIterable;
 import com.datastax.oss.driver.api.core.PagingIterable;
-import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
-import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
-import com.datastax.oss.driver.api.core.cql.PreparedStatement;
-import com.datastax.oss.driver.api.core.cql.ResultSet;
-import com.datastax.oss.driver.api.core.cql.Row;
-import com.datastax.oss.driver.api.core.cql.SimpleStatement;
-import com.datastax.oss.driver.api.core.cql.Statement;
+import com.datastax.oss.driver.api.core.cql.*;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.mapper.MapperContext;
 import com.datastax.oss.driver.api.mapper.MapperException;
@@ -57,7 +51,7 @@ public class DaoBase {
 
   protected static CompletionStage<PreparedStatement> prepare(
       SimpleStatement statement, MapperContext context) {
-    return context.getSession().prepareAsync(statement);
+    return context.getSession().execute(statement, PrepareRequest.ASYNC);
   }
 
   /**
@@ -175,7 +169,7 @@ public class DaoBase {
   }
 
   protected ResultSet execute(Statement<?> statement) {
-    return context.getSession().execute(statement);
+    return context.getSession().execute(statement, Statement.SYNC);
   }
 
   protected boolean executeAndMapWasAppliedToBoolean(Statement<?> statement) {
@@ -234,7 +228,8 @@ public class DaoBase {
   }
 
   protected CompletableFuture<AsyncResultSet> executeAsync(Statement<?> statement) {
-    CompletionStage<AsyncResultSet> stage = context.getSession().executeAsync(statement);
+    CompletionStage<AsyncResultSet> stage =
+        context.getSession().execute(statement, Statement.ASYNC);
     // We allow DAO interfaces to return CompletableFuture instead of CompletionStage. This method
     // returns CompletableFuture, which makes the implementation code a bit simpler to generate.
     // In practice this has no performance impact, because the default implementation of

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/internal/mapper/DefaultMapperContext.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/internal/mapper/DefaultMapperContext.java
@@ -16,7 +16,7 @@
 package com.datastax.oss.driver.internal.mapper;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
-import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.mapper.MapperContext;
 import com.datastax.oss.driver.api.mapper.MapperException;
 import com.datastax.oss.driver.api.mapper.entity.naming.NameConverter;
@@ -31,14 +31,13 @@ import java.util.concurrent.ConcurrentMap;
 
 public class DefaultMapperContext implements MapperContext {
 
-  private final CqlSession session;
+  private final Session session;
   private final CqlIdentifier keyspaceId;
   private final CqlIdentifier tableId;
   private final ConcurrentMap<Class<? extends NameConverter>, NameConverter> nameConverterCache;
   private final Map<Object, Object> customState;
 
-  public DefaultMapperContext(
-      @NonNull CqlSession session, @NonNull Map<Object, Object> customState) {
+  public DefaultMapperContext(@NonNull Session session, @NonNull Map<Object, Object> customState) {
     this(
         session,
         null,
@@ -48,7 +47,7 @@ public class DefaultMapperContext implements MapperContext {
   }
 
   private DefaultMapperContext(
-      CqlSession session,
+      Session session,
       CqlIdentifier keyspaceId,
       CqlIdentifier tableId,
       ConcurrentMap<Class<? extends NameConverter>, NameConverter> nameConverterCache,
@@ -71,7 +70,7 @@ public class DefaultMapperContext implements MapperContext {
 
   @NonNull
   @Override
-  public CqlSession getSession() {
+  public Session getSession() {
     return session;
   }
 


### PR DESCRIPTION
Motivation:

The initial implementation of Mapper required a CqlSession be passed to it to use for queries.
However when trying to implement a custom request processor following the GuavaSession example this
caused issues:

Caused by: java.lang.IllegalArgumentException: No request processor found for com.datastax.oss.driver.internal.core.cql.DefaultPrepareRequest@2d88361b
    at com.datastax.oss.driver.internal.core.session.RequestProcessorRegistry.processorFor(RequestProcessorRegistry.java:74)
    at com.datastax.oss.driver.internal.core.session.DefaultSession.execute(DefaultSession.java:205)
    at com.datastax.oss.driver.api.core.CqlSession.prepareAsync(CqlSession.java:196)
    at com.datastax.oss.driver.internal.mapper.DaoBase.prepare(DaoBase.java:60)
    at CarDAOImpl__MapperGenerated.initAsync(CarDAOImpl__MapperGenerated.java:105)
    ... 33 more

Since I overrode the CqlSession with my own that would handle asynchronous queries using Ratpack Promies (similar to Guava ListenableFuture).

Thus I felt it made sense to change the Mapper code to use the more generic Session interface, since this allows for better support for
those who are using their own custom request processeors.

Result:

I had added a simple test in where the Mapper is configured to use the existing GuavaSession example instead of the CqlSession, and it all works.