### PR TITLE
JAVA-2549: Deprecate ConditionChecker in favor of Awaitility

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/config/MapBasedConfigLoaderIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/config/MapBasedConfigLoaderIT.java
@@ -20,6 +20,7 @@ import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.unavailable;
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.when;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
@@ -38,12 +39,12 @@ import com.datastax.oss.driver.api.core.servererrors.UnavailableException;
 import com.datastax.oss.driver.api.core.servererrors.WriteType;
 import com.datastax.oss.driver.api.core.session.Request;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
-import com.datastax.oss.driver.api.testinfra.utils.ConditionChecker;
 import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.config.ConfigChangeEvent;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -82,7 +83,10 @@ public class MapBasedConfigLoaderIT {
 
       optionsMap.put(TypedDriverOption.CONNECTION_POOL_LOCAL_SIZE, 2);
 
-      ConditionChecker.checkThat(() -> node.getOpenConnections() == 3).becomesTrue();
+      await()
+          .pollInterval(500, TimeUnit.MILLISECONDS)
+          .atMost(60, TimeUnit.SECONDS)
+          .until(() -> node.getOpenConnections() == 3);
     }
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/context/LifecycleListenerIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/context/LifecycleListenerIT.java
@@ -15,15 +15,14 @@
  */
 package com.datastax.oss.driver.core.context;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.awaitility.Awaitility.await;
 
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
-import com.datastax.oss.driver.api.testinfra.utils.ConditionChecker;
 import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader;
 import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
@@ -36,6 +35,7 @@ import com.datastax.oss.simulacron.server.RejectScope;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -54,11 +54,11 @@ public class LifecycleListenerIT {
     assertThat(listener.closed).isFalse();
 
     try (CqlSession session = newSession(listener)) {
-      ConditionChecker.checkThat(() -> listener.ready).before(1, SECONDS).becomesTrue();
+      await().atMost(1, TimeUnit.SECONDS).until(() -> listener.ready);
       assertThat(listener.closed).isFalse();
     }
     assertThat(listener.ready).isTrue();
-    ConditionChecker.checkThat(() -> listener.closed).before(1, SECONDS).becomesTrue();
+    await().atMost(1, TimeUnit.SECONDS).until(() -> listener.closed);
   }
 
   @Test
@@ -75,7 +75,7 @@ public class LifecycleListenerIT {
       SIMULACRON_RULE.cluster().acceptConnections();
     }
     assertThat(listener.ready).isFalse();
-    ConditionChecker.checkThat(() -> listener.closed).before(1, SECONDS).becomesTrue();
+    await().atMost(1, TimeUnit.SECONDS).until(() -> listener.closed);
   }
 
   private CqlSession newSession(TestLifecycleListener listener) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/NodeTargetingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/loadbalancing/NodeTargetingIT.java
@@ -20,6 +20,7 @@ import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.unavailable;
 import static com.datastax.oss.simulacron.common.stubbing.PrimeDsl.when;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
+import static org.awaitility.Awaitility.await;
 
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -32,7 +33,6 @@ import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.datastax.oss.driver.api.core.servererrors.UnavailableException;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
-import com.datastax.oss.driver.api.testinfra.utils.ConditionChecker;
 import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
 import com.datastax.oss.simulacron.common.codec.ConsistencyLevel;
@@ -63,8 +63,10 @@ public class NodeTargetingIT {
     SIMULACRON_RULE.cluster().clearLogs();
     SIMULACRON_RULE.cluster().clearPrimes(true);
     SIMULACRON_RULE.cluster().node(4).stop();
-    ConditionChecker.checkThat(() -> getNode(4).getState() == NodeState.DOWN)
-        .before(5, TimeUnit.SECONDS);
+    await()
+        .pollInterval(500, TimeUnit.MILLISECONDS)
+        .atMost(5, TimeUnit.SECONDS)
+        .until(() -> getNode(4).getState() == NodeState.DOWN);
   }
 
   @Test

