### PR TITLE
JAVA-2107: Add XML formatting plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 ## Code formatting
 
+### Java
+
 We follow the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html). See
 https://github.com/google/google-java-format for IDE plugins. The rules are not configurable.
 
@@ -11,11 +13,20 @@ The build will fail if the code is not formatted. To format all files from the c
 mvn fmt:format
 ```
 
-Some aspects are not covered by the formatter:
+Some aspects are not covered by the formatter: braces must be used with `if`, `else`, `for`, `do`
+and `while` statements, even when the body is empty or contains only a single statement.
 
-* braces must be used with `if`, `else`, `for`, `do` and `while` statements, even when the body is
-  empty or contains only a single statement.
-* XML files: indent with two spaces and wrap to respect the column limit of 100 characters.
+### XML
+
+The build will fail if XML files are not formatted correctly. Run the following command before you
+commit:
+
+```java
+mvn xml-format:xml-format
+```
+
+The formatter does not enforce a maximum line length, but please try to keep it below 100 characters
+to keep files readable across all mediums (IDE, terminal, Github...).
 
 ## Coding style -- production code
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.4.0 (in progress)
 
+- [improvement] JAVA-2107: Add XML formatting plugin
 
 ### 4.3.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,11 @@
           <version>2.9</version>
         </plugin>
         <plugin>
+          <groupId>au.com.acegi</groupId>
+          <artifactId>xml-format-maven-plugin</artifactId>
+          <version>3.1.1</version>
+        </plugin>
+        <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>3.0</version>
@@ -438,6 +443,24 @@
             <phase>process-sources</phase>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>au.com.acegi</groupId>
+        <artifactId>xml-format-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>xml-check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <excludes>
+            <exclude>.idea/**</exclude>
+            <exclude>**/target/**</exclude>
+            <exclude>**/dependency-reduced-pom.xml</exclude>
+          </excludes>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>com.mycila</groupId>


### PR DESCRIPTION
I haven't run the formatter yet. It's better to do it at the last minute, to avoid unnecessary conflicts if the POMs change before we're ready to merge this:
```
mvn xml-format:xml-format
```
(incidentally, this is why the build fails)

I did a test run locally, it's pretty similar to what we have already, and overall satisfactory. There are a few whacky edge cases around comments, but I didn't find any [configuration options](https://acegi.github.io/xml-format-maven-plugin/xml-format-mojo.html) to avoid them. I don't want to spend too much time fighting the formatter, consistency is what matters.