### PR TITLE
JAVA-2430: Use variable metadata to infer the routing keyspace on bound statements

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.2.1 (in progress)
 
+- [bug] JAVA-2430: Use variable metadata to infer the routing keyspace on bound statements
 
 ### 4.2.0
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
@@ -258,7 +258,7 @@ public class DefaultBoundStatement implements BoundStatement {
     if (routingKeyspace != null) {
       return routingKeyspace;
     } else {
-      ColumnDefinitions definitions = preparedStatement.getResultSetDefinitions();
+      ColumnDefinitions definitions = preparedStatement.getVariableDefinitions();
       return (definitions.size() == 0) ? null : definitions.get(0).getKeyspace();
     }
   }


### PR DESCRIPTION
The previous version was erroneously using the result metadata, which is
empty for non-conditional mutations.