--- a/test-infra/pom.xml
+++ b/test-infra/pom.xml
@@ -64,6 +64,10 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/simulacron/QueryCounter.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/simulacron/QueryCounter.java
@@ -16,8 +16,8 @@
 package com.datastax.oss.driver.api.testinfra.simulacron;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
-import com.datastax.oss.driver.api.testinfra.utils.ConditionChecker;
 import com.datastax.oss.simulacron.common.cluster.QueryLog;
 import com.datastax.oss.simulacron.server.BoundNode;
 import com.datastax.oss.simulacron.server.BoundTopic;
@@ -83,10 +83,10 @@ public class QueryCounter {
    * expected count within the configured time period.
    */
   public void assertTotalCount(int expected) {
-    ConditionChecker.checkThat(() -> assertThat(totalCount.get()).isEqualTo(expected))
-        .every(10, TimeUnit.MILLISECONDS)
-        .before(beforeTimeout, beforeUnit)
-        .becomesTrue();
+    await()
+        .pollInterval(10, TimeUnit.MILLISECONDS)
+        .atMost(beforeTimeout, beforeUnit)
+        .untilAsserted(() -> assertThat(totalCount.get()).isEqualTo(expected));
   }
 
   /**
@@ -104,10 +104,10 @@ public class QueryCounter {
         expectedCounts.put(id, counts[id]);
       }
     }
-    ConditionChecker.checkThat(() -> assertThat(countMap).containsAllEntriesOf(expectedCounts))
-        .every(10, TimeUnit.MILLISECONDS)
-        .before(beforeTimeout, beforeUnit)
-        .becomesTrue();
+    await()
+        .pollInterval(10, TimeUnit.MILLISECONDS)
+        .atMost(beforeTimeout, beforeUnit)
+        .untilAsserted(() -> assertThat(countMap).containsAllEntriesOf(expectedCounts));
   }
 
   public static class QueryCounterBuilder {

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/utils/ConditionChecker.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/utils/ConditionChecker.java
@@ -25,12 +25,21 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BooleanSupplier;
 
+/**
+ * @deprecated We've replaced this home-grown utility by Awaitility in our tests. We're preserving
+ *     it because it was part of the public test infrastructure API, but it won't be maintained
+ *     anymore, and removed in the next major version.
+ * @see <a href="https://github.com/awaitility/awaitility">Awaitility homepage</a>
+ */
+@Deprecated
 public class ConditionChecker {
 
   private static final int DEFAULT_PERIOD_MILLIS = 500;
 
   private static final int DEFAULT_TIMEOUT_MILLIS = 60000;
 
+  /** @deprecated see {@link ConditionChecker} */
+  @Deprecated
   public static class ConditionCheckerBuilder {
 
     private long timeout = DEFAULT_TIMEOUT_MILLIS;

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/utils/NodeUtils.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/utils/NodeUtils.java
@@ -17,6 +17,7 @@ package com.datastax.oss.driver.api.testinfra.utils;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
 
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metadata.NodeState;
@@ -47,9 +48,9 @@ public class NodeUtils {
 
   public static void waitFor(Node node, int timeoutSeconds, NodeState nodeState) {
     logger.debug("Waiting for node {} to enter state {}", node, nodeState);
-    ConditionChecker.checkThat(() -> node.getState().equals(nodeState))
-        .every(100, MILLISECONDS)
-        .before(timeoutSeconds, SECONDS)
-        .becomesTrue();
+    await()
+        .pollInterval(100, MILLISECONDS)
+        .atMost(timeoutSeconds, SECONDS)
+        .until(() -> node.getState().equals(nodeState));
   }
 }


### PR DESCRIPTION
The defaults are different:
||Polling Interval|Timeout|
|---|---|---|
|ConditionChecker|500ms|60s|
|Awaitility|100ms|10s|

I've updated the calls accordingly, to keep the exact same behavior (except for 1 second waits, where I've kept the 100ms default).