### PR TITLE
Fossa scanning workflow (3.x)

### DIFF
--- a/.github/workflows/dep-lic-scan.yaml
+++ b/.github/workflows/dep-lic-scan.yaml
@@ -1,0 +1,23 @@
+name: Dependency and License Scan
+on:
+  push:
+    branches:
+      - '4.x'
+      - '3.x'
+    paths-ignore:
+      - 'manual/**'
+      - 'faq/**'
+      - 'upgrade_guide/**'
+      - 'changelog/**'
+jobs:
+  scan-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Install Fossa CLI
+        run: |
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash -s -- -b .
+      - name: Scan for dependencies and licenses
+        run: |
+          FOSSA_API_KEY=${{ secrets.FOSSA_PUSH_ONLY_API_KEY }} ./fossa analyze


### PR DESCRIPTION
Add a new GitHub action to trigger Fossa scans using a provided build. This will always scan the latest content of the 3.x branch.

Successful test run of the action in my fork here for reference:  https://github.com/jdonenine/java-driver/actions/runs/1658560860