### PR TITLE
JAVA-2367: Fix column names in EntityHelper.updateByPrimaryKey

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.2.0 (in progress)
 
+- [bug] JAVA-2367: Fix column names in EntityHelper.updateByPrimaryKey
 - [bug] JAVA-2358: Fix list of reserved CQL keywords
 - [improvement] JAVA-2359: Allow default keyspace at the mapper level
 - [improvement] JAVA-2306: Clear security tokens from memory immediately after use

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UpdateNamingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/UpdateNamingIT.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.mapper.MapperBuilder;
+import com.datastax.oss.driver.api.mapper.annotations.Dao;
+import com.datastax.oss.driver.api.mapper.annotations.DaoFactory;
+import com.datastax.oss.driver.api.mapper.annotations.Entity;
+import com.datastax.oss.driver.api.mapper.annotations.Mapper;
+import com.datastax.oss.driver.api.mapper.annotations.NamingStrategy;
+import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
+import com.datastax.oss.driver.api.mapper.annotations.Select;
+import com.datastax.oss.driver.api.mapper.annotations.Update;
+import com.datastax.oss.driver.api.mapper.entity.naming.NamingConvention;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+/**
+ * For JAVA-2367: ensure that PK column names are properly handled in the WHERE clause of a
+ * generated UPDATE query.
+ */
+@Category(ParallelizableTests.class)
+public class UpdateNamingIT {
+  private static CcmRule ccm = CcmRule.getInstance();
+
+  private static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccm).build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccm).around(sessionRule);
+
+  private static TestDao dao;
+
+  @BeforeClass
+  public static void setup() {
+    CqlSession session = sessionRule.session();
+    session.execute(
+        SimpleStatement.builder("CREATE TABLE foo(mykey int PRIMARY KEY, value int)")
+            .setExecutionProfile(sessionRule.slowProfile())
+            .build());
+
+    TestMapper mapper =
+        TestMapper.builder(session).withDefaultKeyspace(sessionRule.keyspace()).build();
+    dao = mapper.dao();
+  }
+
+  @Test
+  public void should_update_with_case_insensitive_pk_name() {
+    dao.update(new Foo(1, 1));
+    Foo foo = dao.get(1);
+    assertThat(foo.getValue()).isEqualTo(1);
+  }
+
+  @Mapper
+  public interface TestMapper {
+
+    @DaoFactory
+    TestDao dao();
+
+    static MapperBuilder<TestMapper> builder(CqlSession session) {
+      return new UpdateNamingIT_TestMapperBuilder(session);
+    }
+  }
+
+  @Dao
+  public interface TestDao {
+    @Select
+    Foo get(int key);
+
+    @Update
+    void update(Foo template);
+  }
+
+  @Entity
+  @NamingStrategy(convention = NamingConvention.CASE_INSENSITIVE)
+  public static class Foo {
+    @PartitionKey private int myKey;
+    private int value;
+
+    public Foo() {}
+
+    public Foo(int myKey, int value) {
+      this.myKey = myKey;
+      this.value = value;
+    }
+
+    public int getMyKey() {
+      return myKey;
+    }
+
+    public void setMyKey(int myKey) {
+      this.myKey = myKey;
+    }
+
+    public int getValue() {
+      return value;
+    }
+
+    public void setValue(int value) {
+      this.value = value;
+    }
+  }
+}

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityHelperUpdateByPrimaryKeyMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/EntityHelperUpdateByPrimaryKeyMethodGenerator.java
@@ -46,7 +46,7 @@ public class EntityHelperUpdateByPrimaryKeyMethodGenerator implements MethodGene
 
     for (PropertyDefinition property : entityDefinition.getPrimaryKey()) {
       methodBuilder.addCode(
-          "\n.where($1T.column($2S).isEqualTo($3T.bindMarker($2S)))",
+          "\n.where($1T.column($2L).isEqualTo($3T.bindMarker($2L)))",
           Relation.class,
           property.getCqlName(),
           QueryBuilder.class);


### PR DESCRIPTION
I left the test in a separate commit to make it easy to reproduce the issue, will squash everything together before merging.