### PR TITLE
JAVA-2800: Avoid SLF4J warnings when using the mapper processor

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.8.0 (in progress)
 
+- [bug] JAVA-2800: Avoid SLF4J warnings when using the mapper processor
 - [bug] JAVA-2846: Give system properties the highest precedence in DefaultDriverConfigLoader
 - [new feature] JAVA-2691: Provide driver 4 support for extra codecs
 - [improvement] Allow injection of CodecRegistry on session builder

--- a/mapper-processor/pom.xml
+++ b/mapper-processor/pom.xml
@@ -57,6 +57,15 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
     </dependency>
+    <!--
+      The processor depends on SLF4J because it's used in generated code, but it doesn't have a
+      proper SLF4J backend in its own classpath. This can generate warnings in certain scenarios
+      (JAVA-2800), so add a no-op implementation as a workaround.
+    -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-nop</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.google.testing.compile</groupId>
       <artifactId>compile-testing</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
         <version>${slf4j.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-nop</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${logback.version}</version>


### PR DESCRIPTION
This is the easy option with slf4j-nop.

I've pushed another branch [java2800_exclude](https://github.com/datastax/java-driver/tree/java2800_exclude) with my attempt to exclude SLF4J from the processor path, but as I said in JIRA I couldn't make it work.