### PR TITLE
JAVA-2717: Add OSS Cassandra 4.0 to build.yaml (3.x)

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -25,9 +25,9 @@ schedules:
       exclude:
         # exclude builds for newer Cassandra versions and older JDKs
         - java: openjdk6
-          cassandra: ['2.2', '3.0', '3.11']
+          cassandra: ['2.2', '3.0', '3.11', '4.0']
         - java: openjdk7
-          cassandra: ['2.1', '3.0', '3.11']
+          cassandra: ['2.1', '3.0', '3.11', '4.0']
         # exclude builds for older Cassandra versions and newer JDKs
         - java: openjdk11
           cassandra: ['2.1', '2.2']
@@ -64,6 +64,7 @@ cassandra:
   - '2.2'
   - '3.0'
   - '3.11'
+  - '4.0'
 build:
   - script: |
       . /usr/local/bin/jdk_switcher.sh

--- a/driver-core/src/main/java/com/datastax/driver/core/AbstractTableMetadata.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/AbstractTableMetadata.java
@@ -258,14 +258,19 @@ public abstract class AbstractTableMetadata {
     sb.append("WITH ");
     if (options.isCompactStorage()) and(sb.append("COMPACT STORAGE"), formatted);
     if (!clusteringOrder.isEmpty()) and(appendClusteringOrder(sb), formatted);
-    sb.append("read_repair_chance = ").append(options.getReadRepairChance());
-    and(sb, formatted)
-        .append("dclocal_read_repair_chance = ")
-        .append(options.getLocalReadRepairChance());
+    if (cassandraVersion.getMajor() < 4)
+      sb.append("read_repair_chance = ").append(options.getReadRepairChance());
+    else sb.append("read_repair = 'BLOCKING'");
+    if (cassandraVersion.getMajor() < 4)
+      and(sb, formatted)
+          .append("dclocal_read_repair_chance = ")
+          .append(options.getLocalReadRepairChance());
     if (cassandraVersion.getMajor() < 2
         || (cassandraVersion.getMajor() == 2 && cassandraVersion.getMinor() == 0))
       and(sb, formatted).append("replicate_on_write = ").append(options.getReplicateOnWrite());
     and(sb, formatted).append("gc_grace_seconds = ").append(options.getGcGraceInSeconds());
+    if (cassandraVersion.getMajor() > 3)
+      and(sb, formatted).append("additional_write_policy = '99p'");
     and(sb, formatted)
         .append("bloom_filter_fp_chance = ")
         .append(options.getBloomFilterFalsePositiveChance());

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -1090,7 +1090,7 @@ public class CCMBridge implements CCMAccess {
 
     private static boolean isThriftSupported(VersionNumber cassandraVersion) {
       // Thrift is removed from some pre-release 4.x versions, make the comparison work for those
-      return cassandraVersion.compareTo(VersionNumber.parse("4.0-a")) < 0;
+      return cassandraVersion.nextStable().compareTo(VersionNumber.parse("4.0")) < 0;
     }
 
     public int weight() {

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -1093,6 +1093,10 @@ public class CCMBridge implements CCMAccess {
       return cassandraVersion.nextStable().compareTo(VersionNumber.parse("4.0")) < 0;
     }
 
+    private static boolean isMaterializedViewsSupported(VersionNumber cassandraVersion) {
+      return cassandraVersion.nextStable().compareTo(VersionNumber.parse("4.0")) >= 0;
+    }
+
     public int weight() {
       // the weight is simply function of the number of nodes
       int totalNodes = 0;

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -1089,7 +1089,8 @@ public class CCMBridge implements CCMAccess {
     }
 
     private static boolean isThriftSupported(VersionNumber cassandraVersion) {
-      return cassandraVersion.compareTo(VersionNumber.parse("4.0")) < 0;
+      // Thrift is removed from some pre-release 4.x versions, make the comparison work for those
+      return cassandraVersion.compareTo(VersionNumber.parse("4.0-a")) < 0;
     }
 
     public int weight() {

--- a/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMBridge.java
@@ -1047,6 +1047,14 @@ public class CCMBridge implements CCMAccess {
         cassandraConfiguration.remove("rpc_port");
         cassandraConfiguration.remove("thrift_prepared_statements_cache_size_mb");
       }
+      if (isMaterializedViewsSupported(cassandraVersion)) {
+        // enable materialized views
+        cassandraConfiguration.put("enable_materialized_views", true);
+      }
+      if (isSasiConfigEnablementRequired(cassandraVersion)) {
+        // enable SASI indexing in config (disabled by default in C* 4.0)
+        cassandraConfiguration.put("enable_sasi_indexes", true);
+      }
       final CCMBridge ccm =
           new CCMBridge(
               clusterName,
@@ -1094,6 +1102,10 @@ public class CCMBridge implements CCMAccess {
     }
 
     private static boolean isMaterializedViewsSupported(VersionNumber cassandraVersion) {
+      return cassandraVersion.nextStable().compareTo(VersionNumber.parse("4.0")) >= 0;
+    }
+
+    private static boolean isSasiConfigEnablementRequired(VersionNumber cassandraVersion) {
       return cassandraVersion.nextStable().compareTo(VersionNumber.parse("4.0")) >= 0;
     }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/ExportAsStringTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ExportAsStringTest.java
@@ -146,7 +146,7 @@ public class ExportAsStringTest extends CCMTestsSupport {
         // matter, alphabetical does.
         session.execute(
             "CREATE MATERIALIZED VIEW cyclist_by_r_age "
-                + "AS SELECT age, birthday, name, country "
+                + "AS SELECT cid, age, birthday, name, country "
                 + "FROM cyclist_mv "
                 + "WHERE age IS NOT NULL AND cid IS NOT NULL "
                 + "PRIMARY KEY (age, cid) "
@@ -163,7 +163,7 @@ public class ExportAsStringTest extends CCMTestsSupport {
         // A materialized view for cyclist_mv, select columns
         session.execute(
             "CREATE MATERIALIZED VIEW cyclist_by_age "
-                + "AS SELECT age, birthday, name, country "
+                + "AS SELECT cid, age, birthday, name, country "
                 + "FROM cyclist_mv "
                 + "WHERE age IS NOT NULL AND cid IS NOT NULL "
                 + "PRIMARY KEY (age, cid) WITH comment = 'simple view'");

--- a/driver-core/src/test/java/com/datastax/driver/core/MissingRpcAddressTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/MissingRpcAddressTest.java
@@ -67,10 +67,18 @@ public class MissingRpcAddressTest extends CCMTestsSupport {
                         Policies.defaultLoadBalancingPolicy(), Lists.newArrayList(firstHost)))
                 .build());
     Session session = cluster.connect();
-    String deleteStmt =
-        String.format(
-            "DELETE rpc_address FROM system.peers WHERE peer = '%s'",
-            ccm().addressOfNode(2).getHostName());
+    String deleteStmt;
+    if (ccm().getCassandraVersion().nextStable().compareTo(VersionNumber.parse("4.0")) < 0) {
+      deleteStmt =
+          String.format(
+              "DELETE rpc_address FROM system.peers WHERE peer = '%s'",
+              ccm().addressOfNode(2).getHostName());
+    } else {
+      deleteStmt =
+          String.format(
+              "DELETE native_address, native_port FROM system.peers_v2 WHERE peer = '%s' and peer_port = %d",
+              ccm().addressOfNode(2).getHostName(), ccm().getStoragePort());
+    }
     session.execute(deleteStmt);
     session.close();
     cluster.close();

--- a/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/SchemaChangesTest.java
@@ -257,7 +257,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     // Create view and ensure event is received and metadata is updated
     session1.execute(
         String.format(
-            "CREATE MATERIALIZED VIEW %s.mv1 AS SELECT c FROM %s.table1 WHERE c IS NOT NULL PRIMARY KEY (pk, c)",
+            "CREATE MATERIALIZED VIEW %s.mv1 AS SELECT pk, c FROM %s.table1 WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (pk, c)",
             keyspace, keyspace));
     for (SchemaChangeListener listener : listeners) {
       ArgumentCaptor<MaterializedViewMetadata> viewAdded =
@@ -506,7 +506,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     session1.execute(String.format("CREATE TABLE %s.table1 (pk int PRIMARY KEY, c int)", keyspace));
     session1.execute(
         String.format(
-            "CREATE MATERIALIZED VIEW %s.mv1 AS SELECT c FROM %s.table1 WHERE c IS NOT NULL PRIMARY KEY (pk, c)",
+            "CREATE MATERIALIZED VIEW %s.mv1 AS SELECT pk, c FROM %s.table1 WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (pk, c)",
             keyspace, keyspace));
     for (SchemaChangeListener listener : listeners) {
       ArgumentCaptor<MaterializedViewMetadata> removed =
@@ -525,7 +525,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     session1.execute(String.format("CREATE TABLE %s.table1 (pk int PRIMARY KEY, c int)", keyspace));
     session1.execute(
         String.format(
-            "CREATE MATERIALIZED VIEW %s.mv1 AS SELECT c FROM %s.table1 WHERE c IS NOT NULL PRIMARY KEY (pk, c) WITH compaction = { 'class' : 'SizeTieredCompactionStrategy' }",
+            "CREATE MATERIALIZED VIEW %s.mv1 AS SELECT pk, c FROM %s.table1 WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (pk, c) WITH compaction = { 'class' : 'SizeTieredCompactionStrategy' }",
             keyspace, keyspace));
     for (SchemaChangeListener listener : listeners) {
       ArgumentCaptor<MaterializedViewMetadata> removed =
@@ -576,7 +576,7 @@ public class SchemaChangesTest extends CCMTestsSupport {
     session1.execute(String.format("CREATE TABLE %s.table1 (pk int PRIMARY KEY, c int)", keyspace));
     session1.execute(
         String.format(
-            "CREATE MATERIALIZED VIEW %s.mv1 AS SELECT c FROM %s.table1 WHERE c IS NOT NULL PRIMARY KEY (pk, c)",
+            "CREATE MATERIALIZED VIEW %s.mv1 AS SELECT pk, c FROM %s.table1 WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (pk, c)",
             keyspace, keyspace));
     session1.execute(String.format("DROP MATERIALIZED VIEW %s.mv1", keyspace));
     for (SchemaChangeListener listener : listeners) {

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -986,7 +986,7 @@ public abstract class TestUtils {
    * @param ccm cluster to check against
    */
   public static void compactStorageSupportCheck(CCMAccess ccm) {
-    if (ccm.getCassandraVersion().compareTo(VersionNumber.parse("4.0-a")) >= 0) {
+    if (ccm.getCassandraVersion().nextStable().compareTo(VersionNumber.parse("4.0")) >= 0) {
       throw new SkipException(
           "Compact tables are not allowed in Cassandra starting with 4.0 version");
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/TestUtils.java
@@ -986,7 +986,7 @@ public abstract class TestUtils {
    * @param ccm cluster to check against
    */
   public static void compactStorageSupportCheck(CCMAccess ccm) {
-    if (ccm.getCassandraVersion().compareTo(VersionNumber.parse("4.0.0")) >= 0) {
+    if (ccm.getCassandraVersion().compareTo(VersionNumber.parse("4.0-a")) >= 0) {
       throw new SkipException(
           "Compact tables are not allowed in Cassandra starting with 4.0 version");
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/querybuilder/QueryBuilderExecutionTest.java
@@ -951,7 +951,7 @@ public class QueryBuilderExecutionTest extends CCMTestsSupport {
         String.format("INSERT INTO %s (pk, cc, v) VALUES (0,1,1)", table),
         String.format("INSERT INTO %s (pk, cc, v) VALUES (0,2,2)", table),
         String.format(
-            "CREATE MATERIALIZED VIEW %s AS SELECT cc FROM %s WHERE cc IS NOT NULL PRIMARY KEY (pk, cc)",
+            "CREATE MATERIALIZED VIEW %s AS SELECT pk, cc FROM %s WHERE cc IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (pk, cc)",
             mv, table));
 
     // Wait until the MV is fully constructed

--- a/driver-core/src/test/resources/export_as_string_test_4.0.cql
+++ b/driver-core/src/test/resources/export_as_string_test_4.0.cql
@@ -1,0 +1,185 @@
+CREATE KEYSPACE complex_ks WITH REPLICATION = { 'class' : 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1' } AND DURABLE_WRITES = true;
+
+CREATE TYPE complex_ks.btype (
+    a text
+);
+
+CREATE TYPE complex_ks.xtype (
+    d text
+);
+
+CREATE TYPE complex_ks.ztype (
+    c text,
+    a int
+);
+
+CREATE TYPE complex_ks.ctype (
+    "Z" frozen<complex_ks.ztype>,
+    x frozen<complex_ks.xtype>
+);
+
+CREATE TYPE complex_ks.atype (
+    c frozen<complex_ks.ctype>
+);
+
+CREATE TABLE complex_ks.cyclist_mv (
+    cid uuid,
+    age int,
+    birthday date,
+    country text,
+    name text,
+    PRIMARY KEY (cid)
+) WITH read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.0
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold' : 32, 'min_threshold' : 4 }
+    AND compression = { 'chunk_length_in_kb' : 16, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99p'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0
+    AND cdc = false
+    AND memtable_flush_period_in_ms = 0;
+
+CREATE INDEX cyclist_by_country ON complex_ks.cyclist_mv (country);
+
+CREATE MATERIALIZED VIEW complex_ks.cyclist_by_a_age AS
+    SELECT *
+    FROM complex_ks.cyclist_mv
+    WHERE age IS NOT NULL AND cid IS NOT NULL
+    PRIMARY KEY (age, cid)
+    WITH CLUSTERING ORDER BY (cid ASC)
+    AND read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.0
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold' : 32, 'min_threshold' : 4 }
+    AND compression = { 'chunk_length_in_kb' : 16, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99p'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0
+    AND cdc = false
+    AND memtable_flush_period_in_ms = 0;
+
+CREATE MATERIALIZED VIEW complex_ks.cyclist_by_age AS
+    SELECT age, cid, birthday, country, name
+    FROM complex_ks.cyclist_mv
+    WHERE age IS NOT NULL AND cid IS NOT NULL
+    PRIMARY KEY (age, cid)
+    WITH CLUSTERING ORDER BY (cid ASC)
+    AND read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.0
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = 'simple view'
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold' : 32, 'min_threshold' : 4 }
+    AND compression = { 'chunk_length_in_kb' : 16, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99p'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0
+    AND cdc = false
+    AND memtable_flush_period_in_ms = 0;
+
+CREATE MATERIALIZED VIEW complex_ks.cyclist_by_r_age AS
+    SELECT age, cid, birthday, country, name
+    FROM complex_ks.cyclist_mv
+    WHERE age IS NOT NULL AND cid IS NOT NULL
+    PRIMARY KEY (age, cid)
+    WITH CLUSTERING ORDER BY (cid DESC)
+    AND read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.0
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold' : 32, 'min_threshold' : 4 }
+    AND compression = { 'chunk_length_in_kb' : 16, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99p'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0
+    AND cdc = false
+    AND memtable_flush_period_in_ms = 0;
+
+CREATE TABLE complex_ks.rank_by_year_and_name (
+    race_year int,
+    race_name text,
+    rank int,
+    cyclist_name text,
+    PRIMARY KEY ((race_year, race_name), rank)
+) WITH CLUSTERING ORDER BY (rank ASC)
+    AND read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.0
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold' : 32, 'min_threshold' : 4 }
+    AND compression = { 'chunk_length_in_kb' : 16, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99p'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0
+    AND cdc = false
+    AND memtable_flush_period_in_ms = 0;
+
+CREATE INDEX rrank ON complex_ks.rank_by_year_and_name (rank);
+
+CREATE INDEX ryear ON complex_ks.rank_by_year_and_name (race_year);
+
+CREATE TABLE complex_ks.ztable (
+    zkey text,
+    a frozen<complex_ks.atype>,
+    PRIMARY KEY (zkey)
+) WITH read_repair_chance = 0.0
+    AND dclocal_read_repair_chance = 0.0
+    AND gc_grace_seconds = 864000
+    AND bloom_filter_fp_chance = 0.1
+    AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
+    AND comment = ''
+    AND compaction = { 'class' : 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy', 'max_threshold' : 32, 'min_threshold' : 4, 'sstable_size_in_mb' : 95 }
+    AND compression = { 'chunk_length_in_kb' : 16, 'class' : 'org.apache.cassandra.io.compress.LZ4Compressor' }
+    AND default_time_to_live = 0
+    AND speculative_retry = '99p'
+    AND min_index_interval = 128
+    AND max_index_interval = 2048
+    AND crc_check_chance = 1.0
+    AND cdc = false
+    AND memtable_flush_period_in_ms = 0;
+
+CREATE FUNCTION complex_ks.avgfinal(state tuple<int, bigint>)
+    CALLED ON NULL INPUT
+    RETURNS double
+    LANGUAGE java
+    AS 'double r = 0; if (state.getInt(0) == 0) return null; r = state.getLong(1); r /= state.getInt(0); return Double.valueOf(r);';
+
+CREATE FUNCTION complex_ks.avgstate(state tuple<int, bigint>,val int)
+    CALLED ON NULL INPUT
+    RETURNS tuple<int, bigint>
+    LANGUAGE java
+    AS 'if (val !=null) { state.setInt(0, state.getInt(0)+1); state.setLong(1, state.getLong(1)+val.intValue()); } return state;';
+
+CREATE AGGREGATE complex_ks.average(int)
+    SFUNC avgstate
+    STYPE tuple<int, bigint>
+    FINALFUNC avgfinal
+    INITCOND (0,0);
+
+CREATE AGGREGATE complex_ks.mean(int)
+    SFUNC avgstate
+    STYPE tuple<int, bigint>
+    FINALFUNC avgfinal
+    INITCOND (0,0);

--- a/driver-core/src/test/resources/export_as_string_test_4.0.cql
+++ b/driver-core/src/test/resources/export_as_string_test_4.0.cql
@@ -29,9 +29,9 @@ CREATE TABLE complex_ks.cyclist_mv (
     country text,
     name text,
     PRIMARY KEY (cid)
-) WITH read_repair_chance = 0.0
-    AND dclocal_read_repair_chance = 0.0
+) WITH read_repair = 'BLOCKING'
     AND gc_grace_seconds = 864000
+    AND additional_write_policy = '99p'
     AND bloom_filter_fp_chance = 0.01
     AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
     AND comment = ''
@@ -53,9 +53,9 @@ CREATE MATERIALIZED VIEW complex_ks.cyclist_by_a_age AS
     WHERE age IS NOT NULL AND cid IS NOT NULL
     PRIMARY KEY (age, cid)
     WITH CLUSTERING ORDER BY (cid ASC)
-    AND read_repair_chance = 0.0
-    AND dclocal_read_repair_chance = 0.0
+    AND read_repair = 'BLOCKING'
     AND gc_grace_seconds = 864000
+    AND additional_write_policy = '99p'
     AND bloom_filter_fp_chance = 0.01
     AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
     AND comment = ''
@@ -75,9 +75,9 @@ CREATE MATERIALIZED VIEW complex_ks.cyclist_by_age AS
     WHERE age IS NOT NULL AND cid IS NOT NULL
     PRIMARY KEY (age, cid)
     WITH CLUSTERING ORDER BY (cid ASC)
-    AND read_repair_chance = 0.0
-    AND dclocal_read_repair_chance = 0.0
+    AND read_repair = 'BLOCKING'
     AND gc_grace_seconds = 864000
+    AND additional_write_policy = '99p'
     AND bloom_filter_fp_chance = 0.01
     AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
     AND comment = 'simple view'
@@ -97,9 +97,9 @@ CREATE MATERIALIZED VIEW complex_ks.cyclist_by_r_age AS
     WHERE age IS NOT NULL AND cid IS NOT NULL
     PRIMARY KEY (age, cid)
     WITH CLUSTERING ORDER BY (cid DESC)
-    AND read_repair_chance = 0.0
-    AND dclocal_read_repair_chance = 0.0
+    AND read_repair = 'BLOCKING'
     AND gc_grace_seconds = 864000
+    AND additional_write_policy = '99p'
     AND bloom_filter_fp_chance = 0.01
     AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
     AND comment = ''
@@ -120,9 +120,9 @@ CREATE TABLE complex_ks.rank_by_year_and_name (
     cyclist_name text,
     PRIMARY KEY ((race_year, race_name), rank)
 ) WITH CLUSTERING ORDER BY (rank ASC)
-    AND read_repair_chance = 0.0
-    AND dclocal_read_repair_chance = 0.0
+    AND read_repair = 'BLOCKING'
     AND gc_grace_seconds = 864000
+    AND additional_write_policy = '99p'
     AND bloom_filter_fp_chance = 0.01
     AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
     AND comment = ''
@@ -144,9 +144,9 @@ CREATE TABLE complex_ks.ztable (
     zkey text,
     a frozen<complex_ks.atype>,
     PRIMARY KEY (zkey)
-) WITH read_repair_chance = 0.0
-    AND dclocal_read_repair_chance = 0.0
+) WITH read_repair = 'BLOCKING'
     AND gc_grace_seconds = 864000
+    AND additional_write_policy = '99p'
     AND bloom_filter_fp_chance = 0.1
     AND caching = { 'keys' : 'ALL', 'rows_per_partition' : 'NONE' }
     AND comment = ''

--- a/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperMaterializedViewTest.java
+++ b/driver-mapping/src/test/java/com/datastax/driver/mapping/MapperMaterializedViewTest.java
@@ -43,22 +43,22 @@ public class MapperMaterializedViewTest extends CCMTestsSupport {
             + "       SELECT * FROM scores\n"
             + "       WHERE game IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL\n"
             + "       PRIMARY KEY (game, score, user, year, month, day)\n"
-            + "       WITH CLUSTERING ORDER BY (score desc)",
+            + "       WITH CLUSTERING ORDER BY (score DESC, user ASC, year ASC, month ASC, day ASC)",
         "CREATE MATERIALIZED VIEW dailyhigh AS\n"
             + "       SELECT * FROM scores\n"
             + "       WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL\n"
             + "       PRIMARY KEY ((game, year, month, day), score, user)\n"
-            + "       WITH CLUSTERING ORDER BY (score DESC)",
+            + "       WITH CLUSTERING ORDER BY (score DESC, user ASC)",
         "CREATE MATERIALIZED VIEW monthlyhigh AS\n"
             + "       SELECT * FROM scores\n"
             + "       WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL AND day IS NOT NULL\n"
             + "       PRIMARY KEY ((game, year, month), score, user, day)\n"
-            + "       WITH CLUSTERING ORDER BY (score DESC)",
+            + "       WITH CLUSTERING ORDER BY (score DESC, user ASC, day ASC)",
         "CREATE MATERIALIZED VIEW filtereduserhigh AS\n"
             + "       SELECT * FROM scores\n"
             + "       WHERE user in ('jbellis', 'pcmanus') AND game IS NOT NULL AND score IS NOT NULL AND year is NOT NULL AND day is not NULL and month IS NOT NULL\n"
             + "       PRIMARY KEY (game, score, user, year, month, day)\n"
-            + "       WITH CLUSTERING ORDER BY (score DESC)",
+            + "       WITH CLUSTERING ORDER BY (score DESC, user ASC, year ASC, month ASC, day ASC)",
         "INSERT INTO scores (user, game, year, month, day, score) VALUES ('pcmanus', 'Coup', 2015, 5, 1, 4000)",
         "INSERT INTO scores (user, game, year, month, day, score) VALUES ('jbellis', 'Coup', 2015, 5, 3, 1750)",
         "INSERT INTO scores (user, game, year, month, day, score) VALUES ('yukim', 'Coup', 2015, 5, 3, 2250)",

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
@@ -165,7 +165,6 @@ public class BundleOptions {
                 mavenBundle("ch.qos.logback", "logback-classic", getVersion("logback.version")),
                 mavenBundle("ch.qos.logback", "logback-core", getVersion("logback.version")),
                 mavenBundle("io.dropwizard.metrics", "metrics-core", getVersion("metrics.version")),
-                // mavenBundle("org.yaml", "snakeyaml", getVersion("snakeyaml.version")),
                 mavenBundle(
                     "com.fasterxml.jackson.core",
                     "jackson-databind",

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
@@ -165,7 +165,17 @@ public class BundleOptions {
                 mavenBundle("ch.qos.logback", "logback-classic", getVersion("logback.version")),
                 mavenBundle("ch.qos.logback", "logback-core", getVersion("logback.version")),
                 mavenBundle("io.dropwizard.metrics", "metrics-core", getVersion("metrics.version")),
-                mavenBundle("org.yaml", "snakeyaml", getVersion("snakeyaml.version")),
+                // mavenBundle("org.yaml", "snakeyaml", getVersion("snakeyaml.version")),
+                mavenBundle(
+                    "com.fasterxml.jackson.core",
+                    "jackson-databind",
+                    getVersion("jackson-databind.version")),
+                mavenBundle(
+                    "com.fasterxml.jackson.core", "jackson-core", getVersion("jackson.version")),
+                mavenBundle(
+                    "com.fasterxml.jackson.core",
+                    "jackson-annotations",
+                    getVersion("jackson.version")),
                 mavenBundle("org.testng", "testng", getVersion("testng.version")),
                 systemPackages(
                     "org.testng",


### PR DESCRIPTION
This PR simply adds Cassandra 4.0 to the build matrix on the old Jenkins server that is triggered via Job Creator:
https://jenkins-drivers-old.build.dsinternal.org/view/java-driver/job/datastax.java-driver.java2717.commit/

We'll need either this PR merged <b>OR</b> merge the [PR here](https://github.com/datastax/java-driver/pull/1420) if we want to switch the 3.x branch over to CloudBees