### PR TITLE
JAVA-2518: Reduce nightly build matrix

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -21,11 +21,21 @@ schedules:
   nightly:
     # Run full suite nightly on change for all primary branches if they have changes.
     schedule: nightly
+    matrix:
+      exclude:
+        # exclude builds for newer Cassandra versions and older JDKs
+        - java: openjdk6
+          cassandra: ['2.2', '3.0', '3.11']
+        - java: openjdk7
+          cassandra: ['2.1', '3.0', '3.11']
+        # exclude builds for older Cassandra versions and newer JDKs
+        - java: openjdk11
+          cassandra: ['2.1', '2.2']
     branches:
       # regex matches primary branch format (2.1, 3.x, 3.0.x, 3.1.x, etc).
       include: ["/\\d+(\\.[\\dx]+)+/"]
     env_vars: |
-      TEST_GROUP="long"
+      TEST_GROUP="short"
     disable_commit_status: true
     disable_pull_requests: true
     notify:

--- a/build.yaml
+++ b/build.yaml
@@ -35,7 +35,8 @@ schedules:
       # regex matches primary branch format (2.1, 3.x, 3.0.x, 3.1.x, etc).
       include: ["/\\d+(\\.[\\dx]+)+/"]
     env_vars: |
-      TEST_GROUP="short"
+      TEST_GROUP="long"
+      NIGHTLY="true"
     disable_commit_status: true
     disable_pull_requests: true
     notify:
@@ -76,7 +77,8 @@ build:
       jdk_switcher use $JAVA_VERSION
   - type: maven
     version: 3.2.5
-    goals: verify --fail-never -P$TEST_GROUP
+    # for Nightly builds, only run the "long" tests against OpenJDK8
+    goals: verify --fail-never -P$(if [ "${NIGHTLY}" = "true" -a "${JAVA_VERSION}" != "openjdk8" ]; then echo "short"; else echo ${TEST_GROUP}; fi)
     properties: |
       com.datastax.driver.TEST_BASE_NODE_WAIT=120
       com.datastax.driver.NEW_NODE_DELAY_SECONDS=100

--- a/build.yaml
+++ b/build.yaml
@@ -36,7 +36,6 @@ schedules:
       include: ["/\\d+(\\.[\\dx]+)+/"]
     env_vars: |
       TEST_GROUP="long"
-      NIGHTLY="true"
     disable_commit_status: true
     disable_pull_requests: true
     notify:
@@ -77,8 +76,7 @@ build:
       jdk_switcher use $JAVA_VERSION
   - type: maven
     version: 3.2.5
-    # for Nightly builds, only run the "long" tests against OpenJDK8
-    goals: verify --fail-never -P$(if [ "${NIGHTLY}" = "true" -a "${JAVA_VERSION}" != "openjdk8" ]; then echo "short"; else echo ${TEST_GROUP}; fi)
+    goals: verify --fail-never -P$TEST_GROUP
     properties: |
       com.datastax.driver.TEST_BASE_NODE_WAIT=120
       com.datastax.driver.NEW_NODE_DELAY_SECONDS=100


### PR DESCRIPTION
The change proposed will reduce the matrix to the following:
![jenkins_3 x_matrix](https://user-images.githubusercontent.com/1253074/67587018-8e49fc80-f718-11e9-8750-30f6cb1aa2d1.png)
