### PR TITLE
BasicLoadBalancingPolicy remote compute nodes check all liveNodes

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicy.java
@@ -55,8 +55,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntUnaryOperator;
-import java.util.stream.Collectors;
-
 import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -326,10 +324,11 @@ public class BasicLoadBalancingPolicy implements LoadBalancingPolicy {
           @Override
           protected Object[] computeNodes() {
             Set<String> dcs = liveNodes.dcs();
-            Object[] remoteNodes = dcs.stream()
-                            .filter(Predicates.not(Predicates.equalTo(localDc)))
-                            .flatMap(dc -> liveNodes.dc(dc).stream().limit(maxNodesPerRemoteDc))
-                            .toArray();
+            Object[] remoteNodes =
+                dcs.stream()
+                    .filter(Predicates.not(Predicates.equalTo(localDc)))
+                    .flatMap(dc -> liveNodes.dc(dc).stream().limit(maxNodesPerRemoteDc))
+                    .toArray();
 
             int remoteNodesLength = remoteNodes.length;
             if (remoteNodesLength == 0) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicy.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/loadbalancing/BasicLoadBalancingPolicy.java
@@ -323,10 +323,7 @@ public class BasicLoadBalancingPolicy implements LoadBalancingPolicy {
           @Override
           protected Object[] computeNodes() {
             Object[] dcs = liveNodes.dcs().toArray();
-            if (dcs.length <= 1) {
-              return EMPTY_NODES;
-            }
-            Object[] remoteNodes = new Object[(dcs.length - 1) * maxNodesPerRemoteDc];
+            Object[] remoteNodes = new Object[dcs.length * maxNodesPerRemoteDc];
             int remoteNodesLength = 0;
             for (Object dc : dcs) {
               if (!dc.equals(localDc)) {


### PR DESCRIPTION
BasicLoadBalancingPolicy remote compute nodes minor fix : don't presume local dc nodes are up and among the liveNodes that where found (can happen if the local dc wasn't up when the application started)