### PR TITLE
JAVA-2497: Make DefaultExecutionInfo/DefaultNode serializable

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultExecutionInfo.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultExecutionInfo.java
@@ -26,6 +26,7 @@ import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.protocol.internal.Frame;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
@@ -35,8 +36,8 @@ import java.util.concurrent.CompletionStage;
 import net.jcip.annotations.Immutable;
 
 @Immutable
-public class DefaultExecutionInfo implements ExecutionInfo {
-
+public class DefaultExecutionInfo implements ExecutionInfo, Serializable {
+  private static final long serialVersionUID = 1;
   private final Statement<?> statement;
   private final Node coordinator;
   private final int speculativeExecutionCount;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultNode.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultNode.java
@@ -25,6 +25,7 @@ import com.datastax.oss.driver.internal.core.metrics.NodeMetricUpdater;
 import com.datastax.oss.driver.internal.core.metrics.NoopNodeMetricUpdater;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.Map;
@@ -38,8 +39,8 @@ import net.jcip.annotations.ThreadSafe;
  * from {@link MetadataManager}'s admin thread.
  */
 @ThreadSafe
-public class DefaultNode implements Node {
-
+public class DefaultNode implements Node, Serializable {
+  private static final long serialVersionUID = 1;
   private volatile EndPoint endPoint;
   private volatile NodeMetricUpdater metricUpdater;
 


### PR DESCRIPTION
This is necessary because both types appear in numerous Exception
classes. On the server-side one can see the below error when things
fail:

`java.io.NotSerializableException: com.datastax.oss.driver.internal.core.metadata.DefaultNode`