### PR TITLE
Correct documentation around Authorizer initialResponse

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/auth/Authenticator.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/auth/Authenticator.java
@@ -57,8 +57,8 @@ public interface Authenticator {
    * Obtain an initial response token for initializing the SASL handshake.
    *
    * @return a completion stage that will complete with the initial response to send to the server
-   *     (which may be {@code null}). Note that, if the returned byte buffer is writable, the driver
-   *     will <b>clear its contents</b> immediately after use (to avoid keeping sensitive
+   *     (which may not be {@code null}). Note that, if the returned byte buffer is writable, the
+   *     driver will <b>clear its contents</b> immediately after use (to avoid keeping sensitive
    *     information in memory); do not reuse the same buffer across multiple invocations.
    *     Alternatively, if the contents are not sensitive, you can make the buffer {@linkplain
    *     ByteBuffer#asReadOnlyBuffer() read-only} and safely reuse it.


### PR DESCRIPTION
Having Authorizer#initialResponse return a null `ByteBuffer` results in an NPE, so update the docs to indicate that it cannot return a null buffer.

Sample stack trace with com.datastax.oss:java-driver-core:4.12.0, com.datastax.oss:native-protocol:1.5.0
```
Caused by: io.netty.handler.codec.EncoderException: java.lang.NullPointerException
		at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:104)
		at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:717)
		at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:709)
		at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:792)
		at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:702)
		at com.datastax.oss.driver.internal.core.channel.InFlightHandler.write(InFlightHandler.java:151)
		at com.datastax.oss.driver.internal.core.channel.InFlightHandler.write(InFlightHandler.java:108)
		at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:717)
		at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:764)
		at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:790)
		at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:758)
		at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:808)
		at io.netty.channel.DefaultChannelPipeline.writeAndFlush(DefaultChannelPipeline.java:1025)
		at io.netty.channel.AbstractChannel.writeAndFlush(AbstractChannel.java:294)
		at com.datastax.oss.driver.internal.core.channel.ChannelHandlerRequest.send(ChannelHandlerRequest.java:75)
		... 12 more
	Caused by: java.lang.NullPointerException
		at com.datastax.oss.protocol.internal.request.AuthResponse$Codec.encode(AuthResponse.java:54)
		at com.datastax.oss.protocol.internal.FrameCodec.encodeBodyInto(FrameCodec.java:229)
		at com.datastax.oss.protocol.internal.FrameCodec.encodeInto(FrameCodec.java:204)
		at com.datastax.oss.protocol.internal.FrameCodec.encode(FrameCodec.java:129)
		at com.datastax.oss.driver.internal.core.protocol.FrameEncoder.encode(FrameEncoder.java:43)
		at com.datastax.oss.driver.internal.core.protocol.FrameEncoder.encode(FrameEncoder.java:28)
		at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:89)
		... 26 more
```

Code path:
- ProtocolInitHandler assigns initial token to authResponseToken[1]
- null token gets passed into AuthResponse[2]
- NPE when trying to mark token before encoding[3]

1: https://github.com/datastax/java-driver/blob/4.12.0/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandler.java#L218,L231
2: https://github.com/datastax/java-driver/blob/4.12.0/core/src/main/java/com/datastax/oss/driver/internal/core/channel/ProtocolInitHandler.java#L182
3: https://github.com/datastax/native-protocol/blob/1.5.0/src/main/java/com/datastax/oss/protocol/internal/request/AuthResponse.java#L54