### PR TITLE
JAVA-2982: Follow-up to recent PR making ESRI an optional dependency

### DIFF
--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -146,8 +146,6 @@
                   -->
                   <include>com.datastax.oss:java-driver-core</include>
                   <include>io.netty:*</include>
-                  <include>org.json:*</include>
-                  <include>org.codehaus.jackson:*</include>
                   <include>com.fasterxml.jackson.core:*</include>
                 </includes>
               </artifactSet>
@@ -159,14 +157,6 @@
                 <relocation>
                   <pattern>io.netty</pattern>
                   <shadedPattern>com.datastax.oss.driver.shaded.netty</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.json</pattern>
-                  <shadedPattern>com.datastax.oss.driver.shaded.json</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.codehaus.jackson</pattern>
-                  <shadedPattern>com.datastax.oss.driver.shaded.codehaus.jackson</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.fasterxml.jackson</pattern>
@@ -185,18 +175,6 @@
                 </filter>
                 <filter>
                   <artifact>io.netty:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/**</exclude>
-                  </excludes>
-                </filter>
-                <filter>
-                  <artifact>org.json:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/**</exclude>
-                  </excludes>
-                </filter>
-                <filter>
-                  <artifact>org.codehaus.jackson:*</artifact>
                   <excludes>
                     <exclude>META-INF/**</exclude>
                   </excludes>

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -312,7 +312,7 @@
                   <!--
                   1) Don't import packages shaded in the driver bundle. Note that shaded-guava lives
                   in its own bundle, so we must explicitly *not* mention it here.
-                  -->!com.datastax.oss.driver.shaded.netty.*, !com.datastax.oss.driver.shaded.json.*, !com.datastax.oss.driver.shaded.codehaus.jackson.*, !com.datastax.oss.driver.shaded.fasterxml.jackson.*,
+                  -->!com.datastax.oss.driver.shaded.netty.*, !com.datastax.oss.driver.shaded.fasterxml.jackson.*,
                   <!--
                   2) Don't include the packages below because they contain annotations only and are
                   not required at runtime.
@@ -338,7 +338,7 @@
                 1) The driver's packages (API and internal);
                 2) All shaded packages, except Guava which resides in a separate bundle.
                 -->
-                <Export-Package>com.datastax.oss.driver.api.core.*, com.datastax.oss.driver.internal.core.*, com.datastax.dse.driver.api.core.*, com.datastax.dse.driver.internal.core.*, com.datastax.oss.driver.shaded.netty.*, com.datastax.oss.driver.shaded.json.*, com.datastax.oss.driver.shaded.codehaus.jackson.*, com.datastax.oss.driver.shaded.fasterxml.jackson.*,</Export-Package>
+                <Export-Package>com.datastax.oss.driver.api.core.*, com.datastax.oss.driver.internal.core.*, com.datastax.dse.driver.api.core.*, com.datastax.dse.driver.internal.core.*, com.datastax.oss.driver.shaded.netty.*, com.datastax.oss.driver.shaded.fasterxml.jackson.*,</Export-Package>
               </instructions>
               <rebuildBundle>true</rebuildBundle>
             </configuration>

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -146,7 +146,6 @@
                   -->
                   <include>com.datastax.oss:java-driver-core</include>
                   <include>io.netty:*</include>
-                  <include>com.esri.geometry:*</include>
                   <include>org.json:*</include>
                   <include>org.codehaus.jackson:*</include>
                   <include>com.fasterxml.jackson.core:*</include>
@@ -160,10 +159,6 @@
                 <relocation>
                   <pattern>io.netty</pattern>
                   <shadedPattern>com.datastax.oss.driver.shaded.netty</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.esri</pattern>
-                  <shadedPattern>com.datastax.oss.driver.shaded.esri</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.json</pattern>
@@ -190,12 +185,6 @@
                 </filter>
                 <filter>
                   <artifact>io.netty:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/**</exclude>
-                  </excludes>
-                </filter>
-                <filter>
-                  <artifact>com.esri.geometry:*</artifact>
                   <excludes>
                     <exclude>META-INF/**</exclude>
                   </excludes>
@@ -311,6 +300,11 @@
                   <artifactId>jctools-core</artifactId>
                   <version>2.1.2</version>
                 </additionalDependency>
+                <additionalDependency>
+                  <groupId>com.esri.geometry</groupId>
+                  <artifactId>esri-geometry-api</artifactId>
+                  <version>1.2.1</version>
+                </additionalDependency>
               </additionalDependencies>
             </configuration>
           </execution>
@@ -340,7 +334,7 @@
                   <!--
                   1) Don't import packages shaded in the driver bundle. Note that shaded-guava lives
                   in its own bundle, so we must explicitly *not* mention it here.
-                  -->!com.datastax.oss.driver.shaded.netty.*, !com.datastax.oss.driver.shaded.esri.*, !com.datastax.oss.driver.shaded.json.*, !com.datastax.oss.driver.shaded.codehaus.jackson.*, !com.datastax.oss.driver.shaded.fasterxml.jackson.*,
+                  -->!com.datastax.oss.driver.shaded.netty.*, !com.datastax.oss.driver.shaded.json.*, !com.datastax.oss.driver.shaded.codehaus.jackson.*, !com.datastax.oss.driver.shaded.fasterxml.jackson.*,
                   <!--
                   2) Don't include the packages below because they contain annotations only and are
                   not required at runtime.
@@ -366,7 +360,7 @@
                 1) The driver's packages (API and internal);
                 2) All shaded packages, except Guava which resides in a separate bundle.
                 -->
-                <Export-Package>com.datastax.oss.driver.api.core.*, com.datastax.oss.driver.internal.core.*, com.datastax.dse.driver.api.core.*, com.datastax.dse.driver.internal.core.*, com.datastax.oss.driver.shaded.netty.*, com.datastax.oss.driver.shaded.esri.*, com.datastax.oss.driver.shaded.json.*, com.datastax.oss.driver.shaded.codehaus.jackson.*, com.datastax.oss.driver.shaded.fasterxml.jackson.*,</Export-Package>
+                <Export-Package>com.datastax.oss.driver.api.core.*, com.datastax.oss.driver.internal.core.*, com.datastax.dse.driver.api.core.*, com.datastax.dse.driver.internal.core.*, com.datastax.oss.driver.shaded.netty.*, com.datastax.oss.driver.shaded.json.*, com.datastax.oss.driver.shaded.codehaus.jackson.*, com.datastax.oss.driver.shaded.fasterxml.jackson.*,</Export-Package>
               </instructions>
               <rebuildBundle>true</rebuildBundle>
             </configuration>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -211,6 +211,11 @@
       <artifactId>blockhound-junit-platform</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.esri.geometry</groupId>
+      <artifactId>esri-geometry-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/manual/core/integration/README.md
+++ b/manual/core/integration/README.md
@@ -509,6 +509,10 @@ library you must now explicitly specify it as a dependency :
 </dependency>
 ```
 
+The dependency specification above will introduce a dependency on version 1.2.1 of the Esri
+library.  While this release is older now we still recommend it's use in order to maximize
+compatibility with DSE.
+
 #### TinkerPop
 
 [Apache TinkerPop™](http://tinkerpop.apache.org/) is used in our [graph API](../dse/graph/),

--- a/manual/core/integration/README.md
+++ b/manual/core/integration/README.md
@@ -479,8 +479,9 @@ don't use any of the above features, you can safely exclude the dependency:
 Our [geospatial types](../dse/geotypes/) implementation is based on the [Esri Geometry
 API](https://github.com/Esri/geometry-api-java).
 
-Esri is declared as a required dependency, but the driver can operate normally without it. If you
-don't use geospatial types anywhere in your application, you can exclude the dependency:
+For driver versions >= 4.4.0 and < 4.14.0 Esri is declared as a required dependency,
+although the driver can operate normally without it. If you don't use geospatial types
+anywhere in your application you can exclude the dependency:
 
 ```xml
 <dependency>
@@ -493,6 +494,18 @@ don't use geospatial types anywhere in your application, you can exclude the dep
      <artifactId>*</artifactId>
    </exclusion>
   </exclusions>
+</dependency>
+```
+
+Starting with driver 4.14.0 Esri has been changed to an optional dependency.  You no longer have to
+explicitly exclude the dependency if it's not used, but if you do wish to make use of the Esri
+library you must now explicitly specify it as a dependency :
+
+```xml
+<dependency>
+  <groupId>com.esri.geometry</groupId>
+  <artifactId>esri-geometry-api</artifactId>
+  <version>${esri.version}</version>
 </dependency>
 ```
 

--- a/manual/core/integration/README.md
+++ b/manual/core/integration/README.md
@@ -509,9 +509,9 @@ library you must now explicitly specify it as a dependency :
 </dependency>
 ```
 
-The dependency specification above will introduce a dependency on version 1.2.1 of the Esri
-library.  While this release is older now we still recommend it's use in order to maximize
-compatibility with DSE.
+In the dependency specification above you should use any 1.2.x version of Esri (we recommend
+1.2.1).  These versions are older than the current 2.x versions of the library but they are
+guaranteed to be fully compatible with DSE.
 
 #### TinkerPop
 

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -9,6 +9,26 @@ request cannot be executed because all nodes tried were busy. Previously you wou
 `NoNodeAvailableException` but you will now get back an `AllNodesFailedException` where the
 `getAllErrors` map contains a `NodeUnavailableException` for that node.
 
+#### Esri Geometry dependency now optional
+
+Previous versions of the Java driver defined a mandatory dependency on the Esri geometry library.
+This library offered support for primitive geometric types supported by DSE.  As of driver 4.14.0
+this dependency is now optional.
+
+If you do not use DSE (or if you do but do not use the support for geometric types within DSE) you
+should experience no disruption.  If you are using geometric types with DSE you'll now need to
+explicitly declare a dependency on the Esri library:
+
+```xml
+<dependency>
+  <groupId>com.esri.geometry</groupId>
+  <artifactId>esri-geometry-api</artifactId>
+  <version>${esri.version}</version>
+</dependency>
+```
+
+See the [integration](../manual/core/integration/#esri) section in the manual for more details.
+
 ### 4.13.0
 
 #### Enhanced support for GraalVM native images 


### PR DESCRIPTION
Follow up to recent PR (https://github.com/datastax/java-driver/pull/1575) making ESRI an optional dependency.

I've empirically validated that as of this change the following statements are true:

* The core JAR contains no classes from the ESRI jar (expected... this was true before and shouldn't have changed in this effort)
* The shaded JAR contains no classes from the ESRI jar (new)
    * After https://github.com/datastax/java-driver/pull/1580/commits/953c72f428c70a6c7450d94843fc33b1c7cd3cf1 no classes from ESRI's transitive dependencies are included in the shaded JAR
* Both the core and shaded JAR now declare an optional dependency on ESRI (new)
    * ESRI's transitive dependencies are also optional as well
* All unit and integration tests still pass