### PR TITLE
JAVA-2940: Add GraalVM native image build configurations

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -4,6 +4,7 @@
 
 ### 4.13.0 (in progress)
 
+- [improvement] JAVA-2940: Add GraalVM native image build configurations
 - [improvement] JAVA-2953: Promote ProgrammaticPlainTextAuthProvider to the public API and add
   credentials hot-reload
 - [improvement] JAVA-2951: Accept multiple node state listeners, schema change listeners and request trackers

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -148,6 +148,10 @@
                 </includes>
               </artifactSet>
               <relocations>
+                <!--
+                Check if relocations declared here must also be declared below to operate on
+                GraalVM's reflection.json file. Currently this is required for Netty only.
+                -->
                 <relocation>
                   <pattern>io.netty</pattern>
                   <shadedPattern>com.datastax.oss.driver.shaded.netty</shadedPattern>
@@ -174,7 +178,9 @@
                 <filter>
                   <artifact>com.datastax.oss:*</artifact>
                   <excludes>
-                    <exclude>META-INF/**</exclude>
+                    <!-- Don't exclude META-INF/services and META-INF/native-image -->
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                    <exclude>META-INF/maven/**</exclude>
                   </excludes>
                 </filter>
                 <filter>
@@ -252,6 +258,31 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <!-- Apply shading to classes declared in GraalVM reflection.json config file -->
+      <plugin>
+        <groupId>com.google.code.maven-replacer-plugin</groupId>
+        <artifactId>replacer</artifactId>
+        <version>1.5.3</version>
+        <executions>
+          <execution>
+            <id>shade-graalvm-files</id>
+            <phase>package</phase>
+            <goals>
+              <goal>replace</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <ignoreMissingFile>false</ignoreMissingFile>
+          <filesToInclude>${project.build.directory}/classes/META-INF/native-image/com.datastax.oss/java-driver-core/reflection.json,${project.build.directory}/shaded-sources/META-INF/native-image/com.datastax.oss/java-driver-core/reflection.json</filesToInclude>
+          <replacements>
+            <replacement>
+              <token>io.netty</token>
+              <value>com.datastax.oss.driver.shaded.netty</value>
+            </replacement>
+          </replacements>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>

--- a/core/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-core/native-image.properties
+++ b/core/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-core/native-image.properties
@@ -1,0 +1,7 @@
+Args=-H:IncludeResources=reference\\.conf \
+  -H:IncludeResources=application\\.conf \
+  -H:IncludeResources=application\\.json \
+  -H:IncludeResources=application\\.properties \
+  -H:IncludeResources=.*Driver\\.properties \
+  -H:DynamicProxyConfigurationResources=${.}/proxy.json \
+  -H:ReflectionConfigurationResources=${.}/reflection.json

--- a/core/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-core/proxy.json
+++ b/core/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-core/proxy.json
@@ -1,0 +1,3 @@
+[
+  ["java.lang.reflect.TypeVariable"]
+]

--- a/core/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-core/reflection.json
+++ b/core/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-core/reflection.json
@@ -1,0 +1,154 @@
+[
+  {
+    "name": "com.datastax.oss.driver.internal.core.loadbalancing.DefaultLoadBalancingPolicy",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext", "java.lang.String" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.loadbalancing.DcInferringLoadBalancingPolicy",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext", "java.lang.String" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.loadbalancing.BasicLoadBalancingPolicy",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext", "java.lang.String" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.connection.ExponentialReconnectionPolicy",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.connection.ConstantReconnectionPolicy",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.retry.DefaultRetryPolicy",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext", "java.lang.String" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.retry.ConsistencyDowngradingRetryPolicy",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext", "java.lang.String" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.specex.NoSpeculativeExecutionPolicy",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext", "java.lang.String" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.specex.ConstantSpeculativeExecutionPolicy",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext", "java.lang.String" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.time.AtomicTimestampGenerator",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.time.ThreadLocalTimestampGenerator",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.time.ServerSideTimestampGenerator",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.tracker.NoopRequestTracker",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.tracker.RequestLogger",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.session.throttling.PassThroughRequestThrottler",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.session.throttling.RateLimitingRequestThrottler",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.session.throttling.ConcurrencyLimitingRequestThrottler",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.metadata.NoopNodeStateListener",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.metadata.schema.NoopSchemaChangeListener",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.addresstranslation.PassThroughAddressTranslator",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.addresstranslation.Ec2MultiRegionAddressTranslator",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.auth.PlainTextAuthProvider",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.dse.driver.internal.core.auth.DseGssApiAuthProvider",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.ssl.DefaultSslEngineFactory",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.metrics.DefaultMetricsFactory",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.metrics.NoopMetricsFactory",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.metrics.DropwizardMetricsFactory",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.metrics.DefaultMetricIdGenerator",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "com.datastax.oss.driver.internal.core.metrics.TaggingMetricIdGenerator",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  },
+  {
+    "name": "io.netty.channel.socket.nio.NioSocketChannel",
+    "methods": [ { "name": "<init>", "parameterTypes": [] } ]
+  },
+  {
+    "name": "io.netty.buffer.AbstractByteBufAllocator",
+    "methods": [ { "name": "toLeakAwareBuffer", "parameterTypes": ["io.netty.buffer.ByteBuf" ] } ]
+  },
+  {
+    "name": "io.netty.util.ReferenceCountUtil",
+    "methods": [ { "name": "touch", "parameterTypes": ["java.lang.Object", "java.lang.Object" ] } ]
+  },
+  {
+    "name" : "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+    "fields": [ {"name": "producerIndex", "allowUnsafeAccess": true} ]
+  },
+  {
+    "name" : "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+    "fields": [ {"name": "producerLimit", "allowUnsafeAccess": true} ]
+  },
+  {
+    "name" : "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+    "fields": [ {"name": "consumerIndex", "allowUnsafeAccess": true} ]
+  },
+  {
+    "name" : "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
+    "fields": [ {"name": "producerIndex", "allowUnsafeAccess": true} ]
+  },
+  {
+    "name" : "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
+    "fields": [ {"name": "producerLimit", "allowUnsafeAccess": true} ]
+  },
+  {
+    "name" : "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
+    "fields": [ {"name": "consumerIndex", "allowUnsafeAccess": true} ]
+  }
+]

--- a/manual/core/compression/README.md
+++ b/manual/core/compression/README.md
@@ -27,7 +27,6 @@ datastax-java-driver {
 
 Compression must be set before opening a session, it cannot be changed at runtime.
 
-
 Two algorithms are supported out of the box: [LZ4](https://github.com/jpountz/lz4-java) and
 [Snappy](http://google.github.io/snappy/). The LZ4 implementation is a good first choice; it offers
 fallback implementations in case native libraries fail to load and
@@ -78,6 +77,8 @@ Dependency:
   <version>1.1.2.6</version>
 </dependency>
 ```
+
+**Important: Snappy is not supported when building a [GraalVM native image](../graalvm).**
 
 Always double-check the exact Snappy version needed; you can find it in the driver's [parent POM].
 

--- a/manual/core/graalvm/README.md
+++ b/manual/core/graalvm/README.md
@@ -1,0 +1,315 @@
+## Using the driver in GraalVM native images
+
+### Quick overview
+
+* [GraalVM Native images](https://www.graalvm.org/reference-manual/native-image/) using the driver 
+  can be built with no additional configuration starting with driver 4.13.0.
+* But extra configurations are required in a few cases:
+  * When using [reactive programming](../reactive);
+  * When using [Jackson](../integration#Jackson);
+  * When using LZ4 [compression](../compression/);
+  * Depending on the [logging backend](../logging) in use.
+* DSE-specific features:
+  * [Geospatial types](../dse/geotypes) are supported.
+  * [DSE Graph](../dse/graph) is not officially supported, although it may work.
+* The [shaded jar](../shaded_jar) is not officially supported, although it may work.
+
+-----
+
+### Concepts
+
+Starting with version 4.13.0, the driver ships with [embedded GraalVM configuration files] that 
+allow GraalVM native images including the driver to be built without hassle, barring a few 
+exceptions and caveats listed below.
+
+[embedded GraalVM configuration files]:https://www.graalvm.org/reference-manual/native-image/BuildConfiguration/#embedding-a-configuration-file
+
+### Classes instantiated by reflection
+
+The driver instantiates its components by reflection. The actual classes that will be instantiated 
+in this way need to be registered for reflection. All built-in implementations of various driver 
+components, such as `LoadBalancingPolicy` or `TimestampGenerator`, are automatically registered for 
+reflection, along with a few other internal components tha are also instantiated by reflection.
+_You don't need to manually register any of these built-in implementations_.
+
+But if you intend to use a custom implementation in lieu of a driver built-in class, then it is your 
+responsibility to register that custom implementation for reflection.
+
+For example, assuming that you have the following load balancing policy implementation:
+
+```java
+
+package com.example.app;
+
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.internal.core.loadbalancing.DefaultLoadBalancingPolicy;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+public class CustomLoadBalancingPolicy extends DefaultLoadBalancingPolicy {
+
+  public CustomLoadBalancingPolicy(DriverContext context, String profileName) {
+    super(context, profileName);
+  }
+  // rest of class omitted for brevity
+}
+```
+
+And assuming that you declared the above class in your application.conf file as follows:
+
+```hocon
+datastax-java-driver.basic{
+  load-balancing-policy.class = com.example.app.CustomLoadBalancingPolicy
+}
+```
+
+Then you will have to register that class for reflection:
+
+1. Create the following reflection.json file, or add the entry to an existing file:
+
+```json
+[
+  { "name": "com.example.app.CustomLoadBalancingPolicy", "allPublicConstructors": true }
+]
+```
+
+2. When invoking the native image builder, add a `-H:ReflectionConfigurationFiles=reflection.json`
+   flag and point it to the file created above.
+
+Note: some frameworks allow you to simplify the registration process. For example, Quarkus offers
+the `io.quarkus.runtime.annotations.RegisterForReflection` annotation that you can use to annotate
+your class:
+
+```java
+@RegisterForReflection
+public class CustomLoadBalancingPolicy extends DefaultLoadBalancingPolicy {
+  //...
+}
+```
+
+In this case, no other manual configuration is required for the above class to be correctly 
+registered for reflection.
+
+### Configuration resources 
+
+The default driver [configuration](../configuration) mechanism is based on the TypeSafe Config
+library. TypeSafe Config looks for a few classpath resources when initializing the configuration: 
+`reference.conf`, `application.conf`, `application.json`, `application.properties`. _These classpath 
+resources are all automatically included in the native image: you should not need to do it 
+manually_. See [Accessing Resources in Native Images] for more information on how classpath 
+resources are handled in native images.
+
+[Accessing Resources in Native Images]: https://www.graalvm.org/reference-manual/native-image/Resources/
+
+### Configuring the logging backend
+
+When configuring [logging](../logging), the choice of a backend must be considered carefully, as 
+most logging backends resort to reflection during their configuration phase. 
+
+By default, GraalVM native images provide support for the java.util.logging (JUL) backend. See 
+[this page](https://www.graalvm.org/reference-manual/native-image/Logging/) for more information.
+
+For other logging backends, please refer to the logging library documentation to find out if GraalVM 
+native images are supported.
+
+### Using reactive-style programming
+
+The [reactive execution model](../reactive) is compatible with GraalVM native images, but the
+following configurations must be added:
+
+1. Create the following reflection.json file, or add the entry to an existing file:
+
+```json
+[
+  { "name": "org.reactivestreams.Publisher" }
+]
+```
+
+2. When invoking the native image builder, add a `-H:ReflectionConfigurationFiles=reflection.json`
+   flag and point it to the file created above.
+
+### Using the Jackson JSON library
+
+[Jackson](https://github.com/FasterXML/jackson) is used in [a few places](../integration#Jackson) in 
+the driver, but is an optional dependency; if you intend to use Jackson, the following 
+configurations must be added:
+
+1. Create the following reflection.json file, or add these entries to an existing file:
+
+```json
+[
+  { "name": "com.fasterxml.jackson.core.JsonParser" },
+  { "name": "com.fasterxml.jackson.databind.ObjectMapper" }
+]
+```
+
+**Important**: when using the shaded jar – which is not officially supported on GraalVM native 
+images, see below for more details – replace the above entries with the below ones:
+
+```json
+[
+  { "name": "com.datastax.oss.driver.shaded.fasterxml.jackson.core.JsonParser" },
+  { "name": "com.datastax.oss.driver.shaded.fasterxml.jackson.databind.ObjectMapper" }
+]
+```
+2. When invoking the native image builder, add a `-H:ReflectionConfigurationFiles=reflection.json`
+   flag and point it to the file created above.
+
+### Enabling compression
+
+When using [compression](../compression/), only LZ4 can be enabled in native images. **Snappy
+compression is not supported.**
+
+In order for LZ4 compression to work in a native image, the following additional GraalVM
+configuration is required:
+
+1. Create the following reflection.json file, or add these entries to an existing file:
+
+```json
+[
+  { "name" : "net.jpountz.lz4.LZ4Compressor" },
+  {
+    "name" : "net.jpountz.lz4.LZ4JNICompressor",
+    "allDeclaredConstructors": true,
+    "allPublicFields": true
+  },
+  {
+    "name" : "net.jpountz.lz4.LZ4JavaSafeCompressor",
+    "allDeclaredConstructors": true,
+    "allPublicFields": true
+  },
+  {
+    "name" : "net.jpountz.lz4.LZ4JavaUnsafeCompressor",
+    "allDeclaredConstructors": true,
+    "allPublicFields": true
+  },
+  {
+    "name" : "net.jpountz.lz4.LZ4HCJavaSafeCompressor",
+    "allDeclaredConstructors": true,
+    "allPublicFields": true
+  },
+  {
+    "name" : "net.jpountz.lz4.LZ4HCJavaUnsafeCompressor",
+    "allDeclaredConstructors": true,
+    "allPublicFields": true
+  },
+  {
+    "name" : "net.jpountz.lz4.LZ4JavaSafeSafeDecompressor",
+    "allDeclaredConstructors": true,
+    "allPublicFields": true
+  },
+  {
+    "name" : "net.jpountz.lz4.LZ4JavaSafeFastDecompressor",
+    "allDeclaredConstructors": true,
+    "allPublicFields": true
+  },
+  {
+    "name" : "net.jpountz.lz4.LZ4JavaUnsafeSafeDecompressor",
+    "allDeclaredConstructors": true,
+    "allPublicFields": true
+  },
+  {
+    "name" : "net.jpountz.lz4.LZ4JavaUnsafeFastDecompressor",
+    "allDeclaredConstructors": true,
+    "allPublicFields": true
+  }
+]
+```
+
+2. When invoking the native image builder, add a `-H:ReflectionConfigurationFiles=reflection.json`
+   flag and point it to the file created above.
+
+### Native calls
+
+The driver performs a few [native calls](../integration#Native-libraries) using 
+[JNR](https://github.com/jnr).
+
+Starting with driver 4.7.0, native calls are also possible in a GraalVM native image, without any
+extra configuration.
+
+### Using DataStax Enterprise (DSE) features
+
+#### DSE Geospatial types
+
+DSE [Geospatial types](../dse/geotypes) are supported on GraalVM native images; the following
+configurations must be added:
+
+1. Create the following reflection.json file, or add the entry to an existing file:
+
+```json
+[
+  { "name": "com.esri.core.geometry.ogc.OGCGeometry" }
+]
+```
+
+**Important**: when using the shaded jar – which is not officially supported on GraalVM native 
+images, as stated above – replace the above entry with the below one:
+
+```json
+[
+  { "name": "com.datastax.oss.driver.shaded.esri.core.geometry.ogc.OGCGeometry" }
+]
+```
+
+2. When invoking the native image builder, add a `-H:ReflectionConfigurationFiles=reflection.json`
+   flag and point it to the file created above.
+
+#### DSE Graph
+
+**[DSE Graph](../dse/graph) is not officially supported on GraalVM native images.**
+
+The following configuration can be used as a starting point for users wishing to build a native
+image for a DSE Graph application. DataStax does not guarantee however that the below configuration
+will work in all cases. If the native image build fails, a good option is to use GraalVM's
+[Tracing Agent](https://www.graalvm.org/reference-manual/native-image/Agent/) to understand why.
+
+1. Create the following reflection.json file, or add these entries to an existing file:
+
+```json
+[
+  { "name": "org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3d0" },
+  { "name": "org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal" },
+  { "name": "org.apache.tinkerpop.gremlin.structure.Graph",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  { "name": "org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  { "name": " org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  { "name": "org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  }
+]
+```
+
+2. When invoking the native image builder, add the following flags:
+
+```
+-H:ReflectionConfigurationFiles=reflection.json
+--initialize-at-build-time=org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3d0
+--initialize-at-build-time=org.apache.tinkerpop.shaded.jackson.databind.deser.std.StdDeserializer
+```
+
+### Using the shaded jar
+
+**The [shaded jar](../shaded_jar) is not officially supported in a GraalVM native image.**
+
+However, it has been reported that the shaded jar can be included in a GraalVM native image as a
+drop-in replacement for the regular driver jar for simple applications, without any extra GraalVM
+configuration.

--- a/manual/core/integration/README.md
+++ b/manual/core/integration/README.md
@@ -6,6 +6,8 @@
 * explanations about [driver dependencies](#driver-dependencies) and when they can be manually
   excluded.
 
+Note: guidelines to build a GraalVM native image can be found [here](../graalvm).
+
 -----
 
 ### Which artifact(s) should I use?

--- a/metrics/micrometer/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-metrics-micrometer/native-image.properties
+++ b/metrics/micrometer/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-metrics-micrometer/native-image.properties
@@ -1,0 +1,1 @@
+Args = -H:ReflectionConfigurationResources=${.}/reflection.json

--- a/metrics/micrometer/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-metrics-micrometer/reflection.json
+++ b/metrics/micrometer/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-metrics-micrometer/reflection.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "com.datastax.oss.driver.internal.metrics.micrometer.MicrometerMetricsFactory",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  }
+]

--- a/metrics/microprofile/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-metrics-microprofile/native-image.properties
+++ b/metrics/microprofile/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-metrics-microprofile/native-image.properties
@@ -1,0 +1,1 @@
+Args = -H:ReflectionConfigurationResources=${.}/reflection.json

--- a/metrics/microprofile/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-metrics-microprofile/reflection.json
+++ b/metrics/microprofile/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-metrics-microprofile/reflection.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "com.datastax.oss.driver.internal.metrics.microprofile.MicroProfileMetricsFactory",
+    "methods": [ { "name": "<init>", "parameterTypes": [ "com.datastax.oss.driver.api.core.context.DriverContext" ] } ]
+  }
+]

--- a/pom.xml
+++ b/pom.xml
@@ -664,6 +664,7 @@ limitations under the License.]]></inlineHeader>
             <include>**/pom.xml</include>
           </includes>
           <excludes>
+            <exclude>src/**/native-image.properties</exclude>
             <exclude>**/src/main/config/ide/**</exclude>
           </excludes>
           <mapping>


### PR DESCRIPTION
Spun off of work done on JAVA-2940

Developed and tested as a feature branch off of https://github.com/datastax/java-driver/pull/1559.  Moved over to 4.11.x under the assumption we might want to fix this with a 4.11 release as well.  Can always move it back if we decide not to do so.