### PR TITLE
JAVA-3073 Memoize ByteOrderedToken hashCode to avoid expensive computation

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/ByteOrderedToken.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/ByteOrderedToken.java
@@ -30,6 +30,7 @@ import net.jcip.annotations.Immutable;
 public class ByteOrderedToken implements Token {
 
   private final ByteBuffer value;
+  private int hashCode = 0;
 
   public ByteOrderedToken(@NonNull ByteBuffer value) {
     this.value = ByteBuffer.wrap(Bytes.getArray(value)).asReadOnlyBuffer();
@@ -54,7 +55,14 @@ public class ByteOrderedToken implements Token {
 
   @Override
   public int hashCode() {
-    return value.hashCode();
+    int hash = this.hashCode;
+    if (hash == 0) {
+      // memoize hashCode via benign data race to avoid expensive computation
+      // when Token are used in hash based data structures
+      hash = value.hashCode();
+      this.hashCode = hash;
+    }
+    return hash;
   }
 
   @Override

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/TokenRangeBase.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/token/TokenRangeBase.java
@@ -26,7 +26,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import net.jcip.annotations.Immutable;
 
 @Immutable
@@ -277,7 +276,7 @@ public abstract class TokenRangeBase implements TokenRange {
 
   @Override
   public int hashCode() {
-    return Objects.hash(start, end);
+    return (31 + start.hashCode()) * 31 + end.hashCode();
   }
 
   @Override


### PR DESCRIPTION
While profiling a service using java-driver 3.x, in JFR output I noticed significant CPU cycles and memory allocations corresponding to computing `TokenRange::hashCode()`. Note that this is likely due to use of byte ordered partitioner for this Cassandra instance as the ByteOrderToken must traverse the ByteBuffer each time, and `TokenRangeBase` (in 4.x, `TokenRange` in 3.x) is using `Objects.hash(start, end)` that allocates an array for var args for each invocation. 


![image](https://github.com/datastax/java-driver/assets/54594/f287b365-7b20-48dc-9456-5bcad2e2c75c)

![image](https://github.com/datastax/java-driver/assets/54594/b9a8eed3-df6b-455c-9c5b-a269b022f037)

![image](https://github.com/datastax/java-driver/assets/54594/b60fea6d-ab3a-4765-a8c4-8c79a2ce4b56)

