### PR TITLE
JAVA-2435: Add automatic-module-names to the manifests

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.6.0 (in progress)
 
+- [improvement] JAVA-2435: Add automatic-module-names to the manifests
 - [new feature] JAVA-2054: Add now_in_seconds to protocol v5 query messages
 - [bug] JAVA-2711: Fix handling of UDT keys in the mapper
 - [improvement] JAVA-2631: Add getIndex() shortcuts to TableMetadata

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -303,6 +303,7 @@
             </goals>
             <configuration>
               <instructions>
+                <Automatic-Module-Name>com.datastax.oss.driver.core</Automatic-Module-Name>
                 <Bundle-SymbolicName>com.datastax.oss.driver.core</Bundle-SymbolicName>
                 <!--
                 Allow importing code from other packages

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -218,6 +218,13 @@
     <plugins>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.datastax.oss.driver.core</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
         <executions>
           <execution>
             <id>test-jar</id>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -153,6 +153,16 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.datastax.oss.driver.examples</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>
         <configuration>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -192,6 +192,13 @@
     <plugins>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.datastax.oss.driver.tests.integration</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
         <executions>
           <execution>
             <id>test-jar</id>

--- a/manual/core/integration/README.md
+++ b/manual/core/integration/README.md
@@ -236,6 +236,25 @@ If your build tool can't fetch dependencies from Maven central, we publish a bin
 The driver and its dependencies must be in the compile-time classpath. Application resources, such
 as `application.conf` and `logback.xml` in our previous examples, must be in the runtime classpath.
 
+### JPMS support
+
+All the driver's artifacts are JPMS automatic modules.
+
+Note that TinkerPop cannot currently be used in a JPMS application. You will get the following
+error:
+
+```
+Error occurred during initialization of boot layer
+java.lang.module.FindException: Unable to derive module descriptor for /path/to/gremlin-shaded-3.4.5.jar
+Caused by: java.lang.module.InvalidModuleDescriptorException: Provider class com.fasterxml.jackson.core.JsonFactory not in module
+```
+
+This is a known issue that will be resolved in TinkerPop 3.4.7. The driver will upgrade as soon as
+possible, see [JAVA-2726](https://datastax-oss.atlassian.net/browse/JAVA-2726).
+
+Unfortunately, the only workaround in the meantime is to exclude TinkerPop dependencies, as
+explained [here](#tinker-pop). Graph functionality won't be available.
+
 ### Driver dependencies
 
 The driver depends on a number of third-party libraries; some of those dependencies are opt-in,

--- a/mapper-processor/pom.xml
+++ b/mapper-processor/pom.xml
@@ -121,6 +121,13 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.datastax.oss.driver.mapper.processor</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
         <executions>
           <!--
             This module only has internal classes, yet we need a javadoc JAR to pass Maven central

--- a/mapper-runtime/pom.xml
+++ b/mapper-runtime/pom.xml
@@ -111,6 +111,16 @@
     </testResources>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.datastax.oss.driver.mapper.runtime</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <threadCount>1</threadCount>

--- a/query-builder/pom.xml
+++ b/query-builder/pom.xml
@@ -96,6 +96,16 @@
     </testResources>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.datastax.oss.driver.querybuilder</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>

--- a/test-infra/pom.xml
+++ b/test-infra/pom.xml
@@ -68,6 +68,16 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>com.datastax.oss.driver.tests.infrastructure</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
This change adds an Automatic-Module-Name entry to the manifest which specifies name of the module used by JPMS. It's a potentially breaking change because, by default, module's name is based on the jar's filename.