### PR TITLE
Update native protocol documentation to use a valid (capitalized) protocol version

### DIFF
--- a/manual/core/native_protocol/README.md
+++ b/manual/core/native_protocol/README.md
@@ -62,7 +62,8 @@ the [configuration](../configuration/):
 ```
 datastax-java-driver {
   advanced.protocol {
-    version = v3
+    # The V in the version parameter must be capitalized
+    version = V3
   }
 }
 ```


### PR DESCRIPTION
While working with the [spring-petclinic-reactive](https://github.com/spring-petclinic/spring-petclinic-reactive) example application, I needed to downgrade the java-driver's cassandra protocol version (from V5 to V4). I copy and pasted the example in the docs and ran into the following exception:

```
petclinic-backend     \| Caused by: java.lang.IllegalArgumentException: Unknown protocol version name: v4
--
petclinic-backend     \|         at com.datastax.oss.driver.internal.core.DefaultProtocolVersionRegistry.fromName(DefaultProtocolVersionRegistry.java:78)
petclinic-backend     \|         at com.datastax.oss.driver.internal.core.channel.ChannelFactory.<init>(ChannelFactory.java:114)
petclinic-backend     \|         at com.datastax.oss.driver.internal.core.context.DefaultDriverContext.buildChannelFactory(DefaultDriverContext.java:483)
petclinic-backend     \|         at com.datastax.oss.driver.internal.core.util.concurrent.LazyReference.get(LazyReference.java:55)
petclinic-backend     \|         at com.datastax.oss.driver.internal.core.context.DefaultDriverContext.getChannelFactory(DefaultDriverContext.java:855)
petclinic-backend     \|         at com.datastax.oss.driver.internal.core.control.ControlConnection$SingleThreaded.connect(ControlConnection.java:364)
petclinic-backend     \|         at com.datastax.oss.driver.internal.core.control.ControlConnection$SingleThreaded.init(ControlConnection.java:303)
petclinic-backend     \|         at com.datastax.oss.driver.internal.core.control.ControlConnection$SingleThreaded.access$1100(ControlConnection.java:243)
petclinic-backend     \|         at com.datastax.oss.driver.internal.core.control.ControlConnection.lambda$init$0(ControlConnection.java:122)
petclinic-backend     \|         at io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:98)
petclinic-backend     \|         at io.netty.util.concurrent.PromiseTask.run(PromiseTask.java:106)
petclinic-backend     \|         at io.netty.channel.DefaultEventLoop.run(DefaultEventLoop.java:54)
petclinic-backend     \|         at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
petclinic-backend     \|         at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
petclinic-backend     \|         at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
petclinic-backend     \|         at java.base/java.lang.Thread.run(Unknown Source)
petclinic-backend exited with code 1
```

After looking at the source code, I realized that the enum used as a [lookup](https://github.com/datastax/java-driver/blob/f91979f99dd7271c036a3dae8d35b71e59fe396d/core/src/main/java/com/datastax/oss/driver/internal/core/DefaultProtocolVersionRegistry.java#L76) requires a capitalized `V` in the protocol version. Updating `advanced.protocol.version` to use `V4` resulted in a working application: