### PR TITLE
JAVA-2302: Better target mapper errors and warnings for inherited methods

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.2.0 (in progress)
 
+- [improvement] JAVA-2302: Better target mapper errors and warnings for inherited methods
 - [improvement] JAVA-2336: Expose byte utility methods in the public API 
 - [improvement] JAVA-2338: Revisit toString() for data container types
 - [bug] JAVA-2367: Fix column names in EntityHelper.updateByPrimaryKey

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/CodeGeneratorFactory.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/CodeGeneratorFactory.java
@@ -56,7 +56,9 @@ public interface CodeGeneratorFactory {
    * @see #newMapperImplementation(TypeElement)
    */
   Optional<MethodGenerator> newMapperImplementationMethod(
-      ExecutableElement methodElement, MapperImplementationSharedCode enclosingClass);
+      ExecutableElement methodElement,
+      TypeElement processedType,
+      MapperImplementationSharedCode enclosingClass);
 
   /** The builder associated to a {@link Mapper}-annotated interface. */
   CodeGenerator newMapperBuilder(TypeElement interfaceElement);
@@ -64,9 +66,8 @@ public interface CodeGeneratorFactory {
   /**
    * The implementation of a {@link Dao}-annotated interface.
    *
-   * <p>The default code factory calls {@link #newDaoImplementationMethod(ExecutableElement, Map,
-   * DaoImplementationSharedCode)} for each non-static, non-default method, but this is not a hard
-   * requirement.
+   * <p>The default code factory calls {@link #newDaoImplementationMethod} for each non-static,
+   * non-default method, but this is not a hard requirement.
    */
   CodeGenerator newDaoImplementation(TypeElement interfaceElement);
 
@@ -80,6 +81,7 @@ public interface CodeGeneratorFactory {
   Optional<MethodGenerator> newDaoImplementationMethod(
       ExecutableElement methodElement,
       Map<Name, TypeElement> typeParameters,
+      TypeElement processedType,
       DaoImplementationSharedCode enclosingClass);
 
   DaoReturnTypeParser getDaoReturnTypeParser();

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/DecoratedMessager.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/DecoratedMessager.java
@@ -15,8 +15,11 @@
  */
 package com.datastax.oss.driver.internal.mapper.processor;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.annotation.processing.Messager;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic;
 
 /** Wraps {@link Messager} to provide convenience methods. */
@@ -28,15 +31,145 @@ public class DecoratedMessager {
     this.messager = messager;
   }
 
-  public void warn(Element element, String template, Object... arguments) {
-    messager.printMessage(Diagnostic.Kind.WARNING, String.format(template, arguments), element);
-  }
-
+  /** Emits a global warning that doesn't target a particular element. */
   public void warn(String template, Object... arguments) {
     messager.printMessage(Diagnostic.Kind.WARNING, String.format(template, arguments));
   }
 
-  public void error(Element element, String template, Object... arguments) {
-    messager.printMessage(Diagnostic.Kind.ERROR, String.format(template, arguments), element);
+  /** Emits a warning for a type. */
+  public void warn(TypeElement typeElement, String template, Object... arguments) {
+    messager.printMessage(Diagnostic.Kind.WARNING, String.format(template, arguments), typeElement);
+  }
+
+  /** Emits an error for a type. */
+  public void error(TypeElement typeElement, String template, Object... arguments) {
+    messager.printMessage(Diagnostic.Kind.ERROR, String.format(template, arguments), typeElement);
+  }
+
+  /**
+   * Emits a warning for a program element that might be inherited from another type.
+   *
+   * @param targetElement the element to target.
+   * @param processedType the type that we were processing when we detected the issue.
+   */
+  public void warn(
+      Element targetElement, TypeElement processedType, String template, Object... arguments) {
+    new ElementMessager(targetElement, processedType)
+        .print(Diagnostic.Kind.WARNING, template, arguments);
+  }
+
+  /**
+   * Emits an error for a program element that might be inherited from another type.
+   *
+   * @param targetElement the element to target.
+   * @param processedType the type that we were processing when we detected the issue.
+   */
+  public void error(
+      Element targetElement, TypeElement processedType, String template, Object... arguments) {
+    new ElementMessager(targetElement, processedType)
+        .print(Diagnostic.Kind.ERROR, template, arguments);
+  }
+
+  /**
+   * Abstracts logic to produce better messages if the target element is inherited from a compiled
+   * type.
+   *
+   * <p>Consider the following situation:
+   *
+   * <pre>
+   *   interface BaseDao {
+   *     &#64;Select
+   *     void select();
+   *   }
+   *   &#64;Dao
+   *   interface ConcreteDao extends BaseDao {}
+   * </pre>
+   *
+   * If {@code BaseDao} belongs to a JAR dependency, it is already compiled and the warning or error
+   * message can't reference a file or line number, it doesn't even mention {@code ConcreteDao}.
+   *
+   * <p>The goal of this class is to detect those cases, and issue the message on {@code
+   * ConcreteDao} instead.
+   */
+  private class ElementMessager {
+
+    private final Element actualTargetElement;
+    // Additional location information that will get prepended to the message
+    private final String locationInfo;
+
+    /**
+     * @param processedType the type that we are currently processing ({@code ConcreteDao} in the
+     *     example above).
+     */
+    ElementMessager(@NonNull Element intendedTargetElement, @NonNull TypeElement processedType) {
+
+      TypeElement declaringType;
+      switch (intendedTargetElement.getKind()) {
+        case CLASS:
+        case INTERFACE:
+          if (processedType.equals(intendedTargetElement)
+              || isSourceFile((TypeElement) intendedTargetElement)) {
+            this.actualTargetElement = intendedTargetElement;
+            this.locationInfo = "";
+          } else {
+            this.actualTargetElement = processedType;
+            this.locationInfo =
+                String.format("[Ancestor %s]", intendedTargetElement.getSimpleName());
+          }
+          break;
+        case FIELD:
+        case METHOD:
+        case CONSTRUCTOR:
+          declaringType = (TypeElement) intendedTargetElement.getEnclosingElement();
+          if (processedType.equals(declaringType) || isSourceFile(declaringType)) {
+            this.actualTargetElement = intendedTargetElement;
+            this.locationInfo = "";
+          } else {
+            this.actualTargetElement = processedType;
+            this.locationInfo =
+                String.format(
+                    "[%s inherited from %s] ",
+                    intendedTargetElement, declaringType.getSimpleName());
+          }
+          break;
+        case PARAMETER:
+          ExecutableElement method =
+              (ExecutableElement) intendedTargetElement.getEnclosingElement();
+          declaringType = (TypeElement) method.getEnclosingElement();
+          if (processedType.equals(declaringType) || isSourceFile(declaringType)) {
+            this.actualTargetElement = intendedTargetElement;
+            this.locationInfo = "";
+          } else {
+            this.actualTargetElement = processedType;
+            this.locationInfo =
+                String.format(
+                    "[Parameter %s of %s inherited from %s] ",
+                    intendedTargetElement.getSimpleName(),
+                    method.getSimpleName(),
+                    declaringType.getSimpleName());
+          }
+          break;
+        default:
+          // We don't emit messages for other types of elements in the mapper processor. Handle
+          // gracefully nevertheless:
+          this.actualTargetElement = intendedTargetElement;
+          this.locationInfo = "";
+          break;
+      }
+    }
+
+    void print(Diagnostic.Kind level, String template, Object... arguments) {
+      messager.printMessage(
+          level, String.format(locationInfo + template, arguments), actualTargetElement);
+    }
+
+    private boolean isSourceFile(TypeElement element) {
+      try {
+        Class.forName(element.getQualifiedName().toString());
+        return false;
+      } catch (ClassNotFoundException e) {
+        return true;
+      }
+    }
   }
 }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/DefaultCodeGeneratorFactory.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/DefaultCodeGeneratorFactory.java
@@ -75,10 +75,13 @@ public class DefaultCodeGeneratorFactory implements CodeGeneratorFactory {
 
   @Override
   public Optional<MethodGenerator> newMapperImplementationMethod(
-      ExecutableElement methodElement, MapperImplementationSharedCode enclosingClass) {
+      ExecutableElement methodElement,
+      TypeElement processedType,
+      MapperImplementationSharedCode enclosingClass) {
     if (methodElement.getAnnotation(DaoFactory.class) != null) {
       return Optional.of(
-          new MapperDaoFactoryMethodGenerator(methodElement, enclosingClass, context));
+          new MapperDaoFactoryMethodGenerator(
+              methodElement, processedType, enclosingClass, context));
     } else {
       return Optional.empty();
     }
@@ -98,32 +101,40 @@ public class DefaultCodeGeneratorFactory implements CodeGeneratorFactory {
   public Optional<MethodGenerator> newDaoImplementationMethod(
       ExecutableElement methodElement,
       Map<Name, TypeElement> typeParameters,
+      TypeElement processedType,
       DaoImplementationSharedCode enclosingClass) {
     if (methodElement.getAnnotation(SetEntity.class) != null) {
       return Optional.of(
-          new DaoSetEntityMethodGenerator(methodElement, typeParameters, enclosingClass, context));
+          new DaoSetEntityMethodGenerator(
+              methodElement, typeParameters, processedType, enclosingClass, context));
     } else if (methodElement.getAnnotation(Insert.class) != null) {
       return Optional.of(
-          new DaoInsertMethodGenerator(methodElement, typeParameters, enclosingClass, context));
+          new DaoInsertMethodGenerator(
+              methodElement, typeParameters, processedType, enclosingClass, context));
     } else if (methodElement.getAnnotation(GetEntity.class) != null) {
       return Optional.of(
-          new DaoGetEntityMethodGenerator(methodElement, typeParameters, enclosingClass, context));
+          new DaoGetEntityMethodGenerator(
+              methodElement, typeParameters, processedType, enclosingClass, context));
     } else if (methodElement.getAnnotation(Select.class) != null) {
       return Optional.of(
-          new DaoSelectMethodGenerator(methodElement, typeParameters, enclosingClass, context));
+          new DaoSelectMethodGenerator(
+              methodElement, typeParameters, processedType, enclosingClass, context));
     } else if (methodElement.getAnnotation(Delete.class) != null) {
       return Optional.of(
-          new DaoDeleteMethodGenerator(methodElement, typeParameters, enclosingClass, context));
+          new DaoDeleteMethodGenerator(
+              methodElement, typeParameters, processedType, enclosingClass, context));
     } else if (methodElement.getAnnotation(Query.class) != null) {
       return Optional.of(
-          new DaoQueryMethodGenerator(methodElement, typeParameters, enclosingClass, context));
+          new DaoQueryMethodGenerator(
+              methodElement, typeParameters, processedType, enclosingClass, context));
     } else if (methodElement.getAnnotation(Update.class) != null) {
       return Optional.of(
-          new DaoUpdateMethodGenerator(methodElement, typeParameters, enclosingClass, context));
+          new DaoUpdateMethodGenerator(
+              methodElement, typeParameters, processedType, enclosingClass, context));
     } else if (methodElement.getAnnotation(QueryProvider.class) != null) {
       return Optional.of(
           new DaoQueryProviderMethodGenerator(
-              methodElement, typeParameters, enclosingClass, context));
+              methodElement, typeParameters, processedType, enclosingClass, context));
     } else {
       return Optional.empty();
     }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/MapperProcessor.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/MapperProcessor.java
