### PR TITLE
JAVA-2473: Don't reconnect control connection if protocol is downgraded

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.4.0 (in progress)
 
+- [improvement] JAVA-2473: Don't reconnect control connection if protocol is downgraded
 - [new feature] JAVA-2532: Add BoundStatement ReturnType for insert, update, and delete DAO methods
 - [improvement] JAVA-2107: Add XML formatting plugin
 - [bug] JAVA-2527: Allow AllNodesFailedException to accept more than one error per node

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
@@ -246,14 +246,6 @@ public class MetadataManager implements AsyncAutoCloseable {
     }
   }
 
-  /**
-   * Returns a future that completes after the first schema refresh attempt, whether that attempt
-   * succeeded or not (we wait for that refresh at init, but if it fails it's not fatal).
-   */
-  public CompletionStage<Void> firstSchemaRefreshFuture() {
-    return singleThreaded.firstSchemaRefreshFuture;
-  }
-
   @NonNull
   @Override
   public CompletionStage<Void> closeFuture() {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
@@ -32,7 +32,6 @@ import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.context.LifecycleListener;
-import com.datastax.oss.driver.internal.core.control.ControlConnection;
 import com.datastax.oss.driver.internal.core.metadata.MetadataManager;
 import com.datastax.oss.driver.internal.core.metadata.NodeStateEvent;
 import com.datastax.oss.driver.internal.core.metadata.NodeStateManager;
@@ -362,7 +361,6 @@ public class DefaultSession implements CqlSession {
       try {
         boolean protocolWasForced =
             context.getConfig().getDefaultProfile().isDefined(DefaultDriverOption.PROTOCOL_VERSION);
-        boolean needSchemaRefresh = true;
         if (!protocolWasForced) {
           ProtocolVersion currentVersion = context.getProtocolVersion();
           ProtocolVersion bestVersion =
@@ -378,36 +376,27 @@ public class DefaultSession implements CqlSession {
                 bestVersion);
             context.getChannelFactory().setProtocolVersion(bestVersion);
 
-            // If the control connection has already initialized, force a reconnect to use the new
-            // version.
-            // (note: it might not have initialized yet if there is a custom TopologyMonitor)
-            ControlConnection controlConnection = context.getControlConnection();
-            if (controlConnection.isInit()) {
-              controlConnection.reconnectNow();
-              // Reconnection already triggers a full schema refresh
-              needSchemaRefresh = false;
-            }
+            // Note that, with the default topology monitor, the control connection is already
+            // connected with currentVersion at this point. This doesn't really matter because none
+            // of the control queries use any protocol-dependent feature.
+            // Keep going as-is, the control connection might switch to the "correct" version later
+            // if it reconnects to another node.
           }
         }
-        if (needSchemaRefresh) {
-          metadataManager
-              .refreshSchema(null, false, true)
-              .whenComplete(
-                  (metadata, error) -> {
-                    if (error != null) {
-                      Loggers.warnWithException(
-                          LOG,
-                          "[{}] Unexpected error while refreshing schema during initialization, "
-                              + "keeping previous version",
-                          logPrefix,
-                          error);
-                    }
-                  });
-        }
         metadataManager
-            .firstSchemaRefreshFuture()
-            .thenAccept(v -> afterInitialSchemaRefresh(keyspace));
-
+            .refreshSchema(null, false, true)
+            .whenComplete(
+                (metadata, error) -> {
+                  if (error != null) {
+                    Loggers.warnWithException(
+                        LOG,
+                        "[{}] Unexpected error while refreshing schema during initialization, "
+                            + "keeping previous version",
+                        logPrefix,
+                        error);
+                  }
+                  afterInitialSchemaRefresh(keyspace);
+                });
       } catch (Throwable throwable) {
         initFuture.completeExceptionally(throwable);
       }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/session/DefaultSessionPoolsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/session/DefaultSessionPoolsTest.java
@@ -130,8 +130,6 @@ public class DefaultSessionPoolsTest {
 
     // Init sequence:
     when(metadataManager.refreshNodes()).thenReturn(CompletableFuture.completedFuture(null));
-    when(metadataManager.firstSchemaRefreshFuture())
-        .thenReturn(CompletableFuture.completedFuture(null));
     when(metadataManager.refreshSchema(null, false, true))
         .thenReturn(CompletableFuture.completedFuture(null));
     when(context.getMetadataManager()).thenReturn(metadataManager);


### PR DESCRIPTION
Motivation:

In theory, the control connection is an implementation detail of the
topology monitor and metadata manager. If those components are
overridden with custom versions that use another way to get the data,
the rest of the driver should be able to function without initializing
the control connection at all.

This is currently not the case: DefaultSession references the control
connection, in order to reconnect if the protocol version was
downgraded after the initial connection (JAVA-1295).

Modifications:

Do not reconnect the control connection in that case; it's not really
needed because none of the control queries use any protocol-dependent
feature.

This also allows us to remove MetadataManager.firstSchemaRefreshFuture()
and slightly simplify session initialization.

Result:

DefaultSession does not reference ControlConnection.

If the protocol version is downgraded, the control connection keeps
using the initial version. It might switch to the "correct" version
later if it reconnects to another node.