### PR TITLE
JAVA-2911: Prevent control connection from scheduling too many reconnections

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.10.0 (in progress)
 
+- [bug] JAVA-2911: Prevent control connection from scheduling too many reconnections
 - [new feature] JAVA-2903: BlockHound integration
 - [improvement] JAVA-2877: Allow skipping validation for individual mapped entities
 - [improvement] JAVA-2871: Allow keyspace exclusions in the metadata, and exclude system keyspaces

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -427,13 +427,15 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
                       connect(nodes, errors, onSuccess, onFailure);
                     } else {
                       LOG.debug("[{}] New channel opened {}", logPrefix, channel);
-                      // Make sure previous channel gets closed (it may still be open if
-                      // reconnection was forced)
                       DriverChannel previousChannel = ControlConnection.this.channel;
+                      ControlConnection.this.channel = channel;
                       if (previousChannel != null) {
+                        // We were reconnecting: make sure previous channel gets closed (it may
+                        // still be open if reconnection was forced)
+                        LOG.debug(
+                            "[{}] Forcefully closing previous channel {}", logPrefix, channel);
                         previousChannel.forceClose();
                       }
-                      ControlConnection.this.channel = channel;
                       context.getEventBus().fire(ChannelEvent.channelOpened(node));
                       channel
                           .closeFuture()
@@ -505,9 +507,21 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
     private void onChannelClosed(DriverChannel channel, Node node) {
       assert adminExecutor.inEventLoop();
       if (!closeWasCalled) {
-        LOG.debug("[{}] Lost channel {}", logPrefix, channel);
         context.getEventBus().fire(ChannelEvent.channelClosed(node));
-        reconnection.start();
+        // If this channel is the current control channel, we must start a
+        // reconnection attempt to get a new control channel.
+        if (channel == ControlConnection.this.channel) {
+          LOG.debug(
+              "[{}] The current control channel {} was closed, scheduling reconnection",
+              logPrefix,
+              channel);
+          reconnection.start();
+        } else {
+          LOG.trace(
+              "[{}] A previous control channel {} was closed, reconnection not required",
+              logPrefix,
+              channel);
+        }
       }
     }
 


### PR DESCRIPTION
Not sure how to unit-test this, will try to come up with something but we need to complete the reconnection _before_ calling `onChannelClosed` which is hard.