### PR TITLE
Updated log message to inform about incorrect CL for read repair (3.x)

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/exceptions/ReadTimeoutException.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/exceptions/ReadTimeoutException.java
@@ -42,7 +42,8 @@ public class ReadTimeoutException extends QueryConsistencyException {
     super(
         endPoint,
         String.format(
-            "Cassandra timeout during read query at consistency %s (%s)",
+            "Cassandra timeout during read query at consistency %s (%s). "
+                + "In case this was generated during read repair, the consistency level is not representative of the actual consistency.",
             consistency, formatDetails(received, required, dataPresent)),
         consistency,
         received,


### PR DESCRIPTION
What was the issue?
During read repair failure, incorrect CL is being generated which needs correction.

What was fixed?
During read repair failure, incorrect CL is being generated. To rectify this we're adding additional clarification to not refer to CL logged in the error message in case of Read Repair Failure.