### PR TITLE
JAVA-2704: Remove protocol v5 beta status

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -71,7 +71,7 @@
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>native-protocol</artifactId>
-        <version>1.4.12</version>
+        <version>1.4.13-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,10 @@
 
 <!-- Note: contrary to 3.x, insert new entries *first* in their section -->
 
+### 4.11.0 (in progress)
+
+- [improvement] JAVA-2704: Remove protocol v5 beta status, add v6-beta
+
 ### 4.10.0
 
 - [improvement] JAVA-2907: Switch Tinkerpop to an optional dependency

--- a/core/src/main/java/com/datastax/oss/driver/api/core/DefaultProtocolVersion.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/DefaultProtocolVersion.java
@@ -30,14 +30,17 @@ public enum DefaultProtocolVersion implements ProtocolVersion {
   /** Version 4, supported by Cassandra 2.2 and above. */
   V4(ProtocolConstants.Version.V4, false),
 
+  /** Version 5, supported by Cassandra 4.0 and above. */
+  V5(ProtocolConstants.Version.V5, false),
+
   /**
-   * Version 5, currently supported as a beta preview in Cassandra 3.10 and above.
+   * Version 6, currently supported as a beta preview in Cassandra 4.0 and above.
    *
    * <p>Do not use this in production.
    *
    * @see ProtocolVersion#isBeta()
    */
-  V5(ProtocolConstants.Version.V5, true),
+  V6(ProtocolConstants.Version.V6, true),
   ;
   // Note that, for the sake of convenience, we also expose shortcuts to these constants on the
   // ProtocolVersion interface. If you add a new enum constant, remember to update the interface as

--- a/core/src/main/java/com/datastax/oss/driver/api/core/ProtocolVersion.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/ProtocolVersion.java
@@ -31,13 +31,14 @@ public interface ProtocolVersion {
   ProtocolVersion V3 = DefaultProtocolVersion.V3;
   ProtocolVersion V4 = DefaultProtocolVersion.V4;
   ProtocolVersion V5 = DefaultProtocolVersion.V5;
+  ProtocolVersion V6 = DefaultProtocolVersion.V6;
   ProtocolVersion DSE_V1 = DseProtocolVersion.DSE_V1;
   ProtocolVersion DSE_V2 = DseProtocolVersion.DSE_V2;
 
   /** The default version used for {@link Detachable detached} objects. */
   // Implementation note: we can't use the ProtocolVersionRegistry here, this has to be a
   // compile-time constant.
-  ProtocolVersion DEFAULT = DefaultProtocolVersion.V4;
+  ProtocolVersion DEFAULT = DefaultProtocolVersion.V5;
 
   /**
    * A numeric code that uniquely identifies the version (this is the code used in network frames).

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultProtocolVersionRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultProtocolVersionRegistry.java
@@ -61,6 +61,9 @@ public class DefaultProtocolVersionRegistry implements ProtocolVersionRegistry {
   @VisibleForTesting
   static final Version DSE_6_0_0 = Objects.requireNonNull(Version.parse("6.0.0"));
 
+  @VisibleForTesting
+  static final Version DSE_7_0_0 = Objects.requireNonNull(Version.parse("7.0.0"));
+
   private final String logPrefix;
 
   public DefaultProtocolVersionRegistry(String logPrefix) {
@@ -150,9 +153,12 @@ public class DefaultProtocolVersionRegistry implements ProtocolVersionRegistry {
         } else if (dseVersion.compareTo(DSE_6_0_0) < 0) {
           // DSE 5.1
           removeHigherThan(DefaultProtocolVersion.V4, DseProtocolVersion.DSE_V1, candidates);
-        } else {
+        } else if (dseVersion.compareTo(DSE_7_0_0) < 0) {
           // DSE 6
           removeHigherThan(DefaultProtocolVersion.V4, DseProtocolVersion.DSE_V2, candidates);
+        } else {
+          // DSE 7.0
+          removeHigherThan(DefaultProtocolVersion.V5, DseProtocolVersion.DSE_V2, candidates);
         }
       } else { // not DSE
         Version cassandraVersion = node.getCassandraVersion();
@@ -181,9 +187,12 @@ public class DefaultProtocolVersionRegistry implements ProtocolVersionRegistry {
         } else if (cassandraVersion.compareTo(Version.V2_2_0) < 0) {
           // 2.1.0
           removeHigherThan(DefaultProtocolVersion.V3, null, candidates);
-        } else {
+        } else if (cassandraVersion.compareTo(Version.V4_0_0) < 0) {
           // 2.2, 3.x
           removeHigherThan(DefaultProtocolVersion.V4, null, candidates);
+        } else {
+          // 4.0
+          removeHigherThan(DefaultProtocolVersion.V5, null, candidates);
         }
       }
     }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/NowInSecondsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/NowInSecondsIT.java
@@ -18,9 +18,6 @@ package com.datastax.oss.driver.core.cql;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
-import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
-import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.cql.BatchStatement;
 import com.datastax.oss.driver.api.core.cql.BatchType;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
@@ -45,27 +42,13 @@ import org.junit.rules.TestRule;
 @CassandraRequirement(min = "4.0")
 @DseRequirement(
     // Use next version -- not sure if it will be in by then, but as a reminder to check
-    min = "6.9",
+    min = "7.0",
     description = "Feature not available in DSE yet")
 public class NowInSecondsIT {
 
   private static final CcmRule CCM_RULE = CcmRule.getInstance();
 
-  private static final SessionRule<CqlSession> SESSION_RULE = buildSessionRule();
-
-  private static SessionRule<CqlSession> buildSessionRule() {
-    // Reminder to revisit the test when V5 comes out of beta: remove the custom config loader and
-    // inline this method.
-    assertThat(DefaultProtocolVersion.V5.isBeta())
-        .as("This test can be simplified now that protocol v5 is stable")
-        .isTrue();
-    return SessionRule.builder(CCM_RULE)
-        .withConfigLoader(
-            DriverConfigLoader.programmaticBuilder()
-                .withString(DefaultDriverOption.PROTOCOL_VERSION, "V5")
-                .build())
-        .build();
-  }
+  private static final SessionRule<CqlSession> SESSION_RULE = SessionRule.builder(CCM_RULE).build();
 
   @ClassRule
   public static final TestRule CHAIN = RuleChain.outerRule(CCM_RULE).around(SESSION_RULE);


### PR DESCRIPTION
> We also need to investigate whether or not a connection with v5 is possible if there is a mismatch between driver and server regarding the beta status of this protocol. If a connection is not possible, we should also instruct users to upgrade to this driver version if they want to use protocol v5 with C* 4.0.

I haven't done this part yet. I would suggest to wait until `V5` is officially out of beta in C* to decide what to do here.