### PR TITLE
fix typo in manual regarding named vs positional setters

### DIFF
--- a/manual/core/statements/prepared/README.md
+++ b/manual/core/statements/prepared/README.md
@@ -208,10 +208,10 @@ BoundStatement bound = ps1.bind()
   .setString("sku", "324378")
   .setString("description", "LCD screen");
 
-// Positional:
+// Named:
 bound = bound.unset("description");
 
-// Named:
+// Positional:
 bound = bound.unset(1);
 ```
 


### PR DESCRIPTION
In the prepared statements documentation, there is a place where the comments mix up "named" and "positional", and this pr fixes that