### PR TITLE
JAVA-2889: Remove TypeSafe imports from DriverConfigLoader

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.10.0 (in progress)
 
+- [bug] JAVA-2889: Remove TypeSafe imports from DriverConfigLoader
 - [bug] JAVA-2647: Handle token types in QueryBuilder.literal()
 - [bug] JAVA-2887: Handle composite profiles with more than one key and/or backed by only one profile
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DriverConfigLoader.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DriverConfigLoader.java
@@ -15,16 +15,12 @@
  */
 package com.datastax.oss.driver.api.core.config;
 
-import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.context.DriverContext;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
 import com.datastax.oss.driver.internal.core.config.composite.CompositeDriverConfigLoader;
 import com.datastax.oss.driver.internal.core.config.map.MapBasedDriverConfigLoader;
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader;
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultProgrammaticDriverConfigLoaderBuilder;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import com.typesafe.config.ConfigParseOptions;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
 import java.net.URL;
@@ -92,19 +88,7 @@ public interface DriverConfigLoader extends AutoCloseable {
   @NonNull
   static DriverConfigLoader fromClasspath(
       @NonNull String resourceBaseName, @NonNull ClassLoader appClassLoader) {
-    return new DefaultDriverConfigLoader(
-        () -> {
-          ConfigFactory.invalidateCaches();
-          Config config =
-              ConfigFactory.defaultOverrides()
-                  .withFallback(
-                      ConfigFactory.parseResourcesAnySyntax(
-                          resourceBaseName,
-                          ConfigParseOptions.defaults().setClassLoader(appClassLoader)))
-                  .withFallback(ConfigFactory.defaultReference(CqlSession.class.getClassLoader()))
-                  .resolve();
-          return config.getConfig(DefaultDriverConfigLoader.DEFAULT_ROOT_PATH);
-        });
+    return DefaultDriverConfigLoader.fromClasspath(resourceBaseName, appClassLoader);
   }
 
   /**
@@ -154,16 +138,7 @@ public interface DriverConfigLoader extends AutoCloseable {
    */
   @NonNull
   static DriverConfigLoader fromFile(@NonNull File file) {
-    return new DefaultDriverConfigLoader(
-        () -> {
-          ConfigFactory.invalidateCaches();
-          Config config =
-              ConfigFactory.defaultOverrides()
-                  .withFallback(ConfigFactory.parseFileAnySyntax(file))
-                  .withFallback(ConfigFactory.defaultReference(CqlSession.class.getClassLoader()))
-                  .resolve();
-          return config.getConfig(DefaultDriverConfigLoader.DEFAULT_ROOT_PATH);
-        });
+    return DefaultDriverConfigLoader.fromFile(file);
   }
 
   /**
@@ -188,16 +163,7 @@ public interface DriverConfigLoader extends AutoCloseable {
    */
   @NonNull
   static DriverConfigLoader fromUrl(@NonNull URL url) {
-    return new DefaultDriverConfigLoader(
-        () -> {
-          ConfigFactory.invalidateCaches();
-          Config config =
-              ConfigFactory.defaultOverrides()
-                  .withFallback(ConfigFactory.parseURL(url))
-                  .withFallback(ConfigFactory.defaultReference(CqlSession.class.getClassLoader()))
-                  .resolve();
-          return config.getConfig(DefaultDriverConfigLoader.DEFAULT_ROOT_PATH);
-        });
+    return DefaultDriverConfigLoader.fromUrl(url);
   }
 
   /**
@@ -227,17 +193,7 @@ public interface DriverConfigLoader extends AutoCloseable {
    */
   @NonNull
   static DriverConfigLoader fromString(@NonNull String contents) {
-    return new DefaultDriverConfigLoader(
-        () -> {
-          ConfigFactory.invalidateCaches();
-          Config config =
-              ConfigFactory.defaultOverrides()
-                  .withFallback(ConfigFactory.parseString(contents))
-                  .withFallback(ConfigFactory.defaultReference(CqlSession.class.getClassLoader()))
-                  .resolve();
-          return config.getConfig(DefaultDriverConfigLoader.DEFAULT_ROOT_PATH);
-        },
-        false);
+    return DefaultDriverConfigLoader.fromString(contents);
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/config/typesafe/DefaultDriverConfigLoader.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/config/typesafe/DefaultDriverConfigLoader.java
@@ -30,9 +30,12 @@ import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.driver.internal.core.util.concurrent.RunOrSchedule;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigParseOptions;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.ScheduledFuture;
+import java.io.File;
+import java.net.URL;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -64,6 +67,67 @@ public class DefaultDriverConfigLoader implements DriverConfigLoader {
             .resolve()
             .getConfig(DEFAULT_ROOT_PATH);
       };
+
+  @NonNull
+  public static DefaultDriverConfigLoader fromClasspath(
+      @NonNull String resourceBaseName, @NonNull ClassLoader appClassLoader) {
+    return new DefaultDriverConfigLoader(
+        () -> {
+          ConfigFactory.invalidateCaches();
+          Config config =
+              ConfigFactory.defaultOverrides()
+                  .withFallback(
+                      ConfigFactory.parseResourcesAnySyntax(
+                          resourceBaseName,
+                          ConfigParseOptions.defaults().setClassLoader(appClassLoader)))
+                  .withFallback(ConfigFactory.defaultReference(CqlSession.class.getClassLoader()))
+                  .resolve();
+          return config.getConfig(DEFAULT_ROOT_PATH);
+        });
+  }
+
+  @NonNull
+  public static DriverConfigLoader fromFile(@NonNull File file) {
+    return new DefaultDriverConfigLoader(
+        () -> {
+          ConfigFactory.invalidateCaches();
+          Config config =
+              ConfigFactory.defaultOverrides()
+                  .withFallback(ConfigFactory.parseFileAnySyntax(file))
+                  .withFallback(ConfigFactory.defaultReference(CqlSession.class.getClassLoader()))
+                  .resolve();
+          return config.getConfig(DEFAULT_ROOT_PATH);
+        });
+  }
+
+  @NonNull
+  public static DriverConfigLoader fromUrl(@NonNull URL url) {
+    return new DefaultDriverConfigLoader(
+        () -> {
+          ConfigFactory.invalidateCaches();
+          Config config =
+              ConfigFactory.defaultOverrides()
+                  .withFallback(ConfigFactory.parseURL(url))
+                  .withFallback(ConfigFactory.defaultReference(CqlSession.class.getClassLoader()))
+                  .resolve();
+          return config.getConfig(DEFAULT_ROOT_PATH);
+        });
+  }
+
+  @NonNull
+  public static DefaultDriverConfigLoader fromString(@NonNull String contents) {
+    return new DefaultDriverConfigLoader(
+        () -> {
+          ConfigFactory.invalidateCaches();
+          Config config =
+              ConfigFactory.defaultOverrides()
+                  .withFallback(ConfigFactory.parseString(contents))
+                  .withFallback(ConfigFactory.defaultReference(CqlSession.class.getClassLoader()))
+                  .resolve();
+          return config.getConfig(DEFAULT_ROOT_PATH);
+        },
+        false);
+  }
 
   private final Supplier<Config> configSupplier;
   private final TypesafeDriverConfig driverConfig;

--- a/manual/core/configuration/README.md
+++ b/manual/core/configuration/README.md
@@ -351,9 +351,28 @@ CqlSession session = CqlSession.builder().withConfigLoader(loader).build();
 
 If Typesafe Config doesn't work for you, it is possible to get rid of it entirely.
 
-You will need to provide your own implementations of [DriverConfig] and [DriverExecutionProfile].
-Then write a [DriverConfigLoader] and pass it to the session at initialization, as shown in the
-previous sections. Study the built-in implementation (package
+Start by excluding Typesafe Config from the list of dependencies required by the driver; if you are 
+using Maven, this can be achieved as follows:
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>com.datastax.oss</groupId>
+        <artifactId>java-driver-core</artifactId>
+        <version>...</version>
+        <exclusions>
+            <exclusion>
+                <groupId>com.typesafe</groupId>
+                <artifactId>config</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
+</dependencies>
+
+```
+Next, you will need to provide your own implementations of [DriverConfig] and 
+[DriverExecutionProfile]. Then write a [DriverConfigLoader] and pass it to the session at 
+initialization, as shown in the previous sections. Study the built-in implementation (package
 `com.datastax.oss.driver.internal.core.config.typesafe`) for reference.
 
 Reloading is not mandatory: you can choose not to implement it, and the driver will simply keep


### PR DESCRIPTION
I manually validated that it is now possible to exclude Typesafe Config.