### PR TITLE
JAVA-2527: Allow AllNodesFailedException to accept more than one error per node

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,8 +2,9 @@
 
 <!-- Note: contrary to 3.x, insert new entries *first* in their section -->
 
-### 4.4.0 (in progress)
+### 4.3.1 (in progress)
 
+- [bug] JAVA-2527: Allow AllNodesFailedException to accept more than one error per node
 
 ### 4.3.0
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/AllNodesFailedException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/AllNodesFailedException.java
@@ -19,16 +19,15 @@ import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import com.datastax.oss.driver.shaded.guava.common.collect.Iterables;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 
 /**
  * Thrown when a query failed on all the coordinators it was tried on. This exception may wrap
@@ -43,7 +42,7 @@ public class AllNodesFailedException extends DriverException {
     if (errors == null || errors.isEmpty()) {
       return new NoNodeAvailableException();
     } else {
-      return new AllNodesFailedException(groupByNode(errors.entrySet()));
+      return new AllNodesFailedException(groupByNode(errors));
     }
   }
 
@@ -64,7 +63,8 @@ public class AllNodesFailedException extends DriverException {
       @NonNull String message,
       @Nullable ExecutionInfo executionInfo,
       @NonNull Map<Node, Throwable> errors) {
-    this(message, executionInfo, groupByNode(errors.entrySet()));
+    super(message, executionInfo, null, true);
+    this.errors = toDeepImmutableMap(groupByNode(errors));
   }
 
   protected AllNodesFailedException(
@@ -75,18 +75,18 @@ public class AllNodesFailedException extends DriverException {
     this.errors = toDeepImmutableMap(errors);
   }
 
-  private AllNodesFailedException(Collection<Entry<Node, List<Throwable>>> errors) {
+  private AllNodesFailedException(Map<Node, List<Throwable>> errors) {
     this(
         buildMessage(
             String.format("All %d node(s) tried for the query failed", errors.size()), errors),
         null,
-        errors);
+        errors.entrySet());
   }
 
-  private static String buildMessage(
-      String baseMessage, Collection<Entry<Node, List<Throwable>>> errors) {
+  private static String buildMessage(String baseMessage, Map<Node, List<Throwable>> errors) {
     int limit = Math.min(errors.size(), 3);
-    Iterator<Entry<Node, List<Throwable>>> iterator = errors.iterator();
+    Iterator<Entry<Node, List<Throwable>>> iterator =
+        Iterables.limit(errors.entrySet(), limit).iterator();
     StringBuilder details = new StringBuilder();
     while (iterator.hasNext()) {
       Entry<Node, List<Throwable>> entry = iterator.next();
@@ -96,7 +96,8 @@ public class AllNodesFailedException extends DriverException {
       }
     }
     return String.format(
-        "%s (showing first %d, use getAllErrors() for more): %s", baseMessage, limit, details);
+        "%s (showing first %d nodes, use getAllErrors() for more): %s",
+        baseMessage, limit, details);
   }
 
   /**
@@ -132,11 +133,14 @@ public class AllNodesFailedException extends DriverException {
   @NonNull
   public AllNodesFailedException reword(String newMessage) {
     return new AllNodesFailedException(
-        buildMessage(newMessage, errors.entrySet()), getExecutionInfo(), errors.entrySet());
+        buildMessage(newMessage, errors), getExecutionInfo(), errors.entrySet());
   }
 
-  private static Set<Entry<Node, List<Throwable>>> groupByNode(
-      Iterable<Entry<Node, Throwable>> errors) {
+  private static Map<Node, List<Throwable>> groupByNode(Map<Node, Throwable> errors) {
+    return groupByNode(errors.entrySet());
+  }
+
+  private static Map<Node, List<Throwable>> groupByNode(Iterable<Entry<Node, Throwable>> errors) {
     // no need for immutable collections here
     Map<Node, List<Throwable>> map = new LinkedHashMap<>();
     for (Entry<Node, Throwable> entry : errors) {
@@ -152,7 +156,11 @@ public class AllNodesFailedException extends DriverException {
             return v;
           });
     }
-    return map.entrySet();
+    return map;
+  }
+
+  private static Map<Node, List<Throwable>> toDeepImmutableMap(Map<Node, List<Throwable>> errors) {
+    return toDeepImmutableMap(errors.entrySet());
   }
 
   private static Map<Node, List<Throwable>> toDeepImmutableMap(

--- a/core/src/main/java/com/datastax/oss/driver/api/core/DriverException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/DriverException.java
@@ -74,8 +74,8 @@ public abstract class DriverException extends RuntimeException {
    *
    * <p>Note that this is only set for exceptions that are rethrown directly to the client from a
    * session call. For example, individual node errors stored in {@link
-   * AllNodesFailedException#getErrors()} or {@link ExecutionInfo#getErrors()} do not contain their
-   * own execution info, and therefore return null from this method.
+   * AllNodesFailedException#getAllErrors()} or {@link ExecutionInfo#getErrors()} do not contain
+   * their own execution info, and therefore return null from this method.
    *
    * <p>It will also be null if you serialize and deserialize an exception.
    */

