### PR TITLE
Improve ByteBufPrimitiveCodec readBytes

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/ByteBufPrimitiveCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/ByteBufPrimitiveCodec.java
@@ -115,7 +115,9 @@ public class ByteBufPrimitiveCodec implements PrimitiveCodec<ByteBuf> {
     int length = readInt(source);
     if (length < 0) return null;
     ByteBuf slice = source.readSlice(length);
-    return ByteBuffer.wrap(readRawBytes(slice));
+    byte[] bytes = new byte[slice.readableBytes()];
+    slice.readBytes(bytes);
+    return ByteBuffer.wrap(bytes);
   }
 
   @Override
@@ -218,22 +220,6 @@ public class ByteBufPrimitiveCodec implements PrimitiveCodec<ByteBuf> {
   public void writeShortBytes(byte[] bytes, ByteBuf dest) {
     writeUnsignedShort(bytes.length, dest);
     dest.writeBytes(bytes);
-  }
-
-  // Reads *all* readable bytes from a buffer and return them.
-  // If the buffer is backed by an array, this will return the underlying array directly, without
-  // copy.
-  private static byte[] readRawBytes(ByteBuf buffer) {
-    if (buffer.hasArray() && buffer.readableBytes() == buffer.array().length) {
-      // Move the readerIndex just so we consistently consume the input
-      buffer.readerIndex(buffer.writerIndex());
-      return buffer.array();
-    }
-
-    // Otherwise, just read the bytes in a new array
-    byte[] bytes = new byte[buffer.readableBytes()];
-    buffer.readBytes(bytes);
-    return bytes;
   }
 
   private static String readString(ByteBuf source, int length) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/ByteBufPrimitiveCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/ByteBufPrimitiveCodec.java
@@ -114,7 +114,6 @@ public class ByteBufPrimitiveCodec implements PrimitiveCodec<ByteBuf> {
   public ByteBuffer readBytes(ByteBuf source) {
     int length = readInt(source);
     if (length < 0) return null;
-    if (source.readableBytes() < length) throw new IndexOutOfBoundsException();
     byte[] bytes = new byte[length];
     source.readBytes(bytes);
     return ByteBuffer.wrap(bytes);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/ByteBufPrimitiveCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/ByteBufPrimitiveCodec.java
@@ -114,9 +114,9 @@ public class ByteBufPrimitiveCodec implements PrimitiveCodec<ByteBuf> {
   public ByteBuffer readBytes(ByteBuf source) {
     int length = readInt(source);
     if (length < 0) return null;
-    ByteBuf slice = source.readSlice(length);
-    byte[] bytes = new byte[slice.readableBytes()];
-    slice.readBytes(bytes);
+    if (source.readableBytes() < length) throw new IndexOutOfBoundsException();
+    byte[] bytes = new byte[length];
+    source.readBytes(bytes);
     return ByteBuffer.wrap(bytes);
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/protocol/ByteBufPrimitiveCodecTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/protocol/ByteBufPrimitiveCodecTest.java
@@ -165,6 +165,22 @@ public class ByteBufPrimitiveCodecTest {
   }
 
   @Test
+  public void read_bytes_should_throw_when_not_enough_content() {
+    ByteBuf source =
+        ByteBufs.wrap(
+            // length (as an int) : 4 bytes
+            0x00,
+            0x00,
+            0x00,
+            0x04,
+            // contents : only 2 bytes
+            0xca,
+            0xfe);
+    assertThatThrownBy(() -> codec.readBytes(source))
+        .isInstanceOf(IndexOutOfBoundsException.class);
+  }
+
+  @Test
   public void should_read_null_bytes() {
     ByteBuf source = ByteBufs.wrap(0xFF, 0xFF, 0xFF, 0xFF); // -1 (as an int)
     assertThat(codec.readBytes(source)).isNull();

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/protocol/ByteBufPrimitiveCodecTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/protocol/ByteBufPrimitiveCodecTest.java
@@ -165,6 +165,49 @@ public class ByteBufPrimitiveCodecTest {
   }
 
   @Test
+  public void should_read_bytes_when_extra_data() {
+    ByteBuf source =
+        ByteBufs.wrap(
+            // length (as an int)
+            0x00,
+            0x00,
+            0x00,
+            0x04,
+            // contents
+            0xca,
+            0xfe,
+            0xba,
+            0xbe,
+            0xde,
+            0xda,
+            0xdd);
+    ByteBuffer bytes = codec.readBytes(source);
+    assertThat(Bytes.toHexString(bytes)).isEqualTo("0xcafebabe");
+  }
+
+  @Test
+  public void read_bytes_should_udpate_reader_index() {
+    ByteBuf source =
+        ByteBufs.wrap(
+            // length (as an int)
+            0x00,
+            0x00,
+            0x00,
+            0x04,
+            // contents
+            0xca,
+            0xfe,
+            0xba,
+            0xbe,
+            0xde,
+            0xda,
+            0xdd);
+    codec.readBytes(source);
+
+    assertThat(source.readerIndex()).isEqualTo(8);
+  }
+
+  @Test
   public void read_bytes_should_throw_when_not_enough_content() {
     ByteBuf source =
         ByteBufs.wrap(


### PR DESCRIPTION
 -> Remove a needless call to `ByteBuff::hasArray`
 
  -> Removes needless slicing