### PR TITLE
JAVA-2846: Load system settings when application.conf is also provided

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.8.0 (in progress)
 
+- [bug] JAVA-2846: Give system properties the highest precedence in DefaultDriverConfigLoader
 - [new feature] JAVA-2691: Provide driver 4 support for extra codecs
 - [improvement] Allow injection of CodecRegistry on session builder
 - [improvement] JAVA-2828: Add safe paging state wrapper

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/config/typesafe/DefaultDriverConfigLoader.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/config/typesafe/DefaultDriverConfigLoader.java
@@ -58,8 +58,10 @@ public class DefaultDriverConfigLoader implements DriverConfigLoader {
         ConfigFactory.invalidateCaches();
         // The thread's context class loader will be used for application classpath resources,
         // while the driver class loader will be used for reference classpath resources.
-        return ConfigFactory.defaultApplication()
+        return ConfigFactory.defaultOverrides()
+            .withFallback(ConfigFactory.defaultApplication())
             .withFallback(ConfigFactory.defaultReference(CqlSession.class.getClassLoader()))
+            .resolve()
             .getConfig(DEFAULT_ROOT_PATH);
       };
 
@@ -95,8 +97,10 @@ public class DefaultDriverConfigLoader implements DriverConfigLoader {
     this(
         () -> {
           ConfigFactory.invalidateCaches();
-          return ConfigFactory.defaultApplication(appClassLoader)
+          return ConfigFactory.defaultOverrides()
+              .withFallback(ConfigFactory.defaultApplication(appClassLoader))
               .withFallback(ConfigFactory.defaultReference(CqlSession.class.getClassLoader()))
+              .resolve()
               .getConfig(DEFAULT_ROOT_PATH);
         });
   }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/map/MapBasedDriverConfigLoaderTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/map/MapBasedDriverConfigLoaderTest.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.driver.internal.core.config.map;
 
+import static com.typesafe.config.ConfigFactory.defaultReference;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -30,6 +31,7 @@ import com.datastax.oss.driver.internal.core.config.MockOptions;
 import com.datastax.oss.driver.internal.core.config.MockTypedOptions;
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader;
 import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -58,7 +60,14 @@ public class MapBasedDriverConfigLoaderTest {
     DriverExecutionProfile mapBasedConfig =
         DriverConfigLoader.fromMap(optionsMap).getInitialConfig().getDefaultProfile();
     DriverExecutionProfile fileBasedConfig =
-        new DefaultDriverConfigLoader().getInitialConfig().getDefaultProfile();
+        new DefaultDriverConfigLoader(
+                () -> {
+                  // Only load reference.conf since we are focusing on driver defaults
+                  ConfigFactory.invalidateCaches();
+                  return defaultReference().getConfig(DefaultDriverConfigLoader.DEFAULT_ROOT_PATH);
+                })
+            .getInitialConfig()
+            .getDefaultProfile();
 
     // Make sure we're not missing any options. -1 is for CONFIG_RELOAD_INTERVAL, which is not
     // defined by OptionsMap because it is irrelevant for the map-based config.

--- a/core/src/test/resources/application.conf
+++ b/core/src/test/resources/application.conf
@@ -1,0 +1,3 @@
+datastax-java-driver {
+  basic.request.timeout = ${datastax-java-driver.advanced.connection.init-query-timeout}
+}


### PR DESCRIPTION
The config loader bug manifests when system setting is provided AND `application.conf`

It seems that the problematic part is in `DefaultDriverConfigLoader` (the `defaultApplication()`):
```
  public static final Supplier<Config> DEFAULT_CONFIG_SUPPLIER =
      () -> {
        ConfigFactory.invalidateCaches();
        // The thread's context class loader will be used for application classpath resources,
        // while the driver class loader will be used for reference classpath resources.
        return ConfigFactory.defaultApplication()
            .withFallback(ConfigFactory.defaultReference(CqlSession.class.getClassLoader()))
            .getConfig(DEFAULT_ROOT_PATH);
      };
```
?
When changing this to:
```
  public static final Supplier<Config> DEFAULT_CONFIG_SUPPLIER =
      () -> {
        ConfigFactory.invalidateCaches();
        // The thread's context class loader will be used for application classpath resources,
        // while the driver class loader will be used for reference classpath resources.
        return ConfigFactory.defaultOverrides()
            .withFallback(ConfigFactory.defaultReference(CqlSession.class.getClassLoader()))
            .getConfig(DEFAULT_ROOT_PATH);
      };
```
(please note `ConfigFactory.defaultOverrides()`) then the `-D` settings are picked up.

So if both are provided, the setting from `application.conf` has a priority over `-D` setting; according to the doc of `defaultApplication` :
`@return the default application.conf or system-property-configured configuration`
it should be another way around - so the system-property should have the higher property and override everything else, isn' i?

@adutra do you remember the context of those changes?
