### PR TITLE
Documentation changes from 4.14 release for docs migration

### DIFF
--- a/modules/ROOT/pages/core/integration.adoc
+++ b/modules/ROOT/pages/core/integration.adoc
@@ -460,8 +460,8 @@ library you must now explicitly specify it as a dependency :
 </dependency>
 ----
 
-In the dependency specification above you should use any 1.2.x version of Esri (we recommend
-1.2.1).  These versions are older than the current 2.x versions of the library but they are
+In the dependency specification above, use any 1.2.x version of Esri. DataStax recommends
+1.2.1. These versions are older than the current 2.x versions of the library, but they are
 guaranteed to be fully compatible with DSE.
 
 === TinkerPop

--- a/modules/ROOT/pages/core/integration.adoc
+++ b/modules/ROOT/pages/core/integration.adoc
@@ -447,9 +447,9 @@ anywhere in your application you can exclude the dependency:
 </dependency>
 ----
 
-Starting with driver 4.14.0 Esri has been changed to an optional dependency.  You no longer have to
-explicitly exclude the dependency if it's not used, but if you do wish to make use of the Esri
-library you must now explicitly specify it as a dependency :
+Starting with driver 4.14.0, Esri has been changed to an optional dependency.  If the dependency is not used, you 
+no longer have to explicitly exclude the dependency. If you want to use the Esri
+library, explicitly specify it as a dependency:
 
 [source,xml]
 ----

--- a/modules/ROOT/pages/core/integration.adoc
+++ b/modules/ROOT/pages/core/integration.adoc
@@ -430,7 +430,7 @@ Our xref:core/dse/geotypes.adoc[geospatial types] implementation is based on the
 
 For driver versions >= 4.4.0 and < 4.14.0 Esri is declared as a required dependency,
 although the driver can operate normally without it. If you don't use geospatial types
-anywhere in your application you can exclude the dependency:
+anywhere in your application, you can exclude the dependency:
 
 [source,xml]
 ----

--- a/modules/ROOT/pages/core/integration.adoc
+++ b/modules/ROOT/pages/core/integration.adoc
@@ -428,8 +428,9 @@ If you don't use any of the above features, you can safely exclude the dependenc
 
 Our xref:core/dse/geotypes.adoc[geospatial types] implementation is based on the https://github.com/Esri/geometry-api-java[Esri Geometry API].
 
-Esri is declared as a required dependency, but the driver can operate normally without it.
-If you don't use geospatial types anywhere in your application, you can exclude the dependency:
+For driver versions >= 4.4.0 and < 4.14.0 Esri is declared as a required dependency,
+although the driver can operate normally without it. If you don't use geospatial types
+anywhere in your application you can exclude the dependency:
 
 [source,xml]
 ----
@@ -445,6 +446,23 @@ If you don't use geospatial types anywhere in your application, you can exclude 
   </exclusions>
 </dependency>
 ----
+
+Starting with driver 4.14.0 Esri has been changed to an optional dependency.  You no longer have to
+explicitly exclude the dependency if it's not used, but if you do wish to make use of the Esri
+library you must now explicitly specify it as a dependency :
+
+[source,xml]
+----
+<dependency>
+  <groupId>com.esri.geometry</groupId>
+  <artifactId>esri-geometry-api</artifactId>
+  <version>${esri.version}</version>
+</dependency>
+----
+
+In the dependency specification above you should use any 1.2.x version of Esri (we recommend
+1.2.1).  These versions are older than the current 2.x versions of the library but they are
+guaranteed to be fully compatible with DSE.
 
 === TinkerPop
 


### PR DESCRIPTION
PR to support documentation migration.  Content here taken from [this commit](https://github.com/datastax/java-driver/commit/415f789f4e1db7c003ee110153965fc91b70fdf5).  Does not include upgrade guide changes from the same commit.