### PR TITLE
JAVA-2835: Correctly handle unresolved addresses in DefaultEndPoint.equals

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.8.0 (in progress)
 
+- [bug] JAVA-2835: Correctly handle unresolved addresses in DefaultEndPoint.equals
 - [bug] JAVA-2838: Avoid ConcurrentModificationException when closing connection
 - [bug] JAVA-2837: make StringCodec strict about unicode in ascii
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultEndPoint.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/DefaultEndPoint.java
@@ -44,8 +44,16 @@ public class DefaultEndPoint implements EndPoint, Serializable {
     if (other == this) {
       return true;
     } else if (other instanceof DefaultEndPoint) {
-      DefaultEndPoint that = (DefaultEndPoint) other;
-      return this.address.equals(that.address);
+      InetSocketAddress thisAddress = this.address;
+      InetSocketAddress thatAddress = ((DefaultEndPoint) other).address;
+      // If only one of the addresses is unresolved, resolve the other. Otherwise (both resolved or
+      // both unresolved), compare as-is.
+      if (thisAddress.isUnresolved() && !thatAddress.isUnresolved()) {
+        thisAddress = new InetSocketAddress(thisAddress.getHostName(), thisAddress.getPort());
+      } else if (thatAddress.isUnresolved() && !thisAddress.isUnresolved()) {
+        thatAddress = new InetSocketAddress(thatAddress.getHostName(), thatAddress.getPort());
+      }
+      return thisAddress.equals(thatAddress);
     } else {
       return false;
     }


### PR DESCRIPTION
Motivation:

In InitialNodeListRefresh, the driver tries to match contact points
Nodes with system.peers rows, in order to refresh their data. Because
the Nodes's hostIds are not known yet, we match by EndPoint (which for
the Nodes are the addresses passed by the user, and for the peers rows
are the values in rpc_address).

The default TopologyMonitor parses rpc_address into *resolved*
InetSocketAddress instances. If one of the contact points was passed as
an *unresolved* address, the comparison fails. The contact point is
considered removed, and the row gets added as a new node.

In addition, this will issue the DC mismatch warning ("some contact
points are from a different DC"), because the contact point's datacenter
was never filled.

Modifications:

In DefaultEndPoint.equals, if one of the addresses is unresolved but the
other is, resolve the former.

Result:

The comparison in InitialNodeListRefresh succeeds. The contact point
Node matches its system.peers row, and gets refreshed properly.

Note that:
* if both addresses are unresolved, we don't need to resolve. This
  can happen if the user has a custom AddressTranslator (or a custom
  TopologyMonitor) that parses system.peers addresses as unresolved
  addresses.
* this EndPoint comparison only happens during the initial refresh.
  After that, we know the Nodes' hostIds, so we use that instead (see
  FullNodeListRefresh).