### PR TITLE
JAVA-2934: Handle empty non-final pages in ReactiveResultSetSubscription

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,10 @@
 
 <!-- Note: contrary to 3.x, insert new entries *first* in their section -->
 
+### 4.12.0 (in progress)
+
+- [bug] JAVA-2934: Handle empty non-final pages in ReactiveResultSetSubscription
+
 ### 4.11.0
 
 - [improvement] JAVA-2930: Allow Micrometer to record histograms for timers

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/cql/reactive/ReactiveResultSetSubscription.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/cql/reactive/ReactiveResultSetSubscription.java
@@ -277,13 +277,10 @@ public class ReactiveResultSetSubscription<ResultSetT extends AsyncPagingIterabl
         if (pages.poll() == null) {
           throw new AssertionError("Queue is empty, this should not happen");
         }
-        current = pages.peek();
         // if the next page is readily available,
         // serve its first row now, no need to wait
         // for the next drain.
-        if (current != null && current.hasMoreRows()) {
-          return current.nextRow();
-        }
+        return tryNext();
       }
     }
     // No items available right now.

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/cql/reactive/TestSubscriber.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/cql/reactive/TestSubscriber.java
@@ -31,8 +31,17 @@ public class TestSubscriber<T> implements Subscriber<T> {
 
   private final List<T> elements = new ArrayList<>();
   private final CountDownLatch latch = new CountDownLatch(1);
+  private final long demand;
   private Subscription subscription;
   private Throwable error;
+
+  public TestSubscriber() {
+    this.demand = Long.MAX_VALUE;
+  }
+
+  public TestSubscriber(long demand) {
+    this.demand = demand;
+  }
 
   @Override
   public void onSubscribe(Subscription s) {
@@ -40,7 +49,7 @@ public class TestSubscriber<T> implements Subscriber<T> {
       fail("already subscribed");
     }
     subscription = s;
-    s.request(Long.MAX_VALUE);
+    subscription.request(demand);
   }
 
   @Override
@@ -71,5 +80,6 @@ public class TestSubscriber<T> implements Subscriber<T> {
 
   public void awaitTermination() {
     Uninterruptibles.awaitUninterruptibly(latch, 1, TimeUnit.MINUTES);
+    if (latch.getCount() > 0) fail("subscriber not terminated");
   }
 }


### PR DESCRIPTION
Hi !

I tried to use this driver with scylladb database, because it supports CQL protocol. But code started to hang for some queries:

```
val source = Source.fromPublisher(session.executeReactive(statement))
Await.result(source.runWith(Sink.ignore), scala.concurrent.duration.Duration.Inf))
println("finished")
```

The reason is that scylladb sometime returns a page with no data but with pagingState != null and it leads to code hanging

For instance, if `pages` queue contains three pages:
 - first page *with* data and with `pagingState` != null
 - second page *without* data and `pagingState` != null
 - third page *without* data and `pagingState` = null

Akka stream calls `request(1)` if it needs data  and `request` calls `drain` that sends one row to akka stream subscriber. It works well for pages with data. But if there is page without data and `pagingState` != null the following situation appears:

Akka stream calls `requests(1)` that calls `drain` that calls  `tryNext`. `tryNext` method detects that there is no data anymore in page `1` and it gets second page from `pages` queue. But because of second page has no data, tryNext() will return `null` and no data will be sent to akka stream subscriber. Because no data will be sent to akka subscriber, akka stream will not call `request(1)` anymore and `drain` will not be called from anywhere because all pages are already loaded.

I don't know why scylladb returns pages without data and `pagingState` != null. I will ask scylladb team, but it also would be good to fix this case in driver as well 






