### PR TITLE
JAVA-2887: Handle composite profiles with more than one key and/or backed by only one profile

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.10.0 (in progress)
 
+- [bug] JAVA-2887: Handle composite profiles with more than one key and/or backed by only one profile
 
 ### 4.9.0
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/composite/CompositeDriverConfigTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/composite/CompositeDriverConfigTest.java
@@ -16,7 +16,9 @@
 package com.datastax.oss.driver.internal.core.config.composite;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
+import com.datastax.dse.driver.api.core.config.DseDriverOption;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
@@ -59,6 +61,10 @@ public class CompositeDriverConfigTest {
         .isTrue();
     assertThat(compositeDefaultProfile.getInt(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE))
         .isEqualTo(1);
+    assertThat(compositeDefaultProfile.entrySet())
+        .containsExactly(
+            entry(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE.getPath(), 1),
+            entry(DseDriverOption.CONTINUOUS_PAGING_MAX_PAGES.getPath(), 1));
   }
 
   @Test
@@ -70,6 +76,10 @@ public class CompositeDriverConfigTest {
         .isTrue();
     assertThat(compositeDefaultProfile.getInt(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE))
         .isEqualTo(1);
+    assertThat(compositeDefaultProfile.entrySet())
+        .containsExactly(
+            entry(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE.getPath(), 1),
+            entry(DseDriverOption.CONTINUOUS_PAGING_MAX_PAGES.getPath(), 1));
   }
 
   @Test
@@ -80,6 +90,10 @@ public class CompositeDriverConfigTest {
         .isTrue();
     assertThat(compositeDefaultProfile.getInt(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE))
         .isEqualTo(1);
+    assertThat(compositeDefaultProfile.entrySet())
+        .containsExactly(
+            entry(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE.getPath(), 1),
+            entry(DseDriverOption.CONTINUOUS_PAGING_MAX_PAGES.getPath(), 1));
   }
 
   @Test
@@ -112,5 +126,20 @@ public class CompositeDriverConfigTest {
                 .getProfile("onlyInFallback")
                 .getInt(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE))
         .isEqualTo(4);
+
+    assertThat(compositeConfig.getProfile("onlyInPrimary").entrySet())
+        .containsExactly(
+            entry(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE.getPath(), 1),
+            entry(DseDriverOption.CONTINUOUS_PAGING_MAX_PAGES.getPath(), 1));
+
+    assertThat(compositeConfig.getProfile("inBoth").entrySet())
+        .containsExactly(
+            entry(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE.getPath(), 2),
+            entry(DseDriverOption.CONTINUOUS_PAGING_MAX_PAGES.getPath(), 1));
+
+    assertThat(compositeConfig.getProfile("onlyInFallback").entrySet())
+        .containsExactly(
+            entry(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE.getPath(), 4),
+            entry(DseDriverOption.CONTINUOUS_PAGING_MAX_PAGES.getPath(), 1));
   }
 }


### PR DESCRIPTION
Composite profiles with more than one key currently throw `ClassCastException`
from `CompositeDriverExecutionProfile.entrySet`.

Composite profiles backed by only one profile currently throw `NullPointerException`
from `CompositeDriverExecutionProfile.entrySet`.