### PR TITLE
Allow the use of CODECs with primitive getters

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableById.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableById.java
@@ -197,6 +197,29 @@ public interface GettableById extends GettableByIndex, AccessibleById {
   }
 
   /**
+   * Returns the value for the first occurrence of {@code id} as a Java primitive boolean
+   * using the provided {@code codec}.
+   *
+   * <p>By default, this works with CQL type {@code boolean}.
+   *
+   * <p>Note that, due to its signature, this method cannot return {@code null}. If the CQL value is
+   * {@code NULL}, it will return {@code false}. If this doesn't work for you, either call {@link
+   * #isNull(CqlIdentifier)} before calling this method, or use {@code get(id, Boolean.class)}
+   * instead.
+   *
+   * <p>If an identifier appears multiple times, this can only be used to access the first value.
+   * For the other ones, use positional getters.
+   *
+   * <p>If you want to avoid the overhead of building a {@code CqlIdentifier}, use the variant of
+   * this method that takes a string argument.
+   *
+   * @throws IllegalArgumentException if the id is invalid.
+   */
+  default boolean getBoolean(@NonNull CqlIdentifier id, TypeCodec<Boolean> codec) {
+    return getBoolean(firstIndexOf(id), codec);
+  }
+
+  /**
    * @deprecated this method only exists to ease the transition from driver 3, it is an alias for
    *     {@link #getBoolean(CqlIdentifier)}.
    */

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableById.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableById.java
@@ -314,6 +314,27 @@ public interface GettableById extends GettableByIndex, AccessibleById {
   }
 
   /**
+   * Returns the value for the first occurrence of {@code id} as a Java primitive long using the given {@code codec}.
+   *
+   * <p>By default, this works with CQL types {@code bigint} and {@code counter}.
+   *
+   * <p>Note that, due to its signature, this method cannot return {@code null}. If the CQL value is
+   * {@code NULL}, it will return {@code 0}. If this doesn't work for you, either call {@link
+   * #isNull(CqlIdentifier)} before calling this method, or use {@code get(id, codec)} instead.
+   *
+   * <p>If an identifier appears multiple times, this can only be used to access the first value.
+   * For the other ones, use positional getters.
+   *
+   * <p>If you want to avoid the overhead of building a {@code CqlIdentifier}, use the variant of
+   * this method that takes a string argument.
+   *
+   * @throws IllegalArgumentException if the id is invalid.
+   */
+  default long getLong(@NonNull CqlIdentifier id, TypeCodec<Long> codec) {
+    return getLong(firstIndexOf(id), codec);
+  }
+
+  /**
    * Returns the value for the first occurrence of {@code id} as a Java primitive short.
    *
    * <p>By default, this works with CQL type {@code smallint}.

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByIndex.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByIndex.java
@@ -167,6 +167,21 @@ public interface GettableByIndex extends AccessibleByIndex {
   default boolean getBoolean(int i) {
     DataType cqlType = getType(i);
     TypeCodec<Boolean> codec = codecRegistry().codecFor(cqlType, Boolean.class);
+    return getBoolean(i, codec);
+  }
+
+  /**
+   * Returns the {@code i}th value as a Java primitive boolean using the provided {@code codec}.
+   *
+   * <p>By default, this works with CQL type {@code boolean}.
+   *
+   * <p>Note that, due to its signature, this method cannot return {@code null}. If the CQL value is
+   * {@code NULL}, it will return {@code false}. If this doesn't work for you, either call {@link
+   * #isNull(int)} before calling this method, or use {@code get(i, Boolean.class)} instead.
+   *
+   * @throws IndexOutOfBoundsException if the index is invalid.
+   */
+  default boolean getBoolean(int i, TypeCodec<Boolean> codec) {
     if (codec instanceof PrimitiveBooleanCodec) {
       return ((PrimitiveBooleanCodec) codec).decodePrimitive(getBytesUnsafe(i), protocolVersion());
     } else {

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByIndex.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByIndex.java
@@ -286,6 +286,21 @@ public interface GettableByIndex extends AccessibleByIndex {
   default long getLong(int i) {
     DataType cqlType = getType(i);
     TypeCodec<Long> codec = codecRegistry().codecFor(cqlType, Long.class);
+    return getLong(i, codec);
+  }
+
+  /**
+   * Returns the {@code i}th value as a Java primitive long using the provided {@code codec}.
+   *
+   * <p>By default, this works with CQL types {@code bigint} and {@code counter}.
+   *
+   * <p>Note that, due to its signature, this method cannot return {@code null}. If the CQL value is
+   * {@code NULL}, it will return {@code 0}. If this doesn't work for you, either call {@link
+   * #isNull(int)} before calling this method, or use {@code get(i, codec)} instead.
+   *
+   * @throws IndexOutOfBoundsException if the index is invalid.
+   */
+  default long getLong(int i, TypeCodec<Long> codec) {
     if (codec instanceof PrimitiveLongCodec) {
       return ((PrimitiveLongCodec) codec).decodePrimitive(getBytesUnsafe(i), protocolVersion());
     } else {

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByName.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByName.java
@@ -311,6 +311,28 @@ public interface GettableByName extends GettableByIndex, AccessibleByName {
   }
 
   /**
+   * Returns the value for the first occurrence of {@code name} as a Java primitive
+   * long using the provided {@code codec}.
+   *
+   * <p>By default, this works with CQL types {@code bigint} and {@code counter}.
+   *
+   * <p>Note that, due to its signature, this method cannot return {@code null}. If the CQL value is
+   * {@code NULL}, it will return {@code 0}. If this doesn't work for you, either call {@link
+   * #isNull(String)} before calling this method, or use {@code get(name, codec)} instead.
+   *
+   * <p>If an identifier appears multiple times, this can only be used to access the first value.
+   * For the other ones, use positional getters.
+   *
+   * <p>This method deals with case sensitivity in the way explained in the documentation of {@link
+   * AccessibleByName}.
+   *
+   * @throws IllegalArgumentException if the name is invalid.
+   */
+  default long getLong(@NonNull String name, TypeCodec<Long> codec) {
+    return getLong(firstIndexOf(name), codec);
+  }
+
+  /**
    * Returns the value for the first occurrence of {@code name} as a Java primitive short.
    *
    * <p>By default, this works with CQL type {@code smallint}.

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByName.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByName.java
@@ -197,6 +197,28 @@ public interface GettableByName extends GettableByIndex, AccessibleByName {
   }
 
   /**
+   * Returns the value for the first occurrence of {@code name} as a Java primitive boolean
+   * using the provided {@code codec}.
+   *
+   * <p>By default, this works with CQL type {@code boolean}.
+   *
+   * <p>Note that, due to its signature, this method cannot return {@code null}. If the CQL value is
+   * {@code NULL}, it will return {@code false}. If this doesn't work for you, either call {@link
+   * #isNull(String)} before calling this method, or use {@code get(name, Boolean.class)} instead.
+   *
+   * <p>If an identifier appears multiple times, this can only be used to access the first value.
+   * For the other ones, use positional getters.
+   *
+   * <p>This method deals with case sensitivity in the way explained in the documentation of {@link
+   * AccessibleByName}.
+   *
+   * @throws IllegalArgumentException if the name is invalid.
+   */
+  default boolean getBoolean(@NonNull String name, TypeCodec<Boolean> codec) {
+    return getBoolean(firstIndexOf(name), codec);
+  }
+
+  /**
    * @deprecated this method only exists to ease the transition from driver 3, it is an alias for
    *     {@link #getBoolean(String)}.
    */


### PR DESCRIPTION
From what I observe a typical Cassandra application spends a few percent
CPU time computing CODEC. This computation can typically be avoided
by passing manually the codec that matches the data types.

In this draft pull request, I propose to allow similar optimisation for primitive getX methods, 
withoutpaying the price of unboxing X.class.

I did the change for `Long` and `Boolean` so far.

If this is consensual enough, I will carry other the change to the other types (Float, Double, Short, Int, Byte) and take care of this change for setter as well to get a well rounded API.