### PR TITLE
JAVA-2744: Recompute token map when node is added

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.6.0 (in progress)
 
+- [bug] JAVA-2744: Recompute token map when node is added
 - [new feature] JAVA-2614: Provide a utility to emulate offset paging on the client side
 - [new feature] JAVA-2718: Warn when the number of sessions exceeds a configurable threshold
 - [improvement] JAVA-2664: Add a callback to inject the session in listeners

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/AddNodeRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/AddNodeRefresh.java
@@ -40,7 +40,7 @@ public class AddNodeRefresh extends NodesRefresh {
     Node existing = oldNodes.get(newNodeInfo.getHostId());
     if (existing == null) {
       DefaultNode newNode = new DefaultNode(newNodeInfo.getEndPoint(), context);
-      copyInfos(newNodeInfo, newNode, null, context);
+      copyInfos(newNodeInfo, newNode, context);
       Map<UUID, Node> newNodes =
           ImmutableMap.<UUID, Node>builder()
               .putAll(oldNodes)
@@ -54,7 +54,7 @@ public class AddNodeRefresh extends NodesRefresh {
       // an addition, even though the host_id hasn't changed :(
       // Update the existing instance and emit an UP event to trigger a pool reconnection.
       if (!existing.getEndPoint().equals(newNodeInfo.getEndPoint())) {
-        copyInfos(newNodeInfo, ((DefaultNode) existing), null, context);
+        copyInfos(newNodeInfo, ((DefaultNode) existing), context);
         assert newNodeInfo.getBroadcastRpcAddress().isPresent(); // always for peer nodes
         return new Result(
             oldMetadata,

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/FullNodeListRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/FullNodeListRefresh.java
@@ -72,7 +72,7 @@ class FullNodeListRefresh extends NodesRefresh {
       if (tokenFactory == null && nodeInfo.getPartitioner() != null) {
         tokenFactory = tokenFactoryRegistry.tokenFactoryFor(nodeInfo.getPartitioner());
       }
-      tokensChanged |= copyInfos(nodeInfo, node, tokenFactory, context);
+      tokensChanged |= copyInfos(nodeInfo, node, context);
     }
 
     Set<UUID> removed = Sets.difference(oldNodes.keySet(), seen);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/InitialNodeListRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/InitialNodeListRefresh.java
@@ -72,7 +72,7 @@ class InitialNodeListRefresh extends NodesRefresh {
       if (tokenMapEnabled && tokenFactory == null && nodeInfo.getPartitioner() != null) {
         tokenFactory = tokenFactoryRegistry.tokenFactoryFor(nodeInfo.getPartitioner());
       }
-      copyInfos(nodeInfo, node, tokenFactory, context);
+      copyInfos(nodeInfo, node, context);
       newNodesBuilder.put(node.getHostId(), node);
     }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/MetadataManager.java
@@ -174,7 +174,7 @@ public class MetadataManager implements AsyncAutoCloseable {
             maybeInfo -> {
               if (maybeInfo.isPresent()) {
                 boolean tokensChanged =
-                    NodesRefresh.copyInfos(maybeInfo.get(), (DefaultNode) node, null, context);
+                    NodesRefresh.copyInfos(maybeInfo.get(), (DefaultNode) node, context);
                 if (tokensChanged) {
                   apply(new TokensChangedRefresh());
                 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/NodesRefresh.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/NodesRefresh.java
@@ -17,7 +17,6 @@ package com.datastax.oss.driver.internal.core.metadata;
 
 import com.datastax.oss.driver.api.core.Version;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
-import com.datastax.oss.driver.internal.core.metadata.token.TokenFactory;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.Objects;
@@ -35,10 +34,7 @@ abstract class NodesRefresh implements MetadataRefresh {
    *     mutate the tokens in-place, so there is no way to check this after the fact).
    */
   protected static boolean copyInfos(
-      NodeInfo nodeInfo,
-      DefaultNode node,
-      TokenFactory tokenFactory,
-      InternalDriverContext context) {
+      NodeInfo nodeInfo, DefaultNode node, InternalDriverContext context) {
 
     node.setEndPoint(nodeInfo.getEndPoint(), context);
     node.broadcastRpcAddress = nodeInfo.getBroadcastRpcAddress().orElse(null);
@@ -58,7 +54,7 @@ abstract class NodesRefresh implements MetadataRefresh {
           versionString,
           node.getEndPoint());
     }
-    boolean tokensChanged = tokenFactory != null && !node.rawTokens.equals(nodeInfo.getTokens());
+    boolean tokensChanged = !node.rawTokens.equals(nodeInfo.getTokens());
     if (tokensChanged) {
       node.rawTokens = nodeInfo.getTokens();
     }

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
@@ -298,6 +298,15 @@ public class CcmBridge implements AutoCloseable {
     execute("node" + n, "stop");
   }
 
+  public void add(int n, String dc) {
+    execute("add", "-i", ipPrefix + n, "-d", dc, "node" + n);
+    start(n);
+  }
+
+  public void decommission(int n) {
+    nodetool(n, "decommission");
+  }
+
   synchronized void execute(String... args) {
     String command =
         "ccm "


### PR DESCRIPTION
I don't know how to unit-test this because the `Node` interface does not expose the node's raw tokens.

So i went for integration tests, but I had to amend `CcmBridge` and introduce a new `add()` method.