### PR TITLE
Added Failover Policy

### DIFF
--- a/core/revapi.json
+++ b/core/revapi.json
@@ -4809,6 +4809,10 @@
         "code": "java.method.addedToInterface",
         "new": "method java.lang.String com.datastax.oss.driver.api.core.data.UdtValue::toString()",
         "justification": "False positive -- all objects implicitly have toString()"
+      },{
+        "code": "java.method.addedToInterface",
+        "new": "method java.util.Map<java.lang.String, com.datastax.oss.driver.api.core.failover.FailoverPolicy> com.datastax.oss.driver.api.core.context.DriverContext::getFailoverPolicies()",
+        "justification": "Added FailoverPolicy"
       }
     ]
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -175,7 +175,10 @@ public enum DefaultDriverOption implements DriverOption {
   REQUEST_LOG_WARNINGS("advanced.request.log-warnings"),
 
   NETTY_DAEMON("advanced.netty.daemon"),
-  ;
+
+  FAILOVER_POLICY("advanced.failover-policy"),
+  FAILOVER_POLICY_CLASS("advanced.failover-policy.class"),
+  FAILOVER_POLICY_PROFILE("advanced.failover-policy.profile");
 
   private final String path;
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/context/DriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/context/DriverContext.java
@@ -22,6 +22,7 @@ import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.connection.ReconnectionPolicy;
 import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
+import com.datastax.oss.driver.api.core.failover.FailoverPolicy;
 import com.datastax.oss.driver.api.core.loadbalancing.LoadBalancingPolicy;
 import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
 import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
@@ -54,6 +55,25 @@ public interface DriverContext extends AttachmentPoint {
   @NonNull
   DriverConfigLoader getConfigLoader();
 
+  /**
+   * @return The driver's failover policies, keyed by profile name; the returned map is guaranteed
+   *     to never be {@code null} and to always contain an entry for the {@value
+   *     DriverExecutionProfile#DEFAULT_NAME} profile.
+   */
+  @NonNull
+  Map<String, FailoverPolicy> getFailoverPolicies();
+
+  /**
+   * @param profileName the profile name; never {@code null}.
+   * @return The driver's failover policy for the given profile; never {@code null}.
+   */
+  @NonNull
+  default FailoverPolicy getFailoverPolicy(@NonNull String profileName) {
+    FailoverPolicy policy = getFailoverPolicies().get(profileName);
+    return (policy != null)
+        ? policy
+        : getFailoverPolicies().get(DriverExecutionProfile.DEFAULT_NAME);
+  }
   /**
    * @return The driver's load balancing policies, keyed by profile name; the returned map is
    *     guaranteed to never be {@code null} and to always contain an entry for the {@value

--- a/core/src/main/java/com/datastax/oss/driver/api/core/failover/FailoverPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/failover/FailoverPolicy.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.failover;
+
+import com.datastax.oss.driver.api.core.cql.Statement;
+
+/**
+ * The default failover policy.
+ *
+ * <p>To activate this policy, modify the {@code advanced.failover-policy} section in the driver
+ * configuration, for example:
+ *
+ * <pre>
+ * datastax-java-driver {
+ *   advanced.failover-policy {
+ *     class = DefaultFailoverPolicy
+ *     profile = failoverProfileName
+ *   }
+ * }
+ * </pre>
+ *
+ * See {@code reference.conf} (in the manual or core driver JAR) for more details.
+ */
+public interface FailoverPolicy extends AutoCloseable {
+
+  /**
+   * Whether to failover when throwable is thrown.
+   *
+   * @param throwable thrown throwable
+   * @param request the request that threw throwable
+   */
+  Boolean shouldFailover(Throwable throwable, Statement<?> request);
+
+  /**
+   * Process the request object to adjust for the failover
+   *
+   * @param request request to be adjusted
+   * @return adjusted request
+   */
+  Statement processRequest(Statement<?> request);
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/failover/DefaultFailoverPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/failover/DefaultFailoverPolicy.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.failover;
+
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.cql.Statement;
+import com.datastax.oss.driver.api.core.failover.FailoverPolicy;
+import com.datastax.oss.driver.internal.core.cql.Conversions;
+import net.jcip.annotations.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@inheritDoc}
+ *
+ * <p>A failover is activated when any of the following Exceptions occcur: AllNodesFailedException,
+ * DriverTimeoutException, InvalidKeyspaceException, or NoNodeAvailableException
+ */
+@ThreadSafe
+public class DefaultFailoverPolicy implements FailoverPolicy {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultFailoverPolicy.class);
+
+  private final String logPrefix;
+
+  private final DriverContext context;
+
+  public DefaultFailoverPolicy(
+      @SuppressWarnings("unused") DriverContext context,
+      @SuppressWarnings("unused") String profileName) {
+    this.context = context;
+    this.logPrefix = (context != null ? context.getSessionName() : null) + "|" + profileName;
+  }
+
+  @Override
+  public void close() {
+    // nothing to do
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Evalutes the exception and triggers a failover when any of the following Exceptions occcur:
+   * AllNodesFailedException, DriverTimeoutException, InvalidKeyspaceException, or
+   * NoNodeAvailableException
+   */
+  @Override
+  public Boolean shouldFailover(Throwable throwable, Statement<?> request) {
+    DriverExecutionProfile driverExecutionProfile =
+        Conversions.resolveExecutionProfile(request, context);
+
+    if (!driverExecutionProfile.isDefined(DefaultDriverOption.FAILOVER_POLICY_PROFILE)) {
+      return false;
+    }
+
+    if (driverExecutionProfile
+        .getString(DefaultDriverOption.FAILOVER_POLICY_PROFILE)
+        .equals(request.getExecutionProfileName())) {
+      return false;
+    }
+
+    if (throwable instanceof com.datastax.oss.driver.api.core.AllNodesFailedException) {
+      LOG.info(
+          "[{}] {} was detected, initiating failover",
+          logPrefix,
+          throwable.getClass().toGenericString());
+      return true;
+    } else if (throwable instanceof com.datastax.oss.driver.api.core.DriverTimeoutException) {
+      LOG.info(
+          "[{}] {} was detected, initiating failover",
+          logPrefix,
+          throwable.getClass().toGenericString());
+      return true;
+    } else if (throwable instanceof com.datastax.oss.driver.api.core.InvalidKeyspaceException) {
+      LOG.info(
+          "[{}] {} was detected, initiating failover",
+          logPrefix,
+          throwable.getClass().toGenericString());
+      return true;
+    } else if (throwable instanceof com.datastax.oss.driver.api.core.NoNodeAvailableException) {
+      LOG.info(
+          "[{}] {} was detected, initiating failover",
+          logPrefix,
+          throwable.getClass().toGenericString());
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Adjusts the request to use the profile defined in advanced.failover-profile.profile
+   */
+  @Override
+  public Statement processRequest(Statement<?> request) {
+    DriverExecutionProfile driverExecutionProfile =
+        Conversions.resolveExecutionProfile(request, context);
+    if (!driverExecutionProfile.isDefined(DefaultDriverOption.FAILOVER_POLICY_PROFILE)) {
+      throw new IllegalArgumentException("Failover Policy Profile is not defined");
+    }
+    String failoverProfile =
+        driverExecutionProfile.getString(DefaultDriverOption.FAILOVER_POLICY_PROFILE);
+    LOG.info(
+        "[{}] Failing over request from profile {} to {}",
+        logPrefix,
+        request.getExecutionProfileName(),
+        failoverProfile);
+    return request.setExecutionProfile(context.getConfig().getProfile(failoverProfile));
+  }
+}

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -335,6 +335,27 @@ datastax-java-driver {
     class = DefaultRetryPolicy
   }
 
+  # The policy that controls if the driver failovers requests that have failed on one node.
+  #
+  # Required: no
+  # Modifiable at runtime: no
+  # Overridable in a profile: yes. Note that the driver creates as few instances as possible: if a
+  #   named profile inherits from the default profile, or if two sibling profiles have the exact
+  #   same configuration, they will share a single policy instance at runtime.
+  advanced.failover-policy {
+    # The class of the policy. If it is not qualified, the driver assumes that it resides in the
+    # package com.datastax.oss.driver.internal.core.failover.
+    #
+    # The driver provides a single implementation out of the box: DefaultFailoverPolicy.
+    #
+    # You can also specify a custom class that implements FailoverPolicy and has a public constructor
+    # with two arguments: the DriverContext and a String representing the profile name.
+    //class = DefaultFailoverPolicy
+
+    # Name of a profile that should be failed over to
+    // profile = ProfileName
+  }
+
   # The policy that controls if the driver pre-emptively tries other nodes if a node takes too long
   # to respond.
   #

--- a/core/src/test/java/com/datastax/oss/driver/api/core/failover/DefaultFailoverPolicyTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/failover/DefaultFailoverPolicyTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.failover;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.datastax.oss.driver.api.core.AllNodesFailedException;
+import com.datastax.oss.driver.api.core.DriverTimeoutException;
+import com.datastax.oss.driver.api.core.InvalidKeyspaceException;
+import com.datastax.oss.driver.api.core.NoNodeAvailableException;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfig;
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.cql.Statement;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.failover.DefaultFailoverPolicy;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultFailoverPolicyTest {
+
+  @Mock protected InternalDriverContext context;
+  @Mock protected DriverConfig config;
+  @Mock protected Statement statementOriginal;
+  @Mock protected Statement statementNew;
+  @Mock protected DriverExecutionProfile driverExecutionProfileOriginal;
+  @Mock protected DriverExecutionProfile driverExecutionProfileNew;
+
+  FailoverPolicy policy;
+
+  @Before
+  public void setup() {
+
+    String originalProfile = "OriginalProfile";
+    String failoverProfile = "NewProfile";
+
+    when(context.getConfig()).thenReturn(config);
+    when(config.getDefaultProfile()).thenReturn(driverExecutionProfileOriginal);
+    when(config.getProfile(failoverProfile)).thenReturn(driverExecutionProfileNew);
+
+    when(statementOriginal.getExecutionProfile()).thenReturn(driverExecutionProfileOriginal);
+    when(statementOriginal.getExecutionProfileName()).thenReturn(originalProfile);
+    when(statementOriginal.setExecutionProfile(driverExecutionProfileNew)).thenReturn(statementNew);
+
+    when(driverExecutionProfileOriginal.isDefined(DefaultDriverOption.FAILOVER_POLICY_PROFILE))
+        .thenReturn(true);
+    when(driverExecutionProfileOriginal.getString(DefaultDriverOption.FAILOVER_POLICY_PROFILE))
+        .thenReturn(failoverProfile);
+
+    when(statementNew.getExecutionProfile()).thenReturn(driverExecutionProfileNew);
+
+    this.policy = new DefaultFailoverPolicy(context, "ProfileName");
+  }
+
+  @Test
+  public void should_return_true() {
+    assertTrue(
+        policy.shouldFailover(mock(AllNodesFailedException.class), mock(SimpleStatement.class)));
+    assertTrue(
+        policy.shouldFailover(mock(DriverTimeoutException.class), mock(SimpleStatement.class)));
+    assertTrue(
+        policy.shouldFailover(mock(InvalidKeyspaceException.class), mock(SimpleStatement.class)));
+    assertTrue(
+        policy.shouldFailover(mock(NoNodeAvailableException.class), mock(SimpleStatement.class)));
+  }
+
+  @Test
+  public void should_return_false() {
+    assertFalse(policy.shouldFailover(mock(AssertionError.class), mock(SimpleStatement.class)));
+  }
+
+  @Test
+  public void should_change_profile() {
+    assertEquals(
+        policy.processRequest(statementOriginal).getExecutionProfile(), driverExecutionProfileNew);
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/internal/core/failover/DefaultFailoverPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/internal/core/failover/DefaultFailoverPolicyIT.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.failover;
+
+import static org.junit.Assert.assertEquals;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+@Category(ParallelizableTests.class)
+public class DefaultFailoverPolicyIT {
+
+  private static CcmRule ccm = CcmRule.getInstance();
+
+  private static SessionRule<CqlSession> sessionRule = SessionRule.builder(ccm).build();
+
+  @ClassRule public static TestRule chain = RuleChain.outerRule(ccm).around(sessionRule);
+
+  @BeforeClass
+  public static void setupSchema() {}
+
+  @Test(expected = IllegalArgumentException.class)
+  public void should_throw_exception_invalid_profile() throws Exception {
+    DriverConfigLoader loader =
+        SessionUtils.configLoaderBuilder()
+            .withString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER, "dc2")
+            .withClass(DefaultDriverOption.FAILOVER_POLICY_CLASS, DefaultFailoverPolicy.class)
+            .withString(DefaultDriverOption.FAILOVER_POLICY_PROFILE, "failover")
+            .build();
+    try (CqlSession session = SessionUtils.newSession(ccm, loader)) {
+      session.execute("select * from system.local");
+    }
+  }
+
+  @Test
+  public void should_failover_bad_dc() throws Exception {
+    DriverConfigLoader loader =
+        SessionUtils.configLoaderBuilder()
+            .withString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER, "dc2")
+            .withClass(DefaultDriverOption.FAILOVER_POLICY_CLASS, DefaultFailoverPolicy.class)
+            .withString(DefaultDriverOption.FAILOVER_POLICY_PROFILE, "failover")
+            .startProfile("failover")
+            .withString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER, "dc1")
+            .endProfile()
+            .build();
+    try (CqlSession session = SessionUtils.newSession(ccm, loader)) {
+      ResultSet rs = session.execute("select * from system.local");
+      assertEquals("dc1", rs.getExecutionInfo().getCoordinator().getDatacenter());
+      assertEquals(
+          "failover", rs.getExecutionInfo().getStatement().getExecutionProfile().getName());
+    }
+  }
+
+  @Test
+  public void should_not_failover_good_dc() throws Exception {
+    DriverConfigLoader loader =
+        SessionUtils.configLoaderBuilder()
+            .withString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER, "dc1")
+            .withClass(DefaultDriverOption.FAILOVER_POLICY_CLASS, DefaultFailoverPolicy.class)
+            .withString(DefaultDriverOption.FAILOVER_POLICY_PROFILE, "failover")
+            .startProfile("failover")
+            .withString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER, "dc2")
+            .endProfile()
+            .build();
+    try (CqlSession session = SessionUtils.newSession(ccm, loader)) {
+      ResultSet rs = session.execute("select * from system.local");
+      assertEquals("dc1", rs.getExecutionInfo().getCoordinator().getDatacenter());
+      assertEquals(null, rs.getExecutionInfo().getStatement().getExecutionProfileName());
+    }
+  }
+}


### PR DESCRIPTION
Motivation:

Failover is a critical aspect of the database layer that is missing in the current
implementation of the driver. While a cloud model does lend itself to marking down
a full site, other deployment models do not. The goal of the failover policy is to
build a simple tie in to allow for failvoer decisions to be made based on caught
exceptions as well as statement attributes.

The included DefaultFailoverPolicy allows failover to a second policy which could
then be a new dc, consistency, or many other variations.

Modifications:

Added new failover parameters, FailoverPolicy interface, and DefaultFailoverPolicy
objects. This was integrated to the CqlRequestHandler#handle method by adding a
new exceptionally stage which evaluates if a failover should occur then triggers
a new CqlRequestHandler with the modified statement.

Result:

New FailoverPolicy is available to failover statements in the event of a failure.