### PR TITLE
JAVA-2883: Use root locale explicitly when changing string case

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.10.0 (in progress)
 
+- [bug] JAVA-2883: Use root locale explicitly when changing string case
 - [bug] JAVA-2647: Handle token types in QueryBuilder.literal()
 - [bug] JAVA-2887: Handle composite profiles with more than one key and/or backed by only one profile
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/CqlIdentifier.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/CqlIdentifier.java
@@ -21,6 +21,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.util.Locale;
 import net.jcip.annotations.Immutable;
 
 /**
@@ -75,7 +76,7 @@ public class CqlIdentifier implements Serializable {
     if (Strings.isDoubleQuoted(cql)) {
       internal = Strings.unDoubleQuote(cql);
     } else {
-      internal = cql.toLowerCase();
+      internal = cql.toLowerCase(Locale.ROOT);
       Preconditions.checkArgument(
           !Strings.needsDoubleQuotes(internal), "Invalid CQL form [%s]: needs double quotes", cql);
     }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlDuration.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlDuration.java
@@ -28,6 +28,7 @@ import java.time.temporal.TemporalAmount;
 import java.time.temporal.TemporalUnit;
 import java.time.temporal.UnsupportedTemporalTypeException;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.jcip.annotations.Immutable;
@@ -232,7 +233,7 @@ public final class CqlDuration implements TemporalAmount {
   }
 
   private static Builder add(@NonNull Builder builder, long number, @NonNull String symbol) {
-    String s = symbol.toLowerCase();
+    String s = symbol.toLowerCase(Locale.ROOT);
     if (s.equals("y")) {
       return builder.addYears(number);
     } else if (s.equals("mo")) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/data/IdentifierIndex.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/data/IdentifierIndex.java
@@ -23,6 +23,7 @@ import com.datastax.oss.driver.internal.core.util.Strings;
 import com.datastax.oss.driver.shaded.guava.common.collect.LinkedListMultimap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ListMultimap;
 import java.util.List;
+import java.util.Locale;
 import net.jcip.annotations.Immutable;
 
 /**
@@ -47,7 +48,7 @@ public class IdentifierIndex {
     for (CqlIdentifier id : ids) {
       byId.put(id, i);
       byCaseSensitiveName.put(id.asInternal(), i);
-      byCaseInsensitiveName.put(id.asInternal().toLowerCase(), i);
+      byCaseInsensitiveName.put(id.asInternal().toLowerCase(Locale.ROOT), i);
       i += 1;
     }
   }
@@ -59,7 +60,7 @@ public class IdentifierIndex {
   public List<Integer> allIndicesOf(String name) {
     return Strings.isDoubleQuoted(name)
         ? byCaseSensitiveName.get(Strings.unDoubleQuote(name))
-        : byCaseInsensitiveName.get(name.toLowerCase());
+        : byCaseInsensitiveName.get(name.toLowerCase(Locale.ROOT));
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/DataTypeCqlNameParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/DataTypeCqlNameParser.java
@@ -28,6 +28,7 @@ import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import net.jcip.annotations.ThreadSafe;
 
@@ -68,7 +69,7 @@ public class DataTypeCqlNameParser implements DataTypeParser {
       return DataTypes.custom(type);
     }
 
-    DataType nativeType = NATIVE_TYPES_BY_NAME.get(type.toLowerCase());
+    DataType nativeType = NATIVE_TYPES_BY_NAME.get(type.toLowerCase(Locale.ROOT));
     if (nativeType != null) {
       return nativeType;
     }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/BuiltInCompressors.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/BuiltInCompressors.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.context.DriverContext;
 import com.datastax.oss.protocol.internal.Compressor;
 import io.netty.buffer.ByteBuf;
+import java.util.Locale;
 
 /**
  * Provides a single entry point to create compressor instances in the driver.
@@ -29,7 +30,7 @@ import io.netty.buffer.ByteBuf;
 public class BuiltInCompressors {
 
   public static Compressor<ByteBuf> newInstance(String name, DriverContext context) {
-    switch (name.toLowerCase()) {
+    switch (name.toLowerCase(Locale.ROOT)) {
       case "lz4":
         return new Lz4Compressor(context);
       case "snappy":

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/CompressorSubstitutions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/CompressorSubstitutions.java
@@ -22,6 +22,7 @@ import com.oracle.svm.core.annotate.Delete;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import io.netty.buffer.ByteBuf;
+import java.util.Locale;
 import java.util.function.BooleanSupplier;
 
 /**
@@ -38,7 +39,7 @@ public class CompressorSubstitutions {
   public static final class BuiltInCompressorsLz4Only {
     @Substitute
     public static Compressor<ByteBuf> newInstance(String name, DriverContext context) {
-      switch (name.toLowerCase()) {
+      switch (name.toLowerCase(Locale.ROOT)) {
         case "lz4":
           return new Lz4Compressor(context);
         case "snappy":
@@ -59,7 +60,7 @@ public class CompressorSubstitutions {
   public static final class NoBuiltInCompressors {
     @Substitute
     public static Compressor<ByteBuf> newInstance(String name, DriverContext context) {
-      switch (name.toLowerCase()) {
+      switch (name.toLowerCase(Locale.ROOT)) {
         case "lz4":
           throw new UnsupportedOperationException(
               "This native image was not built with support for LZ4 compression");

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/PrimitiveType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/PrimitiveType.java
@@ -20,6 +20,7 @@ import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.Serializable;
+import java.util.Locale;
 import net.jcip.annotations.Immutable;
 
 @Immutable
@@ -67,7 +68,7 @@ public class PrimitiveType implements DataType, Serializable {
   @NonNull
   @Override
   public String asCql(boolean includeFrozen, boolean pretty) {
-    return codeName(protocolCode).toLowerCase();
+    return codeName(protocolCode).toLowerCase(Locale.ROOT);
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/Strings.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/Strings.java
@@ -15,7 +15,9 @@
  */
 package com.datastax.oss.driver.internal.core.util;
 
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
+import java.util.Locale;
 
 public class Strings {
 
@@ -230,8 +232,9 @@ public class Strings {
     return new String(result);
   }
 
-  private static boolean isReservedCqlKeyword(String id) {
-    return id != null && RESERVED_KEYWORDS.contains(id.toLowerCase());
+  @VisibleForTesting
+  static boolean isReservedCqlKeyword(String id) {
+    return id != null && RESERVED_KEYWORDS.contains(id.toLowerCase(Locale.ROOT));
   }
 
   /**

--- a/core/src/test/java/com/datastax/oss/driver/TestDataProviders.java
+++ b/core/src/test/java/com/datastax/oss/driver/TestDataProviders.java
@@ -17,6 +17,7 @@ package com.datastax.oss.driver;
 
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import java.util.Arrays;
+import java.util.Locale;
 
 public class TestDataProviders {
 
@@ -82,5 +83,25 @@ public class TestDataProviders {
   @DataProvider
   public static Object[][] booleans() {
     return fromList(true, false);
+  }
+
+  /** An arbitrary set of locales to use when testing locale-sensitive operations. */
+  @DataProvider
+  public static Object[][] locales() {
+    return new Object[][] {
+      new Object[] {Locale.US},
+      // non-latin alphabets
+      new Object[] {Locale.CHINA},
+      new Object[] {Locale.JAPAN},
+      new Object[] {Locale.KOREA},
+      new Object[] {new Locale("gr") /* greek */},
+      new Object[] {new Locale("ar") /* arabic */},
+      // latin-based alphabets with extended character sets
+      new Object[] {new Locale("vi") /* vietnamese */},
+      // JAVA-2883: Turkish is the most problematic locale as String.toLowerCase("TITLE")
+      // wouldn't return "title" but rather  "tıtle", where 'ı' is the 'LATIN SMALL LETTER
+      // DOTLESS I' character specific to the Turkish language.
+      new Object[] {new Locale("tr") /* turkish*/},
+    };
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/api/core/data/CqlDurationTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/data/CqlDurationTest.java
@@ -19,92 +19,119 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
+import com.datastax.oss.driver.TestDataProviders;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.UnsupportedTemporalTypeException;
+import java.util.Locale;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(DataProviderRunner.class)
 public class CqlDurationTest {
 
   @Test
-  public void should_parse_from_string_with_standard_pattern() {
-    assertThat(CqlDuration.from("1y2mo")).isEqualTo(CqlDuration.newInstance(14, 0, 0));
-    assertThat(CqlDuration.from("-1y2mo")).isEqualTo(CqlDuration.newInstance(-14, 0, 0));
-    assertThat(CqlDuration.from("1Y2MO")).isEqualTo(CqlDuration.newInstance(14, 0, 0));
-    assertThat(CqlDuration.from("2w")).isEqualTo(CqlDuration.newInstance(0, 14, 0));
-    assertThat(CqlDuration.from("2d10h"))
-        .isEqualTo(CqlDuration.newInstance(0, 2, 10 * CqlDuration.NANOS_PER_HOUR));
-    assertThat(CqlDuration.from("2d")).isEqualTo(CqlDuration.newInstance(0, 2, 0));
-    assertThat(CqlDuration.from("30h"))
-        .isEqualTo(CqlDuration.newInstance(0, 0, 30 * CqlDuration.NANOS_PER_HOUR));
-    assertThat(CqlDuration.from("30h20m"))
-        .isEqualTo(
-            CqlDuration.newInstance(
-                0, 0, 30 * CqlDuration.NANOS_PER_HOUR + 20 * CqlDuration.NANOS_PER_MINUTE));
-    assertThat(CqlDuration.from("20m"))
-        .isEqualTo(CqlDuration.newInstance(0, 0, 20 * CqlDuration.NANOS_PER_MINUTE));
-    assertThat(CqlDuration.from("56s"))
-        .isEqualTo(CqlDuration.newInstance(0, 0, 56 * CqlDuration.NANOS_PER_SECOND));
-    assertThat(CqlDuration.from("567ms"))
-        .isEqualTo(CqlDuration.newInstance(0, 0, 567 * CqlDuration.NANOS_PER_MILLI));
-    assertThat(CqlDuration.from("1950us"))
-        .isEqualTo(CqlDuration.newInstance(0, 0, 1950 * CqlDuration.NANOS_PER_MICRO));
-    assertThat(CqlDuration.from("1950µs"))
-        .isEqualTo(CqlDuration.newInstance(0, 0, 1950 * CqlDuration.NANOS_PER_MICRO));
-    assertThat(CqlDuration.from("1950000ns")).isEqualTo(CqlDuration.newInstance(0, 0, 1950000));
-    assertThat(CqlDuration.from("1950000NS")).isEqualTo(CqlDuration.newInstance(0, 0, 1950000));
-    assertThat(CqlDuration.from("-1950000ns")).isEqualTo(CqlDuration.newInstance(0, 0, -1950000));
-    assertThat(CqlDuration.from("1y3mo2h10m"))
-        .isEqualTo(CqlDuration.newInstance(15, 0, 130 * CqlDuration.NANOS_PER_MINUTE));
+  @UseDataProvider(location = TestDataProviders.class, value = "locales")
+  public void should_parse_from_string_with_standard_pattern(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      assertThat(CqlDuration.from("1y2mo")).isEqualTo(CqlDuration.newInstance(14, 0, 0));
+      assertThat(CqlDuration.from("-1y2mo")).isEqualTo(CqlDuration.newInstance(-14, 0, 0));
+      assertThat(CqlDuration.from("1Y2MO")).isEqualTo(CqlDuration.newInstance(14, 0, 0));
+      assertThat(CqlDuration.from("2w")).isEqualTo(CqlDuration.newInstance(0, 14, 0));
+      assertThat(CqlDuration.from("2d10h"))
+          .isEqualTo(CqlDuration.newInstance(0, 2, 10 * CqlDuration.NANOS_PER_HOUR));
+      assertThat(CqlDuration.from("2d")).isEqualTo(CqlDuration.newInstance(0, 2, 0));
+      assertThat(CqlDuration.from("30h"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 30 * CqlDuration.NANOS_PER_HOUR));
+      assertThat(CqlDuration.from("30h20m"))
+          .isEqualTo(
+              CqlDuration.newInstance(
+                  0, 0, 30 * CqlDuration.NANOS_PER_HOUR + 20 * CqlDuration.NANOS_PER_MINUTE));
+      assertThat(CqlDuration.from("20m"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 20 * CqlDuration.NANOS_PER_MINUTE));
+      assertThat(CqlDuration.from("56s"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 56 * CqlDuration.NANOS_PER_SECOND));
+      assertThat(CqlDuration.from("567ms"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 567 * CqlDuration.NANOS_PER_MILLI));
+      assertThat(CqlDuration.from("1950us"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 1950 * CqlDuration.NANOS_PER_MICRO));
+      assertThat(CqlDuration.from("1950µs"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 1950 * CqlDuration.NANOS_PER_MICRO));
+      assertThat(CqlDuration.from("1950000ns")).isEqualTo(CqlDuration.newInstance(0, 0, 1950000));
+      assertThat(CqlDuration.from("1950000NS")).isEqualTo(CqlDuration.newInstance(0, 0, 1950000));
+      assertThat(CqlDuration.from("-1950000ns")).isEqualTo(CqlDuration.newInstance(0, 0, -1950000));
+      assertThat(CqlDuration.from("1y3mo2h10m"))
+          .isEqualTo(CqlDuration.newInstance(15, 0, 130 * CqlDuration.NANOS_PER_MINUTE));
+    } finally {
+      Locale.setDefault(def);
+    }
   }
 
   @Test
-  public void should_parse_from_string_with_iso8601_pattern() {
-    assertThat(CqlDuration.from("P1Y2D")).isEqualTo(CqlDuration.newInstance(12, 2, 0));
-    assertThat(CqlDuration.from("P1Y2M")).isEqualTo(CqlDuration.newInstance(14, 0, 0));
-    assertThat(CqlDuration.from("P2W")).isEqualTo(CqlDuration.newInstance(0, 14, 0));
-    assertThat(CqlDuration.from("P1YT2H"))
-        .isEqualTo(CqlDuration.newInstance(12, 0, 2 * CqlDuration.NANOS_PER_HOUR));
-    assertThat(CqlDuration.from("-P1Y2M")).isEqualTo(CqlDuration.newInstance(-14, 0, 0));
-    assertThat(CqlDuration.from("P2D")).isEqualTo(CqlDuration.newInstance(0, 2, 0));
-    assertThat(CqlDuration.from("PT30H"))
-        .isEqualTo(CqlDuration.newInstance(0, 0, 30 * CqlDuration.NANOS_PER_HOUR));
-    assertThat(CqlDuration.from("PT30H20M"))
-        .isEqualTo(
-            CqlDuration.newInstance(
-                0, 0, 30 * CqlDuration.NANOS_PER_HOUR + 20 * CqlDuration.NANOS_PER_MINUTE));
-    assertThat(CqlDuration.from("PT20M"))
-        .isEqualTo(CqlDuration.newInstance(0, 0, 20 * CqlDuration.NANOS_PER_MINUTE));
-    assertThat(CqlDuration.from("PT56S"))
-        .isEqualTo(CqlDuration.newInstance(0, 0, 56 * CqlDuration.NANOS_PER_SECOND));
-    assertThat(CqlDuration.from("P1Y3MT2H10M"))
-        .isEqualTo(CqlDuration.newInstance(15, 0, 130 * CqlDuration.NANOS_PER_MINUTE));
+  @UseDataProvider(location = TestDataProviders.class, value = "locales")
+  public void should_parse_from_string_with_iso8601_pattern(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      assertThat(CqlDuration.from("P1Y2D")).isEqualTo(CqlDuration.newInstance(12, 2, 0));
+      assertThat(CqlDuration.from("P1Y2M")).isEqualTo(CqlDuration.newInstance(14, 0, 0));
+      assertThat(CqlDuration.from("P2W")).isEqualTo(CqlDuration.newInstance(0, 14, 0));
+      assertThat(CqlDuration.from("P1YT2H"))
+          .isEqualTo(CqlDuration.newInstance(12, 0, 2 * CqlDuration.NANOS_PER_HOUR));
+      assertThat(CqlDuration.from("-P1Y2M")).isEqualTo(CqlDuration.newInstance(-14, 0, 0));
+      assertThat(CqlDuration.from("P2D")).isEqualTo(CqlDuration.newInstance(0, 2, 0));
+      assertThat(CqlDuration.from("PT30H"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 30 * CqlDuration.NANOS_PER_HOUR));
+      assertThat(CqlDuration.from("PT30H20M"))
+          .isEqualTo(
+              CqlDuration.newInstance(
+                  0, 0, 30 * CqlDuration.NANOS_PER_HOUR + 20 * CqlDuration.NANOS_PER_MINUTE));
+      assertThat(CqlDuration.from("PT20M"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 20 * CqlDuration.NANOS_PER_MINUTE));
+      assertThat(CqlDuration.from("PT56S"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 56 * CqlDuration.NANOS_PER_SECOND));
+      assertThat(CqlDuration.from("P1Y3MT2H10M"))
+          .isEqualTo(CqlDuration.newInstance(15, 0, 130 * CqlDuration.NANOS_PER_MINUTE));
+    } finally {
+      Locale.setDefault(def);
+    }
   }
 
   @Test
-  public void should_parse_from_string_with_iso8601_alternative_pattern() {
-    assertThat(CqlDuration.from("P0001-00-02T00:00:00"))
-        .isEqualTo(CqlDuration.newInstance(12, 2, 0));
-    assertThat(CqlDuration.from("P0001-02-00T00:00:00"))
-        .isEqualTo(CqlDuration.newInstance(14, 0, 0));
-    assertThat(CqlDuration.from("P0001-00-00T02:00:00"))
-        .isEqualTo(CqlDuration.newInstance(12, 0, 2 * CqlDuration.NANOS_PER_HOUR));
-    assertThat(CqlDuration.from("-P0001-02-00T00:00:00"))
-        .isEqualTo(CqlDuration.newInstance(-14, 0, 0));
-    assertThat(CqlDuration.from("P0000-00-02T00:00:00"))
-        .isEqualTo(CqlDuration.newInstance(0, 2, 0));
-    assertThat(CqlDuration.from("P0000-00-00T30:00:00"))
-        .isEqualTo(CqlDuration.newInstance(0, 0, 30 * CqlDuration.NANOS_PER_HOUR));
-    assertThat(CqlDuration.from("P0000-00-00T30:20:00"))
-        .isEqualTo(
-            CqlDuration.newInstance(
-                0, 0, 30 * CqlDuration.NANOS_PER_HOUR + 20 * CqlDuration.NANOS_PER_MINUTE));
-    assertThat(CqlDuration.from("P0000-00-00T00:20:00"))
-        .isEqualTo(CqlDuration.newInstance(0, 0, 20 * CqlDuration.NANOS_PER_MINUTE));
-    assertThat(CqlDuration.from("P0000-00-00T00:00:56"))
-        .isEqualTo(CqlDuration.newInstance(0, 0, 56 * CqlDuration.NANOS_PER_SECOND));
-    assertThat(CqlDuration.from("P0001-03-00T02:10:00"))
-        .isEqualTo(CqlDuration.newInstance(15, 0, 130 * CqlDuration.NANOS_PER_MINUTE));
+  @UseDataProvider(location = TestDataProviders.class, value = "locales")
+  public void should_parse_from_string_with_iso8601_alternative_pattern(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      assertThat(CqlDuration.from("P0001-00-02T00:00:00"))
+          .isEqualTo(CqlDuration.newInstance(12, 2, 0));
+      assertThat(CqlDuration.from("P0001-02-00T00:00:00"))
+          .isEqualTo(CqlDuration.newInstance(14, 0, 0));
+      assertThat(CqlDuration.from("P0001-00-00T02:00:00"))
+          .isEqualTo(CqlDuration.newInstance(12, 0, 2 * CqlDuration.NANOS_PER_HOUR));
+      assertThat(CqlDuration.from("-P0001-02-00T00:00:00"))
+          .isEqualTo(CqlDuration.newInstance(-14, 0, 0));
+      assertThat(CqlDuration.from("P0000-00-02T00:00:00"))
+          .isEqualTo(CqlDuration.newInstance(0, 2, 0));
+      assertThat(CqlDuration.from("P0000-00-00T30:00:00"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 30 * CqlDuration.NANOS_PER_HOUR));
+      assertThat(CqlDuration.from("P0000-00-00T30:20:00"))
+          .isEqualTo(
+              CqlDuration.newInstance(
+                  0, 0, 30 * CqlDuration.NANOS_PER_HOUR + 20 * CqlDuration.NANOS_PER_MINUTE));
+      assertThat(CqlDuration.from("P0000-00-00T00:20:00"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 20 * CqlDuration.NANOS_PER_MINUTE));
+      assertThat(CqlDuration.from("P0000-00-00T00:00:56"))
+          .isEqualTo(CqlDuration.newInstance(0, 0, 56 * CqlDuration.NANOS_PER_SECOND));
+      assertThat(CqlDuration.from("P0001-03-00T02:10:00"))
+          .isEqualTo(CqlDuration.newInstance(15, 0, 130 * CqlDuration.NANOS_PER_MINUTE));
+    } finally {
+      Locale.setDefault(def);
+    }
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/data/IdentifierIndexTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/data/IdentifierIndexTest.java
@@ -17,10 +17,16 @@ package com.datastax.oss.driver.internal.core.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.datastax.oss.driver.TestDataProviders;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import java.util.Locale;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(DataProviderRunner.class)
 public class IdentifierIndexTest {
   private static final CqlIdentifier Foo = CqlIdentifier.fromInternal("Foo");
   private static final CqlIdentifier foo = CqlIdentifier.fromInternal("foo");
@@ -41,13 +47,31 @@ public class IdentifierIndexTest {
   }
 
   @Test
-  public void should_find_first_index_of_case_insensitive_name() {
-    assertThat(index.firstIndexOf("foo")).isEqualTo(0);
+  @UseDataProvider(location = TestDataProviders.class, value = "locales")
+  public void should_find_first_index_of_case_insensitive_name(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      assertThat(index.firstIndexOf("foo")).isEqualTo(0);
+      assertThat(index.firstIndexOf("FOO")).isEqualTo(0);
+      assertThat(index.firstIndexOf("fOO")).isEqualTo(0);
+    } finally {
+      Locale.setDefault(def);
+    }
   }
 
   @Test
-  public void should_not_find_first_index_of_nonexistent_case_insensitive_name() {
-    assertThat(index.firstIndexOf("bar")).isEqualTo(-1);
+  @UseDataProvider(location = TestDataProviders.class, value = "locales")
+  public void should_not_find_first_index_of_nonexistent_case_insensitive_name(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      assertThat(index.firstIndexOf("bar")).isEqualTo(-1);
+      assertThat(index.firstIndexOf("BAR")).isEqualTo(-1);
+      assertThat(index.firstIndexOf("bAR")).isEqualTo(-1);
+    } finally {
+      Locale.setDefault(def);
+    }
   }
 
   @Test
@@ -75,13 +99,31 @@ public class IdentifierIndexTest {
   }
 
   @Test
-  public void should_all_indices_of_case_insensitive_name() {
-    assertThat(index.allIndicesOf("foo")).containsExactly(0, 1, 2, 3, 4, 5);
+  @UseDataProvider(location = TestDataProviders.class, value = "locales")
+  public void should_find_all_indices_of_case_insensitive_name(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      assertThat(index.allIndicesOf("foo")).containsExactly(0, 1, 2, 3, 4, 5);
+      assertThat(index.allIndicesOf("FOO")).containsExactly(0, 1, 2, 3, 4, 5);
+      assertThat(index.allIndicesOf("fOO")).containsExactly(0, 1, 2, 3, 4, 5);
+    } finally {
+      Locale.setDefault(def);
+    }
   }
 
   @Test
-  public void should_not_find_indices_of_nonexistent_case_insensitive_name() {
-    assertThat(index.allIndicesOf("bar")).isEmpty();
+  @UseDataProvider(location = TestDataProviders.class, value = "locales")
+  public void should_not_find_indices_of_nonexistent_case_insensitive_name(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      assertThat(index.allIndicesOf("bar")).isEmpty();
+      assertThat(index.allIndicesOf("BAR")).isEmpty();
+      assertThat(index.allIndicesOf("bAR")).isEmpty();
+    } finally {
+      Locale.setDefault(def);
+    }
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/DataTypeClassNameParserTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/DataTypeClassNameParserTest.java
@@ -19,6 +19,7 @@ import static com.datastax.oss.driver.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.datastax.oss.driver.TestDataProviders;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.driver.api.core.type.DataTypes;
@@ -27,14 +28,17 @@ import com.datastax.oss.driver.api.core.type.TupleType;
 import com.datastax.oss.driver.api.core.type.UserDefinedType;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import java.util.Locale;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(DataProviderRunner.class)
 public class DataTypeClassNameParserTest {
 
   private static final CqlIdentifier KEYSPACE_ID = CqlIdentifier.fromInternal("ks");
@@ -44,131 +48,167 @@ public class DataTypeClassNameParserTest {
 
   @Before
   public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
     parser = new DataTypeClassNameParser();
   }
 
   @Test
-  public void should_parse_native_types() {
-    for (Map.Entry<String, DataType> entry :
-        DataTypeClassNameParser.NATIVE_TYPES_BY_CLASS_NAME.entrySet()) {
+  @UseDataProvider(location = TestDataProviders.class, value = "locales")
+  public void should_parse_native_types(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      for (Map.Entry<String, DataType> entry :
+          DataTypeClassNameParser.NATIVE_TYPES_BY_CLASS_NAME.entrySet()) {
 
-      String className = entry.getKey();
-      DataType expectedType = entry.getValue();
+        String className = entry.getKey();
+        DataType expectedType = entry.getValue();
 
-      assertThat(parse(className)).isEqualTo(expectedType);
+        assertThat(parse(className)).isEqualTo(expectedType);
+      }
+    } finally {
+      Locale.setDefault(def);
     }
   }
 
   @Test
-  public void should_parse_collection_types() {
-    assertThat(
-            parse(
-                "org.apache.cassandra.db.marshal.ListType("
-                    + "org.apache.cassandra.db.marshal.UTF8Type)"))
-        .isEqualTo(DataTypes.listOf(DataTypes.TEXT));
+  @UseDataProvider(location = TestDataProviders.class, value = "locales")
+  public void should_parse_collection_types(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      assertThat(
+              parse(
+                  "org.apache.cassandra.db.marshal.ListType("
+                      + "org.apache.cassandra.db.marshal.UTF8Type)"))
+          .isEqualTo(DataTypes.listOf(DataTypes.TEXT));
 
-    assertThat(
-            parse(
-                "org.apache.cassandra.db.marshal.FrozenType("
-                    + ("org.apache.cassandra.db.marshal.ListType("
-                        + "org.apache.cassandra.db.marshal.UTF8Type))")))
-        .isEqualTo(DataTypes.frozenListOf(DataTypes.TEXT));
+      assertThat(
+              parse(
+                  "org.apache.cassandra.db.marshal.FrozenType("
+                      + ("org.apache.cassandra.db.marshal.ListType("
+                          + "org.apache.cassandra.db.marshal.UTF8Type))")))
+          .isEqualTo(DataTypes.frozenListOf(DataTypes.TEXT));
 
-    assertThat(
-            parse(
-                "org.apache.cassandra.db.marshal.SetType("
-                    + "org.apache.cassandra.db.marshal.UTF8Type)"))
-        .isEqualTo(DataTypes.setOf(DataTypes.TEXT));
+      assertThat(
+              parse(
+                  "org.apache.cassandra.db.marshal.SetType("
+                      + "org.apache.cassandra.db.marshal.UTF8Type)"))
+          .isEqualTo(DataTypes.setOf(DataTypes.TEXT));
 
-    assertThat(
-            parse(
-                "org.apache.cassandra.db.marshal.MapType("
-                    + "org.apache.cassandra.db.marshal.UTF8Type,"
-                    + "org.apache.cassandra.db.marshal.UTF8Type)"))
-        .isEqualTo(DataTypes.mapOf(DataTypes.TEXT, DataTypes.TEXT));
+      assertThat(
+              parse(
+                  "org.apache.cassandra.db.marshal.MapType("
+                      + "org.apache.cassandra.db.marshal.UTF8Type,"
+                      + "org.apache.cassandra.db.marshal.UTF8Type)"))
+          .isEqualTo(DataTypes.mapOf(DataTypes.TEXT, DataTypes.TEXT));
 
-    assertThat(
-            parse(
-                "org.apache.cassandra.db.marshal.MapType("
-                    + "org.apache.cassandra.db.marshal.UTF8Type,"
-                    + "org.apache.cassandra.db.marshal.FrozenType("
-                    + ("org.apache.cassandra.db.marshal.MapType("
-                        + "org.apache.cassandra.db.marshal.Int32Type,"
-                        + "org.apache.cassandra.db.marshal.Int32Type)))")))
-        .isEqualTo(
-            DataTypes.mapOf(DataTypes.TEXT, DataTypes.frozenMapOf(DataTypes.INT, DataTypes.INT)));
+      assertThat(
+              parse(
+                  "org.apache.cassandra.db.marshal.MapType("
+                      + "org.apache.cassandra.db.marshal.UTF8Type,"
+                      + "org.apache.cassandra.db.marshal.FrozenType("
+                      + ("org.apache.cassandra.db.marshal.MapType("
+                          + "org.apache.cassandra.db.marshal.Int32Type,"
+                          + "org.apache.cassandra.db.marshal.Int32Type)))")))
+          .isEqualTo(
+              DataTypes.mapOf(DataTypes.TEXT, DataTypes.frozenMapOf(DataTypes.INT, DataTypes.INT)));
+    } finally {
+      Locale.setDefault(def);
+    }
   }
 
   @Test
-  public void should_parse_user_type_when_definition_not_already_available() {
-    UserDefinedType addressType =
-        (UserDefinedType)
-            parse(
-                "org.apache.cassandra.db.marshal.UserType("
-                    + "foo,61646472657373,"
-                    + ("737472656574:org.apache.cassandra.db.marshal.UTF8Type,"
-                        + "7a6970636f6465:org.apache.cassandra.db.marshal.Int32Type,"
-                        + ("70686f6e6573:org.apache.cassandra.db.marshal.SetType("
-                            + "org.apache.cassandra.db.marshal.UserType(foo,70686f6e65,"
-                            + "6e616d65:org.apache.cassandra.db.marshal.UTF8Type,"
-                            + "6e756d626572:org.apache.cassandra.db.marshal.UTF8Type)")
-                        + "))"));
+  @UseDataProvider(location = TestDataProviders.class, value = "locales")
+  public void should_parse_user_type_when_definition_not_already_available(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      UserDefinedType addressType =
+          (UserDefinedType)
+              parse(
+                  "org.apache.cassandra.db.marshal.UserType("
+                      + "foo,61646472657373,"
+                      + ("737472656574:org.apache.cassandra.db.marshal.UTF8Type,"
+                          + "7a6970636f6465:org.apache.cassandra.db.marshal.Int32Type,"
+                          + ("70686f6e6573:org.apache.cassandra.db.marshal.SetType("
+                              + "org.apache.cassandra.db.marshal.UserType(foo,70686f6e65,"
+                              + "6e616d65:org.apache.cassandra.db.marshal.UTF8Type,"
+                              + "6e756d626572:org.apache.cassandra.db.marshal.UTF8Type)")
+                          + "))"));
 
-    assertThat(addressType.getKeyspace().asInternal()).isEqualTo("foo");
-    assertThat(addressType.getName().asInternal()).isEqualTo("address");
-    assertThat(addressType.isFrozen()).isTrue();
-    assertThat(addressType.getFieldNames().size()).isEqualTo(3);
+      assertThat(addressType.getKeyspace().asInternal()).isEqualTo("foo");
+      assertThat(addressType.getName().asInternal()).isEqualTo("address");
+      assertThat(addressType.isFrozen()).isTrue();
+      assertThat(addressType.getFieldNames().size()).isEqualTo(3);
 
-    assertThat(addressType.getFieldNames().get(0).asInternal()).isEqualTo("street");
-    assertThat(addressType.getFieldTypes().get(0)).isEqualTo(DataTypes.TEXT);
+      assertThat(addressType.getFieldNames().get(0).asInternal()).isEqualTo("street");
+      assertThat(addressType.getFieldTypes().get(0)).isEqualTo(DataTypes.TEXT);
 
-    assertThat(addressType.getFieldNames().get(1).asInternal()).isEqualTo("zipcode");
-    assertThat(addressType.getFieldTypes().get(1)).isEqualTo(DataTypes.INT);
+      assertThat(addressType.getFieldNames().get(1).asInternal()).isEqualTo("zipcode");
+      assertThat(addressType.getFieldTypes().get(1)).isEqualTo(DataTypes.INT);
 
-    assertThat(addressType.getFieldNames().get(2).asInternal()).isEqualTo("phones");
-    DataType phonesType = addressType.getFieldTypes().get(2);
-    assertThat(phonesType).isInstanceOf(SetType.class);
-    UserDefinedType phoneType = ((UserDefinedType) ((SetType) phonesType).getElementType());
+      assertThat(addressType.getFieldNames().get(2).asInternal()).isEqualTo("phones");
+      DataType phonesType = addressType.getFieldTypes().get(2);
+      assertThat(phonesType).isInstanceOf(SetType.class);
+      UserDefinedType phoneType = ((UserDefinedType) ((SetType) phonesType).getElementType());
 
-    assertThat(phoneType.getKeyspace().asInternal()).isEqualTo("foo");
-    assertThat(phoneType.getName().asInternal()).isEqualTo("phone");
-    assertThat(phoneType.isFrozen()).isTrue();
-    assertThat(phoneType.getFieldNames().size()).isEqualTo(2);
+      assertThat(phoneType.getKeyspace().asInternal()).isEqualTo("foo");
+      assertThat(phoneType.getName().asInternal()).isEqualTo("phone");
+      assertThat(phoneType.isFrozen()).isTrue();
+      assertThat(phoneType.getFieldNames().size()).isEqualTo(2);
 
-    assertThat(phoneType.getFieldNames().get(0).asInternal()).isEqualTo("name");
-    assertThat(phoneType.getFieldTypes().get(0)).isEqualTo(DataTypes.TEXT);
+      assertThat(phoneType.getFieldNames().get(0).asInternal()).isEqualTo("name");
+      assertThat(phoneType.getFieldTypes().get(0)).isEqualTo(DataTypes.TEXT);
 
-    assertThat(phoneType.getFieldNames().get(1).asInternal()).isEqualTo("number");
-    assertThat(phoneType.getFieldTypes().get(1)).isEqualTo(DataTypes.TEXT);
+      assertThat(phoneType.getFieldNames().get(1).asInternal()).isEqualTo("number");
+      assertThat(phoneType.getFieldTypes().get(1)).isEqualTo(DataTypes.TEXT);
+    } finally {
+      Locale.setDefault(def);
+    }
   }
 
   @Test
-  public void should_make_a_frozen_copy_user_type_when_definition_already_available() {
-    UserDefinedType existing = mock(UserDefinedType.class);
+  @UseDataProvider(location = TestDataProviders.class, value = "locales")
+  public void should_make_a_frozen_copy_user_type_when_definition_already_available(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      UserDefinedType existing = mock(UserDefinedType.class);
 
-    parse(
-        "org.apache.cassandra.db.marshal.UserType(foo,70686f6e65,"
-            + "6e616d65:org.apache.cassandra.db.marshal.UTF8Type,"
-            + "6e756d626572:org.apache.cassandra.db.marshal.UTF8Type)",
-        ImmutableMap.of(CqlIdentifier.fromInternal("phone"), existing));
+      parse(
+          "org.apache.cassandra.db.marshal.UserType(foo,70686f6e65,"
+              + "6e616d65:org.apache.cassandra.db.marshal.UTF8Type,"
+              + "6e756d626572:org.apache.cassandra.db.marshal.UTF8Type)",
+          ImmutableMap.of(CqlIdentifier.fromInternal("phone"), existing));
 
-    verify(existing).copy(true);
+      verify(existing).copy(true);
+    } finally {
+      Locale.setDefault(def);
+    }
   }
 
   @Test
-  public void should_parse_tuple() {
-    TupleType tupleType =
-        (TupleType)
-            parse(
-                "org.apache.cassandra.db.marshal.TupleType("
-                    + "org.apache.cassandra.db.marshal.Int32Type,"
-                    + "org.apache.cassandra.db.marshal.UTF8Type,"
-                    + "org.apache.cassandra.db.marshal.FloatType)");
+  @UseDataProvider(location = TestDataProviders.class, value = "locales")
+  public void should_parse_tuple(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      TupleType tupleType =
+          (TupleType)
+              parse(
+                  "org.apache.cassandra.db.marshal.TupleType("
+                      + "org.apache.cassandra.db.marshal.Int32Type,"
+                      + "org.apache.cassandra.db.marshal.UTF8Type,"
+                      + "org.apache.cassandra.db.marshal.FloatType)");
 
-    assertThat(tupleType.getComponentTypes().size()).isEqualTo(3);
-    assertThat(tupleType.getComponentTypes().get(0)).isEqualTo(DataTypes.INT);
-    assertThat(tupleType.getComponentTypes().get(1)).isEqualTo(DataTypes.TEXT);
-    assertThat(tupleType.getComponentTypes().get(2)).isEqualTo(DataTypes.FLOAT);
+      assertThat(tupleType.getComponentTypes().size()).isEqualTo(3);
+      assertThat(tupleType.getComponentTypes().get(0)).isEqualTo(DataTypes.INT);
+      assertThat(tupleType.getComponentTypes().get(1)).isEqualTo(DataTypes.TEXT);
+      assertThat(tupleType.getComponentTypes().get(2)).isEqualTo(DataTypes.FLOAT);
+    } finally {
+      Locale.setDefault(def);
+    }
   }
 
   private DataType parse(String toParse) {

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/protocol/BuiltInCompressorsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/protocol/BuiltInCompressorsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.datastax.oss.driver.TestDataProviders;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.protocol.internal.NoopCompressor;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import java.util.Locale;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(DataProviderRunner.class)
+public class BuiltInCompressorsTest {
+
+  @Mock private DriverContext context;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  @UseDataProvider(location = TestDataProviders.class, value = "locales")
+  public void should_create_instance_for_supported_algorithms(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      assertThat(BuiltInCompressors.newInstance("lz4", context)).isInstanceOf(Lz4Compressor.class);
+      assertThat(BuiltInCompressors.newInstance("snappy", context))
+          .isInstanceOf(SnappyCompressor.class);
+      assertThat(BuiltInCompressors.newInstance("none", context))
+          .isInstanceOf(NoopCompressor.class);
+      assertThat(BuiltInCompressors.newInstance("LZ4", context)).isInstanceOf(Lz4Compressor.class);
+      assertThat(BuiltInCompressors.newInstance("SNAPPY", context))
+          .isInstanceOf(SnappyCompressor.class);
+      assertThat(BuiltInCompressors.newInstance("NONE", context))
+          .isInstanceOf(NoopCompressor.class);
+    } finally {
+      Locale.setDefault(def);
+    }
+  }
+
+  @Test
+  public void should_throw_when_unsupported_algorithm() {
+    assertThatThrownBy(() -> BuiltInCompressors.newInstance("GZIP", context))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unsupported compression algorithm 'GZIP'");
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/PrimitiveTypeTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/PrimitiveTypeTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.TestDataProviders;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import java.util.Locale;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(DataProviderRunner.class)
+public class PrimitiveTypeTest {
+
+  @Test
+  public void should_report_protocol_code() {
+    assertThat(DataTypes.ASCII.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.ASCII);
+    assertThat(DataTypes.BIGINT.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.BIGINT);
+    assertThat(DataTypes.BLOB.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.BLOB);
+    assertThat(DataTypes.BOOLEAN.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.BOOLEAN);
+    assertThat(DataTypes.COUNTER.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.COUNTER);
+    assertThat(DataTypes.DECIMAL.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.DECIMAL);
+    assertThat(DataTypes.DOUBLE.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.DOUBLE);
+    assertThat(DataTypes.FLOAT.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.FLOAT);
+    assertThat(DataTypes.INT.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.INT);
+    assertThat(DataTypes.TIMESTAMP.getProtocolCode())
+        .isEqualTo(ProtocolConstants.DataType.TIMESTAMP);
+    assertThat(DataTypes.UUID.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.UUID);
+    assertThat(DataTypes.VARINT.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.VARINT);
+    assertThat(DataTypes.TIMEUUID.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.TIMEUUID);
+    assertThat(DataTypes.INET.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.INET);
+    assertThat(DataTypes.DATE.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.DATE);
+    assertThat(DataTypes.TEXT.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.VARCHAR);
+    assertThat(DataTypes.TIME.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.TIME);
+    assertThat(DataTypes.SMALLINT.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.SMALLINT);
+    assertThat(DataTypes.TINYINT.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.TINYINT);
+    assertThat(DataTypes.DURATION.getProtocolCode()).isEqualTo(ProtocolConstants.DataType.DURATION);
+  }
+
+  @Test
+  @UseDataProvider(location = TestDataProviders.class, value = "locales")
+  public void should_format_as_cql(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      assertThat(DataTypes.ASCII.asCql(true, true)).isEqualTo("ascii");
+      assertThat(DataTypes.BIGINT.asCql(true, true)).isEqualTo("bigint");
+      assertThat(DataTypes.BLOB.asCql(true, true)).isEqualTo("blob");
+      assertThat(DataTypes.BOOLEAN.asCql(true, true)).isEqualTo("boolean");
+      assertThat(DataTypes.COUNTER.asCql(true, true)).isEqualTo("counter");
+      assertThat(DataTypes.DECIMAL.asCql(true, true)).isEqualTo("decimal");
+      assertThat(DataTypes.DOUBLE.asCql(true, true)).isEqualTo("double");
+      assertThat(DataTypes.FLOAT.asCql(true, true)).isEqualTo("float");
+      assertThat(DataTypes.INT.asCql(true, true)).isEqualTo("int");
+      assertThat(DataTypes.TIMESTAMP.asCql(true, true)).isEqualTo("timestamp");
+      assertThat(DataTypes.UUID.asCql(true, true)).isEqualTo("uuid");
+      assertThat(DataTypes.VARINT.asCql(true, true)).isEqualTo("varint");
+      assertThat(DataTypes.TIMEUUID.asCql(true, true)).isEqualTo("timeuuid");
+      assertThat(DataTypes.INET.asCql(true, true)).isEqualTo("inet");
+      assertThat(DataTypes.DATE.asCql(true, true)).isEqualTo("date");
+      assertThat(DataTypes.TEXT.asCql(true, true)).isEqualTo("text");
+      assertThat(DataTypes.TIME.asCql(true, true)).isEqualTo("time");
+      assertThat(DataTypes.SMALLINT.asCql(true, true)).isEqualTo("smallint");
+      assertThat(DataTypes.TINYINT.asCql(true, true)).isEqualTo("tinyint");
+      assertThat(DataTypes.DURATION.asCql(true, true)).isEqualTo("duration");
+    } finally {
+      Locale.setDefault(def);
+    }
+  }
+
+  @Test
+  @UseDataProvider(location = TestDataProviders.class, value = "locales")
+  public void should_format_as_string(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+      assertThat(DataTypes.ASCII.toString()).isEqualTo("ASCII");
+      assertThat(DataTypes.BIGINT.toString()).isEqualTo("BIGINT");
+      assertThat(DataTypes.BLOB.toString()).isEqualTo("BLOB");
+      assertThat(DataTypes.BOOLEAN.toString()).isEqualTo("BOOLEAN");
+      assertThat(DataTypes.COUNTER.toString()).isEqualTo("COUNTER");
+      assertThat(DataTypes.DECIMAL.toString()).isEqualTo("DECIMAL");
+      assertThat(DataTypes.DOUBLE.toString()).isEqualTo("DOUBLE");
+      assertThat(DataTypes.FLOAT.toString()).isEqualTo("FLOAT");
+      assertThat(DataTypes.INT.toString()).isEqualTo("INT");
+      assertThat(DataTypes.TIMESTAMP.toString()).isEqualTo("TIMESTAMP");
+      assertThat(DataTypes.UUID.toString()).isEqualTo("UUID");
+      assertThat(DataTypes.VARINT.toString()).isEqualTo("VARINT");
+      assertThat(DataTypes.TIMEUUID.toString()).isEqualTo("TIMEUUID");
+      assertThat(DataTypes.INET.toString()).isEqualTo("INET");
+      assertThat(DataTypes.DATE.toString()).isEqualTo("DATE");
+      assertThat(DataTypes.TEXT.toString()).isEqualTo("TEXT");
+      assertThat(DataTypes.TIME.toString()).isEqualTo("TIME");
+      assertThat(DataTypes.SMALLINT.toString()).isEqualTo("SMALLINT");
+      assertThat(DataTypes.TINYINT.toString()).isEqualTo("TINYINT");
+      assertThat(DataTypes.DURATION.toString()).isEqualTo("DURATION");
+    } finally {
+      Locale.setDefault(def);
+    }
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/util/StringsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/util/StringsTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.TestDataProviders;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import java.util.Locale;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(DataProviderRunner.class)
+public class StringsTest {
+
+  @Test
+  @UseDataProvider(location = TestDataProviders.class, value = "locales")
+  public void should_report_cql_keyword(Locale locale) {
+    Locale def = Locale.getDefault();
+    try {
+      Locale.setDefault(locale);
+
+      assertThat(Strings.isReservedCqlKeyword(null)).isFalse();
+      assertThat(Strings.isReservedCqlKeyword("NOT A RESERVED KEYWORD")).isFalse();
+
+      assertThat(Strings.isReservedCqlKeyword("add")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("allow")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("alter")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("and")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("apply")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("asc")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("authorize")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("batch")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("begin")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("by")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("columnfamily")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("create")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("default")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("delete")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("desc")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("describe")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("drop")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("entries")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("execute")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("from")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("full")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("grant")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("if")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("in")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("index")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("infinity")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("insert")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("into")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("is")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("keyspace")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("limit")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("materialized")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("mbean")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("mbeans")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("modify")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("nan")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("norecursive")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("not")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("null")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("of")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("on")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("or")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("order")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("primary")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("rename")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("replace")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("revoke")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("schema")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("select")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("set")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("table")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("to")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("token")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("truncate")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("unlogged")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("unset")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("update")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("use")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("using")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("view")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("where")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("with")).isTrue();
+
+      assertThat(Strings.isReservedCqlKeyword("ALLOW")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("ALTER")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("AND")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("APPLY")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("ASC")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("AUTHORIZE")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("BATCH")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("BEGIN")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("BY")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("COLUMNFAMILY")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("CREATE")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("DEFAULT")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("DELETE")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("DESC")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("DESCRIBE")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("DROP")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("ENTRIES")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("EXECUTE")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("FROM")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("FULL")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("GRANT")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("IF")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("IN")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("INDEX")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("INFINITY")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("INSERT")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("INTO")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("IS")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("KEYSPACE")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("LIMIT")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("MATERIALIZED")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("MBEAN")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("MBEANS")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("MODIFY")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("NAN")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("NORECURSIVE")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("NOT")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("NULL")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("OF")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("ON")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("OR")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("ORDER")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("PRIMARY")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("RENAME")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("REPLACE")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("REVOKE")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("SCHEMA")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("SELECT")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("SET")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("TABLE")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("TO")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("TOKEN")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("TRUNCATE")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("UNLOGGED")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("UNSET")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("UPDATE")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("USE")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("USING")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("VIEW")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("WHERE")).isTrue();
+      assertThat(Strings.isReservedCqlKeyword("WITH")).isTrue();
+    } finally {
+      Locale.setDefault(def);
+    }
+  }
+}


### PR DESCRIPTION
This commit changes all occurrences of String.toLowerCase() in
production code to use String.toLowerCase(Locale.ROOT) instead.

No occurrences of String.toUpperCase() were found in production
code.