### PR TITLE
Add availability to pass NettyOptions via ProgrammaticArguments

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/ProgrammaticArguments.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/ProgrammaticArguments.java
@@ -23,6 +23,7 @@ import com.datastax.oss.driver.api.core.ssl.SslEngineFactory;
 import com.datastax.oss.driver.api.core.tracker.RequestTracker;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.codec.registry.MutableCodecRegistry;
+import com.datastax.oss.driver.internal.core.context.NettyOptions;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -61,6 +62,7 @@ public class ProgrammaticArguments {
   private final String startupApplicationVersion;
   private final MutableCodecRegistry codecRegistry;
   private final Object metricRegistry;
+  private final NettyOptions nettyOptions;
 
   private ProgrammaticArguments(
       @NonNull List<TypeCodec<?>> typeCodecs,
@@ -77,7 +79,8 @@ public class ProgrammaticArguments {
       @Nullable String startupApplicationName,
       @Nullable String startupApplicationVersion,
       @Nullable MutableCodecRegistry codecRegistry,
-      @Nullable Object metricRegistry) {
+      @Nullable Object metricRegistry,
+      @Nullable NettyOptions nettyOptions) {
 
     this.typeCodecs = typeCodecs;
     this.nodeStateListener = nodeStateListener;
@@ -94,6 +97,7 @@ public class ProgrammaticArguments {
     this.startupApplicationVersion = startupApplicationVersion;
     this.codecRegistry = codecRegistry;
     this.metricRegistry = metricRegistry;
+    this.nettyOptions = nettyOptions;
   }
 
   @NonNull
@@ -171,6 +175,11 @@ public class ProgrammaticArguments {
     return metricRegistry;
   }
 
+  @Nullable
+  public NettyOptions getNettyOptions() {
+    return nettyOptions;
+  }
+
   public static class Builder {
 
     private final ImmutableList.Builder<TypeCodec<?>> typeCodecsBuilder = ImmutableList.builder();
@@ -189,6 +198,7 @@ public class ProgrammaticArguments {
     private String startupApplicationVersion;
     private MutableCodecRegistry codecRegistry;
     private Object metricRegistry;
+    private NettyOptions nettyOptions;
 
     @NonNull
     public Builder addTypeCodecs(@NonNull TypeCodec<?>... typeCodecs) {
@@ -305,6 +315,12 @@ public class ProgrammaticArguments {
     }
 
     @NonNull
+    public Builder withNettyOptions(@Nullable NettyOptions nettyOptions) {
+      this.nettyOptions = nettyOptions;
+      return this;
+    }
+
+    @NonNull
     public ProgrammaticArguments build() {
       return new ProgrammaticArguments(
           typeCodecsBuilder.build(),
@@ -321,7 +337,8 @@ public class ProgrammaticArguments {
           startupApplicationName,
           startupApplicationVersion,
           codecRegistry,
-          metricRegistry);
+          metricRegistry,
+          nettyOptions);
     }
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
@@ -42,6 +42,7 @@ import com.datastax.oss.driver.internal.core.config.cloud.CloudConfigFactory;
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader;
 import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.context.NettyOptions;
 import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
 import com.datastax.oss.driver.internal.core.session.DefaultSession;
 import com.datastax.oss.driver.internal.core.util.concurrent.BlockingOperation;
@@ -670,6 +671,13 @@ public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
   @NonNull
   public SelfT withMetricRegistry(@Nullable Object metricRegistry) {
     this.programmaticArgumentsBuilder.withMetricRegistry(metricRegistry);
+    return self;
+  }
+
+  /** The custom netty options. */
+  @NonNull
+  public SelfT withNettyOptions(@Nullable NettyOptions nettyOptions) {
+    this.programmaticArgumentsBuilder.withNettyOptions(nettyOptions);
     return self;
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
@@ -113,6 +113,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -179,8 +180,7 @@ public class DefaultDriverContext implements InternalDriverContext {
           "consistencyLevelRegistry", this::buildConsistencyLevelRegistry, cycleDetector);
   private final LazyReference<WriteTypeRegistry> writeTypeRegistryRef =
       new LazyReference<>("writeTypeRegistry", this::buildWriteTypeRegistry, cycleDetector);
-  private final LazyReference<NettyOptions> nettyOptionsRef =
-      new LazyReference<>("nettyOptions", this::buildNettyOptions, cycleDetector);
+  private final LazyReference<NettyOptions> nettyOptionsRef;
   private final LazyReference<WriteCoalescer> writeCoalescerRef =
       new LazyReference<>("writeCoalescer", this::buildWriteCoalescer, cycleDetector);
   private final LazyReference<Optional<SslHandlerFactory>> sslHandlerFactoryRef =
@@ -299,6 +299,14 @@ public class DefaultDriverContext implements InternalDriverContext {
     }
     this.initStackTrace = stackTrace;
     this.metricRegistry = programmaticArguments.getMetricRegistry();
+
+    Supplier<NettyOptions> optionsSupplier;
+    if (programmaticArguments.getNettyOptions() != null) {
+      optionsSupplier = programmaticArguments::getNettyOptions;
+    } else {
+      optionsSupplier = this::buildNettyOptions;
+    }
+    this.nettyOptionsRef = new LazyReference<>("nettyOptions", optionsSupplier, cycleDetector);
   }
 
   /**


### PR DESCRIPTION
Docs are saying that if you need to customize netty options you should do smth like [that](https://docs.datastax.com/en/developer/java-driver/4.9/manual/developer/common/context/).
Unfortunately, it is impossible to pass these options in case if you have some existing `CqlSessionBuilder` which is already enriched with some logic and data you don't want to lose.
So I think the only way for now.