### PR TITLE
JAVA-2431: Set all occurrences when bound variables are used multiple times

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.8.0 (in progress)
 
+- [improvement] JAVA-2431: Set all occurrences when bound variables are used multiple times
 - [improvement] JAVA-2829: Log protocol negotiation messages at DEBUG level
 - [bug] JAVA-2846: Give system properties the highest precedence in DefaultDriverConfigLoader
 - [new feature] JAVA-2691: Provide driver 4 support for extra codecs

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/cql/reactive/DefaultReactiveRow.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/cql/reactive/DefaultReactiveRow.java
@@ -381,6 +381,12 @@ class DefaultReactiveRow implements ReactiveRow {
     return row.getTupleValue(name);
   }
 
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull String name) {
+    return row.allIndicesOf(name);
+  }
+
   @Override
   public int firstIndexOf(@NonNull String name) {
     return row.firstIndexOf(name);
@@ -536,6 +542,12 @@ class DefaultReactiveRow implements ReactiveRow {
   @Override
   public TupleValue getTupleValue(@NonNull CqlIdentifier id) {
     return row.getTupleValue(id);
+  }
+
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull CqlIdentifier id) {
+    return row.allIndicesOf(id);
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/BoundStatementBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/BoundStatementBuilder.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import net.jcip.annotations.NotThreadSafe;
 
@@ -98,6 +99,16 @@ public class BoundStatementBuilder extends StatementBuilder<BoundStatementBuilde
     this.node = template.getNode();
   }
 
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull CqlIdentifier id) {
+    List<Integer> indices = variableDefinitions.allIndicesOf(id);
+    if (indices.isEmpty()) {
+      throw new IllegalArgumentException(id + " is not a variable in this bound statement");
+    }
+    return indices;
+  }
+
   @Override
   public int firstIndexOf(@NonNull CqlIdentifier id) {
     int indexOf = variableDefinitions.firstIndexOf(id);
@@ -105,6 +116,16 @@ public class BoundStatementBuilder extends StatementBuilder<BoundStatementBuilde
       throw new IllegalArgumentException(id + " is not a variable in this bound statement");
     }
     return indexOf;