@@ -109,7 +109,7 @@ public class MapperProcessor extends AbstractProcessor {
     for (Element element : roundEnvironment.getElementsAnnotatedWith(annotationClass)) {
       if (element.getKind() != expectedKind) {
         messager.error(
-            element,
+            (TypeElement) element,
             "Only %s elements can be annotated with %s",
             expectedKind,
             annotationClass.getSimpleName());
@@ -120,7 +120,7 @@ public class MapperProcessor extends AbstractProcessor {
           generatorFactory.apply(typeElement).generate();
         } catch (Exception e) {
           messager.error(
-              element,
+              (TypeElement) element,
               "Unexpected error while writing generated code: %s",
               Throwables.getStackTraceAsString(e));
         }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoDeleteMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoDeleteMethodGenerator.java
@@ -54,9 +54,10 @@ public class DaoDeleteMethodGenerator extends DaoMethodGenerator {
   public DaoDeleteMethodGenerator(
       ExecutableElement methodElement,
       Map<Name, TypeElement> typeParameters,
+      TypeElement processedType,
       DaoImplementationSharedCode enclosingClass,
       ProcessorContext context) {
-    super(methodElement, typeParameters, enclosingClass, context);
+    super(methodElement, typeParameters, processedType, enclosingClass, context);
   }
 
   protected Set<DaoReturnTypeKind> getSupportedReturnTypes() {
@@ -74,6 +75,7 @@ public class DaoDeleteMethodGenerator extends DaoMethodGenerator {
           .getMessager()
           .error(
               methodElement,
+              processedType,
               "Invalid annotation parameters: %s cannot have both ifExists and customIfClause",
               Delete.class.getSimpleName());
       return Optional.empty();
@@ -97,6 +99,7 @@ public class DaoDeleteMethodGenerator extends DaoMethodGenerator {
           .getMessager()
           .error(
               methodElement,
+              processedType,
               "Wrong number of parameters: %s methods with no custom clause "
                   + "must take either an entity instance, or the partition key components",
               Delete.class.getSimpleName());
@@ -117,6 +120,7 @@ public class DaoDeleteMethodGenerator extends DaoMethodGenerator {
             .getMessager()
             .error(
                 methodElement,
+                processedType,
                 "Invalid parameter list: %s methods that have a custom where clause "
                     + "must not take an Entity (%s) as a parameter",
                 Delete.class.getSimpleName(),
@@ -131,6 +135,7 @@ public class DaoDeleteMethodGenerator extends DaoMethodGenerator {
             .getMessager()
             .error(
                 methodElement,
+                processedType,
                 "Missing entity class: %s methods that do not operate on an entity "
                     + "instance must have an 'entityClass' argument",
                 Delete.class.getSimpleName());
@@ -154,6 +159,7 @@ public class DaoDeleteMethodGenerator extends DaoMethodGenerator {
                 .getMessager()
                 .error(
                     methodElement,
+                    processedType,
                     "Invalid parameter list: %s methods that have a custom if clause"
                         + "must specify the entire primary key (expected primary keys of %s: %s)",
                     Delete.class.getSimpleName(),
@@ -169,12 +175,13 @@ public class DaoDeleteMethodGenerator extends DaoMethodGenerator {
 
         primaryKeyParameterCount = primaryKeyParameters.size();
         if (!EntityUtils.areParametersValid(
-            context,
-            methodElement,
             entityElement,
             entityDefinition,
             primaryKeyParameters,
             Delete.class,
+            context,
+            methodElement,
+            processedType,
             "do not operate on an entity instance and lack a custom where clause")) {
           return Optional.empty();
         }
@@ -243,6 +250,7 @@ public class DaoDeleteMethodGenerator extends DaoMethodGenerator {
             .getMessager()
             .error(
                 methodElement,
+                processedType,
                 "Wrong number of parameters: %s methods can only have additional "
                     + "parameters if they specify a custom WHERE or IF clause",
                 Delete.class.getSimpleName());
@@ -297,6 +305,7 @@ public class DaoDeleteMethodGenerator extends DaoMethodGenerator {
               .getMessager()
               .warn(
                   methodElement,
+                  processedType,
                   "Too many entity classes: %s must have at most one 'entityClass' argument "
                       + "(will use the first one: %s)",
                   Delete.class.getSimpleName(),

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoGetEntityMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoGetEntityMethodGenerator.java
@@ -53,9 +53,10 @@ public class DaoGetEntityMethodGenerator extends DaoMethodGenerator {
   public DaoGetEntityMethodGenerator(
       ExecutableElement methodElement,
       Map<Name, TypeElement> typeParameters,
+      TypeElement processedType,
       DaoImplementationSharedCode enclosingClass,
       ProcessorContext context) {
-    super(methodElement, typeParameters, enclosingClass, context);
+    super(methodElement, typeParameters, processedType, enclosingClass, context);
   }
 
   @Override
@@ -67,6 +68,7 @@ public class DaoGetEntityMethodGenerator extends DaoMethodGenerator {
           .getMessager()
           .error(
               methodElement,
+              processedType,
               "Wrong number of parameters: %s methods must have exactly one",
               GetEntity.class.getSimpleName());
       return Optional.empty();
@@ -82,7 +84,8 @@ public class DaoGetEntityMethodGenerator extends DaoMethodGenerator {
       context
           .getMessager()
           .error(
-              parameterElement,
+              methodElement,
+              processedType,
               "Invalid parameter type: %s methods must take a %s, %s or %s",
               GetEntity.class.getSimpleName(),
               GettableByName.class.getSimpleName(),
@@ -105,6 +108,7 @@ public class DaoGetEntityMethodGenerator extends DaoMethodGenerator {
               .getMessager()
               .error(
                   methodElement,
+                  processedType,
                   "Invalid return type: %s methods must return %s if the argument is %s",
                   GetEntity.class.getSimpleName(),
                   PagingIterable.class.getSimpleName(),
@@ -119,6 +123,7 @@ public class DaoGetEntityMethodGenerator extends DaoMethodGenerator {
               .getMessager()
               .error(
                   methodElement,
+                  processedType,
                   "Invalid return type: %s methods must return %s if the argument is %s",
                   GetEntity.class.getSimpleName(),
                   MappedAsyncPagingIterable.class.getSimpleName(),
@@ -134,6 +139,7 @@ public class DaoGetEntityMethodGenerator extends DaoMethodGenerator {
           .getMessager()
           .error(
               methodElement,
+              processedType,
               "Invalid return type: "
                   + "%s methods must return a %s-annotated class, or a %s or %s thereof",
               GetEntity.class.getSimpleName(),

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoInsertMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoInsertMethodGenerator.java
@@ -53,9 +53,10 @@ public class DaoInsertMethodGenerator extends DaoMethodGenerator {
   public DaoInsertMethodGenerator(
       ExecutableElement methodElement,
       Map<Name, TypeElement> typeParameters,
+      TypeElement processedType,
       DaoImplementationSharedCode enclosingClass,
       ProcessorContext context) {
-    super(methodElement, typeParameters, enclosingClass, context);
+    super(methodElement, typeParameters, processedType, enclosingClass, context);
     nullSavingStrategyValidation = new NullSavingStrategyValidation(context);
   }
 
@@ -94,6 +95,7 @@ public class DaoInsertMethodGenerator extends DaoMethodGenerator {
           .getMessager()
           .error(
               methodElement,
+              processedType,
               "%s methods must take the entity to insert as the first parameter",
               Insert.class.getSimpleName());
       return Optional.empty();
@@ -111,6 +113,7 @@ public class DaoInsertMethodGenerator extends DaoMethodGenerator {
           .getMessager()
           .error(
               methodElement,
+              processedType,
               "Invalid return type: %s methods must return the same entity as their argument ",
               Insert.class.getSimpleName());
       return Optional.empty();

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoMethodGenerator.java
@@ -42,6 +42,7 @@ import javax.lang.model.type.TypeMirror;
 public abstract class DaoMethodGenerator implements MethodGenerator {
 
   protected final ExecutableElement methodElement;
+  protected final TypeElement processedType;
   protected final DaoImplementationSharedCode enclosingClass;
   protected final ProcessorContext context;
   protected final Map<Name, TypeElement> typeParameters;
@@ -49,10 +50,12 @@ public abstract class DaoMethodGenerator implements MethodGenerator {
   public DaoMethodGenerator(
       ExecutableElement methodElement,
       Map<Name, TypeElement> typeParameters,
+      TypeElement processedType,
       DaoImplementationSharedCode enclosingClass,
       ProcessorContext context) {
     this.methodElement = methodElement;
     this.typeParameters = typeParameters;
+    this.processedType = processedType;
     this.enclosingClass = enclosingClass;
     this.context = context;
   }
@@ -70,6 +73,7 @@ public abstract class DaoMethodGenerator implements MethodGenerator {
           .getMessager()
           .error(
               methodElement,
+              processedType,
               "Invalid return type: %s methods must return one of %s",
               annotationName,
               validKinds);
@@ -102,6 +106,7 @@ public abstract class DaoMethodGenerator implements MethodGenerator {
               .getMessager()
               .warn(
                   methodElement,
+                  processedType,
                   "Invalid "
                       + valueDescription
                       + " value: "
@@ -118,6 +123,7 @@ public abstract class DaoMethodGenerator implements MethodGenerator {
               .getMessager()
               .warn(
                   methodElement,
+                  processedType,
                   "Invalid "
                       + valueDescription
                       + " value: "
@@ -193,11 +199,11 @@ public abstract class DaoMethodGenerator implements MethodGenerator {
           context
               .getMessager()
               .error(
-                  parameter,
-                  "Method %s: parameter %s is declared in a compiled method "
+                  methodElement,
+                  processedType,
+                  "Parameter %s is declared in a compiled method "
                       + "and refers to a bind marker "
                       + "and thus must be annotated with @%s",
-                  methodElement,
                   parameter.getSimpleName(),
                   CqlName.class.getSimpleName());
           valid = false;
@@ -214,10 +220,9 @@ public abstract class DaoMethodGenerator implements MethodGenerator {
         context
             .getMessager()
             .warn(
-                parameter,
-                "Method %s: parameter %s does not refer to a bind marker, "
-                    + "@%s annotation will be ignored",
                 methodElement,
+                processedType,
+                "Parameter %s does not refer to a bind marker, " + "@%s annotation will be ignored",
                 parameter.getSimpleName(),
                 CqlName.class.getSimpleName());
       }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoQueryMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoQueryMethodGenerator.java
@@ -46,9 +46,10 @@ public class DaoQueryMethodGenerator extends DaoMethodGenerator {
   public DaoQueryMethodGenerator(
       ExecutableElement methodElement,
       Map<Name, TypeElement> typeParameters,
+      TypeElement processedType,
       DaoImplementationSharedCode enclosingClass,
       ProcessorContext context) {
-    super(methodElement, typeParameters, enclosingClass, context);
+    super(methodElement, typeParameters, processedType, enclosingClass, context);
     this.queryString = methodElement.getAnnotation(Query.class).value();
     nullSavingStrategyValidation = new NullSavingStrategyValidation(context);
   }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoQueryProviderMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoQueryProviderMethodGenerator.java
@@ -40,9 +40,10 @@ public class DaoQueryProviderMethodGenerator extends DaoMethodGenerator {
   public DaoQueryProviderMethodGenerator(
       ExecutableElement methodElement,
       Map<Name, TypeElement> typeParameters,
+      TypeElement processedType,
       DaoImplementationSharedCode enclosingClass,
       ProcessorContext context) {
-    super(methodElement, typeParameters, enclosingClass, context);
+    super(methodElement, typeParameters, processedType, enclosingClass, context);
   }
 
   @Override
@@ -114,6 +115,7 @@ public class DaoQueryProviderMethodGenerator extends DaoMethodGenerator {
                 .getMessager()
                 .error(
                     methodElement,
+                    processedType,
                     "Invalid annotation configuration: the elements in %s.entityHelpers "
                         + "must be %s-annotated classes (offending element: %s)",
                     QueryProvider.class.getSimpleName(),

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoSelectMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoSelectMethodGenerator.java
@@ -53,9 +53,10 @@ public class DaoSelectMethodGenerator extends DaoMethodGenerator {
   public DaoSelectMethodGenerator(
       ExecutableElement methodElement,
       Map<Name, TypeElement> typeParameters,
+      TypeElement processedType,
       DaoImplementationSharedCode enclosingClass,
       ProcessorContext context) {
-    super(methodElement, typeParameters, enclosingClass, context);
+    super(methodElement, typeParameters, processedType, enclosingClass, context);
   }
 
   protected Set<DaoReturnTypeKind> getSupportedReturnTypes() {
@@ -130,12 +131,13 @@ public class DaoSelectMethodGenerator extends DaoMethodGenerator {
     // If we have parameters for some primary key components, validate that the types match:
     if (!primaryKeyParameters.isEmpty()
         && !EntityUtils.areParametersValid(
-            context,
-            methodElement,
             entityElement,
             entityDefinition,
             primaryKeyParameters,
             Select.class,
+            context,
+            methodElement,
+            processedType,
             "don't use a custom clause")) {
       return Optional.empty();
     }
@@ -238,6 +240,7 @@ public class DaoSelectMethodGenerator extends DaoMethodGenerator {
           .getMessager()
           .error(
               methodElement,
+              processedType,
               "Can't parse ordering '%s', expected a column name followed by ASC or DESC",
               orderingSpec);
       return;

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoSetEntityMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoSetEntityMethodGenerator.java
@@ -39,9 +39,10 @@ public class DaoSetEntityMethodGenerator extends DaoMethodGenerator {
   public DaoSetEntityMethodGenerator(
       ExecutableElement methodElement,
       Map<Name, TypeElement> typeParameters,
+      TypeElement processedType,
       DaoImplementationSharedCode enclosingClass,
       ProcessorContext context) {
-    super(methodElement, typeParameters, enclosingClass, context);
+    super(methodElement, typeParameters, processedType, enclosingClass, context);
     nullSavingStrategyValidation = new NullSavingStrategyValidation(context);
   }
 
@@ -59,6 +60,7 @@ public class DaoSetEntityMethodGenerator extends DaoMethodGenerator {
           .getMessager()
           .error(
               methodElement,
+              processedType,
               "Wrong number of parameters: %s methods must have two",
               SetEntity.class.getSimpleName());
       return Optional.empty();
@@ -84,6 +86,7 @@ public class DaoSetEntityMethodGenerator extends DaoMethodGenerator {
           .getMessager()
           .error(
               methodElement,
+              processedType,
               "Wrong parameter types: %s methods must take a %s "
                   + "and an annotated entity (in any order)",
               SetEntity.class.getSimpleName(),
@@ -100,6 +103,7 @@ public class DaoSetEntityMethodGenerator extends DaoMethodGenerator {
             .getMessager()
             .warn(
                 methodElement,
+                processedType,
                 "BoundStatement is immutable, "
                     + "this method will not modify '%s' in place. "
                     + "It should probably return BoundStatement rather than void",
@@ -110,6 +114,7 @@ public class DaoSetEntityMethodGenerator extends DaoMethodGenerator {
           .getMessager()
           .error(
               methodElement,
+              processedType,
               "Invalid return type: %s methods must either be void, or return the same "
                   + "type as their settable parameter (in this case, %s to match '%s')",
               SetEntity.class.getSimpleName(),

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoUpdateMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoUpdateMethodGenerator.java
@@ -52,9 +52,10 @@ public class DaoUpdateMethodGenerator extends DaoMethodGenerator {
   public DaoUpdateMethodGenerator(
       ExecutableElement methodElement,
       Map<Name, TypeElement> typeParameters,
+      TypeElement processedType,
       DaoImplementationSharedCode enclosingClass,
       ProcessorContext context) {
-    super(methodElement, typeParameters, enclosingClass, context);
+    super(methodElement, typeParameters, processedType, enclosingClass, context);
     nullSavingStrategyValidation = new NullSavingStrategyValidation(context);
   }
 
@@ -84,6 +85,7 @@ public class DaoUpdateMethodGenerator extends DaoMethodGenerator {
           .getMessager()
           .error(
               methodElement,
+              processedType,
               "%s methods must take the entity to update as the first parameter",
               Update.class.getSimpleName());
       return Optional.empty();
@@ -220,6 +222,7 @@ public class DaoUpdateMethodGenerator extends DaoMethodGenerator {
           .getMessager()
           .error(
               methodElement,
+              processedType,
               "Invalid annotation parameters: %s cannot have both ifExists and customIfClause",
               Update.class.getSimpleName());
     }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/EntityUtils.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/EntityUtils.java
@@ -98,12 +98,13 @@ public class EntityUtils {
    * message is emitted on the given method element.
    */
   public static boolean areParametersValid(
-      ProcessorContext context,
-      ExecutableElement methodElement,
       TypeElement entityElement,
       EntityDefinition entityDefinition,
       List<? extends VariableElement> parameters,
       Class<? extends Annotation> annotationClass,
+      ProcessorContext context,
+      ExecutableElement methodElement,
+      TypeElement processedType,
       String exceptionCondition) {
     List<TypeName> primaryKeyTypes =
         entityDefinition.getPrimaryKey().stream()
@@ -121,6 +122,7 @@ public class EntityUtils {
           .getMessager()
           .error(
               methodElement,
+              processedType,
               "Invalid parameter list: %s methods that %s "
                   + "must at least specify partition key components "
                   + "(expected partition key of %s: %s)",
@@ -136,6 +138,7 @@ public class EntityUtils {
           .getMessager()
           .error(
               methodElement,
+              processedType,
               "Invalid parameter list: %s methods that %s "
                   + "must match the primary key components in the exact order "
                   + "(expected primary key of %s: %s). Too many parameters provided",
@@ -155,6 +158,7 @@ public class EntityUtils {
             .getMessager()
             .error(
                 methodElement,
+                processedType,
                 "Invalid parameter list: %s methods that %s "
                     + "must match the primary key components in the exact order "
                     + "(expected primary key of %s: %s). Mismatch at index %d: %s should be %s",

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityFactory.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityFactory.java
@@ -24,5 +24,5 @@ public interface EntityFactory {
    * Parses an {@link Entity}-annotated POJO and returns a descriptor of its properties and
    * annotations.
    */
-  EntityDefinition getDefinition(TypeElement classElement);
+  EntityDefinition getDefinition(TypeElement processedClass);
 }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/mapper/MapperDaoFactoryMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/mapper/MapperDaoFactoryMethodGenerator.java
@@ -44,14 +44,17 @@ import javax.lang.model.type.TypeMirror;
 public class MapperDaoFactoryMethodGenerator implements MethodGenerator {
 
   private final ExecutableElement methodElement;
+  private final TypeElement processedType;
   private final MapperImplementationSharedCode enclosingClass;
   private final ProcessorContext context;
 
   public MapperDaoFactoryMethodGenerator(
       ExecutableElement methodElement,
+      TypeElement processedType,
       MapperImplementationSharedCode enclosingClass,
       ProcessorContext context) {
     this.methodElement = methodElement;
+    this.processedType = processedType;
     this.enclosingClass = enclosingClass;
     this.context = context;
   }
@@ -89,6 +92,7 @@ public class MapperDaoFactoryMethodGenerator implements MethodGenerator {
           .getMessager()
           .error(
               methodElement,
+              processedType,
               "Invalid return type: %s methods must return a %s-annotated interface, "
                   + "or future thereof",
               DaoFactory.class.getSimpleName(),
@@ -119,6 +123,7 @@ public class MapperDaoFactoryMethodGenerator implements MethodGenerator {
             .getMessager()
             .error(
                 methodElement,
+                processedType,
                 "Invalid parameter annotations: "
                     + "%s method parameters must be annotated with @%s or @%s",
                 DaoFactory.class.getSimpleName(),
@@ -176,6 +181,7 @@ public class MapperDaoFactoryMethodGenerator implements MethodGenerator {
           .getMessager()
           .error(
               candidate,
+              processedType,
               "Invalid parameter annotations: "
                   + "only one %s method parameter can be annotated with @%s",
               DaoFactory.class.getSimpleName(),
@@ -189,6 +195,7 @@ public class MapperDaoFactoryMethodGenerator implements MethodGenerator {
           .getMessager()
           .error(
               candidate,
+              processedType,
               "Invalid parameter type: @%s-annotated parameter of %s methods must be of type %s or %s",
               annotation.getSimpleName(),
               DaoFactory.class.getSimpleName(),

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/mapper/MapperImplementationGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/mapper/MapperImplementationGenerator.java
@@ -100,12 +100,15 @@ public class MapperImplementationGenerator extends SingleFileCodeGenerator
         Set<Modifier> modifiers = methodElement.getModifiers();
         if (!modifiers.contains(Modifier.STATIC) && !modifiers.contains(Modifier.DEFAULT)) {
           Optional<MethodGenerator> maybeGenerator =
-              context.getCodeGeneratorFactory().newMapperImplementationMethod(methodElement, this);
+              context
+                  .getCodeGeneratorFactory()
+                  .newMapperImplementationMethod(methodElement, interfaceElement, this);
           if (!maybeGenerator.isPresent()) {
             context
                 .getMessager()
                 .error(
                     methodElement,
+                    interfaceElement,
                     "Unrecognized method signature: no implementation will be generated");
           } else {
             maybeGenerator.flatMap(MethodGenerator::generate).ifPresent(classContents::addMethod);

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoDeleteMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoDeleteMethodGeneratorTest.java
@@ -145,8 +145,7 @@ public class DaoDeleteMethodGeneratorTest extends DaoMethodGeneratorTest {
   @Test
   public void should_warn_when_non_bind_marker_has_cql_name() {
     should_succeed_with_expected_warning(
-        "delete(java.util.UUID,java.lang.String): parameter id does not refer "
-            + "to a bind marker, @CqlName annotation will be ignored",
+        "Parameter id does not refer to a bind marker, @CqlName annotation will be ignored",
         MethodSpec.methodBuilder("delete")
             .addAnnotation(
                 AnnotationSpec.builder(Delete.class)

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoUpdateMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoUpdateMethodGeneratorTest.java
@@ -94,7 +94,7 @@ public class DaoUpdateMethodGeneratorTest extends DaoMethodGeneratorTest {
   @Test
   public void should_warn_when_non_bind_marker_has_cql_name() {
     should_succeed_with_expected_warning(
-        "Method update(test.Product,java.lang.String): parameter entity does not refer "
+        "Parameter entity does not refer "
             + "to a bind marker, @CqlName annotation will be ignored",
         MethodSpec.methodBuilder("update")
             .addAnnotation(
@@ -125,7 +125,7 @@ public class DaoUpdateMethodGeneratorTest extends DaoMethodGeneratorTest {
     // given
     ProcessorContext processorContext = mock(ProcessorContext.class);
     DaoUpdateMethodGenerator daoUpdateMethodGenerator =
-        new DaoUpdateMethodGenerator(null, null, null, processorContext);
+        new DaoUpdateMethodGenerator(null, null, null, null, processorContext);
     MethodSpec.Builder builder = MethodSpec.constructorBuilder();
 
     // when
@@ -141,7 +141,7 @@ public class DaoUpdateMethodGeneratorTest extends DaoMethodGeneratorTest {
     // given
     ProcessorContext processorContext = mock(ProcessorContext.class);
     DaoUpdateMethodGenerator daoUpdateMethodGenerator =
-        new DaoUpdateMethodGenerator(null, null, null, processorContext);
+        new DaoUpdateMethodGenerator(null, null, null, null, processorContext);
     MethodSpec.Builder builder = MethodSpec.constructorBuilder();
 
     // when

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/compiled/DaoCompiledMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/compiled/DaoCompiledMethodGeneratorTest.java
@@ -30,8 +30,8 @@ public class DaoCompiledMethodGeneratorTest extends DaoMethodGeneratorTest {
   @Test
   public void should_fail_with_expected_error() {
     should_fail_with_expected_error(
-        "findByDescriptionCompiledWrong(java.lang.String): parameter arg0 "
-            + "is declared in a compiled method "
+        "[findByDescriptionCompiledWrong(java.lang.String) inherited from CompiledProductDao] "
+            + "Parameter arg0 is declared in a compiled method "
             + "and refers to a bind marker "
             + "and thus must be annotated with @CqlName",
         "test",


### PR DESCRIPTION
Motivation:

If
- the mapper processes a class or interface that inherits from another
  type
- that parent type is not part of the current compilation round (e.g.
  it's in a JAR dependency of the current project)
- that parent type is not annotated correctly

Then the errors or warnings issued by the mapper processor do not
provide enough context, because they can't be linked to a source file
and line number.

Modifications:

Wrap all field- and method-level messages in a `TypeMemberMessager`,
that detects the problematic situation, and issues the messages on the
child type instead.

Result:

The errors or warnings will appear on a source file, with a contextual
prefix like "[getId() inherited from BaseEntity]".