### PR TITLE
JAVA-2667: Add ability to fail the build when integration tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - jdk_switcher use openjdk8
   - ./install-snapshots.sh
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-script: mvn test -Djacoco.skip=true -B -V
+script: mvn test -Djacoco.skip=true -Dmaven.test.failure.ignore=true -B -V
 cache:
   directories:
     - $HOME/.m2

--- a/build.yaml
+++ b/build.yaml
@@ -77,7 +77,7 @@ build:
       # Use the matrix JDK for testing
       jabba use $JABBA_JDK_NAME
       # Run tests against matrix JDK
-      mvn -B -V verify --batch-mode --show-version -Dccm.version=$CCM_CASSANDRA_VERSION -Dccm.dse=$CCM_IS_DSE -Dproxy.path=$HOME/proxy -Dmaven.javadoc.skip=true
+      mvn -B -V verify --batch-mode --show-version -Dccm.version=$CCM_CASSANDRA_VERSION -Dccm.dse=$CCM_IS_DSE -Dproxy.path=$HOME/proxy -Dmaven.javadoc.skip=true -Dmaven.test.failure.ignore=true
   - xunit:
     - "**/target/surefire-reports/TEST-*.xml"
     - "**/target/failsafe-reports/TEST-*.xml"

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,7 +4,8 @@
 
 ### 4.6.0 (in progress)
 
- - [bug] JAVA-1861: Add Metadata.getClusterName()
+- [improvement] JAVA-2667: Add ability to fail the build when integration tests fail
+- [bug] JAVA-1861: Add Metadata.getClusterName()
 
 ### 4.5.0
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -268,15 +268,12 @@
             <id>parallelizable-tests</id>
             <goals>
               <goal>integration-test</goal>
-              <goal>verify</goal>
             </goals>
             <configuration>
               <groups>com.datastax.oss.driver.categories.ParallelizableTests</groups>
               <parallel>classes</parallel>
               <threadCountClasses>8</threadCountClasses>
-              <!-- set so test can exit with rc 0 (ci will mark test failures accordingly) -->
-              <testFailureIgnore>true</testFailureIgnore>
-              <reportNameSuffix>parallelized</reportNameSuffix>
+              <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-parallelized.xml</summaryFile>
               <skipITs>${skipParallelizableITs}</skipITs>
             </configuration>
           </execution>
@@ -284,12 +281,10 @@
             <id>serial-tests</id>
             <goals>
               <goal>integration-test</goal>
-              <goal>verify</goal>
             </goals>
             <configuration>
               <excludedGroups>com.datastax.oss.driver.categories.ParallelizableTests, com.datastax.oss.driver.categories.IsolatedTests</excludedGroups>
-              <testFailureIgnore>true</testFailureIgnore>
-              <reportNameSuffix>serial</reportNameSuffix>
+              <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-serial.xml</summaryFile>
               <skipITs>${skipSerialITs}</skipITs>
             </configuration>
           </execution>
@@ -297,16 +292,27 @@
             <id>isolated-tests</id>
             <goals>
               <goal>integration-test</goal>
-              <goal>verify</goal>
             </goals>
             <configuration>
               <groups>com.datastax.oss.driver.categories.IsolatedTests</groups>
               <!-- run each test in its own jvm fork -->
               <forkCount>1</forkCount>
               <reuseForks>false</reuseForks>
-              <testFailureIgnore>true</testFailureIgnore>
-              <reportNameSuffix>isolated</reportNameSuffix>
+              <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-isolated.xml</summaryFile>
               <skipITs>${skipIsolatedITs}</skipITs>
+            </configuration>
+          </execution>
+          <execution>
+            <id>verify</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <summaryFiles>
+                <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-parallelized.xml</summaryFile>
+                <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-serial.xml</summaryFile>
+                <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-isolated.xml</summaryFile>
+              </summaryFiles>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
And at the same time, this PR makes it possible to finish the entire integration test suite before failing the build, if any of the 3 executions (parallel, serial, isolated) fails.