### PR TITLE
GraalVM native image support fixes

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/CompressorSubstitutions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/CompressorSubstitutions.java
@@ -21,7 +21,6 @@ import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.context.DriverContext;
 import com.datastax.oss.driver.internal.core.util.GraalDependencyChecker;
 import com.datastax.oss.protocol.internal.Compressor;
-import com.oracle.svm.core.annotate.Delete;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import io.netty.buffer.ByteBuf;
@@ -81,14 +80,6 @@ public class CompressorSubstitutions {
       }
     }
   }
-
-  @TargetClass(value = Lz4Compressor.class, onlyWith = Lz4Missing.class)
-  @Delete
-  public static final class DeleteLz4Compressor {}
-
-  @TargetClass(value = SnappyCompressor.class)
-  @Delete
-  public static final class DeleteSnappyCompressor {}
 
   public static class Lz4Present implements BooleanSupplier {
     @Override

--- a/core/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-core/native-image.properties
+++ b/core/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-core/native-image.properties
@@ -4,4 +4,5 @@ Args=-H:IncludeResources=reference\\.conf \
   -H:IncludeResources=application\\.properties \
   -H:IncludeResources=.*Driver\\.properties \
   -H:DynamicProxyConfigurationResources=${.}/proxy.json \
-  -H:ReflectionConfigurationResources=${.}/reflection.json
+  -H:ReflectionConfigurationResources=${.}/reflection.json \
+  --initialize-at-build-time=com.datastax.oss.driver.internal.core.util.Dependency


### PR DESCRIPTION
This PR fixes 2 blocking issues (native build broken) observed on https://github.com/spring-projects/spring-aot-smoke-tests/tree/main/data-cassandra which is used to validate the native support of Spring Boot 3. I have provided detailed explanation in the commit messages.

Tested with GraalVM 22.2 and upcoming GraalVM 22.3, but those changes should be fine with previous versions as well.

