### PR TITLE
Improve IdentifierIndex firstIndexOf performance

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/data/IdentifierIndex.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/data/IdentifierIndex.java
@@ -20,6 +20,8 @@ import com.datastax.oss.driver.api.core.data.AccessibleByName;
 import com.datastax.oss.driver.api.core.data.GettableById;
 import com.datastax.oss.driver.api.core.data.GettableByName;
 import com.datastax.oss.driver.internal.core.util.Strings;
+import com.datastax.oss.driver.shaded.guava.common.collect.ArrayListMultimap;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableListMultimap;
 import com.datastax.oss.driver.shaded.guava.common.collect.LinkedListMultimap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ListMultimap;
 import java.util.Iterator;
@@ -41,9 +43,9 @@ public class IdentifierIndex {
   private final ListMultimap<String, Integer> byCaseInsensitiveName;
 
   public IdentifierIndex(List<CqlIdentifier> ids) {
-    this.byId = LinkedListMultimap.create(ids.size());
-    this.byCaseSensitiveName = LinkedListMultimap.create(ids.size());
-    this.byCaseInsensitiveName = LinkedListMultimap.create(ids.size());
+    ImmutableListMultimap.Builder<CqlIdentifier, Integer> byId = ImmutableListMultimap.builder();
+    ImmutableListMultimap.Builder<String, Integer> byCaseSensitiveName = ImmutableListMultimap.builder();
+    ImmutableListMultimap.Builder<String, Integer> byCaseInsensitiveName = ImmutableListMultimap.builder();
 
     int i = 0;
     for (CqlIdentifier id : ids) {
@@ -52,6 +54,10 @@ public class IdentifierIndex {
       byCaseInsensitiveName.put(id.asInternal().toLowerCase(Locale.ROOT), i);
       i += 1;
     }
+
+    this.byId = byId.build();
+    this.byCaseSensitiveName = byCaseSensitiveName.build();
+    this.byCaseInsensitiveName = byCaseInsensitiveName.build();
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/data/IdentifierIndex.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/data/IdentifierIndex.java
@@ -22,6 +22,7 @@ import com.datastax.oss.driver.api.core.data.GettableByName;
 import com.datastax.oss.driver.internal.core.util.Strings;
 import com.datastax.oss.driver.shaded.guava.common.collect.LinkedListMultimap;
 import com.datastax.oss.driver.shaded.guava.common.collect.ListMultimap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import net.jcip.annotations.Immutable;
@@ -68,8 +69,8 @@ public class IdentifierIndex {
    * AccessibleByName}, or -1 if it's not in the list.
    */
   public int firstIndexOf(String name) {
-    List<Integer> indices = allIndicesOf(name);
-    return indices.isEmpty() ? -1 : indices.get(0);
+    Iterator<Integer> indices = allIndicesOf(name).iterator();
+    return indices.hasNext() ? -1 : indices.next();
   }
 
   /** Returns all occurrences of a given identifier. */
@@ -79,7 +80,7 @@ public class IdentifierIndex {
 
   /** Returns the first occurrence of a given identifier, or -1 if it's not in the list. */
   public int firstIndexOf(CqlIdentifier id) {
-    List<Integer> indices = allIndicesOf(id);
-    return indices.isEmpty() ? -1 : indices.get(0);
+    Iterator<Integer> indices = allIndicesOf(id).iterator();
+    return indices.hasNext() ? -1 : indices.next();
   }
 }


### PR DESCRIPTION
Avoids doing two hasmap lookups and instead does a single one, thus improving performances (CPU) of rougthly 33%.

In applications reading lots of rows and not managing manually indexes (which is tricky, boiler plate and error prone),
IdentifierIndex::firstIndexOf is typically a CPU hotspots. In reactive applications it might even run on the driver event loop. As such, performances gains here are welcome.

## Before

```
Benchmark                             Mode  Cnt  Score   Error  Units
IdentifierIndexBench.complexGetFirst  avgt    5  0.046 ± 0.005  us/op
IdentifierIndexBench.simpleGetFirst   avgt    5  0.046 ± 0.002  us/op
```

## After

```
Benchmark                             Mode  Cnt  Score   Error  Units
IdentifierIndexBench.complexGetFirst    avgt    5  0.028 ± 0.002  us/op
IdentifierIndexBench.simpleGetFirst     avgt    5  0.030 ± 0.002  us/op
```

[Use ImmutableListMultimap within IdentifierIndex](https://github.com/datastax/java-driver/pull/1615/commits/1631b6d8c3e8a9cc46d5388382f40f527bb6a558)
[1631b6d](https://github.com/datastax/java-driver/pull/1615/commits/1631b6d8c3e8a9cc46d5388382f40f527bb6a558)

This unlocks massive performance gains upon reads, for a minor slow
down at instanciation time, which won't be felt by applications relying
on prepared statements.

## Before

```
Benchmark                               Mode  Cnt  Score   Error  Units
IdentifierIndexBench.complexAllIndices  avgt    5  0.007 ± 0.001  us/op
IdentifierIndexBench.complexGetFirst    avgt    5  0.026 ± 0.002  us/op
IdentifierIndexBench.createComplex      avgt    5  0.759 ± 0.059  us/op
IdentifierIndexBench.createSimple       avgt    5  0.427 ± 0.048  us/op
IdentifierIndexBench.simpleAllIndices   avgt    5  0.007 ± 0.001  us/op
IdentifierIndexBench.simpleGetFirst     avgt    5  0.027 ± 0.002  us/op
```

## After

```
Benchmark                               Mode  Cnt  Score    Error  Units
IdentifierIndexBench.complexAllIndices  avgt    5  0.004 ±  0.001  us/op
IdentifierIndexBench.complexGetFirst    avgt    5  0.005 ±  0.001  us/op
IdentifierIndexBench.createComplex      avgt    5  0.680 ±  0.020  us/op
IdentifierIndexBench.createSimple       avgt    5  0.538 ±  0.096  us/op
IdentifierIndexBench.simpleAllIndices   avgt    5  0.004 ±  0.001  us/op
IdentifierIndexBench.simpleGetFirst     avgt    5  0.005 ±  0.001  us/op
```
