### PR TITLE
Standardize on DataStax vs Datastax since that appears to be more common

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Datastax Java Driver for Apache Cassandra®
+# DataStax Java Driver for Apache Cassandra®
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.datastax.oss/java-driver-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.datastax.oss/java-driver-core)
 

--- a/core/src/main/java/com/datastax/dse/driver/api/core/cql/continuous/ContinuousSession.java
+++ b/core/src/main/java/com/datastax/dse/driver/api/core/cql/continuous/ContinuousSession.java
@@ -30,8 +30,8 @@ import java.util.concurrent.CompletionStage;
 /**
  * A session that has the ability to execute continuous paging queries.
  *
- * <p>Continuous paging is a new method of streaming bulk amounts of records from Datastax
- * Enterprise (DSE) to the Datastax Java Driver, available since DSE 5.1. It is mainly intended to
+ * <p>Continuous paging is a new method of streaming bulk amounts of records from DataStax
+ * Enterprise (DSE) to the DataStax Java Driver, available since DSE 5.1. It is mainly intended to
  * be leveraged by <a
  * href="https://docs.datastax.com/en/dse/5.1/dse-dev/datastax_enterprise/analytics/analyticsTOC.html">DSE
  * Analytics</a> and Apache Spark™, or by any similar analytics tool that needs to read large
@@ -76,7 +76,7 @@ public interface ContinuousSession extends Session {
    *
    * <p>See {@link ContinuousSession} for more explanations about continuous paging.
    *
-   * <p>This feature is only available with Datastax Enterprise. Executing continuous queries
+   * <p>This feature is only available with DataStax Enterprise. Executing continuous queries
    * against an Apache Cassandra&copy; cluster will result in a runtime error.
    *
    * @param statement the query to execute.
@@ -99,7 +99,7 @@ public interface ContinuousSession extends Session {
    *
    * <p>See {@link ContinuousSession} for more explanations about continuous paging.
    *
-   * <p>This feature is only available with Datastax Enterprise. Executing continuous queries
+   * <p>This feature is only available with DataStax Enterprise. Executing continuous queries
    * against an Apache Cassandra&copy; cluster will result in a runtime error.
    *
    * @param statement the query to execute.

--- a/core/src/main/java/com/datastax/dse/driver/api/core/cql/continuous/reactive/ContinuousReactiveSession.java
+++ b/core/src/main/java/com/datastax/dse/driver/api/core/cql/continuous/reactive/ContinuousReactiveSession.java
@@ -51,7 +51,7 @@ public interface ContinuousReactiveSession extends Session {
    *
    * <p>See {@link ContinuousSession} for more explanations about continuous paging.
    *
-   * <p>This feature is only available with Datastax Enterprise. Executing continuous queries
+   * <p>This feature is only available with DataStax Enterprise. Executing continuous queries
    * against an Apache Cassandra&reg; cluster will result in a runtime error.
    *
    * @param query the query to execute.
@@ -68,7 +68,7 @@ public interface ContinuousReactiveSession extends Session {
    *
    * <p>See {@link ContinuousSession} for more explanations about continuous paging.
    *
-   * <p>This feature is only available with Datastax Enterprise. Executing continuous queries
+   * <p>This feature is only available with DataStax Enterprise. Executing continuous queries
    * against an Apache Cassandra&reg; cluster will result in a runtime error.
    *
    * @param statement the statement to execute.

--- a/core/src/main/java/com/datastax/dse/driver/api/core/graph/GraphSession.java
+++ b/core/src/main/java/com/datastax/dse/driver/api/core/graph/GraphSession.java
@@ -49,7 +49,7 @@ public interface GraphSession extends Session {
    *       configuration and schema.
    * </ul>
    *
-   * <p>This feature is only available with Datastax Enterprise. Executing graph queries against an
+   * <p>This feature is only available with DataStax Enterprise. Executing graph queries against an
    * Apache Cassandra&reg; cluster will result in a runtime error.
    *
    * @see GraphResultSet
@@ -67,7 +67,7 @@ public interface GraphSession extends Session {
    * Executes a graph statement asynchronously (the call returns as soon as the statement was sent,
    * generally before the result is available).
    *
-   * <p>This feature is only available with Datastax Enterprise. Executing graph queries against an
+   * <p>This feature is only available with DataStax Enterprise. Executing graph queries against an
    * Apache Cassandra&reg; cluster will result in a runtime error.
    *
    * @see #execute(GraphStatement)

--- a/core/src/main/java/com/datastax/oss/driver/api/core/CqlSession.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/CqlSession.java
@@ -32,7 +32,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  *
  * <ul>
  *   <li>CQL requests: synchronous, asynchronous or reactive mode;
- *   <li>requests specific to Datastax Enterprise: graph and continuous paging.
+ *   <li>requests specific to DataStax Enterprise: graph and continuous paging.
  * </ul>
  *
  * Client applications can use this interface even if they don't need all the features. In

--- a/core/src/main/java/com/datastax/oss/driver/api/core/auth/PlainTextAuthProviderBase.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/auth/PlainTextAuthProviderBase.java
@@ -100,7 +100,7 @@ public abstract class PlainTextAuthProviderBase implements AuthProvider {
      * Builds an instance for username/password authentication, and proxy authentication with the
      * given authorizationId.
      *
-     * <p>This feature is only available with Datastax Enterprise. If the target server is Apache
+     * <p>This feature is only available with DataStax Enterprise. If the target server is Apache
      * Cassandra, the authorizationId will be ignored.
      */
     public Credentials(

--- a/core/src/main/java/com/datastax/oss/driver/api/core/auth/ProgrammaticPlainTextAuthProvider.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/auth/ProgrammaticPlainTextAuthProvider.java
@@ -67,7 +67,7 @@ public class ProgrammaticPlainTextAuthProvider extends PlainTextAuthProviderBase
    * Builds an instance for username/password authentication, and proxy authentication with the
    * given authorizationId.
    *
-   * <p>This feature is only available with Datastax Enterprise. If the target server is Apache
+   * <p>This feature is only available with DataStax Enterprise. If the target server is Apache
    * Cassandra, use {@link #ProgrammaticPlainTextAuthProvider(String, String)} instead, or set the
    * authorizationId to an empty string.
    */
@@ -109,7 +109,7 @@ public class ProgrammaticPlainTextAuthProvider extends PlainTextAuthProviderBase
    *
    * <p>The new credentials will be used for all connections initiated after this method was called.
    *
-   * <p>This feature is only available with Datastax Enterprise. If the target server is Apache
+   * <p>This feature is only available with DataStax Enterprise. If the target server is Apache
    * Cassandra, this method should not be used.
    *
    * @param authorizationId the new authorization id.

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -793,7 +793,7 @@ public enum DefaultDriverOption implements DriverOption {
   NETTY_DAEMON("advanced.netty.daemon"),
 
   /**
-   * The location of the cloud secure bundle used to connect to Datastax Apache Cassandra as a
+   * The location of the cloud secure bundle used to connect to DataStax Apache Cassandra as a
    * service.
    *
    * <p>Value-type: {@link String}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -617,7 +617,7 @@ public class TypedDriverOption<ValueT> {
   public static final TypedDriverOption<Boolean> NETTY_DAEMON =
       new TypedDriverOption<>(DefaultDriverOption.NETTY_DAEMON, GenericType.BOOLEAN);
   /**
-   * The location of the cloud secure bundle used to connect to Datastax Apache Cassandra as a
+   * The location of the cloud secure bundle used to connect to DataStax Apache Cassandra as a
    * service.
    */
   public static final TypedDriverOption<String> CLOUD_SECURE_CONNECT_BUNDLE =

--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
@@ -351,7 +351,7 @@ public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
    * Configures the session to use DSE plaintext authentication with the given username and
    * password, and perform proxy authentication with the given authorization id.
    *
-   * <p>This feature is only available in Datastax Enterprise. If connecting to Apache Cassandra,
+   * <p>This feature is only available in DataStax Enterprise. If connecting to Apache Cassandra,
    * the authorization id will be ignored; it is recommended to use {@link
    * #withAuthCredentials(String, String)} instead.
    *

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/auth/PlainTextAuthProvider.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/auth/PlainTextAuthProvider.java
@@ -39,7 +39,7 @@ import net.jcip.annotations.ThreadSafe;
  *     username = cassandra
  *     password = cassandra
  *
- *     // If connecting to Datastax Enterprise, this additional option allows proxy authentication
+ *     // If connecting to DataStax Enterprise, this additional option allows proxy authentication
  *     // (login as another user or role)
  *     authorization-id = userOrRole
  *   }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -241,7 +241,7 @@ datastax-java-driver {
     slow-replica-avoidance = true
   }
   basic.cloud {
-    # The location of the cloud secure bundle used to connect to Datastax Apache Cassandra as a
+    # The location of the cloud secure bundle used to connect to DataStax Apache Cassandra as a
     # service.
     # This setting must be a valid URL.
     # If the protocol is not specified, it is implicitly assumed to be the `file://` protocol,
@@ -683,7 +683,7 @@ datastax-java-driver {
     #
     # The driver provides two implementations:
     # - PlainTextAuthProvider: uses plain-text credentials. It requires the `username` and
-    #   `password` options below. When connecting to Datastax Enterprise, an optional
+    #   `password` options below. When connecting to DataStax Enterprise, an optional
     #   `authorization-id` can also be specified.
     #   For backward compatibility with previous driver versions, you can also use the class name
     #   "DsePlainTextAuthProvider" for this provider.

--- a/manual/core/dse/README.md
+++ b/manual/core/dse/README.md
@@ -1,6 +1,6 @@
 ## DSE-specific features
 
-Some driver features only work with Datastax Enterprise:
+Some driver features only work with DataStax Enterprise:
 
 * [Graph](graph/);
 * [Geospatial types](geotypes/);

--- a/manual/core/integration/README.md
+++ b/manual/core/integration/README.md
@@ -453,7 +453,7 @@ dependency:
 
 [Jackson](https://github.com/FasterXML/jackson) is used:
 
-* when connecting to [Datastax Astra](../../cloud/);
+* when connecting to [DataStax Astra](../../cloud/);
 * when Insights monitoring is enabled;
 * when [Json codecs](../custom_codecs) are being used. 
  

--- a/manual/core/metadata/node/README.md
+++ b/manual/core/metadata/node/README.md
@@ -51,7 +51,7 @@ but in general it represents the proximity to the client, and `LOCAL` nodes will
 coordinators. They also influence pooling options.
 
 [Node#getExtras()] contains additional free-form properties. This is intended for future evolution
-or custom driver extensions. In particular, if the driver is connected to Datastax Enterprise, the
+or custom driver extensions. In particular, if the driver is connected to DataStax Enterprise, the
 map will contain additional information under the keys defined in [DseNodeProperties]:
 
 ```java

--- a/manual/query_builder/README.md
+++ b/manual/query_builder/README.md
@@ -70,13 +70,13 @@ SimpleStatement statement = select.build();
 SimpleStatementBuilder builder = select.builder();
 ```
 
-#### Datastax Enterprise
+#### DataStax Enterprise
 
 The driver provides two additional entry points for DSE-specific queries: [DseQueryBuilder] and
 [DseSchemaBuilder]. They extend their respective non-DSE counterparts, so anything that is available
 on the default query builder can also be done with the DSE query builder.
 
-We recommend that you use those classes if you are targeting Datastax Enterprise; they will be
+We recommend that you use those classes if you are targeting DataStax Enterprise; they will be
 enriched in the future if DSE adds custom CQL syntax.
 
 Currently, the only difference is the support for the `DETERMINISTIC` and `MONOTONIC` keywords when

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -372,7 +372,7 @@ least 4.6.1.
 
 ### 4.4.0
 
-Datastax Enterprise support is now available directly in the main driver. There is no longer a
+DataStax Enterprise support is now available directly in the main driver. There is no longer a
 separate DSE driver.
 
 #### For Apache Cassandra® users
@@ -388,7 +388,7 @@ Apart from that, the only visible change is that DSE-specific features are now e
   lean, you can exclude some dependencies when you don't use the corresponding DSE features; see the 
   [Integration>Driver dependencies](../manual/core/integration/#driver-dependencies) section.
 
-#### For Datastax Enterprise users
+#### For DataStax Enterprise users
 
 Adjust your Maven coordinates to use the unified artifact:
 
@@ -514,7 +514,7 @@ We have dropped support for legacy protocol versions v1 and v2. As a result, the
 compatible with:
 
 * **Apache Cassandra®: 2.1 and above**;
-* **Datastax Enterprise: 4.7 and above**.
+* **DataStax Enterprise: 4.7 and above**.
 
 #### Packages
 


### PR DESCRIPTION
prior to this change:
```
akhaku@host:~/datastax-java-driver>(4.x) git grep Datastax | wc -l
      27
akhaku@host:~/datastax-java-driver>(4.x) git grep DataStax | wc -l
    1999
```