### PR TITLE
JAVA-3041 Guava session - cloud bundle support. replaced deprecated constructors

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/api/GuavaSessionBuilder.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/api/GuavaSessionBuilder.java
@@ -18,40 +18,17 @@ package com.datastax.oss.driver.example.guava.api;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.context.DriverContext;
-import com.datastax.oss.driver.api.core.metadata.Node;
-import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
-import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
+import com.datastax.oss.driver.api.core.session.ProgrammaticArguments;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
-import com.datastax.oss.driver.api.core.tracker.RequestTracker;
-import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.example.guava.internal.DefaultGuavaSession;
 import com.datastax.oss.driver.example.guava.internal.GuavaDriverContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Predicate;
 
 public class GuavaSessionBuilder extends SessionBuilder<GuavaSessionBuilder, GuavaSession> {
 
   @Override
-  protected DriverContext buildContext(
-      DriverConfigLoader configLoader,
-      List<TypeCodec<?>> typeCodecs,
-      NodeStateListener nodeStateListener,
-      SchemaChangeListener schemaChangeListener,
-      RequestTracker requestTracker,
-      Map<String, String> localDatacenters,
-      Map<String, Predicate<Node>> nodeFilters,
-      ClassLoader classLoader) {
-    return new GuavaDriverContext(
-        configLoader,
-        typeCodecs,
-        nodeStateListener,
-        schemaChangeListener,
-        requestTracker,
-        localDatacenters,
-        nodeFilters,
-        classLoader);
+  protected DriverContext buildContext(DriverConfigLoader configLoader, ProgrammaticArguments programmaticArguments) {
+    return new GuavaDriverContext(configLoader, programmaticArguments);
   }
 
   @Override

--- a/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/api/GuavaSessionBuilder.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/api/GuavaSessionBuilder.java
@@ -27,7 +27,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class GuavaSessionBuilder extends SessionBuilder<GuavaSessionBuilder, GuavaSession> {
 
   @Override
-  protected DriverContext buildContext(DriverConfigLoader configLoader, ProgrammaticArguments programmaticArguments) {
+  protected DriverContext buildContext(
+      DriverConfigLoader configLoader, ProgrammaticArguments programmaticArguments) {
     return new GuavaDriverContext(configLoader, programmaticArguments);
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/GuavaDriverContext.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/GuavaDriverContext.java
@@ -18,11 +18,7 @@ package com.datastax.oss.driver.example.guava.internal;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.cql.PrepareRequest;
 import com.datastax.oss.driver.api.core.cql.Statement;
-import com.datastax.oss.driver.api.core.metadata.Node;
-import com.datastax.oss.driver.api.core.metadata.NodeStateListener;
-import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
-import com.datastax.oss.driver.api.core.tracker.RequestTracker;
-import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
+import com.datastax.oss.driver.api.core.session.ProgrammaticArguments;
 import com.datastax.oss.driver.example.guava.api.GuavaSession;
 import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
 import com.datastax.oss.driver.internal.core.cql.CqlPrepareAsyncProcessor;
@@ -30,9 +26,6 @@ import com.datastax.oss.driver.internal.core.cql.CqlPrepareSyncProcessor;
 import com.datastax.oss.driver.internal.core.cql.CqlRequestAsyncProcessor;
 import com.datastax.oss.driver.internal.core.cql.CqlRequestSyncProcessor;
 import com.datastax.oss.driver.internal.core.session.RequestProcessorRegistry;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Predicate;
 
 /**
  * A Custom {@link DefaultDriverContext} that overrides {@link #getRequestProcessorRegistry()} to
@@ -40,24 +33,8 @@ import java.util.function.Predicate;
  */
 public class GuavaDriverContext extends DefaultDriverContext {
 
-  public GuavaDriverContext(
-      DriverConfigLoader configLoader,
-      List<TypeCodec<?>> typeCodecs,
-      NodeStateListener nodeStateListener,
-      SchemaChangeListener schemaChangeListener,
-      RequestTracker requestTracker,
-      Map<String, String> localDatacenters,
-      Map<String, Predicate<Node>> nodeFilters,
-      ClassLoader classLoader) {
-    super(
-        configLoader,
-        typeCodecs,
-        nodeStateListener,
-        schemaChangeListener,
-        requestTracker,
-        localDatacenters,
-        nodeFilters,
-        classLoader);
+  public GuavaDriverContext(DriverConfigLoader configLoader, ProgrammaticArguments programmaticArguments) {
+    super(configLoader, programmaticArguments);
   }
 
   @Override

--- a/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/GuavaDriverContext.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/example/guava/internal/GuavaDriverContext.java
@@ -33,7 +33,8 @@ import com.datastax.oss.driver.internal.core.session.RequestProcessorRegistry;
  */
 public class GuavaDriverContext extends DefaultDriverContext {
 
-  public GuavaDriverContext(DriverConfigLoader configLoader, ProgrammaticArguments programmaticArguments) {
+  public GuavaDriverContext(
+      DriverConfigLoader configLoader, ProgrammaticArguments programmaticArguments) {
     super(configLoader, programmaticArguments);
   }
 


### PR DESCRIPTION
# Guava session - cloud bundle support

Hey from [ThingsBoard](https://thingsboard.io/) team!
I want to share my experience connecting [Datastax Astra DB cloud with GuavaSession using Thingsboard](https://github.com/thingsboard/thingsboard/pull/7110). 

The old GuavaSession implementation does not connect with cloud Astra DB.
This is because deprecated constructors were in place.
The paper that describes how to implement GuavaSession instead CqlSession is here:
https://docs.datastax.com/en/developer/java-driver/4.4/manual/developer/request_execution/

Here are the screenshots before I tried to connect with the old version:

![image](https://user-images.githubusercontent.com/79898499/185322620-d9a1bd1c-66de-4f72-ac52-2c5b6e62be13.png)

```
com.datastax.oss.driver.api.core.AllNodesFailedException: Could not reach any contact point, make sure you've provided valid addresses (showing first 3 nodes, use getAllErrors() for more): Node(endPoint=8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com:29042:a837fe38-9fd5-49a6-958e-7f7ca71ae890, hostId=null, hashCode=30c14db4): [com.datastax.oss.driver.api.core.connection.ConnectionInitException: [s0|control|id: 0x70374974, L:/10.8.0.66:19408 - R:8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com/34.77.135.39:29042] Protocol initialization request, step 1 (OPTIONS): unexpected failure (com.datastax.oss.driver.api.core.connection.ClosedConnectionException: Lost connection to remote peer)], Node(endPoint=8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com:29042:ba266e06-dfa4-4171-88cb-75758881bcba, hostId=null, hashCode=4ea6381e): [com.datastax.oss.driver.api.core.connection.ConnectionInitException: [s0|control|id: 0xd498c0a3, L:/10.8.0.66:12650 - R:8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com/34.78.6.86:29042] Protocol initialization request, step 1 (OPTIONS): unexpected failure (com.datastax.oss.driver.api.core.connection.ClosedConnectionException: Lost connection to remote peer)], Node(endPoint=8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com:29042:b16cc260-ee81-4017-b6cf-6b793a5b9935, hostId=null, hashCode=61928b01): [com.datastax.oss.driver.api.core.connection.ConnectionInitException: [s0|control|id: 0x0509e0f8, L:/10.8.0.66:39028 - R:8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com/34.140.171.129:29042] Protocol initialization request, step 1 (OPTIONS): unexpected failure (com.datastax.oss.driver.api.core.connection.ClosedConnectionException: Lost connection to remote peer)]

	at com.datastax.oss.driver.api.core.AllNodesFailedException.copy(AllNodesFailedException.java:141)
	at com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures.getUninterruptibly(CompletableFutures.java:149)
	at com.datastax.oss.driver.api.core.session.SessionBuilder.build(SessionBuilder.java:835)
	at com.datastax.oss.driver.core.session.GuavaToAstraConnectTest.astraConnectWithGuava(GuavaToAstraConnectTest.java:59)
...	
	Suppressed: com.datastax.oss.driver.api.core.connection.ConnectionInitException: [s0|control|id: 0x70374974, L:/10.8.0.66:19408 - R:8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com/34.77.135.39:29042] Protocol initialization request, step 1 (OPTIONS): unexpected failure (com.datastax.oss.driver.api.core.connection.ClosedConnectionException: Lost connection to remote peer)
		at com.datastax.oss.driver.internal.core.channel.ProtocolInitHandler$InitRequest.fail(ProtocolInitHandler.java:356)
		at com.datastax.oss.driver.internal.core.channel.ChannelHandlerRequest.onFailure(ChannelHandlerRequest.java:104)
		at com.datastax.oss.driver.internal.core.channel.InFlightHandler.fail(InFlightHandler.java:381)
		at com.datastax.oss.driver.internal.core.channel.InFlightHandler.abortAllInFlight(InFlightHandler.java:371)
		at com.datastax.oss.driver.internal.core.channel.InFlightHandler.abortAllInFlight(InFlightHandler.java:353)
		at com.datastax.oss.driver.internal.core.channel.InFlightHandler.channelInactive(InFlightHandler.java:331)
...
	Caused by: com.datastax.oss.driver.api.core.connection.ClosedConnectionException: Lost connection to remote peer
```

Now it works like a charm.

![image](https://user-images.githubusercontent.com/79898499/185321504-e4b5155d-f924-4d82-b413-f627a5b824f2.png)


Here is the code example of how I tested the Astra cloud connection with CqlSession and guavaSession

```java
package com.datastax.oss.driver.core.session;

import com.datastax.oss.driver.api.core.CqlSession;
import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
import com.datastax.oss.driver.api.core.cql.ResultSet;
import com.datastax.oss.driver.api.core.cql.Row;
import com.datastax.oss.driver.example.guava.api.GuavaSession;
import com.datastax.oss.driver.example.guava.api.GuavaSessionUtils;
import org.junit.Test;

import java.nio.file.Path;
import java.nio.file.Paths;
import java.util.concurrent.ExecutionException;

public class GuavaToAstraConnectTest {

  static final Path CLOUD_CONFIG_PATH = Paths.get("/home/your_user/projects/astra/secure-connect-thingsboard.zip");
  static final String CLIENT_ID = "tQPHMztQPHMztQPHMztQPHMz";
  static final String SECRET_ID = "5ejkcF9F.j6f64j71Sr.tiRe0Fsq25ejkcF9F.j6f64j71Sr.tiRe0Fsq25ejkcF9F.j6f64j71Sr.tiRe0Fsq2";

  @Test
  public void astraConnectCqlSession() {
    try (CqlSession session = CqlSession.builder()
            .withCloudSecureConnectBundle(CLOUD_CONFIG_PATH)
            .withAuthCredentials(CLIENT_ID, SECRET_ID)
            .build()) {
      ResultSet rs = session.execute("select release_version from system.local");
      Row row = rs.one();
      
      if (row != null) {
        System.out.println(row.getString("release_version"));
      } else {
        System.out.println("An error occurred.");
      }
    }
  }

  @Test
  public void astraConnectWithGuava() throws ExecutionException, InterruptedException {
    try (GuavaSession session = GuavaSessionUtils.builder()
            .withCloudSecureConnectBundle(CLOUD_CONFIG_PATH)
            .withAuthCredentials(CLIENT_ID, SECRET_ID)
            .build()) {
      AsyncResultSet rs = session.executeAsync("select release_version from system.local").get();
      Row row = rs.one();
      if (row != null) {
        System.out.println(row.getString("release_version"));
      } else {
        System.out.println("An error occurred.");
      }
    }
  }
}
```


