### PR TITLE
Don't return empty routing key when partition key is unbound

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultBoundStatement.java
@@ -358,7 +358,8 @@ public class DefaultBoundStatement implements BoundStatement {
       if (indices.isEmpty()) {
         return null;
       } else if (indices.size() == 1) {
-        return getBytesUnsafe(indices.get(0));
+        int index = indices.get(0);
+        return isSet(index) ? getBytesUnsafe(index) : null;
       } else {
         ByteBuffer[] components = new ByteBuffer[indices.size()];
         for (int i = 0; i < components.length; i++) {

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
@@ -475,6 +475,25 @@ public class PreparedStatementIT {
     assertThat(tokenFactory.hash(boundStatement.getRoutingKey())).isEqualTo(expectedToken);
   }
 
+  @Test
+  public void should_return_null_routing_information_when_single_partition_key_is_unbound() {
+    should_return_null_routing_information_when_single_partition_key_is_unbound(
+        "SELECT a FROM prepared_statement_test WHERE a = ?");
+    should_return_null_routing_information_when_single_partition_key_is_unbound(
+        "INSERT INTO prepared_statement_test (a) VALUES (?)");
+    should_return_null_routing_information_when_single_partition_key_is_unbound(
+        "UPDATE prepared_statement_test SET b = 1 WHERE a = ?");
+    should_return_null_routing_information_when_single_partition_key_is_unbound(
+        "DELETE FROM prepared_statement_test WHERE a = ?");
+  }
+
+  private void should_return_null_routing_information_when_single_partition_key_is_unbound(
+      String queryString) {
+    CqlSession session = sessionRule.session();
+    BoundStatement boundStatement = session.prepare(queryString).bind();
+    assertThat(boundStatement.getRoutingKey()).isNull();
+  }
+
   private static Iterable<Row> firstPageOf(CompletionStage<AsyncResultSet> stage) {
     return CompletableFutures.getUninterruptibly(stage).currentPage();
   }


### PR DESCRIPTION
DefaultBoundStatement#getRoutingKey has logic to infer the routing key when no one has explicitly called setRoutingKey or otherwise set the routing key on the statement. It however doesn't check for cases where nothing has been bound yet on the statement.
This causes more problems if the user decides to get a BoundStatementBuilder from the PreparedStatement, set some fields on it, and then copy it by constructing new BoundStatementBuilder objects with the BoundStatement as a parameter, since the empty ByteBuffer gets copied to all bound statements, resulting in all requests being targeted to the same Cassandra node in a token-aware load balancing policy.