### PR TITLE
JAVA-2396: Support Protocol V6

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,9 @@
 
 <!-- Note: contrary to 3.x, insert new entries *first* in their section -->
 
+### 4.11.1
+- [bug] JAVA-2936: Support Protocol V6
+
 ### 4.11.0
 
 - [improvement] JAVA-2930: Allow Micrometer to record histograms for timers

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
@@ -91,6 +91,7 @@ import com.datastax.oss.protocol.internal.FrameCodec;
 import com.datastax.oss.protocol.internal.PrimitiveCodec;
 import com.datastax.oss.protocol.internal.ProtocolV3ClientCodecs;
 import com.datastax.oss.protocol.internal.ProtocolV5ClientCodecs;
+import com.datastax.oss.protocol.internal.ProtocolV6ClientCodecs;
 import com.datastax.oss.protocol.internal.SegmentCodec;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -435,6 +436,7 @@ public class DefaultDriverContext implements InternalDriverContext {
         new ProtocolV3ClientCodecs(),
         new ProtocolV4ClientCodecsForDse(),
         new ProtocolV5ClientCodecs(),
+        new ProtocolV6ClientCodecs(),
         new DseProtocolV1ClientCodecs(),
         new DseProtocolV2ClientCodecs());
   }


### PR DESCRIPTION
Cassandra 4.0-beta5 brought native protocol v5 out of beta and added a beta v6. If the protocol is not specified in the driver config, protocol negotiation fails because DefaultDriverContext does not initialize a codec for v6.