### PR TITLE
JAVA-2818: Remove root path only after merging non-programmatic configs

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,8 +2,9 @@
 
 <!-- Note: contrary to 3.x, insert new entries *first* in their section -->
 
-### 4.8.0 (in progress)
+### 4.7.1 (in progress)
 
+- [bug] JAVA-2818: Remove root path only after merging non-programmatic configs
 
 ### 4.7.0
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/config/typesafe/DefaultProgrammaticDriverConfigLoaderBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/config/typesafe/DefaultProgrammaticDriverConfigLoaderBuilder.java
@@ -90,10 +90,10 @@ public class DefaultProgrammaticDriverConfigLoaderBuilder
    *     haven't been specified programmatically.
    * @param rootPath the root path used in non-programmatic sources (fallback reference.conf and
    *     system properties). In most cases it should be {@link
-   *     DefaultDriverConfigLoader#DEFAULT_ROOT_PATH}.
+   *     DefaultDriverConfigLoader#DEFAULT_ROOT_PATH}. Cannot be null but can be empty.
    */
   public DefaultProgrammaticDriverConfigLoaderBuilder(
-      Supplier<Config> fallbackSupplier, String rootPath) {
+      @NonNull Supplier<Config> fallbackSupplier, @NonNull String rootPath) {
     this.fallbackSupplier = fallbackSupplier;
     this.rootPath = rootPath;
   }


### PR DESCRIPTION
This PR reverts most of the changes introduced by JAVA-2657 to the programmatic config loader builder.