### PR TITLE
Alternate idea to PR 1617

### DIFF
--- a/core/src/main/java/com/datastax/dse/driver/internal/core/graph/ByteBufUtil.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/graph/ByteBufUtil.java
@@ -21,14 +21,19 @@ import java.nio.ByteBuffer;
 
 public class ByteBufUtil {
 
+  public static byte[] copyBytes(ByteBuf buffer, int length) {
+
+    final byte[] bytes = new byte[length];
+    buffer.getBytes(buffer.readerIndex(), bytes, 0, length);
+    return bytes;
+  }
+
   // Does not move the reader index of the ByteBuf parameter
   public static ByteBuffer toByteBuffer(ByteBuf buffer) {
     if (buffer.isDirect()) {
       return buffer.nioBuffer();
     }
-    final byte[] bytes = new byte[buffer.readableBytes()];
-    buffer.getBytes(buffer.readerIndex(), bytes);
-    return ByteBuffer.wrap(bytes);
+    return ByteBuffer.wrap(copyBytes(buffer, buffer.readableBytes()));
   }
 
   static ByteBuf toByteBuf(ByteBuffer buffer) {


### PR DESCRIPTION
Motivated by conversations with @chibenwa on https://github.com/datastax/java-driver/pull/1617.  My hope was that we could implement the fix he discussed while retaining the ability to re-use the backing array from the ByteBuf whenever possible.