### PR TITLE
JAVA-2449: Use non-cryptographic random number generation in Uuids.random()

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.10.0 (in progress)
 
+- [improvement] JAVA-2449: Use non-cryptographic random number generation in Uuids.random()
 - [improvement] JAVA-2893: Allow duplicate keys in DefaultProgrammaticDriverConfigLoaderBuilder
 - [documentation] JAVA-2894: Clarify usage of Statement.setQueryTimestamp
 - [bug] JAVA-2889: Remove TypeSafe imports from DriverConfigLoader

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/insights/InsightsClient.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/insights/InsightsClient.java
@@ -41,6 +41,7 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
+import com.datastax.oss.driver.api.core.uuid.Uuids;
 import com.datastax.oss.driver.internal.core.adminrequest.AdminRequestHandler;
 import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
@@ -65,7 +66,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
@@ -90,7 +90,7 @@ public class InsightsClient {
   static final String DEFAULT_JAVA_APPLICATION = "Default Java Application";
 
   private final ControlConnection controlConnection;
-  private final String id = UUID.randomUUID().toString();
+  private final String id = Uuids.random().toString();
   private final InsightsConfiguration insightsConfiguration;
   private final AtomicInteger numberOfStatusEventErrors = new AtomicInteger();
 

--- a/examples/src/main/java/com/datastax/oss/driver/examples/concurrent/LimitConcurrencyCustom.java
+++ b/examples/src/main/java/com/datastax/oss/driver/examples/concurrent/LimitConcurrencyCustom.java
@@ -21,7 +21,7 @@ import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
-import java.util.UUID;
+import com.datastax.oss.driver.api.core.uuid.Uuids;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -103,7 +103,7 @@ public class LimitConcurrencyCustom {
       executor.submit(
           () -> {
             try {
-              session.execute(pst.bind().setUuid("id", UUID.randomUUID()).setInt("value", counter));
+              session.execute(pst.bind().setUuid("id", Uuids.random()).setInt("value", counter));
               insertsCounter.incrementAndGet();
             } catch (Throwable t) {
               // On production you should leverage logger and use logger.error() method.

--- a/examples/src/main/java/com/datastax/oss/driver/examples/concurrent/LimitConcurrencyCustomAsync.java
+++ b/examples/src/main/java/com/datastax/oss/driver/examples/concurrent/LimitConcurrencyCustomAsync.java
@@ -22,9 +22,9 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.uuid.Uuids;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -124,7 +124,7 @@ public class LimitConcurrencyCustomAsync {
       CqlSession session, PreparedStatement pst, int counter) {
 
     return session
-        .executeAsync(pst.bind().setUuid("id", UUID.randomUUID()).setInt("value", counter))
+        .executeAsync(pst.bind().setUuid("id", Uuids.random()).setInt("value", counter))
         .toCompletableFuture()
         .whenComplete(
             (BiConsumer<AsyncResultSet, Throwable>)

--- a/examples/src/main/java/com/datastax/oss/driver/examples/concurrent/LimitConcurrencyRequestThrottler.java
+++ b/examples/src/main/java/com/datastax/oss/driver/examples/concurrent/LimitConcurrencyRequestThrottler.java
@@ -21,10 +21,10 @@ import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.uuid.Uuids;
 import com.datastax.oss.driver.internal.core.session.throttling.ConcurrencyLimitingRequestThrottler;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -86,7 +86,7 @@ public class LimitConcurrencyRequestThrottler {
     for (int i = 0; i < TOTAL_NUMBER_OF_INSERTS; i++) {
       pending.add(
           session
-              .executeAsync(pst.bind().setUuid("id", UUID.randomUUID()).setInt("value", i))
+              .executeAsync(pst.bind().setUuid("id", Uuids.random()).setInt("value", i))
               // Transform CompletionState toCompletableFuture to be able to wait for execution of
               // all using CompletableFuture.allOf
               .toCompletableFuture());

--- a/examples/src/main/java/com/datastax/oss/driver/examples/mapper/KillrVideoMapperExample.java
+++ b/examples/src/main/java/com/datastax/oss/driver/examples/mapper/KillrVideoMapperExample.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.PagingIterable;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.uuid.Uuids;
 import com.datastax.oss.driver.examples.mapper.killrvideo.KillrVideoMapper;
 import com.datastax.oss.driver.examples.mapper.killrvideo.user.User;
 import com.datastax.oss.driver.examples.mapper.killrvideo.user.UserDao;
@@ -39,7 +40,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -87,8 +87,7 @@ public class KillrVideoMapperExample {
       // Create a new user
       UserDao userDao = mapper.userDao();
 
-      User user =
-          new User(UUID.randomUUID(), "test", "user", "testuser@example.com", Instant.now());
+      User user = new User(Uuids.random(), "test", "user", "testuser@example.com", Instant.now());
 
       if (userDao.create(user, "fakePasswordForTests".toCharArray())) {
         System.out.println("Created " + user);
@@ -99,7 +98,7 @@ public class KillrVideoMapperExample {
 
       // Creating another user with the same email should fail
       assert !userDao.create(
-          new User(UUID.randomUUID(), "test2", "user", "testuser@example.com", Instant.now()),
+          new User(Uuids.random(), "test2", "user", "testuser@example.com", Instant.now()),
           "fakePasswordForTests2".toCharArray());
 
       // Simulate login attempts

--- a/examples/src/main/java/com/datastax/oss/driver/examples/mapper/killrvideo/video/CreateVideoQueryProvider.java
+++ b/examples/src/main/java/com/datastax/oss/driver/examples/mapper/killrvideo/video/CreateVideoQueryProvider.java
@@ -22,13 +22,13 @@ import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
 import com.datastax.oss.driver.api.core.cql.DefaultBatchType;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.uuid.Uuids;
 import com.datastax.oss.driver.api.mapper.MapperContext;
 import com.datastax.oss.driver.api.mapper.entity.EntityHelper;
 import com.datastax.oss.driver.api.mapper.entity.saving.NullSavingStrategy;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.UUID;
 
 /**
  * Provides the implementation of {@link VideoDao#create}.
@@ -68,7 +68,7 @@ class CreateVideoQueryProvider {
 
   void create(Video video) {
     if (video.getVideoid() == null) {
-      video.setVideoid(UUID.randomUUID());
+      video.setVideoid(Uuids.random());
     }
     if (video.getAddedDate() == null) {
       video.setAddedDate(Instant.now());

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -1,5 +1,29 @@
 ## Upgrade guide
 
+### 4.10.0
+
+[JAVA-2449](https://datastax-oss.atlassian.net/browse/JAVA-2449) modified the implementation of
+[Uuids.random()]: this method does not delegate anymore to the JDK's `java.util.UUID.randomUUID()`
+implementation, but instead re-implements random UUID generation using the non-cryptographic
+random number generator `java.util.Random`.
+
+For most users, non cryptographic strength is enough and this change should translate into better 
+performance when generating UUIDs for database insertion. However, in the unlikely case where your
+application requires cryptographic strength for UUID generation, you should update your code to
+use `java.util.UUID.randomUUID()` instead of `com.datastax.oss.driver.api.core.uuid.Uuids.random()` 
+from now on.
+
+This release also introduces two new methods for random UUID generation:
+
+1. [Uuids.random(Random)]: similar to `Uuids.random()` but allows to pass a custom instance of 
+   `java.util.Random` and/or re-use the same instance across calls.
+2. [Uuids.random(SplittableRandom)]: similar to `Uuids.random()` but uses a 
+   `java.util.SplittableRandom` instead.
+
+[Uuids.random()]: https://docs.datastax.com/en/drivers/java/4.10/com/datastax/oss/driver/api/core/uuid/Uuids.html#random--
+[Uuids.random(Random)]: https://docs.datastax.com/en/drivers/java/4.10/com/datastax/oss/driver/api/core/uuid/Uuids.html#random-java.util.Random-
+[Uuids.random(SplittableRandom)]: https://docs.datastax.com/en/drivers/java/4.10/com/datastax/oss/driver/api/core/uuid/Uuids.html#random-java.util.SplittableRandom-
+
 ### 4.5.x - 4.6.0
 
 These versions are subject to [JAVA-2676](https://datastax-oss.atlassian.net/browse/JAVA-2676), a


### PR DESCRIPTION
Should be ready for review now.

Instead of choosing which `Random` to use I think we should give the users the ability to choose themselves.

1. The existing `Uuids.random()` method is retrofitted to use `java.util.Random`. As pointed out in the Jira, the underlying Random instance used was arguably an implementation detail, so I think it's safe to move to `java.util.Random`. I wrote a note in the upgrade guide.
2. Two new methods added: `Uuids.random(Random)` and `Uuids.random(SplittableRandom)`.

Note: a second commit introduces a small optimization for time-based uuids (should not be squashed).