### PR TITLE
Upgrade ESRI geometry to 2.x

### DIFF
--- a/core/src/test/java/com/datastax/dse/driver/internal/core/data/geometry/DefaultLineStringTest.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/data/geometry/DefaultLineStringTest.java
@@ -34,7 +34,8 @@ public class DefaultLineStringTest {
 
   private final String wkt = "LINESTRING (30 10, 10 30, 40 40)";
 
-  private final String json =
+  /* A JSON representation that was explicitly tested for in ESRI < 2.x impls */
+  private final String legacyJson =
       "{\"type\":\"LineString\",\"coordinates\":[[30.0,10.0],[10.0,30.0],[40.0,40.0]]}";
 
   @Test
@@ -94,13 +95,17 @@ public class DefaultLineStringTest {
   }
 
   @Test
-  public void should_parse_valid_geo_json() {
-    assertThat(LineString.fromGeoJson(json)).isEqualTo(lineString);
+  public void should_create_and_parse_geo_json() {
+
+    String geoJsonStr = lineString.asGeoJson();
+    assertThat(JSONUtils.isValidJsonMap(geoJsonStr)).isTrue();
+    LineString newLineString = LineString.fromGeoJson(geoJsonStr);
+    assertThat(newLineString).isEqualTo(lineString);
   }
 
   @Test
-  public void should_convert_to_geo_json() {
-    assertThat(lineString.asGeoJson()).isEqualTo(json);
+  public void should_parse_legacy_geo_json() {
+    assertThat(LineString.fromGeoJson(legacyJson)).isEqualTo(lineString);
   }
 
   @Test

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/data/geometry/DefaultPointTest.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/data/geometry/DefaultPointTest.java
@@ -30,7 +30,8 @@ public class DefaultPointTest {
 
   private final String wkt = "POINT (1.1 2.2)";
 
-  private final String json = "{\"type\":\"Point\",\"coordinates\":[1.1,2.2]}";
+  /* A JSON representation that was explicitly tested for in ESRI < 2.x impls */
+  private final String legacyJson = "{\"type\":\"Point\",\"coordinates\":[1.1,2.2]}";
 
   @Test
   public void should_parse_valid_well_known_text() {
@@ -76,13 +77,17 @@ public class DefaultPointTest {
   }
 
   @Test
-  public void should_parse_valid_geo_json() {
-    assertThat(Point.fromGeoJson(json)).isEqualTo(point);
+  public void should_create_and_parse_geo_json() {
+
+    String geoJsonStr = point.asGeoJson();
+    assertThat(JSONUtils.isValidJsonMap(geoJsonStr)).isTrue();
+    Point newPoint = Point.fromGeoJson(geoJsonStr);
+    assertThat(newPoint).isEqualTo(point);
   }
 
   @Test
-  public void should_convert_to_geo_json() {
-    assertThat(point.asGeoJson()).isEqualTo(json);
+  public void should_parse_legacy_geo_json() {
+    assertThat(Point.fromGeoJson(legacyJson)).isEqualTo(point);
   }
 
   @Test

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/data/geometry/DefaultPolygonTest.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/data/geometry/DefaultPolygonTest.java
@@ -37,7 +37,8 @@ public class DefaultPolygonTest {
 
   private String wkt = "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))";
 
-  private String json =
+  /* A JSON representation that was explicitly tested for in ESRI < 2.x impls */
+  private String legacyJson =
       "{\"type\":\"Polygon\",\"coordinates\":[[[30.0,10.0],[10.0,20.0],[20.0,40.0],[40.0,40.0],[30.0,10.0]]]}";
 
   @Test
@@ -102,13 +103,17 @@ public class DefaultPolygonTest {
   }
 
   @Test
-  public void should_parse_valid_geo_json() {
-    assertThat(Polygon.fromGeoJson(json)).isEqualTo(polygon);
+  public void should_create_and_parse_geo_json() {
+
+    String geoJsonStr = polygon.asGeoJson();
+    assertThat(JSONUtils.isValidJsonMap(geoJsonStr)).isTrue();
+    Polygon newPolygon = Polygon.fromGeoJson(geoJsonStr);
+    assertThat(newPolygon).isEqualTo(polygon);
   }
 
   @Test
-  public void should_convert_to_geo_json() {
-    assertThat(polygon.asGeoJson()).isEqualTo(json);
+  public void should_parse_legacy_geo_json() {
+    assertThat(Polygon.fromGeoJson(legacyJson)).isEqualTo(polygon);
   }
 
   @Test

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/data/geometry/JSONUtils.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/data/geometry/JSONUtils.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.dse.driver.internal.core.data.geometry;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+
+public class JSONUtils {
+
+  public static boolean isValidJsonMap(String str) {
+
+    try {
+      new ObjectMapper().readValue(str, Map.class);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
     <json.version>20210307</json.version>
     <jackson.version>2.12.2</jackson.version>
     <jackson-databind.version>2.12.2</jackson-databind.version>
-    <legacy-jackson.version>1.9.12</legacy-jackson.version>
     <!-- optional dependencies -->
     <snappy.version>1.1.7.3</snappy.version>
     <lz4.version>1.7.1</lz4.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <hdrhistogram.version>2.1.12</hdrhistogram.version>
     <metrics.version>4.1.18</metrics.version>
     <netty.version>4.1.60.Final</netty.version>
-    <esri.version>1.2.1</esri.version>
+    <esri.version>2.2.4</esri.version>
     <!--
     When upgrading TinkerPop please upgrade the version matrix in
     manual/core/integration/README.md


### PR DESCRIPTION
An experiment in upgrading ESRI geometry to 2.x.  Newer versions removed the dependency on an older version of Jackson which in turn would allow us to remove that same dependency from the Java driver.

Additional context at https://github.com/datastax/java-driver/pull/1575#issuecomment-995061242