### PR TITLE
JAVA-3030 Use configuration to determine batch-type instead of settin…

### DIFF
--- a/core/src/main/java/com/datastax/dse/driver/api/core/config/DseDriverOption.java
+++ b/core/src/main/java/com/datastax/dse/driver/api/core/config/DseDriverOption.java
@@ -288,6 +288,13 @@ public enum DseDriverOption implements DriverOption {
    * <p>Value-type: {@link java.time.Duration Duration}
    */
   METRICS_NODE_GRAPH_MESSAGES_SLO("advanced.metrics.node.graph-messages.slo"),
+
+  /**
+   * The batch type that is set in the configuration file
+   *
+   * <p>Value-type: {@link String}
+   */
+  BATCH_TYPE_CONFIGURATION("advanced.batch-type-configuration"),
   ;
 
   private final String path;

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -798,6 +798,11 @@ public class TypedDriverOption<ValueT> {
       new TypedDriverOption<>(
           DseDriverOption.METRICS_NODE_GRAPH_MESSAGES_SLO,
           GenericType.listOf(GenericType.DURATION));
+
+  /** The batch type */
+  public static final TypedDriverOption<String> BATCH_TYPE =
+      new TypedDriverOption<>(DseDriverOption.BATCH_TYPE_CONFIGURATION, GenericType.STRING);
+
   /**
    * The number of significant decimal digits to which internal structures will maintain for graph
    * requests.

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/BatchStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/BatchStatement.java
@@ -41,6 +41,94 @@ import java.util.Collections;
 public interface BatchStatement extends Statement<BatchStatement>, Iterable<BatchableStatement<?>> {
 
   /**
+   * Creates an instance of the default implementation with null batch type.
+   *
+   * <p>Note that the returned object is <b>immutable</b>.
+   */
+  static BatchStatement newInstance() {
+    return new DefaultBatchStatement(
+        BatchType.UNKNOW,
+        new ArrayList<>(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        Collections.emptyMap(),
+        null,
+        false,
+        Statement.NO_DEFAULT_TIMESTAMP,
+        null,
+        Integer.MIN_VALUE,
+        null,
+        null,
+        null,
+        null,
+        Statement.NO_NOW_IN_SECONDS);
+  }
+
+  /**
+   * Creates an instance of the default implementation for the null batch type, containing the given
+   * statements.
+   *
+   * <p>Note that the returned object is <b>immutable</b>.
+   */
+  @NonNull
+  static BatchStatement newInstance(@NonNull Iterable<BatchableStatement<?>> statements) {
+    return new DefaultBatchStatement(
+        BatchType.UNKNOW,
+        ImmutableList.copyOf(statements),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        Collections.emptyMap(),
+        null,
+        false,
+        Statement.NO_DEFAULT_TIMESTAMP,
+        null,
+        Integer.MIN_VALUE,
+        null,
+        null,
+        null,
+        null,
+        Statement.NO_NOW_IN_SECONDS);
+  }
+
+  /**
+   * Creates an instance of the default implementation for the null batch type, containing the given
+   * statements.
+   *
+   * <p>Note that the returned object is <b>immutable</b>.
+   */
+  @NonNull
+  static BatchStatement newInstance(@NonNull BatchableStatement<?>... statements) {
+    return new DefaultBatchStatement(
+        BatchType.UNKNOW,
+        ImmutableList.copyOf(statements),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        Collections.emptyMap(),
+        null,
+        false,
+        Statement.NO_DEFAULT_TIMESTAMP,
+        null,
+        Integer.MIN_VALUE,
+        null,
+        null,
+        null,
+        null,
+        Statement.NO_NOW_IN_SECONDS);
+  }
+
+  /**
    * Creates an instance of the default implementation for the given batch type.
    *
    * <p>Note that the returned object is <b>immutable</b>.
@@ -129,6 +217,15 @@ public interface BatchStatement extends Statement<BatchStatement>, Iterable<Batc
         null,
         null,
         Statement.NO_NOW_IN_SECONDS);
+  }
+
+  /**
+   * Returns a builder to create an instance of the default implementation.
+   *
+   * <p>Note that this builder is mutable and not thread-safe.
+   */
+  static BatchStatementBuilder builder() {
+    return new BatchStatementBuilder(BatchType.UNKNOW);
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/BatchType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/BatchType.java
@@ -28,6 +28,7 @@ public interface BatchType {
   BatchType UNLOGGED = DefaultBatchType.UNLOGGED;
   BatchType COUNTER = DefaultBatchType.COUNTER;
 
+  BatchType UNKNOW = DefaultBatchType.UNKNOW;
   /** The numerical value that the batch type is encoded to. */
   byte getProtocolCode();
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/DefaultBatchType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/DefaultBatchType.java
@@ -37,6 +37,11 @@ public enum DefaultBatchType implements BatchType {
    * it can only contain these.
    */
   COUNTER(ProtocolConstants.BatchType.COUNTER),
+
+  /** UNKNOW BATCH TYPE when user do not set at BatchStatement builder */
+  // TODO should we set the number 3 be a constant at some where or ProtocolConstants.BatchType add
+  // a unknow type ?
+  UNKNOW((byte) 3),
   ;
   // Note that, for the sake of convenience, we also expose shortcuts to these constants on the
   // BatchType interface. If you add a new enum constant, remember to update the interface as

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/BatchTypeRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/BatchTypeRegistry.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core;
+
+import com.datastax.oss.driver.api.core.cql.BatchType;
+
+public interface BatchTypeRegistry {
+  BatchType fromName(String name);
+
+  /** @return all the values known to this driver instance. */
+  Iterable<BatchType> getValues();
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultBatchTypeRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultBatchTypeRegistry.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core;
+
+import com.datastax.oss.driver.api.core.cql.BatchType;
+import com.datastax.oss.driver.api.core.cql.DefaultBatchType;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import net.jcip.annotations.ThreadSafe;
+
+@ThreadSafe
+public class DefaultBatchTypeRegistry implements BatchTypeRegistry {
+  private static final ImmutableList<BatchType> values =
+      ImmutableList.<BatchType>builder().add(DefaultBatchType.values()).build();
+
+  @Override
+  public BatchType fromName(String name) {
+    if (name == null || name.isEmpty()) {
+      return null;
+    }
+    return DefaultBatchType.valueOf(name);
+  }
+
+  @Override
+  public ImmutableList<BatchType> getValues() {
+    return values;
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
@@ -46,7 +46,9 @@ import com.datastax.oss.driver.api.core.tracker.RequestTracker;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
 import com.datastax.oss.driver.api.core.type.codec.registry.MutableCodecRegistry;
+import com.datastax.oss.driver.internal.core.BatchTypeRegistry;
 import com.datastax.oss.driver.internal.core.ConsistencyLevelRegistry;
+import com.datastax.oss.driver.internal.core.DefaultBatchTypeRegistry;
 import com.datastax.oss.driver.internal.core.DefaultConsistencyLevelRegistry;
 import com.datastax.oss.driver.internal.core.DefaultProtocolVersionRegistry;
 import com.datastax.oss.driver.internal.core.ProtocolVersionRegistry;
@@ -175,6 +177,8 @@ public class DefaultDriverContext implements InternalDriverContext {
   private final LazyReference<ConsistencyLevelRegistry> consistencyLevelRegistryRef =
       new LazyReference<>(
           "consistencyLevelRegistry", this::buildConsistencyLevelRegistry, cycleDetector);
+  private final LazyReference<BatchTypeRegistry> batchTypeRegistryRef =
+      new LazyReference<>("batchTypeRegistry", this::buildBatchTypeRegistry, cycleDetector);
   private final LazyReference<WriteTypeRegistry> writeTypeRegistryRef =
       new LazyReference<>("writeTypeRegistry", this::buildWriteTypeRegistry, cycleDetector);
   private final LazyReference<NettyOptions> nettyOptionsRef =
@@ -462,6 +466,10 @@ public class DefaultDriverContext implements InternalDriverContext {
 
   protected ConsistencyLevelRegistry buildConsistencyLevelRegistry() {
     return new DefaultConsistencyLevelRegistry();
+  }
+
+  protected BatchTypeRegistry buildBatchTypeRegistry() {
+    return new DefaultBatchTypeRegistry();
   }
 
   protected WriteTypeRegistry buildWriteTypeRegistry() {
@@ -837,6 +845,12 @@ public class DefaultDriverContext implements InternalDriverContext {
   @Override
   public ConsistencyLevelRegistry getConsistencyLevelRegistry() {
     return consistencyLevelRegistryRef.get();
+  }
+
+  @NonNull
+  @Override
+  public BatchTypeRegistry getBatchTypeRegistry() {
+    return batchTypeRegistryRef.get();
   }
 
   @NonNull

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/InternalDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/InternalDriverContext.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.context.DriverContext;
 import com.datastax.oss.driver.api.core.loadbalancing.NodeDistanceEvaluator;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
+import com.datastax.oss.driver.internal.core.BatchTypeRegistry;
 import com.datastax.oss.driver.internal.core.ConsistencyLevelRegistry;
 import com.datastax.oss.driver.internal.core.ProtocolVersionRegistry;
 import com.datastax.oss.driver.internal.core.channel.ChannelFactory;
@@ -75,6 +76,9 @@ public interface InternalDriverContext extends DriverContext {
 
   @NonNull
   ConsistencyLevelRegistry getConsistencyLevelRegistry();
+
+  @NonNull
+  BatchTypeRegistry getBatchTypeRegistry();
 
   @NonNull
   WriteTypeRegistry getWriteTypeRegistry();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.driver.internal.core.cql;
 
+import com.datastax.dse.driver.api.core.config.DseDriverOption;
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -25,6 +26,7 @@ import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.context.DriverContext;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.BatchStatement;
+import com.datastax.oss.driver.api.core.cql.BatchType;
 import com.datastax.oss.driver.api.core.cql.BatchableStatement;
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
@@ -531,6 +533,37 @@ public class Conversions {
       default:
         return new ProtocolError(node, "Unknown error code: " + errorMessage.code);
     }
+  }
+
+  /**
+   * get the statement if the statement is a BatchStatement and the batch type is not setted the
+   * configuration 's batch type will be used. But if non of them is setted the batch type will be
+   * set with the default LOGGED which is same with cassandra server side.
+   */
+  public static Statement<?> resolveStatement(
+      Statement<?> statement, InternalDriverContext context) {
+    if (statement instanceof BatchStatement) {
+      BatchStatement batchStatement = (BatchStatement) statement;
+      if (batchStatement.getBatchType() == BatchType.UNKNOW) {
+        DriverExecutionProfile driverExecutionProfile = resolveExecutionProfile(statement, context);
+        BatchType batchType;
+        try {
+          batchType =
+              context
+                  .getBatchTypeRegistry()
+                  .fromName(
+                      driverExecutionProfile.getString(DseDriverOption.BATCH_TYPE_CONFIGURATION));
+        } catch (Throwable throwable) {
+          throw new IllegalArgumentException(
+              "IllegalArgumentException occurs for batch type option "
+                  + DseDriverOption.BATCH_TYPE_CONFIGURATION.getPath()
+                  + "'s value in configuration file is illegal when use do not set BATCH TYPE at BatchStatement build stage. ",
+              throwable);
+        }
+        return batchStatement.setBatchType(batchType);
+      }
+    }
+    return statement;
   }
 
   public static boolean resolveIdempotence(Request request, InternalDriverContext context) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
@@ -138,11 +138,10 @@ public class CqlRequestHandler implements Throttled {
     this.startTimeNanos = System.nanoTime();
     this.logPrefix = sessionLogPrefix + "|" + this.hashCode();
     LOG.trace("[{}] Creating new handler for request {}", logPrefix, statement);
-
-    this.initialStatement = statement;
     this.session = session;
     this.keyspace = session.getKeyspace().orElse(null);
     this.context = context;
+    this.initialStatement = Conversions.resolveStatement(statement, context);
     this.result = new CompletableFuture<>();
     this.result.exceptionally(
         t -> {

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/graph/GraphRequestHandlerTestHarness.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/graph/GraphRequestHandlerTestHarness.java
@@ -27,6 +27,7 @@ import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
+import com.datastax.oss.driver.internal.core.DefaultBatchTypeRegistry;
 import com.datastax.oss.driver.internal.core.DefaultConsistencyLevelRegistry;
 import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
 import com.datastax.oss.driver.internal.core.cql.RequestHandlerTestHarness;
@@ -141,6 +142,7 @@ public class GraphRequestHandlerTestHarness extends RequestHandlerTestHarness {
     when(dseDriverContext.getProtocolVersionRegistry()).thenReturn(protocolVersionRegistry);
     when(dseDriverContext.getConsistencyLevelRegistry())
         .thenReturn(new DefaultConsistencyLevelRegistry());
+    when(dseDriverContext.getBatchTypeRegistry()).thenReturn(new DefaultBatchTypeRegistry());
     when(dseDriverContext.getWriteTypeRegistry()).thenReturn(new DefaultWriteTypeRegistry());
     when(dseDriverContext.getRequestThrottler())
         .thenReturn(new PassThroughRequestThrottler(dseDriverContext));

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/DefaultDriverConfigLoaderTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/DefaultDriverConfigLoaderTest.java
@@ -22,11 +22,14 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.datastax.dse.driver.api.core.config.DseDriverOption;
 import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.cql.BatchType;
+import com.datastax.oss.driver.internal.core.DefaultBatchTypeRegistry;
 import com.datastax.oss.driver.internal.core.config.ConfigChangeEvent;
 import com.datastax.oss.driver.internal.core.config.MockOptions;
 import com.datastax.oss.driver.internal.core.context.EventBus;
@@ -78,6 +81,10 @@ public class DefaultDriverConfigLoaderTest {
     when(config.getDefaultProfile()).thenReturn(defaultProfile);
     when(defaultProfile.getDuration(DefaultDriverOption.CONFIG_RELOAD_INTERVAL))
         .thenReturn(Duration.ofSeconds(12));
+
+    when(context.getBatchTypeRegistry()).thenReturn(new DefaultBatchTypeRegistry());
+    when(defaultProfile.getString(DseDriverOption.BATCH_TYPE_CONFIGURATION))
+        .thenReturn(BatchType.LOGGED.toString());
 
     configSource = new AtomicReference<>("int1 = 42");
   }
@@ -205,6 +212,8 @@ public class DefaultDriverConfigLoaderTest {
     // From customApplication.conf:
     assertThat(config.getDuration(DefaultDriverOption.REQUEST_TIMEOUT))
         .isEqualTo(Duration.ofSeconds(5));
+    assertThat(config.getString(DseDriverOption.BATCH_TYPE_CONFIGURATION))
+        .isEqualTo(BatchType.UNLOGGED.toString());
     // From reference.conf:
     assertThat(config.getString(DefaultDriverOption.REQUEST_SERIAL_CONSISTENCY))
         .isEqualTo(DefaultConsistencyLevel.SERIAL.name());

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTestBase.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandlerTestBase.java
@@ -63,6 +63,8 @@ public abstract class CqlRequestHandlerTestBase {
       BatchStatement.newInstance(BatchType.LOGGED, IDEMPOTENT_STATEMENT).setIdempotent(true);
   protected static final BatchStatement NON_IDEMPOTENT_BATCH_STATEMENT =
       BatchStatement.newInstance(BatchType.LOGGED, NON_IDEMPOTENT_STATEMENT).setIdempotent(false);
+  protected static final BatchStatement BATCH_STATEMENT_WITHOUT_BATCH_TYPE =
+      BatchStatement.newInstance(NON_IDEMPOTENT_STATEMENT);
 
   @Mock protected DefaultNode node1;
   @Mock protected DefaultNode node2;

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/RequestHandlerTestHarness.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/RequestHandlerTestHarness.java
@@ -21,12 +21,14 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.datastax.dse.driver.api.core.config.DseDriverOption;
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfig;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.cql.BatchType;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metrics.SessionMetric;
@@ -36,6 +38,7 @@ import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.core.specex.SpeculativeExecutionPolicy;
 import com.datastax.oss.driver.api.core.time.TimestampGenerator;
 import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
+import com.datastax.oss.driver.internal.core.DefaultBatchTypeRegistry;
 import com.datastax.oss.driver.internal.core.DefaultConsistencyLevelRegistry;
 import com.datastax.oss.driver.internal.core.ProtocolFeature;
 import com.datastax.oss.driver.internal.core.ProtocolVersionRegistry;
@@ -112,8 +115,11 @@ public class RequestHandlerTestHarness implements AutoCloseable {
     when(defaultProfile.getBoolean(DefaultDriverOption.REQUEST_DEFAULT_IDEMPOTENCE))
         .thenReturn(builder.defaultIdempotence);
     when(defaultProfile.getBoolean(DefaultDriverOption.PREPARE_ON_ALL_NODES)).thenReturn(true);
+    when(defaultProfile.getString(DseDriverOption.BATCH_TYPE_CONFIGURATION))
+        .thenReturn(BatchType.UNLOGGED.toString());
 
     when(config.getDefaultProfile()).thenReturn(defaultProfile);
+    when(context.getConfig()).thenReturn(config);
     when(context.getConfig()).thenReturn(config);
 
     when(loadBalancingPolicyWrapper.newQueryPlan(
@@ -160,6 +166,8 @@ public class RequestHandlerTestHarness implements AutoCloseable {
     }
 
     when(context.getConsistencyLevelRegistry()).thenReturn(new DefaultConsistencyLevelRegistry());
+
+    when(context.getBatchTypeRegistry()).thenReturn(new DefaultBatchTypeRegistry());
 
     when(context.getWriteTypeRegistry()).thenReturn(new DefaultWriteTypeRegistry());
 

--- a/core/src/test/resources/config/customApplication.conf
+++ b/core/src/test/resources/config/customApplication.conf
@@ -3,4 +3,6 @@ datastax-java-driver {
   basic.request.timeout = ${datastax-java-driver.advanced.connection.init-query-timeout}
 
   advanced.continuous-paging.max-pages = 10
+  advanced.batch-type-configuration = UNLOGGED
+  
 }

--- a/examples/src/main/java/com/datastax/oss/driver/examples/basic/ReadCassandraVersion.java
+++ b/examples/src/main/java/com/datastax/oss/driver/examples/basic/ReadCassandraVersion.java
@@ -16,8 +16,7 @@
 package com.datastax.oss.driver.examples.basic;
 
 import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.cql.ResultSet;
-import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.cql.*;
 
 /**
  * Connects to a Cassandra cluster and extracts basic information from it.

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementUseConfigIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementUseConfigIT.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.core.cql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.cql.BatchStatement;
+import com.datastax.oss.driver.api.core.cql.BatchStatementBuilder;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.DefaultBatchType;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.cql.Statement;
+import com.datastax.oss.driver.api.core.servererrors.InvalidQueryException;
+import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
+
+@Category(ParallelizableTests.class)
+public class BatchStatementUseConfigIT {
+  private CcmRule ccmRule = CcmRule.getInstance();
+
+  private SessionRule<CqlSession> sessionRule = SessionRule.builder(ccmRule).build();
+
+  @Rule public TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
+
+  @Rule public TestName name = new TestName();
+
+  private static final int batchCount = 100;
+
+  @Before
+  public void createTable() {
+    String[] schemaStatements =
+        new String[] {
+          "CREATE TABLE test (k0 text, k1 int, v int, PRIMARY KEY (k0, k1))",
+          "CREATE TABLE counter1 (k0 text PRIMARY KEY, c counter)",
+          "CREATE TABLE counter2 (k0 text PRIMARY KEY, c counter)",
+          "CREATE TABLE counter3 (k0 text PRIMARY KEY, c counter)",
+        };
+
+    for (String schemaStatement : schemaStatements) {
+      sessionRule
+          .session()
+          .execute(
+              SimpleStatement.newInstance(schemaStatement)
+                  .setExecutionProfile(sessionRule.slowProfile()));
+    }
+  }
+
+  @Test
+  public void should_execute_batch_of_simple_statements_with_variables() {
+    // Build a batch of batchCount simple statements, each with their own positional variables.
+    BatchStatementBuilder builder = BatchStatement.builder();
+    for (int i = 0; i < batchCount; i++) {
+      SimpleStatement insert =
+          SimpleStatement.builder(
+                  String.format(
+                      "INSERT INTO test (k0, k1, v) values ('%s', ?, ?)", name.getMethodName()))
+              .addPositionalValues(i, i + 1)
+              .build();
+      builder.addStatement(insert);
+    }
+
+    BatchStatement batchStatement = builder.build();
+    sessionRule.session().execute(batchStatement);
+
+    verifyBatchInsert();
+  }
+
+  @Test
+  public void should_execute_batch_of_bound_statements_with_variables() {
+    // Build a batch of batchCount statements with bound statements, each with their own positional
+    // variables.
+    BatchStatementBuilder builder = BatchStatement.builder();
+    SimpleStatement insert =
+        SimpleStatement.builder(
+                String.format(
+                    "INSERT INTO test (k0, k1, v) values ('%s', ? , ?)", name.getMethodName()))
+            .build();
+    PreparedStatement preparedStatement = sessionRule.session().prepare(insert);
+
+    for (int i = 0; i < batchCount; i++) {
+      builder.addStatement(preparedStatement.bind(i, i + 1));
+    }
+
+    BatchStatement batchStatement = builder.build();
+    sessionRule.session().execute(batchStatement);
+
+    verifyBatchInsert();
+  }
+
+  @Test
+  @CassandraRequirement(min = "2.2")
+  public void should_execute_batch_of_bound_statements_with_unset_values() {
+    // Build a batch of batchCount statements with bound statements, each with their own positional
+    // variables.
+    BatchStatementBuilder builder = BatchStatement.builder();
+    SimpleStatement insert =
+        SimpleStatement.builder(
+                String.format(
+                    "INSERT INTO test (k0, k1, v) values ('%s', ? , ?)", name.getMethodName()))
+            .build();
+    PreparedStatement preparedStatement = sessionRule.session().prepare(insert);
+
+    for (int i = 0; i < batchCount; i++) {
+      builder.addStatement(preparedStatement.bind(i, i + 1));
+    }
+
+    BatchStatement batchStatement = builder.build();
+    sessionRule.session().execute(batchStatement);
+
+    verifyBatchInsert();
+
+    BatchStatementBuilder builder2 = BatchStatement.builder();
+    for (int i = 0; i < batchCount; i++) {
+      BoundStatement boundStatement = preparedStatement.bind(i, i + 2);
+      // unset v every 20 statements.
+      if (i % 20 == 0) {
+        boundStatement = boundStatement.unset(1);
+      }
+      builder.addStatement(boundStatement);
+    }
+
+    sessionRule.session().execute(builder2.build());
+
+    Statement<?> select =
+        SimpleStatement.builder("SELECT * from test where k0 = ?")
+            .addPositionalValue(name.getMethodName())
+            .build();
+
+    ResultSet result = sessionRule.session().execute(select);
+
+    List<Row> rows = result.all();
+    assertThat(rows).hasSize(100);
+
+    Iterator<Row> iterator = rows.iterator();
+    for (int i = 0; i < batchCount; i++) {
+      Row row = iterator.next();
+      assertThat(row.getString("k0")).isEqualTo(name.getMethodName());
+      assertThat(row.getInt("k1")).isEqualTo(i);
+      // value should be from first insert (i + 1) if at row divisble by 20, otherwise second.
+      int expectedValue = i % 20 == 0 ? i + 1 : i + 2;
+      if (i % 20 == 0) {
+        assertThat(row.getInt("v")).isEqualTo(expectedValue);
+      }
+    }
+  }
+
+  @Test
+  public void should_execute_batch_of_bound_statements_with_named_variables() {
+    // Build a batch of batchCount statements with bound statements, each with their own named
+    // variable values.
+    BatchStatementBuilder builder = BatchStatement.builder();
+    PreparedStatement preparedStatement =
+        sessionRule.session().prepare("INSERT INTO test (k0, k1, v) values (:k0, :k1, :v)");
+
+    for (int i = 0; i < batchCount; i++) {
+      builder.addStatement(
+          preparedStatement
+              .boundStatementBuilder()
+              .setString("k0", name.getMethodName())
+              .setInt("k1", i)
+              .setInt("v", i + 1)
+              .build());
+    }
+
+    BatchStatement batchStatement = builder.build();
+    sessionRule.session().execute(batchStatement);
+
+    verifyBatchInsert();
+  }
+
+  @Test
+  public void should_execute_batch_of_bound_and_simple_statements_with_variables() {
+    // Build a batch of batchCount statements with simple and bound statements alternating.
+    BatchStatementBuilder builder = BatchStatement.builder();
+    SimpleStatement insert =
+        SimpleStatement.builder(
+                String.format(
+                    "INSERT INTO test (k0, k1, v) values ('%s', ? , ?)", name.getMethodName()))
+            .build();
+    PreparedStatement preparedStatement = sessionRule.session().prepare(insert);
+
+    for (int i = 0; i < batchCount; i++) {
+      if (i % 2 == 1) {
+        SimpleStatement simpleInsert =
+            SimpleStatement.builder(
+                    String.format(
+                        "INSERT INTO test (k0, k1, v) values ('%s', ?, ?)", name.getMethodName()))
+                .addPositionalValues(i, i + 1)
+                .build();
+        builder.addStatement(simpleInsert);
+      } else {
+        builder.addStatement(preparedStatement.bind(i, i + 1));
+      }
+    }
+
+    BatchStatement batchStatement = builder.build();
+    sessionRule.session().execute(batchStatement);
+
+    verifyBatchInsert();
+  }
+
+  @Test
+  public void should_execute_cas_batch() {
+    // Build a batch with CAS operations on the same partition.
+    BatchStatementBuilder builder = BatchStatement.builder();
+    SimpleStatement insert =
+        SimpleStatement.builder(
+                String.format(
+                    "INSERT INTO test (k0, k1, v) values ('%s', ? , ?) IF NOT EXISTS",
+                    name.getMethodName()))
+            .build();
+    PreparedStatement preparedStatement = sessionRule.session().prepare(insert);
+
+    for (int i = 0; i < batchCount; i++) {
+      builder.addStatement(preparedStatement.bind(i, i + 1));
+    }
+
+    BatchStatement batchStatement = builder.build();
+    ResultSet result = sessionRule.session().execute(batchStatement);
+    assertThat(result.wasApplied()).isTrue();
+
+    verifyBatchInsert();
+
+    // re execute same batch and ensure wasn't applied.
+    result = sessionRule.session().execute(batchStatement);
+    assertThat(result.wasApplied()).isFalse();
+  }
+
+  @Test
+  public void should_execute_counter_batch() {
+    // should be able to do counter increments in a counter batch.
+    BatchStatementBuilder builder = BatchStatement.builder(DefaultBatchType.COUNTER);
+
+    for (int i = 1; i <= 3; i++) {
+      SimpleStatement insert =
+          SimpleStatement.builder(
+                  String.format(
+                      "UPDATE counter%d set c = c + %d where k0 = '%s'",
+                      i, i, name.getMethodName()))
+              .build();
+      builder.addStatement(insert);
+    }
+
+    BatchStatement batchStatement = builder.build();
+    sessionRule.session().execute(batchStatement);
+
+    for (int i = 1; i <= 3; i++) {
+      ResultSet result =
+          sessionRule
+              .session()
+              .execute(
+                  String.format(
+                      "SELECT c from counter%d where k0 = '%s'", i, name.getMethodName()));
+
+      List<Row> rows = result.all();
+      assertThat(rows).hasSize(1);
+
+      Row row = rows.iterator().next();
+      assertThat(row.getLong("c")).isEqualTo(i);
+    }
+  }
+
+  @Test(expected = InvalidQueryException.class)
+  public void should_fail_logged_batch_with_counter_increment() {
+    // should not be able to do counter inserts in a unlogged batch.
+    BatchStatementBuilder builder = BatchStatement.builder(DefaultBatchType.LOGGED);
+
+    for (int i = 1; i <= 3; i++) {
+      SimpleStatement insert =
+          SimpleStatement.builder(
+                  String.format(
+                      "UPDATE counter%d set c = c + %d where k0 = '%s'",
+                      i, i, name.getMethodName()))
+              .build();
+      builder.addStatement(insert);
+    }
+
+    BatchStatement batchStatement = builder.build();
+    sessionRule.session().execute(batchStatement);
+  }
+
+  @Test(expected = InvalidQueryException.class)
+  public void should_fail_counter_batch_with_non_counter_increment() {
+    // should not be able to do a counter batch if it contains a non-counter increment statement.
+    BatchStatementBuilder builder = BatchStatement.builder(DefaultBatchType.COUNTER);
+
+    for (int i = 1; i <= 3; i++) {
+      SimpleStatement insert =
+          SimpleStatement.builder(
+                  String.format(
+                      "UPDATE counter%d set c = c + %d where k0 = '%s'",
+                      i, i, name.getMethodName()))
+              .build();
+      builder.addStatement(insert);
+    }
+    // add a non-counter increment statement.
+    SimpleStatement simpleInsert =
+        SimpleStatement.builder(
+                String.format(
+                    "INSERT INTO test (k0, k1, v) values ('%s', ?, ?)", name.getMethodName()))
+            .addPositionalValues(1, 2)
+            .build();
+    builder.addStatement(simpleInsert);
+
+    BatchStatement batchStatement = builder.build();
+    sessionRule.session().execute(batchStatement);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void should_not_allow_unset_value_when_protocol_less_than_v4() {
+    //    CREATE TABLE test (k0 text, k1 int, v int, PRIMARY KEY (k0, k1))
+    DriverConfigLoader loader =
+        SessionUtils.configLoaderBuilder()
+            .withString(DefaultDriverOption.PROTOCOL_VERSION, "V3")
+            .build();
+    try (CqlSession v3Session = SessionUtils.newSession(ccmRule, sessionRule.keyspace(), loader)) {
+      PreparedStatement prepared =
+          v3Session.prepare("INSERT INTO test (k0, k1, v) values (?, ?, ?)");
+
+      BatchStatementBuilder builder = BatchStatement.builder(DefaultBatchType.LOGGED);
+      builder.addStatements(
+          // All set => OK
+          prepared.bind(name.getMethodName(), 1, 1),
+          // One variable unset => should fail
+          prepared
+              .boundStatementBuilder()
+              .setString(0, name.getMethodName())
+              .setInt(1, 2)
+              .unset(2)
+              .build());
+
+      v3Session.execute(builder.build());
+    }
+  }
+
+  private void verifyBatchInsert() {
+    // validate data inserted by the batch.
+    Statement<?> select =
+        SimpleStatement.builder("SELECT * from test where k0 = ?")
+            .addPositionalValue(name.getMethodName())
+            .build();
+
+    ResultSet result = sessionRule.session().execute(select);
+
+    List<Row> rows = result.all();
+    assertThat(rows).hasSize(100);
+
+    Iterator<Row> iterator = rows.iterator();
+    for (int i = 0; i < batchCount; i++) {
+      Row row = iterator.next();
+      assertThat(row.getString("k0")).isEqualTo(name.getMethodName());
+      assertThat(row.getInt("k1")).isEqualTo(i);
+      assertThat(row.getInt("v")).isEqualTo(i + 1);
+    }
+  }
+}

--- a/integration-tests/src/test/resources/application.conf
+++ b/integration-tests/src/test/resources/application.conf
@@ -17,6 +17,7 @@ datastax-java-driver {
       init-query-timeout = 5 seconds
       set-keyspace-timeout = 5 seconds
     }
+    batch-type-configuration = UNLOGGED
     heartbeat.timeout = 5 seconds
     control-connection.timeout = 5 seconds
     request {


### PR DESCRIPTION
JAVA-3030 Use configuration to determine batch-type instead of setting on a per-batch transaction basis