### PR TITLE
JAVA-3005 Refresh entire node list when new node added

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,10 @@
 
 <!-- Note: contrary to 3.x, insert new entries *first* in their section -->
 
+### 4.14.2 (in progress)
+
+- [bug] JAVA-3002 JAVA-3005: Refresh entire node list when a new node is added
+
 ### 4.14.1
 
 - [improvement] JAVA-3013: Upgrade dependencies to address CVEs and other security issues, 4.14.1 edition

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/NodeStateManager.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/NodeStateManager.java
@@ -185,10 +185,10 @@ public class NodeStateManager implements AsyncAutoCloseable {
             }
           } else {
             LOG.debug(
-                "[{}] Received UP event for unknown node {}, adding it",
+                "[{}] Received UP event for unknown node {}, refreshing node list",
                 logPrefix,
                 event.broadcastRpcAddress);
-            metadataManager.addNode(event.broadcastRpcAddress);
+            metadataManager.refreshNodes();
           }
           break;
         case SUGGEST_DOWN:

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/NodeStateManagerTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metadata/NodeStateManagerTest.java
@@ -147,7 +147,7 @@ public class NodeStateManagerTest {
   }
 
   @Test
-  public void should_add_node_if_up_event_and_not_in_metadata() {
+  public void should_refresh_node_list_if_up_event_and_not_in_metadata() {
     // Given
     new NodeStateManager(context);
 
@@ -157,7 +157,7 @@ public class NodeStateManagerTest {
 
     // Then
     verify(eventBus, never()).fire(any(NodeStateEvent.class));
-    verify(metadataManager).addNode(NEW_ADDRESS);
+    verify(metadataManager).refreshNodes();
   }
 
   @Test


### PR DESCRIPTION
Empirically, Cassandra does not appear to send
TopologyChangeType.REMOVED_NODE when a node in the ring
crashes hard and is eventually replaced, even though the
bad node is removed from the system tables. This results in
the driver holding on to that node until a restart.
The 3.x driver refreshes the entire node list when a node is
added, so when a new node comes up to replace the crashed
node, the crashed node is removed from the driver's state.
With this change we port that behavior to the 4.x driver and
refresh the entire node list when a new node is added.
This also fixes JAVA-3002.