### PR TITLE
JAVA-2521: Use dependencyManagement for internal modules

### DIFF
--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -37,7 +37,6 @@
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <!--
     Repeat all dependencies of the core driver *except* the ones that are going to be shaded,
@@ -169,7 +168,6 @@
                 <artifactItem>
                   <groupId>com.datastax.oss</groupId>
                   <artifactId>java-driver-core-shaded</artifactId>
-                  <version>${project.version}</version>
                   <type>jar</type>
                   <outputDirectory>${project.build.outputDirectory}</outputDirectory>
                 </artifactItem>
@@ -196,7 +194,6 @@
                 <artifactItem>
                   <groupId>com.datastax.oss</groupId>
                   <artifactId>java-driver-core-shaded</artifactId>
-                  <version>${project.version}</version>
                   <type>jar</type>
                   <classifier>sources</classifier>
                   <outputDirectory>${project.build.directory}/shaded-sources</outputDirectory>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -38,17 +38,14 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>java-driver-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>java-driver-query-builder</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>java-driver-mapper-runtime</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <!-- Jackson -->

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -42,32 +42,27 @@
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-test-infra</artifactId>
-      <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-query-builder</artifactId>
-      <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-mapper-processor</artifactId>
-      <version>${project.parent.version}</version>
       <scope>test</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-mapper-runtime</artifactId>
-      <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-core</artifactId>
-      <version>${project.parent.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/mapper-processor/pom.xml
+++ b/mapper-processor/pom.xml
@@ -32,7 +32,6 @@
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-mapper-runtime</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.datastax.oss</groupId>

--- a/mapper-runtime/pom.xml
+++ b/mapper-runtime/pom.xml
@@ -33,12 +33,10 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>java-driver-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>java-driver-query-builder</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.github.stephenc.jcip</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,42 @@
     <dependencies>
       <dependency>
         <groupId>com.datastax.oss</groupId>
+        <artifactId>java-driver-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.datastax.oss</groupId>
+        <artifactId>java-driver-core</artifactId>
+        <version>${project.version}</version>
+        <type>test-jar</type>
+      </dependency>
+      <dependency>
+        <groupId>com.datastax.oss</groupId>
+        <artifactId>java-driver-core-shaded</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.datastax.oss</groupId>
+        <artifactId>java-driver-mapper-processor</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.datastax.oss</groupId>
+        <artifactId>java-driver-mapper-runtime</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.datastax.oss</groupId>
+        <artifactId>java-driver-query-builder</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.datastax.oss</groupId>
+        <artifactId>java-driver-test-infra</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.datastax.oss</groupId>
         <artifactId>native-protocol</artifactId>
         <version>${native-protocol.version}</version>
       </dependency>

--- a/query-builder/pom.xml
+++ b/query-builder/pom.xml
@@ -33,7 +33,6 @@
     <dependency>
       <groupId>com.datastax.oss</groupId>
       <artifactId>java-driver-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.datastax.oss</groupId>


### PR DESCRIPTION
Trivial change to avoid repeating `${project.version}` everywhere.