### PR TITLE
Updated log message to inform about incorrect CL for read repair (4.x)

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/ReadTimeoutException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/ReadTimeoutException.java
@@ -45,7 +45,8 @@ public class ReadTimeoutException extends QueryConsistencyException {
     this(
         coordinator,
         String.format(
-            "Cassandra timeout during read query at consistency %s (%s)",
+            "Cassandra timeout during read query at consistency %s (%s). "
+                + "In case this was generated during read repair, the consistency level is not representative of the actual consistency.",
             consistencyLevel, formatDetails(received, blockFor, dataPresent)),
         consistencyLevel,
         received,


### PR DESCRIPTION
What was the issue?
During read repair failure, incorrect CL is being generated which needs correction.

What was fixed?
During read repair failure, incorrect CL is being generated. To rectify this we're adding additional clarification to not refer to CL logged in the error message in case of Read Repair Failure.