### PR TITLE
JAVA-2600: Introduce map-backed config loader

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.6.0 (in progress)
 
+- [new feature] JAVA-2600: Add map-backed config loader
 - [new feature] JAVA-2105: Add support for transient replication
 - [new feature] JAVA-2670: Provide base class for mapped custom codecs
 - [new feature] JAVA-2633: Add execution profile argument to DAO mapper factory methods

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -722,7 +722,7 @@ public enum DefaultDriverOption implements DriverOption {
    */
   NETTY_ADMIN_SHUTDOWN_QUIET_PERIOD("advanced.netty.admin-group.shutdown.quiet-period"),
   /**
-   * Units for admin group quiet period and timeout.
+   * Max time to wait for admin group shutdown.
    *
    * <p>Value-type: {@link String}
    */

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.config;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+import net.jcip.annotations.Immutable;
+import net.jcip.annotations.ThreadSafe;
+
+/**
+ * An in-memory repository of config options, for use with {@link
+ * DriverConfigLoader#fromMap(OptionsMap)}.
+ *
+ * <p>This class is intended for clients who wish to assemble the driver configuration in memory,
+ * instead of loading it from configuration files. Note that {@link #driverDefaults()} can be used
+ * to pre-initialize the map with the driver's built-in defaults.
+ *
+ * <p>It functions like a two-dimensional map indexed by execution profile and option. All methods
+ * have a profile-less variant that applies to the default profile, for example {@link #get(String,
+ * TypedDriverOption)} and {@link #get(TypedDriverOption)}. Options are represented by {@link
+ * TypedDriverOption}, which allows this class to enforce additional type-safety guarantees (an
+ * option can only be set to a value of its intended type).
+ *
+ * <p>This class is mutable and thread-safe. Live changes are reflected in real time to the driver
+ * session(s) that use this configuration.
+ *
+ * @since 4.6.0
+ */
+@ThreadSafe
+public class OptionsMap implements Serializable {
+
+  private static final long serialVersionUID = 1;
+
+  /**
+   * Creates a new instance that contains the driver's default configuration.
+   *
+   * <p>This will produce a configuration that is equivalent to the {@code reference.conf} file
+   * bundled with the driver (however, this method does not load any file, and doesn't require
+   * Typesafe config in the classpath).
+   */
+  @NonNull
+  public static OptionsMap driverDefaults() {
+    OptionsMap source = new OptionsMap();
+    fillWithDriverDefaults(source);
+    return source;
+  }
+
+  private final ConcurrentHashMap<String, Map<DriverOption, Object>> map;
+
+  private final List<Consumer<OptionsMap>> changeListeners = new CopyOnWriteArrayList<>();
+
+  public OptionsMap() {
+    this(new ConcurrentHashMap<>());
+  }
+
+  private OptionsMap(ConcurrentHashMap<String, Map<DriverOption, Object>> map) {
+    this.map = map;
+  }
+
+  /**
+   * Associates the specified value for the specified option, in the specified execution profile.
+   *
+   * @return the previous value associated with {@code option}, or {@code null} if the option was
+   *     not defined.
+   */
+  @Nullable
+  public <ValueT> ValueT put(
+      @NonNull String profile, @NonNull TypedDriverOption<ValueT> option, @NonNull ValueT value) {
+    Objects.requireNonNull(option, "option");
+    Objects.requireNonNull(value, "value");
+    Object previous = getProfileMap(profile).put(option.getRawOption(), value);
+    if (!value.equals(previous)) {
+      for (Consumer<OptionsMap> listener : changeListeners) {
+        listener.accept(this);
+      }
+    }
+    return cast(previous);
+  }
+
+  /**
+   * Associates the specified value for the specified option, in the default execution profile.
+   *
+   * @return the previous value associated with {@code option}, or {@code null} if the option was
+   *     not defined.
+   */
+  @Nullable
+  public <ValueT> ValueT put(@NonNull TypedDriverOption<ValueT> option, @NonNull ValueT value) {
+    return put(DriverExecutionProfile.DEFAULT_NAME, option, value);
+  }
+
+  /**
+   * Returns the value to which the specified option is mapped in the specified profile, or {@code
+   * null} if the option is not defined.
+   */
+  @Nullable
+  public <ValueT> ValueT get(@NonNull String profile, @NonNull TypedDriverOption<ValueT> option) {
+    Objects.requireNonNull(option, "option");
+    Object result = getProfileMap(profile).get(option.getRawOption());
+    return cast(result);
+  }
+
+  /**
+   * Returns the value to which the specified option is mapped in the default profile, or {@code
+   * null} if the option is not defined.
+   */
+  @Nullable
+  public <ValueT> ValueT get(@NonNull TypedDriverOption<ValueT> option) {
+    return get(DriverExecutionProfile.DEFAULT_NAME, option);
+  }
+
+  /**
+   * Removes the specified option from the specified profile.
+   *
+   * @return the previous value associated with {@code option}, or {@code null} if the option was
+   *     not defined.
+   */
+  @Nullable
+  public <ValueT> ValueT remove(
+      @NonNull String profile, @NonNull TypedDriverOption<ValueT> option) {
+    Objects.requireNonNull(option, "option");
+    Object previous = getProfileMap(profile).remove(option.getRawOption());
+    if (previous != null) {
+      for (Consumer<OptionsMap> listener : changeListeners) {
+        listener.accept(this);
+      }
+    }
+    return cast(previous);
+  }
+
+  /**
+   * Removes the specified option from the default profile.
+   *
+   * @return the previous value associated with {@code option}, or {@code null} if the option was
+   *     not defined.
+   */
+  @Nullable
+  public <ValueT> ValueT remove(@NonNull TypedDriverOption<ValueT> option) {
+    return remove(DriverExecutionProfile.DEFAULT_NAME, option);
+  }
+
+  /**
+   * Registers a listener that will get notified when this object changes.
+   *
+   * <p>This is mostly for internal use by the driver. Note that listeners are transient, and not
+   * taken into account by {@link #equals(Object)} and {@link #hashCode()}.
+   */
+  public void addChangeListener(@NonNull Consumer<OptionsMap> listener) {
+    changeListeners.add(Objects.requireNonNull(listener));
+  }
+
+  /**
+   * Unregisters a listener that was previously registered with {@link
+   * #addChangeListener(Consumer)}.
+   *
+   * @return {@code true} if the listener was indeed registered for this object.
+   */
+  public boolean removeChangeListener(@NonNull Consumer<OptionsMap> listener) {
+    return changeListeners.remove(Objects.requireNonNull(listener));
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    } else if (other instanceof OptionsMap) {
+      OptionsMap that = (OptionsMap) other;
+      return this.map.equals(that.map);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return map.hashCode();
+  }
+
+  /**
+   * Returns a live view of this object, using the driver's untyped {@link DriverOption}.
+   *
+   * <p>This is intended for internal usage by the driver. Modifying the resulting map is strongly
+   * discouraged, as it could break the type-safety guarantees provided by the public methods.
+   */
+  @NonNull
+  protected Map<String, Map<DriverOption, Object>> asRawMap() {
+    return map;
+  }
+
+  @NonNull
+  private Map<DriverOption, Object> getProfileMap(@NonNull String profile) {
+    Objects.requireNonNull(profile, "profile");
+    return map.computeIfAbsent(profile, p -> new ConcurrentHashMap<>());
+  }
+
+  // Isolate the suppressed warning for retrieval. The cast should always succeed unless the user
+  // messes with asMap() directly.
+  @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
+  @Nullable
+  private <ValueT> ValueT cast(@Nullable Object value) {
+    return (ValueT) value;
+  }
+
+  /**
+   * This object gets replaced by an internal proxy for serialization.
+   *
+   * @serialData the serialized form of the {@code Map<String, Map<DriverOption, Object>>} used to
+   *     store options internally (listeners are transient).
+   */
+  private Object writeReplace() {
+    return new SerializationProxy(this.map);
+  }
+
+  // Should never be called since we serialize a proxy
+  @SuppressWarnings("UnusedVariable")
+  private void readObject(ObjectInputStream stream) throws InvalidObjectException {
+    throw new InvalidObjectException("Proxy required");
+  }
+
+  protected static void fillWithDriverDefaults(OptionsMap map) {
+    // Sorted by order of appearance in reference.conf:
+
+    // Skip CONFIG_RELOAD_INTERVAL because the map-based config doesn't need periodic reloading
+    map.put(TypedDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(2));
+    map.put(TypedDriverOption.REQUEST_CONSISTENCY, "LOCAL_ONE");
+    map.put(TypedDriverOption.REQUEST_PAGE_SIZE, 5000);
+    map.put(TypedDriverOption.REQUEST_SERIAL_CONSISTENCY, "SERIAL");
+    map.put(TypedDriverOption.REQUEST_DEFAULT_IDEMPOTENCE, false);
+    map.put(TypedDriverOption.GRAPH_TRAVERSAL_SOURCE, "g");
+    map.put(TypedDriverOption.LOAD_BALANCING_POLICY_CLASS, "DefaultLoadBalancingPolicy");
+    map.put(TypedDriverOption.LOAD_BALANCING_POLICY_SLOW_AVOIDANCE, true);
+    map.put(TypedDriverOption.CONNECTION_CONNECT_TIMEOUT, Duration.ofSeconds(5));
+    map.put(TypedDriverOption.CONNECTION_INIT_QUERY_TIMEOUT, Duration.ofMillis(500));
+    map.put(TypedDriverOption.CONNECTION_SET_KEYSPACE_TIMEOUT, Duration.ofMillis(500));
+    map.put(TypedDriverOption.CONNECTION_POOL_LOCAL_SIZE, 1);
+    map.put(TypedDriverOption.CONNECTION_POOL_REMOTE_SIZE, 1);
+    map.put(TypedDriverOption.CONNECTION_MAX_REQUESTS, 1024);
+    map.put(TypedDriverOption.CONNECTION_MAX_ORPHAN_REQUESTS, 24576);
+    map.put(TypedDriverOption.CONNECTION_WARN_INIT_ERROR, true);
+    map.put(TypedDriverOption.RECONNECT_ON_INIT, false);
+    map.put(TypedDriverOption.RECONNECTION_POLICY_CLASS, "ExponentialReconnectionPolicy");
+    map.put(TypedDriverOption.RECONNECTION_BASE_DELAY, Duration.ofSeconds(1));
+    map.put(TypedDriverOption.RECONNECTION_MAX_DELAY, Duration.ofSeconds(60));
+    map.put(TypedDriverOption.RETRY_POLICY_CLASS, "DefaultRetryPolicy");
+    map.put(TypedDriverOption.SPECULATIVE_EXECUTION_POLICY_CLASS, "NoSpeculativeExecutionPolicy");
+    map.put(TypedDriverOption.TIMESTAMP_GENERATOR_CLASS, "AtomicTimestampGenerator");
+    map.put(TypedDriverOption.TIMESTAMP_GENERATOR_DRIFT_WARNING_THRESHOLD, Duration.ofSeconds(1));
+    map.put(TypedDriverOption.TIMESTAMP_GENERATOR_DRIFT_WARNING_INTERVAL, Duration.ofSeconds(10));
+    map.put(TypedDriverOption.TIMESTAMP_GENERATOR_FORCE_JAVA_CLOCK, false);
+    map.put(TypedDriverOption.REQUEST_TRACKER_CLASS, "NoopRequestTracker");
+    map.put(TypedDriverOption.REQUEST_THROTTLER_CLASS, "PassThroughRequestThrottler");
+    map.put(TypedDriverOption.METADATA_NODE_STATE_LISTENER_CLASS, "NoopNodeStateListener");
+    map.put(TypedDriverOption.METADATA_SCHEMA_CHANGE_LISTENER_CLASS, "NoopSchemaChangeListener");
+    map.put(TypedDriverOption.ADDRESS_TRANSLATOR_CLASS, "PassThroughAddressTranslator");
+    map.put(TypedDriverOption.RESOLVE_CONTACT_POINTS, true);
+    map.put(TypedDriverOption.PROTOCOL_MAX_FRAME_LENGTH, 256L * 1024 * 1024);
+    map.put(TypedDriverOption.REQUEST_WARN_IF_SET_KEYSPACE, true);
+    map.put(TypedDriverOption.REQUEST_TRACE_ATTEMPTS, 5);
+    map.put(TypedDriverOption.REQUEST_TRACE_INTERVAL, Duration.ofMillis(3));
+    map.put(TypedDriverOption.REQUEST_TRACE_CONSISTENCY, "ONE");
+    map.put(TypedDriverOption.REQUEST_LOG_WARNINGS, true);
+    map.put(TypedDriverOption.GRAPH_PAGING_ENABLED, "AUTO");
+    map.put(TypedDriverOption.GRAPH_CONTINUOUS_PAGING_PAGE_SIZE, 5000);
+    map.put(TypedDriverOption.GRAPH_CONTINUOUS_PAGING_MAX_PAGES, 0);
+    map.put(TypedDriverOption.GRAPH_CONTINUOUS_PAGING_MAX_PAGES_PER_SECOND, 0);
+    map.put(TypedDriverOption.GRAPH_CONTINUOUS_PAGING_MAX_ENQUEUED_PAGES, 4);
+    map.put(TypedDriverOption.CONTINUOUS_PAGING_PAGE_SIZE, 5000);
+    map.put(TypedDriverOption.CONTINUOUS_PAGING_PAGE_SIZE_BYTES, false);
+    map.put(TypedDriverOption.CONTINUOUS_PAGING_MAX_PAGES, 0);
+    map.put(TypedDriverOption.CONTINUOUS_PAGING_MAX_PAGES_PER_SECOND, 0);
+    map.put(TypedDriverOption.CONTINUOUS_PAGING_MAX_ENQUEUED_PAGES, 4);
+    map.put(TypedDriverOption.CONTINUOUS_PAGING_TIMEOUT_FIRST_PAGE, Duration.ofSeconds(2));
+    map.put(TypedDriverOption.CONTINUOUS_PAGING_TIMEOUT_OTHER_PAGES, Duration.ofSeconds(1));
+    map.put(TypedDriverOption.MONITOR_REPORTING_ENABLED, true);
+    map.put(TypedDriverOption.METRICS_SESSION_ENABLED, Collections.emptyList());
+    map.put(TypedDriverOption.METRICS_SESSION_CQL_REQUESTS_HIGHEST, Duration.ofSeconds(3));
+    map.put(TypedDriverOption.METRICS_SESSION_CQL_REQUESTS_DIGITS, 3);
+    map.put(TypedDriverOption.METRICS_SESSION_CQL_REQUESTS_INTERVAL, Duration.ofMinutes(5));
+    map.put(TypedDriverOption.METRICS_SESSION_THROTTLING_HIGHEST, Duration.ofSeconds(3));
+    map.put(TypedDriverOption.METRICS_SESSION_THROTTLING_DIGITS, 3);
+    map.put(TypedDriverOption.METRICS_SESSION_THROTTLING_INTERVAL, Duration.ofMinutes(5));
+    map.put(
+        TypedDriverOption.CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_HIGHEST,
+        Duration.ofSeconds(3));
+    map.put(TypedDriverOption.CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_DIGITS, 3);
+    map.put(
+        TypedDriverOption.CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_INTERVAL,
+        Duration.ofMinutes(5));
+    map.put(TypedDriverOption.METRICS_SESSION_GRAPH_REQUESTS_HIGHEST, Duration.ofSeconds(3));
+    map.put(TypedDriverOption.METRICS_SESSION_GRAPH_REQUESTS_DIGITS, 3);
+    map.put(TypedDriverOption.METRICS_SESSION_GRAPH_REQUESTS_INTERVAL, Duration.ofMinutes(5));
+    map.put(TypedDriverOption.METRICS_NODE_ENABLED, Collections.emptyList());
+    map.put(TypedDriverOption.METRICS_NODE_CQL_MESSAGES_HIGHEST, Duration.ofSeconds(3));
+    map.put(TypedDriverOption.METRICS_NODE_CQL_MESSAGES_DIGITS, 3);
+    map.put(TypedDriverOption.METRICS_NODE_CQL_MESSAGES_INTERVAL, Duration.ofMinutes(5));
+    map.put(TypedDriverOption.METRICS_NODE_GRAPH_MESSAGES_HIGHEST, Duration.ofSeconds(3));
+    map.put(TypedDriverOption.METRICS_NODE_GRAPH_MESSAGES_DIGITS, 3);
+    map.put(TypedDriverOption.METRICS_NODE_GRAPH_MESSAGES_INTERVAL, Duration.ofMinutes(5));
+    map.put(TypedDriverOption.SOCKET_TCP_NODELAY, true);
+    map.put(TypedDriverOption.HEARTBEAT_INTERVAL, Duration.ofSeconds(30));
+    map.put(TypedDriverOption.HEARTBEAT_TIMEOUT, Duration.ofMillis(500));
+    map.put(TypedDriverOption.METADATA_TOPOLOGY_WINDOW, Duration.ofSeconds(1));
+    map.put(TypedDriverOption.METADATA_TOPOLOGY_MAX_EVENTS, 20);
+    map.put(TypedDriverOption.METADATA_SCHEMA_ENABLED, true);
+    map.put(TypedDriverOption.METADATA_SCHEMA_REQUEST_TIMEOUT, Duration.ofSeconds(2));
+    map.put(TypedDriverOption.METADATA_SCHEMA_REQUEST_PAGE_SIZE, 5000);
+    map.put(TypedDriverOption.METADATA_SCHEMA_WINDOW, Duration.ofSeconds(1));
+    map.put(TypedDriverOption.METADATA_SCHEMA_MAX_EVENTS, 20);
+    map.put(TypedDriverOption.METADATA_TOKEN_MAP_ENABLED, true);
+    map.put(TypedDriverOption.CONTROL_CONNECTION_TIMEOUT, Duration.ofMillis(500));
+    map.put(TypedDriverOption.CONTROL_CONNECTION_AGREEMENT_INTERVAL, Duration.ofMillis(200));
+    map.put(TypedDriverOption.CONTROL_CONNECTION_AGREEMENT_TIMEOUT, Duration.ofSeconds(10));
+    map.put(TypedDriverOption.CONTROL_CONNECTION_AGREEMENT_WARN, true);
+    map.put(TypedDriverOption.PREPARE_ON_ALL_NODES, true);
+    map.put(TypedDriverOption.REPREPARE_ENABLED, true);
+    map.put(TypedDriverOption.REPREPARE_CHECK_SYSTEM_TABLE, false);
+    map.put(TypedDriverOption.REPREPARE_MAX_STATEMENTS, 0);
+    map.put(TypedDriverOption.REPREPARE_MAX_PARALLELISM, 100);
+    map.put(TypedDriverOption.REPREPARE_TIMEOUT, Duration.ofMillis(500));
+    map.put(TypedDriverOption.NETTY_DAEMON, false);
+    map.put(TypedDriverOption.NETTY_IO_SIZE, 0);
+    map.put(TypedDriverOption.NETTY_IO_SHUTDOWN_QUIET_PERIOD, 2);
+    map.put(TypedDriverOption.NETTY_IO_SHUTDOWN_TIMEOUT, 15);
+    map.put(TypedDriverOption.NETTY_IO_SHUTDOWN_UNIT, "SECONDS");
+    map.put(TypedDriverOption.NETTY_ADMIN_SIZE, 2);
+    map.put(TypedDriverOption.NETTY_ADMIN_SHUTDOWN_QUIET_PERIOD, 2);
+    map.put(TypedDriverOption.NETTY_ADMIN_SHUTDOWN_TIMEOUT, 15);
+    map.put(TypedDriverOption.NETTY_ADMIN_SHUTDOWN_UNIT, "SECONDS");
+    map.put(TypedDriverOption.NETTY_TIMER_TICK_DURATION, Duration.ofMillis(100));
+    map.put(TypedDriverOption.NETTY_TIMER_TICKS_PER_WHEEL, 2048);
+    map.put(TypedDriverOption.COALESCER_MAX_RUNS, 5);
+    map.put(TypedDriverOption.COALESCER_INTERVAL, Duration.of(10, ChronoUnit.MICROS));
+  }
+
+  @Immutable
+  private static class SerializationProxy implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final ConcurrentHashMap<String, Map<DriverOption, Object>> map;
+
+    private SerializationProxy(ConcurrentHashMap<String, Map<DriverOption, Object>> map) {
+      this.map = map;
+    }
+
+    private Object readResolve() {
+      return new OptionsMap(map);
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -1,0 +1,717 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.config;
+
+import com.datastax.dse.driver.api.core.config.DseDriverOption;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * A type-safe wrapper around {@link DriverOption}, that encodes the intended value type of each
+ * option.
+ *
+ * <p>This type was introduced in conjunction with {@link DriverConfigLoader#fromMap(OptionsMap)}.
+ * Unfortunately, for backward compatibility reasons, it wasn't possible to retrofit the rest of the
+ * driver to use it; therefore the APIs used to read the configuration, such as {@link DriverConfig}
+ * and {@link DriverExecutionProfile}, still use the untyped {@link DriverOption}.
+ *
+ * @since 4.6.0
+ */
+public class TypedDriverOption<ValueT> {
+
+  private static volatile Iterable<TypedDriverOption<?>> builtInValues;
+
+  /**
+   * Returns the list of all built-in options known to the driver codebase; in other words, all the
+   * {@link TypedDriverOption} constants defined on this class.
+   *
+   * <p>Note that 3rd-party driver extensions might define their own {@link TypedDriverOption}
+   * constants for custom options.
+   *
+   * <p>This method uses reflection to introspect all the constants on this class; the result is
+   * computed lazily on the first invocation, and then cached for future calls.
+   */
+  public static Iterable<TypedDriverOption<?>> builtInValues() {
+    if (builtInValues == null) {
+      builtInValues = introspectBuiltInValues();
+    }
+    return builtInValues;
+  }
+
+  private final DriverOption rawOption;
+  private final GenericType<ValueT> expectedType;
+
+  public TypedDriverOption(
+      @NonNull DriverOption rawOption, @NonNull GenericType<ValueT> expectedType) {
+    this.rawOption = Objects.requireNonNull(rawOption);
+    this.expectedType = Objects.requireNonNull(expectedType);
+  }
+
+  @NonNull
+  public DriverOption getRawOption() {
+    return rawOption;
+  }
+
+  @NonNull
+  public GenericType<ValueT> getExpectedType() {
+    return expectedType;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    } else if (other instanceof TypedDriverOption) {
+      TypedDriverOption<?> that = (TypedDriverOption<?>) other;
+      return this.rawOption.equals(that.rawOption) && this.expectedType.equals(that.expectedType);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(rawOption, expectedType);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", TypedDriverOption.class.getSimpleName() + "[", "]")
+        .add("rawOption=" + rawOption)
+        .add("expectedType=" + expectedType)
+        .toString();
+  }
+
+  /** The contact points to use for the initial connection to the cluster. */
+  public static final TypedDriverOption<List<String>> CONTACT_POINTS =
+      new TypedDriverOption<>(DefaultDriverOption.CONTACT_POINTS, GenericType.listOf(String.class));
+  /** A name that uniquely identifies the driver instance. */
+  public static final TypedDriverOption<String> SESSION_NAME =
+      new TypedDriverOption<>(DefaultDriverOption.SESSION_NAME, GenericType.STRING);
+  /** The name of the keyspace that the session should initially be connected to. */
+  public static final TypedDriverOption<String> SESSION_KEYSPACE =
+      new TypedDriverOption<>(DefaultDriverOption.SESSION_KEYSPACE, GenericType.STRING);
+  /** How often the driver tries to reload the configuration. */
+  public static final TypedDriverOption<Duration> CONFIG_RELOAD_INTERVAL =
+      new TypedDriverOption<>(DefaultDriverOption.CONFIG_RELOAD_INTERVAL, GenericType.DURATION);
+  /** How long the driver waits for a request to complete. */
+  public static final TypedDriverOption<Duration> REQUEST_TIMEOUT =
+      new TypedDriverOption<>(DefaultDriverOption.REQUEST_TIMEOUT, GenericType.DURATION);
+  /** The consistency level. */
+  public static final TypedDriverOption<String> REQUEST_CONSISTENCY =
+      new TypedDriverOption<>(DefaultDriverOption.REQUEST_CONSISTENCY, GenericType.STRING);
+  /** The page size. */
+  public static final TypedDriverOption<Integer> REQUEST_PAGE_SIZE =
+      new TypedDriverOption<>(DefaultDriverOption.REQUEST_PAGE_SIZE, GenericType.INTEGER);
+  /** The serial consistency level. */
+  public static final TypedDriverOption<String> REQUEST_SERIAL_CONSISTENCY =
+      new TypedDriverOption<>(DefaultDriverOption.REQUEST_SERIAL_CONSISTENCY, GenericType.STRING);
+  /** The default idempotence of a request. */
+  public static final TypedDriverOption<Boolean> REQUEST_DEFAULT_IDEMPOTENCE =
+      new TypedDriverOption<>(DefaultDriverOption.REQUEST_DEFAULT_IDEMPOTENCE, GenericType.BOOLEAN);
+  /** The class of the load balancing policy. */
+  public static final TypedDriverOption<String> LOAD_BALANCING_POLICY_CLASS =
+      new TypedDriverOption<>(DefaultDriverOption.LOAD_BALANCING_POLICY_CLASS, GenericType.STRING);
+  /** The datacenter that is considered "local". */
+  public static final TypedDriverOption<String> LOAD_BALANCING_LOCAL_DATACENTER =
+      new TypedDriverOption<>(
+          DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER, GenericType.STRING);
+  /** A custom filter to include/exclude nodes. */
+  public static final TypedDriverOption<String> LOAD_BALANCING_FILTER_CLASS =
+      new TypedDriverOption<>(DefaultDriverOption.LOAD_BALANCING_FILTER_CLASS, GenericType.STRING);
+  /** The timeout to use for internal queries that run as part of the initialization process. */
+  public static final TypedDriverOption<Duration> CONNECTION_INIT_QUERY_TIMEOUT =
+      new TypedDriverOption<>(
+          DefaultDriverOption.CONNECTION_INIT_QUERY_TIMEOUT, GenericType.DURATION);
+  /** The timeout to use when the driver changes the keyspace on a connection at runtime. */
+  public static final TypedDriverOption<Duration> CONNECTION_SET_KEYSPACE_TIMEOUT =
+      new TypedDriverOption<>(
+          DefaultDriverOption.CONNECTION_SET_KEYSPACE_TIMEOUT, GenericType.DURATION);
+  /** The maximum number of requests that can be executed concurrently on a connection. */
+  public static final TypedDriverOption<Integer> CONNECTION_MAX_REQUESTS =
+      new TypedDriverOption<>(DefaultDriverOption.CONNECTION_MAX_REQUESTS, GenericType.INTEGER);
+  /** The maximum number of "orphaned" requests before a connection gets closed automatically. */
+  public static final TypedDriverOption<Integer> CONNECTION_MAX_ORPHAN_REQUESTS =
+      new TypedDriverOption<>(
+          DefaultDriverOption.CONNECTION_MAX_ORPHAN_REQUESTS, GenericType.INTEGER);
+  /** Whether to log non-fatal errors when the driver tries to open a new connection. */
+  public static final TypedDriverOption<Boolean> CONNECTION_WARN_INIT_ERROR =
+      new TypedDriverOption<>(DefaultDriverOption.CONNECTION_WARN_INIT_ERROR, GenericType.BOOLEAN);
+  /** The number of connections in the LOCAL pool. */
+  public static final TypedDriverOption<Integer> CONNECTION_POOL_LOCAL_SIZE =
+      new TypedDriverOption<>(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE, GenericType.INTEGER);
+  /** The number of connections in the REMOTE pool. */
+  public static final TypedDriverOption<Integer> CONNECTION_POOL_REMOTE_SIZE =
+      new TypedDriverOption<>(DefaultDriverOption.CONNECTION_POOL_REMOTE_SIZE, GenericType.INTEGER);
+  /**
+   * Whether to schedule reconnection attempts if all contact points are unreachable on the first
+   * initialization attempt.
+   */
+  public static final TypedDriverOption<Boolean> RECONNECT_ON_INIT =
+      new TypedDriverOption<>(DefaultDriverOption.RECONNECT_ON_INIT, GenericType.BOOLEAN);
+  /** The class of the reconnection policy. */
+  public static final TypedDriverOption<String> RECONNECTION_POLICY_CLASS =
+      new TypedDriverOption<>(DefaultDriverOption.RECONNECTION_POLICY_CLASS, GenericType.STRING);
+  /** Base delay for computing time between reconnection attempts. */
+  public static final TypedDriverOption<Duration> RECONNECTION_BASE_DELAY =
+      new TypedDriverOption<>(DefaultDriverOption.RECONNECTION_BASE_DELAY, GenericType.DURATION);
+  /** Maximum delay between reconnection attempts. */
+  public static final TypedDriverOption<Duration> RECONNECTION_MAX_DELAY =
+      new TypedDriverOption<>(DefaultDriverOption.RECONNECTION_MAX_DELAY, GenericType.DURATION);
+  /** The class of the retry policy. */
+  public static final TypedDriverOption<String> RETRY_POLICY_CLASS =
+      new TypedDriverOption<>(DefaultDriverOption.RETRY_POLICY_CLASS, GenericType.STRING);
+  /** The class of the speculative execution policy. */
+  public static final TypedDriverOption<String> SPECULATIVE_EXECUTION_POLICY_CLASS =
+      new TypedDriverOption<>(
+          DefaultDriverOption.SPECULATIVE_EXECUTION_POLICY_CLASS, GenericType.STRING);
+  /** The maximum number of executions. */
+  public static final TypedDriverOption<Integer> SPECULATIVE_EXECUTION_MAX =
+      new TypedDriverOption<>(DefaultDriverOption.SPECULATIVE_EXECUTION_MAX, GenericType.INTEGER);
+  /** The delay between each execution. */
+  public static final TypedDriverOption<Duration> SPECULATIVE_EXECUTION_DELAY =
+      new TypedDriverOption<>(
+          DefaultDriverOption.SPECULATIVE_EXECUTION_DELAY, GenericType.DURATION);
+  /** The class of the authentication provider. */
+  public static final TypedDriverOption<String> AUTH_PROVIDER_CLASS =
+      new TypedDriverOption<>(DefaultDriverOption.AUTH_PROVIDER_CLASS, GenericType.STRING);
+  /** Plain text auth provider username. */
+  public static final TypedDriverOption<String> AUTH_PROVIDER_USER_NAME =
+      new TypedDriverOption<>(DefaultDriverOption.AUTH_PROVIDER_USER_NAME, GenericType.STRING);
+  /** Plain text auth provider password. */
+  public static final TypedDriverOption<String> AUTH_PROVIDER_PASSWORD =
+      new TypedDriverOption<>(DefaultDriverOption.AUTH_PROVIDER_PASSWORD, GenericType.STRING);
+  /** The class of the SSL Engine Factory. */
+  public static final TypedDriverOption<String> SSL_ENGINE_FACTORY_CLASS =
+      new TypedDriverOption<>(DefaultDriverOption.SSL_ENGINE_FACTORY_CLASS, GenericType.STRING);
+  /** The cipher suites to enable when creating an SSLEngine for a connection. */
+  public static final TypedDriverOption<List<String>> SSL_CIPHER_SUITES =
+      new TypedDriverOption<>(
+          DefaultDriverOption.SSL_CIPHER_SUITES, GenericType.listOf(String.class));
+  /**
+   * Whether or not to require validation that the hostname of the server certificate's common name
+   * matches the hostname of the server being connected to.
+   */
+  public static final TypedDriverOption<Boolean> SSL_HOSTNAME_VALIDATION =
+      new TypedDriverOption<>(DefaultDriverOption.SSL_HOSTNAME_VALIDATION, GenericType.BOOLEAN);
+  /** The location of the keystore file. */
+  public static final TypedDriverOption<String> SSL_KEYSTORE_PATH =
+      new TypedDriverOption<>(DefaultDriverOption.SSL_KEYSTORE_PATH, GenericType.STRING);
+  /** The keystore password. */
+  public static final TypedDriverOption<String> SSL_KEYSTORE_PASSWORD =
+      new TypedDriverOption<>(DefaultDriverOption.SSL_KEYSTORE_PASSWORD, GenericType.STRING);
+  /** The location of the truststore file. */
+  public static final TypedDriverOption<String> SSL_TRUSTSTORE_PATH =
+      new TypedDriverOption<>(DefaultDriverOption.SSL_TRUSTSTORE_PATH, GenericType.STRING);
+  /** The truststore password. */
+  public static final TypedDriverOption<String> SSL_TRUSTSTORE_PASSWORD =
+      new TypedDriverOption<>(DefaultDriverOption.SSL_TRUSTSTORE_PASSWORD, GenericType.STRING);
+  /** The class of the generator that assigns a microsecond timestamp to each request. */
+  public static final TypedDriverOption<String> TIMESTAMP_GENERATOR_CLASS =
+      new TypedDriverOption<>(DefaultDriverOption.TIMESTAMP_GENERATOR_CLASS, GenericType.STRING);
+  /** Whether to force the driver to use Java's millisecond-precision system clock. */
+  public static final TypedDriverOption<Boolean> TIMESTAMP_GENERATOR_FORCE_JAVA_CLOCK =
+      new TypedDriverOption<>(
+          DefaultDriverOption.TIMESTAMP_GENERATOR_FORCE_JAVA_CLOCK, GenericType.BOOLEAN);
+  /** How far in the future timestamps are allowed to drift before the warning is logged. */
+  public static final TypedDriverOption<Duration> TIMESTAMP_GENERATOR_DRIFT_WARNING_THRESHOLD =
+      new TypedDriverOption<>(
+          DefaultDriverOption.TIMESTAMP_GENERATOR_DRIFT_WARNING_THRESHOLD, GenericType.DURATION);
+  /** How often the warning will be logged if timestamps keep drifting above the threshold. */
+  public static final TypedDriverOption<Duration> TIMESTAMP_GENERATOR_DRIFT_WARNING_INTERVAL =
+      new TypedDriverOption<>(
+          DefaultDriverOption.TIMESTAMP_GENERATOR_DRIFT_WARNING_INTERVAL, GenericType.DURATION);
+  /** The class of a session-wide component that tracks the outcome of requests. */
+  public static final TypedDriverOption<String> REQUEST_TRACKER_CLASS =
+      new TypedDriverOption<>(DefaultDriverOption.REQUEST_TRACKER_CLASS, GenericType.STRING);
+  /** Whether to log successful requests. */
+  public static final TypedDriverOption<Boolean> REQUEST_LOGGER_SUCCESS_ENABLED =
+      new TypedDriverOption<>(
+          DefaultDriverOption.REQUEST_LOGGER_SUCCESS_ENABLED, GenericType.BOOLEAN);
+  /** The threshold to classify a successful request as "slow". */
+  public static final TypedDriverOption<Duration> REQUEST_LOGGER_SLOW_THRESHOLD =
+      new TypedDriverOption<>(
+          DefaultDriverOption.REQUEST_LOGGER_SLOW_THRESHOLD, GenericType.DURATION);
+  /** Whether to log slow requests. */
+  public static final TypedDriverOption<Boolean> REQUEST_LOGGER_SLOW_ENABLED =
+      new TypedDriverOption<>(DefaultDriverOption.REQUEST_LOGGER_SLOW_ENABLED, GenericType.BOOLEAN);
+  /** Whether to log failed requests. */
+  public static final TypedDriverOption<Boolean> REQUEST_LOGGER_ERROR_ENABLED =
+      new TypedDriverOption<>(
+          DefaultDriverOption.REQUEST_LOGGER_ERROR_ENABLED, GenericType.BOOLEAN);
+  /** The maximum length of the query string in the log message. */
+  public static final TypedDriverOption<Integer> REQUEST_LOGGER_MAX_QUERY_LENGTH =
+      new TypedDriverOption<>(
+          DefaultDriverOption.REQUEST_LOGGER_MAX_QUERY_LENGTH, GenericType.INTEGER);
+  /** Whether to log bound values in addition to the query string. */
+  public static final TypedDriverOption<Boolean> REQUEST_LOGGER_VALUES =
+      new TypedDriverOption<>(DefaultDriverOption.REQUEST_LOGGER_VALUES, GenericType.BOOLEAN);
+  /** The maximum length for bound values in the log message. */
+  public static final TypedDriverOption<Integer> REQUEST_LOGGER_MAX_VALUE_LENGTH =
+      new TypedDriverOption<>(
+          DefaultDriverOption.REQUEST_LOGGER_MAX_VALUE_LENGTH, GenericType.INTEGER);
+  /** The maximum number of bound values to log. */
+  public static final TypedDriverOption<Integer> REQUEST_LOGGER_MAX_VALUES =
+      new TypedDriverOption<>(DefaultDriverOption.REQUEST_LOGGER_MAX_VALUES, GenericType.INTEGER);
+  /** Whether to log stack traces for failed queries. */
+  public static final TypedDriverOption<Boolean> REQUEST_LOGGER_STACK_TRACES =
+      new TypedDriverOption<>(DefaultDriverOption.REQUEST_LOGGER_STACK_TRACES, GenericType.BOOLEAN);
+  /**
+   * The class of a session-wide component that controls the rate at which requests are executed.
+   */
+  public static final TypedDriverOption<String> REQUEST_THROTTLER_CLASS =
+      new TypedDriverOption<>(DefaultDriverOption.REQUEST_THROTTLER_CLASS, GenericType.STRING);
+  /** The maximum number of requests that are allowed to execute in parallel. */
+  public static final TypedDriverOption<Integer> REQUEST_THROTTLER_MAX_CONCURRENT_REQUESTS =
+      new TypedDriverOption<>(
+          DefaultDriverOption.REQUEST_THROTTLER_MAX_CONCURRENT_REQUESTS, GenericType.INTEGER);
+  /** The maximum allowed request rate. */
+  public static final TypedDriverOption<Integer> REQUEST_THROTTLER_MAX_REQUESTS_PER_SECOND =
+      new TypedDriverOption<>(
+          DefaultDriverOption.REQUEST_THROTTLER_MAX_REQUESTS_PER_SECOND, GenericType.INTEGER);
+  /**
+   * The maximum number of requests that can be enqueued when the throttling threshold is exceeded.
+   */
+  public static final TypedDriverOption<Integer> REQUEST_THROTTLER_MAX_QUEUE_SIZE =
+      new TypedDriverOption<>(
+          DefaultDriverOption.REQUEST_THROTTLER_MAX_QUEUE_SIZE, GenericType.INTEGER);
+  /** How often the throttler attempts to dequeue requests. */
+  public static final TypedDriverOption<Duration> REQUEST_THROTTLER_DRAIN_INTERVAL =
+      new TypedDriverOption<>(
+          DefaultDriverOption.REQUEST_THROTTLER_DRAIN_INTERVAL, GenericType.DURATION);
+  /** The class of a session-wide component that listens for node state changes. */
+  public static final TypedDriverOption<String> METADATA_NODE_STATE_LISTENER_CLASS =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METADATA_NODE_STATE_LISTENER_CLASS, GenericType.STRING);
+  /** The class of a session-wide component that listens for schema changes. */
+  public static final TypedDriverOption<String> METADATA_SCHEMA_CHANGE_LISTENER_CLASS =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METADATA_SCHEMA_CHANGE_LISTENER_CLASS, GenericType.STRING);
+  /**
+   * The class of the address translator to use to convert the addresses sent by Cassandra nodes
+   * into ones that the driver uses to connect.
+   */
+  public static final TypedDriverOption<String> ADDRESS_TRANSLATOR_CLASS =
+      new TypedDriverOption<>(DefaultDriverOption.ADDRESS_TRANSLATOR_CLASS, GenericType.STRING);
+  /** The native protocol version to use. */
+  public static final TypedDriverOption<String> PROTOCOL_VERSION =
+      new TypedDriverOption<>(DefaultDriverOption.PROTOCOL_VERSION, GenericType.STRING);
+  /** The name of the algorithm used to compress protocol frames. */
+  public static final TypedDriverOption<String> PROTOCOL_COMPRESSION =
+      new TypedDriverOption<>(DefaultDriverOption.PROTOCOL_COMPRESSION, GenericType.STRING);
+  /** The maximum length, in bytes, of the frames supported by the driver. */
+  public static final TypedDriverOption<Long> PROTOCOL_MAX_FRAME_LENGTH =
+      new TypedDriverOption<>(DefaultDriverOption.PROTOCOL_MAX_FRAME_LENGTH, GenericType.LONG);
+  /**
+   * Whether a warning is logged when a request (such as a CQL `USE ...`) changes the active
+   * keyspace.
+   */
+  public static final TypedDriverOption<Boolean> REQUEST_WARN_IF_SET_KEYSPACE =
+      new TypedDriverOption<>(
+          DefaultDriverOption.REQUEST_WARN_IF_SET_KEYSPACE, GenericType.BOOLEAN);
+  /** How many times the driver will attempt to fetch the query trace if it is not ready yet. */
+  public static final TypedDriverOption<Integer> REQUEST_TRACE_ATTEMPTS =
+      new TypedDriverOption<>(DefaultDriverOption.REQUEST_TRACE_ATTEMPTS, GenericType.INTEGER);
+  /** The interval between each attempt. */
+  public static final TypedDriverOption<Duration> REQUEST_TRACE_INTERVAL =
+      new TypedDriverOption<>(DefaultDriverOption.REQUEST_TRACE_INTERVAL, GenericType.DURATION);
+  /** The consistency level to use for trace queries. */
+  public static final TypedDriverOption<String> REQUEST_TRACE_CONSISTENCY =
+      new TypedDriverOption<>(DefaultDriverOption.REQUEST_TRACE_CONSISTENCY, GenericType.STRING);
+  /** List of enabled session-level metrics. */
+  public static final TypedDriverOption<List<String>> METRICS_SESSION_ENABLED =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METRICS_SESSION_ENABLED, GenericType.listOf(String.class));
+  /** List of enabled node-level metrics. */
+  public static final TypedDriverOption<List<String>> METRICS_NODE_ENABLED =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METRICS_NODE_ENABLED, GenericType.listOf(String.class));
+  /** The largest latency that we expect to record for requests. */
+  public static final TypedDriverOption<Duration> METRICS_SESSION_CQL_REQUESTS_HIGHEST =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METRICS_SESSION_CQL_REQUESTS_HIGHEST, GenericType.DURATION);
+  /**
+   * The number of significant decimal digits to which internal structures will maintain for
+   * requests.
+   */
+  public static final TypedDriverOption<Integer> METRICS_SESSION_CQL_REQUESTS_DIGITS =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METRICS_SESSION_CQL_REQUESTS_DIGITS, GenericType.INTEGER);
+  /** The interval at which percentile data is refreshed for requests. */
+  public static final TypedDriverOption<Duration> METRICS_SESSION_CQL_REQUESTS_INTERVAL =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METRICS_SESSION_CQL_REQUESTS_INTERVAL, GenericType.DURATION);
+  /** The largest latency that we expect to record for throttling. */
+  public static final TypedDriverOption<Duration> METRICS_SESSION_THROTTLING_HIGHEST =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METRICS_SESSION_THROTTLING_HIGHEST, GenericType.DURATION);
+  /**
+   * The number of significant decimal digits to which internal structures will maintain for
+   * throttling.
+   */
+  public static final TypedDriverOption<Integer> METRICS_SESSION_THROTTLING_DIGITS =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METRICS_SESSION_THROTTLING_DIGITS, GenericType.INTEGER);
+  /** The interval at which percentile data is refreshed for throttling. */
+  public static final TypedDriverOption<Duration> METRICS_SESSION_THROTTLING_INTERVAL =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METRICS_SESSION_THROTTLING_INTERVAL, GenericType.DURATION);
+  /** The largest latency that we expect to record for requests. */
+  public static final TypedDriverOption<Duration> METRICS_NODE_CQL_MESSAGES_HIGHEST =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METRICS_NODE_CQL_MESSAGES_HIGHEST, GenericType.DURATION);
+  /**
+   * The number of significant decimal digits to which internal structures will maintain for
+   * requests.
+   */
+  public static final TypedDriverOption<Integer> METRICS_NODE_CQL_MESSAGES_DIGITS =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METRICS_NODE_CQL_MESSAGES_DIGITS, GenericType.INTEGER);
+  /** The interval at which percentile data is refreshed for requests. */
+  public static final TypedDriverOption<Duration> METRICS_NODE_CQL_MESSAGES_INTERVAL =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METRICS_NODE_CQL_MESSAGES_INTERVAL, GenericType.DURATION);
+  /** Whether or not to disable the Nagle algorithm. */
+  public static final TypedDriverOption<Boolean> SOCKET_TCP_NODELAY =
+      new TypedDriverOption<>(DefaultDriverOption.SOCKET_TCP_NODELAY, GenericType.BOOLEAN);
+  /** Whether or not to enable TCP keep-alive probes. */
+  public static final TypedDriverOption<Boolean> SOCKET_KEEP_ALIVE =
+      new TypedDriverOption<>(DefaultDriverOption.SOCKET_KEEP_ALIVE, GenericType.BOOLEAN);
+  /** Whether or not to allow address reuse. */
+  public static final TypedDriverOption<Boolean> SOCKET_REUSE_ADDRESS =
+      new TypedDriverOption<>(DefaultDriverOption.SOCKET_REUSE_ADDRESS, GenericType.BOOLEAN);
+  /** Sets the linger interval. */
+  public static final TypedDriverOption<Integer> SOCKET_LINGER_INTERVAL =
+      new TypedDriverOption<>(DefaultDriverOption.SOCKET_LINGER_INTERVAL, GenericType.INTEGER);
+  /** Sets a hint to the size of the underlying buffers for incoming network I/O. */
+  public static final TypedDriverOption<Integer> SOCKET_RECEIVE_BUFFER_SIZE =
+      new TypedDriverOption<>(DefaultDriverOption.SOCKET_RECEIVE_BUFFER_SIZE, GenericType.INTEGER);
+  /** Sets a hint to the size of the underlying buffers for outgoing network I/O. */
+  public static final TypedDriverOption<Integer> SOCKET_SEND_BUFFER_SIZE =
+      new TypedDriverOption<>(DefaultDriverOption.SOCKET_SEND_BUFFER_SIZE, GenericType.INTEGER);
+  /** The connection heartbeat interval. */
+  public static final TypedDriverOption<Duration> HEARTBEAT_INTERVAL =
+      new TypedDriverOption<>(DefaultDriverOption.HEARTBEAT_INTERVAL, GenericType.DURATION);
+  /** How long the driver waits for the response to a heartbeat. */
+  public static final TypedDriverOption<Duration> HEARTBEAT_TIMEOUT =
+      new TypedDriverOption<>(DefaultDriverOption.HEARTBEAT_TIMEOUT, GenericType.DURATION);
+  /** How long the driver waits to propagate a Topology event. */
+  public static final TypedDriverOption<Duration> METADATA_TOPOLOGY_WINDOW =
+      new TypedDriverOption<>(DefaultDriverOption.METADATA_TOPOLOGY_WINDOW, GenericType.DURATION);
+  /** The maximum number of events that can accumulate. */
+  public static final TypedDriverOption<Integer> METADATA_TOPOLOGY_MAX_EVENTS =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METADATA_TOPOLOGY_MAX_EVENTS, GenericType.INTEGER);
+  /** Whether schema metadata is enabled. */
+  public static final TypedDriverOption<Boolean> METADATA_SCHEMA_ENABLED =
+      new TypedDriverOption<>(DefaultDriverOption.METADATA_SCHEMA_ENABLED, GenericType.BOOLEAN);
+  /** The timeout for the requests to the schema tables. */
+  public static final TypedDriverOption<Duration> METADATA_SCHEMA_REQUEST_TIMEOUT =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METADATA_SCHEMA_REQUEST_TIMEOUT, GenericType.DURATION);
+  /** The page size for the requests to the schema tables. */
+  public static final TypedDriverOption<Integer> METADATA_SCHEMA_REQUEST_PAGE_SIZE =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METADATA_SCHEMA_REQUEST_PAGE_SIZE, GenericType.INTEGER);
+  /** The list of keyspaces for which schema and token metadata should be maintained. */
+  public static final TypedDriverOption<List<String>> METADATA_SCHEMA_REFRESHED_KEYSPACES =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES,
+          GenericType.listOf(String.class));
+  /** How long the driver waits to apply a refresh. */
+  public static final TypedDriverOption<Duration> METADATA_SCHEMA_WINDOW =
+      new TypedDriverOption<>(DefaultDriverOption.METADATA_SCHEMA_WINDOW, GenericType.DURATION);
+  /** The maximum number of refreshes that can accumulate. */
+  public static final TypedDriverOption<Integer> METADATA_SCHEMA_MAX_EVENTS =
+      new TypedDriverOption<>(DefaultDriverOption.METADATA_SCHEMA_MAX_EVENTS, GenericType.INTEGER);
+  /** Whether token metadata is enabled. */
+  public static final TypedDriverOption<Boolean> METADATA_TOKEN_MAP_ENABLED =
+      new TypedDriverOption<>(DefaultDriverOption.METADATA_TOKEN_MAP_ENABLED, GenericType.BOOLEAN);
+  /** How long the driver waits for responses to control queries. */
+  public static final TypedDriverOption<Duration> CONTROL_CONNECTION_TIMEOUT =
+      new TypedDriverOption<>(DefaultDriverOption.CONTROL_CONNECTION_TIMEOUT, GenericType.DURATION);
+  /** The interval between each schema agreement check attempt. */
+  public static final TypedDriverOption<Duration> CONTROL_CONNECTION_AGREEMENT_INTERVAL =
+      new TypedDriverOption<>(
+          DefaultDriverOption.CONTROL_CONNECTION_AGREEMENT_INTERVAL, GenericType.DURATION);
+  /** The timeout after which schema agreement fails. */
+  public static final TypedDriverOption<Duration> CONTROL_CONNECTION_AGREEMENT_TIMEOUT =
+      new TypedDriverOption<>(
+          DefaultDriverOption.CONTROL_CONNECTION_AGREEMENT_TIMEOUT, GenericType.DURATION);
+  /** Whether to log a warning if schema agreement fails. */
+  public static final TypedDriverOption<Boolean> CONTROL_CONNECTION_AGREEMENT_WARN =
+      new TypedDriverOption<>(
+          DefaultDriverOption.CONTROL_CONNECTION_AGREEMENT_WARN, GenericType.BOOLEAN);
+  /** Whether `Session.prepare` calls should be sent to all nodes in the cluster. */
+  public static final TypedDriverOption<Boolean> PREPARE_ON_ALL_NODES =
+      new TypedDriverOption<>(DefaultDriverOption.PREPARE_ON_ALL_NODES, GenericType.BOOLEAN);
+  /** Whether the driver tries to prepare on new nodes at all. */
+  public static final TypedDriverOption<Boolean> REPREPARE_ENABLED =
+      new TypedDriverOption<>(DefaultDriverOption.REPREPARE_ENABLED, GenericType.BOOLEAN);
+  /** Whether to check `system.prepared_statements` on the target node before repreparing. */
+  public static final TypedDriverOption<Boolean> REPREPARE_CHECK_SYSTEM_TABLE =
+      new TypedDriverOption<>(
+          DefaultDriverOption.REPREPARE_CHECK_SYSTEM_TABLE, GenericType.BOOLEAN);
+  /** The maximum number of statements that should be reprepared. */
+  public static final TypedDriverOption<Integer> REPREPARE_MAX_STATEMENTS =
+      new TypedDriverOption<>(DefaultDriverOption.REPREPARE_MAX_STATEMENTS, GenericType.INTEGER);
+  /** The maximum number of concurrent requests when repreparing. */
+  public static final TypedDriverOption<Integer> REPREPARE_MAX_PARALLELISM =
+      new TypedDriverOption<>(DefaultDriverOption.REPREPARE_MAX_PARALLELISM, GenericType.INTEGER);
+  /** The request timeout when repreparing. */
+  public static final TypedDriverOption<Duration> REPREPARE_TIMEOUT =
+      new TypedDriverOption<>(DefaultDriverOption.REPREPARE_TIMEOUT, GenericType.DURATION);
+  /** The number of threads in the I/O group. */
+  public static final TypedDriverOption<Integer> NETTY_IO_SIZE =
+      new TypedDriverOption<>(DefaultDriverOption.NETTY_IO_SIZE, GenericType.INTEGER);
+  /** Quiet period for I/O group shutdown. */
+  public static final TypedDriverOption<Integer> NETTY_IO_SHUTDOWN_QUIET_PERIOD =
+      new TypedDriverOption<>(
+          DefaultDriverOption.NETTY_IO_SHUTDOWN_QUIET_PERIOD, GenericType.INTEGER);
+  /** Max time to wait for I/O group shutdown. */
+  public static final TypedDriverOption<Integer> NETTY_IO_SHUTDOWN_TIMEOUT =
+      new TypedDriverOption<>(DefaultDriverOption.NETTY_IO_SHUTDOWN_TIMEOUT, GenericType.INTEGER);
+  /** Units for I/O group quiet period and timeout. */
+  public static final TypedDriverOption<String> NETTY_IO_SHUTDOWN_UNIT =
+      new TypedDriverOption<>(DefaultDriverOption.NETTY_IO_SHUTDOWN_UNIT, GenericType.STRING);
+  /** The number of threads in the Admin group. */
+  public static final TypedDriverOption<Integer> NETTY_ADMIN_SIZE =
+      new TypedDriverOption<>(DefaultDriverOption.NETTY_ADMIN_SIZE, GenericType.INTEGER);
+  /** Quiet period for admin group shutdown. */
+  public static final TypedDriverOption<Integer> NETTY_ADMIN_SHUTDOWN_QUIET_PERIOD =
+      new TypedDriverOption<>(
+          DefaultDriverOption.NETTY_ADMIN_SHUTDOWN_QUIET_PERIOD, GenericType.INTEGER);
+  /** Max time to wait for admin group shutdown. */
+  public static final TypedDriverOption<Integer> NETTY_ADMIN_SHUTDOWN_TIMEOUT =
+      new TypedDriverOption<>(
+          DefaultDriverOption.NETTY_ADMIN_SHUTDOWN_TIMEOUT, GenericType.INTEGER);
+  /** Units for admin group quiet period and timeout. */
+  public static final TypedDriverOption<String> NETTY_ADMIN_SHUTDOWN_UNIT =
+      new TypedDriverOption<>(DefaultDriverOption.NETTY_ADMIN_SHUTDOWN_UNIT, GenericType.STRING);
+  /** How many times the coalescer is allowed to reschedule itself when it did no work. */
+  public static final TypedDriverOption<Integer> COALESCER_MAX_RUNS =
+      new TypedDriverOption<>(DefaultDriverOption.COALESCER_MAX_RUNS, GenericType.INTEGER);
+  /** The coalescer reschedule interval. */
+  public static final TypedDriverOption<Duration> COALESCER_INTERVAL =
+      new TypedDriverOption<>(DefaultDriverOption.COALESCER_INTERVAL, GenericType.DURATION);
+  /** Whether to resolve the addresses passed to `basic.contact-points`. */
+  public static final TypedDriverOption<Boolean> RESOLVE_CONTACT_POINTS =
+      new TypedDriverOption<>(DefaultDriverOption.RESOLVE_CONTACT_POINTS, GenericType.BOOLEAN);
+  /**
+   * This is how frequent the timer should wake up to check for timed-out tasks or speculative
+   * executions.
+   */
+  public static final TypedDriverOption<Duration> NETTY_TIMER_TICK_DURATION =
+      new TypedDriverOption<>(DefaultDriverOption.NETTY_TIMER_TICK_DURATION, GenericType.DURATION);
+  /** Number of ticks in the Timer wheel. */
+  public static final TypedDriverOption<Integer> NETTY_TIMER_TICKS_PER_WHEEL =
+      new TypedDriverOption<>(DefaultDriverOption.NETTY_TIMER_TICKS_PER_WHEEL, GenericType.INTEGER);
+  /**
+   * Whether logging of server warnings generated during query execution should be disabled by the
+   * driver.
+   */
+  public static final TypedDriverOption<Boolean> REQUEST_LOG_WARNINGS =
+      new TypedDriverOption<>(DefaultDriverOption.REQUEST_LOG_WARNINGS, GenericType.BOOLEAN);
+  /** Whether the threads created by the driver should be daemon threads. */
+  public static final TypedDriverOption<Boolean> NETTY_DAEMON =
+      new TypedDriverOption<>(DefaultDriverOption.NETTY_DAEMON, GenericType.BOOLEAN);
+  /**
+   * The location of the cloud secure bundle used to connect to Datastax Apache Cassandra as a
+   * service.
+   */
+  public static final TypedDriverOption<String> CLOUD_SECURE_CONNECT_BUNDLE =
+      new TypedDriverOption<>(DefaultDriverOption.CLOUD_SECURE_CONNECT_BUNDLE, GenericType.STRING);
+  /** Whether the slow replica avoidance should be enabled in the default LBP. */
+  public static final TypedDriverOption<Boolean> LOAD_BALANCING_POLICY_SLOW_AVOIDANCE =
+      new TypedDriverOption<>(
+          DefaultDriverOption.LOAD_BALANCING_POLICY_SLOW_AVOIDANCE, GenericType.BOOLEAN);
+  /** The timeout to use when establishing driver connections. */
+  public static final TypedDriverOption<Duration> CONNECTION_CONNECT_TIMEOUT =
+      new TypedDriverOption<>(DefaultDriverOption.CONNECTION_CONNECT_TIMEOUT, GenericType.DURATION);
+
+  /** The name of the application using the session. */
+  public static final TypedDriverOption<String> APPLICATION_NAME =
+      new TypedDriverOption<>(DseDriverOption.APPLICATION_NAME, GenericType.STRING);
+  /** The version of the application using the session. */
+  public static final TypedDriverOption<String> APPLICATION_VERSION =
+      new TypedDriverOption<>(DseDriverOption.APPLICATION_VERSION, GenericType.STRING);
+  /** Proxy authentication for GSSAPI authentication: allows to login as another user or role. */
+  public static final TypedDriverOption<String> AUTH_PROVIDER_AUTHORIZATION_ID =
+      new TypedDriverOption<>(DseDriverOption.AUTH_PROVIDER_AUTHORIZATION_ID, GenericType.STRING);
+  /** Service name for GSSAPI authentication. */
+  public static final TypedDriverOption<String> AUTH_PROVIDER_SERVICE =
+      new TypedDriverOption<>(DseDriverOption.AUTH_PROVIDER_SERVICE, GenericType.STRING);
+  /** Login configuration for GSSAPI authentication. */
+  public static final TypedDriverOption<String> AUTH_PROVIDER_LOGIN_CONFIGURATION =
+      new TypedDriverOption<>(
+          DseDriverOption.AUTH_PROVIDER_LOGIN_CONFIGURATION, GenericType.STRING);
+  /** Internal SASL properties, if any, such as QOP, for GSSAPI authentication. */
+  public static final TypedDriverOption<Map<String, String>> AUTH_PROVIDER_SASL_PROPERTIES =
+      new TypedDriverOption<>(
+          DseDriverOption.AUTH_PROVIDER_SASL_PROPERTIES,
+          GenericType.mapOf(GenericType.STRING, GenericType.STRING));
+  /** The page size for continuous paging. */
+  public static final TypedDriverOption<Integer> CONTINUOUS_PAGING_PAGE_SIZE =
+      new TypedDriverOption<>(DseDriverOption.CONTINUOUS_PAGING_PAGE_SIZE, GenericType.INTEGER);
+  /**
+   * Whether {@link #CONTINUOUS_PAGING_PAGE_SIZE} should be interpreted in number of rows or bytes.
+   */
+  public static final TypedDriverOption<Boolean> CONTINUOUS_PAGING_PAGE_SIZE_BYTES =
+      new TypedDriverOption<>(
+          DseDriverOption.CONTINUOUS_PAGING_PAGE_SIZE_BYTES, GenericType.BOOLEAN);
+  /** The maximum number of continuous pages to return. */
+  public static final TypedDriverOption<Integer> CONTINUOUS_PAGING_MAX_PAGES =
+      new TypedDriverOption<>(DseDriverOption.CONTINUOUS_PAGING_MAX_PAGES, GenericType.INTEGER);
+  /** The maximum number of continuous pages per second. */
+  public static final TypedDriverOption<Integer> CONTINUOUS_PAGING_MAX_PAGES_PER_SECOND =
+      new TypedDriverOption<>(
+          DseDriverOption.CONTINUOUS_PAGING_MAX_PAGES_PER_SECOND, GenericType.INTEGER);
+  /** The maximum number of continuous pages that can be stored in the local queue. */
+  public static final TypedDriverOption<Integer> CONTINUOUS_PAGING_MAX_ENQUEUED_PAGES =
+      new TypedDriverOption<>(
+          DseDriverOption.CONTINUOUS_PAGING_MAX_ENQUEUED_PAGES, GenericType.INTEGER);
+  /** How long to wait for the coordinator to send the first continuous page. */
+  public static final TypedDriverOption<Duration> CONTINUOUS_PAGING_TIMEOUT_FIRST_PAGE =
+      new TypedDriverOption<>(
+          DseDriverOption.CONTINUOUS_PAGING_TIMEOUT_FIRST_PAGE, GenericType.DURATION);
+  /** How long to wait for the coordinator to send subsequent continuous pages. */
+  public static final TypedDriverOption<Duration> CONTINUOUS_PAGING_TIMEOUT_OTHER_PAGES =
+      new TypedDriverOption<>(
+          DseDriverOption.CONTINUOUS_PAGING_TIMEOUT_OTHER_PAGES, GenericType.DURATION);
+  /** The largest latency that we expect to record for continuous requests. */
+  public static final TypedDriverOption<Duration>
+      CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_HIGHEST =
+          new TypedDriverOption<>(
+              DseDriverOption.CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_HIGHEST,
+              GenericType.DURATION);
+  /**
+   * The number of significant decimal digits to which internal structures will maintain for
+   * continuous requests.
+   */
+  public static final TypedDriverOption<Integer>
+      CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_DIGITS =
+          new TypedDriverOption<>(
+              DseDriverOption.CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_DIGITS,
+              GenericType.INTEGER);
+  /** The interval at which percentile data is refreshed for continuous requests. */
+  public static final TypedDriverOption<Duration>
+      CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_INTERVAL =
+          new TypedDriverOption<>(
+              DseDriverOption.CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_INTERVAL,
+              GenericType.DURATION);
+  /** The read consistency level to use for graph statements. */
+  public static final TypedDriverOption<String> GRAPH_READ_CONSISTENCY_LEVEL =
+      new TypedDriverOption<>(DseDriverOption.GRAPH_READ_CONSISTENCY_LEVEL, GenericType.STRING);
+  /** The write consistency level to use for graph statements. */
+  public static final TypedDriverOption<String> GRAPH_WRITE_CONSISTENCY_LEVEL =
+      new TypedDriverOption<>(DseDriverOption.GRAPH_WRITE_CONSISTENCY_LEVEL, GenericType.STRING);
+  /** The traversal source to use for graph statements. */
+  public static final TypedDriverOption<String> GRAPH_TRAVERSAL_SOURCE =
+      new TypedDriverOption<>(DseDriverOption.GRAPH_TRAVERSAL_SOURCE, GenericType.STRING);
+  /**
+   * The sub-protocol the driver will use to communicate with DSE Graph, on top of the Cassandra
+   * native protocol.
+   */
+  public static final TypedDriverOption<String> GRAPH_SUB_PROTOCOL =
+      new TypedDriverOption<>(DseDriverOption.GRAPH_SUB_PROTOCOL, GenericType.STRING);
+  /** Whether a script statement represents a system query. */
+  public static final TypedDriverOption<Boolean> GRAPH_IS_SYSTEM_QUERY =
+      new TypedDriverOption<>(DseDriverOption.GRAPH_IS_SYSTEM_QUERY, GenericType.BOOLEAN);
+  /** The name of the graph targeted by graph statements. */
+  public static final TypedDriverOption<String> GRAPH_NAME =
+      new TypedDriverOption<>(DseDriverOption.GRAPH_NAME, GenericType.STRING);
+  /** How long the driver waits for a graph request to complete. */
+  public static final TypedDriverOption<Duration> GRAPH_TIMEOUT =
+      new TypedDriverOption<>(DseDriverOption.GRAPH_TIMEOUT, GenericType.DURATION);
+  /** Whether to send events for Insights monitoring. */
+  public static final TypedDriverOption<Boolean> MONITOR_REPORTING_ENABLED =
+      new TypedDriverOption<>(DseDriverOption.MONITOR_REPORTING_ENABLED, GenericType.BOOLEAN);
+  /** Whether to enable paging for Graph queries. */
+  public static final TypedDriverOption<String> GRAPH_PAGING_ENABLED =
+      new TypedDriverOption<>(DseDriverOption.GRAPH_PAGING_ENABLED, GenericType.STRING);
+  /** The page size for Graph continuous paging. */
+  public static final TypedDriverOption<Integer> GRAPH_CONTINUOUS_PAGING_PAGE_SIZE =
+      new TypedDriverOption<>(
+          DseDriverOption.GRAPH_CONTINUOUS_PAGING_PAGE_SIZE, GenericType.INTEGER);
+  /** The maximum number of Graph continuous pages to return. */
+  public static final TypedDriverOption<Integer> GRAPH_CONTINUOUS_PAGING_MAX_PAGES =
+      new TypedDriverOption<>(
+          DseDriverOption.GRAPH_CONTINUOUS_PAGING_MAX_PAGES, GenericType.INTEGER);
+  /** The maximum number of Graph continuous pages per second. */
+  public static final TypedDriverOption<Integer> GRAPH_CONTINUOUS_PAGING_MAX_PAGES_PER_SECOND =
+      new TypedDriverOption<>(
+          DseDriverOption.GRAPH_CONTINUOUS_PAGING_MAX_PAGES_PER_SECOND, GenericType.INTEGER);
+  /** The maximum number of Graph continuous pages that can be stored in the local queue. */
+  public static final TypedDriverOption<Integer> GRAPH_CONTINUOUS_PAGING_MAX_ENQUEUED_PAGES =
+      new TypedDriverOption<>(
+          DseDriverOption.GRAPH_CONTINUOUS_PAGING_MAX_ENQUEUED_PAGES, GenericType.INTEGER);
+  /** The largest latency that we expect to record for graph requests. */
+  public static final TypedDriverOption<Duration> METRICS_SESSION_GRAPH_REQUESTS_HIGHEST =
+      new TypedDriverOption<>(
+          DseDriverOption.METRICS_SESSION_GRAPH_REQUESTS_HIGHEST, GenericType.DURATION);
+  /**
+   * The number of significant decimal digits to which internal structures will maintain for graph
+   * requests.
+   */
+  public static final TypedDriverOption<Integer> METRICS_SESSION_GRAPH_REQUESTS_DIGITS =
+      new TypedDriverOption<>(
+          DseDriverOption.METRICS_SESSION_GRAPH_REQUESTS_DIGITS, GenericType.INTEGER);
+  /** The interval at which percentile data is refreshed for graph requests. */
+  public static final TypedDriverOption<Duration> METRICS_SESSION_GRAPH_REQUESTS_INTERVAL =
+      new TypedDriverOption<>(
+          DseDriverOption.METRICS_SESSION_GRAPH_REQUESTS_INTERVAL, GenericType.DURATION);
+  /** The largest latency that we expect to record for graph requests. */
+  public static final TypedDriverOption<Duration> METRICS_NODE_GRAPH_MESSAGES_HIGHEST =
+      new TypedDriverOption<>(
+          DseDriverOption.METRICS_NODE_GRAPH_MESSAGES_HIGHEST, GenericType.DURATION);
+  /**
+   * The number of significant decimal digits to which internal structures will maintain for graph
+   * requests.
+   */
+  public static final TypedDriverOption<Integer> METRICS_NODE_GRAPH_MESSAGES_DIGITS =
+      new TypedDriverOption<>(
+          DseDriverOption.METRICS_NODE_GRAPH_MESSAGES_DIGITS, GenericType.INTEGER);
+  /** The interval at which percentile data is refreshed for graph requests. */
+  public static final TypedDriverOption<Duration> METRICS_NODE_GRAPH_MESSAGES_INTERVAL =
+      new TypedDriverOption<>(
+          DseDriverOption.METRICS_NODE_GRAPH_MESSAGES_INTERVAL, GenericType.DURATION);
+
+  private static Iterable<TypedDriverOption<?>> introspectBuiltInValues() {
+    try {
+      ImmutableList.Builder<TypedDriverOption<?>> result = ImmutableList.builder();
+      for (Field field : TypedDriverOption.class.getFields()) {
+        if ((field.getModifiers() & PUBLIC_STATIC_FINAL) == PUBLIC_STATIC_FINAL
+            && field.getType() == TypedDriverOption.class) {
+          TypedDriverOption<?> typedOption = (TypedDriverOption<?>) field.get(null);
+          result.add(typedOption);
+        }
+      }
+      return result.build();
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("Unexpected error while introspecting built-in values", e);
+    }
+  }
+
+  private static final int PUBLIC_STATIC_FINAL = Modifier.PUBLIC | Modifier.STATIC | Modifier.FINAL;
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/reflect/GenericType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/reflect/GenericType.java
@@ -31,6 +31,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -103,6 +104,7 @@ public class GenericType<T> {
   public static final GenericType<CqlDuration> CQL_DURATION = of(CqlDuration.class);
   public static final GenericType<TupleValue> TUPLE_VALUE = of(TupleValue.class);
   public static final GenericType<UdtValue> UDT_VALUE = of(UdtValue.class);
+  public static final GenericType<Duration> DURATION = of(Duration.class);
 
   @NonNull
   public static <T> GenericType<T> of(@NonNull Class<T> type) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/config/map/MapBasedDriverConfig.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/config/map/MapBasedDriverConfig.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.config.map;
+
+import com.datastax.oss.driver.api.core.config.DriverConfig;
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.config.DriverOption;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** @see MapBasedDriverConfigLoader */
+public class MapBasedDriverConfig implements DriverConfig {
+
+  private final Map<String, Map<DriverOption, Object>> optionsMap;
+  private final Map<String, MapBasedDriverExecutionProfile> profiles = new ConcurrentHashMap<>();
+
+  public MapBasedDriverConfig(Map<String, Map<DriverOption, Object>> optionsMap) {
+    this.optionsMap = optionsMap;
+    if (!optionsMap.containsKey(DriverExecutionProfile.DEFAULT_NAME)) {
+      throw new IllegalArgumentException(
+          "The options map must contain a profile named " + DriverExecutionProfile.DEFAULT_NAME);
+    }
+    createMissingProfiles();
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile getProfile(@NonNull String profileName) {
+    return profiles.computeIfAbsent(profileName, this::newProfile);
+  }
+
+  @NonNull
+  @Override
+  public Map<String, ? extends DriverExecutionProfile> getProfiles() {
+    // Refresh in case profiles were added to the backing map
+    createMissingProfiles();
+    return Collections.unmodifiableMap(profiles);
+  }
+
+  private void createMissingProfiles() {
+    for (Map.Entry<String, Map<DriverOption, Object>> entry : optionsMap.entrySet()) {
+      String profileName = entry.getKey();
+      if (!profiles.containsKey(profileName)) {
+        profiles.put(profileName, newProfile(profileName));
+      }
+    }
+  }
+
+  private MapBasedDriverExecutionProfile newProfile(String profileName) {
+    return new MapBasedDriverExecutionProfile(optionsMap, profileName);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/config/map/MapBasedDriverConfigLoader.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/config/map/MapBasedDriverConfigLoader.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.config.map;
+
+import com.datastax.oss.driver.api.core.config.DriverConfig;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.config.DriverOption;
+import com.datastax.oss.driver.api.core.config.OptionsMap;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.internal.core.config.ConfigChangeEvent;
+import com.datastax.oss.driver.internal.core.context.EventBus;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
+
+public class MapBasedDriverConfigLoader implements DriverConfigLoader, Consumer<OptionsMap> {
+
+  @NonNull private final OptionsMap source;
+  @NonNull private final Map<String, Map<DriverOption, Object>> rawMap;
+  private volatile EventBus eventBus;
+
+  public MapBasedDriverConfigLoader(
+      @NonNull OptionsMap source, @NonNull Map<String, Map<DriverOption, Object>> rawMap) {
+    this.source = source;
+    this.rawMap = rawMap;
+  }
+
+  @NonNull
+  @Override
+  public DriverConfig getInitialConfig() {
+    return new MapBasedDriverConfig(rawMap);
+  }
+
+  @Override
+  public void onDriverInit(@NonNull DriverContext context) {
+    eventBus = ((InternalDriverContext) context).getEventBus();
+    source.addChangeListener(this);
+  }
+
+  @Override
+  public void accept(OptionsMap map) {
+    assert eventBus != null; // listener is registered after setting this field
+    eventBus.fire(ConfigChangeEvent.INSTANCE);
+  }
+
+  @NonNull
+  @Override
+  public CompletionStage<Boolean> reload() {
+    return CompletableFuture.completedFuture(true);
+  }
+
+  @Override
+  public boolean supportsReloading() {
+    return true;
+  }
+
+  @Override
+  public void close() {
+    source.removeChangeListener(this);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/config/map/MapBasedDriverExecutionProfile.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/config/map/MapBasedDriverExecutionProfile.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.config.map;
+
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.config.DriverOption;
+import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSortedSet;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Duration;
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+
+/** @see MapBasedDriverConfigLoader */
+public class MapBasedDriverExecutionProfile implements DriverExecutionProfile {
+
+  private static final Object NO_VALUE = new Object();
+
+  private final String profileName;
+  // Anything that was overridden in a derived profile with `withXxx` methods. Empty for non-derived
+  // profiles
+  private final Map<DriverOption, Object> overrides;
+  // The backing map for the current profile
+  private final Map<DriverOption, Object> profile;
+  // The backing map for the default profile (if the current one is not the default)
+  private final Map<DriverOption, Object> defaultProfile;
+
+  public MapBasedDriverExecutionProfile(
+      Map<String, Map<DriverOption, Object>> optionsMap, String profileName) {
+    this(
+        profileName,
+        Collections.emptyMap(),
+        optionsMap.get(profileName),
+        profileName.equals(DriverExecutionProfile.DEFAULT_NAME)
+            ? Collections.emptyMap()
+            : optionsMap.get(DriverExecutionProfile.DEFAULT_NAME));
+    Preconditions.checkArgument(
+        optionsMap.containsKey(profileName),
+        "Unknown profile '%s'. Check your configuration.",
+        profileName);
+  }
+
+  public MapBasedDriverExecutionProfile(
+      String profileName,
+      Map<DriverOption, Object> overrides,
+      Map<DriverOption, Object> profile,
+      Map<DriverOption, Object> defaultProfile) {
+    this.profileName = profileName;
+    this.overrides = overrides;
+    this.profile = profile;
+    this.defaultProfile = defaultProfile;
+  }
+
+  @NonNull
+  @Override
+  public String getName() {
+    return profileName;
+  }
+
+  @Override
+  public boolean isDefined(@NonNull DriverOption option) {
+    if (overrides.containsKey(option)) {
+      return overrides.get(option) != NO_VALUE;
+    } else {
+      return profile.containsKey(option) || defaultProfile.containsKey(option);
+    }
+  }
+
+  // Driver options don't encode the type, everything relies on the user putting the right types in
+  // the backing map, so no point in trying to type-check.
+  @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
+  @NonNull
+  private <T> T get(@NonNull DriverOption option) {
+    Object value =
+        overrides.getOrDefault(option, profile.getOrDefault(option, defaultProfile.get(option)));
+    if (value == null || value == NO_VALUE) {
+      throw new IllegalArgumentException("Missing configuration option " + option.getPath());
+    }
+    return (T) value;
+  }
+
+  @Override
+  public boolean getBoolean(@NonNull DriverOption option) {
+    return get(option);
+  }
+
+  @NonNull
+  @Override
+  public List<Boolean> getBooleanList(@NonNull DriverOption option) {
+    return get(option);
+  }
+
+  @Override
+  public int getInt(@NonNull DriverOption option) {
+    return get(option);
+  }
+
+  @NonNull
+  @Override
+  public List<Integer> getIntList(@NonNull DriverOption option) {
+    return get(option);
+  }
+
+  @Override
+  public long getLong(@NonNull DriverOption option) {
+    return get(option);
+  }
+
+  @NonNull
+  @Override
+  public List<Long> getLongList(@NonNull DriverOption option) {
+    return get(option);
+  }
+
+  @Override
+  public double getDouble(@NonNull DriverOption option) {
+    return get(option);
+  }
+
+  @NonNull
+  @Override
+  public List<Double> getDoubleList(@NonNull DriverOption option) {
+    return get(option);
+  }
+
+  @NonNull
+  @Override
+  public String getString(@NonNull DriverOption option) {
+    return get(option);
+  }
+
+  @NonNull
+  @Override
+  public List<String> getStringList(@NonNull DriverOption option) {
+    return get(option);
+  }
+
+  @NonNull
+  @Override
+  public Map<String, String> getStringMap(@NonNull DriverOption option) {
+    return get(option);
+  }
+
+  @Override
+  public long getBytes(@NonNull DriverOption option) {
+    return get(option);
+  }
+
+  @NonNull
+  @Override
+  public List<Long> getBytesList(DriverOption option) {
+    return get(option);
+  }
+
+  @NonNull
+  @Override
+  public Duration getDuration(@NonNull DriverOption option) {
+    return get(option);
+  }
+
+  @NonNull
+  @Override
+  public List<Duration> getDurationList(@NonNull DriverOption option) {
+    return get(option);
+  }
+
+  @NonNull
+  @Override
+  public Object getComparisonKey(@NonNull DriverOption option) {
+    // This method is only used during driver initialization, performance is not crucial
+    String prefix = option.getPath();
+    ImmutableMap.Builder<String, Object> childOptions = ImmutableMap.builder();
+    for (Map.Entry<String, Object> entry : entrySet()) {
+      if (entry.getKey().startsWith(prefix)) {
+        childOptions.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return childOptions.build();
+  }
+
+  @NonNull
+  @Override
+  public SortedSet<Map.Entry<String, Object>> entrySet() {
+    ImmutableSortedSet.Builder<Map.Entry<String, Object>> builder =
+        ImmutableSortedSet.orderedBy(Map.Entry.comparingByKey());
+    for (Map<DriverOption, Object> backingMap :
+        // builder.add() ignores duplicates, so process higher precedence backing maps first
+        ImmutableList.of(overrides, profile, defaultProfile)) {
+      for (Map.Entry<DriverOption, Object> entry : backingMap.entrySet()) {
+        if (entry.getValue() != NO_VALUE) {
+          builder.add(new AbstractMap.SimpleEntry<>(entry.getKey().getPath(), entry.getValue()));
+        }
+      }
+    }
+    return builder.build();
+  }
+
+  private DriverExecutionProfile with(@NonNull DriverOption option, Object value) {
+    ImmutableMap.Builder<DriverOption, Object> newOverrides = ImmutableMap.builder();
+    for (Map.Entry<DriverOption, Object> override : overrides.entrySet()) {
+      if (!override.getKey().equals(option)) {
+        newOverrides.put(override.getKey(), override.getValue());
+      }
+    }
+    newOverrides.put(option, value);
+    return new MapBasedDriverExecutionProfile(
+        profileName, newOverrides.build(), profile, defaultProfile);
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile withBoolean(@NonNull DriverOption option, boolean value) {
+    return with(option, value);
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile withBooleanList(
+      @NonNull DriverOption option, @NonNull List<Boolean> value) {
+    return with(option, value);
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile withInt(@NonNull DriverOption option, int value) {
+    return with(option, value);
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile withIntList(
+      @NonNull DriverOption option, @NonNull List<Integer> value) {
+    return with(option, value);
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile withLong(@NonNull DriverOption option, long value) {
+    return with(option, value);
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile withLongList(
+      @NonNull DriverOption option, @NonNull List<Long> value) {
+    return with(option, value);
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile withDouble(@NonNull DriverOption option, double value) {
+    return with(option, value);
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile withDoubleList(
+      @NonNull DriverOption option, @NonNull List<Double> value) {
+    return with(option, value);
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile withString(@NonNull DriverOption option, @NonNull String value) {
+    return with(option, value);
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile withStringList(
+      @NonNull DriverOption option, @NonNull List<String> value) {
+    return with(option, value);
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile withStringMap(
+      @NonNull DriverOption option, @NonNull Map<String, String> value) {
+    return with(option, value);
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile withBytes(@NonNull DriverOption option, long value) {
+    return with(option, value);
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile withBytesList(
+      @NonNull DriverOption option, @NonNull List<Long> value) {
+    return with(option, value);
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile withDuration(
+      @NonNull DriverOption option, @NonNull Duration value) {
+    return with(option, value);
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile withDurationList(
+      @NonNull DriverOption option, @NonNull List<Duration> value) {
+    return with(option, value);
+  }
+
+  @NonNull
+  @Override
+  public DriverExecutionProfile without(@NonNull DriverOption option) {
+    return with(option, NO_VALUE);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
@@ -339,6 +339,7 @@ public class DefaultDriverContext implements InternalDriverContext {
   protected Map<String, LoadBalancingPolicy> buildLoadBalancingPolicies() {
     return Reflection.buildFromConfigProfiles(
         this,
+        DefaultDriverOption.LOAD_BALANCING_POLICY_CLASS,
         DefaultDriverOption.LOAD_BALANCING_POLICY,
         LoadBalancingPolicy.class,
         "com.datastax.oss.driver.internal.core.loadbalancing",
@@ -348,6 +349,7 @@ public class DefaultDriverContext implements InternalDriverContext {
   protected Map<String, RetryPolicy> buildRetryPolicies() {
     return Reflection.buildFromConfigProfiles(
         this,
+        DefaultDriverOption.RETRY_POLICY_CLASS,
         DefaultDriverOption.RETRY_POLICY,
         RetryPolicy.class,
         "com.datastax.oss.driver.internal.core.retry");
@@ -356,6 +358,7 @@ public class DefaultDriverContext implements InternalDriverContext {
   protected Map<String, SpeculativeExecutionPolicy> buildSpeculativeExecutionPolicies() {
     return Reflection.buildFromConfigProfiles(
         this,
+        DefaultDriverOption.SPECULATIVE_EXECUTION_POLICY_CLASS,
         DefaultDriverOption.SPECULATIVE_EXECUTION_POLICY,
         SpeculativeExecutionPolicy.class,
         "com.datastax.oss.driver.internal.core.specex");

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/Reflection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/Reflection.java
@@ -114,8 +114,11 @@ public class Reflection {
    * the default profile.
    *
    * @param context the driver context.
-   * @param rootOption the root option for the policy (my-policy in the example above). The class
-   *     name is assumed to be in a 'class' child option.
+   * @param classNameOption the option that indicates the class (my-policy.class in the example
+   *     above).
+   * @param rootOption the root of the section containing the policy's configuration (my-policy in
+   *     the example above). Profiles that have the same contents under that section will share the
+   *     same policy instance.
    * @param expectedSuperType a super-type that the class is expected to implement/extend.
    * @param defaultPackages the default packages to prepend to the class name if it's not qualified.
    *     They will be tried in order, the first one that matches an existing class will be used.
@@ -124,6 +127,7 @@ public class Reflection {
    */
   public static <ComponentT> Map<String, ComponentT> buildFromConfigProfiles(
       InternalDriverContext context,
+      DriverOption classNameOption,
       DriverOption rootOption,
       Class<ComponentT> expectedSuperType,
       String... defaultPackages) {
@@ -141,8 +145,7 @@ public class Reflection {
       // Since all profiles use the same config, we can use any of them
       String profileName = profiles.iterator().next();
       ComponentT policy =
-          buildFromConfig(
-                  context, profileName, classOption(rootOption), expectedSuperType, defaultPackages)
+          buildFromConfig(context, profileName, classNameOption, expectedSuperType, defaultPackages)
               .orElseThrow(
                   () ->
                       new IllegalArgumentException(
@@ -238,9 +241,5 @@ public class Reflection {
               className, configPath, cause.getMessage()),
           cause);
     }
-  }
-
-  private static DriverOption classOption(DriverOption rootOption) {
-    return () -> rootOption.getPath() + ".class";
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/api/core/config/OptionsMapTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/config/OptionsMapTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.internal.SerializationHelper;
+import java.time.Duration;
+import java.util.function.Consumer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OptionsMapTest {
+  @Mock private Consumer<OptionsMap> mockListener;
+
+  @Test
+  public void should_serialize_and_deserialize() {
+    // Given
+    OptionsMap initial = OptionsMap.driverDefaults();
+    Duration slowTimeout = Duration.ofSeconds(30);
+    initial.put("slow", TypedDriverOption.REQUEST_TIMEOUT, slowTimeout);
+    initial.addChangeListener(mockListener);
+
+    // When
+    OptionsMap deserialized = SerializationHelper.serializeAndDeserialize(initial);
+
+    // Then
+    assertThat(deserialized.get(TypedDriverOption.REQUEST_TIMEOUT))
+        .isEqualTo(Duration.ofSeconds(2));
+    assertThat(deserialized.get("slow", TypedDriverOption.REQUEST_TIMEOUT)).isEqualTo(slowTimeout);
+    // Listeners are transient
+    assertThat(deserialized.removeChangeListener(mockListener)).isFalse();
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/api/core/config/TypedDriverOptionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/config/TypedDriverOptionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.dse.driver.api.core.config.DseDriverOption;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+
+public class TypedDriverOptionTest {
+
+  /**
+   * Checks that every built-in {@link DriverOption} has an equivalent constant in {@link
+   * TypedDriverOption}.
+   */
+  @Test
+  public void should_have_equivalents_for_all_builtin_untyped_options() {
+    Set<DriverOption> optionsThatHaveATypedEquivalent = new HashSet<>();
+    for (TypedDriverOption<?> typedOption : TypedDriverOption.builtInValues()) {
+      optionsThatHaveATypedEquivalent.add(typedOption.getRawOption());
+    }
+
+    // These options are only used internally to compare policy configurations across profiles.
+    // Users never use them directly, so they don't need typed equivalents.
+    Set<DriverOption> exclusions =
+        ImmutableSet.of(
+            DefaultDriverOption.LOAD_BALANCING_POLICY,
+            DefaultDriverOption.RETRY_POLICY,
+            DefaultDriverOption.SPECULATIVE_EXECUTION_POLICY);
+
+    for (DriverOption option :
+        ImmutableSet.<DriverOption>builder()
+            .add(DefaultDriverOption.values())
+            .add(DseDriverOption.values())
+            .build()) {
+      if (!exclusions.contains(option)) {
+        assertThat(optionsThatHaveATypedEquivalent)
+            .as(
+                "Couldn't find a typed equivalent for %s.%s. "
+                    + "You need to either add a constant in %s, or an exclusion in this test.",
+                option.getClass().getSimpleName(), option, TypedDriverOption.class.getSimpleName())
+            .contains(option);
+      }
+    }
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/MockOptions.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/MockOptions.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.datastax.oss.driver.internal.core.config.typesafe;
+package com.datastax.oss.driver.internal.core.config;
 
 import com.datastax.oss.driver.api.core.config.DriverOption;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-enum MockOptions implements DriverOption {
+public enum MockOptions implements DriverOption {
   INT1("int1"),
   INT2("int2"),
   AUTH_PROVIDER("auth_provider"),

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/MockTypedOptions.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/MockTypedOptions.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.config;
+
+import com.datastax.oss.driver.api.core.config.TypedDriverOption;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+
+public class MockTypedOptions {
+  public static final TypedDriverOption<Integer> INT1 =
+      new TypedDriverOption<>(MockOptions.INT1, GenericType.INTEGER);
+  public static final TypedDriverOption<Integer> INT2 =
+      new TypedDriverOption<>(MockOptions.INT2, GenericType.INTEGER);
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/map/MapBasedDriverConfigLoaderTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/map/MapBasedDriverConfigLoaderTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.config.map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfig;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.config.OptionsMap;
+import com.datastax.oss.driver.internal.core.config.MockOptions;
+import com.datastax.oss.driver.internal.core.config.MockTypedOptions;
+import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader;
+import java.util.Map;
+import java.util.SortedSet;
+import org.junit.Test;
+
+public class MapBasedDriverConfigLoaderTest {
+
+  @Test
+  public void should_reflect_changes_in_real_time() {
+    OptionsMap source = new OptionsMap();
+    source.put(MockTypedOptions.INT1, 1);
+
+    DriverConfigLoader loader = DriverConfigLoader.fromMap(source);
+    DriverConfig config = loader.getInitialConfig();
+    assertThat(config.getDefaultProfile().getInt(MockOptions.INT1)).isEqualTo(1);
+
+    source.put(MockTypedOptions.INT1, 2);
+    assertThat(config.getDefaultProfile().getInt(MockOptions.INT1)).isEqualTo(2);
+  }
+
+  /**
+   * Checks that, if we ask to pre-fill the default profile, then we get the same set of options as
+   * the built-in reference.conf.
+   */
+  @Test
+  public void should_fill_default_profile_like_reference_file() {
+    SortedSet<Map.Entry<String, Object>> memoryBased =
+        DriverConfigLoader.fromMap(OptionsMap.driverDefaults())
+            .getInitialConfig()
+            .getDefaultProfile()
+            .entrySet();
+    SortedSet<Map.Entry<String, Object>> fileBased =
+        new DefaultDriverConfigLoader().getInitialConfig().getDefaultProfile().entrySet();
+
+    for (Map.Entry<String, Object> entry : fileBased) {
+      if (entry.getKey().equals(DefaultDriverOption.CONFIG_RELOAD_INTERVAL.getPath())) {
+        continue;
+      }
+      assertThat(memoryBased).as("Missing entry: " + entry).contains(entry);
+    }
+    assertThat(memoryBased).hasSize(fileBased.size() - 1);
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/map/MapBasedDriverConfigTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/map/MapBasedDriverConfigTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.config.map;
+
+import static com.datastax.oss.driver.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.config.DriverConfig;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.config.OptionsMap;
+import com.datastax.oss.driver.internal.core.config.MockOptions;
+import com.datastax.oss.driver.internal.core.config.MockTypedOptions;
+import org.junit.Test;
+
+public class MapBasedDriverConfigTest {
+
+  @Test
+  public void should_load_minimal_config_with_no_profiles() {
+    OptionsMap source = new OptionsMap();
+    source.put(MockTypedOptions.INT1, 42);
+    DriverConfig config = DriverConfigLoader.fromMap(source).getInitialConfig();
+
+    assertThat(config).hasIntOption(MockOptions.INT1, 42);
+  }
+
+  @Test
+  public void should_inherit_option_in_profile() {
+    OptionsMap source = new OptionsMap();
+    source.put(MockTypedOptions.INT1, 42);
+    // need to add an unrelated option to create the profile
+    source.put("profile1", MockTypedOptions.INT2, 1);
+    DriverConfig config = DriverConfigLoader.fromMap(source).getInitialConfig();
+
+    assertThat(config)
+        .hasIntOption(MockOptions.INT1, 42)
+        .hasIntOption("profile1", MockOptions.INT1, 42);
+  }
+
+  @Test
+  public void should_override_option_in_profile() {
+    OptionsMap source = new OptionsMap();
+    source.put(MockTypedOptions.INT1, 42);
+    source.put("profile1", MockTypedOptions.INT1, 43);
+    DriverConfig config = DriverConfigLoader.fromMap(source).getInitialConfig();
+
+    assertThat(config)
+        .hasIntOption(MockOptions.INT1, 42)
+        .hasIntOption("profile1", MockOptions.INT1, 43);
+  }
+
+  @Test
+  public void should_create_derived_profile_with_new_option() {
+    OptionsMap source = new OptionsMap();
+    source.put(MockTypedOptions.INT1, 42);
+    DriverConfig config = DriverConfigLoader.fromMap(source).getInitialConfig();
+    DriverExecutionProfile base = config.getDefaultProfile();
+    DriverExecutionProfile derived = base.withInt(MockOptions.INT2, 43);
+
+    assertThat(base.isDefined(MockOptions.INT2)).isFalse();
+    assertThat(derived.isDefined(MockOptions.INT2)).isTrue();
+    assertThat(derived.getInt(MockOptions.INT2)).isEqualTo(43);
+  }
+
+  @Test
+  public void should_create_derived_profile_overriding_option() {
+    OptionsMap source = new OptionsMap();
+    source.put(MockTypedOptions.INT1, 42);
+    DriverConfig config = DriverConfigLoader.fromMap(source).getInitialConfig();
+    DriverExecutionProfile base = config.getDefaultProfile();
+    DriverExecutionProfile derived = base.withInt(MockOptions.INT1, 43);
+
+    assertThat(base.getInt(MockOptions.INT1)).isEqualTo(42);
+    assertThat(derived.getInt(MockOptions.INT1)).isEqualTo(43);
+  }
+
+  @Test
+  public void should_create_derived_profile_unsetting_option() {
+    OptionsMap source = new OptionsMap();
+    source.put(MockTypedOptions.INT1, 42);
+    source.put(MockTypedOptions.INT2, 43);
+    DriverConfig config = DriverConfigLoader.fromMap(source).getInitialConfig();
+    DriverExecutionProfile base = config.getDefaultProfile();
+    DriverExecutionProfile derived = base.without(MockOptions.INT2);
+
+    assertThat(base.getInt(MockOptions.INT2)).isEqualTo(43);
+    assertThat(derived.isDefined(MockOptions.INT2)).isFalse();
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/DefaultDriverConfigLoaderTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/DefaultDriverConfigLoaderTest.java
@@ -28,6 +28,7 @@ import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.internal.core.config.ConfigChangeEvent;
+import com.datastax.oss.driver.internal.core.config.MockOptions;
 import com.datastax.oss.driver.internal.core.context.EventBus;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.context.NettyOptions;

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/DefaultProgrammaticDriverConfigLoaderBuilderTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/DefaultProgrammaticDriverConfigLoaderBuilderTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.internal.core.config.MockOptions;
 import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/TypesafeDriverConfigTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/TypesafeDriverConfigTest.java
@@ -19,6 +19,7 @@ import static com.datastax.oss.driver.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.internal.core.config.MockOptions;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import java.util.HashMap;

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/util/ReflectionTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/util/ReflectionTest.java
@@ -63,6 +63,7 @@ public class ReflectionTest {
     Map<String, SpeculativeExecutionPolicy> policies =
         Reflection.buildFromConfigProfiles(
             context,
+            DefaultDriverOption.SPECULATIVE_EXECUTION_POLICY_CLASS,
             DefaultDriverOption.SPECULATIVE_EXECUTION_POLICY,
             SpeculativeExecutionPolicy.class,
             "com.datastax.oss.driver.internal.core.specex");

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/config/MapBasedConfigLoaderIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/config/MapBasedConfigLoaderIT.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.core.config;
+
+import static com.datastax.oss.simulacron.common.codec.ConsistencyLevel.QUORUM;
+import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.unavailable;
+import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.datastax.oss.driver.api.core.AllNodesFailedException;
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.config.OptionsMap;
+import com.datastax.oss.driver.api.core.config.TypedDriverOption;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.retry.RetryDecision;
+import com.datastax.oss.driver.api.core.retry.RetryPolicy;
+import com.datastax.oss.driver.api.core.servererrors.CoordinatorException;
+import com.datastax.oss.driver.api.core.servererrors.UnavailableException;
+import com.datastax.oss.driver.api.core.servererrors.WriteType;
+import com.datastax.oss.driver.api.core.session.Request;
+import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.api.testinfra.utils.ConditionChecker;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.driver.internal.core.config.ConfigChangeEvent;
+import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(ParallelizableTests.class)
+public class MapBasedConfigLoaderIT {
+
+  @ClassRule
+  public static final SimulacronRule SIMULACRON_RULE =
+      new SimulacronRule(ClusterSpec.builder().withNodes(1));
+
+  @Before
+  public void setup() {
+    SIMULACRON_RULE.cluster().clearPrimes(true);
+  }
+
+  /**
+   * Checks that runtime changes to the pool size are reflected in the driver. This is a special
+   * case because unlike other options, the driver does not re-read the option at regular intervals;
+   * instead, it relies on the {@link ConfigChangeEvent} being fired.
+   */
+  @Test
+  public void should_resize_pool_when_config_changes() {
+    OptionsMap optionsMap = OptionsMap.driverDefaults();
+
+    try (CqlSession session =
+        CqlSession.builder()
+            .addContactEndPoints(SIMULACRON_RULE.getContactPoints())
+            .withLocalDatacenter("dc1")
+            .withConfigLoader(DriverConfigLoader.fromMap(optionsMap))
+            .build()) {
+
+      Node node = session.getMetadata().getNodes().values().iterator().next();
+      assertThat(node.getOpenConnections()).isEqualTo(2); // control connection + pool (default 1)
+
+      optionsMap.put(TypedDriverOption.CONNECTION_POOL_LOCAL_SIZE, 2);
+
+      ConditionChecker.checkThat(() -> node.getOpenConnections() == 3).becomesTrue();
+    }
+  }
+
+  /** Checks that profiles that have specific policy options will get their own policy instance. */
+  @Test
+  public void should_create_policies_per_profile() {
+    // Given
+    // a query that throws UNAVAILABLE
+    String mockQuery = "mock query";
+    SIMULACRON_RULE.cluster().prime(when(mockQuery).then(unavailable(QUORUM, 3, 2)));
+
+    // a default profile that uses the default retry policy, and an alternate profile that uses a
+    // policy that ignores all errors
+    OptionsMap optionsMap = OptionsMap.driverDefaults();
+    String alternateProfile = "profile1";
+    optionsMap.put(
+        alternateProfile, TypedDriverOption.RETRY_POLICY_CLASS, IgnoreAllPolicy.class.getName());
+
+    try (CqlSession session =
+        CqlSession.builder()
+            .addContactEndPoints(SIMULACRON_RULE.getContactPoints())
+            .withLocalDatacenter("dc1")
+            .withConfigLoader(DriverConfigLoader.fromMap(optionsMap))
+            .build()) {
+
+      // When
+      // executing the query for the default profile
+      SimpleStatement defaultProfileStatement = SimpleStatement.newInstance(mockQuery);
+      assertThatThrownBy(() -> session.execute(defaultProfileStatement))
+          .satisfies(
+              t -> {
+                // Then
+                // the UNAVAILABLE error is surfaced
+                assertThat(t).isInstanceOf(AllNodesFailedException.class);
+                AllNodesFailedException anfe = (AllNodesFailedException) t;
+                assertThat(anfe.getAllErrors()).hasSize(1);
+                List<Throwable> nodeErrors = anfe.getAllErrors().values().iterator().next();
+                assertThat(nodeErrors).hasSize(1);
+                assertThat(nodeErrors.get(0)).isInstanceOf(UnavailableException.class);
+              });
+
+      // When
+      // executing the query for the alternate profile
+      SimpleStatement alternateProfileStatement =
+          SimpleStatement.newInstance(mockQuery).setExecutionProfileName(alternateProfile);
+      ResultSet rs = session.execute(alternateProfileStatement);
+
+      // Then
+      // the error is ignored
+      assertThat(rs.one()).isNull();
+    }
+  }
+
+  public static class IgnoreAllPolicy implements RetryPolicy {
+
+    public IgnoreAllPolicy(
+        @SuppressWarnings("unused") DriverContext context,
+        @SuppressWarnings("unused") String profile) {
+      // nothing to do
+    }
+
+    @Override
+    public RetryDecision onReadTimeout(
+        @NonNull Request request,
+        @NonNull ConsistencyLevel cl,
+        int blockFor,
+        int received,
+        boolean dataPresent,
+        int retryCount) {
+      return RetryDecision.IGNORE;
+    }
+
+    @Override
+    public RetryDecision onWriteTimeout(
+        @NonNull Request request,
+        @NonNull ConsistencyLevel cl,
+        @NonNull WriteType writeType,
+        int blockFor,
+        int received,
+        int retryCount) {
+      return RetryDecision.IGNORE;
+    }
+
+    @Override
+    public RetryDecision onUnavailable(
+        @NonNull Request request,
+        @NonNull ConsistencyLevel cl,
+        int required,
+        int alive,
+        int retryCount) {
+      return RetryDecision.IGNORE;
+    }
+
+    @Override
+    public RetryDecision onRequestAborted(
+        @NonNull Request request, @NonNull Throwable error, int retryCount) {
+      return RetryDecision.IGNORE;
+    }
+
+    @Override
+    public RetryDecision onErrorResponse(
+        @NonNull Request request, @NonNull CoordinatorException error, int retryCount) {
+      return RetryDecision.IGNORE;
+    }
+
+    @Override
+    public void close() {
+      // nothing to do
+    }
+  }
+}


### PR DESCRIPTION
This is a proposal for a more straightforward approach to programmatic configuration: no files, rely only on maps.

Sample usage:
```java
// This creates a configuration equivalent to the built-in reference.conf:
Map<String, Map<DriverOption, Object>> optionsMap =
    DriverConfigLoader.buildDefaultOptionsMap();

// Customize an option:
optionsMap
  .get(DriverExecutionProfile.DEFAULT_NAME)
  .put(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(5));

DriverConfigLoader loader = DriverConfigLoader.fromMap(optionsMap);
CqlSession session = CqlSession.builder().withConfigLoader(loader).build();
```

See the javadocs of the new method `DriverConfigLoader.fromMap` for more details.