### PR TITLE
Annotate BatchStatement, Statement, SimpleStatement methods with CheckReturnValue

### DIFF
--- a/core/revapi.json
+++ b/core/revapi.json
@@ -6956,6 +6956,139 @@
         "old": "method java.lang.Throwable java.lang.Throwable::fillInStackTrace() @ com.fasterxml.jackson.databind.deser.UnresolvedForwardReference",
         "new": "method com.fasterxml.jackson.databind.deser.UnresolvedForwardReference com.fasterxml.jackson.databind.deser.UnresolvedForwardReference::fillInStackTrace()",
         "justification": "Upgrade jackson-databind to 2.13.4.1 to address CVEs, API change cause: https://github.com/FasterXML/jackson-databind/issues/3419"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method SelfT com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>::setNowInSeconds(int) @ com.datastax.oss.driver.api.core.cql.BatchStatement",
+        "new": "method SelfT com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>::setNowInSeconds(int) @ com.datastax.oss.driver.api.core.cql.BatchStatement",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method SelfT com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>::setNowInSeconds(int) @ com.datastax.oss.driver.api.core.cql.BatchableStatement<SelfT extends com.datastax.oss.driver.api.core.cql.BatchableStatement<SelfT>>",
+        "new": "method SelfT com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>::setNowInSeconds(int) @ com.datastax.oss.driver.api.core.cql.BatchStatement",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method SelfT com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>::setNowInSeconds(int) @ com.datastax.oss.driver.api.core.cql.BatchableStatement<SelfT extends com.datastax.oss.driver.api.core.cql.BatchableStatement<SelfT>>",
+        "new": "method SelfT com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>::setNowInSeconds(int) @ com.datastax.oss.driver.api.core.cql.BatchableStatement<SelfT extends com.datastax.oss.driver.api.core.cql.BatchableStatement<SelfT>>",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method SelfT com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>::setNowInSeconds(int) @ com.datastax.oss.driver.api.core.cql.BoundStatement",
+        "new": "method SelfT com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>::setNowInSeconds(int) @ com.datastax.oss.driver.api.core.cql.BoundStatement",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method SelfT com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>::setNowInSeconds(int) @ com.datastax.oss.driver.api.core.cql.SimpleStatement",
+        "new": "method SelfT com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>::setNowInSeconds(int) @ com.datastax.oss.driver.api.core.cql.SimpleStatement",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method SelfT com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>::setNowInSeconds(int)",
+        "new": "method SelfT com.datastax.oss.driver.api.core.cql.Statement<SelfT extends com.datastax.oss.driver.api.core.cql.Statement<SelfT>>::setNowInSeconds(int)",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method com.datastax.oss.driver.api.core.cql.BatchStatement com.datastax.oss.driver.api.core.cql.BatchStatement::add(com.datastax.oss.driver.api.core.cql.BatchableStatement<?>)",
+        "new": "method com.datastax.oss.driver.api.core.cql.BatchStatement com.datastax.oss.driver.api.core.cql.BatchStatement::add(com.datastax.oss.driver.api.core.cql.BatchableStatement<?>)",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method com.datastax.oss.driver.api.core.cql.BatchStatement com.datastax.oss.driver.api.core.cql.BatchStatement::addAll(com.datastax.oss.driver.api.core.cql.BatchableStatement<?>[])",
+        "new": "method com.datastax.oss.driver.api.core.cql.BatchStatement com.datastax.oss.driver.api.core.cql.BatchStatement::addAll(com.datastax.oss.driver.api.core.cql.BatchableStatement<?>[])",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method com.datastax.oss.driver.api.core.cql.BatchStatement com.datastax.oss.driver.api.core.cql.BatchStatement::addAll(java.lang.Iterable<? extends com.datastax.oss.driver.api.core.cql.BatchableStatement<?>>)",
+        "new": "method com.datastax.oss.driver.api.core.cql.BatchStatement com.datastax.oss.driver.api.core.cql.BatchStatement::addAll(java.lang.Iterable<? extends com.datastax.oss.driver.api.core.cql.BatchableStatement<?>>)",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method com.datastax.oss.driver.api.core.cql.BatchStatement com.datastax.oss.driver.api.core.cql.BatchStatement::clear()",
+        "new": "method com.datastax.oss.driver.api.core.cql.BatchStatement com.datastax.oss.driver.api.core.cql.BatchStatement::clear()",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method com.datastax.oss.driver.api.core.cql.BatchStatement com.datastax.oss.driver.api.core.cql.BatchStatement::setBatchType(com.datastax.oss.driver.api.core.cql.BatchType)",
+        "new": "method com.datastax.oss.driver.api.core.cql.BatchStatement com.datastax.oss.driver.api.core.cql.BatchStatement::setBatchType(com.datastax.oss.driver.api.core.cql.BatchType)",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method com.datastax.oss.driver.api.core.cql.BatchStatement com.datastax.oss.driver.api.core.cql.BatchStatement::setKeyspace(com.datastax.oss.driver.api.core.CqlIdentifier)",
+        "new": "method com.datastax.oss.driver.api.core.cql.BatchStatement com.datastax.oss.driver.api.core.cql.BatchStatement::setKeyspace(com.datastax.oss.driver.api.core.CqlIdentifier)",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "JAVA-2161: Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method com.datastax.oss.driver.api.core.cql.BatchStatement com.datastax.oss.driver.api.core.cql.BatchStatement::setKeyspace(java.lang.String)",
+        "new": "method com.datastax.oss.driver.api.core.cql.BatchStatement com.datastax.oss.driver.api.core.cql.BatchStatement::setKeyspace(java.lang.String)",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "JAVA-2161: Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method com.datastax.oss.driver.api.core.cql.SimpleStatement com.datastax.oss.driver.api.core.cql.SimpleStatement::setQuery(java.lang.String)",
+        "new": "method com.datastax.oss.driver.api.core.cql.SimpleStatement com.datastax.oss.driver.api.core.cql.SimpleStatement::setQuery(java.lang.String)",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method com.datastax.oss.driver.api.core.cql.SimpleStatement com.datastax.oss.driver.api.core.cql.SimpleStatement::setKeyspace(com.datastax.oss.driver.api.core.CqlIdentifier)",
+        "new": "method com.datastax.oss.driver.api.core.cql.SimpleStatement com.datastax.oss.driver.api.core.cql.SimpleStatement::setKeyspace(com.datastax.oss.driver.api.core.CqlIdentifier)",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method com.datastax.oss.driver.api.core.cql.SimpleStatement com.datastax.oss.driver.api.core.cql.SimpleStatement::setKeyspace(java.lang.String)",
+        "new": "method com.datastax.oss.driver.api.core.cql.SimpleStatement com.datastax.oss.driver.api.core.cql.SimpleStatement::setKeyspace(java.lang.String)",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method com.datastax.oss.driver.api.core.cql.SimpleStatement com.datastax.oss.driver.api.core.cql.SimpleStatement::setPositionalValues(java.util.List<java.lang.Object>)",
+        "new": "method com.datastax.oss.driver.api.core.cql.SimpleStatement com.datastax.oss.driver.api.core.cql.SimpleStatement::setPositionalValues(java.util.List<java.lang.Object>)",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method com.datastax.oss.driver.api.core.cql.SimpleStatement com.datastax.oss.driver.api.core.cql.SimpleStatement::setNamedValuesWithIds(java.util.Map<com.datastax.oss.driver.api.core.CqlIdentifier, java.lang.Object>)",
+        "new": "method com.datastax.oss.driver.api.core.cql.SimpleStatement com.datastax.oss.driver.api.core.cql.SimpleStatement::setNamedValuesWithIds(java.util.Map<com.datastax.oss.driver.api.core.CqlIdentifier, java.lang.Object>)",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
+      },
+      {
+        "code": "java.annotation.added",
+        "old": "method com.datastax.oss.driver.api.core.cql.SimpleStatement com.datastax.oss.driver.api.core.cql.SimpleStatement::setNamedValues(java.util.Map<java.lang.String, java.lang.Object>)",
+        "new": "method com.datastax.oss.driver.api.core.cql.SimpleStatement com.datastax.oss.driver.api.core.cql.SimpleStatement::setNamedValues(java.util.Map<java.lang.String, java.lang.Object>)",
+        "annotation": "@edu.umd.cs.findbugs.annotations.CheckReturnValue",
+        "justification": "Annotate mutating methods with @CheckReturnValue"
       }
     ]
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/BatchStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/BatchStatement.java
@@ -26,6 +26,7 @@ import com.datastax.oss.driver.internal.core.time.ServerSideTimestampGenerator;
 import com.datastax.oss.driver.internal.core.util.Sizes;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.protocol.internal.PrimitiveSizes;
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.ArrayList;
@@ -164,6 +165,7 @@ public interface BatchStatement extends Statement<BatchStatement>, Iterable<Batc
    * method. However custom implementations may choose to be mutable and return the same instance.
    */
   @NonNull
