### PR TITLE
Add V4+ features: `DATE_TYPE` and `SMALLINT_AND_TINYINT_TYPES`

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultProtocolFeature.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultProtocolFeature.java
@@ -35,5 +35,19 @@ public enum DefaultProtocolFeature implements ProtocolFeature {
    * @see <a href="https://issues.apache.org/jira/browse/CASSANDRA-10145">CASSANDRA-10145</a>
    */
   PER_REQUEST_KEYSPACE,
+
+  /**
+   * Support for smallint and tinyint types.
+   *
+   * @see <a href="https://jira.apache.org/jira/browse/CASSANDRA-8951">CASSANDRA-8951</a>
+   */
+  SMALLINT_AND_TINYINT_TYPES,
+
+  /**
+   * Support for the date type.
+   *
+   * @see <a href="https://jira.apache.org/jira/browse/CASSANDRA-7523">CASSANDRA-7523</a>
+   */
+  DATE_TYPE,
   ;
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultProtocolVersionRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultProtocolVersionRegistry.java
@@ -230,7 +230,9 @@ public class DefaultProtocolVersionRegistry implements ProtocolVersionRegistry {
   @Override
   public boolean supports(ProtocolVersion version, ProtocolFeature feature) {
     int code = version.getCode();
-    if (DefaultProtocolFeature.UNSET_BOUND_VALUES.equals(feature)) {
+    if (DefaultProtocolFeature.SMALLINT_AND_TINYINT_TYPES.equals(feature)
+        || DefaultProtocolFeature.DATE_TYPE.equals(feature)
+        || DefaultProtocolFeature.UNSET_BOUND_VALUES.equals(feature)) {
       // All DSE versions and all OSS V4+
       return DefaultProtocolVersion.V4.getCode() <= code;
     } else if (DefaultProtocolFeature.PER_REQUEST_KEYSPACE.equals(feature)) {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/DefaultProtocolVersionRegistryTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/DefaultProtocolVersionRegistryTest.java
@@ -15,8 +15,13 @@
  */
 package com.datastax.oss.driver.internal.core;
 
+import static com.datastax.dse.driver.api.core.DseProtocolVersion.DSE_V1;
+import static com.datastax.dse.driver.api.core.DseProtocolVersion.DSE_V2;
 import static com.datastax.oss.driver.api.core.ProtocolVersion.V3;
 import static com.datastax.oss.driver.api.core.ProtocolVersion.V4;
+import static com.datastax.oss.driver.api.core.ProtocolVersion.V5;
+import static com.datastax.oss.driver.internal.core.DefaultProtocolFeature.DATE_TYPE;
+import static com.datastax.oss.driver.internal.core.DefaultProtocolFeature.SMALLINT_AND_TINYINT_TYPES;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.dse.driver.api.core.DseProtocolVersion;
@@ -112,6 +117,24 @@ public class DefaultProtocolVersionRegistryTest {
                     mockCassandraNode("2.1") // oss v3
                     )))
         .isEqualTo(ProtocolVersion.V3);
+  }
+
+  @Test
+  public void should_support_date_type_on_oss_v4_and_later() {
+    assertThat(registry.supports(V3, DATE_TYPE)).isFalse();
+    assertThat(registry.supports(V4, DATE_TYPE)).isTrue();
+    assertThat(registry.supports(V5, DATE_TYPE)).isTrue();
+    assertThat(registry.supports(DSE_V1, DATE_TYPE)).isTrue();
+    assertThat(registry.supports(DSE_V2, DATE_TYPE)).isTrue();
+  }
+
+  @Test
+  public void should_support_smallint_and_tinyint_types_on_oss_v4_and_later() {
+    assertThat(registry.supports(V3, SMALLINT_AND_TINYINT_TYPES)).isFalse();
+    assertThat(registry.supports(V4, SMALLINT_AND_TINYINT_TYPES)).isTrue();
+    assertThat(registry.supports(V5, SMALLINT_AND_TINYINT_TYPES)).isTrue();
+    assertThat(registry.supports(DSE_V1, SMALLINT_AND_TINYINT_TYPES)).isTrue();
+    assertThat(registry.supports(DSE_V2, SMALLINT_AND_TINYINT_TYPES)).isTrue();
   }
 
   private Node mockCassandraNode(String rawVersion) {


### PR DESCRIPTION
This would be nice-to-have (though not essential) for the Spark connector.  The connector code necessarily checks the protocol version in several places when generating queries and thinking about schema.  These checks currently look like regular integer-primitive comparisons, which isn't ideal for readability.  Descriptively-named features are more readable, when available.

Following @adutra's  helpful preliminary comment, I split these features along OSS *C issue lines:

* https://jira.apache.org/jira/browse/CASSANDRA-7523 - date type support
* https://jira.apache.org/jira/browse/CASSANDRA-8951 - combined smallint & tinyint type support

This passed the coveo formatter enforcement and local testing (`mvn -pl core test -Dtest=DefaultProtocolVersionRegistryTest`).