### PR TITLE
JAVA-2740: Ignore peer entries with data_center null

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.6.0 (in progress)
 
+- [bug] JAVA-2740: Extend peer validity check to include datacenter, rack and tokens
 - [bug] JAVA-2744: Recompute token map when node is added
 - [new feature] JAVA-2614: Provide a utility to emulate offset paging on the client side
 - [new feature] JAVA-2718: Warn when the number of sessions exceeds a configurable threshold

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/AdminRow.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/adminrequest/AdminRow.java
@@ -100,6 +100,15 @@ public class AdminRow {
     return get(columnName, MAP_OF_STRING_TO_STRING);
   }
 
+  public boolean isNull(String columnName) {
+    if (!contains(columnName)) {
+      return true;
+    } else {
+      int index = columnSpecs.get(columnName).index;
+      return data.get(index) == null;
+    }
+  }
+
   public boolean contains(String columnName) {
     return columnSpecs.containsKey(columnName);
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultTopologyMonitor.java
@@ -539,13 +539,16 @@ public class DefaultTopologyMonitor implements TopologyMonitor {
    * node's broadcast RPC address and host ID; otherwise the driver may not work properly.
    */
   protected boolean isPeerValid(AdminRow peerRow) {
-    boolean hasPeersRpcAddress = peerRow.getInetAddress("rpc_address") != null;
+    boolean hasPeersRpcAddress = !peerRow.isNull("rpc_address");
     boolean hasPeersV2RpcAddress =
-        peerRow.getInetAddress("native_address") != null
-            && peerRow.getInteger("native_port") != null;
+        !peerRow.isNull("native_address") && !peerRow.isNull("native_port");
     boolean hasRpcAddress = hasPeersV2RpcAddress || hasPeersRpcAddress;
-    boolean hasHostId = peerRow.getUuid("host_id") != null;
-    boolean valid = hasRpcAddress && hasHostId;
+    boolean valid =
+        hasRpcAddress
+            && !peerRow.isNull("host_id")
+            && !peerRow.isNull("data_center")
+            && !peerRow.isNull("rack")
+            && !peerRow.isNull("tokens");
     if (!valid) {
       LOG.warn(
           "[{}] Found invalid row in {} for peer: {}. "

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/InitialNodeListRefreshTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/InitialNodeListRefreshTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata;
+
+import static com.datastax.oss.driver.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.metadata.EndPoint;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.internal.core.channel.ChannelFactory;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InitialNodeListRefreshTest {
+
+  @Mock private InternalDriverContext context;
+  @Mock protected MetricsFactory metricsFactory;
+  @Mock private ChannelFactory channelFactory;
+
+  private DefaultNode contactPoint1;
+  private DefaultNode contactPoint2;
+  private EndPoint endPoint3;
+  private UUID hostId1;
+  private UUID hostId2;
+  private UUID hostId3;
+
+  @Before
+  public void setup() {
+    when(context.getMetricsFactory()).thenReturn(metricsFactory);
+    when(context.getChannelFactory()).thenReturn(channelFactory);
+
+    contactPoint1 = TestNodeFactory.newContactPoint(1, context);
+    contactPoint2 = TestNodeFactory.newContactPoint(2, context);
+
+    endPoint3 = TestNodeFactory.newEndPoint(3);
+    hostId1 = UUID.randomUUID();
+    hostId2 = UUID.randomUUID();
+    hostId3 = UUID.randomUUID();
+  }
+
+  @Test
+  public void should_copy_contact_points() {
+    // Given
+    Iterable<NodeInfo> newInfos =
+        ImmutableList.of(
+            DefaultNodeInfo.builder()
+                .withEndPoint(contactPoint1.getEndPoint())
+                // in practice there are more fields, but hostId is enough to validate the logic
+                .withHostId(hostId1)
+                .build(),
+            DefaultNodeInfo.builder()
+                .withEndPoint(contactPoint2.getEndPoint())
+                .withHostId(hostId2)
+                .build());
+    InitialNodeListRefresh refresh =
+        new InitialNodeListRefresh(newInfos, ImmutableSet.of(contactPoint1, contactPoint2));
+
+    // When
+    MetadataRefresh.Result result = refresh.compute(DefaultMetadata.EMPTY, false, context);
+
+    // Then
+    // contact points have been copied to the metadata, and completed with missing information
+    Map<UUID, Node> newNodes = result.newMetadata.getNodes();
+    assertThat(newNodes).containsOnlyKeys(hostId1, hostId2);
+    assertThat(newNodes.get(hostId1)).isEqualTo(contactPoint1);
+    assertThat(contactPoint1.getHostId()).isEqualTo(hostId1);
+    assertThat(newNodes.get(hostId2)).isEqualTo(contactPoint2);
+    assertThat(contactPoint2.getHostId()).isEqualTo(hostId2);
+  }
+
+  @Test
+  public void should_add_other_nodes() {
+    // Given
+    Iterable<NodeInfo> newInfos =
+        ImmutableList.of(
+            DefaultNodeInfo.builder()
+                .withEndPoint(contactPoint1.getEndPoint())
+                // in practice there are more fields, but hostId is enough to validate the logic
+                .withHostId(hostId1)
+                .build(),
+            DefaultNodeInfo.builder()
+                .withEndPoint(contactPoint2.getEndPoint())
+                .withHostId(hostId2)
+                .build(),
+            DefaultNodeInfo.builder().withEndPoint(endPoint3).withHostId(hostId3).build());
+    InitialNodeListRefresh refresh =
+        new InitialNodeListRefresh(newInfos, ImmutableSet.of(contactPoint1, contactPoint2));
+
+    // When
+    MetadataRefresh.Result result = refresh.compute(DefaultMetadata.EMPTY, false, context);
+
+    // Then
+    // new node created in addition to the contact points
+    Map<UUID, Node> newNodes = result.newMetadata.getNodes();
+    assertThat(newNodes).containsOnlyKeys(hostId1, hostId2, hostId3);
+    Node node3 = newNodes.get(hostId3);
+    assertThat(node3.getEndPoint()).isEqualTo(endPoint3);
+    assertThat(node3.getHostId()).isEqualTo(hostId3);
+  }
+
+  @Test
+  public void should_ignore_duplicate_host_ids() {
+    // Given
+    Iterable<NodeInfo> newInfos =
+        ImmutableList.of(
+            DefaultNodeInfo.builder()
+                .withEndPoint(contactPoint1.getEndPoint())
+                // in practice there are more fields, but hostId is enough to validate the logic
+                .withHostId(hostId1)
+                .withDatacenter("dc1")
+                .build(),
+            DefaultNodeInfo.builder()
+                .withEndPoint(contactPoint1.getEndPoint())
+                .withDatacenter("dc2")
+                .withHostId(hostId1)
+                .build());
+    InitialNodeListRefresh refresh =
+        new InitialNodeListRefresh(newInfos, ImmutableSet.of(contactPoint1));
+
+    // When
+    MetadataRefresh.Result result = refresh.compute(DefaultMetadata.EMPTY, false, context);
+
+    // Then
+    // only the first nodeInfo should have been copied
+    Map<UUID, Node> newNodes = result.newMetadata.getNodes();
+    assertThat(newNodes).containsOnlyKeys(hostId1);
+    assertThat(newNodes.get(hostId1)).isEqualTo(contactPoint1);
+    assertThat(contactPoint1.getHostId()).isEqualTo(hostId1);
+    assertThat(contactPoint1.getDatacenter()).isEqualTo("dc1");
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/TestNodeFactory.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/TestNodeFactory.java
@@ -22,11 +22,15 @@ import java.util.UUID;
 public class TestNodeFactory {
 
   public static DefaultNode newNode(int lastIpByte, InternalDriverContext context) {
-    DefaultEndPoint endPoint = newEndPoint(lastIpByte);
-    DefaultNode node = new DefaultNode(endPoint, context);
+    DefaultNode node = newContactPoint(lastIpByte, context);
     node.hostId = UUID.randomUUID();
-    node.broadcastRpcAddress = endPoint.resolve();
+    node.broadcastRpcAddress = ((InetSocketAddress) node.getEndPoint().resolve());
     return node;
+  }
+
+  public static DefaultNode newContactPoint(int lastIpByte, InternalDriverContext context) {
+    DefaultEndPoint endPoint = newEndPoint(lastIpByte);
+    return new DefaultNode(endPoint, context);
   }
 
   public static DefaultEndPoint newEndPoint(int lastByteOfIp) {


### PR DESCRIPTION
This PR intention is to provide a fix [JAVA-2740](https://datastax-oss.atlassian.net/projects/JAVA/issues/JAVA-2740) to ignore peer entry when a null entry for `schema_version` is found.
Right now it will just throw a `java.lang.IllegalArgumentException: Multiple entries with same key`

edit: After @adutra review, I have moved to the check from `schema_version` to `data_center` column