+  @CheckReturnValue
   BatchStatement setBatchType(@NonNull BatchType newBatchType);
 
   /**
@@ -180,6 +182,7 @@ public interface BatchStatement extends Statement<BatchStatement>, Iterable<Batc
    * @see Request#getKeyspace()
    */
   @NonNull
+  @CheckReturnValue
   BatchStatement setKeyspace(@Nullable CqlIdentifier newKeyspace);
 
   /**
@@ -187,6 +190,7 @@ public interface BatchStatement extends Statement<BatchStatement>, Iterable<Batc
    * setKeyspace(CqlIdentifier.fromCql(newKeyspaceName))}.
    */
   @NonNull
+  @CheckReturnValue
   default BatchStatement setKeyspace(@NonNull String newKeyspaceName) {
     return setKeyspace(CqlIdentifier.fromCql(newKeyspaceName));
   }
@@ -201,6 +205,7 @@ public interface BatchStatement extends Statement<BatchStatement>, Iterable<Batc
    * method. However custom implementations may choose to be mutable and return the same instance.
    */
   @NonNull
+  @CheckReturnValue
   BatchStatement add(@NonNull BatchableStatement<?> statement);
 
   /**
@@ -213,10 +218,12 @@ public interface BatchStatement extends Statement<BatchStatement>, Iterable<Batc
    * method. However custom implementations may choose to be mutable and return the same instance.
    */
   @NonNull
