### PR TITLE
JAVA-2721: Add counter support in the mapper

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.9.0 (in progress)
 
+- [new feature] JAVA-2721: Add counter support in the mapper
 - [bug] JAVA-2863: Reintroduce mapper processor dependency to SLF4J
 
 ### 4.8.0

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/IncrementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/IncrementIT.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.mapper.annotations.Dao;
+import com.datastax.oss.driver.api.mapper.annotations.DaoFactory;
+import com.datastax.oss.driver.api.mapper.annotations.DaoKeyspace;
+import com.datastax.oss.driver.api.mapper.annotations.DefaultNullSavingStrategy;
+import com.datastax.oss.driver.api.mapper.annotations.Entity;
+import com.datastax.oss.driver.api.mapper.annotations.Increment;
+import com.datastax.oss.driver.api.mapper.annotations.Mapper;
+import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
+import com.datastax.oss.driver.api.mapper.annotations.Select;
+import com.datastax.oss.driver.api.mapper.entity.saving.NullSavingStrategy;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import java.util.Objects;
+import java.util.UUID;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+@Category(ParallelizableTests.class)
+public class IncrementIT {
+
+  private static final CcmRule CCM_RULE = CcmRule.getInstance();
+
+  private static final SessionRule<CqlSession> SESSION_RULE = SessionRule.builder(CCM_RULE).build();
+
+  @ClassRule
+  public static final TestRule CHAIN = RuleChain.outerRule(CCM_RULE).around(SESSION_RULE);
+
+  private static ProductRatingDao dao;
+
+  @BeforeClass
+  public static void setup() {
+    CqlSession session = SESSION_RULE.session();
+
+    session.execute(
+        SimpleStatement.builder(
+                "CREATE TABLE product_rating(product_id uuid PRIMARY KEY, "
+                    + "one_star counter, two_star counter, three_star counter, "
+                    + "four_star counter, five_star counter)")
+            .setExecutionProfile(SESSION_RULE.slowProfile())
+            .build());
+
+    InventoryMapper inventoryMapper = new IncrementIT_InventoryMapperBuilder(session).build();
+    dao = inventoryMapper.productRatingDao(SESSION_RULE.keyspace());
+  }
+
+  @Test
+  public void should_increment_counters() {
+    UUID productId1 = UUID.randomUUID();
+    UUID productId2 = UUID.randomUUID();
+
+    dao.incrementFiveStar(productId1, 1);
+    dao.incrementFiveStar(productId1, 1);
+    dao.incrementFourStar(productId1, 1);
+
+    dao.incrementTwoStar(productId2, 1);
+    dao.incrementThreeStar(productId2, 1);
+    dao.incrementOneStar(productId2, 1);
+
+    ProductRating product1Totals = dao.get(productId1);
+    assertThat(product1Totals.getFiveStar()).isEqualTo(2);
+    assertThat(product1Totals.getFourStar()).isEqualTo(1);
+    assertThat(product1Totals.getThreeStar()).isEqualTo(0);
+    assertThat(product1Totals.getTwoStar()).isEqualTo(0);
+    assertThat(product1Totals.getOneStar()).isEqualTo(0);
+
+    ProductRating product2Totals = dao.get(productId2);
+    assertThat(product2Totals.getFiveStar()).isEqualTo(0);
+    assertThat(product2Totals.getFourStar()).isEqualTo(0);
+    assertThat(product2Totals.getThreeStar()).isEqualTo(1);
+    assertThat(product2Totals.getTwoStar()).isEqualTo(1);
+    assertThat(product2Totals.getOneStar()).isEqualTo(1);
+  }
+
+  @Mapper
+  public interface InventoryMapper {
+    @DaoFactory
+    ProductRatingDao productRatingDao(@DaoKeyspace CqlIdentifier keyspace);
+  }
+
+  @Dao
+  @DefaultNullSavingStrategy(NullSavingStrategy.SET_TO_NULL)
+  public interface ProductRatingDao {
+    @Select
+    ProductRating get(UUID productId);
+
+    @Increment(entityClass = ProductRating.class)
+    void incrementOneStar(UUID productId, long oneStar);
+
+    @Increment(entityClass = ProductRating.class)
+    void incrementTwoStar(UUID productId, long twoStar);
+
+    @Increment(entityClass = ProductRating.class)
+    void incrementThreeStar(UUID productId, long threeStar);
+
+    @Increment(entityClass = ProductRating.class)
+    void incrementFourStar(UUID productId, long fourStar);
+
+    @Increment(entityClass = ProductRating.class)
+    void incrementFiveStar(UUID productId, long fiveStar);
+  }
+
+  @Entity
+  public static class ProductRating {
+
+    @PartitionKey private UUID productId;
+    private long oneStar;
+    private long twoStar;
+    private long threeStar;
+    private long fourStar;
+    private long fiveStar;
+
+    public ProductRating() {}
+
+    public UUID getProductId() {
+      return productId;
+    }
+
+    public void setProductId(UUID productId) {
+      this.productId = productId;
+    }
+
+    public long getOneStar() {
+      return oneStar;
+    }
+
+    public void setOneStar(long oneStar) {
+      this.oneStar = oneStar;
+    }
+
+    public long getTwoStar() {
+      return twoStar;
+    }
+
+    public void setTwoStar(long twoStar) {
+      this.twoStar = twoStar;
+    }
+
+    public long getThreeStar() {
+      return threeStar;
+    }
+
+    public void setThreeStar(long threeStar) {
+      this.threeStar = threeStar;
+    }
+
+    public long getFourStar() {
+      return fourStar;
+    }
+
+    public void setFourStar(long fourStar) {
+      this.fourStar = fourStar;
+    }
+
+    public long getFiveStar() {
+      return fiveStar;
+    }
+
+    public void setFiveStar(long fiveStar) {
+      this.fiveStar = fiveStar;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (other == this) {
+        return true;
+      } else if (other instanceof ProductRating) {
+        ProductRating that = (ProductRating) other;
+        return Objects.equals(this.productId, that.productId)
+            && this.oneStar == that.oneStar
+            && this.twoStar == that.twoStar
+            && this.threeStar == that.threeStar
+            && this.fourStar == that.fourStar
+            && this.fiveStar == that.fiveStar;
+      } else {
+        return false;
+      }
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(productId, oneStar, twoStar, threeStar, fourStar, fiveStar);
+    }
+
+    @Override
+    public String toString() {
+      return String.format(
+          "ProductRating(id=%s, 1*=%d, 2*=%d, 3*=%d, 4*=%d, 5*=%d)",
+          productId, oneStar, twoStar, threeStar, fourStar, fiveStar);
+    }
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/IncrementWithNullsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/IncrementWithNullsIT.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.mapper.annotations.Dao;
+import com.datastax.oss.driver.api.mapper.annotations.DaoFactory;
+import com.datastax.oss.driver.api.mapper.annotations.DaoKeyspace;
+import com.datastax.oss.driver.api.mapper.annotations.DefaultNullSavingStrategy;
+import com.datastax.oss.driver.api.mapper.annotations.Increment;
+import com.datastax.oss.driver.api.mapper.annotations.Mapper;
+import com.datastax.oss.driver.api.mapper.annotations.Select;
+import com.datastax.oss.driver.api.mapper.entity.saving.NullSavingStrategy;
+import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.driver.mapper.IncrementIT.ProductRating;
+import java.util.UUID;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+@Category(ParallelizableTests.class)
+@CassandraRequirement(min = "2.2")
+public class IncrementWithNullsIT {
+
+  private static final CcmRule CCM_RULE = CcmRule.getInstance();
+
+  private static final SessionRule<CqlSession> SESSION_RULE = SessionRule.builder(CCM_RULE).build();
+
+  @ClassRule
+  public static final TestRule CHAIN = RuleChain.outerRule(CCM_RULE).around(SESSION_RULE);
+
+  private static ProductRatingDao dao;
+
+  @BeforeClass
+  public static void setup() {
+    CqlSession session = SESSION_RULE.session();
+
+    session.execute(
+        SimpleStatement.builder(
+                "CREATE TABLE product_rating(product_id uuid PRIMARY KEY, "
+                    + "one_star counter, two_star counter, three_star counter, "
+                    + "four_star counter, five_star counter)")
+            .setExecutionProfile(SESSION_RULE.slowProfile())
+            .build());
+
+    InventoryMapper inventoryMapper =
+        new IncrementWithNullsIT_InventoryMapperBuilder(session).build();
+    dao = inventoryMapper.productRatingDao(SESSION_RULE.keyspace());
+  }
+
+  @Test
+  public void should_increment_counters() {
+    UUID productId1 = UUID.randomUUID();
+    UUID productId2 = UUID.randomUUID();
+
+    dao.increment(productId1, null, null, null, null, 1L);
+    dao.increment(productId1, null, null, null, null, 1L);
+    dao.increment(productId1, null, null, null, 1L, null);
+
+    dao.increment(productId2, null, 1L, null, null, null);
+    dao.increment(productId2, null, null, 1L, null, null);
+    dao.increment(productId2, 1L, null, null, null, null);
+
+    ProductRating product1Totals = dao.get(productId1);
+    assertThat(product1Totals.getFiveStar()).isEqualTo(2);
+    assertThat(product1Totals.getFourStar()).isEqualTo(1);
+    assertThat(product1Totals.getThreeStar()).isEqualTo(0);
+    assertThat(product1Totals.getTwoStar()).isEqualTo(0);
+    assertThat(product1Totals.getOneStar()).isEqualTo(0);
+
+    ProductRating product2Totals = dao.get(productId2);
+    assertThat(product2Totals.getFiveStar()).isEqualTo(0);
+    assertThat(product2Totals.getFourStar()).isEqualTo(0);
+    assertThat(product2Totals.getThreeStar()).isEqualTo(1);
+    assertThat(product2Totals.getTwoStar()).isEqualTo(1);
+    assertThat(product2Totals.getOneStar()).isEqualTo(1);
+  }
+
+  @Mapper
+  public interface InventoryMapper {
+    @DaoFactory
+    ProductRatingDao productRatingDao(@DaoKeyspace CqlIdentifier keyspace);
+  }
+
+  @Dao
+  @DefaultNullSavingStrategy(NullSavingStrategy.DO_NOT_SET)
+  public interface ProductRatingDao {
+    @Select
+    ProductRating get(UUID productId);
+
+    @Increment(entityClass = ProductRating.class)
+    void increment(
+        UUID productId, Long oneStar, Long twoStar, Long threeStar, Long fourStar, Long fiveStar);
+  }
+}

--- a/manual/mapper/daos/.nav
+++ b/manual/mapper/daos/.nav
@@ -6,5 +6,6 @@ queryprovider
 select
 setentity
 update
+increment
 null_saving
 statement_attributes

--- a/manual/mapper/daos/README.md
+++ b/manual/mapper/daos/README.md
@@ -44,6 +44,7 @@ annotations:
 * [@Select](select/)
 * [@SetEntity](setentity/)
 * [@Update](update/)
+* [@Increment](increment/)
 
 The methods can have any name. The allowed parameters and return type are specific to each
 annotation.

--- a/manual/mapper/daos/increment/README.md
+++ b/manual/mapper/daos/increment/README.md
@@ -1,0 +1,86 @@
+## Increment methods
+
+Annotate a DAO method with [@Increment] to generate a query that updates a counter table that is
+mapped to an entity:
+
+```java
+// CREATE TABLE votes(article_id int PRIMARY KEY, up_votes counter, down_votes counter);
+
+@Entity
+public class Votes {
+  @PartitionKey private int articleId;
+  private long upVotes;
+  private long downVotes;
+  ... // constructor(s), getters and setters, etc.
+}
+
+@Dao
+public interface VotesDao {
+  @Increment(entityClass = Votes.class)
+  void incrementUpVotes(int articleId, long upVotes);
+
+  @Increment(entityClass = Votes.class)
+  void incrementDownVotes(int articleId, long downVotes);
+  
+  @Select
+  Votes findById(int articleId);
+}
+```
+
+### Parameters
+
+The entity class must be specified with `entityClass` in the annotation.
+
+The method's parameters must start with the [full primary key](../../entities/#primary-key-columns),
+in the exact order (as defined by the [@PartitionKey] and [@ClusteringColumn] annotations in the
+entity class). The parameter names don't necessarily need to match the names of the columns, but the
+types must match. Unlike other methods like [@Select](../select/) or [@Delete](../delete/), counter
+updates cannot operate on a whole partition, they need to target exactly one row; so all the
+partition key and clustering columns must be specified.
+
+Then must follow one or more parameters representing counter increments. Their type must be
+`long` or `java.lang.Long`. The name of the parameter must match the name of the entity
+property that maps to the counter (that is, the name of the getter without "get" and
+decapitalized). Alternatively, you may annotate a parameter with [@CqlName] to specify the
+raw column name directly; in that case, the name of the parameter does not matter:
+
+```java
+@Increment(entityClass = Votes.class)
+void incrementUpVotes(int articleId, @CqlName("up_votes") long foobar);
+```
+
+When you invoke the method, each parameter value is interpreted as a **delta** that will be applied
+to the counter. In other words, if you pass 1, the counter will be incremented by 1. Negative values
+are allowed. If you are using Cassandra 2.2 or above, you can use `Long` and pass `null` for some of
+the parameters, they will be ignored (following [NullSavingStrategy#DO_NOT_SET](../null_saving/)
+semantics). If you are using Cassandra 2.1, `null` values will trigger a runtime error.
+
+A `Function<BoundStatementBuilder, BoundStatementBuilder>` or `UnaryOperator<BoundStatementBuilder>`
+can be added as the **last** parameter. It will be applied to the statement before execution. This
+allows you to customize certain aspects of the request (page size, timeout, etc) at runtime. See
+[statement attributes](../statement_attributes/).
+
+### Return type
+
+The method can return `void`, a void [CompletionStage] or [CompletableFuture], or a
+[ReactiveResultSet].
+
+### Target keyspace and table
+
+If a keyspace was specified [when creating the DAO](../../mapper/#dao-factory-methods), then the
+generated query targets that keyspace. Otherwise, it doesn't specify a keyspace, and will only work
+if the mapper was built from a session that has a [default keyspace] set.
+
+If a table was specified when creating the DAO, then the generated query targets that table.
+Otherwise, it uses the default table name for the entity (which is determined by the name of the
+entity class and the naming convention).
+
+[@Increment]:        https://docs.datastax.com/en/drivers/java/4.8/com/datastax/oss/driver/api/mapper/annotations/Increment.html
+[ReactiveResultSet]: https://docs.datastax.com/en/drivers/java/4.8/com/datastax/dse/driver/api/core/cql/reactive/ReactiveResultSet.html
+[default keyspace]:  https://docs.datastax.com/en/drivers/java/4.8/com/datastax/oss/driver/api/core/session/SessionBuilder.html#withKeyspace-com.datastax.oss.driver.api.core.CqlIdentifier-
+[@ClusteringColumn]:      https://docs.datastax.com/en/drivers/java/4.8/com/datastax/oss/driver/api/mapper/annotations/ClusteringColumn.html
+[@PartitionKey]:          https://docs.datastax.com/en/drivers/java/4.8/com/datastax/oss/driver/api/mapper/annotations/PartitionKey.html
+[@CqlName]:             https://docs.datastax.com/en/drivers/java/4.8/com/datastax/oss/driver/api/mapper/annotations/CqlName.html
+
+[CompletionStage]:   https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html
+[CompletableFuture]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/DefaultCodeGeneratorFactory.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/DefaultCodeGeneratorFactory.java
@@ -18,6 +18,7 @@ package com.datastax.oss.driver.internal.mapper.processor;
 import com.datastax.oss.driver.api.mapper.annotations.DaoFactory;
 import com.datastax.oss.driver.api.mapper.annotations.Delete;
 import com.datastax.oss.driver.api.mapper.annotations.GetEntity;
+import com.datastax.oss.driver.api.mapper.annotations.Increment;
 import com.datastax.oss.driver.api.mapper.annotations.Insert;
 import com.datastax.oss.driver.api.mapper.annotations.Query;
 import com.datastax.oss.driver.api.mapper.annotations.QueryProvider;
@@ -28,6 +29,7 @@ import com.datastax.oss.driver.internal.mapper.processor.dao.DaoDeleteMethodGene
 import com.datastax.oss.driver.internal.mapper.processor.dao.DaoGetEntityMethodGenerator;
 import com.datastax.oss.driver.internal.mapper.processor.dao.DaoImplementationGenerator;
 import com.datastax.oss.driver.internal.mapper.processor.dao.DaoImplementationSharedCode;
+import com.datastax.oss.driver.internal.mapper.processor.dao.DaoIncrementMethodGenerator;
 import com.datastax.oss.driver.internal.mapper.processor.dao.DaoInsertMethodGenerator;
 import com.datastax.oss.driver.internal.mapper.processor.dao.DaoQueryMethodGenerator;
 import com.datastax.oss.driver.internal.mapper.processor.dao.DaoQueryProviderMethodGenerator;
@@ -134,6 +136,10 @@ public class DefaultCodeGeneratorFactory implements CodeGeneratorFactory {
     } else if (methodElement.getAnnotation(QueryProvider.class) != null) {
       return Optional.of(
           new DaoQueryProviderMethodGenerator(
+              methodElement, typeParameters, processedType, enclosingClass, context));
+    } else if (methodElement.getAnnotation(Increment.class) != null) {
+      return Optional.of(
+          new DaoIncrementMethodGenerator(
               methodElement, typeParameters, processedType, enclosingClass, context));
     } else {
       return Optional.empty();

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoIncrementMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoIncrementMethodGenerator.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.mapper.processor.dao;
+
+import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.FUTURE_OF_VOID;
+import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.REACTIVE_RESULT_SET;
+import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoReturnTypeKind.VOID;
+
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.mapper.annotations.CqlName;
+import com.datastax.oss.driver.api.mapper.annotations.Increment;
+import com.datastax.oss.driver.api.mapper.entity.saving.NullSavingStrategy;
+import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
+import com.datastax.oss.driver.api.querybuilder.relation.Relation;
+import com.datastax.oss.driver.internal.mapper.processor.ProcessorContext;
+import com.datastax.oss.driver.internal.mapper.processor.entity.EntityDefinition;
+import com.datastax.oss.driver.internal.mapper.processor.entity.PropertyDefinition;
+import com.datastax.oss.driver.internal.mapper.processor.util.generation.GeneratedCodePatterns;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeName;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+public class DaoIncrementMethodGenerator extends DaoMethodGenerator {
+
+  public DaoIncrementMethodGenerator(
+      ExecutableElement methodElement,
+      Map<Name, TypeElement> typeParameters,
+      TypeElement processedType,
+      DaoImplementationSharedCode enclosingClass,
+      ProcessorContext context) {
+    super(methodElement, typeParameters, processedType, enclosingClass, context);
+  }
+
+  protected Set<DaoReturnTypeKind> getSupportedReturnTypes() {
+    return ImmutableSet.of(VOID, FUTURE_OF_VOID, REACTIVE_RESULT_SET);
+  }
+
+  @Override
+  public boolean requiresReactive() {
+    // Validate the return type:
+    DaoReturnType returnType =
+        parseAndValidateReturnType(getSupportedReturnTypes(), Increment.class.getSimpleName());
+    if (returnType == null) {
+      return false;
+    }
+    return returnType.requiresReactive();
+  }
+
+  @Override
+  public Optional<MethodSpec> generate() {
+
+    TypeElement entityElement = getEntityClassFromAnnotation(Increment.class);
+    EntityDefinition entityDefinition;
+    if (entityElement == null) {
+      context
+          .getMessager()
+          .error(
+              methodElement,
+              processedType,
+              "Missing entity class: %s methods must always have an 'entityClass' argument",
+              Increment.class.getSimpleName());
+      return Optional.empty();
+    } else {
+      entityDefinition = context.getEntityFactory().getDefinition(entityElement);
+    }
+
+    // Validate the parameters:
+    // - all the PK components of the entity, in order.
+    // - one or more increment parameters that must match non-PK columns.
+    // - a Function<BoundStatementBuilder, BoundStatementBuilder> can be added in last position.
+    List<? extends VariableElement> parameters = methodElement.getParameters();
+    VariableElement boundStatementFunction = findBoundStatementFunction(methodElement);
+    if (boundStatementFunction != null) {
+      parameters = parameters.subList(0, parameters.size() - 1);
+    }
+
+    List<? extends VariableElement> primaryKeyParameters = parameters;
+    // Must have at least enough parameters for the full PK
+    if (primaryKeyParameters.size() < entityDefinition.getPrimaryKey().size()) {
+      List<TypeName> primaryKeyTypes =
+          entityDefinition.getPrimaryKey().stream()
+              .map(d -> d.getType().asTypeName())
+              .collect(Collectors.toList());
+      context
+          .getMessager()
+          .error(
+              methodElement,
+              processedType,
+              "Invalid parameter list: %s methods must specify the entire primary key "
+                  + "(expected primary keys of %s: %s)",
+              Increment.class.getSimpleName(),
+              entityElement.getSimpleName(),
+              primaryKeyTypes);
+      return Optional.empty();
+    } else {
+      primaryKeyParameters =
+          primaryKeyParameters.subList(0, entityDefinition.getPrimaryKey().size());
+      warnIfCqlNamePresent(primaryKeyParameters);
+    }
+    // PK parameter types must match
+    if (!EntityUtils.areParametersValid(
+        entityElement,
+        entityDefinition,
+        primaryKeyParameters,
+        Increment.class,
+        context,
+        methodElement,
+        processedType,
+        "" /* no condition, @Increment must always have the full PK */)) {
+      return Optional.empty();
+    }
+
+    // The remaining parameters are the increments to the counter columns
+    List<? extends VariableElement> incrementParameters =
+        parameters.subList(primaryKeyParameters.size(), parameters.size());
+    if (!validateCqlNamesPresent(incrementParameters)) {
+      return Optional.empty();
+    }
+    for (VariableElement parameter : incrementParameters) {
+      TypeMirror type = parameter.asType();
+      if (type.getKind() != TypeKind.LONG && !context.getClassUtils().isSame(type, Long.class)) {
+        context
+            .getMessager()
+            .error(
+                methodElement,
+                processedType,
+                "Invalid argument type: increment parameters of %s methods can only be "
+                    + "primitive longs or java.lang.Long. Offending parameter: '%s' (%s)",
+                Increment.class.getSimpleName(),
+                parameter.getSimpleName(),
+                type);
+        return Optional.empty();
+      }
+    }
+
+    // Validate the return type:
+    DaoReturnType returnType =
+        parseAndValidateReturnType(getSupportedReturnTypes(), Increment.class.getSimpleName());
+    if (returnType == null) {
+      return Optional.empty();
+    }
+
+    // Generate the method:
+    String helperFieldName = enclosingClass.addEntityHelperField(ClassName.get(entityElement));
+    String statementName =
+        enclosingClass.addPreparedStatement(
+            methodElement,
+            (methodBuilder, requestName) ->
+                generatePrepareRequest(
+                    methodBuilder,
+                    requestName,
+                    entityDefinition,
+                    helperFieldName,
+                    incrementParameters));
+
+    CodeBlock.Builder updateStatementBlock = CodeBlock.builder();
+
+    updateStatementBlock.addStatement(
+        "$T boundStatementBuilder = $L.boundStatementBuilder()",
+        BoundStatementBuilder.class,
+        statementName);
+
+    populateBuilderWithStatementAttributes(updateStatementBlock, methodElement);
+    populateBuilderWithFunction(updateStatementBlock, boundStatementFunction);
+
+    // Bind the counter increments. The bind parameter names are always the raw parameter names, see
+    // generatePrepareRequest.
+    List<CodeBlock> bindMarkerNames =
+        incrementParameters.stream()
+            .map(p -> CodeBlock.of("$S", p.getSimpleName()))
+            .collect(Collectors.toList());
+    // Force the null saving strategy. This will fail if the user targets Cassandra 2.2, but
+    // SET_TO_NULL would not work with counters anyway.
+    updateStatementBlock.addStatement(
+        "final $1T nullSavingStrategy = $1T.$2L",
+        NullSavingStrategy.class,
+        NullSavingStrategy.DO_NOT_SET);
+    GeneratedCodePatterns.bindParameters(
+        incrementParameters, bindMarkerNames, updateStatementBlock, enclosingClass, context, true);
+
+    // Bind the PK columns
+    List<CodeBlock> primaryKeyNames =
+        entityDefinition.getPrimaryKey().stream()
+            .map(PropertyDefinition::getCqlName)
+            .collect(Collectors.toList());
+    GeneratedCodePatterns.bindParameters(
+        primaryKeyParameters,
+        primaryKeyNames,
+        updateStatementBlock,
+        enclosingClass,
+        context,
+        false);
+
+    updateStatementBlock
+        .add("\n")
+        .addStatement("$T boundStatement = boundStatementBuilder.build()", BoundStatement.class);
+
+    return crudMethod(updateStatementBlock, returnType, helperFieldName);
+  }
+
+  private void generatePrepareRequest(
+      MethodSpec.Builder methodBuilder,
+      String requestName,
+      EntityDefinition entityDefinition,
+      String helperFieldName,
+      List<? extends VariableElement> incrementParameters) {
+
+    if (incrementParameters.isEmpty()) {
+      context
+          .getMessager()
+          .error(
+              methodElement,
+              processedType,
+              "%s method must take at least one parameter representing an increment to a "
+                  + "counter column",
+              Increment.class.getSimpleName());
+      return;
+    }
+
+    methodBuilder
+        .addStatement("$L.throwIfKeyspaceMissing()", helperFieldName)
+        .addCode(
+            "$[$1T $2L = (($3L.getKeyspaceId() == null)\n"
+                + "? $4T.update($3L.getTableId())\n"
+                + ": $4T.update($3L.getKeyspaceId(), $3L.getTableId()))",
+            SimpleStatement.class,
+            requestName,
+            helperFieldName,
+            QueryBuilder.class);
+
+    // Add an increment clause for every non-PK parameter. Example: for a parameter `long oneStar`
+    // =>  `.append("one_star", QueryBuilder.bindMarker("oneStar"))`
+    for (VariableElement parameter : incrementParameters) {
+      CodeBlock cqlName = null;
+      CqlName annotation = parameter.getAnnotation(CqlName.class);
+      if (annotation != null) {
+        // If a CQL name is provided, use that
+        cqlName = CodeBlock.of("$S", annotation.value());
+      } else {
+        // Otherwise, try to match the parameter to an entity property based on the names, for
+        // example parameter `oneStar` matches `ProductRating.getOneStar()`.
+        for (PropertyDefinition property : entityDefinition.getRegularColumns()) {
+          if (property.getJavaName().equals(parameter.getSimpleName().toString())) {
+            cqlName = property.getCqlName();
+            break;
+          }
+        }
+        if (cqlName == null) {
+          List<String> javaNames =
+              StreamSupport.stream(entityDefinition.getRegularColumns().spliterator(), false)
+                  .map(PropertyDefinition::getJavaName)
+                  .collect(Collectors.toList());
+          context
+              .getMessager()
+              .error(
+                  parameter,
+                  processedType,
+                  "Could not match '%s' with any counter column in %s (expected one of: %s). "
+                      + "You can also specify a CQL name directly with @%s.",
+                  parameter.getSimpleName(),
+                  entityDefinition.getClassName().simpleName(),
+                  javaNames,
+                  CqlName.class.getSimpleName());
+          // Don't return abruptly, execute the rest of the method to finish the Java statement
+          // cleanly (otherwise JavaPoet throws an error). The generated statement will be
+          // incorrect, but that doesn't matter since we've already thrown a compile error.
+          break;
+        }
+      }
+
+      // Always use the parameter name. This is what the binding code will expect (see
+      // GeneratedCodePatterns.bindParameters call in generate())
+      String bindMarkerName = parameter.getSimpleName().toString();
+
+      // We use `append` to generate "c=c+?". QueryBuilder also has `increment` that produces
+      // "c+=?", but that doesn't work with Cassandra 2.1.
+      methodBuilder.addCode(
+          "\n.append($1L, $2T.bindMarker($3S))", cqlName, QueryBuilder.class, bindMarkerName);
+    }
+
+    for (PropertyDefinition property : entityDefinition.getPrimaryKey()) {
+      methodBuilder.addCode(
+          "\n.where($1T.column($2L).isEqualTo($3T.bindMarker($2L)))",
+          Relation.class,
+          property.getCqlName(),
+          QueryBuilder.class);
+    }
+
+    methodBuilder.addCode("\n.build()$];\n");
+  }
+}

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoMethodGenerator.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/DaoMethodGenerator.java
@@ -20,6 +20,8 @@ import static com.datastax.oss.driver.internal.mapper.processor.dao.DefaultDaoRe
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
 import com.datastax.oss.driver.api.mapper.annotations.CqlName;
+import com.datastax.oss.driver.api.mapper.annotations.Delete;
+import com.datastax.oss.driver.api.mapper.annotations.Increment;
 import com.datastax.oss.driver.api.mapper.annotations.StatementAttributes;
 import com.datastax.oss.driver.api.mapper.result.MapperResultProducer;
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
@@ -38,6 +40,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
@@ -270,5 +274,51 @@ public abstract class DaoMethodGenerator implements MethodGenerator {
             .getKind()
             .wrapWithErrorHandling(createStatementBlock.build(), methodElement, typeParameters));
     return Optional.of(method.build());
+  }
+
+  /**
+   * Reads the "entityClass" parameter from method annotations that define it (such as {@link
+   * Delete} or {@link Increment}), and finds the corresponding entity class element if it exists.
+   */
+  protected TypeElement getEntityClassFromAnnotation(Class<?> annotation) {
+
+    // Note: because entityClass references a class, we can't read it directly through
+    // methodElement.getAnnotation(annotation).
+
+    AnnotationMirror annotationMirror = null;
+    for (AnnotationMirror candidate : methodElement.getAnnotationMirrors()) {
+      if (context.getClassUtils().isSame(candidate.getAnnotationType(), annotation)) {
+        annotationMirror = candidate;
+        break;
+      }
+    }
+    assert annotationMirror != null;
+
+    for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry :
+        annotationMirror.getElementValues().entrySet()) {
+      if (entry.getKey().getSimpleName().contentEquals("entityClass")) {
+        @SuppressWarnings("unchecked")
+        List<? extends AnnotationValue> values =
+            (List<? extends AnnotationValue>) entry.getValue().getValue();
+        if (values.isEmpty()) {
+          return null;
+        }
+        TypeMirror mirror = (TypeMirror) values.get(0).getValue();
+        TypeElement element = EntityUtils.asEntityElement(mirror, typeParameters);
+        if (values.size() > 1) {
+          context
+              .getMessager()
+              .warn(
+                  methodElement,
+                  processedType,
+                  "Too many entity classes: %s must have at most one 'entityClass' argument "
+                      + "(will use the first one: %s)",
+                  annotation.getSimpleName(),
+                  mirror);
+        }
+        return element;
+      }
+    }
+    return null;
   }
 }

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/EntityUtils.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/dao/EntityUtils.java
@@ -106,6 +106,13 @@ public class EntityUtils {
       ExecutableElement methodElement,
       TypeElement processedType,
       String exceptionCondition) {
+
+    if (exceptionCondition == null || exceptionCondition.isEmpty()) {
+      exceptionCondition = "";
+    } else {
+      exceptionCondition = " that " + exceptionCondition;
+    }
+
     List<TypeName> primaryKeyTypes =
         entityDefinition.getPrimaryKey().stream()
             .map(d -> d.getType().asTypeName())
@@ -123,7 +130,7 @@ public class EntityUtils {
           .error(
               methodElement,
               processedType,
-              "Invalid parameter list: %s methods that %s "
+              "Invalid parameter list: %s methods%s "
                   + "must at least specify partition key components "
                   + "(expected partition key of %s: %s)",
               annotationClass.getSimpleName(),
@@ -139,7 +146,7 @@ public class EntityUtils {
           .error(
               methodElement,
               processedType,
-              "Invalid parameter list: %s methods that %s "
+              "Invalid parameter list: %s methods%s "
                   + "must match the primary key components in the exact order "
                   + "(expected primary key of %s: %s). Too many parameters provided",
               annotationClass.getSimpleName(),
@@ -159,7 +166,7 @@ public class EntityUtils {
             .error(
                 methodElement,
                 processedType,
-                "Invalid parameter list: %s methods that %s "
+                "Invalid parameter list: %s methods%s "
                     + "must match the primary key components in the exact order "
                     + "(expected primary key of %s: %s). Mismatch at index %d: %s should be %s",
                 annotationClass.getSimpleName(),

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/DefaultPropertyDefinition.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/DefaultPropertyDefinition.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 public class DefaultPropertyDefinition implements PropertyDefinition {
 
+  private final String javaName;
   private final CodeBlock selector;
   private final CodeBlock cqlName;
   private final String getterName;
@@ -35,6 +36,7 @@ public class DefaultPropertyDefinition implements PropertyDefinition {
       String setterName,
       PropertyType type,
       CqlNameGenerator cqlNameGenerator) {
+    this.javaName = javaName;
 
     this.cqlName =
         customCqlName
@@ -53,6 +55,11 @@ public class DefaultPropertyDefinition implements PropertyDefinition {
     this.getterName = getterName;
     this.setterName = setterName;
     this.type = type;
+  }
+
+  @Override
+  public String getJavaName() {
+    return javaName;
   }
 
   @Override

--- a/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/PropertyDefinition.java
+++ b/mapper-processor/src/main/java/com/datastax/oss/driver/internal/mapper/processor/entity/PropertyDefinition.java
@@ -28,6 +28,12 @@ import com.squareup.javapoet.CodeBlock;
 public interface PropertyDefinition {
 
   /**
+   * @return the name of the property, in the JavaBeans sense. In other words this is {@link
+   *     #getGetterName()} minus the "get" prefix and decapitalized.
+   */
+  String getJavaName();
+
+  /**
    * @return A Java snippet that produces the corresponding expression in a <code>SELECT</code>
    *     statement, for example:
    *     <ul>

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Increment.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Increment.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.mapper.annotations;
+
+import com.datastax.dse.driver.api.core.cql.reactive.ReactiveResultSet;
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.session.Session;
+import com.datastax.oss.driver.api.core.session.SessionBuilder;
+import com.datastax.oss.driver.api.mapper.entity.saving.NullSavingStrategy;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+/**
+ * Annotates a {@link Dao} method that increments a counter table that is mapped to an {@link
+ * Entity}-annotated class.
+ *
+ * <p>Example:
+ *
+ * <pre>
+ * &#64;Entity
+ * public class Votes {
+ *   &#64;PartitionKey private int articleId;
+ *   private long upVotes;
+ *   private long downVotes;
+ *   ... // constructor(s), getters and setters, etc.
+ * }
+ * &#64;Dao
+ * public interface VotesDao {
+ *   &#64;Increment(entityClass = Votes.class)
+ *   void incrementUpVotes(int articleId, long upVotes);
+ *
+ *   &#64;Increment(entityClass = Votes.class)
+ *   void incrementDownVotes(int articleId, long downVotes);
+ *
+ *   &#64;Select
+ *   Votes findById(int articleId);
+ * }
+ * </pre>
+ *
+ * <h3>Parameters</h3>
+ *
+ * The entity class must be specified with {@link #entityClass()}.
+ *
+ * <p>The method's parameters must start with the full primary key, in the exact order (as defined
+ * by the {@link PartitionKey} and {@link ClusteringColumn} annotations in the entity class). The
+ * parameter names don't necessarily need to match the names of the columns, but the types must
+ * match. Unlike other methods like {@link Select} or {@link Delete}, counter updates cannot operate
+ * on a whole partition, they need to target exactly one row; so all the partition key and
+ * clustering columns must be specified.
+ *
+ * <p>Then must follow one or more parameters representing counter increments. Their type must be
+ * {@code long} or {@link Long}. The name of the parameter must match the name of the entity
+ * property that maps to the counter (that is, the name of the getter without "get" and
+ * decapitalized). Alternatively, you may annotate a parameter with {@link CqlName} to specify the
+ * raw column name directly; in that case, the name of the parameter does not matter:
+ *
+ * <pre>
+ * &#64;Increment(entityClass = Votes.class)
+ * void incrementUpVotes(int articleId, &#64;CqlName("up_votes") long foobar);
+ * </pre>
+ *
+ * When you invoke the method, each parameter value is interpreted as a <b>delta</b> that will be
+ * applied to the counter. In other words, if you pass 1, the counter will be incremented by 1.
+ * Negative values are allowed. If you are using Cassandra 2.2 or above, you can use {@link Long}
+ * and pass {@code null} for some of the parameters, they will be ignored (following {@link
+ * NullSavingStrategy#DO_NOT_SET} semantics). If you are using Cassandra 2.1, {@code null} values
+ * will trigger a runtime error.
+ *
+ * <p>A {@link Function Function&lt;BoundStatementBuilder, BoundStatementBuilder&gt;} or {@link
+ * UnaryOperator UnaryOperator&lt;BoundStatementBuilder&gt;} can be added as the <b>last</b>
+ * parameter. It will be applied to the statement before execution. This allows you to customize
+ * certain aspects of the request (page size, timeout, etc) at runtime.
+ *
+ * <h3>Return type</h3>
+ *
+ * <p>The method can return {@code void}, a void {@link CompletionStage} or {@link
+ * CompletableFuture}, or a {@link ReactiveResultSet}.
+ *
+ * <h3>Target keyspace and table</h3>
+ *
+ * <p>If a keyspace was specified when creating the DAO (see {@link DaoFactory}), then the generated
+ * query targets that keyspace. Otherwise, it doesn't specify a keyspace, and will only work if the
+ * mapper was built from a {@link Session} that has a {@linkplain
+ * SessionBuilder#withKeyspace(CqlIdentifier) default keyspace} set.
+ *
+ * <p>If a table was specified when creating the DAO, then the generated query targets that table.
+ * Otherwise, it uses the default table name for the entity (which is determined by the name of the
+ * entity class and the naming convention).
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Increment {
+
+  /**
+   * A hint to indicate the entity class that is being targeted. This is mandatory, the mapper will
+   * issue a compile error if you leave it unset.
+   *
+   * <p>Note that, for technical reasons, this is an array, but only one element is expected. If you
+   * specify more than one class, the mapper processor will generate a compile-time warning, and
+   * proceed with the first one.
+   */
+  Class<?>[] entityClass() default {};
+}

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/internal/mapper/DaoBase.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/internal/mapper/DaoBase.java
@@ -174,9 +174,11 @@ public class DaoBase {
   }
 
   protected final MapperContext context;
+  protected final boolean isProtocolVersionV3;
 
   protected DaoBase(MapperContext context) {
     this.context = context;
+    this.isProtocolVersionV3 = isProtocolVersionV3(context);
   }
 
   protected ResultSet execute(Statement<?> statement) {
@@ -282,12 +284,16 @@ public class DaoBase {
   }
 
   protected static void throwIfProtocolVersionV3(MapperContext context) {
-    if (context.getSession().getContext().getProtocolVersion().getCode()
-        <= ProtocolConstants.Version.V3) {
+    if (isProtocolVersionV3(context)) {
       throw new MapperException(
           String.format(
               "You cannot use %s.%s for protocol version V3.",
               NullSavingStrategy.class.getSimpleName(), NullSavingStrategy.DO_NOT_SET.name()));
     }
+  }
+
+  protected static boolean isProtocolVersionV3(MapperContext context) {
+    return context.getSession().getContext().getProtocolVersion().getCode()
+        <= ProtocolConstants.Version.V3;
   }
 }

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/internal/mapper/entity/EntityHelperBase.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/internal/mapper/entity/EntityHelperBase.java
@@ -76,7 +76,7 @@ public abstract class EntityHelperBase<EntityT> implements EntityHelper<EntityT>
     return tableId;
   }
 
-  protected void throwIfKeyspaceMissing() {
+  public void throwIfKeyspaceMissing() {
     if (this.getKeyspaceId() == null && !context.getSession().getKeyspace().isPresent()) {
       throw new MapperException(
           String.format(


### PR DESCRIPTION
~Starting as draft because I'm not 100% sure about the API.~

~The DAO in the integration test uses the same entity class for all operations:~
- ~when you write an instance with `@Increment`, the fields represent the **deltas** to apply to the counters.~
- ~but when you retrieve an instance with `@Select`, you get the counter **totals**.~

EDIT- we switched to a different approach: the method declares the entity PK and each counter increment as discrete parameters. See the integration tests.

TODO:
- [x] don't default to `NullSavingStrategy.SET_TO_NULL` for legacy server versions
- [x] add manual page