### PR TITLE
JAVA-2729: Remove uses of "repomirror.datastax.lan" in Openstack images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -376,7 +376,7 @@ pipeline {
 
   environment {
     OS_VERSION = 'ubuntu/bionic64/java-driver'
-    JABBA_SHELL = '/home/jenkins/.jabba/jabba.sh'
+    JABBA_SHELL = '/usr/lib/jabba/jabba.sh'
     CCM_ENVIRONMENT_SHELL = '/usr/local/bin/ccm_environment.sh'
     SERIAL_ITS_ARGUMENT = "-DskipSerialITs=${params.SKIP_SERIAL_ITS}"
     ISOLATED_ITS_ARGUMENT = "-DskipIsolatedITs=${params.SKIP_ISOLATED_ITS}"


### PR DESCRIPTION
-This change is merely to get the Jenkinsfile in sync with the new
 build images as Jabba is no longer installed in the Jenkins home
 directory