### PR TITLE
chore(pom): update netty to 4.1.68

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <config.version>1.4.1</config.version>
     <hdrhistogram.version>2.1.12</hdrhistogram.version>
     <metrics.version>4.1.18</metrics.version>
-    <netty.version>4.1.60.Final</netty.version>
+    <netty.version>4.1.68.Final</netty.version>
     <esri.version>1.2.1</esri.version>
     <!--
     When upgrading TinkerPop please upgrade the version matrix in


### PR DESCRIPTION
Version 4.1.60 have known security vulnerabilities, which are fixed in 4.1.68:

 - `CVE-2021-37136`
 - `CVE-2021-37137`