### PR TITLE
JAVA-2644: Revisit channel selection when pool size > 1

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.5.0 (in progress)
 
+- [bug] JAVA-2644: Revisit channel selection when pool size > 1
 - [bug] JAVA-2630: Correctly handle custom classes in IndexMetadata.describe
 - [improvement] JAVA-1556: Publish Maven Bill Of Materials POM
 - [improvement] JAVA-2637: Bump Netty to 4.1.45

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/cql/continuous/ContinuousCqlRequestHandler.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/cql/continuous/ContinuousCqlRequestHandler.java
@@ -647,6 +647,7 @@ public class ContinuousCqlRequestHandler
     Duration timeout = executionProfile.getDuration(DefaultDriverOption.REQUEST_TIMEOUT);
     ThrottledAdminRequestHandler.prepare(
             channel,
+            true,
             prepare,
             repreparePayload.customPayload,
             timeout,
@@ -899,6 +900,7 @@ public class ContinuousCqlRequestHandler
     LOG.trace("[{}] Sending request for more pages", logPrefix);
     ThrottledAdminRequestHandler.query(
             channel,
+            true,
             Revise.requestMoreContinuousPages(streamId, nextPages),
             statement.getCustomPayload(),
             timeoutOtherPages,
@@ -1011,6 +1013,7 @@ public class ContinuousCqlRequestHandler
     LOG.trace("[{}] Sending cancel request", logPrefix);
     ThrottledAdminRequestHandler.query(
             channel,
+            true,
             Revise.cancelContinuousPaging(streamId),
             statement.getCustomPayload(),
             timeoutOtherPages,

--- a/core/src/main/java/com/datastax/oss/driver/api/core/connection/BusyConnectionException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/connection/BusyConnectionException.java
@@ -30,12 +30,19 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public class BusyConnectionException extends DriverException {
 
+  // Note: the driver doesn't use this constructor anymore, it is preserved only for backward
+  // compatibility.
+  @SuppressWarnings("unused")
   public BusyConnectionException(int maxAvailableIds) {
     this(
         String.format(
             "Connection has exceeded its maximum of %d simultaneous requests", maxAvailableIds),
         null,
         false);
+  }
+
+  public BusyConnectionException(String message) {
+    this(message, null, false);
   }
 
   private BusyConnectionException(

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/AdminRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/AdminRequestHandler.java
@@ -17,6 +17,7 @@ package com.datastax.oss.driver.internal.core.adminrequest;
 
 import com.datastax.oss.driver.api.core.DriverTimeoutException;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.connection.BusyConnectionException;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
 import com.datastax.oss.driver.internal.core.channel.ResponseCallback;
@@ -54,6 +55,7 @@ public class AdminRequestHandler<ResultT> implements ResponseCallback {
       DriverChannel channel, Query query, Duration timeout, String logPrefix) {
     return new AdminRequestHandler<>(
         channel,
+        true,
         query,
         Frame.NO_PAYLOAD,
         timeout,
@@ -78,7 +80,7 @@ public class AdminRequestHandler<ResultT> implements ResponseCallback {
       debugString += " with parameters " + parameters;
     }
     return new AdminRequestHandler<>(
-        channel, message, Frame.NO_PAYLOAD, timeout, logPrefix, debugString, Rows.class);
+        channel, true, message, Frame.NO_PAYLOAD, timeout, logPrefix, debugString, Rows.class);
   }
 
   public static AdminRequestHandler<AdminResult> query(
@@ -87,6 +89,7 @@ public class AdminRequestHandler<ResultT> implements ResponseCallback {
   }
 
   private final DriverChannel channel;
+  private final boolean shouldPreAcquireId;
   private final Message message;
   private final Map<String, ByteBuffer> customPayload;
   private final Duration timeout;
@@ -100,6 +103,7 @@ public class AdminRequestHandler<ResultT> implements ResponseCallback {
 
   protected AdminRequestHandler(
       DriverChannel channel,
+      boolean shouldPreAcquireId,
       Message message,
       Map<String, ByteBuffer> customPayload,
       Duration timeout,
@@ -107,6 +111,7 @@ public class AdminRequestHandler<ResultT> implements ResponseCallback {
       String debugString,
       Class<? extends Result> expectedResponseType) {
     this.channel = channel;
+    this.shouldPreAcquireId = shouldPreAcquireId;
     this.message = message;
     this.customPayload = customPayload;
     this.timeout = timeout;
@@ -117,7 +122,14 @@ public class AdminRequestHandler<ResultT> implements ResponseCallback {
 
   public CompletionStage<ResultT> start() {
     LOG.debug("[{}] Executing {}", logPrefix, this);
-    channel.write(message, false, customPayload, this).addListener(this::onWriteComplete);
+    if (shouldPreAcquireId && !channel.preAcquireId()) {
+      setFinalError(
+          new BusyConnectionException(
+              String.format(
+                  "%s has reached its maximum number of simultaneous requests", channel)));
+    } else {
+      channel.write(message, false, customPayload, this).addListener(this::onWriteComplete);
+    }
     return result;
   }
 
@@ -199,6 +211,8 @@ public class AdminRequestHandler<ResultT> implements ResponseCallback {
         buildQueryOptions(currentOptions.pageSize, currentOptions.namedValues, pagingState);
     return new AdminRequestHandler<>(
         channel,
+        // This is called for next page queries, so we always need to reacquire an id:
+        true,
         new Query(current.query, newOptions),
         customPayload,
         timeout,

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/ThrottledAdminRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/ThrottledAdminRequestHandler.java
@@ -17,11 +17,15 @@ package com.datastax.oss.driver.internal.core.adminrequest;
 
 import com.datastax.oss.driver.api.core.DriverTimeoutException;
 import com.datastax.oss.driver.api.core.RequestThrottlingException;
+import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
 import com.datastax.oss.driver.api.core.session.throttling.RequestThrottler;
 import com.datastax.oss.driver.api.core.session.throttling.Throttled;
 import com.datastax.oss.driver.internal.core.channel.DriverChannel;
+import com.datastax.oss.driver.internal.core.control.ControlConnection;
 import com.datastax.oss.driver.internal.core.metrics.SessionMetricUpdater;
+import com.datastax.oss.driver.internal.core.pool.ChannelPool;
+import com.datastax.oss.driver.internal.core.session.DefaultSession;
 import com.datastax.oss.protocol.internal.Message;
 import com.datastax.oss.protocol.internal.response.Result;
 import com.datastax.oss.protocol.internal.response.result.Prepared;
@@ -38,8 +42,16 @@ import net.jcip.annotations.ThreadSafe;
 public class ThrottledAdminRequestHandler<ResultT> extends AdminRequestHandler<ResultT>
     implements Throttled {
 
+  /**
+   * @param shouldPreAcquireId whether to call {@link DriverChannel#preAcquireId()} before sending
+   *     the request. This <b>must be false</b> if you obtained the connection from a pool ({@link
+   *     ChannelPool#next()}, or {@link DefaultSession#getChannel(Node, String)}). It <b>must be
+   *     true</b> if you are using a standalone channel (e.g. in {@link ControlConnection} or one of
+   *     its auxiliary components).
+   */
   public static ThrottledAdminRequestHandler<AdminResult> query(
       DriverChannel channel,
+      boolean shouldPreAcquireId,
       Message message,
       Map<String, ByteBuffer> customPayload,
       Duration timeout,
@@ -49,6 +61,7 @@ public class ThrottledAdminRequestHandler<ResultT> extends AdminRequestHandler<R
       String debugString) {
     return new ThrottledAdminRequestHandler<>(
         channel,
+        shouldPreAcquireId,
         message,
         customPayload,
         timeout,
@@ -59,8 +72,14 @@ public class ThrottledAdminRequestHandler<ResultT> extends AdminRequestHandler<R
         Rows.class);
   }
 
+  /**
+   * @param shouldPreAcquireId whether to call {@link DriverChannel#preAcquireId()} before sending
+   *     the request. See {@link #query(DriverChannel, boolean, Message, Map, Duration,
+   *     RequestThrottler, SessionMetricUpdater, String, String)} for more explanations.
+   */
   public static ThrottledAdminRequestHandler<ByteBuffer> prepare(
       DriverChannel channel,
+      boolean shouldPreAcquireId,
       Message message,
       Map<String, ByteBuffer> customPayload,
       Duration timeout,
@@ -69,6 +88,7 @@ public class ThrottledAdminRequestHandler<ResultT> extends AdminRequestHandler<R
       String logPrefix) {
     return new ThrottledAdminRequestHandler<>(
         channel,
+        shouldPreAcquireId,
         message,
         customPayload,
         timeout,
@@ -85,6 +105,7 @@ public class ThrottledAdminRequestHandler<ResultT> extends AdminRequestHandler<R
 
   protected ThrottledAdminRequestHandler(
       DriverChannel channel,
+      boolean preAcquireId,
       Message message,
       Map<String, ByteBuffer> customPayload,
       Duration timeout,
@@ -93,7 +114,15 @@ public class ThrottledAdminRequestHandler<ResultT> extends AdminRequestHandler<R
       String logPrefix,
       String debugString,
       Class<? extends Result> expectedResponseType) {
-    super(channel, message, customPayload, timeout, logPrefix, debugString, expectedResponseType);
+    super(
+        channel,
+        preAcquireId,
+        message,
+        customPayload,
+        timeout,
+        logPrefix,
+        debugString,
+        expectedResponseType);
     this.startTimeNanos = System.nanoTime();
     this.throttler = throttler;
     this.metricUpdater = metricUpdater;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
@@ -17,7 +17,13 @@ package com.datastax.oss.driver.internal.core.channel;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.connection.BusyConnectionException;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.internal.core.adminrequest.AdminRequestHandler;
+import com.datastax.oss.driver.internal.core.adminrequest.ThrottledAdminRequestHandler;
+import com.datastax.oss.driver.internal.core.pool.ChannelPool;
+import com.datastax.oss.driver.internal.core.session.DefaultSession;
 import com.datastax.oss.driver.internal.core.util.concurrent.UncaughtExceptions;
 import com.datastax.oss.protocol.internal.Message;
 import io.netty.channel.Channel;
@@ -129,12 +135,45 @@ public class DriverChannel {
   }
 
   /**
-   * @return the number of available stream ids on the channel. This is used to weigh channels in
-   *     pools that have a size bigger than 1, in the load balancing policy, and for monitoring
-   *     purposes.
+   * @return the number of available stream ids on the channel; more precisely, this is the number
+   *     of {@link #preAcquireId()} calls for which the id has not been released yet. This is used
+   *     to weigh channels in pools that have a size bigger than 1, in the load balancing policy,
+   *     and for monitoring purposes.
    */
   public int getAvailableIds() {
     return inFlightHandler.getAvailableIds();
+  }
+
+  /**
+   * Indicates the intention to send a request using this channel.
+   *
+   * <p>There must be <b>exactly one</b> invocation of this method before each call to {@link
+   * #write(Message, boolean, Map, ResponseCallback)}. If this method returns true, the client
+   * <b>must</b> proceed with the write. If it returns false, it <b>must not</b> proceed.
+   *
+   * <p>This method is used together with {@link #getAvailableIds()} to track how many requests are
+   * currently executing on the channel, and avoid submitting a request that would result in a
+   * {@link BusyConnectionException}. The two methods follow atomic semantics: {@link
+   * #getAvailableIds()} returns the exact count of clients that have called {@link #preAcquireId()}
+   * and not yet released their stream id at this point in time.
+   *
+   * <p>Most of the time, the driver code calls this method automatically:
+   *
+   * <ul>
+   *   <li>if you obtained the channel from a pool ({@link ChannelPool#next()} or {@link
+   *       DefaultSession#getChannel(Node, String)}), <b>do not call</b> this method: it has already
+   *       been done as part of selecting the channel.
+   *   <li>if you use {@link ChannelHandlerRequest} or {@link AdminRequestHandler} for internal
+   *       queries, <b>do not call</b> this method, those classes already do it.
+   *   <li>however, if you use {@link ThrottledAdminRequestHandler}, you must specify a {@code
+   *       shouldPreAcquireId} argument to indicate whether to call this method or not. This is
+   *       because those requests are sometimes used with a channel that comes from a pool
+   *       (requiring {@code shouldPreAcquireId = false}), or sometimes with a standalone channel
+   *       like in the control connection (requiring {@code shouldPreAcquireId = true}).
+   * </ul>
+   */
+  public boolean preAcquireId() {
+    return inFlightHandler.preAcquireId();
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/StreamIdGenerator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/StreamIdGenerator.java
@@ -16,14 +16,17 @@
 package com.datastax.oss.driver.internal.core.channel;
 
 import java.util.BitSet;
+import java.util.concurrent.atomic.AtomicInteger;
 import net.jcip.annotations.NotThreadSafe;
 
 /**
  * Manages the set of identifiers used to distinguish multiplexed requests on a channel.
  *
- * <p>This class is not thread safe: calls to {@link #acquire()} and {@link #release(int)} must be
- * properly synchronized (in practice this is done by only calling them from the I/O thread).
- * However, {@link #getAvailableIds()} has volatile semantics.
+ * <p>{@link #preAcquire()} / {@link #getAvailableIds()} follow atomic semantics. See {@link
+ * DriverChannel#preAcquireId()} for more explanations.
+ *
+ * <p>Other methods are not synchronized, they are only called by {@link InFlightHandler} on the I/O
+ * thread.
  */
 @NotThreadSafe
 class StreamIdGenerator {
@@ -31,38 +34,52 @@ class StreamIdGenerator {
   private final int maxAvailableIds;
   // unset = available, set = borrowed (note that this is the opposite of the 3.x implementation)
   private final BitSet ids;
-  private volatile int availableIds;
+  private AtomicInteger availableIds;
 
   StreamIdGenerator(int maxAvailableIds) {
     this.maxAvailableIds = maxAvailableIds;
     this.ids = new BitSet(this.maxAvailableIds);
-    this.availableIds = this.maxAvailableIds;
+    this.availableIds = new AtomicInteger(this.maxAvailableIds);
   }
 
-  // safe because a given instance is always called from the same I/O thread
-  @SuppressWarnings({"NonAtomicVolatileUpdate", "NonAtomicOperationOnVolatileField"})
+  boolean preAcquire() {
+    while (true) {
+      int current = availableIds.get();
+      assert current >= 0;
+      if (current == 0) {
+        return false;
+      } else if (availableIds.compareAndSet(current, current - 1)) {
+        return true;
+      }
+    }
+  }
+
+  void cancelPreAcquire() {
+    int available = availableIds.incrementAndGet();
+    assert available <= maxAvailableIds;
+  }
+
   int acquire() {
+    assert availableIds.get() < maxAvailableIds;
     int id = ids.nextClearBit(0);
     if (id >= maxAvailableIds) {
       return -1;
     }
     ids.set(id);
-    availableIds--;
     return id;
   }
 
-  @SuppressWarnings({"NonAtomicVolatileUpdate", "NonAtomicOperationOnVolatileField"})
   void release(int id) {
-    if (ids.get(id)) {
-      availableIds++;
-    } else {
+    if (!ids.get(id)) {
       throw new IllegalStateException("Tried to release id that hadn't been borrowed: " + id);
     }
     ids.clear(id);
+    int available = availableIds.incrementAndGet();
+    assert available <= maxAvailableIds;
   }
 
   int getAvailableIds() {
-    return availableIds;
+    return availableIds.get();
   }
 
   int getMaxAvailableIds() {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
@@ -283,6 +283,7 @@ public class CqlPrepareHandler implements Throttled {
       ThrottledAdminRequestHandler<ByteBuffer> handler =
           ThrottledAdminRequestHandler.prepare(
               channel,
+              false,
               message,
               request.getCustomPayload(),
               timeout,

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
@@ -660,6 +660,7 @@ public class CqlRequestHandler implements Throttled {
         ThrottledAdminRequestHandler<ByteBuffer> reprepareHandler =
             ThrottledAdminRequestHandler.prepare(
                 channel,
+                true,
                 reprepareMessage,
                 repreparePayload.customPayload,
                 timeout,

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/PoolManager.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/PoolManager.java
@@ -408,6 +408,7 @@ public class PoolManager implements AsyncAutoCloseable {
         new ReprepareOnUp(
                 logPrefix + "|" + pool.getNode().getEndPoint(),
                 pool,
+                adminExecutor,
                 repreparePayloads,
                 context,
                 () -> RunOrSchedule.on(adminExecutor, () -> onPoolReady(pool)))

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryAvailableIdsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryAvailableIdsTest.java
@@ -69,6 +69,7 @@ public class ChannelFactoryAvailableIdsTest extends ChannelFactoryTestBase {
               assertThat(channel.getAvailableIds()).isEqualTo(128);
 
               // Write a request, should decrease the count
+              assertThat(channel.preAcquireId()).isTrue();
               Future<java.lang.Void> writeFuture =
                   channel.write(new Query("test"), false, Frame.NO_PAYLOAD, responseCallback);
               assertThat(writeFuture)

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/InFlightHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/InFlightHandlerTest.java
@@ -57,6 +57,7 @@ public class InFlightHandlerTest extends ChannelHandlerTestBase {
   public void setup() {
     super.setup();
     MockitoAnnotations.initMocks(this);
+    when(streamIds.preAcquire()).thenReturn(true);
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/StreamIdGeneratorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/StreamIdGeneratorTest.java
@@ -30,6 +30,7 @@ public class StreamIdGeneratorTest {
   public void should_return_available_ids_in_sequence() {
     StreamIdGenerator generator = new StreamIdGenerator(8);
     for (int i = 0; i < 8; i++) {
+      assertThat(generator.preAcquire()).isTrue();
       assertThat(generator.acquire()).isEqualTo(i);
       assertThat(generator.getAvailableIds()).isEqualTo(7 - i);
     }
@@ -39,23 +40,28 @@ public class StreamIdGeneratorTest {
   public void should_return_minus_one_when_no_id_available() {
     StreamIdGenerator generator = new StreamIdGenerator(8);
     for (int i = 0; i < 8; i++) {
-      generator.acquire();
+      assertThat(generator.preAcquire()).isTrue();
+      // also validating that ids are held as soon as preAcquire() is called, even if acquire() has
+      // not been invoked yet
     }
     assertThat(generator.getAvailableIds()).isEqualTo(0);
-    assertThat(generator.acquire()).isEqualTo(-1);
+    assertThat(generator.preAcquire()).isFalse();
   }
 
   @Test
   public void should_return_previously_released_ids() {
     StreamIdGenerator generator = new StreamIdGenerator(8);
     for (int i = 0; i < 8; i++) {
-      generator.acquire();
+      assertThat(generator.preAcquire()).isTrue();
+      assertThat(generator.acquire()).isEqualTo(i);
     }
     generator.release(7);
     generator.release(2);
     assertThat(generator.getAvailableIds()).isEqualTo(2);
+    assertThat(generator.preAcquire()).isTrue();
     assertThat(generator.acquire()).isEqualTo(2);
+    assertThat(generator.preAcquire()).isTrue();
     assertThat(generator.acquire()).isEqualTo(7);
-    assertThat(generator.acquire()).isEqualTo(-1);
+    assertThat(generator.preAcquire()).isFalse();
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/PoolBehavior.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/PoolBehavior.java
@@ -60,6 +60,7 @@ public class PoolBehavior {
       EventLoop eventLoop = mock(EventLoop.class);
       ChannelConfig config = mock(DefaultSocketChannelConfig.class);
       this.writePromise = ImmediateEventExecutor.INSTANCE.newPromise();
+      when(channel.preAcquireId()).thenReturn(true);
       when(channel.write(any(Message.class), anyBoolean(), anyMap(), any(ResponseCallback.class)))
           .thenAnswer(
               invocation -> {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelSetTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/pool/ChannelSetTest.java
@@ -44,6 +44,9 @@ public class ChannelSetTest {
 
   @Test
   public void should_return_element_when_single() {
+    // Given
+    when(channel1.preAcquireId()).thenReturn(true);
+
     // When
     set.add(channel1);
 
@@ -51,6 +54,20 @@ public class ChannelSetTest {
     assertThat(set.size()).isEqualTo(1);
     assertThat(set.next()).isEqualTo(channel1);
     verify(channel1, never()).getAvailableIds();
+    verify(channel1).preAcquireId();
+  }
+
+  @Test
+  public void should_return_null_when_single_but_full() {
+    // Given
+    when(channel1.preAcquireId()).thenReturn(false);
+
+    // When
+    set.add(channel1);
+
+    // Then
+    assertThat(set.next()).isNull();
+    verify(channel1).preAcquireId();
   }
 
   @Test
@@ -59,6 +76,7 @@ public class ChannelSetTest {
     when(channel1.getAvailableIds()).thenReturn(2);
     when(channel2.getAvailableIds()).thenReturn(12);
     when(channel3.getAvailableIds()).thenReturn(8);
+    when(channel2.preAcquireId()).thenReturn(true);
 
     // When
     set.add(channel1);
@@ -71,12 +89,31 @@ public class ChannelSetTest {
     verify(channel1).getAvailableIds();
     verify(channel2).getAvailableIds();
     verify(channel3).getAvailableIds();
+    verify(channel2).preAcquireId();
 
     // When
     when(channel1.getAvailableIds()).thenReturn(15);
+    when(channel1.preAcquireId()).thenReturn(true);
 
     // Then
     assertThat(set.next()).isEqualTo(channel1);
+    verify(channel1).preAcquireId();
+  }
+
+  @Test
+  public void should_return_null_when_multiple_but_all_full() {
+    // Given
+    when(channel1.getAvailableIds()).thenReturn(0);
+    when(channel2.getAvailableIds()).thenReturn(0);
+    when(channel3.getAvailableIds()).thenReturn(0);
+
+    // When
+    set.add(channel1);
+    set.add(channel2);
+    set.add(channel3);
+
+    // Then
+    assertThat(set.next()).isNull();
   }
 
   @Test
@@ -85,6 +122,7 @@ public class ChannelSetTest {
     when(channel1.getAvailableIds()).thenReturn(2);
     when(channel2.getAvailableIds()).thenReturn(12);
     when(channel3.getAvailableIds()).thenReturn(8);
+    when(channel2.preAcquireId()).thenReturn(true);
 
     set.add(channel1);
     set.add(channel2);
@@ -93,6 +131,7 @@ public class ChannelSetTest {
 
     // When
     set.remove(channel2);
+    when(channel3.preAcquireId()).thenReturn(true);
 
     // Then
     assertThat(set.size()).isEqualTo(2);
@@ -100,6 +139,7 @@ public class ChannelSetTest {
 
     // When
     set.remove(channel3);
+    when(channel1.preAcquireId()).thenReturn(true);
 
     // Then
     assertThat(set.size()).isEqualTo(1);
@@ -110,6 +150,28 @@ public class ChannelSetTest {
 
     // Then
     assertThat(set.size()).isEqualTo(0);
+    assertThat(set.next()).isNull();
+  }
+
+  /**
+   * Check that {@link ChannelSet#next()} doesn't spin forever if it keeps racing (see comments in
+   * the implementation).
+   */
+  @Test
+  public void should_not_loop_indefinitely_if_acquisition_keeps_failing() {
+    // Given
+    when(channel1.getAvailableIds()).thenReturn(2);
+    when(channel2.getAvailableIds()).thenReturn(12);
+    when(channel3.getAvailableIds()).thenReturn(8);
+    // channel2 is the most available but we keep failing to acquire (simulating the race condition)
+    when(channel2.preAcquireId()).thenReturn(false);
+
+    // When
+    set.add(channel1);
+    set.add(channel2);
+    set.add(channel3);
+
+    // Then
     assertThat(set.next()).isNull();
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/PoolBalancingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/PoolBalancingIT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.core;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.NoNodeAvailableException;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+@Category(ParallelizableTests.class)
+public class PoolBalancingIT {
+
+  private static final int POOL_SIZE = 2;
+  private static final int REQUESTS_PER_CONNECTION = 20;
+
+  private static final SimulacronRule SIMULACRON_RULE =
+      new SimulacronRule(ClusterSpec.builder().withNodes(1));
+
+  private static final SessionRule<CqlSession> SESSION_RULE =
+      SessionRule.builder(SIMULACRON_RULE)
+          .withConfigLoader(
+              DriverConfigLoader.programmaticBuilder()
+                  .withInt(DefaultDriverOption.CONNECTION_MAX_REQUESTS, REQUESTS_PER_CONNECTION)
+                  .withInt(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE, POOL_SIZE)
+                  .build())
+          .build();
+
+  @ClassRule
+  public static final TestRule CHAIN = RuleChain.outerRule(SIMULACRON_RULE).around(SESSION_RULE);
+
+  private CountDownLatch done;
+  private AtomicReference<Throwable> unexpectedErrorRef;
+
+  @Before
+  public void setup() {
+    done = new CountDownLatch(1);
+    unexpectedErrorRef = new AtomicReference<>();
+  }
+
+  @Test
+  public void should_balance_requests_across_connections() throws InterruptedException {
+    // Generate just the right load to completely fill the pool. All requests should succeed.
+    int simultaneousRequests = POOL_SIZE * REQUESTS_PER_CONNECTION;
+
+    for (int i = 0; i < simultaneousRequests; i++) {
+      reschedule(null, null);
+    }
+    SECONDS.sleep(1);
+    done.countDown();
+
+    Throwable unexpectedError = unexpectedErrorRef.get();
+    if (unexpectedError != null) {
+      fail("At least one request failed unexpectedly", unexpectedError);
+    }
+  }
+
+  private void reschedule(AsyncResultSet asyncResultSet, Throwable throwable) {
+    if (done.getCount() == 1) {
+      if (throwable != null
+          // Actually there is a tiny race condition where pool acquisition may still fail: channel
+          // sizes can change as the client is iterating through them, so it can look like they're
+          // all full even if there's always a free slot somewhere at every point in time. This will
+          // result in NoNodeAvailableException, ignore it.
+          && !(throwable instanceof NoNodeAvailableException)) {
+        unexpectedErrorRef.compareAndSet(null, throwable);
+        // Even a single error is a failure, no need to continue
+        done.countDown();
+      }
+      SESSION_RULE
+          .session()
+          .executeAsync("SELECT release_version FROM system.local")
+          .whenComplete(this::reschedule);
+    }
+  }
+}


### PR DESCRIPTION
~Very early preview because I want to share the direction this is taking ASAP. Tests do not pass yet, and I still have some cleanup and documentation to do.~ edit -- this is ready for review now

In a nutshell, `DriverChannel.preAcquireId()` must be called **exactly once** before each call to `DriverChannel.write()`. No need to explicitly release the id, this will still be done automatically in `InFlightHandler`.

`DriverChannel.getAvailableIds()` now reports the number of ids that have been pre-acquired and not yet released. `preAquireId / getAvailableIds` now have atomic semantics, this allows clients to have a guarantee that once pre-acquired succeeded they won't run into a `BusyConnectionException`.

Unfortunately this re-introduces some of the complexity we had tried to get rid of compared to 3.x: we can't allow the count to get out of sync with the actual number of ids used / about to be used. `ChannelPool.next()` and `ChannelHandlerRequest` automatically pre-acquire. For `AdminRequestHandler`, things get more complicated: while most cases need to pre-acquire (e.g. every use in the control connection), a few cases must not because they operate on a channel that was obtained with `ChannelPool.next()`, we don't want to pre-acquire twice. For now I've introduced a new boolean parameter that must be set every time, I'll see if I can do better tomorrow.