### PR TITLE
JAVA-2982: Switch Esri Geometry API to an optional dependency

### DIFF
--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -89,6 +89,11 @@
       <artifactId>HdrHistogram</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.esri.geometry</groupId>
+      <artifactId>esri-geometry-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.apache.tinkerpop</groupId>
       <artifactId>gremlin-core</artifactId>
       <optional>true</optional>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -90,6 +90,7 @@
     <dependency>
       <groupId>com.esri.geometry</groupId>
       <artifactId>esri-geometry-api</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.tinkerpop</groupId>

--- a/osgi-tests/pom.xml
+++ b/osgi-tests/pom.xml
@@ -79,6 +79,10 @@
       <artifactId>reactive-streams</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.esri.geometry</groupId>
+      <artifactId>esri-geometry-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.tinkerpop</groupId>
       <artifactId>gremlin-core</artifactId>
     </dependency>


### PR DESCRIPTION
Switch Esri Geometry API to an optional dependency

When using the OSS driver it looks like dependency 'esri-geometry-api' is not needed and could be made optional much like Tinkerpop in #1522 ? 

The reason for wanting this change is that 'esri-geometry-api' pulls an old version of Jackson library. I tried update the Esri dependency, but it will fail the serialization tests. 
