### PR TITLE
JAVA-2841: Raise timeouts during connection initialization

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.8.0 (in progress)
 
+- [improvement] JAVA-2841: Raise timeouts during connection initialization
 - [bug] JAVA-2331: Unregister old metrics when a node gets removed or changes RPC address
 - [improvement] JAVA-2850: Ignore credentials in secure connect bundle [DataStax Astra]
 - [improvement] JAVA-2813: Don't fail when secure bundle is specified together with other options

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
@@ -242,6 +242,8 @@ public class OptionsMap implements Serializable {
   }
 
   protected static void fillWithDriverDefaults(OptionsMap map) {
+    Duration initQueryTimeout = Duration.ofSeconds(5);
+
     // Sorted by order of appearance in reference.conf:
 
     // Skip CONFIG_RELOAD_INTERVAL because the map-based config doesn't need periodic reloading
@@ -255,8 +257,8 @@ public class OptionsMap implements Serializable {
     map.put(TypedDriverOption.LOAD_BALANCING_POLICY_SLOW_AVOIDANCE, true);
     map.put(TypedDriverOption.SESSION_LEAK_THRESHOLD, 4);
     map.put(TypedDriverOption.CONNECTION_CONNECT_TIMEOUT, Duration.ofSeconds(5));
-    map.put(TypedDriverOption.CONNECTION_INIT_QUERY_TIMEOUT, Duration.ofMillis(500));
-    map.put(TypedDriverOption.CONNECTION_SET_KEYSPACE_TIMEOUT, Duration.ofMillis(500));
+    map.put(TypedDriverOption.CONNECTION_INIT_QUERY_TIMEOUT, initQueryTimeout);
+    map.put(TypedDriverOption.CONNECTION_SET_KEYSPACE_TIMEOUT, initQueryTimeout);
     map.put(TypedDriverOption.CONNECTION_POOL_LOCAL_SIZE, 1);
     map.put(TypedDriverOption.CONNECTION_POOL_REMOTE_SIZE, 1);
     map.put(TypedDriverOption.CONNECTION_MAX_REQUESTS, 1024);
@@ -324,7 +326,7 @@ public class OptionsMap implements Serializable {
     map.put(TypedDriverOption.METRICS_NODE_EXPIRE_AFTER, Duration.ofHours(1));
     map.put(TypedDriverOption.SOCKET_TCP_NODELAY, true);
     map.put(TypedDriverOption.HEARTBEAT_INTERVAL, Duration.ofSeconds(30));
-    map.put(TypedDriverOption.HEARTBEAT_TIMEOUT, Duration.ofMillis(500));
+    map.put(TypedDriverOption.HEARTBEAT_TIMEOUT, initQueryTimeout);
     map.put(TypedDriverOption.METADATA_TOPOLOGY_WINDOW, Duration.ofSeconds(1));
     map.put(TypedDriverOption.METADATA_TOPOLOGY_MAX_EVENTS, 20);
     map.put(TypedDriverOption.METADATA_SCHEMA_ENABLED, true);
@@ -333,7 +335,7 @@ public class OptionsMap implements Serializable {
     map.put(TypedDriverOption.METADATA_SCHEMA_WINDOW, Duration.ofSeconds(1));
     map.put(TypedDriverOption.METADATA_SCHEMA_MAX_EVENTS, 20);
     map.put(TypedDriverOption.METADATA_TOKEN_MAP_ENABLED, true);
-    map.put(TypedDriverOption.CONTROL_CONNECTION_TIMEOUT, Duration.ofMillis(500));
+    map.put(TypedDriverOption.CONTROL_CONNECTION_TIMEOUT, initQueryTimeout);
     map.put(TypedDriverOption.CONTROL_CONNECTION_AGREEMENT_INTERVAL, Duration.ofMillis(200));
     map.put(TypedDriverOption.CONTROL_CONNECTION_AGREEMENT_TIMEOUT, Duration.ofSeconds(10));
     map.put(TypedDriverOption.CONTROL_CONNECTION_AGREEMENT_WARN, true);
@@ -342,7 +344,7 @@ public class OptionsMap implements Serializable {
     map.put(TypedDriverOption.REPREPARE_CHECK_SYSTEM_TABLE, false);
     map.put(TypedDriverOption.REPREPARE_MAX_STATEMENTS, 0);
     map.put(TypedDriverOption.REPREPARE_MAX_PARALLELISM, 100);
-    map.put(TypedDriverOption.REPREPARE_TIMEOUT, Duration.ofMillis(500));
+    map.put(TypedDriverOption.REPREPARE_TIMEOUT, initQueryTimeout);
     map.put(TypedDriverOption.NETTY_DAEMON, false);
     map.put(TypedDriverOption.NETTY_IO_SIZE, 0);
     map.put(TypedDriverOption.NETTY_IO_SHUTDOWN_QUIET_PERIOD, 2);

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
@@ -243,13 +243,18 @@ public class OptionsMap implements Serializable {
 
   protected static void fillWithDriverDefaults(OptionsMap map) {
     Duration initQueryTimeout = Duration.ofSeconds(5);
+    Duration requestTimeout = Duration.ofSeconds(2);
+    int requestPageSize = 5000;
+    int continuousMaxPages = 0;
+    int continuousMaxPagesPerSecond = 0;
+    int continuousMaxEnqueuedPages = 4;
 
     // Sorted by order of appearance in reference.conf:
 
     // Skip CONFIG_RELOAD_INTERVAL because the map-based config doesn't need periodic reloading
-    map.put(TypedDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(2));
+    map.put(TypedDriverOption.REQUEST_TIMEOUT, requestTimeout);
     map.put(TypedDriverOption.REQUEST_CONSISTENCY, "LOCAL_ONE");
-    map.put(TypedDriverOption.REQUEST_PAGE_SIZE, 5000);
+    map.put(TypedDriverOption.REQUEST_PAGE_SIZE, requestPageSize);
     map.put(TypedDriverOption.REQUEST_SERIAL_CONSISTENCY, "SERIAL");
     map.put(TypedDriverOption.REQUEST_DEFAULT_IDEMPOTENCE, false);
     map.put(TypedDriverOption.GRAPH_TRAVERSAL_SOURCE, "g");
@@ -287,15 +292,18 @@ public class OptionsMap implements Serializable {
     map.put(TypedDriverOption.REQUEST_TRACE_CONSISTENCY, "ONE");
     map.put(TypedDriverOption.REQUEST_LOG_WARNINGS, true);
     map.put(TypedDriverOption.GRAPH_PAGING_ENABLED, "AUTO");
-    map.put(TypedDriverOption.GRAPH_CONTINUOUS_PAGING_PAGE_SIZE, 5000);
-    map.put(TypedDriverOption.GRAPH_CONTINUOUS_PAGING_MAX_PAGES, 0);
-    map.put(TypedDriverOption.GRAPH_CONTINUOUS_PAGING_MAX_PAGES_PER_SECOND, 0);
-    map.put(TypedDriverOption.GRAPH_CONTINUOUS_PAGING_MAX_ENQUEUED_PAGES, 4);
-    map.put(TypedDriverOption.CONTINUOUS_PAGING_PAGE_SIZE, 5000);
+    map.put(TypedDriverOption.GRAPH_CONTINUOUS_PAGING_PAGE_SIZE, requestPageSize);
+    map.put(TypedDriverOption.GRAPH_CONTINUOUS_PAGING_MAX_PAGES, continuousMaxPages);
+    map.put(
+        TypedDriverOption.GRAPH_CONTINUOUS_PAGING_MAX_PAGES_PER_SECOND,
+        continuousMaxPagesPerSecond);
+    map.put(
+        TypedDriverOption.GRAPH_CONTINUOUS_PAGING_MAX_ENQUEUED_PAGES, continuousMaxEnqueuedPages);
+    map.put(TypedDriverOption.CONTINUOUS_PAGING_PAGE_SIZE, requestPageSize);
     map.put(TypedDriverOption.CONTINUOUS_PAGING_PAGE_SIZE_BYTES, false);
-    map.put(TypedDriverOption.CONTINUOUS_PAGING_MAX_PAGES, 0);
-    map.put(TypedDriverOption.CONTINUOUS_PAGING_MAX_PAGES_PER_SECOND, 0);
-    map.put(TypedDriverOption.CONTINUOUS_PAGING_MAX_ENQUEUED_PAGES, 4);
+    map.put(TypedDriverOption.CONTINUOUS_PAGING_MAX_PAGES, continuousMaxPages);
+    map.put(TypedDriverOption.CONTINUOUS_PAGING_MAX_PAGES_PER_SECOND, continuousMaxPagesPerSecond);
+    map.put(TypedDriverOption.CONTINUOUS_PAGING_MAX_ENQUEUED_PAGES, continuousMaxEnqueuedPages);
     map.put(TypedDriverOption.CONTINUOUS_PAGING_TIMEOUT_FIRST_PAGE, Duration.ofSeconds(2));
     map.put(TypedDriverOption.CONTINUOUS_PAGING_TIMEOUT_OTHER_PAGES, Duration.ofSeconds(1));
     map.put(TypedDriverOption.MONITOR_REPORTING_ENABLED, true);
@@ -330,8 +338,8 @@ public class OptionsMap implements Serializable {
     map.put(TypedDriverOption.METADATA_TOPOLOGY_WINDOW, Duration.ofSeconds(1));
     map.put(TypedDriverOption.METADATA_TOPOLOGY_MAX_EVENTS, 20);
     map.put(TypedDriverOption.METADATA_SCHEMA_ENABLED, true);
-    map.put(TypedDriverOption.METADATA_SCHEMA_REQUEST_TIMEOUT, Duration.ofSeconds(2));
-    map.put(TypedDriverOption.METADATA_SCHEMA_REQUEST_PAGE_SIZE, 5000);
+    map.put(TypedDriverOption.METADATA_SCHEMA_REQUEST_TIMEOUT, requestTimeout);
+    map.put(TypedDriverOption.METADATA_SCHEMA_REQUEST_PAGE_SIZE, requestPageSize);
     map.put(TypedDriverOption.METADATA_SCHEMA_WINDOW, Duration.ofSeconds(1));
     map.put(TypedDriverOption.METADATA_SCHEMA_MAX_EVENTS, 20);
     map.put(TypedDriverOption.METADATA_TOKEN_MAP_ENABLED, true);

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -377,7 +377,7 @@ datastax-java-driver {
     # Modifiable at runtime: yes, the new value will be used for connections created after the
     #   change.
     # Overridable in a profile: no
-    init-query-timeout = 500 milliseconds
+    init-query-timeout = 5 seconds
 
     # The timeout to use when the driver changes the keyspace on a connection at runtime (this
     # happens when the client issues a `USE ...` query, and all connections belonging to the current

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/DefaultDriverConfigLoaderTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/DefaultDriverConfigLoaderTest.java
@@ -185,7 +185,7 @@ public class DefaultDriverConfigLoaderTest {
     DriverExecutionProfile config = loader.getInitialConfig().getDefaultProfile();
     // From customApplication.conf:
     assertThat(config.getDuration(DefaultDriverOption.REQUEST_TIMEOUT))
-        .isEqualTo(Duration.ofMillis(500));
+        .isEqualTo(Duration.ofSeconds(5));
     // From customApplication.json:
     assertThat(config.getInt(DefaultDriverOption.REQUEST_PAGE_SIZE)).isEqualTo(2000);
     // From customApplication.properties:
@@ -204,7 +204,7 @@ public class DefaultDriverConfigLoaderTest {
     DriverExecutionProfile config = loader.getInitialConfig().getDefaultProfile();
     // From customApplication.conf:
     assertThat(config.getDuration(DefaultDriverOption.REQUEST_TIMEOUT))
-        .isEqualTo(Duration.ofMillis(500));
+        .isEqualTo(Duration.ofSeconds(5));
     // From reference.conf:
     assertThat(config.getString(DefaultDriverOption.REQUEST_SERIAL_CONSISTENCY))
         .isEqualTo(DefaultConsistencyLevel.SERIAL.name());
@@ -220,7 +220,7 @@ public class DefaultDriverConfigLoaderTest {
       DriverExecutionProfile config = loader.getInitialConfig().getDefaultProfile();
       // From customApplication.conf:
       assertThat(config.getDuration(DefaultDriverOption.REQUEST_TIMEOUT))
-          .isEqualTo(Duration.ofMillis(500));
+          .isEqualTo(Duration.ofSeconds(5));
       // From reference.conf:
       assertThat(config.getString(DefaultDriverOption.REQUEST_SERIAL_CONSISTENCY))
           .isEqualTo(DefaultConsistencyLevel.SERIAL.name());


### PR DESCRIPTION
I've tested the new timeout by connecting to Astra cluster that is in us-west from central Europe using this code:
```
public class AstraTest {
  public static void main(String[] args) {

    for (int i = 0; i < 100; i++) {
      Path bundle = Paths.get("/Users/tomaszlelek/Downloads/secure-connect-cass-dc.zip");

      try (CqlSession session =
          CqlSession.builder()
              .withCloudSecureConnectBundle(bundle)
              .withAuthCredentials("datastax", "datastax")
              .build()) {
        ResultSet set = session.execute("select * from system.local");
        System.out.println(set.all());
      }
    }
  }
}
```
with the previous timeout of 500 milliseconds, it was constantly failing to connect.
For the new timeout of 5 seconds, it has successfully connected 100 times.
I don't see a clear reason to increase `connect-timeout` timeout as well - @adutra can you elaborate more on that suggestion?