### PR TITLE
JAVA-2436: Extract simplified parse method in DataTypeCqlNameParser

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/ShallowUserDefinedType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/ShallowUserDefinedType.java
@@ -20,6 +20,7 @@ import com.datastax.oss.driver.api.core.data.UdtValue;
 import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
 import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.driver.api.core.type.UserDefinedType;
+import com.datastax.oss.driver.internal.core.metadata.schema.parsing.UserDefinedTypeParser;
 import com.datastax.oss.driver.internal.core.type.DefaultUserDefinedType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -33,11 +34,16 @@ import net.jcip.annotations.Immutable;
 /**
  * A temporary UDT implementation that only contains the keyspace and name.
  *
- * <p>When we process a schema refresh that spans multiple UDTs, we can't fully materialize them
- * right away, because they might depend on each other and the system table query does not return
- * them in topological order. So we do a first pass where UDT field that are also UDTs are resolved
- * as instances of this class, then a topological sort, then a second pass to replace all shallow
- * definitions by the actual instance (which will be a {@link DefaultUserDefinedType}).
+ * <p>When we refresh a keyspace's UDTs, we can't fully materialize them right away, because they
+ * might depend on each other and the system table query does not return them in topological order.
+ * So we do a first pass where UDTs that are nested into other UDTsare resolved as instances of this
+ * class, then a topological sort, then a second pass to replace all shallow definitions by the
+ * actual instance (which will be a {@link DefaultUserDefinedType}).
+ *
+ * <p>This type is also used in the schema builder's internal representation: the keyspace, name and
+ * frozen-ness are the only things we need to generate a query string.
+ *
+ * @see UserDefinedTypeParser
  */
 @Immutable
 public class ShallowUserDefinedType implements UserDefinedType, Serializable {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/UserDefinedTypeBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/UserDefinedTypeBuilder.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.type;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
 import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.driver.api.core.type.UserDefinedType;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
@@ -37,6 +38,7 @@ public class UserDefinedTypeBuilder {
   private boolean frozen;
   private final ImmutableList.Builder<CqlIdentifier> fieldNames;
   private final ImmutableList.Builder<DataType> fieldTypes;
+  private AttachmentPoint attachmentPoint = AttachmentPoint.NONE;
 
   public UserDefinedTypeBuilder(CqlIdentifier keyspaceName, CqlIdentifier typeName) {
     this.keyspaceName = keyspaceName;
@@ -69,8 +71,13 @@ public class UserDefinedTypeBuilder {
     return this;
   }
 
+  public UserDefinedTypeBuilder withAttachmentPoint(AttachmentPoint attachmentPoint) {
+    this.attachmentPoint = attachmentPoint;
+    return this;
+  }
+
   public UserDefinedType build() {
     return new DefaultUserDefinedType(
-        keyspaceName, typeName, frozen, fieldNames.build(), fieldTypes.build());
+        keyspaceName, typeName, frozen, fieldNames.build(), fieldTypes.build(), attachmentPoint);
   }
 }


### PR DESCRIPTION
/cc @RussellSpitzer 

The new method takes `AttachmentPoint`, which is just a wrapper around protocolVersion + codecRegistry.

I wonder if it wouldn't be simpler to duplicate the method in Cassandra. I'm not happy about Cassandra core depending on a low-level internal method (or depending on the driver at all for that matter -- speaking strictly of the core, I'm ok with tools like stress using it).