### PR TITLE
JAVA-2627: Avoid logging error message including stack trace in reque…

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -5,6 +5,11 @@
   3.x versions get published.
 -->
 
+## 3.9.0 (in progress)
+
+- [bug] JAVA-2627: Avoid logging error message including stack trace in request handler.
+
+
 ## 3.8.0
 
 - [new feature] JAVA-2356: Support for DataStax Cloud API.

--- a/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/RequestHandler.java
@@ -427,7 +427,10 @@ class RequestHandler {
                 findNextHostAndQuery();
               } catch (RuntimeException e) {
                 if (connection != null) connection.release();
-                logger.error("Unexpected error while querying " + host.getEndPoint(), e);
+                logger.warn(
+                    "Unexpected error while querying {} - [{}]. Find next host to query.",
+                    host.getEndPoint(),
+                    e.toString());
                 logError(host.getEndPoint(), e);
                 findNextHostAndQuery();
               }
@@ -438,7 +441,10 @@ class RequestHandler {
               if (t instanceof BusyPoolException) {
                 logError(host.getEndPoint(), t);
               } else {
-                logger.error("Unexpected error while querying " + host.getEndPoint(), t);
+                logger.warn(
+                    "Unexpected error while querying {} - [{}]. Find next host to query.",
+                    host.getEndPoint(),
+                    t.toString());
                 logError(host.getEndPoint(), t);
               }
               findNextHostAndQuery();


### PR DESCRIPTION
…st handler

Avoid logging error messages inluding stack trace from within
SpeculativeExecution, when the request "continues" by querying the next
host.

Logging level is changed to WARNING and the stack trace is removed.

The stack trace is logged in the debug message instead.