### PR TITLE
JAVA-2539: Stop assuming CDC unavailable for Cassandra prior to 3.8.0

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractTableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractTableMetadata.java
@@ -269,9 +269,7 @@ public abstract class AbstractTableMetadata {
         if (cassandraVersion.getMajor() > 2) {
             and(sb, formatted).append("crc_check_chance = ").append(options.getCrcCheckChance());
         }
-        if (cassandraVersion.getMajor() > 3 || (cassandraVersion.getMajor() == 3 && cassandraVersion.getMinor() >= 8)) {
-            and(sb, formatted).append("cdc = ").append(options.isCDC());
-        }
+        and(sb, formatted).append("cdc = ").append(options.isCDC());
         sb.append(';');
         return sb;
     }

--- a/driver-core/src/main/java/com/datastax/driver/core/TableOptionsMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/TableOptionsMetadata.java
@@ -87,7 +87,6 @@ public class TableOptionsMetadata {
         boolean is200 = version.getMajor() == 2 && version.getMinor() == 0;
         boolean is210 = version.getMajor() == 2 && version.getMinor() >= 1;
         boolean is400OrHigher = version.getMajor() > 3;
-        boolean is380OrHigher = is400OrHigher || version.getMajor() == 3 && version.getMinor() >= 8;
         boolean is300OrHigher = version.getMajor() > 2;
         boolean is210OrHigher = is210 || is300OrHigher;
 
@@ -160,12 +159,7 @@ public class TableOptionsMetadata {
         else
             this.extensions = ImmutableMap.of();
 
-        if (is380OrHigher)
-            this.cdc = isNullOrAbsent(row, CDC)
-                    ? DEFAULT_CDC
-                    : row.getBool(CDC);
-        else
-            this.cdc = DEFAULT_CDC;
+        this.cdc = isNullOrAbsent(row, CDC) ? DEFAULT_CDC : row.getBool(CDC);
     }
 
     private static boolean isNullOrAbsent(Row row, String name) {
@@ -379,11 +373,12 @@ public class TableOptionsMetadata {
     }
 
     /**
-     * Returns whether or not change data capture is enabled for this table.
+     * Returns whether or not change data capture (CDC) is enabled for this table.
      * <p/>
-     * For Cassandra versions prior to 3.8.0, this method always returns false.
+     * Note that Apache Cassandra officially introduced CDC via CASSANDRA-12041 in Cassandra 3.8.0.
+     * So older versions of Cassandra will always return false unless running a custom variant which back-ports CDC.
      *
-     * @return whether or not change data capture is enabled for this table.
+     * @return whether or not change data capture (CDC) is enabled for this table.
      */
     public boolean isCDC() {
         return cdc;

--- a/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/TableOptions.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/schemabuilder/TableOptions.java
@@ -362,7 +362,9 @@ public abstract class TableOptions<T extends TableOptions> extends SchemaStateme
     /**
      * Define whether or not change data capture is enabled on this table.
      * <p/>
-     * Note that using this option with a version of Apache Cassandra less than 3.8 will raise a syntax error.
+     * Note that Apache Cassandra officially introduced CDC via CASSANDRA-12041 in Cassandra 3.8.0.
+     * Setting this option with a version of Apache Cassandra less than 3.8.0 will raise a syntax error
+     * unless running a custom variant which fully back-ports CDC.
      * <p/>
      * If no call is made to this method, the default value set by Cassandra is {@code false}.
      *


### PR DESCRIPTION
Simple change to use CDC value as reported by Cassandra instead of forcing to false when Cassandra version is less than 3.8.0. This change unblocks my team from using a custom Cassandra variant which backports CDC to an older version.

FYI I'm submitting this PR to 3.2.x because that's the branch which first introduces CDC (along with the Cassandra version restriction). I'm not actually using 3.2.x; my team is currently migrating from 3.3.2 to 3.7.1. We'd be migrating to latest release except that 3.7.2 introduced a small performance improvement incompatible with latest published release of Simulacron (see [Simulacron issue 88 Please publish 0.8.11 to maven central](https://github.com/datastax/simulacron/issues/88)). Once Simulacron 0.8.11 is published to maven central my team will likely upgrade to 3.8.0.