### PR TITLE
JAVA-2976 Protocol v5 error codes CAS_WRITE_UNKNOWN, CDC_WRITE_FAILURE not supported (4.x)

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -71,7 +71,7 @@
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>native-protocol</artifactId>
-        <version>1.5.1-SNAPSHOT</version>
+        <version>1.5.1</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -71,7 +71,7 @@
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>native-protocol</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/CASWriteUnknownException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/CASWriteUnknownException.java
@@ -25,7 +25,7 @@ import com.datastax.oss.driver.api.core.session.Request;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * The result of a CAS operation is in an unknown state
+ * The result of a CAS operation is in an unknown state.
  *
  * <p>This exception is processed by {@link RetryPolicy#onErrorResponseVerdict(Request,
  * CoordinatorException, int)} , which will decide if it is rethrown directly to the client or if

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/CASWriteUnknownException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/CASWriteUnknownException.java
@@ -27,10 +27,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 /**
  * The result of a CAS operation is in an unknown state
  *
- * <p>This exception is processed by {@link RetryPolicy#onReadTimeoutVerdict(Request,
- * ConsistencyLevel, int, int, boolean, int)}, which will decide if it is rethrown directly to the
- * client or if the request should be retried. If all other tried nodes also fail, this exception
- * will appear in the {@link AllNodesFailedException} thrown to the client.
+ * <p>This exception is processed by {@link RetryPolicy#onErrorResponseVerdict(Request,
+ * CoordinatorException, int)} , which will decide if it is rethrown directly to the client or if
+ * the request should be retried. If all other tried nodes also fail, this exception will appear in
+ * the {@link AllNodesFailedException} thrown to the client.
  */
 public class CASWriteUnknownException extends QueryConsistencyException {
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/CASWriteUnknownException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/CASWriteUnknownException.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.servererrors;
+
+import com.datastax.oss.driver.api.core.AllNodesFailedException;
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.retry.RetryPolicy;
+import com.datastax.oss.driver.api.core.session.Request;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * The result of a CAS operation is in an unknown state
+ *
+ * <p>This exception is processed by {@link RetryPolicy#onReadTimeoutVerdict(Request,
+ * ConsistencyLevel, int, int, boolean, int)}, which will decide if it is rethrown directly to the
+ * client or if the request should be retried. If all other tried nodes also fail, this exception
+ * will appear in the {@link AllNodesFailedException} thrown to the client.
+ */
+public class CASWriteUnknownException extends QueryConsistencyException {
+
+  public CASWriteUnknownException(
+      @NonNull Node coordinator,
+      @NonNull ConsistencyLevel consistencyLevel,
+      int received,
+      int blockFor) {
+    this(
+        coordinator,
+        String.format(
+            "CAS operation result is unknown - proposal was not accepted by a quorum. (%d / %d)",
+            received, blockFor),
+        consistencyLevel,
+        received,
+        blockFor,
+        null,
+        false);
+  }
+
+  private CASWriteUnknownException(
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @NonNull ConsistencyLevel consistencyLevel,
+      int received,
+      int blockFor,
+      ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(
+        coordinator,
+        message,
+        consistencyLevel,
+        received,
+        blockFor,
+        executionInfo,
+        writableStackTrace);
+  }
+
+  @NonNull
+  @Override
+  public DriverException copy() {
+    return new CASWriteUnknownException(
+        getCoordinator(),
+        getMessage(),
+        getConsistencyLevel(),
+        getReceived(),
+        getBlockFor(),
+        getExecutionInfo(),
+        true);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/CDCWriteFailureException.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/servererrors/CDCWriteFailureException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.servererrors;
+
+import com.datastax.oss.driver.api.core.AllNodesFailedException;
+import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.retry.RetryPolicy;
+import com.datastax.oss.driver.api.core.session.Request;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * An attempt was made to write to a commitlog segment which doesn't support CDC mutations.
+ *
+ * <p>This exception is processed by {@link RetryPolicy#onErrorResponseVerdict(Request,
+ * CoordinatorException, int)}, which will decide if it is rethrown directly to the client or if the
+ * request should be retried. If all other tried nodes also fail, this exception will appear in the
+ * {@link AllNodesFailedException} thrown to the client.
+ */
+public class CDCWriteFailureException extends QueryExecutionException {
+
+  public CDCWriteFailureException(@NonNull Node coordinator) {
+    super(coordinator, "Commitlog does not support CDC mutations", null, false);
+  }
+
+  public CDCWriteFailureException(@NonNull Node coordinator, @NonNull String message) {
+    super(coordinator, "Commitlog does not support CDC mutations", null, false);
+  }
+
+  private CDCWriteFailureException(
+      @NonNull Node coordinator,
+      @NonNull String message,
+      @Nullable ExecutionInfo executionInfo,
+      boolean writableStackTrace) {
+    super(coordinator, message, executionInfo, writableStackTrace);
+  }
+
+  @NonNull
+  @Override
+  public DriverException copy() {
+    return new CDCWriteFailureException(getCoordinator(), getMessage(), getExecutionInfo(), true);
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
@@ -513,10 +513,10 @@ public class Conversions {
       case ProtocolConstants.ErrorCode.CAS_WRITE_UNKNOWN:
         CASWriteUnknown casFailure = (CASWriteUnknown) errorMessage;
         return new CASWriteUnknownException(
-                node,
-                context.getConsistencyLevelRegistry().codeToLevel(casFailure.consistencyLevel),
-                casFailure.received,
-                casFailure.blockFor);
+            node,
+            context.getConsistencyLevelRegistry().codeToLevel(casFailure.consistencyLevel),
+            casFailure.received,
+            casFailure.blockFor);
       case ProtocolConstants.ErrorCode.SYNTAX_ERROR:
         return new SyntaxError(node, errorMessage.message);
       case ProtocolConstants.ErrorCode.UNAUTHORIZED:

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
@@ -40,6 +40,8 @@ import com.datastax.oss.driver.api.core.metadata.schema.RelationMetadata;
 import com.datastax.oss.driver.api.core.retry.RetryPolicy;
 import com.datastax.oss.driver.api.core.servererrors.AlreadyExistsException;
 import com.datastax.oss.driver.api.core.servererrors.BootstrappingException;
+import com.datastax.oss.driver.api.core.servererrors.CASWriteUnknownException;
+import com.datastax.oss.driver.api.core.servererrors.CDCWriteFailureException;
 import com.datastax.oss.driver.api.core.servererrors.CoordinatorException;
 import com.datastax.oss.driver.api.core.servererrors.FunctionFailureException;
 import com.datastax.oss.driver.api.core.servererrors.InvalidConfigurationInQueryException;
@@ -75,6 +77,7 @@ import com.datastax.oss.protocol.internal.request.query.QueryOptions;
 import com.datastax.oss.protocol.internal.response.Error;
 import com.datastax.oss.protocol.internal.response.Result;
 import com.datastax.oss.protocol.internal.response.error.AlreadyExists;
+import com.datastax.oss.protocol.internal.response.error.CASWriteUnknown;
 import com.datastax.oss.protocol.internal.response.error.ReadFailure;
 import com.datastax.oss.protocol.internal.response.error.ReadTimeout;
 import com.datastax.oss.protocol.internal.response.error.Unavailable;
@@ -505,6 +508,15 @@ public class Conversions {
             context.getWriteTypeRegistry().fromName(writeFailure.writeType),
             writeFailure.numFailures,
             writeFailure.reasonMap);
+      case ProtocolConstants.ErrorCode.CDC_WRITE_FAILURE:
+        return new CDCWriteFailureException(node, errorMessage.message);
+      case ProtocolConstants.ErrorCode.CAS_WRITE_UNKNOWN:
+        CASWriteUnknown casFailure = (CASWriteUnknown) errorMessage;
+        return new CASWriteUnknownException(
+                node,
+                context.getConsistencyLevelRegistry().codeToLevel(casFailure.consistencyLevel),
+                casFailure.received,
+                casFailure.blockFor);
       case ProtocolConstants.ErrorCode.SYNTAX_ERROR:
         return new SyntaxError(node, errorMessage.message);
       case ProtocolConstants.ErrorCode.UNAUTHORIZED:

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/ProtocolUtils.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/ProtocolUtils.java
@@ -95,6 +95,10 @@ public class ProtocolUtils {
         return "FUNCTION_FAILURE";
       case ProtocolConstants.ErrorCode.WRITE_FAILURE:
         return "WRITE_FAILURE";
+      case ProtocolConstants.ErrorCode.CDC_WRITE_FAILURE:
+        return "CDC_WRITE_FAILURE";
+      case ProtocolConstants.ErrorCode.CAS_WRITE_UNKNOWN:
+        return "CAS_WRITE_UNKNOWN";
       case ProtocolConstants.ErrorCode.SYNTAX_ERROR:
         return "SYNTAX_ERROR";
       case ProtocolConstants.ErrorCode.UNAUTHORIZED:


### PR DESCRIPTION
4.x equivalent to https://github.com/datastax/java-driver/pull/1585.  Relies on https://github.com/datastax/native-protocol/pull/42 to build and function correctly.