+  }
+
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull String name) {
+    List<Integer> indices = variableDefinitions.allIndicesOf(name);
+    if (indices.isEmpty()) {
+      throw new IllegalArgumentException(name + " is not a variable in this bound statement");
+    }
+    return indices;
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/ColumnDefinitions.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/ColumnDefinitions.java
@@ -18,7 +18,10 @@ package com.datastax.oss.driver.api.core.cql;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.data.AccessibleByName;
 import com.datastax.oss.driver.api.core.detach.Detachable;
+import com.datastax.oss.driver.internal.core.util.Loggers;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Metadata about a set of CQL columns.
@@ -98,21 +101,60 @@ public interface ColumnDefinitions extends Iterable<ColumnDefinition>, Detachabl
   boolean contains(@NonNull CqlIdentifier id);
 
   /**
+   * Returns the indices of all columns that use the given name.
+   *
+   * <p>Because raw strings are ambiguous with regard to case-sensitivity, the argument will be
+   * interpreted according to the rules described in {@link AccessibleByName}.
+   *
+   * @return the indices, or an empty list if no column uses this name.
+   * @apiNote the default implementation only exists for backward compatibility. It wraps the result
+   *     of {@link #firstIndexOf(String)} in a singleton list, which is not entirely correct, as it
+   *     will only return the first occurrence. Therefore it also logs a warning.
+   *     <p>Implementors should always override this method (all built-in driver implementations
+   *     do).
+   */
+  @NonNull
+  default List<Integer> allIndicesOf(@NonNull String name) {
+    Loggers.COLUMN_DEFINITIONS.warn(
+        "{} should override allIndicesOf(String), the default implementation is a "
+            + "workaround for backward compatibility, it only returns the first occurrence",
+        getClass().getName());
+    return Collections.singletonList(firstIndexOf(name));
+  }
+
+  /**
    * Returns the index of the first column that uses the given name.
    *
    * <p>Because raw strings are ambiguous with regard to case-sensitivity, the argument will be
    * interpreted according to the rules described in {@link AccessibleByName}.
    *
-   * <p>Also, note that if multiple columns use the same name, there is no way to find the index for
-   * the next occurrences. One way to avoid this is to use aliases in your CQL queries.
+   * @return the index, or -1 if no column uses this name.
    */
   int firstIndexOf(@NonNull String name);
 
   /**
+   * Returns the indices of all columns that use the given identifier.
+   *
+   * @return the indices, or an empty list if no column uses this identifier.
+   * @apiNote the default implementation only exists for backward compatibility. It wraps the result
+   *     of {@link #firstIndexOf(CqlIdentifier)} in a singleton list, which is not entirely correct,
+   *     as it will only return the first occurrence. Therefore it also logs a warning.
+   *     <p>Implementors should always override this method (all built-in driver implementations
+   *     do).
+   */
+  @NonNull
+  default List<Integer> allIndicesOf(@NonNull CqlIdentifier id) {
+    Loggers.COLUMN_DEFINITIONS.warn(
+        "{} should override allIndicesOf(CqlIdentifier), the default implementation is a "
+            + "workaround for backward compatibility, it only returns the first occurrence",
+        getClass().getName());
+    return Collections.singletonList(firstIndexOf(id));
+  }
+
+  /**
    * Returns the index of the first column that uses the given identifier.
    *
-   * <p>Note that if multiple columns use the same identifier, there is no way to find the index for
-   * the next occurrences. One way to avoid this is to use aliases in your CQL queries.
+   * @return the index, or -1 if no column uses this identifier.
    */
   int firstIndexOf(@NonNull CqlIdentifier id);
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/AccessibleById.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/AccessibleById.java
@@ -17,7 +17,10 @@ package com.datastax.oss.driver.api.core.data;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.internal.core.util.Loggers;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * A data structure where the values are accessible via a CQL identifier.
@@ -25,6 +28,25 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * <p>In the driver, these data structures are always accessible by index as well.
  */
 public interface AccessibleById extends AccessibleByIndex {
+
+  /**
+   * Returns all the indices where a given identifier appears.
+   *
+   * @throws IllegalArgumentException if the id is invalid.
+   * @apiNote the default implementation only exists for backward compatibility. It wraps the result
+   *     of {@link #firstIndexOf(CqlIdentifier)} in a singleton list, which is not entirely correct,
+   *     as it will only return the first occurrence. Therefore it also logs a warning.
+   *     <p>Implementors should always override this method (all built-in driver implementations
+   *     do).
+   */
+  @NonNull
+  default List<Integer> allIndicesOf(@NonNull CqlIdentifier id) {
+    Loggers.ACCESSIBLE_BY_ID.warn(
+        "{} should override allIndicesOf(CqlIdentifier), the default implementation is a "
+            + "workaround for backward compatibility, it only returns the first occurrence",
+        getClass().getName());
+    return Collections.singletonList(firstIndexOf(id));
+  }
 
   /**
    * Returns the first index where a given identifier appears (depending on the implementation,

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/AccessibleByName.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/AccessibleByName.java
@@ -17,7 +17,10 @@ package com.datastax.oss.driver.api.core.data;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.internal.core.util.Loggers;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * A data structure where the values are accessible via a name string.
@@ -41,6 +44,25 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * <p>In the driver, these data structures are always accessible by index as well.
  */
 public interface AccessibleByName extends AccessibleByIndex {
+
+  /**
+   * Returns all the indices where a given identifier appears.
+   *
+   * @throws IllegalArgumentException if the name is invalid.
+   * @apiNote the default implementation only exists for backward compatibility. It wraps the result
+   *     of {@link #firstIndexOf(String)} in a singleton list, which is not entirely correct, as it
+   *     will only return the first occurrence. Therefore it also logs a warning.
+   *     <p>Implementors should always override this method (all built-in driver implementations
+   *     do).
+   */
+  @NonNull
+  default List<Integer> allIndicesOf(@NonNull String name) {
+    Loggers.ACCESSIBLE_BY_NAME.warn(
+        "{} should override allIndicesOf(String), the default implementation is a "
+            + "workaround for backward compatibility, it only returns the first occurrence",
+        getClass().getName());
+    return Collections.singletonList(firstIndexOf(name));
+  }
 
   /**
    * Returns the first index where a given identifier appears (depending on the implementation,

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableById.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableById.java
@@ -41,7 +41,7 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
     extends SettableByIndex<SelfT>, AccessibleById {
 
   /**
-   * Sets the raw binary representation of the value for the first occurrence of {@code id}.
+   * Sets the raw binary representation of the value for all occurrences of {@code id}.
    *
    * <p>This is primarily for internal use; you'll likely want to use one of the typed setters
    * instead, to pass a higher-level Java representation.
@@ -59,7 +59,12 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setBytesUnsafe(@NonNull CqlIdentifier id, @Nullable ByteBuffer v) {
-    return setBytesUnsafe(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setBytesUnsafe(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   @NonNull
@@ -69,7 +74,7 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to CQL {@code NULL}.
+   * Sets the value for all occurrences of {@code id} to CQL {@code NULL}.
    *
    * <p>If you want to avoid the overhead of building a {@code CqlIdentifier}, use the variant of
    * this method that takes a string argument.
@@ -79,12 +84,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setToNull(@NonNull CqlIdentifier id) {
-    return setToNull(firstIndexOf(id));
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setToNull(i);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id}, using the given codec for the
-   * conversion.
+   * Sets the value for all occurrences of {@code id}, using the given codec for the conversion.
    *
    * <p>This method completely bypasses the {@link #codecRegistry()}, and forces the driver to use
    * the given codec instead. This can be useful if the codec would collide with a previously
@@ -102,11 +111,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @CheckReturnValue
   default <ValueT> SelfT set(
       @NonNull CqlIdentifier id, @Nullable ValueT v, @NonNull TypeCodec<ValueT> codec) {
-    return set(firstIndexOf(id), v, codec);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).set(i, v, codec);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id}, converting it to the given Java type.
+   * Sets the value for all occurrences of {@code id}, converting it to the given Java type.
    *
    * <p>The {@link #codecRegistry()} will be used to look up a codec to handle the conversion.
    *
@@ -123,11 +137,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @CheckReturnValue
   default <ValueT> SelfT set(
       @NonNull CqlIdentifier id, @Nullable ValueT v, @NonNull GenericType<ValueT> targetType) {
-    return set(firstIndexOf(id), v, targetType);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).set(i, v, targetType);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Returns the value for the first occurrence of {@code id}, converting it to the given Java type.
+   * Returns the value for all occurrences of {@code id}, converting it to the given Java type.
    *
    * <p>The {@link #codecRegistry()} will be used to look up a codec to handle the conversion.
    *
@@ -143,11 +162,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @CheckReturnValue
   default <ValueT> SelfT set(
       @NonNull CqlIdentifier id, @Nullable ValueT v, @NonNull Class<ValueT> targetClass) {
-    return set(firstIndexOf(id), v, targetClass);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).set(i, v, targetClass);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java primitive boolean.
+   * Sets the value for all occurrences of {@code id} to the provided Java primitive boolean.
    *
    * <p>By default, this works with CQL type {@code boolean}.
    *
@@ -162,11 +186,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setBoolean(@NonNull CqlIdentifier id, boolean v) {
-    return setBoolean(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setBoolean(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java primitive byte.
+   * Sets the value for all occurrences of {@code id} to the provided Java primitive byte.
    *
    * <p>By default, this works with CQL type {@code tinyint}.
    *
@@ -181,11 +210,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setByte(@NonNull CqlIdentifier id, byte v) {
-    return setByte(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setByte(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java primitive double.
+   * Sets the value for all occurrences of {@code id} to the provided Java primitive double.
    *
    * <p>By default, this works with CQL type {@code double}.
    *
@@ -200,11 +234,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setDouble(@NonNull CqlIdentifier id, double v) {
-    return setDouble(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setDouble(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java primitive float.
+   * Sets the value for all occurrences of {@code id} to the provided Java primitive float.
    *
    * <p>By default, this works with CQL type {@code float}.
    *
@@ -219,11 +258,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setFloat(@NonNull CqlIdentifier id, float v) {
-    return setFloat(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setFloat(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java primitive integer.
+   * Sets the value for all occurrences of {@code id} to the provided Java primitive integer.
    *
    * <p>By default, this works with CQL type {@code int}.
    *
@@ -238,11 +282,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setInt(@NonNull CqlIdentifier id, int v) {
-    return setInt(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setInt(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java primitive long.
+   * Sets the value for all occurrences of {@code id} to the provided Java primitive long.
    *
    * <p>By default, this works with CQL types {@code bigint} and {@code counter}.
    *
@@ -257,11 +306,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setLong(@NonNull CqlIdentifier id, long v) {
-    return setLong(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setLong(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java primitive short.
+   * Sets the value for all occurrences of {@code id} to the provided Java primitive short.
    *
    * <p>By default, this works with CQL type {@code smallint}.
    *
@@ -276,11 +330,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setShort(@NonNull CqlIdentifier id, short v) {
-    return setShort(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setShort(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java instant.
+   * Sets the value for all occurrences of {@code id} to the provided Java instant.
    *
    * <p>By default, this works with CQL type {@code timestamp}.
    *
@@ -292,11 +351,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setInstant(@NonNull CqlIdentifier id, @Nullable Instant v) {
-    return setInstant(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setInstant(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java local date.
+   * Sets the value for all occurrences of {@code id} to the provided Java local date.
    *
    * <p>By default, this works with CQL type {@code date}.
    *
@@ -308,11 +372,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setLocalDate(@NonNull CqlIdentifier id, @Nullable LocalDate v) {
-    return setLocalDate(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setLocalDate(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java local time.
+   * Sets the value for all occurrences of {@code id} to the provided Java local time.
    *
    * <p>By default, this works with CQL type {@code time}.
    *
@@ -324,11 +393,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setLocalTime(@NonNull CqlIdentifier id, @Nullable LocalTime v) {
-    return setLocalTime(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setLocalTime(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java byte buffer.
+   * Sets the value for all occurrences of {@code id} to the provided Java byte buffer.
    *
    * <p>By default, this works with CQL type {@code blob}.
    *
@@ -340,11 +414,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setByteBuffer(@NonNull CqlIdentifier id, @Nullable ByteBuffer v) {
-    return setByteBuffer(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setByteBuffer(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java string.
+   * Sets the value for all occurrences of {@code id} to the provided Java string.
    *
    * <p>By default, this works with CQL types {@code text}, {@code varchar} and {@code ascii}.
    *
@@ -356,11 +435,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setString(@NonNull CqlIdentifier id, @Nullable String v) {
-    return setString(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setString(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java big integer.
+   * Sets the value for all occurrences of {@code id} to the provided Java big integer.
    *
    * <p>By default, this works with CQL type {@code varint}.
    *
@@ -372,11 +456,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setBigInteger(@NonNull CqlIdentifier id, @Nullable BigInteger v) {
-    return setBigInteger(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setBigInteger(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java big decimal.
+   * Sets the value for all occurrences of {@code id} to the provided Java big decimal.
    *
    * <p>By default, this works with CQL type {@code decimal}.
    *
@@ -388,11 +477,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setBigDecimal(@NonNull CqlIdentifier id, @Nullable BigDecimal v) {
-    return setBigDecimal(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setBigDecimal(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java UUID.
+   * Sets the value for all occurrences of {@code id} to the provided Java UUID.
    *
    * <p>By default, this works with CQL types {@code uuid} and {@code timeuuid}.
    *
@@ -404,11 +498,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setUuid(@NonNull CqlIdentifier id, @Nullable UUID v) {
-    return setUuid(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setUuid(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java IP address.
+   * Sets the value for all occurrences of {@code id} to the provided Java IP address.
    *
    * <p>By default, this works with CQL type {@code inet}.
    *
@@ -420,11 +519,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setInetAddress(@NonNull CqlIdentifier id, @Nullable InetAddress v) {
-    return setInetAddress(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setInetAddress(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided duration.
+   * Sets the value for all occurrences of {@code id} to the provided duration.
    *
    * <p>By default, this works with CQL type {@code duration}.
    *
@@ -436,11 +540,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setCqlDuration(@NonNull CqlIdentifier id, @Nullable CqlDuration v) {
-    return setCqlDuration(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setCqlDuration(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided token.
+   * Sets the value for all occurrences of {@code id} to the provided token.
    *
    * <p>This works with the CQL type matching the partitioner in use for this cluster: {@code
    * bigint} for {@code Murmur3Partitioner}, {@code blob} for {@code ByteOrderedPartitioner}, and
@@ -454,11 +563,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setToken(@NonNull CqlIdentifier id, @NonNull Token v) {
-    return setToken(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setToken(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java list.
+   * Sets the value for all occurrences of {@code id} to the provided Java list.
    *
    * <p>By default, this works with CQL type {@code list}.
    *
@@ -476,11 +590,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
       @NonNull CqlIdentifier id,
       @Nullable List<ElementT> v,
       @NonNull Class<ElementT> elementsClass) {
-    return setList(firstIndexOf(id), v, elementsClass);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setList(i, v, elementsClass);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java set.
+   * Sets the value for all occurrences of {@code id} to the provided Java set.
    *
    * <p>By default, this works with CQL type {@code set}.
    *
@@ -498,11 +617,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
       @NonNull CqlIdentifier id,
       @Nullable Set<ElementT> v,
       @NonNull Class<ElementT> elementsClass) {
-    return setSet(firstIndexOf(id), v, elementsClass);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setSet(i, v, elementsClass);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided Java map.
+   * Sets the value for all occurrences of {@code id} to the provided Java map.
    *
    * <p>By default, this works with CQL type {@code map}.
    *
@@ -521,11 +645,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
       @Nullable Map<KeyT, ValueT> v,
       @NonNull Class<KeyT> keyClass,
       @NonNull Class<ValueT> valueClass) {
-    return setMap(firstIndexOf(id), v, keyClass, valueClass);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setMap(i, v, keyClass, valueClass);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided user defined type value.
+   * Sets the value for all occurrences of {@code id} to the provided user defined type value.
    *
    * <p>By default, this works with CQL user-defined types.
    *
@@ -537,11 +666,16 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setUdtValue(@NonNull CqlIdentifier id, @Nullable UdtValue v) {
-    return setUdtValue(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setUdtValue(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code id} to the provided tuple value.
+   * Sets the value for all occurrences of {@code id} to the provided tuple value.
    *
    * <p>By default, this works with CQL tuples.
    *
@@ -553,6 +687,11 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setTupleValue(@NonNull CqlIdentifier id, @Nullable TupleValue v) {
-    return setTupleValue(firstIndexOf(id), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(id)) {
+      result = (result == null ? this : result).setTupleValue(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableByName.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableByName.java
@@ -40,7 +40,7 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
     extends SettableByIndex<SelfT>, AccessibleByName {
 
   /**
-   * Sets the raw binary representation of the value for the first occurrence of {@code name}.
+   * Sets the raw binary representation of the value for all occurrences of {@code name}.
    *
    * <p>This is primarily for internal use; you'll likely want to use one of the typed setters
    * instead, to pass a higher-level Java representation.
@@ -58,7 +58,12 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setBytesUnsafe(@NonNull String name, @Nullable ByteBuffer v) {
-    return setBytesUnsafe(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setBytesUnsafe(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   @NonNull
@@ -68,7 +73,7 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to CQL {@code NULL}.
+   * Sets the value for all occurrences of {@code name} to CQL {@code NULL}.
    *
    * <p>This method deals with case sensitivity in the way explained in the documentation of {@link
    * AccessibleByName}.
@@ -78,12 +83,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setToNull(@NonNull String name) {
-    return setToNull(firstIndexOf(name));
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setToNull(i);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name}, using the given codec for the
-   * conversion.
+   * Sets the value for all occurrences of {@code name}, using the given codec for the conversion.
    *
    * <p>This method completely bypasses the {@link #codecRegistry()}, and forces the driver to use
    * the given codec instead. This can be useful if the codec would collide with a previously
@@ -101,11 +110,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @CheckReturnValue
   default <ValueT> SelfT set(
       @NonNull String name, @Nullable ValueT v, @NonNull TypeCodec<ValueT> codec) {
-    return set(firstIndexOf(name), v, codec);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).set(i, v, codec);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name}, converting it to the given Java type.
+   * Sets the value for all occurrences of {@code name}, converting it to the given Java type.
    *
    * <p>The {@link #codecRegistry()} will be used to look up a codec to handle the conversion.
    *
@@ -122,12 +136,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @CheckReturnValue
   default <ValueT> SelfT set(
       @NonNull String name, @Nullable ValueT v, @NonNull GenericType<ValueT> targetType) {
-    return set(firstIndexOf(name), v, targetType);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).set(i, v, targetType);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Returns the value for the first occurrence of {@code name}, converting it to the given Java
-   * type.
+   * Returns the value for all occurrences of {@code name}, converting it to the given Java type.
    *
    * <p>The {@link #codecRegistry()} will be used to look up a codec to handle the conversion.
    *
@@ -143,11 +161,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @CheckReturnValue
   default <ValueT> SelfT set(
       @NonNull String name, @Nullable ValueT v, @NonNull Class<ValueT> targetClass) {
-    return set(firstIndexOf(name), v, targetClass);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).set(i, v, targetClass);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java primitive boolean.
+   * Sets the value for all occurrences of {@code name} to the provided Java primitive boolean.
    *
    * <p>By default, this works with CQL type {@code boolean}.
    *
@@ -162,11 +185,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setBoolean(@NonNull String name, boolean v) {
-    return setBoolean(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setBoolean(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java primitive byte.
+   * Sets the value for all occurrences of {@code name} to the provided Java primitive byte.
    *
    * <p>By default, this works with CQL type {@code tinyint}.
    *
@@ -181,11 +209,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setByte(@NonNull String name, byte v) {
-    return setByte(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setByte(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java primitive double.
+   * Sets the value for all occurrences of {@code name} to the provided Java primitive double.
    *
    * <p>By default, this works with CQL type {@code double}.
    *
@@ -200,11 +233,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setDouble(@NonNull String name, double v) {
-    return setDouble(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setDouble(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java primitive float.
+   * Sets the value for all occurrences of {@code name} to the provided Java primitive float.
    *
    * <p>By default, this works with CQL type {@code float}.
    *
@@ -219,11 +257,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setFloat(@NonNull String name, float v) {
-    return setFloat(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setFloat(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java primitive integer.
+   * Sets the value for all occurrences of {@code name} to the provided Java primitive integer.
    *
    * <p>By default, this works with CQL type {@code int}.
    *
@@ -238,11 +281,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setInt(@NonNull String name, int v) {
-    return setInt(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setInt(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java primitive long.
+   * Sets the value for all occurrences of {@code name} to the provided Java primitive long.
    *
    * <p>By default, this works with CQL types {@code bigint} and {@code counter}.
    *
@@ -257,11 +305,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setLong(@NonNull String name, long v) {
-    return setLong(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setLong(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java primitive short.
+   * Sets the value for all occurrences of {@code name} to the provided Java primitive short.
    *
    * <p>By default, this works with CQL type {@code smallint}.
    *
@@ -276,11 +329,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setShort(@NonNull String name, short v) {
-    return setShort(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setShort(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java instant.
+   * Sets the value for all occurrences of {@code name} to the provided Java instant.
    *
    * <p>By default, this works with CQL type {@code timestamp}.
    *
@@ -292,11 +350,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setInstant(@NonNull String name, @Nullable Instant v) {
-    return setInstant(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setInstant(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java local date.
+   * Sets the value for all occurrences of {@code name} to the provided Java local date.
    *
    * <p>By default, this works with CQL type {@code date}.
    *
@@ -308,11 +371,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setLocalDate(@NonNull String name, @Nullable LocalDate v) {
-    return setLocalDate(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setLocalDate(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java local time.
+   * Sets the value for all occurrences of {@code name} to the provided Java local time.
    *
    * <p>By default, this works with CQL type {@code time}.
    *
@@ -324,11 +392,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setLocalTime(@NonNull String name, @Nullable LocalTime v) {
-    return setLocalTime(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setLocalTime(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java byte buffer.
+   * Sets the value for all occurrences of {@code name} to the provided Java byte buffer.
    *
    * <p>By default, this works with CQL type {@code blob}.
    *
@@ -340,11 +413,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setByteBuffer(@NonNull String name, @Nullable ByteBuffer v) {
-    return setByteBuffer(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setByteBuffer(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java string.
+   * Sets the value for all occurrences of {@code name} to the provided Java string.
    *
    * <p>By default, this works with CQL types {@code text}, {@code varchar} and {@code ascii}.
    *
@@ -356,11 +434,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setString(@NonNull String name, @Nullable String v) {
-    return setString(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setString(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java big integer.
+   * Sets the value for all occurrences of {@code name} to the provided Java big integer.
    *
    * <p>By default, this works with CQL type {@code varint}.
    *
@@ -372,11 +455,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setBigInteger(@NonNull String name, @Nullable BigInteger v) {
-    return setBigInteger(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setBigInteger(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java big decimal.
+   * Sets the value for all occurrences of {@code name} to the provided Java big decimal.
    *
    * <p>By default, this works with CQL type {@code decimal}.
    *
@@ -388,11 +476,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setBigDecimal(@NonNull String name, @Nullable BigDecimal v) {
-    return setBigDecimal(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setBigDecimal(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java UUID.
+   * Sets the value for all occurrences of {@code name} to the provided Java UUID.
    *
    * <p>By default, this works with CQL types {@code uuid} and {@code timeuuid}.
    *
@@ -404,11 +497,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setUuid(@NonNull String name, @Nullable UUID v) {
-    return setUuid(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setUuid(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java IP address.
+   * Sets the value for all occurrences of {@code name} to the provided Java IP address.
    *
    * <p>By default, this works with CQL type {@code inet}.
    *
@@ -420,11 +518,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setInetAddress(@NonNull String name, @Nullable InetAddress v) {
-    return setInetAddress(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setInetAddress(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided duration.
+   * Sets the value for all occurrences of {@code name} to the provided duration.
    *
    * <p>By default, this works with CQL type {@code duration}.
    *
@@ -436,11 +539,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setCqlDuration(@NonNull String name, @Nullable CqlDuration v) {
-    return setCqlDuration(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setCqlDuration(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided token.
+   * Sets the value for all occurrences of {@code name} to the provided token.
    *
    * <p>This works with the CQL type matching the partitioner in use for this cluster: {@code
    * bigint} for {@code Murmur3Partitioner}, {@code blob} for {@code ByteOrderedPartitioner}, and
@@ -454,11 +562,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setToken(@NonNull String name, @NonNull Token v) {
-    return setToken(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setToken(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java list.
+   * Sets the value for all occurrences of {@code name} to the provided Java list.
    *
    * <p>By default, this works with CQL type {@code list}.
    *
@@ -474,11 +587,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @CheckReturnValue
   default <ElementT> SelfT setList(
       @NonNull String name, @Nullable List<ElementT> v, @NonNull Class<ElementT> elementsClass) {
-    return setList(firstIndexOf(name), v, elementsClass);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setList(i, v, elementsClass);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java set.
+   * Sets the value for all occurrences of {@code name} to the provided Java set.
    *
    * <p>By default, this works with CQL type {@code set}.
    *
@@ -494,11 +612,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @CheckReturnValue
   default <ElementT> SelfT setSet(
       @NonNull String name, @Nullable Set<ElementT> v, @NonNull Class<ElementT> elementsClass) {
-    return setSet(firstIndexOf(name), v, elementsClass);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setSet(i, v, elementsClass);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided Java map.
+   * Sets the value for all occurrences of {@code name} to the provided Java map.
    *
    * <p>By default, this works with CQL type {@code map}.
    *
@@ -517,12 +640,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
       @Nullable Map<KeyT, ValueT> v,
       @NonNull Class<KeyT> keyClass,
       @NonNull Class<ValueT> valueClass) {
-    return setMap(firstIndexOf(name), v, keyClass, valueClass);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setMap(i, v, keyClass, valueClass);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided user defined type
-   * value.
+   * Sets the value for all occurrences of {@code name} to the provided user defined type value.
    *
    * <p>By default, this works with CQL user-defined types.
    *
@@ -534,11 +661,16 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setUdtValue(@NonNull String name, @Nullable UdtValue v) {
-    return setUdtValue(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setUdtValue(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 
   /**
-   * Sets the value for the first occurrence of {@code name} to the provided tuple value.
+   * Sets the value for all occurrences of {@code name} to the provided tuple value.
    *
    * <p>By default, this works with CQL tuples.
    *
@@ -550,6 +682,11 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default SelfT setTupleValue(@NonNull String name, @Nullable TupleValue v) {
-    return setTupleValue(firstIndexOf(name), v);
+    SelfT result = null;
+    for (Integer i : allIndicesOf(name)) {
+      result = (result == null ? this : result).setTupleValue(i, v);
+    }
+    assert result != null; // allIndices throws if there are no results
+    return result;
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/UserDefinedType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/UserDefinedType.java
@@ -21,9 +21,11 @@ import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
 import com.datastax.oss.driver.api.core.metadata.schema.Describable;
 import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
 import com.datastax.oss.driver.internal.core.metadata.schema.ScriptBuilder;
+import com.datastax.oss.driver.internal.core.util.Loggers;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Collections;
 import java.util.List;
 
 public interface UserDefinedType extends DataType, Describable {
@@ -39,7 +41,39 @@ public interface UserDefinedType extends DataType, Describable {
   @NonNull
   List<CqlIdentifier> getFieldNames();
 
+  /**
+   * @apiNote the default implementation only exists for backward compatibility. It wraps the result
+   *     of {@link #firstIndexOf(CqlIdentifier)} in a singleton list, which is not entirely correct,
+   *     as it will only return the first occurrence. Therefore it also logs a warning.
+   *     <p>Implementors should always override this method (all built-in driver implementations
+   *     do).
+   */
+  @NonNull
+  default List<Integer> allIndicesOf(@NonNull CqlIdentifier id) {
+    Loggers.USER_DEFINED_TYPE.warn(
+        "{} should override allIndicesOf(CqlIdentifier), the default implementation is a "
+            + "workaround for backward compatibility, it only returns the first occurrence",
+        getClass().getName());
+    return Collections.singletonList(firstIndexOf(id));
+  }
+
   int firstIndexOf(@NonNull CqlIdentifier id);
+
+  /**
+   * @apiNote the default implementation only exists for backward compatibility. It wraps the result
+   *     of {@link #firstIndexOf(String)} in a singleton list, which is not entirely correct, as it
+   *     will only return the first occurrence. Therefore it also logs a warning.
+   *     <p>Implementors should always override this method (all built-in driver implementations
+   *     do).
+   */
+  @NonNull
+  default List<Integer> allIndicesOf(@NonNull String name) {
+    Loggers.USER_DEFINED_TYPE.warn(
+        "{} should override allIndicesOf(String), the default implementation is a "
+            + "workaround for backward compatibility, it only returns the first occurrence",
+        getClass().getName());
+    return Collections.singletonList(firstIndexOf(name));
+  }
 
   int firstIndexOf(@NonNull String name);
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
@@ -117,6 +117,16 @@ public class DefaultBoundStatement implements BoundStatement {
     return variableDefinitions.get(i).getType();
   }
 
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull CqlIdentifier id) {
+    List<Integer> indices = variableDefinitions.allIndicesOf(id);
+    if (indices.isEmpty()) {
+      throw new IllegalArgumentException(id + " is not a variable in this bound statement");
+    }
+    return indices;
+  }
+
   @Override
   public int firstIndexOf(@NonNull CqlIdentifier id) {
     int indexOf = variableDefinitions.firstIndexOf(id);
@@ -124,6 +134,16 @@ public class DefaultBoundStatement implements BoundStatement {
       throw new IllegalArgumentException(id + " is not a variable in this bound statement");
     }
     return indexOf;
+  }
+
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull String name) {
+    List<Integer> indices = variableDefinitions.allIndicesOf(name);
+    if (indices.isEmpty()) {
+      throw new IllegalArgumentException(name + " is not a variable in this bound statement");
+    }
+    return indices;
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultColumnDefinitions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultColumnDefinitions.java
@@ -74,9 +74,21 @@ public class DefaultColumnDefinitions implements ColumnDefinitions, Serializable
     return index.firstIndexOf(id) >= 0;
   }
 
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull String name) {
+    return index.allIndicesOf(name);
+  }
+
   @Override
   public int firstIndexOf(@NonNull String name) {
     return index.firstIndexOf(name);
+  }
+
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull CqlIdentifier id) {
+    return index.allIndicesOf(id);
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultRow.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultRow.java
@@ -68,6 +68,16 @@ public class DefaultRow implements Row, Serializable {
     return definitions.get(i).getType();
   }
 
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull CqlIdentifier id) {
+    List<Integer> indices = definitions.allIndicesOf(id);
+    if (indices.isEmpty()) {
+      throw new IllegalArgumentException(id + " is not a column in this row");
+    }
+    return indices;
+  }
+
   @Override
   public int firstIndexOf(@NonNull CqlIdentifier id) {
     int indexOf = definitions.firstIndexOf(id);
@@ -81,6 +91,16 @@ public class DefaultRow implements Row, Serializable {
   @Override
   public DataType getType(@NonNull CqlIdentifier id) {
     return definitions.get(firstIndexOf(id)).getType();
+  }
+
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull String name) {
+    List<Integer> indices = definitions.allIndicesOf(name);
+    if (indices.isEmpty()) {
+      throw new IllegalArgumentException(name + " is not a column in this row");
+    }
+    return indices;
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/EmptyColumnDefinitions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/EmptyColumnDefinitions.java
@@ -22,6 +22,7 @@ import com.datastax.oss.driver.api.core.detach.AttachmentPoint;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * The singleton that represents no column definitions (implemented as an enum which provides the
@@ -51,9 +52,21 @@ public enum EmptyColumnDefinitions implements ColumnDefinitions {
     return false;
   }
 
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull String name) {
+    return Collections.emptyList();
+  }
+
   @Override
   public int firstIndexOf(@NonNull String name) {
     return -1;
+  }
+
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull CqlIdentifier id) {
+    return Collections.emptyList();
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/data/DefaultUdtValue.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/data/DefaultUdtValue.java
@@ -29,6 +29,7 @@ import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Objects;
 import net.jcip.annotations.NotThreadSafe;
 
@@ -75,6 +76,16 @@ public class DefaultUdtValue implements UdtValue, Serializable {
     return values.length;
   }
 
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull CqlIdentifier id) {
+    List<Integer> indices = type.allIndicesOf(id);
+    if (indices.isEmpty()) {
+      throw new IllegalArgumentException(id + " is not a field in this UDT");
+    }
+    return indices;
+  }
+
   @Override
   public int firstIndexOf(@NonNull CqlIdentifier id) {
     int indexOf = type.firstIndexOf(id);
@@ -82,6 +93,16 @@ public class DefaultUdtValue implements UdtValue, Serializable {
       throw new IllegalArgumentException(id + " is not a field in this UDT");
     }
     return indexOf;
+  }
+
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull String name) {
+    List<Integer> indices = type.allIndicesOf(name);
+    if (indices.isEmpty()) {
+      throw new IllegalArgumentException(name + " is not a field in this UDT");
+    }
+    return indices;
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/data/IdentifierIndex.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/data/IdentifierIndex.java
@@ -20,9 +20,9 @@ import com.datastax.oss.driver.api.core.data.AccessibleByName;
 import com.datastax.oss.driver.api.core.data.GettableById;
 import com.datastax.oss.driver.api.core.data.GettableByName;
 import com.datastax.oss.driver.internal.core.util.Strings;
-import com.datastax.oss.driver.shaded.guava.common.collect.Maps;
+import com.datastax.oss.driver.shaded.guava.common.collect.LinkedListMultimap;
+import com.datastax.oss.driver.shaded.guava.common.collect.ListMultimap;
 import java.util.List;
-import java.util.Map;
 import net.jcip.annotations.Immutable;
 
 /**
@@ -34,22 +34,32 @@ import net.jcip.annotations.Immutable;
 @Immutable
 public class IdentifierIndex {
 
-  private final Map<CqlIdentifier, Integer> byId;
-  private final Map<String, Integer> byCaseSensitiveName;
-  private final Map<String, Integer> byCaseInsensitiveName;
+  private final ListMultimap<CqlIdentifier, Integer> byId;
+  private final ListMultimap<String, Integer> byCaseSensitiveName;
+  private final ListMultimap<String, Integer> byCaseInsensitiveName;
 
   public IdentifierIndex(List<CqlIdentifier> ids) {
-    this.byId = Maps.newHashMapWithExpectedSize(ids.size());
-    this.byCaseSensitiveName = Maps.newHashMapWithExpectedSize(ids.size());
-    this.byCaseInsensitiveName = Maps.newHashMapWithExpectedSize(ids.size());
+    this.byId = LinkedListMultimap.create(ids.size());
+    this.byCaseSensitiveName = LinkedListMultimap.create(ids.size());
+    this.byCaseInsensitiveName = LinkedListMultimap.create(ids.size());
 
     int i = 0;
     for (CqlIdentifier id : ids) {
-      byId.putIfAbsent(id, i);
-      byCaseSensitiveName.putIfAbsent(id.asInternal(), i);
-      byCaseInsensitiveName.putIfAbsent(id.asInternal().toLowerCase(), i);
+      byId.put(id, i);
+      byCaseSensitiveName.put(id.asInternal(), i);
+      byCaseInsensitiveName.put(id.asInternal().toLowerCase(), i);
       i += 1;
     }
+  }
+
+  /**
+   * Returns all occurrences of a given name, given the matching rules described in {@link
+   * AccessibleByName}.
+   */
+  public List<Integer> allIndicesOf(String name) {
+    return Strings.isDoubleQuoted(name)
+        ? byCaseSensitiveName.get(Strings.unDoubleQuote(name))
+        : byCaseInsensitiveName.get(name.toLowerCase());
   }
 
   /**
@@ -57,16 +67,18 @@ public class IdentifierIndex {
    * AccessibleByName}, or -1 if it's not in the list.
    */
   public int firstIndexOf(String name) {
-    Integer index =
-        Strings.isDoubleQuoted(name)
-            ? byCaseSensitiveName.get(Strings.unDoubleQuote(name))
-            : byCaseInsensitiveName.get(name.toLowerCase());
-    return (index == null) ? -1 : index;
+    List<Integer> indices = allIndicesOf(name);
+    return indices.isEmpty() ? -1 : indices.get(0);
+  }
+
+  /** Returns all occurrences of a given identifier. */
+  public List<Integer> allIndicesOf(CqlIdentifier id) {
+    return byId.get(id);
   }
 
   /** Returns the first occurrence of a given identifier, or -1 if it's not in the list. */
   public int firstIndexOf(CqlIdentifier id) {
-    Integer index = byId.get(id);
-    return (index == null) ? -1 : index;
+    List<Integer> indices = allIndicesOf(id);
+    return indices.isEmpty() ? -1 : indices.get(0);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/ShallowUserDefinedType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/ShallowUserDefinedType.java
@@ -84,8 +84,22 @@ public class ShallowUserDefinedType implements UserDefinedType, Serializable {
         "This implementation should only be used internally, this is likely a driver bug");
   }
 
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull CqlIdentifier id) {
+    throw new UnsupportedOperationException(
+        "This implementation should only be used internally, this is likely a driver bug");
+  }
+
   @Override
   public int firstIndexOf(@NonNull CqlIdentifier id) {
+    throw new UnsupportedOperationException(
+        "This implementation should only be used internally, this is likely a driver bug");
+  }
+
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull String name) {
     throw new UnsupportedOperationException(
         "This implementation should only be used internally, this is likely a driver bug");
   }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultUserDefinedType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/DefaultUserDefinedType.java
