### PR TITLE
JAVA-2426: Update CqlDuration documentation

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.2.1 (in progress)
 
+- [documentation] JAVA-2426: Fix month pattern in CqlDuration documentation
 - [bug] JAVA-2451: Make zero a valid estimated size for PagingIterableSpliterator
 - [bug] JAVA-2443: Compute prepared statement PK indices for protocol v3
 - [bug] JAVA-2430: Use variable metadata to infer the routing keyspace on bound statements

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlDuration.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlDuration.java
@@ -115,7 +115,7 @@ public final class CqlDuration implements TemporalAmount {
    *   <li>multiple digits followed by a time unit like: 12h30m where the time unit can be:
    *       <ul>
    *         <li>{@code y}: years
-   *         <li>{@code m}: months
+   *         <li>{@code mo}: months
    *         <li>{@code w}: weeks
    *         <li>{@code d}: days
    *         <li>{@code h}: hours


### PR DESCRIPTION
This scenario is actually already covered by unit tests, just need to update the documentation to match.