### PR TITLE
JAVA-2871: Allow keyspace exclusions in the metadata, and exclude system keyspaces by default

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,8 @@
 
 ### 4.10.0 (in progress)
 
+- [improvement] JAVA-2871: Allow keyspace exclusions in the metadata, and exclude system keyspaces
+  by default
 
 ### 4.9.0
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.driver.api.core.config;
 
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.InvalidObjectException;
@@ -339,6 +340,9 @@ public class OptionsMap implements Serializable {
     map.put(TypedDriverOption.METADATA_TOPOLOGY_WINDOW, Duration.ofSeconds(1));
     map.put(TypedDriverOption.METADATA_TOPOLOGY_MAX_EVENTS, 20);
     map.put(TypedDriverOption.METADATA_SCHEMA_ENABLED, true);
+    map.put(
+        TypedDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES,
+        ImmutableList.of("!system", "!/^system_.*/", "!/^dse_.*/", "!solr_admin"));
     map.put(TypedDriverOption.METADATA_SCHEMA_REQUEST_TIMEOUT, requestTimeout);
     map.put(TypedDriverOption.METADATA_SCHEMA_REQUEST_PAGE_SIZE, requestPageSize);
     map.put(TypedDriverOption.METADATA_SCHEMA_WINDOW, Duration.ofSeconds(1));

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/CassandraSchemaQueries.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/CassandraSchemaQueries.java
@@ -70,7 +70,7 @@ public abstract class CassandraSchemaQueries implements SchemaQueries {
         config.getStringList(
             DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES, Collections.emptyList());
     assert refreshedKeyspaces != null; // per the default value
-    this.keyspaceFilter = new KeyspaceFilter(logPrefix, refreshedKeyspaces);
+    this.keyspaceFilter = KeyspaceFilter.newInstance(logPrefix, refreshedKeyspaces);
   }
 
   protected abstract String selectKeyspacesQuery();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/CassandraSchemaQueries.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/CassandraSchemaQueries.java
@@ -48,7 +48,7 @@ public abstract class CassandraSchemaQueries implements SchemaQueries {
   private final String logPrefix;
   private final Duration timeout;
   private final int pageSize;
-  private final String whereClause;
+  private final KeyspaceFilter keyspaceFilter;
   // The future we return from execute, completes when all the queries are done.
   private final CompletableFuture<SchemaRows> schemaRowsFuture = new CompletableFuture<>();
   private final long startTimeNs = System.nanoTime();
@@ -69,25 +69,8 @@ public abstract class CassandraSchemaQueries implements SchemaQueries {
     List<String> refreshedKeyspaces =
         config.getStringList(
             DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES, Collections.emptyList());
-    this.whereClause = buildWhereClause(refreshedKeyspaces);
-  }
-
-  private static String buildWhereClause(List<String> refreshedKeyspaces) {
-    if (refreshedKeyspaces.isEmpty()) {
-      return "";
-    } else {
-      StringBuilder builder = new StringBuilder(" WHERE keyspace_name in (");
-      boolean first = true;
-      for (String keyspace : refreshedKeyspaces) {
-        if (first) {
-          first = false;
-        } else {
-          builder.append(",");
-        }
-        builder.append('\'').append(keyspace).append('\'');
-      }
-      return builder.append(")").toString();
-    }
+    assert refreshedKeyspaces != null; // per the default value
+    this.keyspaceFilter = new KeyspaceFilter(logPrefix, refreshedKeyspaces);
   }
 
   protected abstract String selectKeyspacesQuery();
@@ -125,7 +108,8 @@ public abstract class CassandraSchemaQueries implements SchemaQueries {
   private void executeOnAdminExecutor() {
     assert adminExecutor.inEventLoop();
 
-    schemaRowsBuilder = new CassandraSchemaRows.Builder(node, logPrefix);
+    schemaRowsBuilder = new CassandraSchemaRows.Builder(node, keyspaceFilter, logPrefix);
+    String whereClause = keyspaceFilter.getWhereClause();
 
     query(selectKeyspacesQuery() + whereClause, schemaRowsBuilder::withKeyspaces);
     query(selectTypesQuery() + whereClause, schemaRowsBuilder::withTypes);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/KeyspaceFilter.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/KeyspaceFilter.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata.schema.queries;
+
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Filters keyspaces during schema metadata queries.
+ *
+ * <p>Depending on the circumstances, we do it either on the server side with a WHERE IN clause that
+ * will be appended to every query, or on the client side with a predicate that will be applied to
+ * every fetched row.
+ */
+public class KeyspaceFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KeyspaceFilter.class);
+
+  private static final Pattern EXACT_INCLUDE = Pattern.compile("\\w+");
+  private static final Pattern EXACT_EXCLUDE = Pattern.compile("!(\\w+)");
+  private static final Pattern REGEX_INCLUDE = Pattern.compile("/(.+)/");
+  private static final Pattern REGEX_EXCLUDE = Pattern.compile("!/(.+)/");
+
+  private final String logPrefix;
+  private final String whereClause;
+  private final Set<String> exactIncludes = new HashSet<>();
+  private final Set<String> exactExcludes = new HashSet<>();
+  private final List<Predicate<String>> regexIncludes = new ArrayList<>();
+  private final List<Predicate<String>> regexExcludes = new ArrayList<>();
+  private final boolean hasNoIncludes;
+
+  private final boolean isDebugEnabled;
+  private final Set<String> loggedKeyspaces;
+
+  public KeyspaceFilter(@NonNull String logPrefix, @NonNull List<String> specs) {
+    this.logPrefix = logPrefix;
+    for (String spec : specs) {
+      spec = spec.trim();
+      Matcher matcher;
+      if (EXACT_INCLUDE.matcher(spec).matches()) {
+        exactIncludes.add(spec);
+      } else if ((matcher = EXACT_EXCLUDE.matcher(spec)).matches()) {
+        exactExcludes.add(matcher.group(1));
+      } else if ((matcher = REGEX_INCLUDE.matcher(spec)).matches()) {
+        compile(matcher.group(1)).map(regexIncludes::add);
+      } else if ((matcher = REGEX_EXCLUDE.matcher(spec)).matches()) {
+        compile(matcher.group(1)).map(regexExcludes::add);
+      } else {
+        LOG.warn(
+            "[{}] Error while parsing {}: invalid element '{}', skipping",
+            logPrefix,
+            DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES.getPath(),
+            spec);
+      }
+    }
+
+    if (!exactIncludes.isEmpty() && regexIncludes.isEmpty()) {
+      // We can filter on the server
+      whereClause = buildWhereClause(exactIncludes);
+      if (!exactExcludes.isEmpty() || !regexExcludes.isEmpty()) {
+        // Proceed, but this is probably a mistake
+        LOG.warn(
+            "[{}] {} only includes explicit keyspace names, but also defines exclusions. "
+                + "This can probably be simplified.",
+            logPrefix,
+            DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES.getPath());
+      }
+      LOG.debug("[{}] Filtering server-side with '{}'", logPrefix, whereClause);
+    } else {
+      whereClause = "";
+      LOG.debug("[{}] No server-side filtering", logPrefix);
+    }
+
+    hasNoIncludes = exactIncludes.isEmpty() && regexIncludes.isEmpty();
+
+    isDebugEnabled = LOG.isDebugEnabled();
+    loggedKeyspaces = isDebugEnabled ? new HashSet<>() : null;
+  }
+
+  @VisibleForTesting
+  public KeyspaceFilter(String... specs) {
+    this("test", Arrays.asList(specs));
+  }
+
+  /** The WHERE IN clause, or an empty string if there is no server-side filtering. */
+  @NonNull
+  public String getWhereClause() {
+    return whereClause;
+  }
+
+  /** The predicate that will be invoked for client-side filtering. */
+  public boolean includes(@NonNull String keyspace) {
+    if (exactIncludes.contains(keyspace)) {
+      log(keyspace, true, "it is included by name");
+      return true;
+    } else if (exactExcludes.contains(keyspace)) {
+      log(keyspace, false, "it is excluded by name");
+      return false;
+    } else if (hasNoIncludes || matchesAny(keyspace, regexIncludes)) {
+      if (matchesAny(keyspace, regexExcludes)) {
+        log(keyspace, false, "it matches at least one regex exclude");
+        return false;
+      } else {
+        log(
+            keyspace,
+            true,
+            "it matches at least one inclusion rule, and none of the exclusion rules");
+        return true;
+      }
+    } else {
+      log(keyspace, false, "it doesn't match any inclusion rule");
+      return false;
+    }
+  }
+
+  private void log(@NonNull String keyspace, boolean include, @NonNull String reason) {
+    if (isDebugEnabled && loggedKeyspaces.add(keyspace)) {
+      LOG.debug(
+          "[{}] Filtering {} '{}' because {}", logPrefix, include ? "in" : "out", keyspace, reason);
+    }
+  }
+
+  private boolean matchesAny(String keyspace, List<Predicate<String>> rules) {
+    for (Predicate<String> rule : rules) {
+      if (rule.test(keyspace)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private Optional<Predicate<String>> compile(String regex) {
+    try {
+      return Optional.of(Pattern.compile(regex).asPredicate());
+    } catch (PatternSyntaxException e) {
+      LOG.warn(
+          "[{}] Error while parsing {}: syntax error in regex /{}/ ({}), skipping",
+          this.logPrefix,
+          DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES.getPath(),
+          regex,
+          e.getMessage());
+      return Optional.empty();
+    }
+  }
+
+  private static String buildWhereClause(Set<String> keyspaces) {
+    StringBuilder builder = new StringBuilder(" WHERE keyspace_name IN (");
+    boolean first = true;
+    for (String keyspace : keyspaces) {
+      if (first) {
+        first = false;
+      } else {
+        builder.append(",");
+      }
+      builder.append('\'').append(keyspace).append('\'');
+    }
+    return builder.append(')').toString();
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/KeyspaceFilter.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/KeyspaceFilter.java
@@ -15,21 +15,10 @@
  */
 package com.datastax.oss.driver.internal.core.metadata.schema.queries;
 
-import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Filters keyspaces during schema metadata queries.
@@ -38,148 +27,39 @@ import org.slf4j.LoggerFactory;
  * will be appended to every query, or on the client side with a predicate that will be applied to
  * every fetched row.
  */
-public class KeyspaceFilter {
+public interface KeyspaceFilter {
 
-  private static final Logger LOG = LoggerFactory.getLogger(KeyspaceFilter.class);
-
-  private static final Pattern EXACT_INCLUDE = Pattern.compile("\\w+");
-  private static final Pattern EXACT_EXCLUDE = Pattern.compile("!(\\w+)");
-  private static final Pattern REGEX_INCLUDE = Pattern.compile("/(.+)/");
-  private static final Pattern REGEX_EXCLUDE = Pattern.compile("!/(.+)/");
-
-  private final String logPrefix;
-  private final String whereClause;
-  private final Set<String> exactIncludes = new HashSet<>();
-  private final Set<String> exactExcludes = new HashSet<>();
-  private final List<Predicate<String>> regexIncludes = new ArrayList<>();
-  private final List<Predicate<String>> regexExcludes = new ArrayList<>();
-  private final boolean hasNoIncludes;
-
-  private final boolean isDebugEnabled;
-  private final Set<String> loggedKeyspaces;
-
-  public KeyspaceFilter(@NonNull String logPrefix, @NonNull List<String> specs) {
-    this.logPrefix = logPrefix;
-    for (String spec : specs) {
-      spec = spec.trim();
-      Matcher matcher;
-      if (EXACT_INCLUDE.matcher(spec).matches()) {
-        exactIncludes.add(spec);
-      } else if ((matcher = EXACT_EXCLUDE.matcher(spec)).matches()) {
-        exactExcludes.add(matcher.group(1));
-      } else if ((matcher = REGEX_INCLUDE.matcher(spec)).matches()) {
-        compile(matcher.group(1)).map(regexIncludes::add);
-      } else if ((matcher = REGEX_EXCLUDE.matcher(spec)).matches()) {
-        compile(matcher.group(1)).map(regexExcludes::add);
-      } else {
-        LOG.warn(
-            "[{}] Error while parsing {}: invalid element '{}', skipping",
-            logPrefix,
-            DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES.getPath(),
-            spec);
-      }
-    }
-
-    if (!exactIncludes.isEmpty() && regexIncludes.isEmpty()) {
-      // We can filter on the server
-      whereClause = buildWhereClause(exactIncludes);
-      if (!exactExcludes.isEmpty() || !regexExcludes.isEmpty()) {
-        // Proceed, but this is probably a mistake
-        LOG.warn(
-            "[{}] {} only includes explicit keyspace names, but also defines exclusions. "
-                + "This can probably be simplified.",
-            logPrefix,
-            DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES.getPath());
-      }
-      LOG.debug("[{}] Filtering server-side with '{}'", logPrefix, whereClause);
+  static KeyspaceFilter newInstance(@NonNull String logPrefix, @NonNull List<String> specs) {
+    if (specs.isEmpty()) {
+      return INCLUDE_ALL;
     } else {
-      whereClause = "";
-      LOG.debug("[{}] No server-side filtering", logPrefix);
+      return new RuleBasedKeyspaceFilter(logPrefix, specs);
     }
-
-    hasNoIncludes = exactIncludes.isEmpty() && regexIncludes.isEmpty();
-
-    isDebugEnabled = LOG.isDebugEnabled();
-    loggedKeyspaces = isDebugEnabled ? new HashSet<>() : null;
   }
 
   @VisibleForTesting
-  public KeyspaceFilter(String... specs) {
-    this("test", Arrays.asList(specs));
+  static KeyspaceFilter newInstance(@NonNull String... specs) {
+    return newInstance("test", Arrays.asList(specs));
   }
 
   /** The WHERE IN clause, or an empty string if there is no server-side filtering. */
   @NonNull
-  public String getWhereClause() {
-    return whereClause;
-  }
+  String getWhereClause();
 
   /** The predicate that will be invoked for client-side filtering. */
-  public boolean includes(@NonNull String keyspace) {
-    if (exactIncludes.contains(keyspace)) {
-      log(keyspace, true, "it is included by name");
-      return true;
-    } else if (exactExcludes.contains(keyspace)) {
-      log(keyspace, false, "it is excluded by name");
-      return false;
-    } else if (hasNoIncludes || matchesAny(keyspace, regexIncludes)) {
-      if (matchesAny(keyspace, regexExcludes)) {
-        log(keyspace, false, "it matches at least one regex exclude");
-        return false;
-      } else {
-        log(
-            keyspace,
-            true,
-            "it matches at least one inclusion rule, and none of the exclusion rules");
-        return true;
-      }
-    } else {
-      log(keyspace, false, "it doesn't match any inclusion rule");
-      return false;
-    }
-  }
+  boolean includes(@NonNull String keyspace);
 
-  private void log(@NonNull String keyspace, boolean include, @NonNull String reason) {
-    if (isDebugEnabled && loggedKeyspaces.add(keyspace)) {
-      LOG.debug(
-          "[{}] Filtering {} '{}' because {}", logPrefix, include ? "in" : "out", keyspace, reason);
-    }
-  }
+  KeyspaceFilter INCLUDE_ALL =
+      new KeyspaceFilter() {
+        @NonNull
+        @Override
+        public String getWhereClause() {
+          return "";
+        }
 
-  private boolean matchesAny(String keyspace, List<Predicate<String>> rules) {
-    for (Predicate<String> rule : rules) {
-      if (rule.test(keyspace)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private Optional<Predicate<String>> compile(String regex) {
-    try {
-      return Optional.of(Pattern.compile(regex).asPredicate());
-    } catch (PatternSyntaxException e) {
-      LOG.warn(
-          "[{}] Error while parsing {}: syntax error in regex /{}/ ({}), skipping",
-          this.logPrefix,
-          DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES.getPath(),
-          regex,
-          e.getMessage());
-      return Optional.empty();
-    }
-  }
-
-  private static String buildWhereClause(Set<String> keyspaces) {
-    StringBuilder builder = new StringBuilder(" WHERE keyspace_name IN (");
-    boolean first = true;
-    for (String keyspace : keyspaces) {
-      if (first) {
-        first = false;
-      } else {
-        builder.append(",");
-      }
-      builder.append('\'').append(keyspace).append('\'');
-    }
-    return builder.append(')').toString();
-  }
+        @Override
+        public boolean includes(@NonNull String keyspace) {
+          return true;
+        }
+      };
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/KeyspaceFilter.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/KeyspaceFilter.java
@@ -37,11 +37,6 @@ public interface KeyspaceFilter {
     }
   }
 
-  @VisibleForTesting
-  static KeyspaceFilter newInstance(@NonNull String... specs) {
-    return newInstance("test", Arrays.asList(specs));
-  }
-
   /** The WHERE IN clause, or an empty string if there is no server-side filtering. */
   @NonNull
   String getWhereClause();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/KeyspaceFilter.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/KeyspaceFilter.java
@@ -15,9 +15,7 @@
  */
 package com.datastax.oss.driver.internal.core.metadata.schema.queries;
 
-import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Arrays;
 import java.util.List;
 
 /**

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/RuleBasedKeyspaceFilter.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/RuleBasedKeyspaceFilter.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata.schema.queries;
+
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Filters keyspaces during schema metadata queries.
+ *
+ * <p>Depending on the circumstances, we do it either on the server side with a WHERE IN clause that
+ * will be appended to every query, or on the client side with a predicate that will be applied to
+ * every fetched row.
+ */
+class RuleBasedKeyspaceFilter implements KeyspaceFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RuleBasedKeyspaceFilter.class);
+
+  private static final Pattern EXACT_INCLUDE = Pattern.compile("\\w+");
+  private static final Pattern EXACT_EXCLUDE = Pattern.compile("!\\s*(\\w+)");
+  private static final Pattern REGEX_INCLUDE = Pattern.compile("/(.+)/");
+  private static final Pattern REGEX_EXCLUDE = Pattern.compile("!\\s*/(.+)/");
+
+  private final String logPrefix;
+  private final String whereClause;
+  private final Set<String> exactIncludes = new HashSet<>();
+  private final Set<String> exactExcludes = new HashSet<>();
+  private final List<Predicate<String>> regexIncludes = new ArrayList<>();
+  private final List<Predicate<String>> regexExcludes = new ArrayList<>();
+
+  private final boolean isDebugEnabled;
+  private final Set<String> loggedKeyspaces;
+
+  RuleBasedKeyspaceFilter(@NonNull String logPrefix, @NonNull List<String> specs) {
+    assert !specs.isEmpty(); // see KeyspaceFilter#newInstance
+
+    this.logPrefix = logPrefix;
+    for (String spec : specs) {
+      spec = spec.trim();
+      Matcher matcher;
+      if (EXACT_INCLUDE.matcher(spec).matches()) {
+        exactIncludes.add(spec);
+        if (exactExcludes.remove(spec)) {
+          LOG.warn(
+              "[{}] '{}' is both included and excluded, ignoring the exclusion", logPrefix, spec);
+        }
+      } else if ((matcher = EXACT_EXCLUDE.matcher(spec)).matches()) {
+        String name = matcher.group(1);
+        if (exactIncludes.contains(name)) {
+          LOG.warn(
+              "[{}] '{}' is both included and excluded, ignoring the exclusion", logPrefix, name);
+        } else {
+          exactExcludes.add(name);
+        }
+      } else if ((matcher = REGEX_INCLUDE.matcher(spec)).matches()) {
+        compile(matcher.group(1)).map(regexIncludes::add);
+      } else if ((matcher = REGEX_EXCLUDE.matcher(spec)).matches()) {
+        compile(matcher.group(1)).map(regexExcludes::add);
+      } else {
+        LOG.warn(
+            "[{}] Error while parsing {}: invalid element '{}', skipping",
+            logPrefix,
+            DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES.getPath(),
+            spec);
+      }
+    }
+
+    if (!exactIncludes.isEmpty() && regexIncludes.isEmpty() && regexExcludes.isEmpty()) {
+      // We can filter on the server
+      whereClause = buildWhereClause(exactIncludes);
+      if (!exactExcludes.isEmpty()) {
+        // Proceed, but this is probably a mistake
+        LOG.warn(
+            "[{}] {} only has exact includes and excludes, the excludes are redundant",
+            logPrefix,
+            DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES.getPath());
+      }
+      LOG.debug("[{}] Filtering server-side with '{}'", logPrefix, whereClause);
+    } else {
+      whereClause = "";
+      LOG.debug("[{}] No server-side filtering", logPrefix);
+    }
+
+    isDebugEnabled = LOG.isDebugEnabled();
+    loggedKeyspaces = isDebugEnabled ? new HashSet<>() : null;
+  }
+
+  @NonNull
+  @Override
+  public String getWhereClause() {
+    return whereClause;
+  }
+
+  @Override
+  public boolean includes(@NonNull String keyspace) {
+    if (exactIncludes.contains(keyspace)) {
+      log(keyspace, true, "it is included by name");
+      return true;
+    } else if (exactExcludes.contains(keyspace)) {
+      log(keyspace, false, "it is excluded by name");
+      return false;
+    } else if (regexIncludes.isEmpty()) {
+      if (regexExcludes.isEmpty()) {
+        log(keyspace, false, "it is not included by name");
+        return false;
+      } else if (matchesAny(keyspace, regexExcludes)) {
+        log(keyspace, false, "it matches at least one regex exclude");
+        return false;
+      } else {
+        log(keyspace, true, "it does not match any regex exclude");
+        return true;
+      }
+    } else { // !regexIncludes.isEmpty()
+      if (regexExcludes.isEmpty()) {
+        if (matchesAny(keyspace, regexIncludes)) {
+          log(keyspace, true, "it matches at least one regex include");
+          return true;
+        } else {
+          log(keyspace, false, "it does not match any regex include");
+          return false;
+        }
+      } else {
+        if (matchesAny(keyspace, regexIncludes) && !matchesAny(keyspace, regexExcludes)) {
+          log(keyspace, true, "it matches at least one regex include, and no regex exclude");
+          return true;
+        } else {
+          log(keyspace, false, "it matches either no regex include, or at least one regex exclude");
+          return false;
+        }
+      }
+    }
+  }
+
+  private void log(@NonNull String keyspace, boolean include, @NonNull String reason) {
+    if (isDebugEnabled && loggedKeyspaces.add(keyspace)) {
+      LOG.debug(
+          "[{}] Filtering {} '{}' because {}", logPrefix, include ? "in" : "out", keyspace, reason);
+    }
+  }
+
+  private boolean matchesAny(String keyspace, List<Predicate<String>> rules) {
+    for (Predicate<String> rule : rules) {
+      if (rule.test(keyspace)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private Optional<Predicate<String>> compile(String regex) {
+    try {
+      return Optional.of(Pattern.compile(regex).asPredicate());
+    } catch (PatternSyntaxException e) {
+      LOG.warn(
+          "[{}] Error while parsing {}: syntax error in regex /{}/ ({}), skipping",
+          this.logPrefix,
+          DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES.getPath(),
+          regex,
+          e.getMessage());
+      return Optional.empty();
+    }
+  }
+
+  private static String buildWhereClause(Set<String> keyspaces) {
+    StringBuilder builder = new StringBuilder(" WHERE keyspace_name IN (");
+    boolean first = true;
+    for (String keyspace : keyspaces) {
+      if (first) {
+        first = false;
+      } else {
+        builder.append(",");
+      }
+      builder.append('\'').append(keyspace).append('\'');
+    }
+    return builder.append(')').toString();
+  }
+}

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1785,14 +1785,37 @@ datastax-java-driver {
       # Overridable in a profile: no
       enabled = true
 
-      # The list of keyspaces for which schema and token metadata should be maintained. If this
-      # property is absent or empty, all existing keyspaces are processed.
+      # The keyspaces for which schema and token metadata should be maintained.
       #
-      # Required: no
+      # Each element can be one of the following:
+      # 1. An exact name inclusion, for example "Ks1". If the name is case-sensitive, it must appear
+      #    in its exact case.
+      # 2. An exact name exclusion, for example "!Ks1".
+      # 3. A regex inclusion, enclosed in slashes, for example "/^Ks.*/". The part between the
+      #    slashes must follow the syntax rules of java.util.regex.Pattern.
+      # 4. A regex exclusion, for example "!/^Ks.*/".
+      #
+      # If a keyspace matches an exact name inclusion, it will always be included, regardless of
+      # rules 2, 3 and 4.
+      # Otherwise, if it matches an exact name exclusion, it will always be excluded, regardless of
+      # rules 3 and 4.
+      # Otherwise, a keyspace is included if:
+      # - there are no includes at all, or it matches at least one regex include
+      # - AND it doesn't match any regex exclude.
+      #
+      # If an element is malformed, or if its regex has a syntax error, a warning is logged and that
+      # single element is ignored.
+      #
+      # Try to use only exact name inclusions if possible. This allows the driver to filter on the
+      # server side with a WHERE IN clause. If you use any other rule, it has to fetch all system
+      # rows and filter on the client side.
+      #
+      # Required: no. The default value excludes all Cassandra and DSE system keyspaces. If the
+      #   option is unset, or set to an empty list, this is interpreted as "include all keyspaces".
       # Modifiable at runtime: yes, the new value will be used for refreshes issued after the
       #   change.
       # Overridable in a profile: no
-      // refreshed-keyspaces = [ "ks1", "ks2" ]
+      refreshed-keyspaces = [ "!system", "!/^system_.*/", "!/^dse_.*/", "!solr_admin" ]
 
       # The timeout for the requests to the schema tables.
       #

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1795,13 +1795,17 @@ datastax-java-driver {
       #    slashes must follow the syntax rules of java.util.regex.Pattern.
       # 4. A regex exclusion, for example "!/^Ks.*/".
       #
-      # If a keyspace matches an exact name inclusion, it will always be included, regardless of
-      # rules 2, 3 and 4.
-      # Otherwise, if it matches an exact name exclusion, it will always be excluded, regardless of
-      # rules 3 and 4.
-      # Otherwise, a keyspace is included if:
-      # - there are no includes at all, or it matches at least one regex include
-      # - AND it doesn't match any regex exclude.
+      # If the list is empty, or the option is unset, all keyspaces will match. Otherwise:
+      #
+      # If a keyspace matches an exact name inclusion, it is always included, regardless of what any
+      # other rule says.
+      # Otherwise, if it matches an exact name exclusion, it is always excluded, regardless of what
+      # any regex rule says.
+      # Otherwise, if there are regex rules:
+      # - if they're only inclusions, the keyspace must match at least one of them.
+      # - if they're only exclusions, the keyspace must match none of them.
+      # - if they're both, the keyspace must match at least one inclusion and none of the
+      #   exclusions.
       #
       # If an element is malformed, or if its regex has a syntax error, a warning is logged and that
       # single element is ignored.
@@ -1811,7 +1815,7 @@ datastax-java-driver {
       # rows and filter on the client side.
       #
       # Required: no. The default value excludes all Cassandra and DSE system keyspaces. If the
-      #   option is unset, or set to an empty list, this is interpreted as "include all keyspaces".
+      #   option is unset, this is interpreted as "include all keyspaces".
       # Modifiable at runtime: yes, the new value will be used for refreshes issued after the
       #   change.
       # Overridable in a profile: no

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/AggregateParserTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/AggregateParserTest.java
@@ -56,7 +56,9 @@ public class AggregateParserTest extends SchemaParserTestBase {
           "0");
 
   @Before
+  @Override
   public void setup() {
+    super.setup();
     when(context.getCodecRegistry()).thenReturn(CodecRegistry.DEFAULT);
     when(context.getProtocolVersion()).thenReturn(ProtocolVersion.DEFAULT);
   }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/SchemaParserTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/SchemaParserTest.java
@@ -137,7 +137,8 @@ public class SchemaParserTest extends SchemaParserTestBase {
   }
 
   private MetadataRefresh parse(Consumer<CassandraSchemaRows.Builder> builderConfig) {
-    CassandraSchemaRows.Builder builder = new CassandraSchemaRows.Builder(NODE_3_0, "test");
+    CassandraSchemaRows.Builder builder =
+        new CassandraSchemaRows.Builder(NODE_3_0, keyspaceFilter, "test");
     builderConfig.accept(builder);
     SchemaRows rows = builder.build();
     return new CassandraSchemaParser(rows, context).parse();

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/SchemaParserTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/SchemaParserTestBase.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.metadata.schema.parsing;
 
 import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -25,11 +26,13 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminRow;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metadata.DefaultMetadata;
+import com.datastax.oss.driver.internal.core.metadata.schema.queries.KeyspaceFilter;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
+import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -42,6 +45,12 @@ public abstract class SchemaParserTestBase {
   protected static final CqlIdentifier KEYSPACE_ID = CqlIdentifier.fromInternal("ks");
   @Mock protected DefaultMetadata currentMetadata;
   @Mock protected InternalDriverContext context;
+  @Mock protected KeyspaceFilter keyspaceFilter;
+
+  @Before
+  public void setup() {
+    when(keyspaceFilter.includes(anyString())).thenReturn(true);
+  }
 
   protected static AdminRow mockFunctionRow(
       String keyspace,

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/TableParserTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/TableParserTest.java
@@ -204,7 +204,7 @@ public class TableParserTest extends SchemaParserTestBase {
   private SchemaRows rows(
       AdminRow tableRow, Iterable<AdminRow> columnRows, Iterable<AdminRow> indexesRows, Node node) {
     CassandraSchemaRows.Builder builder =
-        new CassandraSchemaRows.Builder(node, "test")
+        new CassandraSchemaRows.Builder(node, keyspaceFilter, "test")
             .withTables(ImmutableList.of(tableRow))
             .withColumns(columnRows);
     if (indexesRows != null) {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/ViewParserTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/ViewParserTest.java
@@ -86,7 +86,7 @@ public class ViewParserTest extends SchemaParserTestBase {
   }
 
   private SchemaRows rows(AdminRow viewRow, Iterable<AdminRow> columnRows) {
-    return new CassandraSchemaRows.Builder(NODE_3_0, "test")
+    return new CassandraSchemaRows.Builder(NODE_3_0, keyspaceFilter, "test")
         .withViews(ImmutableList.of(viewRow))
         .withColumns(columnRows)
         .build();

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra3SchemaQueriesTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/Cassandra3SchemaQueriesTest.java
@@ -58,7 +58,7 @@ public class Cassandra3SchemaQueriesTest extends SchemaQueriesTest {
             DefaultDriverOption.METADATA_SCHEMA_REFRESHED_KEYSPACES, Collections.emptyList()))
         .thenReturn(ImmutableList.of("ks1", "ks2"));
 
-    should_query_with_where_clause(" WHERE keyspace_name in ('ks1','ks2')");
+    should_query_with_where_clause(" WHERE keyspace_name IN ('ks1','ks2')");
   }
 
   private void should_query_with_where_clause(String whereClause) {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/KeyspaceFilterTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/KeyspaceFilterTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metadata.schema.queries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class KeyspaceFilterTest {
+
+  @Test
+  public void should_not_filter_when_no_rules() {
+    KeyspaceFilter filter = new KeyspaceFilter();
+    assertThat(filter.getWhereClause()).isEmpty();
+    assertThat(filter.includes("system")).isTrue();
+    assertThat(filter.includes("ks1")).isTrue();
+  }
+
+  @Test
+  public void should_filter_on_server_when_only_exact_inclusions_and_no_exclusions() {
+    KeyspaceFilter filter = new KeyspaceFilter("ks1", "ks2");
+    assertThat(filter.getWhereClause()).isEqualTo(" WHERE keyspace_name IN ('ks1','ks2')");
+    assertThat(filter.includes("ks1")).isTrue();
+    assertThat(filter.includes("ks2")).isTrue();
+  }
+
+  @Test
+  public void should_filter_on_server_when_only_exact_inclusions_and_some_exclusions() {
+    // The exclusion is useless, probably a user error (we log a warning)
+    KeyspaceFilter filter = new KeyspaceFilter("ks1", "ks2", "!/KS.*/");
+    assertThat(filter.getWhereClause()).isEqualTo(" WHERE keyspace_name IN ('ks1','ks2')");
+    assertThat(filter.includes("ks1")).isTrue();
+    assertThat(filter.includes("ks2")).isTrue();
+    // The implementations honors the exclude client side, even though we'll never encounter that
+    // keyspace given the where clause
+    assertThat(filter.includes("KS1")).isFalse();
+  }
+
+  @Test
+  public void should_filter_on_client_when_only_exclusions() {
+    KeyspaceFilter filter = new KeyspaceFilter("!system");
+    assertThat(filter.getWhereClause()).isEmpty();
+    assertThat(filter.includes("system")).isFalse();
+    assertThat(filter.includes("ks1")).isTrue();
+  }
+
+  @Test
+  public void should_filter_on_client_when_regex_inclusions() {
+    KeyspaceFilter filter = new KeyspaceFilter("foo1", "/bar.*/", "!BAR2", "!/.*3/");
+    assertThat(filter.getWhereClause()).isEmpty();
+    assertThat(filter.includes("foo1")).isTrue();
+    assertThat(filter.includes("bar1")).isTrue();
+    assertThat(filter.includes("bar2")).isTrue();
+    assertThat(filter.includes("BAR2")).isFalse();
+    assertThat(filter.includes("foo3")).isFalse();
+  }
+
+  @Test
+  public void should_honor_exact_inclusion_over_any_other_rule() {
+    KeyspaceFilter filter = new KeyspaceFilter("ks1", "!ks1", "!/ks.*/");
+    assertThat(filter.getWhereClause()).isEqualTo(" WHERE keyspace_name IN ('ks1')");
+    assertThat(filter.includes("ks1")).isTrue();
+
+    filter = new KeyspaceFilter("ks1", "/.*1/", "!ks1", "!/ks.*/");
+    assertThat(filter.getWhereClause()).isEmpty();
+    assertThat(filter.includes("ks1")).isTrue();
+  }
+
+  @Test
+  public void should_honor_exact_exclusion_over_regexes() {
+    KeyspaceFilter filter = new KeyspaceFilter("!ks1", "/ks.*/");
+    assertThat(filter.getWhereClause()).isEmpty();
+    assertThat(filter.includes("ks1")).isFalse();
+    assertThat(filter.includes("ks2")).isTrue();
+  }
+
+  @Test
+  public void should_use_intersection_if_only_regexes() {
+    KeyspaceFilter filter = new KeyspaceFilter("/ks.*/", "!/.*2/");
+    assertThat(filter.getWhereClause()).isEmpty();
+    // Matches the inclusion and not the exclusion
+    assertThat(filter.includes("ks1")).isTrue();
+    // Matches the inclusion but also the exclusion
+    assertThat(filter.includes("ks2")).isFalse();
+    // Does not match the exclusion, but neither the inclusion
+    assertThat(filter.includes("foo1")).isFalse();
+
+    // No inclusions == include "/.*/"
+    filter = new KeyspaceFilter("!/.*2/");
+    assertThat(filter.getWhereClause()).isEmpty();
+    assertThat(filter.includes("ks1")).isTrue();
+    assertThat(filter.includes("foo1")).isTrue();
+    assertThat(filter.includes("ks2")).isFalse();
+  }
+
+  @Test
+  public void should_skip_malformed_rule() {
+    KeyspaceFilter filter = new KeyspaceFilter("ks1", "ks2", "//");
+    assertThat(filter.getWhereClause()).isEqualTo(" WHERE keyspace_name IN ('ks1','ks2')");
+    assertThat(filter.includes("ks1")).isTrue();
+    assertThat(filter.includes("ks2")).isTrue();
+  }
+
+  @Test
+  public void should_skip_invalid_regex() {
+    KeyspaceFilter filter = new KeyspaceFilter("ks1", "ks2", "/*/");
+    assertThat(filter.getWhereClause()).isEqualTo(" WHERE keyspace_name IN ('ks1','ks2')");
+    assertThat(filter.includes("ks1")).isTrue();
+    assertThat(filter.includes("ks2")).isTrue();
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/KeyspaceFilterTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/KeyspaceFilterTest.java
@@ -41,7 +41,7 @@ public class KeyspaceFilterTest {
         KeyspaceFilter.newInstance("inventory_test", "customers_test", "!system");
     // Note that exact excludes are redundant in this case: either they match an include and will be
     // ignored, or they don't and the keyspace is already ignored.
-    // We let it slides, but a warning is logged.
+    // We let it slide, but a warning is logged.
     assertThat(filter.getWhereClause())
         .isEqualTo(" WHERE keyspace_name IN ('inventory_test','customers_test')");
     assertThat(apply(filter, KEYSPACES)).containsOnly("inventory_test", "customers_test");

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/KeyspaceFilterTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/KeyspaceFilterTest.java
@@ -17,108 +17,112 @@ package com.datastax.oss.driver.internal.core.metadata.schema.queries;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.Test;
 
 public class KeyspaceFilterTest {
 
+  private static final ImmutableSet<String> KEYSPACES =
+      ImmutableSet.of(
+          "system", "inventory_test", "inventory_prod", "customers_test", "customers_prod");
+
   @Test
   public void should_not_filter_when_no_rules() {
-    KeyspaceFilter filter = new KeyspaceFilter();
+    KeyspaceFilter filter = KeyspaceFilter.newInstance();
     assertThat(filter.getWhereClause()).isEmpty();
-    assertThat(filter.includes("system")).isTrue();
-    assertThat(filter.includes("ks1")).isTrue();
+    assertThat(apply(filter, KEYSPACES)).isEqualTo(KEYSPACES);
   }
 
   @Test
-  public void should_filter_on_server_when_only_exact_inclusions_and_no_exclusions() {
-    KeyspaceFilter filter = new KeyspaceFilter("ks1", "ks2");
-    assertThat(filter.getWhereClause()).isEqualTo(" WHERE keyspace_name IN ('ks1','ks2')");
-    assertThat(filter.includes("ks1")).isTrue();
-    assertThat(filter.includes("ks2")).isTrue();
+  public void should_filter_on_server_when_only_exact_rules() {
+    KeyspaceFilter filter =
+        KeyspaceFilter.newInstance("inventory_test", "customers_test", "!system");
+    // Note that exact excludes are redundant in this case: either they match an include and will be
+    // ignored, or they don't and the keyspace is already ignored.
+    // We let it slides, but a warning is logged.
+    assertThat(filter.getWhereClause())
+        .isEqualTo(" WHERE keyspace_name IN ('inventory_test','customers_test')");
+    assertThat(apply(filter, KEYSPACES)).containsOnly("inventory_test", "customers_test");
   }
 
   @Test
-  public void should_filter_on_server_when_only_exact_inclusions_and_some_exclusions() {
-    // The exclusion is useless, probably a user error (we log a warning)
-    KeyspaceFilter filter = new KeyspaceFilter("ks1", "ks2", "!/KS.*/");
-    assertThat(filter.getWhereClause()).isEqualTo(" WHERE keyspace_name IN ('ks1','ks2')");
-    assertThat(filter.includes("ks1")).isTrue();
-    assertThat(filter.includes("ks2")).isTrue();
-    // The implementations honors the exclude client side, even though we'll never encounter that
-    // keyspace given the where clause
-    assertThat(filter.includes("KS1")).isFalse();
+  public void should_ignore_exact_exclude_that_collides_with_exact_include() {
+    KeyspaceFilter filter = KeyspaceFilter.newInstance("inventory_test", "!inventory_test");
+    assertThat(filter.getWhereClause()).isEqualTo(" WHERE keyspace_name IN ('inventory_test')");
+    assertThat(apply(filter, KEYSPACES)).containsOnly("inventory_test");
+
+    // Order does not matter
+    filter = KeyspaceFilter.newInstance("!inventory_test", "inventory_test");
+    assertThat(filter.getWhereClause()).isEqualTo(" WHERE keyspace_name IN ('inventory_test')");
+    assertThat(apply(filter, KEYSPACES)).containsOnly("inventory_test");
   }
 
   @Test
-  public void should_filter_on_client_when_only_exclusions() {
-    KeyspaceFilter filter = new KeyspaceFilter("!system");
+  public void should_apply_disjoint_exact_and_regex_rules() {
+    KeyspaceFilter filter = KeyspaceFilter.newInstance("inventory_test", "/^customers.*/");
     assertThat(filter.getWhereClause()).isEmpty();
-    assertThat(filter.includes("system")).isFalse();
-    assertThat(filter.includes("ks1")).isTrue();
+    assertThat(apply(filter, KEYSPACES))
+        .containsOnly("inventory_test", "customers_test", "customers_prod");
+
+    filter = KeyspaceFilter.newInstance("!system", "!/^inventory.*/");
+    assertThat(filter.getWhereClause()).isEmpty();
+    assertThat(apply(filter, KEYSPACES)).containsOnly("customers_test", "customers_prod");
+
+    // The remaining cases could be simplified, but they are supported nevertheless:
+    filter = KeyspaceFilter.newInstance("!/^customers.*/", /*redundant:*/ "inventory_test");
+    assertThat(filter.getWhereClause()).isEmpty();
+    assertThat(apply(filter, KEYSPACES)).containsOnly("inventory_test", "inventory_prod", "system");
+
+    filter = KeyspaceFilter.newInstance("/^customers.*/", /*redundant:*/ "!system");
+    assertThat(filter.getWhereClause()).isEmpty();
+    assertThat(apply(filter, KEYSPACES)).containsOnly("customers_test", "customers_prod");
   }
 
   @Test
-  public void should_filter_on_client_when_regex_inclusions() {
-    KeyspaceFilter filter = new KeyspaceFilter("foo1", "/bar.*/", "!BAR2", "!/.*3/");
+  public void should_apply_intersecting_exact_and_regex_rules() {
+    // Include all customer keyspaces except one:
+    KeyspaceFilter filter = KeyspaceFilter.newInstance("/^customers.*/", "!customers_test");
     assertThat(filter.getWhereClause()).isEmpty();
-    assertThat(filter.includes("foo1")).isTrue();
-    assertThat(filter.includes("bar1")).isTrue();
-    assertThat(filter.includes("bar2")).isTrue();
-    assertThat(filter.includes("BAR2")).isFalse();
-    assertThat(filter.includes("foo3")).isFalse();
+    assertThat(apply(filter, KEYSPACES)).containsOnly("customers_prod");
+
+    // Exclude all customer keyspaces except one (also implies include every other keyspace):
+    filter = KeyspaceFilter.newInstance("!/^customers.*/", "customers_test");
+    assertThat(filter.getWhereClause()).isEmpty();
+    assertThat(apply(filter, KEYSPACES))
+        .containsOnly("customers_test", "inventory_test", "inventory_prod", "system");
   }
 
   @Test
-  public void should_honor_exact_inclusion_over_any_other_rule() {
-    KeyspaceFilter filter = new KeyspaceFilter("ks1", "!ks1", "!/ks.*/");
-    assertThat(filter.getWhereClause()).isEqualTo(" WHERE keyspace_name IN ('ks1')");
-    assertThat(filter.includes("ks1")).isTrue();
-
-    filter = new KeyspaceFilter("ks1", "/.*1/", "!ks1", "!/ks.*/");
+  public void should_apply_intersecting_regex_rules() {
+    KeyspaceFilter filter = KeyspaceFilter.newInstance("/^customers.*/", "!/.*test$/");
     assertThat(filter.getWhereClause()).isEmpty();
-    assertThat(filter.includes("ks1")).isTrue();
-  }
+    assertThat(apply(filter, KEYSPACES)).containsOnly("customers_prod");
 
-  @Test
-  public void should_honor_exact_exclusion_over_regexes() {
-    KeyspaceFilter filter = new KeyspaceFilter("!ks1", "/ks.*/");
+    // Throwing an exact name in the mix doesn't change the other rules
+    filter = KeyspaceFilter.newInstance("inventory_prod", "/^customers.*/", "!/.*test$/");
     assertThat(filter.getWhereClause()).isEmpty();
-    assertThat(filter.includes("ks1")).isFalse();
-    assertThat(filter.includes("ks2")).isTrue();
-  }
-
-  @Test
-  public void should_use_intersection_if_only_regexes() {
-    KeyspaceFilter filter = new KeyspaceFilter("/ks.*/", "!/.*2/");
-    assertThat(filter.getWhereClause()).isEmpty();
-    // Matches the inclusion and not the exclusion
-    assertThat(filter.includes("ks1")).isTrue();
-    // Matches the inclusion but also the exclusion
-    assertThat(filter.includes("ks2")).isFalse();
-    // Does not match the exclusion, but neither the inclusion
-    assertThat(filter.includes("foo1")).isFalse();
-
-    // No inclusions == include "/.*/"
-    filter = new KeyspaceFilter("!/.*2/");
-    assertThat(filter.getWhereClause()).isEmpty();
-    assertThat(filter.includes("ks1")).isTrue();
-    assertThat(filter.includes("foo1")).isTrue();
-    assertThat(filter.includes("ks2")).isFalse();
+    assertThat(apply(filter, KEYSPACES)).containsOnly("inventory_prod", "customers_prod");
   }
 
   @Test
   public void should_skip_malformed_rule() {
-    KeyspaceFilter filter = new KeyspaceFilter("ks1", "ks2", "//");
-    assertThat(filter.getWhereClause()).isEqualTo(" WHERE keyspace_name IN ('ks1','ks2')");
-    assertThat(filter.includes("ks1")).isTrue();
-    assertThat(filter.includes("ks2")).isTrue();
+    KeyspaceFilter filter = KeyspaceFilter.newInstance("inventory_test", "customers_test", "//");
+    assertThat(filter.getWhereClause())
+        .isEqualTo(" WHERE keyspace_name IN ('inventory_test','customers_test')");
+    assertThat(apply(filter, KEYSPACES)).containsOnly("inventory_test", "customers_test");
   }
 
   @Test
   public void should_skip_invalid_regex() {
-    KeyspaceFilter filter = new KeyspaceFilter("ks1", "ks2", "/*/");
-    assertThat(filter.getWhereClause()).isEqualTo(" WHERE keyspace_name IN ('ks1','ks2')");
-    assertThat(filter.includes("ks1")).isTrue();
-    assertThat(filter.includes("ks2")).isTrue();
+    KeyspaceFilter filter = KeyspaceFilter.newInstance("inventory_test", "customers_test", "/*/");
+    assertThat(filter.getWhereClause())
+        .isEqualTo(" WHERE keyspace_name IN ('inventory_test','customers_test')");
+    assertThat(apply(filter, KEYSPACES)).containsOnly("inventory_test", "customers_test");
+  }
+
+  private static Set<String> apply(KeyspaceFilter filter, Set<String> keyspaces) {
+    return keyspaces.stream().filter(filter::includes).collect(Collectors.toSet());
   }
 }

--- a/manual/core/metadata/schema/README.md
+++ b/manual/core/metadata/schema/README.md
@@ -138,7 +138,8 @@ Each element in the list can be one of the following:
    its exact case.
 2. An exact name exclusion, for example `"!Ks1"`.
 3. A regex inclusion, enclosed in slashes, for example `"/^Ks.*/"`. The part between the slashes
-   must follow the syntax rules of [java.util.regex.Pattern].
+   must follow the syntax rules of [java.util.regex.Pattern]. The regex must match the entire
+   keyspace name (no partial matching).
 4. A regex exclusion, for example `"!/^Ks.*/"`.
 
 If the list is empty, or the option is unset, all keyspaces will match. Otherwise:

--- a/manual/core/metadata/schema/README.md
+++ b/manual/core/metadata/schema/README.md
@@ -132,7 +132,53 @@ You can also limit the metadata to a subset of keyspaces:
 datastax-java-driver.advanced.metadata.schema.refreshed-keyspaces = [ "users", "products" ]
 ```
 
-If the property is absent or the list is empty, it is interpreted as "all keyspaces".
+Each element in the list can be one of the following:
+
+1. An exact name inclusion, for example `"Ks1"`. If the name is case-sensitive, it must appear in
+   its exact case.
+2. An exact name exclusion, for example `"!Ks1"`.
+3. A regex inclusion, enclosed in slashes, for example `"/^Ks.*/"`. The part between the slashes
+   must follow the syntax rules of [java.util.regex.Pattern].
+4. A regex exclusion, for example `"!/^Ks.*/"`.
+
+If the list is empty, or the option is unset, all keyspaces will match. Otherwise:
+
+* If a keyspace matches an exact name inclusion, it is always included, regardless of what any other
+  rule says.
+* Otherwise, if it matches an exact name exclusion, it is always excluded, regardless of what any
+  regex rule says.
+* Otherwise, if there are regex rules:
+
+  * if they're only inclusions, the keyspace must match at least one of them.
+  * if they're only exclusions, the keyspace must match none of them.
+  * if they're both, the keyspace must match at least one inclusion and none of the
+    exclusions.
+
+For example, given the keyspaces `system`, `ks1`, `ks2`, `data1` and `data2`, here's the outcome of
+a few filters:
+
+|Filter|Outcome|Translation|
+|---|---|---|
+| `[]` | `system`, `ks1`, `ks2`, `data1`, `data2` | Include all. |
+| `["ks1", "ks2"]` | `ks1`, `ks2` | Include ks1 and ks2 (recommended, see explanation below). |
+| `["!system"]` | `ks1`, `ks2`, `data1`, `data2` | Include all except system. |
+| `["/^ks.*/"]` | `ks1`, `ks2` | Include all that start with ks. |
+| `["!/^ks.*/"]` | `system`, `data1`, `data2` | Exclude all that start with ks (and include everything else). |
+| `["system", "/^ks.*/"]` | `system`, `ks1`, `ks2` | Include system, and all that start with ks. |
+| `["/^ks.*/", "!ks2"]` | `ks1` | Include all that start with ks, except ks2. |
+| `["!/^ks.*/", "ks1"]` | `system`, `ks1`, `data1`, `data2` | Exclude all that start with ks, except ks1 (and also include everything else). |
+| `["/^s.*/", /^ks.*/", "!/.*2$/"]` | `system`, `ks1` | Include all that start with s or ks, except if they end with 2. |
+
+
+If an element is malformed, or if its regex has a syntax error, a warning is logged and that single
+element is ignored.
+
+The default configuration (see [reference.conf](../../configuration/reference/)) excludes all
+Cassandra and DSE system keyspaces.
+
+Try to use only exact name inclusions if possible. This allows the driver to filter on the server
+side with a `WHERE IN` clause. If you use any other rule, it has to fetch all system rows and filter
+on the client side.
 
 Note that, if you change the list at runtime, `onKeyspaceAdded`/`onKeyspaceDropped` will be invoked
 on your schema listeners for the newly included/excluded keyspaces. 
@@ -272,3 +318,4 @@ take a look at the [Performance](../../performance/#schema-updates) page for a f
 [DseAggregateMetadata]: https://docs.datastax.com/en/drivers/java/4.9/com/datastax/dse/driver/api/core/metadata/schema/DseAggregateMetadata.html
 
 [JAVA-750]: https://datastax-oss.atlassian.net/browse/JAVA-750
+[java.util.regex.Pattern]: https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html


### PR DESCRIPTION
The [manual](https://github.com/datastax/java-driver/tree/java2871/manual/core/metadata/schema#filtering) has the best description of the rules. I've left out the weird corner cases, but they are covered by the unit tests.

TODO:
- [x] update manual