### PR TITLE
JAVA-2532: Add BoundStatement ReturnType for insert, update, and delete DAO methods

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DeleteIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DeleteIT.java
@@ -21,6 +21,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.PagingIterable;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
@@ -175,6 +176,21 @@ public class DeleteIT extends InventoryITBase {
   }
 
   @Test
+  public void should_delete_with_condition_statement() {
+    UUID id = FLAMETHROWER.getId();
+    assertThat(dao.findById(id)).isNotNull();
+
+    BoundStatement bs = dao.deleteIfDescriptionMatchesStatement(id, "foo");
+    ResultSet rs = SESSION_RULE.session().execute(bs);
+    assertThat(rs.wasApplied()).isFalse();
+    assertThat(rs.one().getString("description")).isEqualTo(FLAMETHROWER.getDescription());
+
+    rs = dao.deleteIfDescriptionMatches(id, FLAMETHROWER.getDescription());
+    assertThat(rs.wasApplied()).isTrue();
+    assertThat(dao.findById(id)).isNull();
+  }
+
+  @Test
   public void should_delete_with_condition_asynchronously() {
     UUID id = FLAMETHROWER.getId();
     assertThat(dao.findById(id)).isNotNull();
@@ -199,9 +215,26 @@ public class DeleteIT extends InventoryITBase {
   }
 
   @Test
+  public void should_delete_by_partition_key_statement() {
+    // should delete FLAMETHROWER_SALE_[1-4]
+    SESSION_RULE.session().execute(saleDao.deleteByIdForDayStatement(FLAMETHROWER.getId(), DATE_1));
+    assertThat(saleDao.all().all()).containsOnly(FLAMETHROWER_SALE_5, MP3_DOWNLOAD_SALE_1);
+  }
+
+  @Test
   public void should_delete_by_partition_key_and_partial_clustering() {
     // should delete FLAMETHROWER_SALE_{1,3,4]
     saleDao.deleteByIdForCustomer(FLAMETHROWER.getId(), DATE_1, 1);
+    assertThat(saleDao.all().all())
+        .containsOnly(FLAMETHROWER_SALE_2, FLAMETHROWER_SALE_5, MP3_DOWNLOAD_SALE_1);
+  }
+
+  @Test
+  public void should_delete_by_partition_key_and_partial_clustering_statement() {
+    // should delete FLAMETHROWER_SALE_{1,3,4]
+    SESSION_RULE
+        .session()
+        .execute(saleDao.deleteByIdForCustomerStatement(FLAMETHROWER.getId(), DATE_1, 1));
     assertThat(saleDao.all().all())
         .containsOnly(FLAMETHROWER_SALE_2, FLAMETHROWER_SALE_5, MP3_DOWNLOAD_SALE_1);
   }
@@ -211,6 +244,23 @@ public class DeleteIT extends InventoryITBase {
     // should delete FLAMETHROWER_SALE_2
     saleDao.deleteByIdForCustomerAtTime(
         FLAMETHROWER.getId(), DATE_1, 2, FLAMETHROWER_SALE_2.getTs());
+    assertThat(saleDao.all().all())
+        .containsOnly(
+            FLAMETHROWER_SALE_1,
+            FLAMETHROWER_SALE_3,
+            FLAMETHROWER_SALE_4,
+            FLAMETHROWER_SALE_5,
+            MP3_DOWNLOAD_SALE_1);
+  }
+
+  @Test
+  public void should_delete_by_primary_key_sales_statement() {
+    // should delete FLAMETHROWER_SALE_2
+    SESSION_RULE
+        .session()
+        .execute(
+            saleDao.deleteByIdForCustomerAtTimeStatement(
+                FLAMETHROWER.getId(), DATE_1, 2, FLAMETHROWER_SALE_2.getTs()));
     assertThat(saleDao.all().all())
         .containsOnly(
             FLAMETHROWER_SALE_1,
@@ -234,6 +284,26 @@ public class DeleteIT extends InventoryITBase {
     result =
         saleDao.deleteIfPriceMatches(
             FLAMETHROWER.getId(), DATE_1, 2, FLAMETHROWER_SALE_2.getTs(), 500.0);
+
+    assertThat(result.wasApplied()).isTrue();
+  }
+
+  @Test
+  public void should_delete_if_price_matchesStatement() {
+    BoundStatement bs =
+        saleDao.deleteIfPriceMatchesStatement(
+            FLAMETHROWER.getId(), DATE_1, 2, FLAMETHROWER_SALE_2.getTs(), 250.0);
+    ResultSet result = SESSION_RULE.session().execute(bs);
+
+    assertThat(result.wasApplied()).isFalse();
+    Row row = result.one();
+    assertThat(row).isNotNull();
+    assertThat(row.getDouble("price")).isEqualTo(500.0);
+
+    bs =
+        saleDao.deleteIfPriceMatchesStatement(
+            FLAMETHROWER.getId(), DATE_1, 2, FLAMETHROWER_SALE_2.getTs(), 500.0);
+    result = SESSION_RULE.session().execute(bs);
 
     assertThat(result.wasApplied()).isTrue();
   }
@@ -263,6 +333,24 @@ public class DeleteIT extends InventoryITBase {
   }
 
   @Test
+  public void should_delete_within_time_range_statement() {
+    // should delete FLAMETHROWER_SALE_{1,3}, but not 4 because range ends before
+    SESSION_RULE
+        .session()
+        .execute(
+            saleDao.deleteInTimeRangeStatement(
+                FLAMETHROWER.getId(),
+                DATE_1,
+                1,
+                FLAMETHROWER_SALE_1.getTs(),
+                Uuids.startOf(Uuids.unixTimestamp(FLAMETHROWER_SALE_4.getTs()) - 1000)));
+
+    assertThat(saleDao.all().all())
+        .containsOnly(
+            FLAMETHROWER_SALE_2, FLAMETHROWER_SALE_4, FLAMETHROWER_SALE_5, MP3_DOWNLOAD_SALE_1);
+  }
+
+  @Test
   public void should_delete_if_price_matches_custom_where() {
     ResultSet result =
         saleDao.deleteCustomWhereCustomIf(
@@ -276,6 +364,26 @@ public class DeleteIT extends InventoryITBase {
     result =
         saleDao.deleteCustomWhereCustomIf(
             2, FLAMETHROWER.getId(), DATE_1, FLAMETHROWER_SALE_2.getTs(), 500.0);
+
+    assertThat(result.wasApplied()).isTrue();
+  }
+
+  @Test
+  public void should_delete_if_price_matches_custom_where_statement() {
+    BoundStatement bs =
+        saleDao.deleteCustomWhereCustomIfStatement(
+            2, FLAMETHROWER.getId(), DATE_1, FLAMETHROWER_SALE_2.getTs(), 250.0);
+    ResultSet result = SESSION_RULE.session().execute(bs);
+
+    assertThat(result.wasApplied()).isFalse();
+    Row row = result.one();
+    assertThat(row).isNotNull();
+    assertThat(row.getDouble("price")).isEqualTo(500.0);
+
+    bs =
+        saleDao.deleteCustomWhereCustomIfStatement(
+            2, FLAMETHROWER.getId(), DATE_1, FLAMETHROWER_SALE_2.getTs(), 500.0);
+    result = SESSION_RULE.session().execute(bs);
 
     assertThat(result.wasApplied()).isTrue();
   }
@@ -304,6 +412,9 @@ public class DeleteIT extends InventoryITBase {
 
     @Delete(entityClass = Product.class, customIfClause = "description = :expectedDescription")
     ResultSet deleteIfDescriptionMatches(UUID productId, String expectedDescription);
+
+    @Delete(entityClass = Product.class, customIfClause = "description = :expectedDescription")
+    BoundStatement deleteIfDescriptionMatchesStatement(UUID productId, String expectedDescription);
 
     @Delete
     CompletionStage<Void> deleteAsync(Product product);
@@ -335,16 +446,33 @@ public class DeleteIT extends InventoryITBase {
     @Delete(entityClass = ProductSale.class)
     ResultSet deleteByIdForDay(UUID id, String day);
 
+    // delete all rows in partition
+    @Delete(entityClass = ProductSale.class)
+    BoundStatement deleteByIdForDayStatement(UUID id, String day);
+
     // delete by partition key and partial clustering key
     @Delete(entityClass = ProductSale.class)
     ResultSet deleteByIdForCustomer(UUID id, String day, int customerId);
+
+    // delete by partition key and partial clustering key
+    @Delete(entityClass = ProductSale.class)
+    BoundStatement deleteByIdForCustomerStatement(UUID id, String day, int customerId);
 
     // delete row (full primary key)
     @Delete(entityClass = ProductSale.class)
     ResultSet deleteByIdForCustomerAtTime(UUID id, String day, int customerId, UUID ts);
 
+    // delete row (full primary key)
+    @Delete(entityClass = ProductSale.class)
+    BoundStatement deleteByIdForCustomerAtTimeStatement(
+        UUID id, String day, int customerId, UUID ts);
+
     @Delete(entityClass = ProductSale.class, customIfClause = "price = :expectedPrice")
     ResultSet deleteIfPriceMatches(
+        UUID id, String day, int customerId, UUID ts, double expectedPrice);
+
+    @Delete(entityClass = ProductSale.class, customIfClause = "price = :expectedPrice")
+    BoundStatement deleteIfPriceMatchesStatement(
         UUID id, String day, int customerId, UUID ts, double expectedPrice);
 
     @Delete(
@@ -354,12 +482,28 @@ public class DeleteIT extends InventoryITBase {
                 + ":endTs")
     ResultSet deleteInTimeRange(UUID id, String day, int customerId, UUID startTs, UUID endTs);
 
+    @Delete(
+        entityClass = ProductSale.class,
+        customWhereClause =
+            "id = :id and day = :day and customer_id = :customerId and ts >= :startTs and ts < "
+                + ":endTs")
+    BoundStatement deleteInTimeRangeStatement(
+        UUID id, String day, int customerId, UUID startTs, UUID endTs);
+
     // transpose order of parameters so doesn't match primary key to ensure that works.
     @Delete(
         entityClass = ProductSale.class,
         customWhereClause = "id = :id and day = :day and customer_id = :customerId and ts = :ts",
         customIfClause = "price = :expectedPrice")
     ResultSet deleteCustomWhereCustomIf(
+        int customerId, UUID id, String day, UUID ts, double expectedPrice);
+
+    // transpose order of parameters so doesn't match primary key to ensure that works.
+    @Delete(
+        entityClass = ProductSale.class,
+        customWhereClause = "id = :id and day = :day and customer_id = :customerId and ts = :ts",
+        customIfClause = "price = :expectedPrice")
+    BoundStatement deleteCustomWhereCustomIfStatement(
         int customerId, UUID id, String day, UUID ts, double expectedPrice);
 
     @Delete(entityClass = ProductSale.class, ifExists = true)

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InsertIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InsertIT.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
@@ -94,6 +95,15 @@ public class InsertIT extends InventoryITBase {
     assertThat(dao.findById(FLAMETHROWER.getId())).isNull();
 
     ResultSet rs = dao.saveReturningResultSet(FLAMETHROWER);
+    assertThat(rs.getAvailableWithoutFetching()).isZero();
+    assertThat(dao.findById(FLAMETHROWER.getId())).isEqualTo(FLAMETHROWER);
+  }
+
+  @Test
+  public void should_return_bound_statement_to_execute() {
+    assertThat(dao.findById(FLAMETHROWER.getId())).isNull();
+    BoundStatement bs = dao.saveReturningBoundStatement(FLAMETHROWER);
+    ResultSet rs = SESSION_RULE.session().execute(bs);
     assertThat(rs.getAvailableWithoutFetching()).isZero();
     assertThat(dao.findById(FLAMETHROWER.getId())).isEqualTo(FLAMETHROWER);
   }
@@ -288,6 +298,9 @@ public class InsertIT extends InventoryITBase {
 
     @Insert
     ResultSet saveReturningResultSet(Product product);
+
+    @Insert
+    BoundStatement saveReturningBoundStatement(Product product);
 
     @Insert(timestamp = ":timestamp")
     void saveWithBoundTimestamp(Product product, long timestamp);

--- a/manual/mapper/daos/delete/README.md
+++ b/manual/mapper/daos/delete/README.md
@@ -105,6 +105,14 @@ The method can return:
     ResultSet deleteIfDescriptionMatches(UUID productId, String expectedDescription);
     // if the condition fails, the result set will contain columns '[applied]' and 'description'
     ```
+  
+* a [BoundStatement]. This is intended for queries where you will execute this statement later
+  or in a batch.
+  
+    ```java
+    @Delete
+    BoundStatement delete(Product product);
+    ```
     
 * a [CompletionStage] or [CompletableFuture] of any of the above. The method will execute the query
   asynchronously. Note that for result sets, you need to switch to [AsyncResultSet].
@@ -141,6 +149,7 @@ entity class and the [naming strategy](../../entities/#naming-strategy)).
 [@PartitionKey]:          https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/mapper/annotations/PartitionKey.html
 [ResultSet]:              https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/cql/ResultSet.html
 [ResultSet#wasApplied()]: https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/cql/ResultSet.html#wasApplied--
+[BoundStatement]:         https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/cql/BoundStatement.html
 
 [CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
 [CompletableFuture]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html

--- a/manual/mapper/daos/insert/README.md
+++ b/manual/mapper/daos/insert/README.md
@@ -68,6 +68,12 @@ The method can return:
     @Insert
     ResultSet save(Product product);
     ```
+* a [BoundStatement]. This is intended for cases where you intend to execute this statement later or in a batch:
+  
+    ```java
+    @Insert
+    BoundStatement save(Product product);
+    ```    
     
 * a [CompletionStage] or [CompletableFuture] of any of the above. The mapper will execute the query
   asynchronously.
@@ -98,7 +104,7 @@ entity class and the [naming strategy](../../entities/#naming-strategy)).
 [ResultSet]:                    https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/cql/ResultSet.html
 [ResultSet#wasApplied()]:       https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/cql/ResultSet.html#wasApplied--
 [ResultSet#getExecutionInfo()]: https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/cql/ResultSet.html#getExecutionInfo--
-
+[BoundStatement]:               https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/cql/BoundStatement.html
 
 
 [CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html

--- a/manual/mapper/daos/query/README.md
+++ b/manual/mapper/daos/query/README.md
@@ -54,6 +54,9 @@ The method can return:
 
 * a [ResultSet]. The method will return the raw query result, without any conversion.
 
+* a [BoundStatement]. This is intended for queries where you will execute this statement later
+  or in a batch.
+
 * a [PagingIterable]. The method will convert each row into an entity instance.
 
 * a [CompletionStage] or [CompletableFuture] of any of the above. The method will execute the query
@@ -111,6 +114,7 @@ Then:
 [MappedAsyncPagingIterable]: https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/MappedAsyncPagingIterable.html
 [PagingIterable]:            https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/PagingIterable.html
 [Row]:                       https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/cql/Row.html
+[BoundStatement]:            https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/cql/BoundStatement.html
 
 [CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
 [CompletableFuture]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html

--- a/manual/mapper/daos/update/README.md
+++ b/manual/mapper/daos/update/README.md
@@ -101,6 +101,13 @@ The method can return:
     ResultSet updateIfExists(Product product);
     // if the condition fails, the result set will contain columns '[applied]' and 'description'
     ```
+  
+* a [BoundStatement]. This is intended for queries where you will execute this statement later or in a batch:
+  
+    ```java
+    @Update
+    BoundStatement update(Product product);
+    ```
 
 * a [CompletionStage] or [CompletableFuture] of any of the above. The mapper will execute the query
   asynchronously. 
@@ -130,8 +137,9 @@ entity class and the naming convention).
 [default keyspace]: https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withKeyspace-com.datastax.oss.driver.api.core.CqlIdentifier-
 [@Update]:          https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/mapper/annotations/Update.html
 
-[AsyncResultSet]: https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/cql/AsyncResultSet.html
-[Boolean]: https://docs.oracle.com/javase/8/docs/api/index.html?java/lang/Boolean.html
-[CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
-[CompletableFuture]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html
+[AsyncResultSet]:       https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/cql/AsyncResultSet.html
+[Boolean]:              https://docs.oracle.com/javase/8/docs/api/index.html?java/lang/Boolean.html
+[CompletionStage]:      https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
+[CompletableFuture]:    https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html
 [ResultSet]:            https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/cql/ResultSet.html
+[BoundStatement]:       https://docs.datastax.com/en/drivers/java/4.3/com/datastax/oss/driver/api/core/cql/BoundStatement.html

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoDeleteMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoDeleteMethodGenerator.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.mapper.processor.dao;
 
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.BOOLEAN;
+import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.BOUND_STATEMENT;
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.FUTURE_OF_ASYNC_RESULT_SET;
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.FUTURE_OF_BOOLEAN;
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.FUTURE_OF_VOID;
@@ -62,7 +63,13 @@ public class DaoDeleteMethodGenerator extends DaoMethodGenerator {
 
   protected Set<DaoReturnTypeKind> getSupportedReturnTypes() {
     return ImmutableSet.of(
-        VOID, FUTURE_OF_VOID, BOOLEAN, FUTURE_OF_BOOLEAN, RESULT_SET, FUTURE_OF_ASYNC_RESULT_SET);
+        VOID,
+        FUTURE_OF_VOID,
+        BOOLEAN,
+        FUTURE_OF_BOOLEAN,
+        RESULT_SET,
+        BOUND_STATEMENT,
+        FUTURE_OF_ASYNC_RESULT_SET);
   }
 
   @Override

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoInsertMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoInsertMethodGenerator.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.mapper.processor.dao;
 
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.BOOLEAN;
+import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.BOUND_STATEMENT;
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.ENTITY;
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.FUTURE_OF_ASYNC_RESULT_SET;
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.FUTURE_OF_BOOLEAN;
@@ -71,6 +72,7 @@ public class DaoInsertMethodGenerator extends DaoMethodGenerator {
         BOOLEAN,
         FUTURE_OF_BOOLEAN,
         RESULT_SET,
+        BOUND_STATEMENT,
         FUTURE_OF_ASYNC_RESULT_SET);
   }
 

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoReturnType.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoReturnType.java
@@ -26,6 +26,8 @@ public class DaoReturnType {
   public static final DaoReturnType ROW = new DaoReturnType(DefaultDaoReturnTypeKind.ROW);
   public static final DaoReturnType RESULT_SET =
       new DaoReturnType(DefaultDaoReturnTypeKind.RESULT_SET);
+  public static final DaoReturnType BOUND_STATEMENT =
+      new DaoReturnType(DefaultDaoReturnTypeKind.BOUND_STATEMENT);
   public static final DaoReturnType FUTURE_OF_VOID =
       new DaoReturnType(DefaultDaoReturnTypeKind.FUTURE_OF_VOID);
   public static final DaoReturnType FUTURE_OF_BOOLEAN =

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoUpdateMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoUpdateMethodGenerator.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.mapper.processor.dao;
 
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.BOOLEAN;
+import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.BOUND_STATEMENT;
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.FUTURE_OF_ASYNC_RESULT_SET;
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.FUTURE_OF_BOOLEAN;
 import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.FUTURE_OF_VOID;
@@ -61,7 +62,13 @@ public class DaoUpdateMethodGenerator extends DaoMethodGenerator {
 
   protected Set<DaoReturnTypeKind> getSupportedReturnTypes() {
     return ImmutableSet.of(
-        VOID, FUTURE_OF_VOID, RESULT_SET, FUTURE_OF_ASYNC_RESULT_SET, BOOLEAN, FUTURE_OF_BOOLEAN);
+        VOID,
+        FUTURE_OF_VOID,
+        RESULT_SET,
+        BOUND_STATEMENT,
+        FUTURE_OF_ASYNC_RESULT_SET,
+        BOOLEAN,
+        FUTURE_OF_BOOLEAN);
   }
 
   @Override

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DefaultDaoReturnTypeKind.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DefaultDaoReturnTypeKind.java
@@ -64,6 +64,12 @@ public enum DefaultDaoReturnTypeKind implements DaoReturnTypeKind {
       methodBuilder.addStatement("return execute(boundStatement)");
     }
   },
+  BOUND_STATEMENT(false) {
+    @Override
+    public void addExecuteStatement(CodeBlock.Builder methodBuilder, String helperFieldName) {
+      methodBuilder.addStatement("return boundStatement");
+    }
+  },
   PAGING_ITERABLE(false) {
     @Override
     public void addExecuteStatement(CodeBlock.Builder methodBuilder, String helperFieldName) {

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DefaultDaoReturnTypeParser.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DefaultDaoReturnTypeParser.java
@@ -18,6 +18,7 @@ package com.datastax.oss.driver.internal.mapper.processor.dao;
 import com.datastax.oss.driver.api.core.MappedAsyncPagingIterable;
 import com.datastax.oss.driver.api.core.PagingIterable;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.internal.mapper.processor.ProcessorContext;
@@ -55,6 +56,7 @@ public class DefaultDaoReturnTypeParser implements DaoReturnTypeParser {
           .put(Long.class, DaoReturnType.LONG)
           .put(Row.class, DaoReturnType.ROW)
           .put(ResultSet.class, DaoReturnType.RESULT_SET)
+          .put(BoundStatement.class, DaoReturnType.BOUND_STATEMENT)
           .build();
 
   /**

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoDeleteMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoDeleteMethodGeneratorTest.java
@@ -105,7 +105,7 @@ public class DaoDeleteMethodGeneratorTest extends DaoMethodGeneratorTest {
       },
       {
         "Delete methods must return one of [VOID, FUTURE_OF_VOID, BOOLEAN, FUTURE_OF_BOOLEAN, "
-            + "RESULT_SET, FUTURE_OF_ASYNC_RESULT_SET]",
+            + "RESULT_SET, BOUND_STATEMENT, FUTURE_OF_ASYNC_RESULT_SET]",
         MethodSpec.methodBuilder("delete")
             .addAnnotation(Delete.class)
             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoInsertMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoInsertMethodGeneratorTest.java
@@ -57,7 +57,8 @@ public class DaoInsertMethodGeneratorTest extends DaoMethodGeneratorTest {
       },
       {
         "Insert methods must return one of [VOID, FUTURE_OF_VOID, ENTITY, FUTURE_OF_ENTITY, "
-            + "OPTIONAL_ENTITY, FUTURE_OF_OPTIONAL_ENTITY, BOOLEAN, FUTURE_OF_BOOLEAN, RESULT_SET, FUTURE_OF_ASYNC_RESULT_SET]",
+            + "OPTIONAL_ENTITY, FUTURE_OF_OPTIONAL_ENTITY, BOOLEAN, FUTURE_OF_BOOLEAN, RESULT_SET, BOUND_STATEMENT, "
+            + "FUTURE_OF_ASYNC_RESULT_SET]",
         MethodSpec.methodBuilder("insert")
             .addAnnotation(Insert.class)
             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoQueryMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoQueryMethodGeneratorTest.java
@@ -42,7 +42,7 @@ public class DaoQueryMethodGeneratorTest extends DaoMethodGeneratorTest {
     return new Object[][] {
       {
         "Invalid return type: Query methods must return one of [VOID, BOOLEAN, LONG, ROW, "
-            + "ENTITY, OPTIONAL_ENTITY, RESULT_SET, PAGING_ITERABLE, FUTURE_OF_VOID, "
+            + "ENTITY, OPTIONAL_ENTITY, RESULT_SET, BOUND_STATEMENT, PAGING_ITERABLE, FUTURE_OF_VOID, "
             + "FUTURE_OF_BOOLEAN, FUTURE_OF_LONG, FUTURE_OF_ROW, FUTURE_OF_ENTITY, "
             + "FUTURE_OF_OPTIONAL_ENTITY, FUTURE_OF_ASYNC_RESULT_SET, "
             + "FUTURE_OF_ASYNC_PAGING_ITERABLE]",

--- a/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoUpdateMethodGeneratorTest.java
+++ b/mapper-processor/src/test/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoUpdateMethodGeneratorTest.java
@@ -67,7 +67,7 @@ public class DaoUpdateMethodGeneratorTest extends DaoMethodGeneratorTest {
       },
       {
         "Invalid return type: Update methods must return one of [VOID, FUTURE_OF_VOID, "
-            + "RESULT_SET, FUTURE_OF_ASYNC_RESULT_SET, BOOLEAN, FUTURE_OF_BOOLEAN]",
+            + "RESULT_SET, BOUND_STATEMENT, FUTURE_OF_ASYNC_RESULT_SET, BOOLEAN, FUTURE_OF_BOOLEAN]",
         MethodSpec.methodBuilder("update")
             .addAnnotation(UPDATE_ANNOTATION)
             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Delete.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Delete.java
@@ -17,6 +17,7 @@ package com.datastax.oss.driver.api.mapper.annotations;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
@@ -90,6 +91,12 @@ import java.util.function.UnaryOperator;
  * &#64;Delete(entityClass = Product.class, customIfClause = "description = :expectedDescription")
  * ResultSet deleteIfDescriptionMatches(UUID productId, String expectedDescription);
  * // if the condition fails, the result set will contain columns '[applied]' and 'description'
+ *       </pre>
+ *   <li>a {@link BoundStatement}. This is intended for queries where you will execute this
+ *       statement later or in a batch.
+ *       <pre>
+ * &#64;Delete
+ * BoundStatement delete(Product product);
  *       </pre>
  *   <li>a {@link CompletionStage} or {@link CompletableFuture} of any of the above. The method will
  *       execute the query asynchronously. Note that for result sets, you need to switch to {@link

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Insert.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Insert.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.api.mapper.annotations;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
@@ -91,6 +92,12 @@ import java.util.function.UnaryOperator;
  * &#64;Insert
  * ResultSet save(Product product);
  *       </pre>
+ *   <li>a {@link BoundStatement} This is intended for cases where you intend to execute this
+ *       statement later or in a batch:
+ *       <pre>
+ * &#64;Insert
+ * BoundStatement save(Product product);
+ *      </pre>
  *   <li>a {@link CompletionStage} or {@link CompletableFuture} of any of the above. The mapper will
  *       execute the query asynchronously.
  *       <pre>

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Query.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Query.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.MappedAsyncPagingIterable;
 import com.datastax.oss.driver.api.core.PagingIterable;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.session.Session;
@@ -83,6 +84,8 @@ import java.util.function.UnaryOperator;
  *   <li>an {@link Optional} of an entity class. The method will extract the first row and convert
  *       it, or return {@code Optional.empty()} if the result set is empty.
  *   <li>a {@link ResultSet}. The method will return the raw query result, without any conversion.
+ *   <li>a {@link BoundStatement}. This is intended for cases where you intend to execute this
+ *       statement later or in a batch:
  *   <li>a {@link PagingIterable}. The method will convert each row into an entity instance.
  *   <li>a {@link CompletionStage} or {@link CompletableFuture} of any of the above. The method will
  *       execute the query asynchronously. Note that for result sets and iterables, you need to

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Update.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Update.java
@@ -17,6 +17,7 @@ package com.datastax.oss.driver.api.mapper.annotations;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
@@ -46,8 +47,8 @@ import java.util.function.UnaryOperator;
  *
  * <h3>Parameters</h3>
  *
- * The first parameter must be an entity instance. All of its non-PK properties will be interpreted
- * as values to update.
+ * <p>The first parameter must be an entity instance. All of its non-PK properties will be
+ * interpreted as values to update.
  *
  * <ul>
  *   <li>If {@link #customWhereClause()} is empty, the mapper defaults to an update by primary key
@@ -85,7 +86,7 @@ import java.util.function.UnaryOperator;
  *
  * <h3>Return type</h3>
  *
- * The method can return:
+ * <p>The method can return:
  *
  * <ul>
  *   <li>{@code void}.
@@ -103,6 +104,12 @@ import java.util.function.UnaryOperator;
  * ResultSet updateIfDescriptionMatches(Product product, String expectedDescription);
  * // if the condition fails, the result set will contain columns '[applied]' and 'description'
  *       </pre>
+ *   <li>a {@link BoundStatement}. This is intended for queries where you will execute this
+ *       statement later or in a batch:
+ *       <pre>
+ * &#64;Update
+ * BoundStatement update(Product product);
+ *      </pre>
  *   <li>a {@link CompletionStage} or {@link CompletableFuture} of any of the above. The mapper will
  *       execute the query asynchronously. Note that for result sets, you need to switch to the
  *       asynchronous equivalent {@link AsyncResultSet}.
@@ -120,7 +127,7 @@ import java.util.function.UnaryOperator;
  *
  * <h3>Target keyspace and table</h3>
  *
- * If a keyspace was specified when creating the DAO (see {@link DaoFactory}), then the generated
+ * <p>If a keyspace was specified when creating the DAO (see {@link DaoFactory}), then the generated
  * query targets that keyspace. Otherwise, it doesn't specify a keyspace, and will only work if the
  * mapper was built from a {@link Session} that has a {@linkplain
  * SessionBuilder#withKeyspace(CqlIdentifier) default keyspace} set.


### PR DESCRIPTION
Motivation:

In the 3.x driver the object-mapper had Mapper.saveQuery(entity) and
 Mapper.deleteQuery(id) which returned a BoundStatement that you could
 later execute. This was useful for creating a list of BoundStatement
 that would be added to a LOGGED Batch statement for atomically saving
 data that is saved across several denormalized tables (to support
 different query patterns on the same data).

While the current code sort of enables that with the @SetEntity, it
 however lacks a lot of the features that the other DAO methods have,
 for instance setting a TTL, custom IF and WHERE clauses that are
 are supported by the @Insert, @Update, and @Delete methods. And not
 all of these feature may be supportable on this more generic implemenation.

Modifcations:

Added a new DaoReturnType.BOUND_STATEMENT that is practically identical to
 to the existing DaoReturnType. Since it just returns the BoundStatment
 instead of executing it.

Result:

For @Insert, @Update, @Delete, and @Query DAO methods BoundStatement is
 now a new supported return type. This is an additive change to the API
 of the Mapper so it is non-breaking.