### PR TITLE
JAVA-2837: make StringCodec strict about unicode in ascii

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.8.0 (in progress)
 
+- [bug] JAVA-2837: make StringCodec strict about unicode in ascii
 
 ### 4.7.2
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/StringCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/StringCodec.java
@@ -20,22 +20,47 @@ import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import com.datastax.oss.driver.internal.core.util.Strings;
-import com.datastax.oss.protocol.internal.util.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import io.netty.util.concurrent.FastThreadLocal;
 import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CodingErrorAction;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
 public class StringCodec implements TypeCodec<String> {
 
   private final DataType cqlType;
-  private final Charset charset;
+  private final FastThreadLocal<CharsetEncoder> charsetEncoder;
+  private final FastThreadLocal<CharsetDecoder> charsetDecoder;
 
   public StringCodec(@NonNull DataType cqlType, @NonNull Charset charset) {
     this.cqlType = cqlType;
-    this.charset = charset;
+    charsetEncoder =
+        new FastThreadLocal<CharsetEncoder>() {
+          @Override
+          protected CharsetEncoder initialValue() throws Exception {
+            return charset
+                .newEncoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT);
+          }
+        };
+    charsetDecoder =
+        new FastThreadLocal<CharsetDecoder>() {
+          @Override
+          protected CharsetDecoder initialValue() throws Exception {
+            return charset
+                .newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT);
+          }
+        };
   }
 
   @NonNull
@@ -63,7 +88,14 @@ public class StringCodec implements TypeCodec<String> {
   @Nullable
   @Override
   public ByteBuffer encode(@Nullable String value, @NonNull ProtocolVersion protocolVersion) {
-    return (value == null) ? null : ByteBuffer.wrap(value.getBytes(charset));
+    if (value == null) {
+      return null;
+    }
+    try {
+      return charsetEncoder.get().encode(CharBuffer.wrap(value));
+    } catch (CharacterCodingException e) {
+      throw new IllegalArgumentException(e);
+    }
   }
 
   @Nullable
@@ -74,7 +106,11 @@ public class StringCodec implements TypeCodec<String> {
     } else if (bytes.remaining() == 0) {
       return "";
     } else {
-      return new String(Bytes.getArray(bytes), charset);
+      try {
+        return charsetDecoder.get().decode(bytes.duplicate()).toString();
+      } catch (CharacterCodingException e) {
+        throw new IllegalArgumentException(e);
+      }
     }
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/AsciiCodecTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/AsciiCodecTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.type.codec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import org.junit.Test;
+
+public class AsciiCodecTest extends CodecTestBase<String> {
+  public AsciiCodecTest() {
+    this.codec = TypeCodecs.ASCII;
+  }
+
+  @Test
+  public void should_encode() {
+    assertThat(encode("hello")).isEqualTo("0x68656c6c6f");
+    assertThat(encode(null)).isNull();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void should_fail_to_encode_non_ascii() {
+    encode("hëllo");
+  }
+
+  @Test
+  public void should_decode() {
+    assertThat(decode("0x68656c6c6f")).isEqualTo("hello");
+    assertThat(decode("0x")).isEmpty();
+    assertThat(decode(null)).isNull();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void should_fail_to_decode_non_ascii() {
+    decode("0x68c3ab6c6c6f");
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/TextCodecTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/TextCodecTest.java
@@ -21,10 +21,10 @@ import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import org.junit.Test;
 
-public class StringCodecTest extends CodecTestBase<String> {
+public class TextCodecTest extends CodecTestBase<String> {
 
-  public StringCodecTest() {
-    // We don't test ASCII, since it only differs by the encoding used
+  public TextCodecTest() {
+    // We will test edge cases of ASCII in AsciiCodecTest
     this.codec = TypeCodecs.TEXT;
   }
 


### PR DESCRIPTION
Somewhere between 3.x and 4.x the StringCodec implementation started
using String.getBytes(charset), which has the caveat of translating
unmappable characters into a charset-dependent replacement character,
which for ascii is '?'. In other words, if you were to put unicode data
into an ascii field, it will just insert a lot of question marks.

With this patch the driver will throw an InvalidArgumentException if
that happens.