@@ -109,9 +109,21 @@ public class DefaultUserDefinedType implements UserDefinedType, Serializable {
     return fieldNames;
   }
 
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull CqlIdentifier id) {
+    return index.allIndicesOf(id);
+  }
+
   @Override
   public int firstIndexOf(@NonNull CqlIdentifier id) {
     return index.firstIndexOf(id);
+  }
+
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull String name) {
+    return index.allIndicesOf(name);
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/Loggers.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/Loggers.java
@@ -15,7 +15,12 @@
  */
 package com.datastax.oss.driver.internal.core.util;
 
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.data.AccessibleById;
+import com.datastax.oss.driver.api.core.data.AccessibleByName;
+import com.datastax.oss.driver.api.core.type.UserDefinedType;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Loggers {
 
@@ -38,4 +43,10 @@ public class Loggers {
       }
     }
   }
+
+  // Loggers for API interfaces, declared here in order to keep them internal.
+  public static Logger COLUMN_DEFINITIONS = LoggerFactory.getLogger(ColumnDefinitions.class);
+  public static Logger ACCESSIBLE_BY_ID = LoggerFactory.getLogger(AccessibleById.class);
+  public static Logger ACCESSIBLE_BY_NAME = LoggerFactory.getLogger(AccessibleByName.class);
+  public static Logger USER_DEFINED_TYPE = LoggerFactory.getLogger(UserDefinedType.class);
 }

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/cql/reactive/MockRow.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/cql/reactive/MockRow.java
@@ -29,6 +29,8 @@ import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
 import com.datastax.oss.driver.internal.core.cql.EmptyColumnDefinitions;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
 
 class MockRow implements Row {
 
@@ -61,9 +63,21 @@ class MockRow implements Row {
     return EmptyColumnDefinitions.INSTANCE;
   }
 
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull String name) {
+    return Collections.singletonList(0);
+  }
+
   @Override
   public int firstIndexOf(@NonNull String name) {
     return 0;
+  }
+
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull CqlIdentifier id) {
+    return Collections.singletonList(0);
   }
 
   @Override

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/data/IdentifierIndexTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/data/IdentifierIndexTest.java
@@ -25,7 +25,8 @@ public class IdentifierIndexTest {
   private static final CqlIdentifier Foo = CqlIdentifier.fromInternal("Foo");
   private static final CqlIdentifier foo = CqlIdentifier.fromInternal("foo");
   private static final CqlIdentifier fOO = CqlIdentifier.fromInternal("fOO");
-  private IdentifierIndex index = new IdentifierIndex(ImmutableList.of(Foo, foo, fOO));
+  private IdentifierIndex index =
+      new IdentifierIndex(ImmutableList.of(Foo, foo, fOO, Foo, foo, fOO));
 
   @Test
   public void should_find_first_index_of_existing_identifier() {
@@ -59,5 +60,39 @@ public class IdentifierIndexTest {
   @Test
   public void should_not_find_index_of_nonexistent_case_sensitive_name() {
     assertThat(index.firstIndexOf("\"FOO\"")).isEqualTo(-1);
+  }
+
+  @Test
+  public void should_find_all_indices_of_existing_identifier() {
+    assertThat(index.allIndicesOf(Foo)).containsExactly(0, 3);
+    assertThat(index.allIndicesOf(foo)).containsExactly(1, 4);
+    assertThat(index.allIndicesOf(fOO)).containsExactly(2, 5);
+  }
+
+  @Test
+  public void should_not_find_indices_of_nonexistent_identifier() {
+    assertThat(index.allIndicesOf(CqlIdentifier.fromInternal("FOO"))).isEmpty();
+  }
+
+  @Test
+  public void should_all_indices_of_case_insensitive_name() {
+    assertThat(index.allIndicesOf("foo")).containsExactly(0, 1, 2, 3, 4, 5);
+  }
+
+  @Test
+  public void should_not_find_indices_of_nonexistent_case_insensitive_name() {
+    assertThat(index.allIndicesOf("bar")).isEmpty();
+  }
+
+  @Test
+  public void should_find_all_indices_of_case_sensitive_name() {
+    assertThat(index.allIndicesOf("\"Foo\"")).containsExactly(0, 3);
+    assertThat(index.allIndicesOf("\"foo\"")).containsExactly(1, 4);
+    assertThat(index.allIndicesOf("\"fOO\"")).containsExactly(2, 5);
+  }
+
+  @Test
+  public void should_not_find_indices_of_nonexistent_case_sensitive_name() {
+    assertThat(index.allIndicesOf("\"FOO\"")).isEmpty();
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
@@ -27,6 +27,7 @@ import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
@@ -363,6 +364,44 @@ public class BoundStatementCcmIT {
       assertThat(routingKey)
           .isEqualTo(RoutingKey.compose(bs.getBytesUnsafe(2), bs.getBytesUnsafe(1)));
     }
+  }
+
+  @Test
+  public void should_set_all_occurrences_of_variable() {
+    CqlSession session = sessionRule.session();
+    PreparedStatement ps = session.prepare("INSERT INTO test3 (pk1, pk2, v) VALUES (:i, :i, :i)");
+
+    CqlIdentifier id = CqlIdentifier.fromCql("i");
+    ColumnDefinitions variableDefinitions = ps.getVariableDefinitions();
+    assertThat(variableDefinitions.allIndicesOf(id)).containsExactly(0, 1, 2);
+
+    should_set_all_occurrences_of_variable(ps.bind().setInt(id, 12));
+    should_set_all_occurrences_of_variable(ps.boundStatementBuilder().setInt(id, 12).build());
+  }
+
+  private void should_set_all_occurrences_of_variable(BoundStatement bs) {
+    assertThat(bs.getInt(0)).isEqualTo(12);
+    assertThat(bs.getInt(1)).isEqualTo(12);
+    assertThat(bs.getInt(2)).isEqualTo(12);
+
+    // Nothing should be shared internally (this would be a bug if the client later retrieves a
+    // buffer with getBytesUnsafe and modifies it)
+    ByteBuffer bytes0 = bs.getBytesUnsafe(0);
+    ByteBuffer bytes1 = bs.getBytesUnsafe(1);
+    assertThat(bytes0).isNotNull();
+    assertThat(bytes1).isNotNull();
+    // Not the same instance
+    assertThat(bytes0).isNotSameAs(bytes1);
+    // Contents are not shared
+    bytes0.putInt(0, 11);
+    assertThat(bytes1.getInt(0)).isEqualTo(12);
+    bytes0.putInt(0, 12);
+
+    CqlSession session = sessionRule.session();
+    session.execute(bs);
+    Row row = session.execute("SELECT * FROM test3 WHERE pk1 = 12 AND pk2 = 12").one();
+    assertThat(row).isNotNull();
+    assertThat(row.getInt("v")).isEqualTo(12);
   }
 
   private static void verifyUnset(

--- a/mapper-runtime/src/test/java/com/datastax/dse/driver/api/mapper/reactive/MockRow.java
+++ b/mapper-runtime/src/test/java/com/datastax/dse/driver/api/mapper/reactive/MockRow.java
@@ -29,6 +29,8 @@ import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
 import com.datastax.oss.driver.internal.core.cql.EmptyColumnDefinitions;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
 
 class MockRow implements Row {
 
@@ -61,9 +63,21 @@ class MockRow implements Row {
     return EmptyColumnDefinitions.INSTANCE;
   }
 
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull String name) {
+    return Collections.singletonList(0);
+  }
+
   @Override
   public int firstIndexOf(@NonNull String name) {
     return 0;
+  }
+
+  @NonNull
+  @Override
+  public List<Integer> allIndicesOf(@NonNull CqlIdentifier id) {
+    return Collections.singletonList(0);
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -709,6 +709,11 @@ limitations under the License.]]></inlineHeader>
           <doclint>all,-missing</doclint>
           <excludePackageNames>com.datastax.*.driver.internal*</excludePackageNames>
           <tags>
+            <tag>
+              <name>apiNote</name>
+              <placement>a</placement>
+              <head>API note:</head>
+            </tag>
             <!--
               For custom `leaks-private-api` tag (apparently dash separators are not handled
               correctly)


### PR DESCRIPTION
Draft to see what it takes to restore the 3.x behavior. It's not as bad as I thought, see inline comments regarding the tradeoffs to avoid breaking the API.