### PR TITLE
JAVA-2938: servererrors.OverloadedException message is misleading

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,10 @@
 
 <!-- Note: contrary to 3.x, insert new entries *first* in their section -->
 
+### 4.11.2 (in progress)
+
+- [bug] JAVA-2938: OverloadedException message is misleading
+
 ### 4.11.1
 
 - [bug] JAVA-2910: Add a configuration option to support strong values for prepared statements cache

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/OverloadedException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/OverloadedException.java
@@ -34,8 +34,8 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  */
 public class OverloadedException extends QueryExecutionException {
 
-  public OverloadedException(@NonNull Node coordinator) {
-    super(coordinator, String.format("%s is bootstrapping", coordinator), null, false);
+  public OverloadedException(@NonNull Node coordinator, @NonNull String message) {
+    super(coordinator, String.format("%s is overloaded: %s", coordinator, message), null, false);
   }
 
   private OverloadedException(

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
@@ -462,7 +462,7 @@ public class Conversions {
             unavailable.required,
             unavailable.alive);
       case ProtocolConstants.ErrorCode.OVERLOADED:
-        return new OverloadedException(node);
+        return new OverloadedException(node, errorMessage.message);
       case ProtocolConstants.ErrorCode.IS_BOOTSTRAPPING:
         return new BootstrappingException(node);
       case ProtocolConstants.ErrorCode.TRUNCATE_ERROR:


### PR DESCRIPTION
OverloadedException is misleading probably due to a copy&paste mistake.

Adding the original server message to the exception, as in 3.x series.

Original thread: https://groups.google.com/a/lists.datastax.com/g/java-driver-user/c/KNPE34iOBgI/m/fWv5zOxNAQAJ
