### PR TITLE
JAVA-2455: Improve logging of schema refresh errors

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.2.1 (in progress)
 
+- [improvement] JAVA-2455: Improve logging of schema refresh errors
 - [documentation] JAVA-2429: Document expected types on DefaultDriverOption
 - [documentation] JAVA-2426: Fix month pattern in CqlDuration documentation
 - [bug] JAVA-2451: Make zero a valid estimated size for PagingIterableSpliterator

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
@@ -609,7 +609,7 @@ public class CqlRequestHandler implements Throttled {
                             Loggers.warnWithException(
                                 LOG,
                                 "[{}] Error while refreshing schema after DDL query, "
-                                    + "new metadata might be incomplete",
+                                    + "keeping previous version",
                                 logPrefix,
                                 error);
                             return null;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
@@ -608,7 +608,7 @@ public class CqlRequestHandler implements Throttled {
                           error -> {
                             Loggers.warnWithException(
                                 LOG,
-                                "[{}] Error while refreshing schema after DDL query, "
+                                "[{}] Unexpected error while refreshing schema after DDL query, "
                                     + "keeping previous version",
                                 logPrefix,
                                 error);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
@@ -113,7 +113,7 @@ public class MetadataManager implements AsyncAutoCloseable {
                   Loggers.warnWithException(
                       LOG,
                       "[{}] Unexpected error while refreshing schema after it was re-enabled "
-                          + "in the configuration, keeping the previous version",
+                          + "in the configuration, keeping previous version",
                       logPrefix,
                       error);
                 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
@@ -395,7 +395,7 @@ public class DefaultSession implements CqlSession {
                       Loggers.warnWithException(
                           LOG,
                           "[{}] Unexpected error while refreshing schema during intialization, "
-                              + "keeping the previous version",
+                              + "keeping previous version",
                           logPrefix,
                           error);
                     }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
@@ -387,7 +387,19 @@ public class DefaultSession implements CqlSession {
           }
         }
         if (needSchemaRefresh) {
-          metadataManager.refreshSchema(null, false, true);
+          metadataManager
+              .refreshSchema(null, false, true)
+              .whenComplete(
+                  (metadata, error) -> {
+                    if (error != null) {
+                      Loggers.warnWithException(
+                          LOG,
+                          "[{}] Unexpected error while refreshing schema during intialization, "
+                              + "keeping the previous version",
+                          logPrefix,
+                          error);
+                    }
+                  });
         }
         metadataManager
             .firstSchemaRefreshFuture()

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/control/ControlConnectionTestBase.java
@@ -17,6 +17,8 @@ package com.datastax.oss.driver.internal.core.control;
 
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -120,6 +122,8 @@ abstract class ControlConnectionTestBase {
     mockQueryPlan(node1, node2);
 
     when(metadataManager.refreshNodes()).thenReturn(CompletableFuture.completedFuture(null));
+    when(metadataManager.refreshSchema(anyString(), anyBoolean(), anyBoolean()))
+        .thenReturn(CompletableFuture.completedFuture(null));
     when(context.getMetadataManager()).thenReturn(metadataManager);
 
     when(context.getConfig()).thenReturn(config);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/DefaultSessionPoolsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/DefaultSessionPoolsTest.java
@@ -132,6 +132,8 @@ public class DefaultSessionPoolsTest {
     when(metadataManager.refreshNodes()).thenReturn(CompletableFuture.completedFuture(null));
     when(metadataManager.firstSchemaRefreshFuture())
         .thenReturn(CompletableFuture.completedFuture(null));
+    when(metadataManager.refreshSchema(null, false, true))
+        .thenReturn(CompletableFuture.completedFuture(null));
     when(context.getMetadataManager()).thenReturn(metadataManager);
 
     when(topologyMonitor.init()).thenReturn(CompletableFuture.completedFuture(null));


### PR DESCRIPTION
Motivation:

While debugging JAVA-2454, we noticed that the error wasn't surfaced in
the logs as expected. MetadataManager.startSchemaRequest has a listener
for that purpose, but it's on the wrong future; parsing errors will
surface on currentSchemaRefresh.

Modifications:

Don't try to log errors in MetadataManager. Instead, handle it on all
call sites of MetadataManager.refreshSchema, *if* the future is not
returned to the client.

Result:

If a user-initiated refresh fails, they will get back a failed future.
If an internal refresh fails, it will be logged.