### PR TITLE
Cassandra Socks5 Proxy options

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -186,6 +186,11 @@
       <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler-proxy</artifactId>
+      <version>4.1.72.Final</version>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -943,13 +943,13 @@ public enum DefaultDriverOption implements DriverOption {
    *
    * <p>Value-type: {@link String}
    */
-  SOCKS_PROXY_HOST("socks.proxyHost"),
+  SOCKS_PROXY_HOST("socks.proxy-host"),
   /**
    * Port which the Socks5 Proxy runs on
    *
    * <p>Value-type: int
    */
-  SOCKS_PROXY_PORT("socks.proxyPort"),
+  SOCKS_PROXY_PORT("socks.proxy-port"),
   ;
 
   private final String path;

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -266,19 +266,6 @@ public enum DefaultDriverOption implements DriverOption {
    */
   SSL_TRUSTSTORE_PASSWORD("advanced.ssl-engine-factory.truststore-password"),
   /**
-   * Socks5 Proxy Host to route Cassandra traffic through
-   *
-   * <p>Value-type: {@link String}
-   */
-  SOCKS_PROXY_HOST("socks.proxyHost"),
-  /**
-   * Port which the Socks5 Proxy runs on
-   *
-   * <p>Value-type: int
-   */
-  SOCKS_PROXY_PORT("socks.proxyPort"),
-
-  /**
    * The class of the generator that assigns a microsecond timestamp to each request.
    *
    * <p>Value-type: {@link int}
@@ -951,6 +938,18 @@ public enum DefaultDriverOption implements DriverOption {
    * <p>Value-type: List of {@link String}
    */
   METADATA_SCHEMA_CHANGE_LISTENER_CLASSES("advanced.schema-change-listener.classes"),
+  /**
+   * Socks5 Proxy Host to route Cassandra traffic through
+   *
+   * <p>Value-type: {@link String}
+   */
+  SOCKS_PROXY_HOST("socks.proxyHost"),
+  /**
+   * Port which the Socks5 Proxy runs on
+   *
+   * <p>Value-type: int
+   */
+  SOCKS_PROXY_PORT("socks.proxyPort"),
   ;
 
   private final String path;

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -265,11 +265,23 @@ public enum DefaultDriverOption implements DriverOption {
    * <p>Value-type: {@link String}
    */
   SSL_TRUSTSTORE_PASSWORD("advanced.ssl-engine-factory.truststore-password"),
+  /**
+   * Socks5 Proxy Host to route Cassandra traffic through
+   *
+   * <p>Value-type: {@link String}
+   */
+  SOCKS_PROXY_HOST("socks.proxyHost"),
+  /**
+   * Port which the Socks5 Proxy runs on
+   *
+   * <p>Value-type: int
+   */
+  SOCKS_PROXY_PORT("socks.proxyPort"),
 
   /**
    * The class of the generator that assigns a microsecond timestamp to each request.
    *
-   * <p>Value-type: {@link String}
+   * <p>Value-type: {@link int}
    */
   TIMESTAMP_GENERATOR_CLASS("advanced.timestamp-generator.class"),
   /**

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -241,10 +241,10 @@ public class TypedDriverOption<ValueT> {
       new TypedDriverOption<>(DefaultDriverOption.SSL_TRUSTSTORE_PASSWORD, GenericType.STRING);
   /** Host which runs as a SOCKS5 proxy, through which Cassandra traffic should be routed.. */
   public static final TypedDriverOption<String> SOCKS_PROXY_HOST =
-          new TypedDriverOption<>(DefaultDriverOption.SOCKS_PROXY_HOST, GenericType.STRING);
+      new TypedDriverOption<>(DefaultDriverOption.SOCKS_PROXY_HOST, GenericType.STRING);
   /** Port on which the SOCKS5 proxy is running. */
   public static final TypedDriverOption<Integer> SOCKS_PROXY_PORT =
-          new TypedDriverOption<>(DefaultDriverOption.SOCKS_PROXY_PORT, GenericType.INTEGER);
+      new TypedDriverOption<>(DefaultDriverOption.SOCKS_PROXY_PORT, GenericType.INTEGER);
   /** The class of the generator that assigns a microsecond timestamp to each request. */
   public static final TypedDriverOption<String> TIMESTAMP_GENERATOR_CLASS =
       new TypedDriverOption<>(DefaultDriverOption.TIMESTAMP_GENERATOR_CLASS, GenericType.STRING);

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -239,6 +239,12 @@ public class TypedDriverOption<ValueT> {
   /** The truststore password. */
   public static final TypedDriverOption<String> SSL_TRUSTSTORE_PASSWORD =
       new TypedDriverOption<>(DefaultDriverOption.SSL_TRUSTSTORE_PASSWORD, GenericType.STRING);
+  /** Host which runs as a SOCKS5 proxy, through which Cassandra traffic should be routed.. */
+  public static final TypedDriverOption<String> SOCKS_PROXY_HOST =
+          new TypedDriverOption<>(DefaultDriverOption.SOCKS_PROXY_HOST, GenericType.STRING);
+  /** Port on which the SOCKS5 proxy is running. */
+  public static final TypedDriverOption<Integer> SOCKS_PROXY_PORT =
+          new TypedDriverOption<>(DefaultDriverOption.SOCKS_PROXY_PORT, GenericType.INTEGER);
   /** The class of the generator that assigns a microsecond timestamp to each request. */
   public static final TypedDriverOption<String> TIMESTAMP_GENERATOR_CLASS =
       new TypedDriverOption<>(DefaultDriverOption.TIMESTAMP_GENERATOR_CLASS, GenericType.STRING);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
@@ -16,7 +16,6 @@
 package com.datastax.oss.driver.internal.core.context;
 
 import static com.datastax.oss.driver.internal.core.util.Dependency.JACKSON;
-import static java.util.Objects.isNull;
 
 import com.datastax.dse.driver.api.core.config.DseDriverOption;
 import com.datastax.dse.driver.internal.core.InsightsClientLifecycleListener;
@@ -471,10 +470,12 @@ public class DefaultDriverContext implements InternalDriverContext {
 
   protected NettyOptions buildNettyOptions() {
     DriverExecutionProfile defaultProfile = getConfig().getDefaultProfile();
-    String socksProxyHost = defaultProfile.isDefined(DefaultDriverOption.SOCKS_PROXY_HOST)
+    String socksProxyHost =
+        defaultProfile.isDefined(DefaultDriverOption.SOCKS_PROXY_HOST)
             ? defaultProfile.getString(DefaultDriverOption.SOCKS_PROXY_HOST)
             : "none";
-    int socksProxyPort = defaultProfile.isDefined(DefaultDriverOption.SOCKS_PROXY_PORT)
+    int socksProxyPort =
+        defaultProfile.isDefined(DefaultDriverOption.SOCKS_PROXY_PORT)
             ? defaultProfile.getInt(DefaultDriverOption.SOCKS_PROXY_PORT)
             : 0;
     if (!socksProxyHost.equals("none") && !socksProxyHost.isEmpty() && socksProxyPort > 0) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
@@ -469,7 +469,12 @@ public class DefaultDriverContext implements InternalDriverContext {
   }
 
   protected NettyOptions buildNettyOptions() {
-    return new DefaultNettyOptions(this);
+    String socksProxyHost = String.valueOf(DefaultDriverOption.SOCKS_PROXY_HOST);
+    int socksProxyPort = Integer.parseInt(String.valueOf(DefaultDriverOption.SOCKS_PROXY_PORT));
+    if (socksProxyHost.isEmpty() || socksProxyHost == null) {
+      return new DefaultNettyOptions(this);
+    }
+    return new SocksProxyNettyOptions(this, socksProxyHost, socksProxyPort);
   }
 
   protected Optional<SslHandlerFactory> buildSslHandlerFactory() {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/SocksProxyNettyOptions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/SocksProxyNettyOptions.java
@@ -1,0 +1,27 @@
+package com.datastax.oss.driver.internal.core.context;
+
+import io.netty.channel.Channel;
+import io.netty.handler.proxy.Socks5ProxyHandler;
+
+import java.net.InetSocketAddress;
+
+public class SocksProxyNettyOptions extends DefaultNettyOptions {
+    private String socksProxyHost;
+    private Integer socksProxyPort;
+
+    public SocksProxyNettyOptions(InternalDriverContext context, String socksProxyHost, Integer socksProxyPort) {
+        super(context);
+        this.socksProxyHost = socksProxyHost;
+        this.socksProxyPort = socksProxyPort;
+    }
+
+    @Override
+    public void afterChannelInitialized(Channel channel) throws RuntimeException {
+        try{
+            channel.pipeline().addFirst(new Socks5ProxyHandler(new InetSocketAddress(socksProxyHost, socksProxyPort)));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/SocksProxyNettyOptions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/SocksProxyNettyOptions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.datastax.oss.driver.internal.core.context;
 
 import io.netty.channel.Channel;

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/SocksProxyNettyOptions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/SocksProxyNettyOptions.java
@@ -2,26 +2,27 @@ package com.datastax.oss.driver.internal.core.context;
 
 import io.netty.channel.Channel;
 import io.netty.handler.proxy.Socks5ProxyHandler;
-
 import java.net.InetSocketAddress;
 
 public class SocksProxyNettyOptions extends DefaultNettyOptions {
-    private String socksProxyHost;
-    private Integer socksProxyPort;
+  private String socksProxyHost;
+  private Integer socksProxyPort;
 
-    public SocksProxyNettyOptions(InternalDriverContext context, String socksProxyHost, Integer socksProxyPort) {
-        super(context);
-        this.socksProxyHost = socksProxyHost;
-        this.socksProxyPort = socksProxyPort;
+  public SocksProxyNettyOptions(
+      InternalDriverContext context, String socksProxyHost, Integer socksProxyPort) {
+    super(context);
+    this.socksProxyHost = socksProxyHost;
+    this.socksProxyPort = socksProxyPort;
+  }
+
+  @Override
+  public void afterChannelInitialized(Channel channel) throws RuntimeException {
+    try {
+      channel
+          .pipeline()
+          .addFirst(new Socks5ProxyHandler(new InetSocketAddress(socksProxyHost, socksProxyPort)));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
-
-    @Override
-    public void afterChannelInitialized(Channel channel) throws RuntimeException {
-        try{
-            channel.pipeline().addFirst(new Socks5ProxyHandler(new InetSocketAddress(socksProxyHost, socksProxyPort)));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-    }
+  }
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -775,6 +775,18 @@ datastax-java-driver {
     // keystore-password = password123
   }
 
+  socks {
+    # Required: No
+    # Socks5 Proxy Host to route Cassandra traffic through
+    # If not set, defaults to none
+    // proxy-host = none
+
+    # Required: No
+    # Port which the Socks5 Proxy runs on
+    # If not set, defaults to 0
+    // proxy-port = 0
+  }
+
   # The generator that assigns a microsecond timestamp to each request.
   #
   # Required: yes

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContextTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContextTest.java
@@ -28,18 +28,17 @@ import com.datastax.oss.protocol.internal.NoopCompressor;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import io.netty.buffer.ByteBuf;
-
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(DataProviderRunner.class)
 public class DefaultDriverContextTest {
 
-  private DefaultDriverContext buildMockedContextWithCompressionOptions(Optional<String> compressionOption) {
+  private DefaultDriverContext buildMockedContextWithCompressionOptions(
+      Optional<String> compressionOption) {
 
     DriverExecutionProfile defaultProfile = mock(DriverExecutionProfile.class);
     when(defaultProfile.getString(DefaultDriverOption.PROTOCOL_COMPRESSION, "none"))
@@ -48,26 +47,21 @@ public class DefaultDriverContextTest {
   }
 
   private DefaultDriverContext buildMockedContextWithCompressorAndNettyOptions(
-          Optional<String> compressionOption, String socksProxyHost, int socksProxyPort) {
+      Optional<String> compressionOption, String socksProxyHost, int socksProxyPort) {
     DriverExecutionProfile defaultProfile = mock(DriverExecutionProfile.class);
     when(defaultProfile.getString(DefaultDriverOption.PROTOCOL_COMPRESSION, "none"))
-            .thenReturn(compressionOption.orElse("none"));
-    when(defaultProfile.isDefined(DefaultDriverOption.SOCKS_PROXY_HOST))
-            .thenReturn(true);
-    when(defaultProfile.isDefined(DefaultDriverOption.SOCKS_PROXY_PORT))
-            .thenReturn(true);
-    when(defaultProfile.getString(DefaultDriverOption.SOCKS_PROXY_HOST))
-            .thenReturn(socksProxyHost);
-    when(defaultProfile.getInt(DefaultDriverOption.SOCKS_PROXY_PORT))
-            .thenReturn(socksProxyPort);
+        .thenReturn(compressionOption.orElse("none"));
+    when(defaultProfile.isDefined(DefaultDriverOption.SOCKS_PROXY_HOST)).thenReturn(true);
+    when(defaultProfile.isDefined(DefaultDriverOption.SOCKS_PROXY_PORT)).thenReturn(true);
+    when(defaultProfile.getString(DefaultDriverOption.SOCKS_PROXY_HOST)).thenReturn(socksProxyHost);
+    when(defaultProfile.getInt(DefaultDriverOption.SOCKS_PROXY_PORT)).thenReturn(socksProxyPort);
     when(defaultProfile.getString(DefaultDriverOption.NETTY_IO_SHUTDOWN_UNIT))
-            .thenReturn(TimeUnit.SECONDS.toString());
+        .thenReturn(TimeUnit.SECONDS.toString());
     when(defaultProfile.getString(DefaultDriverOption.NETTY_ADMIN_SHUTDOWN_UNIT))
-            .thenReturn(TimeUnit.SECONDS.toString());
+        .thenReturn(TimeUnit.SECONDS.toString());
     when(defaultProfile.getDuration(DefaultDriverOption.NETTY_TIMER_TICK_DURATION))
-            .thenReturn(Duration.ofSeconds(1));
-    when(defaultProfile.getInt(DefaultDriverOption.NETTY_TIMER_TICKS_PER_WHEEL))
-            .thenReturn(2048);
+        .thenReturn(Duration.ofSeconds(1));
+    when(defaultProfile.getInt(DefaultDriverOption.NETTY_TIMER_TICKS_PER_WHEEL)).thenReturn(2048);
 
     return MockedDriverContextFactory.defaultDriverContext(Optional.of(defaultProfile));
   }
@@ -110,8 +104,8 @@ public class DefaultDriverContextTest {
   @Test
   @DataProvider({"none", "snappy", "lz4"})
   public void should_create_default_netty_options_regardless_of_compressor(String name) {
-    DefaultDriverContext ctx = buildMockedContextWithCompressorAndNettyOptions(
-            Optional.of(name), "none", 0);
+    DefaultDriverContext ctx =
+        buildMockedContextWithCompressorAndNettyOptions(Optional.of(name), "none", 0);
     NettyOptions nettyOptions = ctx.getNettyOptions();
     assertThat(nettyOptions).isInstanceOf(DefaultNettyOptions.class);
     assertThat(nettyOptions).isNotInstanceOf(SocksProxyNettyOptions.class);
@@ -119,8 +113,10 @@ public class DefaultDriverContextTest {
 
   @Test
   @DataProvider({"none", "snappy", "lz4"})
-  public void should_create_socks_proxy_netty_options_if_host_and_port_config_provided(String name) {
-    DefaultDriverContext ctx = buildMockedContextWithCompressorAndNettyOptions(
+  public void should_create_socks_proxy_netty_options_if_host_and_port_config_provided(
+      String name) {
+    DefaultDriverContext ctx =
+        buildMockedContextWithCompressorAndNettyOptions(
             Optional.of(name), "someproxyurl.com", 1080);
     NettyOptions nettyOptions = ctx.getNettyOptions();
     assertThat(nettyOptions).isInstanceOf(SocksProxyNettyOptions.class);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/context/MockedDriverContextFactory.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/context/MockedDriverContextFactory.java
@@ -29,7 +29,6 @@ import com.datastax.oss.driver.api.core.tracker.RequestTracker;
 import com.datastax.oss.driver.shaded.guava.common.collect.Maps;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 public class MockedDriverContextFactory {
 
@@ -53,16 +52,6 @@ public class MockedDriverContextFactory {
                   .thenReturn(true);
               when(blankProfile.getString(DefaultDriverOption.METRICS_FACTORY_CLASS))
                   .thenReturn("DefaultMetricsFactory");
-              when(blankProfile.isDefined(DefaultDriverOption.SOCKS_PROXY_HOST))
-                  .thenReturn(true);
-              when(blankProfile.isDefined(DefaultDriverOption.SOCKS_PROXY_PORT))
-                  .thenReturn(true);
-              when(blankProfile.getString(DefaultDriverOption.SOCKS_PROXY_HOST))
-                  .thenReturn("none");
-              when(blankProfile.getInt(DefaultDriverOption.SOCKS_PROXY_PORT))
-                  .thenReturn(0);
-              when(blankProfile.getString(DefaultDriverOption.NETTY_IO_SHUTDOWN_UNIT))
-                  .thenReturn(TimeUnit.SECONDS.toString());
               return blankProfile;
             });
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/context/MockedDriverContextFactory.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/context/MockedDriverContextFactory.java
@@ -29,6 +29,7 @@ import com.datastax.oss.driver.api.core.tracker.RequestTracker;
 import com.datastax.oss.driver.shaded.guava.common.collect.Maps;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 public class MockedDriverContextFactory {
 
@@ -52,6 +53,16 @@ public class MockedDriverContextFactory {
                   .thenReturn(true);
               when(blankProfile.getString(DefaultDriverOption.METRICS_FACTORY_CLASS))
                   .thenReturn("DefaultMetricsFactory");
+              when(blankProfile.isDefined(DefaultDriverOption.SOCKS_PROXY_HOST))
+                  .thenReturn(true);
+              when(blankProfile.isDefined(DefaultDriverOption.SOCKS_PROXY_PORT))
+                  .thenReturn(true);
+              when(blankProfile.getString(DefaultDriverOption.SOCKS_PROXY_HOST))
+                  .thenReturn("none");
+              when(blankProfile.getInt(DefaultDriverOption.SOCKS_PROXY_PORT))
+                  .thenReturn(0);
+              when(blankProfile.getString(DefaultDriverOption.NETTY_IO_SHUTDOWN_UNIT))
+                  .thenReturn(TimeUnit.SECONDS.toString());
               return blankProfile;
             });
 


### PR DESCRIPTION
I have a requirement to get a number of applications/services to route their Cassandra traffic through a Socks5 proxy layer. 

This has proven to be an easy task for many of these services as they make use of the com.datastax.driver.core.Cluster library - this library exposes methods such as Cluster.withNettyOptions() which makes routing Cassandra traffic through a proxy possible, following the example in this blog post: https://community.datastax.com/questions/851/connection-to-a-cluster-via-a-socks-proxy.html

However, my instance of Kafka-Connect-Cassandra uses the Datastax/Kafka-Sink library (which consumes this Java-Driver library under the hood) - which sadly does not expose any way to route Cassandra traffic through a Socks 5 proxy. This PR is an attempt to inner source and implement this feature.

The accompanying Kafka-Sink PR to this change is as follows: https://github.com/datastax/kafka-sink/pull/131 