### PR TITLE
JAVA-2578 Fix ConnectIT when run from dse driver

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ConnectIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ConnectIT.java
@@ -37,6 +37,7 @@ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
 import com.datastax.oss.driver.api.testinfra.utils.ConditionChecker;
 import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.connection.ConstantReconnectionPolicy;
+import com.datastax.oss.driver.internal.core.loadbalancing.DefaultLoadBalancingPolicy;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
 import com.datastax.oss.simulacron.server.BoundCluster;
 import com.datastax.oss.simulacron.server.RejectScope;
@@ -131,6 +132,8 @@ public class ConnectIT {
     DriverConfigLoader loader =
         SessionUtils.configLoaderBuilder()
             .without(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER)
+            .withClass(
+                DefaultDriverOption.LOAD_BALANCING_POLICY_CLASS, DefaultLoadBalancingPolicy.class)
             .build();
     assertThatThrownBy(
             () ->

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/ConnectIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/ConnectIT.java
@@ -37,7 +37,6 @@ import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
 import com.datastax.oss.driver.api.testinfra.utils.ConditionChecker;
 import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.connection.ConstantReconnectionPolicy;
-import com.datastax.oss.driver.internal.core.loadbalancing.DefaultLoadBalancingPolicy;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
 import com.datastax.oss.simulacron.server.BoundCluster;
 import com.datastax.oss.simulacron.server.RejectScope;
@@ -132,12 +131,10 @@ public class ConnectIT {
     DriverConfigLoader loader =
         SessionUtils.configLoaderBuilder()
             .without(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER)
-            .withClass(
-                DefaultDriverOption.LOAD_BALANCING_POLICY_CLASS, DefaultLoadBalancingPolicy.class)
             .build();
     assertThatThrownBy(
             () ->
-                CqlSession.builder()
+                SessionUtils.baseBuilder()
                     .addContactEndPoints(SIMULACRON_RULE.getContactPoints())
                     .withConfigLoader(loader)
                     .build())


### PR DESCRIPTION
Default LBP needs to be set explicitly in order to work from the dse-driver's nightly runs