### PR TITLE
JAVA-2637: Bump Netty to 4.1.45

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.5.0 (in progress)
 
+- [improvement] JAVA-2637: Bump Netty to 4.1.45
 - [bug] JAVA-2617: Reinstate generation of deps.txt for Insights
 - [new feature] JAVA-2625: Provide user-friendly programmatic configuration for kerberos
 - [improvement] JAVA-2624: Expose a config option for the connect timeout

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/insights/InsightsClientTest.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/insights/InsightsClientTest.java
@@ -21,9 +21,9 @@ import static com.datastax.dse.driver.internal.core.insights.ExecutionProfileMoc
 import static com.datastax.dse.driver.internal.core.insights.PackageUtil.DEFAULT_AUTH_PROVIDER_PACKAGE;
 import static com.datastax.dse.driver.internal.core.insights.PackageUtil.DEFAULT_LOAD_BALANCING_PACKAGE;
 import static com.datastax.dse.driver.internal.core.insights.PackageUtil.DEFAULT_SPECULATIVE_EXECUTION_PACKAGE;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.awaitility.Duration.ONE_SECOND;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -284,7 +284,7 @@ public class InsightsClientTest {
     InsightsClient.scheduleInsightsTask(100L, Executors.newScheduledThreadPool(1), runnable);
 
     // then
-    await().atMost(ONE_SECOND).until(() -> counter.get() >= 1);
+    await().atMost(1, SECONDS).until(() -> counter.get() >= 1);
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <hdrhistogram.version>2.1.11</hdrhistogram.version>
     <metrics.version>4.0.5</metrics.version>
     <native-protocol.version>1.4.9</native-protocol.version>
-    <netty.version>4.1.39.Final</netty.version>
+    <netty.version>4.1.45.Final</netty.version>
     <slf4j.version>1.7.26</slf4j.version>
     <esri.version>1.2.1</esri.version>
     <tinkerpop.version>3.3.3</tinkerpop.version>
@@ -72,7 +72,7 @@
     <json.version>20180130</json.version>
     <!-- esri dependency (used only in OSGi integration tests) -->
     <legacy-jackson.version>1.9.12</legacy-jackson.version>
-    <awaitility.version>3.1.6</awaitility.version>
+    <awaitility.version>4.0.2</awaitility.version>
     <apacheds.version>2.0.0-M19</apacheds.version>
     <surefire.version>2.22.2</surefire.version>
     <skipTests>false</skipTests>


### PR DESCRIPTION
This required adjustements in a few unit tests, where
`waitForPendingAdminTasks` methods relied on the fact that a task
scheduled on the event loop with a short delay would be executed after
any current immediate task.

This doesn't work anymore, possibly after the event loop refactoring in
Netty 4.1.44. It was replaced with a combination of Awaitility and
timeouts in `Mockito.verify` calls.