### PR TITLE
JAVA-2443: Compute prepared statement PK indices for protocol v3

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.2.1 (in progress)
 
+- [bug] JAVA-2443: Compute prepared statement PK indices for protocol v3
 - [bug] JAVA-2430: Use variable metadata to infer the routing keyspace on bound statements
 
 ### 4.2.0

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
@@ -35,6 +35,8 @@ import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.RelationMetadata;
 import com.datastax.oss.driver.api.core.metadata.token.Token;
 import com.datastax.oss.driver.api.core.servererrors.AlreadyExistsException;
 import com.datastax.oss.driver.api.core.servererrors.BootstrappingException;
@@ -63,6 +65,7 @@ import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metadata.token.ByteOrderedToken;
 import com.datastax.oss.driver.internal.core.metadata.token.Murmur3Token;
 import com.datastax.oss.driver.internal.core.metadata.token.RandomToken;
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.primitives.Ints;
 import com.datastax.oss.protocol.internal.Message;
@@ -358,11 +361,21 @@ public class Conversions {
 
   public static DefaultPreparedStatement toPreparedStatement(
       Prepared response, PrepareRequest request, InternalDriverContext context) {
+    ColumnDefinitions variableDefinitions =
+        toColumnDefinitions(response.variablesMetadata, context);
+
+    int[] pkIndicesInResponse = response.variablesMetadata.pkIndices;
+    // null means a legacy protocol version that doesn't provide the info, try to compute it
+    List<Integer> pkIndices =
+        (pkIndicesInResponse == null)
+            ? computePkIndices(variableDefinitions, context)
+            : Ints.asList(pkIndicesInResponse);
+
     return new DefaultPreparedStatement(
         ByteBuffer.wrap(response.preparedQueryId).asReadOnlyBuffer(),
         request.getQuery(),
-        toColumnDefinitions(response.variablesMetadata, context),
-        asList(response.variablesMetadata.pkIndices),
+        variableDefinitions,
+        pkIndices,
         (response.resultMetadataId == null)
             ? null
             : ByteBuffer.wrap(response.resultMetadataId).asReadOnlyBuffer(),
@@ -396,12 +409,39 @@ public class Conversions {
     return DefaultColumnDefinitions.valueOf(ImmutableList.copyOf(values));
   }
 
-  public static List<Integer> asList(int[] pkIndices) {
-    if (pkIndices == null || pkIndices.length == 0) {
+  public static List<Integer> computePkIndices(
+      ColumnDefinitions variables, InternalDriverContext context) {
+    if (variables.size() == 0) {
       return Collections.emptyList();
-    } else {
-      return Ints.asList(pkIndices);
     }
+    // The rest of the computation relies on the fact that CQL does not have joins: all variables
+    // belong to the same keyspace and table.
+    ColumnDefinition firstVariable = variables.get(0);
+    return context
+        .getMetadataManager()
+        .getMetadata()
+        .getKeyspace(firstVariable.getKeyspace())
+        .flatMap(ks -> ks.getTable(firstVariable.getTable()))
+        .map(RelationMetadata::getPartitionKey)
+        .map(pk -> findIndices(pk, variables))
+        .orElse(Collections.emptyList());
+  }
+
+  // Find at which position in `variables` each element of `partitionKey` appears
+  @VisibleForTesting
+  static List<Integer> findIndices(List<ColumnMetadata> partitionKey, ColumnDefinitions variables) {
+    ImmutableList.Builder<Integer> result =
+        ImmutableList.builderWithExpectedSize(partitionKey.size());
+    for (ColumnMetadata pkColumn : partitionKey) {
+      int firstIndex = variables.firstIndexOf(pkColumn.getName());
+      if (firstIndex < 0) {
+        // If a single column is missing, we can abort right away
+        return Collections.emptyList();
+      } else {
+        result.add(firstIndex);
+      }
+    }
+    return result.build();
   }
 
   public static CoordinatorException toThrowable(

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/ConversionsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/ConversionsTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.cql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+
+public class ConversionsTest {
+  @Test
+  public void should_find_pk_indices_if_all_bound() {
+    assertThat(Conversions.findIndices(partitionKey("pk"), variables("pk"))).containsExactly(0);
+    assertThat(Conversions.findIndices(partitionKey("pk"), variables("pk", "c")))
+        .containsExactly(0);
+    assertThat(Conversions.findIndices(partitionKey("pk"), variables("c", "pk")))
+        .containsExactly(1);
+    assertThat(
+            Conversions.findIndices(
+                partitionKey("pk1", "pk2", "pk3"),
+                variables("c1", "pk2", "pk3", "c2", "pk1", "c3")))
+        .containsExactly(4, 1, 2);
+  }
+
+  @Test
+  public void should_use_first_pk_index_if_bound_multiple_times() {
+    assertThat(Conversions.findIndices(partitionKey("pk"), variables("pk", "pk")))
+        .containsExactly(0);
+    assertThat(Conversions.findIndices(partitionKey("pk"), variables("pk", "c1", "pk", "c2")))
+        .containsExactly(0);
+    assertThat(
+            Conversions.findIndices(
+                partitionKey("pk1", "pk2", "pk3"),
+                variables("c1", "pk2", "pk3", "c2", "pk1", "c3", "pk1", "pk2")))
+        .containsExactly(4, 1, 2);
+  }
+
+  @Test
+  public void should_return_empty_pk_indices_if_at_least_one_component_not_bound() {
+    assertThat(Conversions.findIndices(partitionKey("pk"), variables("c1", "c2"))).isEmpty();
+    assertThat(
+            Conversions.findIndices(
+                partitionKey("pk1", "pk2", "pk3"), variables("c1", "pk2", "c2", "pk1", "c3")))
+        .isEmpty();
+  }
+
+  private List<ColumnMetadata> partitionKey(String... columnNames) {
+    ImmutableList.Builder<ColumnMetadata> columns =
+        ImmutableList.builderWithExpectedSize(columnNames.length);
+    for (String columnName : columnNames) {
+      ColumnMetadata column = mock(ColumnMetadata.class);
+      when(column.getName()).thenReturn(CqlIdentifier.fromInternal(columnName));
+      columns.add(column);
+    }
+    return columns.build();
+  }
+
+  private ColumnDefinitions variables(String... columnNames) {
+    ImmutableList.Builder<ColumnDefinition> columns =
+        ImmutableList.builderWithExpectedSize(columnNames.length);
+    for (String columnName : columnNames) {
+      ColumnDefinition column = mock(ColumnDefinition.class);
+      when(column.getName()).thenReturn(CqlIdentifier.fromInternal(columnName));
+      columns.add(column);
+    }
+    return DefaultColumnDefinitions.valueOf(columns.build());
+  }
+}


### PR DESCRIPTION
This is covered by the test in #1328 when it runs in the Cassandra 2.1 suite. Although we might want to cover more complex scenarios.