### PR TITLE
Rebrand Apollo to Astra

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ not yet have been released. You can find the documentation for the latest
 version through the [Java driver
 docs](http://docs.datastax.com/en/developer/java-driver/latest/index.html) or via the release tags,
 [e.g.
-3.10.0](https://github.com/datastax/java-driver/tree/3.10.0).*
+3.10.2](https://github.com/datastax/java-driver/tree/3.10.2).*
 
 A modern, [feature-rich](manual/) and highly tunable Java client
 library for Apache Cassandra (2.1+) and using exclusively Cassandra's binary protocol 
@@ -55,7 +55,7 @@ The driver contains the following modules:
 - API: https://docs.datastax.com/en/drivers/java/3.10
 - GITHUB REPOSITORY: https://github.com/datastax/java-driver
 - [changelog](changelog/)
-- [binary tarball](http://downloads.datastax.com/java-driver/cassandra-java-driver-3.10.0.tar.gz)
+- [binary tarball](http://downloads.datastax.com/java-driver/cassandra-java-driver-3.10.2.tar.gz)
 
 ## Getting the driver
 
@@ -67,7 +67,7 @@ using DataStax Enterprise, install the [DataStax Enterprise Java driver][dse-dri
 <dependency>
   <groupId>com.datastax.cassandra</groupId>
   <artifactId>cassandra-driver-core</artifactId>
-  <version>3.10.0</version>
+  <version>3.10.2</version>
 </dependency>
 ```
 
@@ -77,7 +77,7 @@ Note that the object mapper is published as a separate artifact:
 <dependency>
   <groupId>com.datastax.cassandra</groupId>
   <artifactId>cassandra-driver-mapping</artifactId>
-  <version>3.10.0</version>
+  <version>3.10.2</version>
 </dependency>
 ```
 
@@ -87,7 +87,7 @@ The 'extras' module is also published as a separate artifact:
 <dependency>
   <groupId>com.datastax.cassandra</groupId>
   <artifactId>cassandra-driver-extras</artifactId>
-  <version>3.10.0</version>
+  <version>3.10.2</version>
 </dependency>
 ```
 
@@ -96,12 +96,12 @@ We also provide a [shaded JAR](manual/shaded_jar/)
 to avoid the explicit dependency to Netty.
 
 If you can't use a dependency management tool, a
-[binary tarball](http://downloads.datastax.com/java-driver/cassandra-java-driver-3.10.0.tar.gz)
+[binary tarball](http://downloads.datastax.com/java-driver/cassandra-java-driver-3.10.2.tar.gz)
 is available for download.
 
 ## Compatibility
 
-The Java client driver 3.10.0 ([branch 3.x](https://github.com/datastax/java-driver/tree/3.x)) is compatible with Apache
+The Java client driver 3.10.2 ([branch 3.x](https://github.com/datastax/java-driver/tree/3.x)) is compatible with Apache
 Cassandra 2.1, 2.2 and 3.0+ (see [this page](http://docs.datastax.com/en/developer/java-driver/latest/manual/native_protocol/) for
 the most up-to-date compatibility information).
 

--- a/driver-examples/src/main/java/com/datastax/driver/examples/astra/AstraReadCassandraVersion.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/astra/AstraReadCassandraVersion.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.datastax.driver.examples.apollo;
+package com.datastax.driver.examples.astra;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ResultSet;
@@ -23,27 +23,28 @@ import com.datastax.driver.core.Session;
 import java.io.File;
 
 /**
- * Connects to a DataStax Apollo cluster and extracts basic information from it.
+ * Connects to a DataStax Astra cluster and extracts basic information from it.
  *
  * <p>Preconditions:
  *
  * <ul>
- *   <li>A DataStax Apollo cluster is running and accessible.
- *   <li>A DataStax Apollo secure connect bundle for the running cluster.
+ *   <li>A DataStax Astra cluster is running and accessible.
+ *   <li>A DataStax Astra secure connect bundle for the running cluster.
  * </ul>
  *
  * <p>Side effects: none.
  *
+ * @see <a href="https://docs.astra.datastax.com/docs/creating-your-astra-database">Creating an
+ *     Astra Database</a>
  * @see <a
- *     href="https://helpdocs.datastax.com/gcp/dscloud/apollo/dscloudGettingStarted.html#dscloudCreateCluster">
- *     Creating an Apollo Database</a>
- * @see <a href="https://helpdocs.datastax.com/gcp/dscloud/apollo/dscloudShareClusterDetails.html">
- *     Providing access to Apollo databases</a>
- * @see <a href="https://helpdocs.datastax.com/gcp/dscloud/apollo/dscloudObtainingCredentials.html">
- *     Obtaining Apollo secure connect bundle</a>
+ *     href="https://docs.astra.datastax.com/docs/obtaining-database-credentials#sharing-your-secure-connect-bundle">
+ *     Providing access to Astra databases</a>
+ * @see <a
+ *     href="https://docs.astra.datastax.com/docs/obtaining-database-credentials#getting-your-secure-connect-bundle">
+ *     Obtaining Astra secure connect bundle</a>
  * @see <a href="http://datastax.github.io/java-driver/manual/">Java driver online manual</a>
  */
-public class ApolloReadCassandraVersion {
+public class AstraReadCassandraVersion {
 
   public static void main(String[] args) {
 
@@ -58,7 +59,7 @@ public class ApolloReadCassandraVersion {
           Cluster.builder()
               // Change the path here to the secure connect bundle location (see javadocs above)
               .withCloudSecureConnectBundle(new File("/path/to/secure-connect-database_name.zip"))
-              // Change the user_name and password here for the Apollo instance
+              // Change the user_name and password here for the Astra instance
               .withCredentials("user_name", "password")
               // Uncomment the next line to use a specific keyspace
               // .withKeyspace("keyspace_name")

--- a/manual/cloud/README.md
+++ b/manual/cloud/README.md
@@ -1,22 +1,20 @@
-## Connecting to Apollo (Cloud)
+## Connecting to Astra (Cloud)
 
-Using the DataStax Java Driver to connect to a DataStax Apollo database is almost identical to using
+Using the DataStax Java Driver to connect to a DataStax Astra database is almost identical to using
 the driver to connect to any normal Apache Cassandra® database. The only differences are in how the
 driver is configured in an application and that you will need to obtain a `secure connect bundle`.
 
-The following is a Quick Start guide to writing a simple application that can connect to an Apollo
+The following is a Quick Start guide to writing a simple application that can connect to an Astra
 database.
 
 ### Prerequisites
 
 1. [Download][Download Maven] and [install][Install Maven] Maven.
-1. Create an Apollo database on [GCP][Create an Apollo database - GCP] or
-   [AWS][Create an Apollo database - AWS]; alternatively, have a team member provide access to their
-   Apollo database (instructions for [GCP][Access an Apollo database - GCP] and 
-   [AWS][Access an Apollo database - AWS]) to obtain database connection details.
+1. Create an Astra database on [GCP/AWS/Azure][Create an Astra database - GCP/AWS/Azure]; alternatively,
+   have a team member provide access to their Astra database (instructions for 
+   [GCP/AWS/Azure][Access an Astra database - GCP/AWS/Azure]) to obtain database connection details.
 1. Download the secure connect bundle (instructions for
-   [GCP][Download the secure connect bundle - GCP] and 
-   [AWS][Download the secure connect bundle - AWS]) to obtain connection credentials for your 
+   [GCP/AWS/Azure][Download the secure connect bundle - GCP/AWS/Azure]) to obtain connection credentials for your 
    database.
 1. Ensure you are using Java 8 or higher. The cloud connect api does not support java 6 or 7.
 
@@ -36,11 +34,11 @@ database.
       ```
 
     b. Copy the following code for your DataStax Driver into the `ConnectDatabase.java` file.  
-    The following example implements a `ConnectDatabase` class to connect to your Apollo database,
+    The following example implements a `ConnectDatabase` class to connect to your Astra database,
     runs a CQL query, and prints the output to the console.
 
       **Note:** With the `Cluster.builder()` object, make sure to set the path to the secure
-      connect bundle for your Apollo database (**"/path/to/secure-connect-database_name.zip"**) in
+      connect bundle for your Astra database (**"/path/to/secure-connect-database_name.zip"**) in
       the `withCloudSecureConnectBundle()` method as shown in the following example.  
       * DataStax Java Driver for Apache Cassandra 3.x
 
@@ -81,9 +79,9 @@ database.
 
     c. Save and close the ConnectDatabase.java file.
 
-### Apollo Differences
+### Astra Differences
 
-In most circumstances, the client code for interacting with an Apollo cluster will be the same as
+In most circumstances, the client code for interacting with an Astra cluster will be the same as
 interacting with any other Cassandra cluster. The exceptions being:
 
   * An SSL connection will be established automatically. Manual SSL configuration is not necessary.
@@ -97,10 +95,7 @@ interacting with any other Cassandra cluster. The exceptions being:
 
 [Download Maven]: https://maven.apache.org/download.cgi
 [Install Maven]: https://maven.apache.org/install.html
-[Create an Apollo database - GCP]: https://helpdocs.datastax.com/gcp/dscloud/apollo/dscloudGettingStarted.html#dscloudCreateCluster
-[Create an Apollo database - AWS]: https://helpdocs.datastax.com/aws/dscloud/apollo/dscloudGettingStarted.html#dscloudCreateCluster
-[Access an Apollo database - GCP]: https://helpdocs.datastax.com/gcp/dscloud/apollo/dscloudShareClusterDetails.html
-[Access an Apollo database - AWS]: https://helpdocs.datastax.com/aws/dscloud/apollo/dscloudShareClusterDetails.html
-[Download the secure connect bundle - GCP]: https://helpdocs.datastax.com/gcp/dscloud/apollo/dscloudObtainingCredentials.html
-[Download the secure connect bundle - AWS]: https://helpdocs.datastax.com/aws/dscloud/apollo/dscloudObtainingCredentials.html
+[Create an Astra database - GCP/AWS/Azure]: https://docs.astra.datastax.com/docs/creating-your-astra-database#dscloudCreateCluster
+[Access an Astra database - GCP/AWS/Azure]: https://docs.astra.datastax.com/docs/obtaining-database-credentials#sharing-your-secure-connect-bundle
+[Download the secure connect bundle - GCP/AWS/Azure]: https://docs.astra.datastax.com/docs/obtaining-database-credentials
 [pom.xml dependency]: ../../#getting-the-driver


### PR DESCRIPTION
Rebrand Apollo to Astra in the 3.x version of docs