### PR TITLE
JAVA-2664: Add a callback to inject the session in node state listeners

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.6.0 (in progress)
 
+- [improvement] JAVA-2664: Add a callback to inject the session in listeners
 - [bug] JAVA-2698: TupleCodec and UdtCodec give wrong error message when parsing fails
 - [improvement] JAVA-2435: Add automatic-module-names to the manifests
 - [new feature] JAVA-2054: Add now_in_seconds to protocol v5 query messages

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/tracker/MultiplexingRequestTracker.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/tracker/MultiplexingRequestTracker.java
@@ -18,6 +18,7 @@ package com.datastax.dse.driver.internal.core.tracker;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.session.Request;
+import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.core.tracker.RequestTracker;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -106,6 +107,17 @@ public class MultiplexingRequestTracker implements RequestTracker {
         tracker.onNodeError(request, error, latencyNanos, executionProfile, node, logPrefix);
       } catch (Throwable t) {
         LOG.error("[{}] Unexpected error while invoking request tracker", logPrefix, t);
+      }
+    }
+  }
+
+  @Override
+  public void onSessionReady(@NonNull Session session) {
+    for (RequestTracker tracker : trackers) {
+      try {
+        tracker.onSessionReady(session);
+      } catch (Throwable t) {
+        LOG.error("[{}] Unexpected error while invoking request tracker", session.getName(), t);
       }
     }
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/SafeInitNodeStateListener.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/SafeInitNodeStateListener.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.metadata;
+
+import com.datastax.oss.driver.api.core.session.Session;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.BiConsumer;
+import net.jcip.annotations.GuardedBy;
+
+/**
+ * A node state listener wrapper that delays (or ignores) init events until after the session is
+ * ready.
+ *
+ * <p>By default, the driver calls node state events, such as {@link #onUp} and {@link #onAdd},
+ * before the session is ready; see {@link NodeStateListener#onSessionReady(Session)} for a detailed
+ * explanation. This can make things complicated if your listener implementation needs the session
+ * to process those events.
+ *
+ * <p>This class wraps another implementation to shield it from those details:
+ *
+ * <pre>
+ * NodeStateListener delegate = ... // your listener implementation
+ *
+ * SafeInitNodeStateListener wrapper =
+ *     new SafeInitNodeStateListener(delegate, true);
+ *
+ * CqlSession session = CqlSession.builder()
+ *     .withNodeStateListener(wrapper)
+ *     .build();
+ * </pre>
+ *
+ * With this setup, {@code delegate.onSessionReady} is guaranteed to be invoked first, before any
+ * other method. The second constructor argument indicates what to do with the method calls that
+ * were ignored before that:
+ *
+ * <ul>
+ *   <li>if {@code true}, they are recorded, and replayed to {@code delegate} immediately after
+ *       {@link #onSessionReady}. They are guaranteed to happen in the original order, and before
+ *       any post-initialization events.
+ *   <li>if {@code false}, they are discarded.
+ * </ul>
+ *
+ * @since 4.6.0
+ */
+public class SafeInitNodeStateListener implements NodeStateListener {
+
+  private final NodeStateListener delegate;
+  private final boolean replayInitEvents;
+
+  // Write lock: recording init events or setting sessionReady
+  // Read lock: reading init events or checking sessionReady
+  private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+  @GuardedBy("lock")
+  private boolean sessionReady;
+
+  @GuardedBy("lock")
+  private final List<InitEvent> initEvents = new ArrayList<>();
+
+  /**
+   * Creates a new instance.
+   *
+   * @param delegate the wrapped listener, to which method invocations will be forwarded.
+   * @param replayInitEvents whether to record events during initialization and replay them to the
+   *     child listener once it's created, or just ignore them.
+   */
+  public SafeInitNodeStateListener(@NonNull NodeStateListener delegate, boolean replayInitEvents) {
+    this.delegate = Objects.requireNonNull(delegate);
+    this.replayInitEvents = replayInitEvents;
+  }
+
+  @Override
+  public void onSessionReady(@NonNull Session session) {
+    lock.writeLock().lock();
+    try {
+      if (!sessionReady) {
+        sessionReady = true;
+        delegate.onSessionReady(session);
+        if (replayInitEvents) {
+          for (InitEvent event : initEvents) {
+            event.invoke(delegate);
+          }
+        }
+      }
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public void onAdd(@NonNull Node node) {
+    onEvent(node, InitEvent.Type.ADD);
+  }
+
+  @Override
+  public void onUp(@NonNull Node node) {
+    onEvent(node, InitEvent.Type.UP);
+  }
+
+  @Override
+  public void onDown(@NonNull Node node) {
+    onEvent(node, InitEvent.Type.DOWN);
+  }
+
+  @Override
+  public void onRemove(@NonNull Node node) {
+    onEvent(node, InitEvent.Type.REMOVE);
+  }
+
+  private void onEvent(Node node, InitEvent.Type eventType) {
+
+    // Cheap case: the session is ready, just delegate
+    lock.readLock().lock();
+    try {
+      if (sessionReady) {
+        eventType.listenerMethod.accept(delegate, node);
+        return;
+      }
+    } finally {
+      lock.readLock().unlock();
+    }
+
+    // Otherwise, we must acquire the write lock to record the event
+    if (replayInitEvents) {
+      lock.writeLock().lock();
+      try {
+        // Must re-check because we completely released the lock for a short duration
+        if (sessionReady) {
+          eventType.listenerMethod.accept(delegate, node);
+        } else {
+          initEvents.add(new InitEvent(node, eventType));
+        }
+      } finally {
+        lock.writeLock().unlock();
+      }
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    delegate.close();
+  }
+
+  private static class InitEvent {
+    enum Type {
+      ADD(NodeStateListener::onAdd),
+      UP(NodeStateListener::onUp),
+      DOWN(NodeStateListener::onDown),
+      REMOVE(NodeStateListener::onRemove),
+      ;
+
+      @SuppressWarnings("ImmutableEnumChecker")
+      final BiConsumer<NodeStateListener, Node> listenerMethod;
+
+      Type(BiConsumer<NodeStateListener, Node> listenerMethod) {
+        this.listenerMethod = listenerMethod;
+      }
+    }
+
+    final Node node;
+    final Type type;
+
+    InitEvent(@NonNull Node node, @NonNull Type type) {
+      this.node = Objects.requireNonNull(node);
+      this.type = Objects.requireNonNull(type);
+    }
+
+    void invoke(@NonNull NodeStateListener target) {
+      type.listenerMethod.accept(Objects.requireNonNull(target), node);
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/schema/SchemaChangeListener.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/schema/SchemaChangeListener.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.driver.api.core.metadata.schema;
 
+import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
 import com.datastax.oss.driver.api.core.type.UserDefinedType;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -71,4 +72,20 @@ public interface SchemaChangeListener extends AutoCloseable {
   void onViewDropped(@NonNull ViewMetadata view);
 
   void onViewUpdated(@NonNull ViewMetadata current, @NonNull ViewMetadata previous);
+
+  /**
+   * Invoked when the session is ready to process user requests.
+   *
+   * <p>This corresponds to the moment when {@link SessionBuilder#build()} returns, or the future
+   * returned by {@link SessionBuilder#buildAsync()} completes. If the session initialization fails,
+   * this method will not get called.
+   *
+   * <p>Listener methods are invoked from different threads; if you store the session in a field,
+   * make it at least volatile to guarantee proper publication.
+   *
+   * <p>This method is guaranteed to be the first one invoked on this object.
+   *
+   * <p>The default implementation is empty.
+   */
+  default void onSessionReady(@NonNull Session session) {}
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/tracker/RequestTracker.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/tracker/RequestTracker.java
@@ -159,4 +159,25 @@ public interface RequestTracker extends AutoCloseable {
     // method
     onNodeSuccess(request, latencyNanos, executionProfile, node);
   }
+
+  /**
+   * Invoked when the session is ready to process user requests.
+   *
+   * <p><b>WARNING: if you use {@code session.execute()} in your tracker implementation, keep in
+   * mind that those requests will in turn recurse back into {@code onSuccess} / {@code onError}
+   * methods.</b> Make sure you don't trigger an infinite loop; one way to do that is to use a
+   * custom execution profile for internal requests.
+   *
+   * <p>This corresponds to the moment when {@link SessionBuilder#build()} returns, or the future
+   * returned by {@link SessionBuilder#buildAsync()} completes. If the session initialization fails,
+   * this method will not get called.
+   *
+   * <p>Listener methods are invoked from different threads; if you store the session in a field,
+   * make it at least volatile to guarantee proper publication.
+   *
+   * <p>This method is guaranteed to be the first one invoked on this object.
+   *
+   * <p>The default implementation is empty.
+   */
+  default void onSessionReady(@NonNull Session session) {}
 }

--- a/core/src/test/java/com/datastax/oss/driver/api/core/metadata/SafeInitNodeStateListenerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/metadata/SafeInitNodeStateListenerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.metadata;
+
+import com.datastax.oss.driver.api.core.session.Session;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SafeInitNodeStateListenerTest {
+
+  @Mock private NodeStateListener delegate;
+  @Mock private Node node;
+  @Mock private Session session;
+
+  @Test
+  public void should_replay_init_events() {
+    SafeInitNodeStateListener wrapper = new SafeInitNodeStateListener(delegate, true);
+
+    // Not a realistic sequence of invocations in the driver, but that doesn't matter
+    wrapper.onAdd(node);
+    wrapper.onUp(node);
+    wrapper.onSessionReady(session);
+    wrapper.onDown(node);
+
+    InOrder inOrder = Mockito.inOrder(delegate);
+    inOrder.verify(delegate).onSessionReady(session);
+    inOrder.verify(delegate).onAdd(node);
+    inOrder.verify(delegate).onUp(node);
+    inOrder.verify(delegate).onDown(node);
+  }
+
+  @Test
+  public void should_discard_init_events() {
+    SafeInitNodeStateListener wrapper = new SafeInitNodeStateListener(delegate, false);
+
+    wrapper.onAdd(node);
+    wrapper.onUp(node);
+    wrapper.onSessionReady(session);
+    wrapper.onDown(node);
+
+    InOrder inOrder = Mockito.inOrder(delegate);
+    inOrder.verify(delegate).onSessionReady(session);
+    inOrder.verify(delegate).onDown(node);
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/session/ListenersIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/session/ListenersIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.core.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
+import com.datastax.oss.driver.api.core.metadata.SafeInitNodeStateListener;
+import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
+import com.datastax.oss.driver.api.core.tracker.RequestTracker;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@Category(ParallelizableTests.class)
+@RunWith(MockitoJUnitRunner.class)
+public class ListenersIT {
+
+  @ClassRule
+  public static final SimulacronRule SIMULACRON_RULE =
+      new SimulacronRule(ClusterSpec.builder().withNodes(1));
+
+  @Mock private NodeStateListener nodeListener;
+  @Mock private SchemaChangeListener schemaListener;
+  @Mock private RequestTracker requestTracker;
+  @Captor private ArgumentCaptor<Node> nodeCaptor;
+
+  @Test
+  public void should_inject_session_in_listeners() {
+    try (CqlSession session =
+        (CqlSession)
+            SessionUtils.baseBuilder()
+                .addContactEndPoints(SIMULACRON_RULE.getContactPoints())
+                .withNodeStateListener(new SafeInitNodeStateListener(nodeListener, true))
+                .withSchemaChangeListener(schemaListener)
+                .withRequestTracker(requestTracker)
+                .build()) {
+
+      InOrder inOrder = inOrder(nodeListener);
+      inOrder.verify(nodeListener).onSessionReady(session);
+      inOrder.verify(nodeListener).onUp(nodeCaptor.capture());
+      assertThat(nodeCaptor.getValue().getEndPoint())
+          .isEqualTo(SIMULACRON_RULE.getContactPoints().iterator().next());
+
+      verify(schemaListener).onSessionReady(session);
+      verify(requestTracker).onSessionReady(session);
+    }
+  }
+}


### PR DESCRIPTION
Work in progress, I'm pushing early to have something concrete to discuss on the JIRA ticket.

TODO
- [x] tests
- [x] do the same on `SchemaChangeListener`.
  - I think we also need the replay mechanism, because the control connection can receive schema events before the session is fully initialized.
  - One thing to warn users about is to not do schema-altering queries in a listener. Although it seems unlikely that they would do it in a way that causes infinite recursion (e.g. every callback invocation creates a table).
- [x] maybe do the same on `RequestTracker`. But here the risk of recursion is much higher, users must actively defend against it (e.g. by using a profile) otherwise every `session.execute` call from within the listener will in turn invoke a callback. 