### PR TITLE
JAVA-3061 CqlVector refinements

### DIFF
--- a/core/revapi.json
+++ b/core/revapi.json
@@ -17,6 +17,12 @@
     },
     "ignore": [
       {
+        "code": "java.method.returnTypeChangedCovariantly",
+        "old": "method java.lang.Iterable<T> com.datastax.oss.driver.api.core.data.CqlVector<T>::getValues()",
+        "new": "method java.util.List<T> com.datastax.oss.driver.api.core.data.CqlVector<T>::getValues()",
+        "justification": "Simplification of new API with no observable impact"
+      },
+      {
         "code": "java.method.removed",
         "old": "method com.datastax.oss.driver.api.core.cql.BatchStatementBuilder com.datastax.oss.driver.api.core.cql.BatchStatementBuilder::withKeyspace(com.datastax.oss.driver.api.core.CqlIdentifier)",
         "justification": "JAVA-2164: Rename statement builder methods to setXxx"

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlVector.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlVector.java
@@ -67,6 +67,7 @@ public class CqlVector<T> implements Iterable<T> {
       builder.append(value).append(", ");
     }
     builder.setLength(builder.length() - ", ".length());
+    builder.append("}");
     return builder.toString();
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/CqlVectorCtorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/CqlVectorCtorTest.java
@@ -15,12 +15,11 @@
  */
 package com.datastax.oss.driver.internal.core.type.codec;
 
-import com.datastax.oss.driver.api.core.data.CqlVector;
-import org.junit.Test;
-
-import java.util.ArrayList;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.data.CqlVector;
+import java.util.ArrayList;
+import org.junit.Test;
 
 /**
  * These tests are here simply to demonstrate the disambiguation on the CqlVector constructors,

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/CqlVectorCtorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/CqlVectorCtorTest.java
@@ -40,11 +40,22 @@ public class CqlVectorCtorTest {
     unqualifiedGenericType.add(2.5f);
     CqlVector withInferredType = new CqlVector(unqualifiedGenericType);
 
+    CqlVector.Builder builder = CqlVector.builder();
+    builder.add(1.0f);
+    builder.add(2.5f);
+    CqlVector fromBuilder = builder.build();
+
     assertThat(withVarargsStatic.getValues()).containsExactly(1.0f, 2.5f);
     assertThat(withParameterizedList.getValues()).containsExactly(1.0f, 2.5f);
     assertThat(withInferredType.getValues()).containsExactly(1.0f, 2.5f);
+    assertThat(fromBuilder.getValues()).containsExactly(1.0f, 2.5f);
 
     assertThat(withVarargsStatic).isEqualTo(withParameterizedList);
     assertThat(withVarargsStatic).isEqualTo(withInferredType);
+    assertThat(fromBuilder).isEqualTo(withInferredType);
+
+    assertThat(withVarargsStatic.toString()).isEqualTo(
+            "CqlVector{1.0, 2.5}"
+    );
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/CqlVectorCtorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/CqlVectorCtorTest.java
@@ -17,7 +17,9 @@ package com.datastax.oss.driver.internal.core.type.codec;
 
 import com.datastax.oss.driver.api.core.data.CqlVector;
 import org.junit.Test;
+
 import java.util.ArrayList;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -54,8 +56,6 @@ public class CqlVectorCtorTest {
     assertThat(withVarargsStatic).isEqualTo(withInferredType);
     assertThat(fromBuilder).isEqualTo(withInferredType);
 
-    assertThat(withVarargsStatic.toString()).isEqualTo(
-            "CqlVector{1.0, 2.5}"
-    );
+    assertThat(withVarargsStatic.toString()).isEqualTo("CqlVector{1.0, 2.5}");
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/CqlVectorCtorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/CqlVectorCtorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.type.codec;
+
+import com.datastax.oss.driver.api.core.data.CqlVector;
+import org.junit.Test;
+import java.util.ArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * These tests are here simply to demonstrate the disambiguation on the CqlVector constructors,
+ * where List of T as well as varags T... are both provided.
+ */
+public class CqlVectorCtorTest {
+
+  @Test
+  public void shouldAllBeEquivalent() {
+    CqlVector withVarargsStatic = CqlVector.of(1.0f, 2.5f);
+
+    ArrayList<Float> qualifiedType = new ArrayList<>();
+    qualifiedType.add(1.0f);
+    qualifiedType.add(2.5f);
+    CqlVector withParameterizedList = new CqlVector(qualifiedType);
+
+    ArrayList unqualifiedGenericType = new ArrayList();
+    unqualifiedGenericType.add(1.0f);
+    unqualifiedGenericType.add(2.5f);
+    CqlVector withInferredType = new CqlVector(unqualifiedGenericType);
+
+    assertThat(withVarargsStatic.getValues()).containsExactly(1.0f, 2.5f);
+    assertThat(withParameterizedList.getValues()).containsExactly(1.0f, 2.5f);
+    assertThat(withInferredType.getValues()).containsExactly(1.0f, 2.5f);
+
+    assertThat(withVarargsStatic).isEqualTo(withParameterizedList);
+    assertThat(withVarargsStatic).isEqualTo(withInferredType);
+  }
+}


### PR DESCRIPTION
This PR makes the following refinements to the CqlVector type:
- allows simple ctor construction and data access.
- moves the values iterator to the base type.
- removes unnecessary dependencies. Now only java.util is needed.
- preserves immutability of the data.
- provides a varargs method `of(T... values)` distinct from the list-based ctor.
- preserves the builder interface

This does provide multiple ctor patterns, but I think this is ok because 1) users will find a simple interface of whatever style they are looking for, and 2) they are all idomatic and uncomplicated.