### PR TITLE
JAVA-3003: CVE-2014-4043 Update com.github.jnr:jnr-posix to 3.1.15 to remove the vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
       <dependency>
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-posix</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.15</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>


### PR DESCRIPTION
Updating com.github.jnr:jnr-posix to version 3.1.15 to remove the vulnerability CVE-2014-4043