### PR TITLE
JAVA-3026 Update docs.yaml for 3.11.2 release

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -107,7 +107,7 @@ versions:
   - name: '4.0'
     ref: '4.0.1'
   - name: '3.11'
-    ref: '3.11.1'
+    ref: '3.11.2'
   - name: '3.10'
     ref: '3.10.2_fixes'
   - name: '3.9'


### PR DESCRIPTION
May also need a copy of 3.11.2 Javadoc, not sure if that's already deployed or not