### PR TITLE
JAVA-2959 Descriptive error when a Node has no available connections

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,10 @@
 
 <!-- Note: contrary to 3.x, insert new entries *first* in their section -->
 
+### 4.14.0 (in progress)
+
+- [improvement] JAVA-2959: Don't throw NoNodeAvailableException when all connections busy
+
 ### 4.13.0
 
 - [improvement] JAVA-2940: Add GraalVM native image build configurations

--- a/core/src/main/java/com/datastax/dse/driver/internal/core/graph/GraphRequestHandler.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/graph/GraphRequestHandler.java
@@ -24,6 +24,7 @@ import com.datastax.dse.driver.internal.core.graph.binary.GraphBinaryModule;
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.DriverException;
 import com.datastax.oss.driver.api.core.DriverTimeoutException;
+import com.datastax.oss.driver.api.core.NodeUnavailableException;
 import com.datastax.oss.driver.api.core.RequestThrottlingException;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
@@ -253,6 +254,8 @@ public class GraphRequestHandler implements Throttled {
         channel = session.getChannel(node, logPrefix);
         if (channel != null) {
           break;
+        } else {
+          recordError(node, new NodeUnavailableException(node));
         }
       }
     }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/NodeUnavailableException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/NodeUnavailableException.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core;
+
+import com.datastax.oss.driver.api.core.metadata.Node;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+
+/**
+ * Indicates that a {@link Node} was selected in a query plan, but it had no connection available.
+ *
+ * <p>A common reason to encounter this error is when the configured number of connections per node
+ * and requests per connection is not high enough to absorb the overall request rate. This can be
+ * mitigated by tuning the following options:
+ *
+ * <ul>
+ *   <li>{@code advanced.connection.pool.local.size};
+ *   <li>{@code advanced.connection.pool.remote.size};
+ *   <li>{@code advanced.connection.max-requests-per-connection}.
+ * </ul>
+ *
+ * See {@code reference.conf} for more details.
+ *
+ * <p>Another possibility is when you are trying to direct a request {@linkplain
+ * com.datastax.oss.driver.api.core.cql.Statement#setNode(Node) to a particular node}, but that node
+ * has no connections available.
+ */
+public class NodeUnavailableException extends DriverException {
+
+  private final Node node;
+
+  public NodeUnavailableException(Node node) {
+    super("No connection was available to " + node, null, null, true);
+    this.node = Objects.requireNonNull(node);
+  }
+
+  @NonNull
+  public Node getNode() {
+    return node;
+  }
+
+  @Override
+  @NonNull
+  public DriverException copy() {
+    return new NodeUnavailableException(node);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareHandler.java
@@ -18,6 +18,7 @@ package com.datastax.oss.driver.internal.core.cql;
 import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.DriverTimeoutException;
+import com.datastax.oss.driver.api.core.NodeUnavailableException;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.RequestThrottlingException;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
@@ -188,6 +189,8 @@ public class CqlPrepareHandler implements Throttled {
         channel = session.getChannel(node, logPrefix);
         if (channel != null) {
           break;
+        } else {
+          recordError(node, new NodeUnavailableException(node));
         }
       }
     }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.AllNodesFailedException;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.DriverException;
 import com.datastax.oss.driver.api.core.DriverTimeoutException;
+import com.datastax.oss.driver.api.core.NodeUnavailableException;
 import com.datastax.oss.driver.api.core.RequestThrottlingException;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
@@ -251,6 +252,8 @@ public class CqlRequestHandler implements Throttled {
         channel = session.getChannel(node, logPrefix);
         if (channel != null) {
           break;
+        } else {
+          recordError(node, new NodeUnavailableException(node));
         }
       }
     }

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -1,5 +1,14 @@
 ## Upgrade guide
 
+### 4.14.0
+
+#### AllNodesFailedException instead of NoNodeAvailableException in certain cases
+
+[JAVA-2959](https://datastax-oss.atlassian.net/browse/JAVA-2959) changed the behavior for when a
+request cannot be executed because all nodes tried were busy. Previously you would get back a
+`NoNodeAvailableException` but you will now get back an `AllNodesFailedException` where the
+`getAllErrors` map contains a `NodeUnavailableException` for that node.
+
 ### 4.13.0
 
 #### Enhanced support for GraalVM native images 


### PR DESCRIPTION
For cases in which there are no connections available to
send requests to a Node in the query plan, collect the error
rather than silently skipping over the node. The error will
be thrown as part of an AllNodesFailedException if all nodes
fail.
This can happen when we've saturated the max in-flight
requests across all nodes or when the request is directed to
a particular node and it has no connections available (or
all its connections are saturated).
Note that in the latter case we used to throw a
NoNodeAvailableException but we now throw
AllNodesFailedException.