### PR TITLE
JAVA-2464: Fix initial schema refresh when reconnect-on-init is enabled

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.3.0 (in progress)
 
+- [bug] JAVA-2464: Fix initial schema refresh when reconnect-on-init is enabled
 - [improvement] JAVA-2516: Enable hostname validation with Cloud
 - [documentation]: JAVA-2460: Document how to determine the local DC
 - [improvement] JAVA-2476: Improve error message when codec registry inspects a collection with a

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
@@ -377,8 +377,11 @@ public class DefaultSession implements CqlSession {
                 currentVersion,
                 bestVersion);
             context.getChannelFactory().setProtocolVersion(bestVersion);
+
+            // If the control connection has already initialized, force a reconnect to use the new
+            // version.
+            // (note: it might not have initialized yet if there is a custom TopologyMonitor)
             ControlConnection controlConnection = context.getControlConnection();
-            // Might not have initialized yet if there is a custom TopologyMonitor
             if (controlConnection.isInit()) {
               controlConnection.reconnectNow();
               // Reconnection already triggers a full schema refresh
@@ -394,7 +397,7 @@ public class DefaultSession implements CqlSession {
                     if (error != null) {
                       Loggers.warnWithException(
                           LOG,
-                          "[{}] Unexpected error while refreshing schema during intialization, "
+                          "[{}] Unexpected error while refreshing schema during initialization, "
                               + "keeping previous version",
                           logPrefix,
                           error);


### PR DESCRIPTION
Motivation:

When reconnect-on-init is enabled and the driver does not connect
immediately, the schema metadata is empty.

This is because the initial schema refresh is chained on
ControlConnection.firstConnectionAttemptFuture. The goal was to allow
the session to initialize without waiting for the control connection (if
there is a custom topology monitor that uses another mechanism). But in
the scenario above, firstConnectionAttemptFuture is failed.

Modifications:

Chain the schema refresh to ControlConnection.initFuture (complete,
successful connection).
Remove firstConnectionAttemptFuture.

Result:

The schema is present at startup.

Note that if a custom topology monitor is in place, and it is the
metadata manager that initializes the control connection, the first
schema refresh (and therefore the whole session initialization) will
have to wait for the control connection to successfully connect. All
things considered, this is pretty logical.