--- a/core/src/main/java/com/datastax/oss/driver/api/core/NoNodeAvailableException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/NoNodeAvailableException.java
@@ -31,7 +31,7 @@ public class NoNodeAvailableException extends AllNodesFailedException {
   }
 
   private NoNodeAvailableException(ExecutionInfo executionInfo) {
-    super("No node was available to execute the query", executionInfo, Collections.emptyMap());
+    super("No node was available to execute the query", executionInfo, Collections.emptySet());
   }
 
   @NonNull

--- a/core/src/test/java/com/datastax/oss/driver/api/core/AllNodesFailedExceptionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/AllNodesFailedExceptionTest.java
@@ -54,7 +54,7 @@ public class AllNodesFailedExceptionTest {
     assertThat(e)
         .hasMessage(
             "All 2 node(s) tried for the query failed "
-                + "(showing first 2, use getAllErrors() for more): "
+                + "(showing first 2 nodes, use getAllErrors() for more): "
                 + "node1: [%s], node2: [%s]",
             e1, e2);
     assertThat(e.getAllErrors())
@@ -80,7 +80,7 @@ public class AllNodesFailedExceptionTest {
     assertThat(e)
         .hasMessage(
             "All 2 node(s) tried for the query failed "
-                + "(showing first 2, use getAllErrors() for more): "
+                + "(showing first 2 nodes, use getAllErrors() for more): "
                 + "node1: [%s, %s], node2: [%s]",
             e1a, e1b, e2a);
     assertThat(e.getAllErrors())

--- a/core/src/test/java/com/datastax/oss/driver/api/core/AllNodesFailedExceptionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/AllNodesFailedExceptionTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core;
+
+import static com.datastax.oss.driver.api.core.ConsistencyLevel.QUORUM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.servererrors.ReadTimeoutException;
+import com.datastax.oss.driver.api.core.servererrors.UnavailableException;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AllNodesFailedExceptionTest {
+
+  @Mock(name = "node1")
+  private Node node1;
+
+  @Mock(name = "node2")
+  private Node node2;
+
+  @SuppressWarnings("deprecation")
+  @Test
+  public void should_create_instance_from_map_of_first_errors() {
+    // given
+    UnavailableException e1 = new UnavailableException(node1, QUORUM, 2, 1);
+    ReadTimeoutException e2 = new ReadTimeoutException(node2, QUORUM, 2, 1, false);
+    Map<Node, Throwable> errors = ImmutableMap.of(node1, e1, node2, e2);
+    // when
+    AllNodesFailedException e = AllNodesFailedException.fromErrors(errors);
+    // then
+    assertThat(e)
+        .hasMessage(
+            "All 2 node(s) tried for the query failed "
+                + "(showing first 2, use getAllErrors() for more): "
+                + "node1: [%s], node2: [%s]",
+            e1, e2);
+    assertThat(e.getAllErrors())
+        .hasEntrySatisfying(node1, list -> assertThat(list).containsExactly(e1));
+    assertThat(e.getAllErrors())
+        .hasEntrySatisfying(node2, list -> assertThat(list).containsExactly(e2));
+    assertThat(e.getErrors()).containsEntry(node1, e1);
+    assertThat(e.getErrors()).containsEntry(node2, e2);
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  public void should_create_instance_from_list_of_all_errors() {
+    // given
+    UnavailableException e1a = new UnavailableException(node1, QUORUM, 2, 1);
+    ReadTimeoutException e1b = new ReadTimeoutException(node1, QUORUM, 2, 1, false);
+    ReadTimeoutException e2a = new ReadTimeoutException(node2, QUORUM, 2, 1, false);
+    List<Entry<Node, Throwable>> errors =
+        ImmutableList.of(entry(node1, e1a), entry(node1, e1b), entry(node2, e2a));
+    // when
+    AllNodesFailedException e = AllNodesFailedException.fromErrors(errors);
+    // then
+    assertThat(e)
+        .hasMessage(
+            "All 2 node(s) tried for the query failed "
+                + "(showing first 2, use getAllErrors() for more): "
+                + "node1: [%s, %s], node2: [%s]",
+            e1a, e1b, e2a);
+    assertThat(e.getAllErrors())
+        .hasEntrySatisfying(node1, list -> assertThat(list).containsExactly(e1a, e1b));
+    assertThat(e.getAllErrors())
+        .hasEntrySatisfying(node2, list -> assertThat(list).containsExactly(e2a));
+    assertThat(e.getErrors()).containsEntry(node1, e1a);
+    assertThat(e.getErrors()).containsEntry(node2, e2a);
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerSpeculativeExecutionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerSpeculativeExecutionTest.java
@@ -37,6 +37,7 @@ import com.datastax.oss.driver.internal.core.util.concurrent.CapturingTimer.Capt
 import com.datastax.oss.protocol.internal.ProtocolConstants;
 import com.datastax.oss.protocol.internal.response.Error;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -261,10 +262,11 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
           .isFailed(
               error -> {
                 assertThat(error).isInstanceOf(AllNodesFailedException.class);
-                Map<Node, Throwable> nodeErrors = ((AllNodesFailedException) error).getErrors();
+                Map<Node, List<Throwable>> nodeErrors =
+                    ((AllNodesFailedException) error).getAllErrors();
                 assertThat(nodeErrors).containsOnlyKeys(node1, node2);
-                assertThat(nodeErrors.get(node1)).isInstanceOf(BootstrappingException.class);
-                assertThat(nodeErrors.get(node2)).isInstanceOf(BootstrappingException.class);
+                assertThat(nodeErrors.get(node1).get(0)).isInstanceOf(BootstrappingException.class);
+                assertThat(nodeErrors.get(node2).get(0)).isInstanceOf(BootstrappingException.class);
               });
     }
   }
@@ -315,10 +317,11 @@ public class CqlRequestHandlerSpeculativeExecutionTest extends CqlRequestHandler
           .isFailed(
               error -> {
                 assertThat(error).isInstanceOf(AllNodesFailedException.class);
-                Map<Node, Throwable> nodeErrors = ((AllNodesFailedException) error).getErrors();
+                Map<Node, List<Throwable>> nodeErrors =
+                    ((AllNodesFailedException) error).getAllErrors();
                 assertThat(nodeErrors).containsOnlyKeys(node1, node2);
-                assertThat(nodeErrors.get(node1)).isInstanceOf(BootstrappingException.class);
-                assertThat(nodeErrors.get(node2)).isInstanceOf(BootstrappingException.class);
+                assertThat(nodeErrors.get(node1).get(0)).isInstanceOf(BootstrappingException.class);
+                assertThat(nodeErrors.get(node2).get(0)).isInstanceOf(BootstrappingException.class);
               });
     }
   }

--- a/examples/src/main/java/com/datastax/oss/driver/examples/retry/DowngradingRetry.java
+++ b/examples/src/main/java/com/datastax/oss/driver/examples/retry/DowngradingRetry.java
@@ -34,6 +34,7 @@ import com.datastax.oss.driver.api.core.servererrors.QueryConsistencyException;
 import com.datastax.oss.driver.api.core.servererrors.ReadTimeoutException;
 import com.datastax.oss.driver.api.core.servererrors.UnavailableException;
 import com.datastax.oss.driver.api.core.servererrors.WriteTimeoutException;
+import java.util.List;
 
 /**
  * This example illustrates how to implement a downgrading retry strategy from application code.
@@ -418,9 +419,11 @@ public class DowngradingRetry {
   private static DriverException unwrapAllNodesFailedException(DriverException e) {
     if (e instanceof AllNodesFailedException) {
       AllNodesFailedException noHostAvailable = (AllNodesFailedException) e;
-      for (Throwable error : noHostAvailable.getErrors().values()) {
-        if (error instanceof QueryConsistencyException || error instanceof UnavailableException) {
-          return (DriverException) error;
+      for (List<Throwable> errors : noHostAvailable.getAllErrors().values()) {
+        for (Throwable error : errors) {
+          if (error instanceof QueryConsistencyException || error instanceof UnavailableException) {
+            return (DriverException) error;
+          }
         }
       }
       // Couldn't find an exploitable error to unwrap: abort.

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/AllNodesFailedIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/AllNodesFailedIT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.core;
+
+import static com.datastax.oss.simulacron.common.codec.ConsistencyLevel.ONE;
+import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.readTimeout;
+import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.datastax.oss.driver.api.core.AllNodesFailedException;
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.retry.RetryDecision;
+import com.datastax.oss.driver.api.core.session.Request;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.driver.internal.core.retry.DefaultRetryPolicy;
+import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(ParallelizableTests.class)
+public class AllNodesFailedIT {
+
+  @ClassRule
+  public static final SimulacronRule SIMULACRON_RULE =
+      new SimulacronRule(ClusterSpec.builder().withNodes(2));
+
+  @Test
+  public void should_report_multiple_errors_per_node() {
+    SIMULACRON_RULE.cluster().prime(when("SELECT foo").then(readTimeout(ONE, 0, 0, false)));
+    DriverConfigLoader loader =
+        SessionUtils.configLoaderBuilder()
+            .withClass(DefaultDriverOption.RETRY_POLICY_CLASS, MultipleRetryPolicy.class)
+            .build();
+
+    try (CqlSession session =
+        (CqlSession)
+            SessionUtils.baseBuilder()
+                .addContactEndPoints(SIMULACRON_RULE.getContactPoints())
+                .withConfigLoader(loader)
+                .build()) {
+      // when executing a query.
+      session.execute("SELECT foo");
+      fail("AllNodesFailedException expected");
+    } catch (AllNodesFailedException ex) {
+      assertThat(ex.getAllErrors()).hasSize(2);
+      Iterator<Entry<Node, List<Throwable>>> iterator = ex.getAllErrors().entrySet().iterator();
+      // first node should have been tried twice
+      Entry<Node, List<Throwable>> node1Errors = iterator.next();
+      assertThat(node1Errors.getValue()).hasSize(2);
+      // second node should have been tried twice
+      Entry<Node, List<Throwable>> node2Errors = iterator.next();
+      assertThat(node2Errors.getValue()).hasSize(2);
+    }
+  }
+
+  public static class MultipleRetryPolicy extends DefaultRetryPolicy {
+
+    public MultipleRetryPolicy(DriverContext context, String profileName) {
+      super(context, profileName);
+    }
+
+    @Override
+    public RetryDecision onReadTimeout(
+        @NonNull Request request,
+        @NonNull ConsistencyLevel cl,
+        int blockFor,
+        int received,
+        boolean dataPresent,
+        int retryCount) {
+      // retry each node twice
+      if (retryCount % 2 == 0) {
+        return RetryDecision.RETRY_SAME;
+      } else {
+        return RetryDecision.RETRY_NEXT;
+      }
+    }
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ProtocolVersionInitialNegotiationIT.java
@@ -65,7 +65,7 @@ public class ProtocolVersionInitialNegotiationIT {
       session.execute("select * from system.local");
       fail("Expected an AllNodesFailedException");
     } catch (AllNodesFailedException anfe) {
-      Throwable cause = anfe.getErrors().values().iterator().next();
+      Throwable cause = anfe.getAllErrors().values().iterator().next().get(0);
       assertThat(cause).isInstanceOf(UnsupportedProtocolVersionException.class);
       UnsupportedProtocolVersionException unsupportedException =
           (UnsupportedProtocolVersionException) cause;

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/NodeTargetingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/NodeTargetingIT.java
@@ -100,8 +100,8 @@ public class NodeTargetingIT {
       SESSION_RULE.session().execute(statement);
       fail("Should have thrown AllNodesFailedException");
     } catch (AllNodesFailedException e) {
-      assertThat(e.getErrors().size()).isEqualTo(1);
-      assertThat(e.getErrors().get(node3)).isInstanceOf(UnavailableException.class);
+      assertThat(e.getAllErrors().size()).isEqualTo(1);
+      assertThat(e.getAllErrors().get(node3).get(0)).isInstanceOf(UnavailableException.class);
     }
   }
 
@@ -116,13 +116,13 @@ public class NodeTargetingIT {
       SESSION_RULE.session().execute(statement);
       fail("Query should have failed");
     } catch (NoNodeAvailableException e) {
-      assertThat(e.getErrors()).isEmpty();
+      assertThat(e.getAllErrors()).isEmpty();
     } catch (AllNodesFailedException e) {
       // its also possible that the query is tried.  This can happen if the node was marked
       // down, but not all connections have been closed yet.  In this case, just verify that
       // the expected host failed.
-      assertThat(e.getErrors().size()).isEqualTo(1);
-      assertThat(e.getErrors()).containsOnlyKeys(node4);
+      assertThat(e.getAllErrors().size()).isEqualTo(1);
+      assertThat(e.getAllErrors()).containsOnlyKeys(node4);
     }
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/retry/DefaultRetryPolicyIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/retry/DefaultRetryPolicyIT.java
@@ -61,6 +61,7 @@ import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
@@ -274,7 +275,7 @@ public class DefaultRetryPolicyIT {
     } catch (AllNodesFailedException ex) {
       // then an AllNodesFailedException should be raised indicating that all nodes failed the
       // request.
-      assertThat(ex.getErrors()).hasSize(3);
+      assertThat(ex.getAllErrors()).hasSize(3);
     }
 
     // should have been tried on all nodes.
@@ -496,9 +497,11 @@ public class DefaultRetryPolicyIT {
       fail("Expected an AllNodesFailedException");
     } catch (AllNodesFailedException e) {
       // then we should get an all nodes failed exception, indicating the query was tried each node.
-      assertThat(e.getErrors()).hasSize(3);
-      for (Throwable t : e.getErrors().values()) {
-        assertThat(t).isInstanceOf(ServerError.class);
+      assertThat(e.getAllErrors()).hasSize(3);
+      for (List<Throwable> nodeErrors : e.getAllErrors().values()) {
+        for (Throwable nodeError : nodeErrors) {
+          assertThat(nodeError).isInstanceOf(ServerError.class);
+        }
       }
     }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/ShutdownIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/ShutdownIT.java
@@ -99,9 +99,9 @@ public class ShutdownIT {
                             AllNodesFailedException anfe = (AllNodesFailedException) error;
                             // if there were 0 errors, its a NoNodeAvailableException which is
                             // acceptable.
-                            if (anfe.getErrors().size() > 0) {
-                              assertThat(anfe.getErrors()).hasSize(1);
-                              error = anfe.getErrors().values().iterator().next();
+                            if (anfe.getAllErrors().size() > 0) {
+                              assertThat(anfe.getAllErrors()).hasSize(1);
+                              error = anfe.getAllErrors().values().iterator().next().get(0);
                               if (!(error instanceof IllegalStateException)
                                   && !error.getMessage().endsWith("is closing")) {
                                 unexpectedErrors.add(error.toString());

--- a/manual/core/native_protocol/README.md
+++ b/manual/core/native_protocol/README.md
@@ -59,7 +59,7 @@ If you force a version that is too high for the server, you'll get an error:
 
 ```
 Exception in thread "main" com.datastax.oss.driver.api.core.AllNodesFailedException:
-  All 1 node tried for the query failed (showing first 1, use getErrors() for more:
+  All 1 node tried for the query failed (showing first 1 nodes, use getAllErrors() for more:
     /127.0.0.1:9042: com.datastax.oss.driver.api.core.UnsupportedProtocolVersionException:
                      [/127.0.0.1:9042] Host does not support protocol version V5)
 ```


### PR DESCRIPTION
Note: this PR fixes the core issue and exposes a new getter returning a `Map<Node, List<Throwable>>` structure containing all errors (it also deprecates the old `getErrors` method).

It does not add suppressed exceptions as suggested in JAVA-2528.