### PR TITLE
JAVA-2365: Redeclare default constants when an enum is abstracted behind an interface

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,8 @@
 
 ### 4.2.0 (in progress)
 
+- [improvement] JAVA-2365: Redeclare default constants when an enum is abstracted behind an
+  interface
 - [improvement] JAVA-2302: Better target mapper errors and warnings for inherited methods
 - [improvement] JAVA-2336: Expose byte utility methods in the public API 
 - [improvement] JAVA-2338: Revisit toString() for data container types

--- a/core/src/main/java/com/datastax/oss/driver/api/core/ConsistencyLevel.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/ConsistencyLevel.java
@@ -26,6 +26,18 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public interface ConsistencyLevel {
 
+  ConsistencyLevel ANY = DefaultConsistencyLevel.ANY;
+  ConsistencyLevel ONE = DefaultConsistencyLevel.ONE;
+  ConsistencyLevel TWO = DefaultConsistencyLevel.TWO;
+  ConsistencyLevel THREE = DefaultConsistencyLevel.THREE;
+  ConsistencyLevel QUORUM = DefaultConsistencyLevel.QUORUM;
+  ConsistencyLevel ALL = DefaultConsistencyLevel.ALL;
+  ConsistencyLevel LOCAL_ONE = DefaultConsistencyLevel.LOCAL_ONE;
+  ConsistencyLevel LOCAL_QUORUM = DefaultConsistencyLevel.LOCAL_QUORUM;
+  ConsistencyLevel EACH_QUORUM = DefaultConsistencyLevel.EACH_QUORUM;
+  ConsistencyLevel SERIAL = DefaultConsistencyLevel.SERIAL;
+  ConsistencyLevel LOCAL_SERIAL = DefaultConsistencyLevel.LOCAL_SERIAL;
+
   /** The numerical value that the level is encoded to in protocol frames. */
   int getProtocolCode();
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/DefaultConsistencyLevel.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/DefaultConsistencyLevel.java
@@ -35,6 +35,9 @@ public enum DefaultConsistencyLevel implements ConsistencyLevel {
   SERIAL(ProtocolConstants.ConsistencyLevel.SERIAL),
   LOCAL_SERIAL(ProtocolConstants.ConsistencyLevel.LOCAL_SERIAL),
   ;
+  // Note that, for the sake of convenience, we also expose shortcuts to these constants on the
+  // ConsistencyLevel interface. If you add a new enum constant, remember to update the interface as
+  // well.
 
   private final int protocolCode;
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/DefaultProtocolVersion.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/DefaultProtocolVersion.java
@@ -37,7 +37,11 @@ public enum DefaultProtocolVersion implements ProtocolVersion {
    *
    * @see ProtocolVersion#isBeta()
    */
-  V5(ProtocolConstants.Version.V5, true);
+  V5(ProtocolConstants.Version.V5, true),
+  ;
+  // Note that, for the sake of convenience, we also expose shortcuts to these constants on the
+  // ProtocolVersion interface. If you add a new enum constant, remember to update the interface as
+  // well.
 
   private final int code;
   private final boolean beta;

--- a/core/src/main/java/com/datastax/oss/driver/api/core/ProtocolVersion.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/ProtocolVersion.java
@@ -26,6 +26,11 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * {@code ProtocolVersion}s are {@link DefaultProtocolVersion} instances.
  */
 public interface ProtocolVersion {
+
+  ProtocolVersion V3 = DefaultProtocolVersion.V3;
+  ProtocolVersion V4 = DefaultProtocolVersion.V4;
+  ProtocolVersion V5 = DefaultProtocolVersion.V5;
+
   /** The default version used for {@link Detachable detached} objects. */
   // Implementation note: we can't use the ProtocolVersionRegistry here, this has to be a
   // compile-time constant.

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/BatchType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/BatchType.java
@@ -24,6 +24,10 @@ package com.datastax.oss.driver.api.core.cql;
  */
 public interface BatchType {
 
+  BatchType LOGGED = DefaultBatchType.LOGGED;
+  BatchType UNLOGGED = DefaultBatchType.UNLOGGED;
+  BatchType COUNTER = DefaultBatchType.COUNTER;
+
   /** The numerical value that the batch type is encoded to. */
   byte getProtocolCode();
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/DefaultBatchType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/DefaultBatchType.java
@@ -38,6 +38,9 @@ public enum DefaultBatchType implements BatchType {
    */
   COUNTER(ProtocolConstants.BatchType.COUNTER),
   ;
+  // Note that, for the sake of convenience, we also expose shortcuts to these constants on the
+  // BatchType interface. If you add a new enum constant, remember to update the interface as
+  // well.
 
   private final byte code;
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/DefaultWriteType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/DefaultWriteType.java
@@ -57,4 +57,7 @@ public enum DefaultWriteType implements WriteType {
    */
   CDC,
   ;
+  // Note that, for the sake of convenience, we also expose shortcuts to these constants on the
+  // WriteType interface. If you add a new enum constant, remember to update the interface as
+  // well.
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/WriteType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/WriteType.java
@@ -29,6 +29,15 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public interface WriteType {
 
+  WriteType SIMPLE = DefaultWriteType.SIMPLE;
+  WriteType BATCH = DefaultWriteType.BATCH;
+  WriteType UNLOGGED_BATCH = DefaultWriteType.UNLOGGED_BATCH;
+  WriteType COUNTER = DefaultWriteType.COUNTER;
+  WriteType BATCH_LOG = DefaultWriteType.BATCH_LOG;
+  WriteType CAS = DefaultWriteType.CAS;
+  WriteType VIEW = DefaultWriteType.VIEW;
+  WriteType CDC = DefaultWriteType.CDC;
+
   /** The textual representation that the write type is encoded to in protocol frames. */
   @NonNull
   String name();


### PR DESCRIPTION
A few users have been tricked by this already, this would make us much more completion-friendly:
```java
BatchStatement batch = BatchStatement.newInstance(BatchType.LOGGED);
```

The downside is that it creates a circular dependency. Vanilla Java handles it well, but I think we encountered weird cases in the past (Scala?) where this would be an issue.