### PR TITLE
Remove explicit dependency to javatuples

### DIFF
--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -101,10 +101,6 @@
       <artifactId>tinkergraph-gremlin</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.javatuples</groupId>
-      <artifactId>javatuples</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.reactivestreams</groupId>
       <artifactId>reactive-streams</artifactId>
     </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,10 +66,6 @@
       <artifactId>jnr-posix</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.javatuples</groupId>
-      <artifactId>javatuples</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
       <optional>true</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -191,11 +191,6 @@
         <version>3.1.12</version>
       </dependency>
       <dependency>
-        <groupId>org.javatuples</groupId>
-        <artifactId>javatuples</artifactId>
-        <version>1.2</version>
-      </dependency>
-      <dependency>
         <groupId>com.squareup</groupId>
         <artifactId>javapoet</artifactId>
         <version>1.11.1</version>


### PR DESCRIPTION
It is a transitive dependency of Tinkerpop. We do reference it directly
from the driver code (CqlCollectionPredicate), so in theory we should
redeclare it, but it's only used to deserialize graph stuff and not
exposed in our public API.

The advantage of not declaring it explicitly is that it's one less
thing to exclude manually if you're not using graph.