### PR TITLE
JAVA-2773: Add protocol v5 checksumming to driver 4

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -61,7 +61,7 @@
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>native-protocol</artifactId>
-        <version>1.4.10</version>
+        <version>1.4.11</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.8.0 (in progress)
 
+- [new feature] JAVA-2773: Support new protocol v5 message format
 - [improvement] JAVA-2841: Raise timeouts during connection initialization
 - [bug] JAVA-2331: Unregister old metrics when a node gets removed or changes RPC address
 - [improvement] JAVA-2850: Ignore credentials in secure connect bundle [DataStax Astra]

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/protocol/TinkerpopBufferPrimitiveCodec.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/protocol/TinkerpopBufferPrimitiveCodec.java
@@ -23,6 +23,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.zip.CRC32;
 import org.apache.tinkerpop.gremlin.structure.io.Buffer;
 
 /**
@@ -88,6 +89,16 @@ public class TinkerpopBufferPrimitiveCodec implements PrimitiveCodec<Buffer> {
   }
 
   @Override
+  public void markReaderIndex(Buffer source) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void resetReaderIndex(Buffer source) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public byte readByte(Buffer source) {
     return source.readByte();
   }
@@ -95,6 +106,11 @@ public class TinkerpopBufferPrimitiveCodec implements PrimitiveCodec<Buffer> {
   @Override
   public int readInt(Buffer source) {
     return source.readInt();
+  }
+
+  @Override
+  public int readInt(Buffer source, int offset) {
+    throw new UnsupportedOperationException();
   }
 
   @Override
@@ -146,6 +162,16 @@ public class TinkerpopBufferPrimitiveCodec implements PrimitiveCodec<Buffer> {
   public String readLongString(Buffer source) {
     int length = readInt(source);
     return readString(source, length);
+  }
+
+  @Override
+  public Buffer readRetainedSlice(Buffer source, int sliceLength) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void updateCrc(Buffer source, CRC32 crc) {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/api/core/connection/CrcMismatchException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/connection/CrcMismatchException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.connection;
+
+import com.datastax.oss.driver.api.core.DriverException;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Thrown when the checksums in a server response don't match (protocol v5 or above).
+ *
+ * <p>This indicates a data corruption issue, either due to a hardware issue on the client, or on
+ * the network between the server and the client. It is not recoverable: the driver will drop the
+ * connection.
+ */
+public class CrcMismatchException extends DriverException {
+
+  public CrcMismatchException(@NonNull String message) {
+    super(message, null, null, true);
+  }
+
+  @NonNull
+  @Override
+  public DriverException copy() {
+    return new CrcMismatchException(getMessage());
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultProtocolFeature.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultProtocolFeature.java
@@ -56,5 +56,13 @@ public enum DefaultProtocolFeature implements ProtocolFeature {
    * @see <a href="https://issues.apache.org/jira/browse/CASSANDRA-14664">CASSANDRA-14664</a>
    */
   NOW_IN_SECONDS,
+
+  /**
+   * The new protocol framing format introduced in Cassandra 4: wrapping multiple frames into a
+   * single "segment" to checksum (and possibly compress) them together.
+   *
+   * @see <a href="https://issues.apache.org/jira/browse/CASSANDRA-15299">CASSANDRA-15299</a>
+   */
+  MODERN_FRAMING,
   ;
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultProtocolVersionRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultProtocolVersionRegistry.java
@@ -240,7 +240,8 @@ public class DefaultProtocolVersionRegistry implements ProtocolVersionRegistry {
       return (DefaultProtocolVersion.V5.getCode() <= code
               && code < DseProtocolVersion.DSE_V1.getCode())
           || DseProtocolVersion.DSE_V2.getCode() <= code;
-    } else if (DefaultProtocolFeature.NOW_IN_SECONDS.equals(feature)) {
+    } else if (DefaultProtocolFeature.NOW_IN_SECONDS.equals(feature)
+        || DefaultProtocolFeature.MODERN_FRAMING.equals(feature)) {
       // OSS only, V5+
       return DefaultProtocolVersion.V5.getCode() <= code
           && code < DseProtocolVersion.DSE_V1.getCode();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelFactory.java
@@ -78,8 +78,12 @@ public class ChannelFactory {
   public static final String SSL_HANDLER_NAME = "ssl";
   public static final String INBOUND_TRAFFIC_METER_NAME = "inboundTrafficMeter";
   public static final String OUTBOUND_TRAFFIC_METER_NAME = "outboundTrafficMeter";
-  public static final String FRAME_TO_BYTES_ENCODER_NAME = "encoder";
-  public static final String BYTES_TO_FRAME_DECODER_NAME = "decoder";
+  public static final String FRAME_TO_BYTES_ENCODER_NAME = "frameToBytesEncoder";
+  public static final String FRAME_TO_SEGMENT_ENCODER_NAME = "frameToSegmentEncoder";
+  public static final String SEGMENT_TO_BYTES_ENCODER_NAME = "segmentToBytesEncoder";
+  public static final String BYTES_TO_FRAME_DECODER_NAME = "bytesToFrameDecoder";
+  public static final String BYTES_TO_SEGMENT_DECODER_NAME = "bytesToSegmentDecoder";
+  public static final String SEGMENT_TO_FRAME_DECODER_NAME = "segmentToFrameDecoder";
   public static final String HEARTBEAT_HANDLER_NAME = "heartbeat";
   public static final String INFLIGHT_HANDLER_NAME = "inflight";
   public static final String INIT_HANDLER_NAME = "init";

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ChannelFactory.java
@@ -74,6 +74,16 @@ public class ChannelFactory {
    */
   private static final String UNKNOWN_PRODUCT_TYPE = "UNKNOWN";
 
+  // The names of the handlers on the pipeline:
+  public static final String SSL_HANDLER_NAME = "ssl";
+  public static final String INBOUND_TRAFFIC_METER_NAME = "inboundTrafficMeter";
+  public static final String OUTBOUND_TRAFFIC_METER_NAME = "outboundTrafficMeter";
+  public static final String FRAME_TO_BYTES_ENCODER_NAME = "encoder";
+  public static final String BYTES_TO_FRAME_DECODER_NAME = "decoder";
+  public static final String HEARTBEAT_HANDLER_NAME = "heartbeat";
+  public static final String INFLIGHT_HANDLER_NAME = "inflight";
+  public static final String INIT_HANDLER_NAME = "init";
+
   private final String logPrefix;
   protected final InternalDriverContext context;
 
@@ -312,7 +322,7 @@ public class ChannelFactory {
           context
               .getSslHandlerFactory()
               .map(f -> f.newSslHandler(channel, endPoint))
-              .map(h -> pipeline.addLast("ssl", h));
+              .map(h -> pipeline.addLast(SSL_HANDLER_NAME, h));
 
           // Only add meter handlers on the pipeline if metrics are enabled.
           SessionMetricUpdater sessionMetricUpdater =
@@ -320,23 +330,27 @@ public class ChannelFactory {
           if (nodeMetricUpdater.isEnabled(DefaultNodeMetric.BYTES_RECEIVED, null)
               || sessionMetricUpdater.isEnabled(DefaultSessionMetric.BYTES_RECEIVED, null)) {
             pipeline.addLast(
-                "inboundTrafficMeter",
+                INBOUND_TRAFFIC_METER_NAME,
                 new InboundTrafficMeter(nodeMetricUpdater, sessionMetricUpdater));
           }
 
           if (nodeMetricUpdater.isEnabled(DefaultNodeMetric.BYTES_SENT, null)
               || sessionMetricUpdater.isEnabled(DefaultSessionMetric.BYTES_SENT, null)) {
             pipeline.addLast(
-                "outboundTrafficMeter",
+                OUTBOUND_TRAFFIC_METER_NAME,
                 new OutboundTrafficMeter(nodeMetricUpdater, sessionMetricUpdater));
           }
 
           pipeline
-              .addLast("encoder", new FrameEncoder(context.getFrameCodec(), maxFrameLength))
-              .addLast("decoder", new FrameDecoder(context.getFrameCodec(), maxFrameLength))
+              .addLast(
+                  FRAME_TO_BYTES_ENCODER_NAME,
+                  new FrameEncoder(context.getFrameCodec(), maxFrameLength))
+              .addLast(
+                  BYTES_TO_FRAME_DECODER_NAME,
+                  new FrameDecoder(context.getFrameCodec(), maxFrameLength))
               // Note: HeartbeatHandler is inserted here once init completes
-              .addLast("inflight", inFlightHandler)
-              .addLast("init", initHandler);
+              .addLast(INFLIGHT_HANDLER_NAME, inFlightHandler)
+              .addLast(INIT_HANDLER_NAME, initHandler);
 
           context.getNettyOptions().afterChannelInitialized(channel);
         } catch (Throwable t) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/InFlightHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/InFlightHandler.java
@@ -198,7 +198,7 @@ public class InFlightHandler extends ChannelDuplexHandler {
       ctx.channel().close();
     } else {
       // remove heartbeat handler from pipeline if present.
-      ChannelHandler heartbeatHandler = ctx.pipeline().get("heartbeat");
+      ChannelHandler heartbeatHandler = ctx.pipeline().get(ChannelFactory.HEARTBEAT_HANDLER_NAME);
       if (heartbeatHandler != null) {
         ctx.pipeline().remove(heartbeatHandler);
       }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandler.java
@@ -26,7 +26,12 @@ import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.connection.ConnectionInitException;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import com.datastax.oss.driver.internal.core.DefaultProtocolFeature;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.protocol.BytesToSegmentDecoder;
+import com.datastax.oss.driver.internal.core.protocol.FrameToSegmentEncoder;
+import com.datastax.oss.driver.internal.core.protocol.SegmentToBytesEncoder;
+import com.datastax.oss.driver.internal.core.protocol.SegmentToFrameDecoder;
 import com.datastax.oss.driver.internal.core.util.ProtocolUtils;
 import com.datastax.oss.driver.internal.core.util.concurrent.UncaughtExceptions;
 import com.datastax.oss.protocol.internal.Message;
@@ -46,6 +51,7 @@ import com.datastax.oss.protocol.internal.response.Supported;
 import com.datastax.oss.protocol.internal.response.result.Rows;
 import com.datastax.oss.protocol.internal.response.result.SetKeyspace;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Objects;
@@ -200,10 +206,12 @@ class ProtocolInitHandler extends ConnectInitHandler {
           step = Step.STARTUP;
           send();
         } else if (step == Step.STARTUP && response instanceof Ready) {
+          maybeSwitchToModernFraming();
           context.getAuthProvider().ifPresent(provider -> provider.onMissingChallenge(endPoint));
           step = Step.GET_CLUSTER_NAME;
           send();
         } else if (step == Step.STARTUP && response instanceof Authenticate) {
+          maybeSwitchToModernFraming();
           Authenticate authenticate = (Authenticate) response;
           authenticator = buildAuthenticator(endPoint, authenticate.authenticator);
           authenticator
@@ -363,6 +371,42 @@ class ProtocolInitHandler extends ConnectInitHandler {
     @Override
     public String toString() {
       return "init query " + step;
+    }
+  }
+
+  /**
+   * Rearranges the pipeline to deal with the new framing structure in protocol v5 and above. The
+   * first messages still use the legacy format, we only do this after a successful response to the
+   * first STARTUP message.
+   */
+  private void maybeSwitchToModernFraming() {
+    if (context
+        .getProtocolVersionRegistry()
+        .supports(initialProtocolVersion, DefaultProtocolFeature.MODERN_FRAMING)) {
+
+      ChannelPipeline pipeline = ctx.pipeline();
+
+      // We basically add one conversion step in the middle: frames <-> *segments* <-> bytes
+      // Outbound:
+      pipeline.replace(
+          ChannelFactory.FRAME_TO_BYTES_ENCODER_NAME,
+          ChannelFactory.FRAME_TO_SEGMENT_ENCODER_NAME,
+          new FrameToSegmentEncoder(
+              context.getPrimitiveCodec(), context.getFrameCodec(), logPrefix));
+      pipeline.addBefore(
+          ChannelFactory.FRAME_TO_SEGMENT_ENCODER_NAME,
+          ChannelFactory.SEGMENT_TO_BYTES_ENCODER_NAME,
+          new SegmentToBytesEncoder(context.getSegmentCodec()));
+
+      // Inbound:
+      pipeline.replace(
+          ChannelFactory.BYTES_TO_FRAME_DECODER_NAME,
+          ChannelFactory.BYTES_TO_SEGMENT_DECODER_NAME,
+          new BytesToSegmentDecoder(context.getSegmentCodec()));
+      pipeline.addAfter(
+          ChannelFactory.BYTES_TO_SEGMENT_DECODER_NAME,
+          ChannelFactory.SEGMENT_TO_FRAME_DECODER_NAME,
+          new SegmentToFrameDecoder(context.getFrameCodec(), logPrefix));
     }
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandler.java
@@ -123,7 +123,11 @@ class ProtocolInitHandler extends ConnectInitHandler {
     boolean result = super.setConnectSuccess();
     if (result) {
       // add heartbeat to pipeline now that protocol is initialized.
-      ctx.pipeline().addBefore("inflight", "heartbeat", heartbeatHandler);
+      ctx.pipeline()
+          .addBefore(
+              ChannelFactory.INFLIGHT_HANDLER_NAME,
+              ChannelFactory.HEARTBEAT_HANDLER_NAME,
+              heartbeatHandler);
     }
     return result;
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/InternalDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/InternalDriverContext.java
@@ -39,6 +39,8 @@ import com.datastax.oss.driver.internal.core.ssl.SslHandlerFactory;
 import com.datastax.oss.driver.internal.core.tracker.RequestLogFormatter;
 import com.datastax.oss.protocol.internal.Compressor;
 import com.datastax.oss.protocol.internal.FrameCodec;
+import com.datastax.oss.protocol.internal.PrimitiveCodec;
+import com.datastax.oss.protocol.internal.SegmentCodec;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.netty.buffer.ByteBuf;
@@ -58,7 +60,13 @@ public interface InternalDriverContext extends DriverContext {
   Compressor<ByteBuf> getCompressor();
 
   @NonNull
+  PrimitiveCodec<ByteBuf> getPrimitiveCodec();
+
+  @NonNull
   FrameCodec<ByteBuf> getFrameCodec();
+
+  @NonNull
+  SegmentCodec<ByteBuf> getSegmentCodec();
 
   @NonNull
   ProtocolVersionRegistry getProtocolVersionRegistry();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/ByteBufCompressor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/ByteBufCompressor.java
@@ -25,21 +25,39 @@ public abstract class ByteBufCompressor implements Compressor<ByteBuf> {
 
   @Override
   public ByteBuf compress(ByteBuf uncompressed) {
-    return uncompressed.isDirect() ? compressDirect(uncompressed) : compressHeap(uncompressed);
+    return uncompressed.isDirect()
+        ? compressDirect(uncompressed, true)
+        : compressHeap(uncompressed, true);
   }
 
-  protected abstract ByteBuf compressDirect(ByteBuf input);
+  @Override
+  public ByteBuf compressWithoutLength(ByteBuf uncompressed) {
+    return uncompressed.isDirect()
+        ? compressDirect(uncompressed, false)
+        : compressHeap(uncompressed, false);
+  }
 
-  protected abstract ByteBuf compressHeap(ByteBuf input);
+  protected abstract ByteBuf compressDirect(ByteBuf input, boolean prependWithUncompressedLength);
+
+  protected abstract ByteBuf compressHeap(ByteBuf input, boolean prependWithUncompressedLength);
 
   @Override
   public ByteBuf decompress(ByteBuf compressed) {
-    return compressed.isDirect() ? decompressDirect(compressed) : decompressHeap(compressed);
+    return decompressWithoutLength(compressed, readUncompressedLength(compressed));
   }
 
-  protected abstract ByteBuf decompressDirect(ByteBuf input);
+  protected abstract int readUncompressedLength(ByteBuf compressed);
 
-  protected abstract ByteBuf decompressHeap(ByteBuf input);
+  @Override
+  public ByteBuf decompressWithoutLength(ByteBuf compressed, int uncompressedLength) {
+    return compressed.isDirect()
+        ? decompressDirect(compressed, uncompressedLength)
+        : decompressHeap(compressed, uncompressedLength);
+  }
+
+  protected abstract ByteBuf decompressDirect(ByteBuf input, int uncompressedLength);
+
+  protected abstract ByteBuf decompressHeap(ByteBuf input, int uncompressedLength);
 
   protected static ByteBuffer inputNioBuffer(ByteBuf buf) {
     // Using internalNioBuffer(...) as we only hold the reference in this method and so can

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/ByteBufPrimitiveCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/ByteBufPrimitiveCodec.java
@@ -24,6 +24,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.zip.CRC32;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
@@ -67,6 +68,16 @@ public class ByteBufPrimitiveCodec implements PrimitiveCodec<ByteBuf> {
   }
 
   @Override
+  public void markReaderIndex(ByteBuf source) {
+    source.markReaderIndex();
+  }
+
+  @Override
+  public void resetReaderIndex(ByteBuf source) {
+    source.resetReaderIndex();
+  }
+
+  @Override
   public byte readByte(ByteBuf source) {
     return source.readByte();
   }
@@ -74,6 +85,11 @@ public class ByteBufPrimitiveCodec implements PrimitiveCodec<ByteBuf> {
   @Override
   public int readInt(ByteBuf source) {
     return source.readInt();
+  }
+
+  @Override
+  public int readInt(ByteBuf source, int offset) {
+    return source.getInt(source.readerIndex() + offset);
   }
 
   @Override
@@ -125,6 +141,16 @@ public class ByteBufPrimitiveCodec implements PrimitiveCodec<ByteBuf> {
   public String readLongString(ByteBuf source) {
     int length = readInt(source);
     return readString(source, length);
+  }
+
+  @Override
+  public ByteBuf readRetainedSlice(ByteBuf source, int sliceLength) {
+    return source.readRetainedSlice(sliceLength);
+  }
+
+  @Override
+  public void updateCrc(ByteBuf source, CRC32 crc) {
+    crc.update(source.internalNioBuffer(source.readerIndex(), source.readableBytes()));
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/ByteBufSegmentBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/ByteBufSegmentBuilder.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.protocol;
+
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import com.datastax.oss.protocol.internal.Frame;
+import com.datastax.oss.protocol.internal.FrameCodec;
+import com.datastax.oss.protocol.internal.PrimitiveCodec;
+import com.datastax.oss.protocol.internal.Segment;
+import com.datastax.oss.protocol.internal.SegmentBuilder;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import java.util.ArrayList;
+import java.util.List;
+import net.jcip.annotations.NotThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@NotThreadSafe
+public class ByteBufSegmentBuilder extends SegmentBuilder<ByteBuf, ChannelPromise> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ByteBufSegmentBuilder.class);
+
+  private final ChannelHandlerContext context;
+  private final String logPrefix;
+
+  public ByteBufSegmentBuilder(
+      @NonNull ChannelHandlerContext context,
+      @NonNull PrimitiveCodec<ByteBuf> primitiveCodec,
+      @NonNull FrameCodec<ByteBuf> frameCodec,
+      @NonNull String logPrefix) {
+    super(primitiveCodec, frameCodec);
+    this.context = context;
+    this.logPrefix = logPrefix;
+  }
+
+  @Override
+  @NonNull
+  protected ChannelPromise mergeStates(@NonNull List<ChannelPromise> framePromises) {
+    if (framePromises.size() == 1) {
+      return framePromises.get(0);
+    }
+    // We concatenate multiple frames into one segment. When the segment is written, all the frames
+    // are written.
+    ChannelPromise segmentPromise = context.newPromise();
+    ImmutableList<ChannelPromise> dependents = ImmutableList.copyOf(framePromises);
+    segmentPromise.addListener(
+        future -> {
+          if (future.isSuccess()) {
+            for (ChannelPromise framePromise : dependents) {
+              framePromise.setSuccess();
+            }
+          } else {
+            Throwable cause = future.cause();
+            for (ChannelPromise framePromise : dependents) {
+              framePromise.setFailure(cause);
+            }
+          }
+        });
+    return segmentPromise;
+  }
+
+  @Override
+  @NonNull
+  protected List<ChannelPromise> splitState(@NonNull ChannelPromise framePromise, int sliceCount) {
+    // We split one frame into multiple slices. When all slices are written, the frame is written.
+    List<ChannelPromise> slicePromises = new ArrayList<>(sliceCount);
+    for (int i = 0; i < sliceCount; i++) {
+      slicePromises.add(context.newPromise());
+    }
+    GenericFutureListener<Future<Void>> sliceListener =
+        new SliceWriteListener(framePromise, slicePromises);
+    for (int i = 0; i < sliceCount; i++) {
+      slicePromises.get(i).addListener(sliceListener);
+    }
+    return slicePromises;
+  }
+
+  @Override
+  protected void processSegment(
+      @NonNull Segment<ByteBuf> segment, @NonNull ChannelPromise segmentPromise) {
+    context.write(segment, segmentPromise);
+  }
+
+  @Override
+  protected void onLargeFrameSplit(@NonNull Frame frame, int frameLength, int sliceCount) {
+    LOG.trace(
+        "[{}] Frame {} is too large ({} > {}), splitting into {} segments",
+        logPrefix,
+        frame.streamId,
+        frameLength,
+        Segment.MAX_PAYLOAD_LENGTH,
+        sliceCount);
+  }
+
+  @Override
+  protected void onSegmentFull(
+      @NonNull Frame frame, int frameLength, int currentPayloadLength, int currentFrameCount) {
+    LOG.trace(
+        "[{}] Current self-contained segment is full ({}/{} bytes, {} frames), processing now",
+        logPrefix,
+        currentPayloadLength,
+        Segment.MAX_PAYLOAD_LENGTH,
+        currentFrameCount);
+  }
+
+  @Override
+  protected void onSmallFrameAdded(
+      @NonNull Frame frame, int frameLength, int currentPayloadLength, int currentFrameCount) {
+    LOG.trace(
+        "[{}] Added frame {} to current self-contained segment "
+            + "(bringing it to {}/{} bytes, {} frames)",
+        logPrefix,
+        frame.streamId,
+        currentPayloadLength,
+        Segment.MAX_PAYLOAD_LENGTH,
+        currentFrameCount);
+  }
+
+  @Override
+  protected void onLastSegmentFlushed(int currentPayloadLength, int currentFrameCount) {
+    LOG.trace(
+        "[{}] Flushing last self-contained segment ({}/{} bytes, {} frames)",
+        logPrefix,
+        currentPayloadLength,
+        Segment.MAX_PAYLOAD_LENGTH,
+        currentFrameCount);
+  }
+
+  @NotThreadSafe
+  static class SliceWriteListener implements GenericFutureListener<Future<Void>> {
+
+    private final ChannelPromise parentPromise;
+    private final List<ChannelPromise> slicePromises;
+
+    // All slices are written to the same channel, and the segment is built from the Flusher which
+    // also runs on the same event loop, so we don't need synchronization.
+    private int remainingSlices;
+
+    SliceWriteListener(@NonNull ChannelPromise parentPromise, List<ChannelPromise> slicePromises) {
+      this.parentPromise = parentPromise;
+      this.slicePromises = slicePromises;
+      this.remainingSlices = slicePromises.size();
+    }
+
+    @Override
+    public void operationComplete(@NonNull Future<Void> future) {
+      if (!parentPromise.isDone()) {
+        if (future.isSuccess()) {
+          remainingSlices -= 1;
+          if (remainingSlices == 0) {
+            parentPromise.setSuccess();
+          }
+        } else {
+          // If any slice fails, we can immediately mark the whole frame as failed:
+          parentPromise.setFailure(future.cause());
+          // Cancel any remaining slice, Netty will not send the bytes.
+          for (ChannelPromise slicePromise : slicePromises) {
+            slicePromise.cancel(/*Netty ignores this*/ false);
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/BytesToSegmentDecoder.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/BytesToSegmentDecoder.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.protocol;
+
+import com.datastax.oss.driver.api.core.connection.CrcMismatchException;
+import com.datastax.oss.protocol.internal.Segment;
+import com.datastax.oss.protocol.internal.SegmentCodec;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import java.nio.ByteOrder;
+import net.jcip.annotations.NotThreadSafe;
+
+/**
+ * Decodes {@link Segment}s from a stream of bytes.
+ *
+ * <p>This works like a regular length-field-based decoder, but we override {@link
+ * #getUnadjustedFrameLength} to handle two peculiarities: the length is encoded on 17 bits, and we
+ * also want to check the header CRC before we use it. So we parse the whole segment header ahead of
+ * time, and store it until we're ready to build the segment.
+ */
+@NotThreadSafe
+public class BytesToSegmentDecoder extends LengthFieldBasedFrameDecoder {
+
+  private final SegmentCodec<ByteBuf> segmentCodec;
+  private SegmentCodec.Header header;
+
+  public BytesToSegmentDecoder(@NonNull SegmentCodec<ByteBuf> segmentCodec) {
+    super(
+        // max length (Netty wants this to be the overall length including everything):
+        segmentCodec.headerLength()
+            + SegmentCodec.CRC24_LENGTH
+            + Segment.MAX_PAYLOAD_LENGTH
+            + SegmentCodec.CRC32_LENGTH,
+        // offset and size of the "length" field: that's the whole header
+        0,
+        segmentCodec.headerLength() + SegmentCodec.CRC24_LENGTH,
+        // length adjustment: add the trailing CRC to the declared length
+        SegmentCodec.CRC32_LENGTH,
+        // bytes to skip: the header (we've already parsed it while reading the length)
+        segmentCodec.headerLength() + SegmentCodec.CRC24_LENGTH);
+    this.segmentCodec = segmentCodec;
+  }
+
+  @Override
+  protected Object decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
+    try {
+      ByteBuf payloadAndCrc = (ByteBuf) super.decode(ctx, in);
+      if (payloadAndCrc == null) {
+        return null;
+      } else {
+        assert header != null;
+        try {
+          Segment<ByteBuf> segment = segmentCodec.decode(header, payloadAndCrc);
+          header = null;
+          return segment;
+        } catch (com.datastax.oss.protocol.internal.CrcMismatchException e) {
+          throw new CrcMismatchException(e.getMessage());
+        }
+      }
+    } catch (Exception e) {
+      // Don't hold on to a stale header if we failed to decode the rest of the segment
+      header = null;
+      throw e;
+    }
+  }
+
+  @Override
+  protected long getUnadjustedFrameLength(ByteBuf buffer, int offset, int length, ByteOrder order) {
+    // The parent class calls this repeatedly for the same "frame" if there weren't enough
+    // accumulated bytes the first time. Only decode the header the first time:
+    if (header == null) {
+      try {
+        header = segmentCodec.decodeHeader(buffer.slice(offset, length));
+      } catch (com.datastax.oss.protocol.internal.CrcMismatchException e) {
+        throw new CrcMismatchException(e.getMessage());
+      }
+    }
+    return header.payloadLength;
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/FrameToSegmentEncoder.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/FrameToSegmentEncoder.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.protocol;
+
+import com.datastax.oss.protocol.internal.Frame;
+import com.datastax.oss.protocol.internal.FrameCodec;
+import com.datastax.oss.protocol.internal.PrimitiveCodec;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import net.jcip.annotations.NotThreadSafe;
+
+@NotThreadSafe
+public class FrameToSegmentEncoder extends ChannelOutboundHandlerAdapter {
+
+  private final PrimitiveCodec<ByteBuf> primitiveCodec;
+  private final FrameCodec<ByteBuf> frameCodec;
+  private final String logPrefix;
+
+  private ByteBufSegmentBuilder segmentBuilder;
+
+  public FrameToSegmentEncoder(
+      @NonNull PrimitiveCodec<ByteBuf> primitiveCodec,
+      @NonNull FrameCodec<ByteBuf> frameCodec,
+      @NonNull String logPrefix) {
+    this.primitiveCodec = primitiveCodec;
+    this.frameCodec = frameCodec;
+    this.logPrefix = logPrefix;
+  }
+
+  @Override
+  public void handlerAdded(@NonNull ChannelHandlerContext ctx) {
+    segmentBuilder = new ByteBufSegmentBuilder(ctx, primitiveCodec, frameCodec, logPrefix);
+  }
+
+  @Override
+  public void write(
+      @NonNull ChannelHandlerContext ctx, @NonNull Object msg, @NonNull ChannelPromise promise)
+      throws Exception {
+    if (msg instanceof Frame) {
+      segmentBuilder.addFrame(((Frame) msg), promise);
+    } else {
+      super.write(ctx, msg, promise);
+    }
+  }
+
+  @Override
+  public void flush(@NonNull ChannelHandlerContext ctx) throws Exception {
+    segmentBuilder.flush();
+    super.flush(ctx);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/Lz4Compressor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/Lz4Compressor.java
@@ -17,6 +17,7 @@ package com.datastax.oss.driver.internal.core.protocol;
 
 import com.datastax.oss.driver.api.core.context.DriverContext;
 import com.datastax.oss.driver.internal.core.util.DependencyCheck;
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import java.nio.ByteBuffer;
 import net.jcip.annotations.ThreadSafe;
@@ -35,9 +36,14 @@ public class Lz4Compressor extends ByteBufCompressor {
   private final LZ4FastDecompressor decompressor;
 
   public Lz4Compressor(DriverContext context) {
+    this(context.getSessionName());
+  }
+
+  @VisibleForTesting
+  Lz4Compressor(String sessionName) {
     if (DependencyCheck.LZ4.isPresent()) {
       LZ4Factory lz4Factory = LZ4Factory.fastestInstance();
-      LOG.info("[{}] Using {}", context.getSessionName(), lz4Factory.toString());
+      LOG.info("[{}] Using {}", sessionName, lz4Factory.toString());
       this.compressor = lz4Factory.fastCompressor();
       this.decompressor = lz4Factory.fastDecompressor();
     } else {
@@ -54,17 +60,20 @@ public class Lz4Compressor extends ByteBufCompressor {
   }
 
   @Override
-  protected ByteBuf compressDirect(ByteBuf input) {
+  protected ByteBuf compressDirect(ByteBuf input, boolean prependWithUncompressedLength) {
     int maxCompressedLength = compressor.maxCompressedLength(input.readableBytes());
     // If the input is direct we will allocate a direct output buffer as well as this will allow us
     // to use LZ4Compressor.compress and so eliminate memory copies.
-    ByteBuf output = input.alloc().directBuffer(4 + maxCompressedLength);
+    ByteBuf output =
+        input.alloc().directBuffer((prependWithUncompressedLength ? 4 : 0) + maxCompressedLength);
     try {
       ByteBuffer in = inputNioBuffer(input);
       // Increase reader index.
       input.readerIndex(input.writerIndex());
 
-      output.writeInt(in.remaining());
+      if (prependWithUncompressedLength) {
+        output.writeInt(in.remaining());
+      }
 
       ByteBuffer out = outputNioBuffer(output);
       int written =
@@ -81,7 +90,7 @@ public class Lz4Compressor extends ByteBufCompressor {
   }
 
   @Override
-  protected ByteBuf compressHeap(ByteBuf input) {
+  protected ByteBuf compressHeap(ByteBuf input, boolean prependWithUncompressedLength) {
     int maxCompressedLength = compressor.maxCompressedLength(input.readableBytes());
 
     // Not a direct buffer so use byte arrays...
@@ -93,9 +102,12 @@ public class Lz4Compressor extends ByteBufCompressor {
 
     // Allocate a heap buffer from the ByteBufAllocator as we may use a PooledByteBufAllocator and
     // so can eliminate the overhead of allocate a new byte[].
-    ByteBuf output = input.alloc().heapBuffer(4 + maxCompressedLength);
+    ByteBuf output =
+        input.alloc().heapBuffer((prependWithUncompressedLength ? 4 : 0) + maxCompressedLength);
     try {
-      output.writeInt(len);
+      if (prependWithUncompressedLength) {
+        output.writeInt(len);
+      }
       // calculate the correct offset.
       int offset = output.arrayOffset() + output.writerIndex();
       byte[] out = output.array();
@@ -112,11 +124,15 @@ public class Lz4Compressor extends ByteBufCompressor {
   }
 
   @Override
-  protected ByteBuf decompressDirect(ByteBuf input) {
+  protected int readUncompressedLength(ByteBuf compressed) {
+    return compressed.readInt();
+  }
+
+  @Override
+  protected ByteBuf decompressDirect(ByteBuf input, int uncompressedLength) {
     // If the input is direct we will allocate a direct output buffer as well as this will allow us
     // to use LZ4Compressor.decompress and so eliminate memory copies.
     int readable = input.readableBytes();
-    int uncompressedLength = input.readInt();
     ByteBuffer in = inputNioBuffer(input);
     // Increase reader index.
     input.readerIndex(input.writerIndex());
@@ -124,7 +140,7 @@ public class Lz4Compressor extends ByteBufCompressor {
     try {
       ByteBuffer out = outputNioBuffer(output);
       int read = decompressor.decompress(in, in.position(), out, out.position(), out.remaining());
-      if (read != readable - 4) {
+      if (read != readable) {
         throw new IllegalArgumentException("Compressed lengths mismatch");
       }
 
@@ -139,11 +155,10 @@ public class Lz4Compressor extends ByteBufCompressor {
   }
 
   @Override
-  protected ByteBuf decompressHeap(ByteBuf input) {
+  protected ByteBuf decompressHeap(ByteBuf input, int uncompressedLength) {
     // Not a direct buffer so use byte arrays...
     byte[] in = input.array();
     int len = input.readableBytes();
-    int uncompressedLength = input.readInt();
     int inOffset = input.arrayOffset() + input.readerIndex();
     // Increase reader index.
     input.readerIndex(input.writerIndex());
@@ -153,9 +168,9 @@ public class Lz4Compressor extends ByteBufCompressor {
     ByteBuf output = input.alloc().heapBuffer(uncompressedLength);
     try {
       int offset = output.arrayOffset() + output.writerIndex();
-      byte out[] = output.array();
+      byte[] out = output.array();
       int read = decompressor.decompress(in, inOffset, out, offset, uncompressedLength);
-      if (read != len - 4) {
+      if (read != len) {
         throw new IllegalArgumentException("Compressed lengths mismatch");
       }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/SegmentToBytesEncoder.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/SegmentToBytesEncoder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.protocol;
+
+import com.datastax.oss.protocol.internal.Segment;
+import com.datastax.oss.protocol.internal.SegmentCodec;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+import java.util.List;
+import net.jcip.annotations.ThreadSafe;
+
+@ThreadSafe
+@ChannelHandler.Sharable
+public class SegmentToBytesEncoder extends MessageToMessageEncoder<Segment<ByteBuf>> {
+
+  private final SegmentCodec<ByteBuf> segmentCodec;
+
+  public SegmentToBytesEncoder(@NonNull SegmentCodec<ByteBuf> segmentCodec) {
+    this.segmentCodec = segmentCodec;
+  }
+
+  @Override
+  protected void encode(
+      @NonNull ChannelHandlerContext ctx,
+      @NonNull Segment<ByteBuf> segment,
+      @NonNull List<Object> out) {
+    segmentCodec.encode(segment, out);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/SegmentToFrameDecoder.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/SegmentToFrameDecoder.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.protocol;
+
+import com.datastax.oss.protocol.internal.Frame;
+import com.datastax.oss.protocol.internal.FrameCodec;
+import com.datastax.oss.protocol.internal.Segment;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+import java.util.ArrayList;
+import java.util.List;
+import net.jcip.annotations.NotThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Converts the segments decoded by {@link BytesToSegmentDecoder} into legacy frames understood by
+ * the rest of the driver.
+ */
+@NotThreadSafe
+public class SegmentToFrameDecoder extends MessageToMessageDecoder<Segment<ByteBuf>> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SegmentToFrameDecoder.class);
+
+  private static final int UNKNOWN_LENGTH = Integer.MIN_VALUE;
+
+  private final FrameCodec<ByteBuf> frameCodec;
+  private final String logPrefix;
+
+  // Accumulated state when we are reading a sequence of slices
+  private int targetLength = UNKNOWN_LENGTH;
+  private final List<ByteBuf> accumulatedSlices = new ArrayList<>();
+  private int accumulatedLength;
+
+  public SegmentToFrameDecoder(@NonNull FrameCodec<ByteBuf> frameCodec, @NonNull String logPrefix) {
+    this.logPrefix = logPrefix;
+    this.frameCodec = frameCodec;
+  }
+
+  @Override
+  protected void decode(
+      @NonNull ChannelHandlerContext ctx,
+      @NonNull Segment<ByteBuf> segment,
+      @NonNull List<Object> out) {
+    if (segment.isSelfContained) {
+      decodeSelfContained(segment, out);
+    } else {
+      decodeSlice(segment, ctx.alloc(), out);
+    }
+  }
+
+  private void decodeSelfContained(Segment<ByteBuf> segment, List<Object> out) {
+    ByteBuf payload = segment.payload;
+    int frameCount = 0;
+    do {
+      Frame frame = frameCodec.decode(payload);
+      LOG.trace(
+          "[{}] Decoded response frame {} from self-contained segment", logPrefix, frame.streamId);
+      out.add(frame);
+      frameCount += 1;
+    } while (payload.isReadable());
+    payload.release();
+    LOG.trace("[{}] Done processing self-contained segment ({} frames)", logPrefix, frameCount);
+  }
+
+  private void decodeSlice(Segment<ByteBuf> segment, ByteBufAllocator allocator, List<Object> out) {
+    assert targetLength != UNKNOWN_LENGTH ^ (accumulatedSlices.isEmpty() && accumulatedLength == 0);
+    ByteBuf slice = segment.payload;
+    if (targetLength == UNKNOWN_LENGTH) {
+      // First slice, read ahead to find the target length
+      targetLength = FrameCodec.V3_ENCODED_HEADER_SIZE + frameCodec.decodeBodySize(slice);
+    }
+    accumulatedSlices.add(slice);
+    accumulatedLength += slice.readableBytes();
+    LOG.trace(
+        "[{}] Decoded slice {}, {}/{} bytes",
+        logPrefix,
+        accumulatedSlices.size(),
+        accumulatedLength,
+        targetLength);
+    assert accumulatedLength <= targetLength;
+    if (accumulatedLength == targetLength) {
+      // We've received enough data to reassemble the whole message
+      CompositeByteBuf encodedFrame = allocator.compositeBuffer(accumulatedSlices.size());
+      encodedFrame.addComponents(true, accumulatedSlices);
+      Frame frame = frameCodec.decode(encodedFrame);
+      LOG.trace(
+          "[{}] Decoded response frame {} from {} slices",
+          logPrefix,
+          frame.streamId,
+          accumulatedSlices.size());
+      out.add(frame);
+      // Reset our state
+      targetLength = UNKNOWN_LENGTH;
+      accumulatedSlices.clear();
+      accumulatedLength = 0;
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/Sizes.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/Sizes.java
@@ -44,7 +44,7 @@ public class Sizes {
 
     // Frame header has a fixed size of 9 for protocol version >= V3, which includes Frame flags
     // size
-    int size = FrameCodec.headerEncodedSize();
+    int size = FrameCodec.V3_ENCODED_HEADER_SIZE;
 
     if (!request.getCustomPayload().isEmpty()) {
       // Custom payload is not supported in v3, but assume user won't have a custom payload set if

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ChannelFactoryTestBase.java
@@ -269,7 +269,10 @@ public abstract class ChannelFactoryTestBase {
                     options,
                     heartbeatHandler,
                     productType == null);
-            channel.pipeline().addLast("inflight", inFlightHandler).addLast("init", initHandler);
+            channel
+                .pipeline()
+                .addLast(ChannelFactory.INFLIGHT_HANDLER_NAME, inFlightHandler)
+                .addLast(ChannelFactory.INIT_HANDLER_NAME, initHandler);
           } catch (Throwable t) {
             resultFuture.completeExceptionally(t);
           }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandlerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandlerTest.java
@@ -102,7 +102,7 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     channel
         .pipeline()
         .addLast(
-            "inflight",
+            ChannelFactory.INFLIGHT_HANDLER_NAME,
             new InFlightHandler(
                 DefaultProtocolVersion.V4,
                 new StreamIdGenerator(100),
@@ -120,7 +120,7 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     channel
         .pipeline()
         .addLast(
-            "init",
+            ChannelFactory.INIT_HANDLER_NAME,
             new ProtocolInitHandler(
                 internalDriverContext,
                 DefaultProtocolVersion.V4,
@@ -154,7 +154,7 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     channel
         .pipeline()
         .addLast(
-            "init",
+            ChannelFactory.INIT_HANDLER_NAME,
             new ProtocolInitHandler(
                 internalDriverContext,
                 DefaultProtocolVersion.V4,
@@ -207,12 +207,12 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
             heartbeatHandler,
             false);
 
-    channel.pipeline().addLast("init", protocolInitHandler);
+    channel.pipeline().addLast(ChannelFactory.INIT_HANDLER_NAME, protocolInitHandler);
 
     ChannelFuture connectFuture = channel.connect(new InetSocketAddress("localhost", 9042));
 
     // heartbeat should initially not be in pipeline
-    assertThat(channel.pipeline().get("heartbeat")).isNull();
+    assertThat(channel.pipeline().get(ChannelFactory.HEARTBEAT_HANDLER_NAME)).isNull();
 
     // It should send a STARTUP message
     Frame requestFrame = readOutboundFrame();
@@ -231,7 +231,8 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     assertThat(connectFuture).isSuccess();
 
     // should have added heartbeat handler to pipeline.
-    assertThat(channel.pipeline().get("heartbeat")).isEqualTo(heartbeatHandler);
+    assertThat(channel.pipeline().get(ChannelFactory.HEARTBEAT_HANDLER_NAME))
+        .isEqualTo(heartbeatHandler);
     // should have removed itself from pipeline.
     assertThat(channel.pipeline().last()).isNotEqualTo(protocolInitHandler);
   }
@@ -241,7 +242,7 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     channel
         .pipeline()
         .addLast(
-            "init",
+            ChannelFactory.INIT_HANDLER_NAME,
             new ProtocolInitHandler(
                 internalDriverContext,
                 DefaultProtocolVersion.V4,
@@ -267,7 +268,7 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     channel
         .pipeline()
         .addLast(
-            "init",
+            ChannelFactory.INIT_HANDLER_NAME,
             new ProtocolInitHandler(
                 internalDriverContext,
                 DefaultProtocolVersion.V4,
@@ -332,7 +333,7 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     channel
         .pipeline()
         .addLast(
-            "init",
+            ChannelFactory.INIT_HANDLER_NAME,
             new ProtocolInitHandler(
                 internalDriverContext,
                 DefaultProtocolVersion.V4,
@@ -366,7 +367,7 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     channel
         .pipeline()
         .addLast(
-            "init",
+            ChannelFactory.INIT_HANDLER_NAME,
             new ProtocolInitHandler(
                 internalDriverContext,
                 DefaultProtocolVersion.V4,
@@ -413,7 +414,7 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     channel
         .pipeline()
         .addLast(
-            "init",
+            ChannelFactory.INIT_HANDLER_NAME,
             new ProtocolInitHandler(
                 internalDriverContext,
                 DefaultProtocolVersion.V4,
@@ -444,7 +445,7 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     channel
         .pipeline()
         .addLast(
-            "init",
+            ChannelFactory.INIT_HANDLER_NAME,
             new ProtocolInitHandler(
                 internalDriverContext,
                 DefaultProtocolVersion.V4,
@@ -478,7 +479,7 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     channel
         .pipeline()
         .addLast(
-            "init",
+            ChannelFactory.INIT_HANDLER_NAME,
             new ProtocolInitHandler(
                 internalDriverContext,
                 DefaultProtocolVersion.V4,
@@ -510,7 +511,7 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     channel
         .pipeline()
         .addLast(
-            "init",
+            ChannelFactory.INIT_HANDLER_NAME,
             new ProtocolInitHandler(
                 internalDriverContext,
                 DefaultProtocolVersion.V4,
@@ -545,7 +546,7 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     channel
         .pipeline()
         .addLast(
-            "init",
+            ChannelFactory.INIT_HANDLER_NAME,
             new ProtocolInitHandler(
                 internalDriverContext,
                 DefaultProtocolVersion.V4,
@@ -580,7 +581,7 @@ public class ProtocolInitHandlerTest extends ChannelHandlerTestBase {
     channel
         .pipeline()
         .addLast(
-            "init",
+            ChannelFactory.INIT_HANDLER_NAME,
             new ProtocolInitHandler(
                 internalDriverContext,
                 DefaultProtocolVersion.V4,

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/protocol/BytesToSegmentDecoderTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/protocol/BytesToSegmentDecoderTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.datastax.oss.driver.api.core.connection.CrcMismatchException;
+import com.datastax.oss.protocol.internal.Compressor;
+import com.datastax.oss.protocol.internal.Segment;
+import com.datastax.oss.protocol.internal.SegmentCodec;
+import com.google.common.base.Strings;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BytesToSegmentDecoderTest {
+
+  // Hard-coded test data, the values were generated with our encoding methods.
+  // We're not really testing the decoding itself here, only that our subclass calls the
+  // LengthFieldBasedFrameDecoder parent constructor with the right parameters.
+  private static final ByteBuf REGULAR_HEADER = byteBuf("04000201f9f2");
+  private static final ByteBuf REGULAR_PAYLOAD = byteBuf("00000001");
+  private static final ByteBuf REGULAR_TRAILER = byteBuf("1fd6022d");
+  private static final ByteBuf REGULAR_WRONG_HEADER = byteBuf("04000202f9f2");
+  private static final ByteBuf REGULAR_WRONG_TRAILER = byteBuf("1fd6022e");
+
+  private static final ByteBuf MAX_HEADER = byteBuf("ffff03254047");
+  private static final ByteBuf MAX_PAYLOAD =
+      byteBuf(Strings.repeat("01", Segment.MAX_PAYLOAD_LENGTH));
+  private static final ByteBuf MAX_TRAILER = byteBuf("a05c2f13");
+
+  private static final ByteBuf LZ4_HEADER = byteBuf("120020000491c94f");
+  private static final ByteBuf LZ4_PAYLOAD_UNCOMPRESSED =
+      byteBuf("00000001000000010000000100000001");
+  private static final ByteBuf LZ4_PAYLOAD_COMPRESSED =
+      byteBuf("f00100000001000000010000000100000001");
+  private static final ByteBuf LZ4_TRAILER = byteBuf("2bd67f90");
+
+  private static final Compressor<ByteBuf> LZ4_COMPRESSOR = new Lz4Compressor("test");
+
+  private EmbeddedChannel channel;
+
+  @Before
+  public void setup() {
+    channel = new EmbeddedChannel();
+  }
+
+  @Test
+  public void should_decode_regular_segment() {
+    channel.pipeline().addLast(newDecoder(Compressor.none()));
+    channel.writeInbound(Unpooled.wrappedBuffer(REGULAR_HEADER, REGULAR_PAYLOAD, REGULAR_TRAILER));
+    Segment<ByteBuf> segment = channel.readInbound();
+    assertThat(segment.isSelfContained).isTrue();
+    assertThat(segment.payload).isEqualTo(REGULAR_PAYLOAD);
+  }
+
+  @Test
+  public void should_decode_max_length_segment() {
+    channel.pipeline().addLast(newDecoder(Compressor.none()));
+    channel.writeInbound(Unpooled.wrappedBuffer(MAX_HEADER, MAX_PAYLOAD, MAX_TRAILER));
+    Segment<ByteBuf> segment = channel.readInbound();
+    assertThat(segment.isSelfContained).isTrue();
+    assertThat(segment.payload).isEqualTo(MAX_PAYLOAD);
+  }
+
+  @Test
+  public void should_decode_segment_from_multiple_incoming_chunks() {
+    channel.pipeline().addLast(newDecoder(Compressor.none()));
+    // Send the header in two slices, to cover the case where the length can't be read the first
+    // time:
+    ByteBuf headerStart = REGULAR_HEADER.slice(0, 3);
+    ByteBuf headerEnd = REGULAR_HEADER.slice(3, 3);
+    channel.writeInbound(headerStart);
+    channel.writeInbound(headerEnd);
+    channel.writeInbound(REGULAR_PAYLOAD.duplicate());
+    channel.writeInbound(REGULAR_TRAILER.duplicate());
+    Segment<ByteBuf> segment = channel.readInbound();
+    assertThat(segment.isSelfContained).isTrue();
+    assertThat(segment.payload).isEqualTo(REGULAR_PAYLOAD);
+  }
+
+  @Test
+  public void should_decode_compressed_segment() {
+    channel.pipeline().addLast(newDecoder(LZ4_COMPRESSOR));
+    // We need a contiguous buffer for this one, because of how our decompressor operates
+    ByteBuf buffer = Unpooled.wrappedBuffer(LZ4_HEADER, LZ4_PAYLOAD_COMPRESSED, LZ4_TRAILER).copy();
+    channel.writeInbound(buffer);
+    Segment<ByteBuf> segment = channel.readInbound();
+    assertThat(segment.isSelfContained).isTrue();
+    assertThat(segment.payload).isEqualTo(LZ4_PAYLOAD_UNCOMPRESSED);
+  }
+
+  @Test
+  public void should_surface_header_crc_mismatch() {
+    try {
+      channel.pipeline().addLast(newDecoder(Compressor.none()));
+      channel.writeInbound(
+          Unpooled.wrappedBuffer(REGULAR_WRONG_HEADER, REGULAR_PAYLOAD, REGULAR_TRAILER));
+      fail("Expected a " + DecoderException.class.getSimpleName());
+    } catch (DecoderException exception) {
+      assertThat(exception).hasCauseInstanceOf(CrcMismatchException.class);
+    }
+  }
+
+  @Test
+  public void should_surface_trailer_crc_mismatch() {
+    try {
+      channel.pipeline().addLast(newDecoder(Compressor.none()));
+      channel.writeInbound(
+          Unpooled.wrappedBuffer(REGULAR_HEADER, REGULAR_PAYLOAD, REGULAR_WRONG_TRAILER));
+      fail("Expected a " + DecoderException.class.getSimpleName());
+    } catch (DecoderException exception) {
+      assertThat(exception).hasCauseInstanceOf(CrcMismatchException.class);
+    }
+  }
+
+  private BytesToSegmentDecoder newDecoder(Compressor<ByteBuf> compressor) {
+    return new BytesToSegmentDecoder(
+        new SegmentCodec<>(
+            new ByteBufPrimitiveCodec(UnpooledByteBufAllocator.DEFAULT), compressor));
+  }
+
+  private static ByteBuf byteBuf(String hex) {
+    return Unpooled.unreleasableBuffer(
+        Unpooled.wrappedBuffer(ByteBufUtil.decodeHexDump(hex)).asReadOnly());
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/protocol/SegmentToFrameDecoderTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/protocol/SegmentToFrameDecoderTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.shaded.guava.common.base.Strings;
+import com.datastax.oss.protocol.internal.Compressor;
+import com.datastax.oss.protocol.internal.Frame;
+import com.datastax.oss.protocol.internal.FrameCodec;
+import com.datastax.oss.protocol.internal.Message;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
+import com.datastax.oss.protocol.internal.ProtocolV5ClientCodecs;
+import com.datastax.oss.protocol.internal.ProtocolV5ServerCodecs;
+import com.datastax.oss.protocol.internal.Segment;
+import com.datastax.oss.protocol.internal.request.AuthResponse;
+import com.datastax.oss.protocol.internal.response.result.Void;
+import com.datastax.oss.protocol.internal.util.Bytes;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SegmentToFrameDecoderTest {
+
+  private static final FrameCodec<ByteBuf> FRAME_CODEC =
+      new FrameCodec<>(
+          new ByteBufPrimitiveCodec(UnpooledByteBufAllocator.DEFAULT),
+          Compressor.none(),
+          new ProtocolV5ClientCodecs(),
+          new ProtocolV5ServerCodecs());
+
+  private EmbeddedChannel channel;
+
+  @Before
+  public void setup() {
+    channel = new EmbeddedChannel();
+    channel.pipeline().addLast(new SegmentToFrameDecoder(FRAME_CODEC, "test"));
+  }
+
+  @Test
+  public void should_decode_self_contained() {
+    ByteBuf payload = UnpooledByteBufAllocator.DEFAULT.buffer();
+    payload.writeBytes(encodeFrame(Void.INSTANCE));
+    payload.writeBytes(encodeFrame(new AuthResponse(Bytes.fromHexString("0xabcdef"))));
+
+    channel.writeInbound(new Segment<>(payload, true));
+
+    Frame frame1 = channel.readInbound();
+    assertThat(frame1.message).isInstanceOf(Void.class);
+    Frame frame2 = channel.readInbound();
+    assertThat(frame2.message).isInstanceOf(AuthResponse.class);
+  }
+
+  @Test
+  public void should_decode_sequence_of_slices() {
+    ByteBuf encodedFrame =
+        encodeFrame(new AuthResponse(Bytes.fromHexString("0x" + Strings.repeat("aa", 1011))));
+    int sliceLength = 100;
+    do {
+      ByteBuf payload = encodedFrame.readSlice(Math.min(sliceLength, encodedFrame.readableBytes()));
+      channel.writeInbound(new Segment<>(payload, false));
+    } while (encodedFrame.isReadable());
+
+    Frame frame = channel.readInbound();
+    assertThat(frame.message).isInstanceOf(AuthResponse.class);
+  }
+
+  private static ByteBuf encodeFrame(Message message) {
+    Frame frame =
+        Frame.forResponse(
+            ProtocolConstants.Version.V5,
+            1,
+            null,
+            Collections.emptyMap(),
+            Collections.emptyList(),
+            message);
+    return FRAME_CODEC.encode(frame);
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/protocol/SliceWriteListenerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/protocol/SliceWriteListenerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SliceWriteListenerTest {
+
+  private final EmbeddedChannel channel = new EmbeddedChannel();
+
+  private ChannelPromise framePromise, slicePromise1, slicePromise2, slicePromise3;
+
+  @Before
+  public void setup() {
+    framePromise = channel.newPromise();
+    slicePromise1 = channel.newPromise();
+    slicePromise2 = channel.newPromise();
+    slicePromise3 = channel.newPromise();
+
+    ByteBufSegmentBuilder.SliceWriteListener listener =
+        new ByteBufSegmentBuilder.SliceWriteListener(
+            framePromise, ImmutableList.of(slicePromise1, slicePromise2, slicePromise3));
+    slicePromise1.addListener(listener);
+    slicePromise2.addListener(listener);
+    slicePromise3.addListener(listener);
+
+    assertThat(framePromise.isDone()).isFalse();
+  }
+
+  @Test
+  public void should_succeed_frame_if_all_slices_succeed() {
+    slicePromise1.setSuccess();
+    assertThat(framePromise.isDone()).isFalse();
+    slicePromise2.setSuccess();
+    assertThat(framePromise.isDone()).isFalse();
+    slicePromise3.setSuccess();
+
+    assertThat(framePromise.isSuccess()).isTrue();
+  }
+
+  @Test
+  public void should_fail_frame_and_cancel_remaining_slices_if_one_slice_fails() {
+    slicePromise1.setSuccess();
+    assertThat(framePromise.isDone()).isFalse();
+    Exception failure = new Exception("test");
+    slicePromise2.setFailure(failure);
+
+    assertThat(framePromise.isDone()).isTrue();
+    assertThat(framePromise.isSuccess()).isFalse();
+    assertThat(framePromise.cause()).isEqualTo(failure);
+
+    assertThat(slicePromise3.isCancelled()).isTrue();
+  }
+}


### PR DESCRIPTION
Requires datastax/native-protocol#36 installed in the local repository (also why the Travis checks fail).

TODO:
- [ ] integration tests (in particular with compression)
- [ ] add metrics to track segment sizes in bytes and frames
- [ ] handle Snappy compression, since it's not supported by the server we should probably fail fast