+  @CheckReturnValue
   BatchStatement addAll(@NonNull Iterable<? extends BatchableStatement<?>> statements);
 
   /** @see #addAll(Iterable) */
   @NonNull
+  @CheckReturnValue
   default BatchStatement addAll(@NonNull BatchableStatement<?>... statements) {
     return addAll(Arrays.asList(statements));
   }
@@ -231,6 +238,7 @@ public interface BatchStatement extends Statement<BatchStatement>, Iterable<Batc
    * method. However custom implementations may choose to be mutable and return the same instance.
    */
   @NonNull
+  @CheckReturnValue
   BatchStatement clear();
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/SimpleStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/SimpleStatement.java
@@ -28,6 +28,7 @@ import com.datastax.oss.driver.internal.core.util.Sizes;
 import com.datastax.oss.protocol.internal.PrimitiveSizes;
 import com.datastax.oss.protocol.internal.util.collection.NullAllowingImmutableList;
 import com.datastax.oss.protocol.internal.util.collection.NullAllowingImmutableMap;
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
@@ -197,6 +198,7 @@ public interface SimpleStatement extends BatchableStatement<SimpleStatement> {
    * @see #setNamedValuesWithIds(Map)
    */
   @NonNull
+  @CheckReturnValue
   SimpleStatement setQuery(@NonNull String newQuery);
 
   /**
@@ -209,6 +211,7 @@ public interface SimpleStatement extends BatchableStatement<SimpleStatement> {
    * @see Request#getKeyspace()
    */
   @NonNull
+  @CheckReturnValue
   SimpleStatement setKeyspace(@Nullable CqlIdentifier newKeyspace);
 
   /**
@@ -216,6 +219,7 @@ public interface SimpleStatement extends BatchableStatement<SimpleStatement> {
    * setKeyspace(CqlIdentifier.fromCql(newKeyspaceName))}.
    */
   @NonNull
+  @CheckReturnValue
   default SimpleStatement setKeyspace(@NonNull String newKeyspaceName) {
     return setKeyspace(CqlIdentifier.fromCql(newKeyspaceName));
   }
@@ -236,6 +240,7 @@ public interface SimpleStatement extends BatchableStatement<SimpleStatement> {
    * @see #setQuery(String)
    */
   @NonNull
+  @CheckReturnValue
   SimpleStatement setPositionalValues(@NonNull List<Object> newPositionalValues);
 
   @NonNull
@@ -256,6 +261,7 @@ public interface SimpleStatement extends BatchableStatement<SimpleStatement> {
    * @see #setQuery(String)
    */
   @NonNull
+  @CheckReturnValue
   SimpleStatement setNamedValuesWithIds(@NonNull Map<CqlIdentifier, Object> newNamedValues);
 
   /**
@@ -263,6 +269,7 @@ public interface SimpleStatement extends BatchableStatement<SimpleStatement> {
    * converted on the fly with {@link CqlIdentifier#fromCql(String)}.
    */
   @NonNull
+  @CheckReturnValue
   default SimpleStatement setNamedValues(@NonNull Map<String, Object> newNamedValues) {
     return setNamedValuesWithIds(DefaultSimpleStatement.wrapKeys(newNamedValues));
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/Statement.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/Statement.java
@@ -513,6 +513,7 @@ public interface Statement<SelfT extends Statement<SelfT>> extends Request {
    * @see #NO_NOW_IN_SECONDS
    */
   @NonNull
+  @CheckReturnValue
   @SuppressWarnings("unchecked")
   default SelfT setNowInSeconds(int nowInSeconds) {
     return (SelfT) this;


### PR DESCRIPTION
Since the driver's default implementation is for
BatchStatement#add* methods to be immutable, we should annotate those methods with @CheckReturnValue