### PR TITLE
A call to  CachingCodecRegistry.codecFor for HeapByteBuffer throws a CodecNotFoundException 

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/BlobCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/BlobCodec.java
@@ -47,7 +47,7 @@ public class BlobCodec implements TypeCodec<ByteBuffer> {
 
   @Override
   public boolean accepts(@NonNull Class<?> javaClass) {
-    return ByteBuffer.class.equals(javaClass);
+    return ByteBuffer.class.equals(javaClass) || ByteBuffer.class.isAssignableFrom(javaClass);
   }
 
   @Nullable

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistry.java
@@ -265,7 +265,7 @@ public abstract class CachingCodecRegistry implements MutableCodecRegistry {
     LOG.trace("[{}] Looking up codec for object {}", logPrefix, value);
 
     for (TypeCodec<?> primitiveCodec : primitiveCodecs) {
-      if (primitiveCodec.accepts(value)) {
+      if (primitiveCodec.accepts(value.getClass())) {
         LOG.trace("[{}] Found matching primitive codec {}", logPrefix, primitiveCodec);
         return uncheckedCast(primitiveCodec);
       }


### PR DESCRIPTION
Please forgive my lack of java proficiency, I'm not a java dev.
It seems like updating our spark job to spark 3 raised some issues with cassandra-driver for scala (see graphsense/graphsense-transformation#38 ).
After some research the error was narrowed down to the `CachingCodedRegistry` and `BlobCodec` classes.
In the first one, in the codecFor function, the primitiveCodec.accept function was sent a JavaType and not a Class type object, leading to the test for ByteBuffer.class.equals(javaClass) to fail which in turn lead to a `CodecNotFoundException` being thrown.
In the BlobCodec class, only ByteBuffer.class.equals(javaClass) was used and it didn't test for child classes.
I think this issue may require a fix.
- Quentin.
