### PR TITLE
JAVA-3062: Figure out a better solution for PreparedStatementIT tests…

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCachingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCachingIT.java
@@ -1,0 +1,286 @@
+package com.datastax.oss.driver.core.cql;
+
+import com.codahale.metrics.Gauge;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+import com.datastax.oss.driver.api.core.session.ProgrammaticArguments;
+import com.datastax.oss.driver.api.core.session.SessionBuilder;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.cql.CqlPrepareAsyncProcessor;
+import com.datastax.oss.driver.internal.core.cql.CqlPrepareSyncProcessor;
+import com.datastax.oss.driver.internal.core.metadata.schema.events.TypeChangeEvent;
+import com.datastax.oss.driver.internal.core.session.BuiltInRequestProcessors;
+import com.datastax.oss.driver.internal.core.session.RequestProcessor;
+import com.datastax.oss.driver.internal.core.session.RequestProcessorRegistry;
+import com.datastax.oss.driver.shaded.guava.common.cache.CacheBuilder;
+import com.datastax.oss.driver.shaded.guava.common.collect.Iterables;
+import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Category(ParallelizableTests.class)
+public class PreparedStatementCachingIT {
+
+    private CcmRule ccmRule = CcmRule.getInstance();
+
+    private SessionRule<CqlSession> sessionRule =
+            SessionRule.builder(ccmRule)
+                    .withConfigLoader(
+                            SessionUtils.configLoaderBuilder()
+                                    .withInt(DefaultDriverOption.REQUEST_PAGE_SIZE, 2)
+                                    .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
+                                    .build())
+                    .build();
+
+    @Rule
+    public TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
+
+    private static class TestCqlPrepareAsyncProcessor extends CqlPrepareAsyncProcessor {
+
+        public TestCqlPrepareAsyncProcessor(@NonNull Optional<? extends DefaultDriverContext> context) {
+            super(CacheBuilder.newBuilder().build(), context);
+        }
+    }
+
+
+    private static class TestDefaultDriverContext extends DefaultDriverContext {
+
+        public TestDefaultDriverContext(DriverConfigLoader configLoader, ProgrammaticArguments programmaticArguments) {
+            super(configLoader, programmaticArguments);
+        }
+
+        @Override
+        protected RequestProcessorRegistry buildRequestProcessorRegistry() {
+            List<RequestProcessor<?, ?>> processors =
+                    BuiltInRequestProcessors.createDefaultProcessors(this);
+            processors.removeIf((processor) -> processor instanceof CqlPrepareAsyncProcessor);
+            processors.removeIf((processor) -> processor instanceof CqlPrepareSyncProcessor);
+            CqlPrepareAsyncProcessor asyncProcessor = new TestCqlPrepareAsyncProcessor(Optional.of(this));
+            processors.add(2, asyncProcessor);
+            processors.add(3, new CqlPrepareSyncProcessor(asyncProcessor));
+            return new RequestProcessorRegistry(
+                    getSessionName(), processors.toArray(new RequestProcessor[0]));
+        }
+    }
+
+    private static class TestSessionBuilder extends SessionBuilder {
+
+        private final Logger LOG = LoggerFactory.getLogger(TestSessionBuilder.class);
+
+        @Override
+        protected Object wrap(@NonNull CqlSession defaultSession) {
+            return defaultSession;
+        }
+
+        @Override
+        protected DriverContext buildContext(
+                DriverConfigLoader configLoader, ProgrammaticArguments programmaticArguments) {
+            return new TestDefaultDriverContext(configLoader, programmaticArguments);
+        }
+    }
+
+    @BeforeClass
+    public static void setup() {
+        System.setProperty(SessionUtils.SESSION_BUILDER_CLASS_PROPERTY, PreparedStatementCachingIT.class.getName());
+    }
+
+    @AfterClass
+    public static void teardown() {
+        System.clearProperty(SessionUtils.SESSION_BUILDER_CLASS_PROPERTY);
+    }
+
+    public static SessionBuilder builder() { return new TestSessionBuilder(); }
+
+    private void invalidationResultSetTest(Consumer<CqlSession> createFn) {
+
+        try (CqlSession session = sessionWithCacheSizeMetric()) {
+
+            assertThat(getPreparedCacheSize(session)).isEqualTo(0);
+            createFn.accept(session);
+
+            session.prepare("select f from test_table_1 where e = ?");
+            session.prepare("select h from test_table_2 where g = ?");
+            assertThat(getPreparedCacheSize(session)).isEqualTo(2);
+
+            CountDownLatch latch = new CountDownLatch(1);
+            DefaultDriverContext ctx = (DefaultDriverContext)session.getContext();
+            ctx.getEventBus()
+                    .register(
+                            TypeChangeEvent.class,
+                            (e) -> {
+                                assertThat(e.oldType.getName().toString()).isEqualTo("test_type_2");
+                                latch.countDown();
+                            });
+
+            session.execute("ALTER TYPE test_type_2 add i blob");
+            Uninterruptibles.awaitUninterruptibly(latch, 2, TimeUnit.SECONDS);
+
+            //Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
+
+            assertThat(getPreparedCacheSize(session)).isEqualTo(1);
+        }
+    }
+
+    private void invalidationVariableDefsTest(Consumer<CqlSession> createFn, boolean isCollection) {
+
+        try (CqlSession session = sessionWithCacheSizeMetric()) {
+
+            assertThat(getPreparedCacheSize(session)).isEqualTo(0);
+            createFn.accept(session);
+
+            String fStr = isCollection ? "f contains ?" : "f = ?";
+            session.prepare(String.format("select e from test_table_1 where %s allow filtering", fStr));
+            String hStr = isCollection ? "h contains ?" : "h = ?";
+            session.prepare(String.format("select g from test_table_2 where %s allow filtering", hStr));
+            assertThat(getPreparedCacheSize(session)).isEqualTo(2);
+
+            CountDownLatch latch = new CountDownLatch(1);
+            DefaultDriverContext ctx = (DefaultDriverContext) session.getContext();
+            ctx.getEventBus()
+                    .register(
+                            TypeChangeEvent.class,
+                            (e) -> {
+                                assertThat(e.oldType.getName().toString()).isEqualTo("test_type_2");
+                                latch.countDown();
+                            });
+
+            session.execute("ALTER TYPE test_type_2 add i blob");
+            Uninterruptibles.awaitUninterruptibly(latch, 2, TimeUnit.SECONDS);
+
+            //Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
+
+            assertThat(getPreparedCacheSize(session)).isEqualTo(1);
+        }
+    }
+
+    Consumer<CqlSession> setupCacheEntryTestBasic =
+            (session) -> {
+                session.execute("CREATE TYPE test_type_1 (a text, b int)");
+                session.execute("CREATE TYPE test_type_2 (c int, d text)");
+                session.execute("CREATE TABLE test_table_1 (e int primary key, f frozen<test_type_1>)");
+                session.execute("CREATE TABLE test_table_2 (g int primary key, h frozen<test_type_2>)");
+            };
+
+    @Test
+    public void should_invalidate_cache_entry_on_basic_udt_change_result_set() {
+        invalidationResultSetTest(setupCacheEntryTestBasic);
+    }
+
+    @Test
+    public void should_invalidate_cache_entry_on_basic_udt_change_variable_defs() {
+        invalidationVariableDefsTest(setupCacheEntryTestBasic, false);
+    }
+
+    Consumer<CqlSession> setupCacheEntryTestCollection =
+            (session) -> {
+                session.execute("CREATE TYPE test_type_1 (a text, b int)");
+                session.execute("CREATE TYPE test_type_2 (c int, d text)");
+                session.execute(
+                        "CREATE TABLE test_table_1 (e int primary key, f list<frozen<test_type_1>>)");
+                session.execute(
+                        "CREATE TABLE test_table_2 (g int primary key, h list<frozen<test_type_2>>)");
+            };
+
+    @Test
+    public void should_invalidate_cache_entry_on_collection_udt_change_result_set() {
+        invalidationResultSetTest(setupCacheEntryTestCollection);
+    }
+
+    @Test
+    public void should_invalidate_cache_entry_on_collection_udt_change_variable_defs() {
+        invalidationVariableDefsTest(setupCacheEntryTestCollection, true);
+    }
+
+    Consumer<CqlSession> setupCacheEntryTestTuple =
+            (session) -> {
+                session.execute("CREATE TYPE test_type_1 (a text, b int)");
+                session.execute("CREATE TYPE test_type_2 (c int, d text)");
+                session.execute(
+                        "CREATE TABLE test_table_1 (e int primary key, f tuple<int, test_type_1, text>)");
+                session.execute(
+                        "CREATE TABLE test_table_2 (g int primary key, h tuple<text, test_type_2, int>)");
+            };
+
+    @Test
+    public void should_invalidate_cache_entry_on_tuple_udt_change_result_set() {
+        invalidationResultSetTest(setupCacheEntryTestTuple);
+    }
+
+    @Test
+    public void should_invalidate_cache_entry_on_tuple_udt_change_variable_defs() {
+        invalidationVariableDefsTest(setupCacheEntryTestTuple, false);
+    }
+
+    Consumer<CqlSession> setupCacheEntryTestNested =
+            (session) -> {
+                session.execute("CREATE TYPE test_type_1 (a text, b int)");
+                session.execute("CREATE TYPE test_type_2 (c int, d text)");
+                session.execute("CREATE TYPE test_type_3 (e frozen<test_type_1>, f int)");
+                session.execute("CREATE TYPE test_type_4 (g int, h frozen<test_type_2>)");
+                session.execute("CREATE TABLE test_table_1 (e int primary key, f frozen<test_type_3>)");
+                session.execute("CREATE TABLE test_table_2 (g int primary key, h frozen<test_type_4>)");
+            };
+
+    @Test
+    public void should_invalidate_cache_entry_on_nested_udt_change_result_set() {
+        invalidationResultSetTest(setupCacheEntryTestNested);
+    }
+
+    @Test
+    public void should_invalidate_cache_entry_on_nested_udt_change_variable_defs() {
+        invalidationVariableDefsTest(setupCacheEntryTestNested, false);
+    }
+
+    protected CqlSession sessionWithCacheSizeMetric() {
+        return SessionUtils.newSession(
+                ccmRule,
+                sessionRule.keyspace(),
+                SessionUtils.configLoaderBuilder()
+                        .withInt(DefaultDriverOption.REQUEST_PAGE_SIZE, 2)
+                        .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
+                        .withStringList(
+                                DefaultDriverOption.METRICS_SESSION_ENABLED,
+                                ImmutableList.of(DefaultSessionMetric.CQL_PREPARED_CACHE_SIZE.getPath()))
+                        .build());
+    }
+
+    @SuppressWarnings("unchecked")
+    protected static long getPreparedCacheSize(CqlSession session) {
+        return session
+                .getMetrics()
+                .flatMap(metrics -> metrics.getSessionMetric(DefaultSessionMetric.CQL_PREPARED_CACHE_SIZE))
+                .map(metric -> ((Gauge<Long>) metric).getValue())
+                .orElseThrow(
+                        () ->
+                                new AssertionError(
+                                        "Could not access metric "
+                                                + DefaultSessionMetric.CQL_PREPARED_CACHE_SIZE.getPath()));
+    }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCachingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCachingIT.java
@@ -13,7 +13,6 @@ import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
-import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.cql.CqlPrepareAsyncProcessor;
 import com.datastax.oss.driver.internal.core.cql.CqlPrepareSyncProcessor;
 import com.datastax.oss.driver.internal.core.metadata.schema.events.TypeChangeEvent;
@@ -21,9 +20,7 @@ import com.datastax.oss.driver.internal.core.session.BuiltInRequestProcessors;
 import com.datastax.oss.driver.internal.core.session.RequestProcessor;
 import com.datastax.oss.driver.internal.core.session.RequestProcessorRegistry;
 import com.datastax.oss.driver.shaded.guava.common.cache.CacheBuilder;
-import com.datastax.oss.driver.shaded.guava.common.collect.Iterables;
 import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
-import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.junit.AfterClass;
@@ -258,7 +255,8 @@ public class PreparedStatementCachingIT {
         invalidationVariableDefsTest(setupCacheEntryTestNested, false);
     }
 
-    protected CqlSession sessionWithCacheSizeMetric() {
+    /* ========================= Infrastructure copied from PreparedStatementIT ========================= */
+    private CqlSession sessionWithCacheSizeMetric() {
         return SessionUtils.newSession(
                 ccmRule,
                 sessionRule.keyspace(),
@@ -272,7 +270,7 @@ public class PreparedStatementCachingIT {
     }
 
     @SuppressWarnings("unchecked")
-    protected static long getPreparedCacheSize(CqlSession session) {
+    private static long getPreparedCacheSize(CqlSession session) {
         return session
                 .getMetrics()
                 .flatMap(metrics -> metrics.getSessionMetric(DefaultSessionMetric.CQL_PREPARED_CACHE_SIZE))

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCachingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCachingIT.java
@@ -1,10 +1,29 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.datastax.oss.driver.core.cql;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.codahale.metrics.Gauge;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.cql.PrepareRequest;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
 import com.datastax.oss.driver.api.core.session.ProgrammaticArguments;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
@@ -19,10 +38,22 @@ import com.datastax.oss.driver.internal.core.metadata.schema.events.TypeChangeEv
 import com.datastax.oss.driver.internal.core.session.BuiltInRequestProcessors;
 import com.datastax.oss.driver.internal.core.session.RequestProcessor;
 import com.datastax.oss.driver.internal.core.session.RequestProcessorRegistry;
+import com.datastax.oss.driver.shaded.guava.common.cache.Cache;
 import com.datastax.oss.driver.shaded.guava.common.cache.CacheBuilder;
 import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
 import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -33,252 +64,357 @@ import org.junit.rules.TestRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @Category(ParallelizableTests.class)
 public class PreparedStatementCachingIT {
 
-    private CcmRule ccmRule = CcmRule.getInstance();
+  private static final Logger LOG = LoggerFactory.getLogger(PreparedStatementCachingIT.class);
 
-    private SessionRule<CqlSession> sessionRule =
-            SessionRule.builder(ccmRule)
-                    .withConfigLoader(
-                            SessionUtils.configLoaderBuilder()
-                                    .withInt(DefaultDriverOption.REQUEST_PAGE_SIZE, 2)
-                                    .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
-                                    .build())
-                    .build();
+  private CcmRule ccmRule = CcmRule.getInstance();
 
-    @Rule
-    public TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
+  private SessionRule<CqlSession> sessionRule =
+      SessionRule.builder(ccmRule)
+          .withConfigLoader(
+              SessionUtils.configLoaderBuilder()
+                  .withInt(DefaultDriverOption.REQUEST_PAGE_SIZE, 2)
+                  .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
+                  .build())
+          .build();
 
-    private static class TestCqlPrepareAsyncProcessor extends CqlPrepareAsyncProcessor {
+  @Rule public TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
 
-        public TestCqlPrepareAsyncProcessor(@NonNull Optional<? extends DefaultDriverContext> context) {
-            super(CacheBuilder.newBuilder().build(), context);
-        }
+  private static class PreparedStatementRemovalEvent {
+
+    private final ByteBuffer queryId;
+
+    public PreparedStatementRemovalEvent(ByteBuffer queryId) {
+      this.queryId = queryId;
     }
 
-
-    private static class TestDefaultDriverContext extends DefaultDriverContext {
-
-        public TestDefaultDriverContext(DriverConfigLoader configLoader, ProgrammaticArguments programmaticArguments) {
-            super(configLoader, programmaticArguments);
-        }
-
-        @Override
-        protected RequestProcessorRegistry buildRequestProcessorRegistry() {
-            List<RequestProcessor<?, ?>> processors =
-                    BuiltInRequestProcessors.createDefaultProcessors(this);
-            processors.removeIf((processor) -> processor instanceof CqlPrepareAsyncProcessor);
-            processors.removeIf((processor) -> processor instanceof CqlPrepareSyncProcessor);
-            CqlPrepareAsyncProcessor asyncProcessor = new TestCqlPrepareAsyncProcessor(Optional.of(this));
-            processors.add(2, asyncProcessor);
-            processors.add(3, new CqlPrepareSyncProcessor(asyncProcessor));
-            return new RequestProcessorRegistry(
-                    getSessionName(), processors.toArray(new RequestProcessor[0]));
-        }
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      PreparedStatementRemovalEvent that = (PreparedStatementRemovalEvent) o;
+      return Objects.equals(queryId, that.queryId);
     }
 
-    private static class TestSessionBuilder extends SessionBuilder {
-
-        private final Logger LOG = LoggerFactory.getLogger(TestSessionBuilder.class);
-
-        @Override
-        protected Object wrap(@NonNull CqlSession defaultSession) {
-            return defaultSession;
-        }
-
-        @Override
-        protected DriverContext buildContext(
-                DriverConfigLoader configLoader, ProgrammaticArguments programmaticArguments) {
-            return new TestDefaultDriverContext(configLoader, programmaticArguments);
-        }
+    @Override
+    public int hashCode() {
+      return Objects.hash(queryId);
     }
 
-    @BeforeClass
-    public static void setup() {
-        System.setProperty(SessionUtils.SESSION_BUILDER_CLASS_PROPERTY, PreparedStatementCachingIT.class.getName());
+    @Override
+    public String toString() {
+      return "PreparedStatementRemovalEvent{" + "queryId=" + queryId + '}';
     }
+  }
 
-    @AfterClass
-    public static void teardown() {
-        System.clearProperty(SessionUtils.SESSION_BUILDER_CLASS_PROPERTY);
-    }
+  private static class TestCqlPrepareAsyncProcessor extends CqlPrepareAsyncProcessor {
 
-    public static SessionBuilder builder() { return new TestSessionBuilder(); }
+    private static final Logger LOG =
+        LoggerFactory.getLogger(PreparedStatementCachingIT.TestCqlPrepareAsyncProcessor.class);
 
-    private void invalidationResultSetTest(Consumer<CqlSession> createFn) {
+    private static Function<
+            Optional<? extends DefaultDriverContext>,
+            Cache<PrepareRequest, CompletableFuture<PreparedStatement>>>
+        buildCache =
+            (contextOption) -> {
 
-        try (CqlSession session = sessionWithCacheSizeMetric()) {
+              // Default CqlPrepareAsyncProcessor uses weak values here as well.  We avoid doing so
+              // to prevent cache
+              // entries from unexpectedly disappearing mid-test.
+              CacheBuilder builder = CacheBuilder.newBuilder();
+              contextOption.ifPresent(
+                  (ctx) -> {
+                    builder.removalListener(
+                        (evt) -> {
+                          try {
 
-            assertThat(getPreparedCacheSize(session)).isEqualTo(0);
-            createFn.accept(session);
-
-            session.prepare("select f from test_table_1 where e = ?");
-            session.prepare("select h from test_table_2 where g = ?");
-            assertThat(getPreparedCacheSize(session)).isEqualTo(2);
-
-            CountDownLatch latch = new CountDownLatch(1);
-            DefaultDriverContext ctx = (DefaultDriverContext)session.getContext();
-            ctx.getEventBus()
-                    .register(
-                            TypeChangeEvent.class,
-                            (e) -> {
-                                assertThat(e.oldType.getName().toString()).isEqualTo("test_type_2");
-                                latch.countDown();
-                            });
-
-            session.execute("ALTER TYPE test_type_2 add i blob");
-            Uninterruptibles.awaitUninterruptibly(latch, 2, TimeUnit.SECONDS);
-
-            //Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
-
-            assertThat(getPreparedCacheSize(session)).isEqualTo(1);
-        }
-    }
-
-    private void invalidationVariableDefsTest(Consumer<CqlSession> createFn, boolean isCollection) {
-
-        try (CqlSession session = sessionWithCacheSizeMetric()) {
-
-            assertThat(getPreparedCacheSize(session)).isEqualTo(0);
-            createFn.accept(session);
-
-            String fStr = isCollection ? "f contains ?" : "f = ?";
-            session.prepare(String.format("select e from test_table_1 where %s allow filtering", fStr));
-            String hStr = isCollection ? "h contains ?" : "h = ?";
-            session.prepare(String.format("select g from test_table_2 where %s allow filtering", hStr));
-            assertThat(getPreparedCacheSize(session)).isEqualTo(2);
-
-            CountDownLatch latch = new CountDownLatch(1);
-            DefaultDriverContext ctx = (DefaultDriverContext) session.getContext();
-            ctx.getEventBus()
-                    .register(
-                            TypeChangeEvent.class,
-                            (e) -> {
-                                assertThat(e.oldType.getName().toString()).isEqualTo("test_type_2");
-                                latch.countDown();
-                            });
-
-            session.execute("ALTER TYPE test_type_2 add i blob");
-            Uninterruptibles.awaitUninterruptibly(latch, 2, TimeUnit.SECONDS);
-
-            //Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
-
-            assertThat(getPreparedCacheSize(session)).isEqualTo(1);
-        }
-    }
-
-    Consumer<CqlSession> setupCacheEntryTestBasic =
-            (session) -> {
-                session.execute("CREATE TYPE test_type_1 (a text, b int)");
-                session.execute("CREATE TYPE test_type_2 (c int, d text)");
-                session.execute("CREATE TABLE test_table_1 (e int primary key, f frozen<test_type_1>)");
-                session.execute("CREATE TABLE test_table_2 (g int primary key, h frozen<test_type_2>)");
+                            CompletableFuture<PreparedStatement> future =
+                                (CompletableFuture<PreparedStatement>) evt.getValue();
+                            ByteBuffer queryId =
+                                Uninterruptibles.getUninterruptibly(future).getId();
+                            ctx.getEventBus().fire(new PreparedStatementRemovalEvent(queryId));
+                          } catch (Exception e) {
+                            LOG.error("Unable to register removal handler", e);
+                          }
+                        });
+                  });
+              return builder.build();
             };
 
-    @Test
-    public void should_invalidate_cache_entry_on_basic_udt_change_result_set() {
-        invalidationResultSetTest(setupCacheEntryTestBasic);
+    public TestCqlPrepareAsyncProcessor(@NonNull Optional<? extends DefaultDriverContext> context) {
+      super(TestCqlPrepareAsyncProcessor.buildCache.apply(context), context);
+    }
+  }
+
+  private static class TestDefaultDriverContext extends DefaultDriverContext {
+
+    public TestDefaultDriverContext(
+        DriverConfigLoader configLoader, ProgrammaticArguments programmaticArguments) {
+      super(configLoader, programmaticArguments);
     }
 
-    @Test
-    public void should_invalidate_cache_entry_on_basic_udt_change_variable_defs() {
-        invalidationVariableDefsTest(setupCacheEntryTestBasic, false);
+    @Override
+    protected RequestProcessorRegistry buildRequestProcessorRegistry() {
+      List<RequestProcessor<?, ?>> processors =
+          BuiltInRequestProcessors.createDefaultProcessors(this);
+      processors.removeIf((processor) -> processor instanceof CqlPrepareAsyncProcessor);
+      processors.removeIf((processor) -> processor instanceof CqlPrepareSyncProcessor);
+      CqlPrepareAsyncProcessor asyncProcessor = new TestCqlPrepareAsyncProcessor(Optional.of(this));
+      processors.add(2, asyncProcessor);
+      processors.add(3, new CqlPrepareSyncProcessor(asyncProcessor));
+      return new RequestProcessorRegistry(
+          getSessionName(), processors.toArray(new RequestProcessor[0]));
+    }
+  }
+
+  private static class TestSessionBuilder extends SessionBuilder {
+
+    private final Logger LOG = LoggerFactory.getLogger(TestSessionBuilder.class);
+
+    @Override
+    protected Object wrap(@NonNull CqlSession defaultSession) {
+      return defaultSession;
     }
 
-    Consumer<CqlSession> setupCacheEntryTestCollection =
-            (session) -> {
-                session.execute("CREATE TYPE test_type_1 (a text, b int)");
-                session.execute("CREATE TYPE test_type_2 (c int, d text)");
-                session.execute(
-                        "CREATE TABLE test_table_1 (e int primary key, f list<frozen<test_type_1>>)");
-                session.execute(
-                        "CREATE TABLE test_table_2 (g int primary key, h list<frozen<test_type_2>>)");
-            };
-
-    @Test
-    public void should_invalidate_cache_entry_on_collection_udt_change_result_set() {
-        invalidationResultSetTest(setupCacheEntryTestCollection);
+    @Override
+    protected DriverContext buildContext(
+        DriverConfigLoader configLoader, ProgrammaticArguments programmaticArguments) {
+      return new TestDefaultDriverContext(configLoader, programmaticArguments);
     }
+  }
 
-    @Test
-    public void should_invalidate_cache_entry_on_collection_udt_change_variable_defs() {
-        invalidationVariableDefsTest(setupCacheEntryTestCollection, true);
+  @BeforeClass
+  public static void setup() {
+    System.setProperty(
+        SessionUtils.SESSION_BUILDER_CLASS_PROPERTY, PreparedStatementCachingIT.class.getName());
+  }
+
+  @AfterClass
+  public static void teardown() {
+    System.clearProperty(SessionUtils.SESSION_BUILDER_CLASS_PROPERTY);
+  }
+
+  public static SessionBuilder builder() {
+    return new TestSessionBuilder();
+  }
+
+  private void invalidationResultSetTest(Consumer<CqlSession> createFn) {
+
+    try (CqlSession session = sessionWithCacheSizeMetric()) {
+
+      assertThat(getPreparedCacheSize(session)).isEqualTo(0);
+      createFn.accept(session);
+
+      session.prepare("select f from test_table_1 where e = ?");
+      ByteBuffer queryId2 = session.prepare("select h from test_table_2 where g = ?").getId();
+      assertThat(getPreparedCacheSize(session)).isEqualTo(2);
+
+      CountDownLatch latch = new CountDownLatch(1);
+      DefaultDriverContext ctx = (DefaultDriverContext) session.getContext();
+      AtomicReference<Optional<String>> changeRef = new AtomicReference<>(Optional.empty());
+      AtomicReference<Optional<ByteBuffer>> idRef = new AtomicReference<>(Optional.empty());
+      ctx.getEventBus()
+          .register(
+              TypeChangeEvent.class,
+              (e) -> {
+                if (!changeRef.compareAndSet(
+                    Optional.empty(), Optional.of(e.oldType.getName().toString())))
+                  // TODO: Note that we actually do see this error for tests around nested UDTs.
+                  // What's happening is that
+                  // we see an event for the changed type itself and then we get an event for the
+                  // nesting type that contains
+                  // it.  Upshot is that this logic is dependent on the order of event delivery; as
+                  // long as the event for the
+                  // type itself is first this test will behave as expected.
+                  //
+                  // We probably want something more robust here.
+                  LOG.error("Unable to set reference for type change event " + e);
+              });
+      ctx.getEventBus()
+          .register(
+              PreparedStatementRemovalEvent.class,
+              (e) -> {
+                if (!idRef.compareAndSet(Optional.empty(), Optional.of(e.queryId)))
+                  LOG.error("Unable to set reference for PS removal event");
+                latch.countDown();
+              });
+
+      session.execute("ALTER TYPE test_type_2 add i blob");
+      Uninterruptibles.awaitUninterruptibly(latch, 2, TimeUnit.SECONDS);
+
+      /* Okay, the latch triggered so cache processing should now be done.  Let's validate :allthethings: */
+      assertThat(changeRef.get()).isNotEmpty();
+      assertThat(changeRef.get().get()).isEqualTo("test_type_2");
+      assertThat(idRef.get()).isNotEmpty();
+      assertThat(idRef.get().get()).isEqualTo(queryId2);
+      assertThat(getPreparedCacheSize(session)).isEqualTo(1);
     }
+  }
 
-    Consumer<CqlSession> setupCacheEntryTestTuple =
-            (session) -> {
-                session.execute("CREATE TYPE test_type_1 (a text, b int)");
-                session.execute("CREATE TYPE test_type_2 (c int, d text)");
-                session.execute(
-                        "CREATE TABLE test_table_1 (e int primary key, f tuple<int, test_type_1, text>)");
-                session.execute(
-                        "CREATE TABLE test_table_2 (g int primary key, h tuple<text, test_type_2, int>)");
-            };
+  private void invalidationVariableDefsTest(Consumer<CqlSession> createFn, boolean isCollection) {
 
-    @Test
-    public void should_invalidate_cache_entry_on_tuple_udt_change_result_set() {
-        invalidationResultSetTest(setupCacheEntryTestTuple);
+    /* TODO: There's a lot more infrastructure in this test now, which means we're duplicating a lot of setup with
+     *   the ResultSet test above.  Probably worth while to see if we can merge the two. */
+    try (CqlSession session = sessionWithCacheSizeMetric()) {
+
+      assertThat(getPreparedCacheSize(session)).isEqualTo(0);
+      createFn.accept(session);
+
+      String fStr = isCollection ? "f contains ?" : "f = ?";
+      session.prepare(String.format("select e from test_table_1 where %s allow filtering", fStr));
+      String hStr = isCollection ? "h contains ?" : "h = ?";
+      ByteBuffer queryId2 =
+          session
+              .prepare(String.format("select g from test_table_2 where %s allow filtering", hStr))
+              .getId();
+      assertThat(getPreparedCacheSize(session)).isEqualTo(2);
+
+      CountDownLatch latch = new CountDownLatch(1);
+      DefaultDriverContext ctx = (DefaultDriverContext) session.getContext();
+      AtomicReference<Optional<String>> changeRef = new AtomicReference<>(Optional.empty());
+      AtomicReference<Optional<ByteBuffer>> idRef = new AtomicReference<>(Optional.empty());
+      ctx.getEventBus()
+          .register(
+              TypeChangeEvent.class,
+              (e) -> {
+                if (!changeRef.compareAndSet(
+                    Optional.empty(), Optional.of(e.oldType.getName().toString())))
+                  // TODO: Note that we actually do see this error for tests around nested UDTs.
+                  // What's happening is that
+                  // we see an event for the changed type itself and then we get an event for the
+                  // nesting type that contains
+                  // it.  Upshot is that this logic is dependent on the order of event delivery; as
+                  // long as the event for the
+                  // type itself is first this test will behave as expected.
+                  //
+                  // We probably want something more robust here.
+                  LOG.error("Unable to set reference for type change event " + e);
+              });
+      ctx.getEventBus()
+          .register(
+              PreparedStatementRemovalEvent.class,
+              (e) -> {
+                if (!idRef.compareAndSet(Optional.empty(), Optional.of(e.queryId)))
+                  LOG.error("Unable to set reference for PS removal event");
+                latch.countDown();
+              });
+
+      session.execute("ALTER TYPE test_type_2 add i blob");
+      Uninterruptibles.awaitUninterruptibly(latch, 2, TimeUnit.SECONDS);
+
+      /* Okay, the latch triggered so cache processing should now be done.  Let's validate :allthethings: */
+      assertThat(changeRef.get()).isNotEmpty();
+      assertThat(changeRef.get().get()).isEqualTo("test_type_2");
+      assertThat(idRef.get()).isNotEmpty();
+      assertThat(idRef.get().get()).isEqualTo(queryId2);
+      assertThat(getPreparedCacheSize(session)).isEqualTo(1);
     }
+  }
 
-    @Test
-    public void should_invalidate_cache_entry_on_tuple_udt_change_variable_defs() {
-        invalidationVariableDefsTest(setupCacheEntryTestTuple, false);
-    }
+  Consumer<CqlSession> setupCacheEntryTestBasic =
+      (session) -> {
+        session.execute("CREATE TYPE test_type_1 (a text, b int)");
+        session.execute("CREATE TYPE test_type_2 (c int, d text)");
+        session.execute("CREATE TABLE test_table_1 (e int primary key, f frozen<test_type_1>)");
+        session.execute("CREATE TABLE test_table_2 (g int primary key, h frozen<test_type_2>)");
+      };
 
-    Consumer<CqlSession> setupCacheEntryTestNested =
-            (session) -> {
-                session.execute("CREATE TYPE test_type_1 (a text, b int)");
-                session.execute("CREATE TYPE test_type_2 (c int, d text)");
-                session.execute("CREATE TYPE test_type_3 (e frozen<test_type_1>, f int)");
-                session.execute("CREATE TYPE test_type_4 (g int, h frozen<test_type_2>)");
-                session.execute("CREATE TABLE test_table_1 (e int primary key, f frozen<test_type_3>)");
-                session.execute("CREATE TABLE test_table_2 (g int primary key, h frozen<test_type_4>)");
-            };
+  @Test
+  public void should_invalidate_cache_entry_on_basic_udt_change_result_set() {
+    invalidationResultSetTest(setupCacheEntryTestBasic);
+  }
 
-    @Test
-    public void should_invalidate_cache_entry_on_nested_udt_change_result_set() {
-        invalidationResultSetTest(setupCacheEntryTestNested);
-    }
+  @Test
+  public void should_invalidate_cache_entry_on_basic_udt_change_variable_defs() {
+    invalidationVariableDefsTest(setupCacheEntryTestBasic, false);
+  }
 
-    @Test
-    public void should_invalidate_cache_entry_on_nested_udt_change_variable_defs() {
-        invalidationVariableDefsTest(setupCacheEntryTestNested, false);
-    }
+  Consumer<CqlSession> setupCacheEntryTestCollection =
+      (session) -> {
+        session.execute("CREATE TYPE test_type_1 (a text, b int)");
+        session.execute("CREATE TYPE test_type_2 (c int, d text)");
+        session.execute(
+            "CREATE TABLE test_table_1 (e int primary key, f list<frozen<test_type_1>>)");
+        session.execute(
+            "CREATE TABLE test_table_2 (g int primary key, h list<frozen<test_type_2>>)");
+      };
 
-    /* ========================= Infrastructure copied from PreparedStatementIT ========================= */
-    private CqlSession sessionWithCacheSizeMetric() {
-        return SessionUtils.newSession(
-                ccmRule,
-                sessionRule.keyspace(),
-                SessionUtils.configLoaderBuilder()
-                        .withInt(DefaultDriverOption.REQUEST_PAGE_SIZE, 2)
-                        .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
-                        .withStringList(
-                                DefaultDriverOption.METRICS_SESSION_ENABLED,
-                                ImmutableList.of(DefaultSessionMetric.CQL_PREPARED_CACHE_SIZE.getPath()))
-                        .build());
-    }
+  @Test
+  public void should_invalidate_cache_entry_on_collection_udt_change_result_set() {
+    invalidationResultSetTest(setupCacheEntryTestCollection);
+  }
 
-    @SuppressWarnings("unchecked")
-    private static long getPreparedCacheSize(CqlSession session) {
-        return session
-                .getMetrics()
-                .flatMap(metrics -> metrics.getSessionMetric(DefaultSessionMetric.CQL_PREPARED_CACHE_SIZE))
-                .map(metric -> ((Gauge<Long>) metric).getValue())
-                .orElseThrow(
-                        () ->
-                                new AssertionError(
-                                        "Could not access metric "
-                                                + DefaultSessionMetric.CQL_PREPARED_CACHE_SIZE.getPath()));
-    }
+  @Test
+  public void should_invalidate_cache_entry_on_collection_udt_change_variable_defs() {
+    invalidationVariableDefsTest(setupCacheEntryTestCollection, true);
+  }
+
+  Consumer<CqlSession> setupCacheEntryTestTuple =
+      (session) -> {
+        session.execute("CREATE TYPE test_type_1 (a text, b int)");
+        session.execute("CREATE TYPE test_type_2 (c int, d text)");
+        session.execute(
+            "CREATE TABLE test_table_1 (e int primary key, f tuple<int, test_type_1, text>)");
+        session.execute(
+            "CREATE TABLE test_table_2 (g int primary key, h tuple<text, test_type_2, int>)");
+      };
+
+  @Test
+  public void should_invalidate_cache_entry_on_tuple_udt_change_result_set() {
+    invalidationResultSetTest(setupCacheEntryTestTuple);
+  }
+
+  @Test
+  public void should_invalidate_cache_entry_on_tuple_udt_change_variable_defs() {
+    invalidationVariableDefsTest(setupCacheEntryTestTuple, false);
+  }
+
+  Consumer<CqlSession> setupCacheEntryTestNested =
+      (session) -> {
+        session.execute("CREATE TYPE test_type_1 (a text, b int)");
+        session.execute("CREATE TYPE test_type_2 (c int, d text)");
+        session.execute("CREATE TYPE test_type_3 (e frozen<test_type_1>, f int)");
+        session.execute("CREATE TYPE test_type_4 (g int, h frozen<test_type_2>)");
+        session.execute("CREATE TABLE test_table_1 (e int primary key, f frozen<test_type_3>)");
+        session.execute("CREATE TABLE test_table_2 (g int primary key, h frozen<test_type_4>)");
+      };
+
+  @Test
+  public void should_invalidate_cache_entry_on_nested_udt_change_result_set() {
+    invalidationResultSetTest(setupCacheEntryTestNested);
+  }
+
+  @Test
+  public void should_invalidate_cache_entry_on_nested_udt_change_variable_defs() {
+    invalidationVariableDefsTest(setupCacheEntryTestNested, false);
+  }
+
+  /* ========================= Infrastructure copied from PreparedStatementIT ========================= */
+  private CqlSession sessionWithCacheSizeMetric() {
+    return SessionUtils.newSession(
+        ccmRule,
+        sessionRule.keyspace(),
+        SessionUtils.configLoaderBuilder()
+            .withInt(DefaultDriverOption.REQUEST_PAGE_SIZE, 2)
+            .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(30))
+            .withStringList(
+                DefaultDriverOption.METRICS_SESSION_ENABLED,
+                ImmutableList.of(DefaultSessionMetric.CQL_PREPARED_CACHE_SIZE.getPath()))
+            .build());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static long getPreparedCacheSize(CqlSession session) {
+    return session
+        .getMetrics()
+        .flatMap(metrics -> metrics.getSessionMetric(DefaultSessionMetric.CQL_PREPARED_CACHE_SIZE))
+        .map(metric -> ((Gauge<Long>) metric).getValue())
+        .orElseThrow(
+            () ->
+                new AssertionError(
+                    "Could not access metric "
+                        + DefaultSessionMetric.CQL_PREPARED_CACHE_SIZE.getPath()));
+  }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
@@ -39,20 +39,14 @@ import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.categories.ParallelizableTests;
-import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
-import com.datastax.oss.driver.internal.core.metadata.schema.events.TypeChangeEvent;
 import com.datastax.oss.driver.internal.core.metadata.token.DefaultTokenMap;
 import com.datastax.oss.driver.internal.core.metadata.token.TokenFactory;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
-import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
 import com.datastax.oss.protocol.internal.util.Bytes;
 import com.google.common.collect.ImmutableList;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.Rule;
@@ -485,8 +479,7 @@ public class PreparedStatementIT {
     return CompletableFutures.getUninterruptibly(stage).currentPage();
   }
 
-  /* We have subclasses now so we must think of the children */
-  protected CqlSession sessionWithCacheSizeMetric() {
+  private CqlSession sessionWithCacheSizeMetric() {
     return SessionUtils.newSession(
         ccmRule,
         sessionRule.keyspace(),
@@ -500,8 +493,7 @@ public class PreparedStatementIT {
   }
 
   @SuppressWarnings("unchecked")
-  /* We have subclasses now so we must think of the children */
-  protected static long getPreparedCacheSize(CqlSession session) {
+  private static long getPreparedCacheSize(CqlSession session) {
     return session
         .getMetrics()
         .flatMap(metrics -> metrics.getSessionMetric(DefaultSessionMetric.CQL_PREPARED_CACHE_SIZE))

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementIT.java
@@ -450,142 +450,6 @@ public class PreparedStatementIT {
     }
   }
 
-  private void invalidationResultSetTest(Consumer<CqlSession> createFn) {
-
-    try (CqlSession session = sessionWithCacheSizeMetric()) {
-
-      assertThat(getPreparedCacheSize(session)).isEqualTo(0);
-      createFn.accept(session);
-
-      session.prepare("select f from test_table_1 where e = ?");
-      session.prepare("select h from test_table_2 where g = ?");
-      assertThat(getPreparedCacheSize(session)).isEqualTo(2);
-
-      CountDownLatch latch = new CountDownLatch(1);
-      DefaultDriverContext ctx = (DefaultDriverContext) session.getContext();
-      ctx.getEventBus()
-          .register(
-              TypeChangeEvent.class,
-              (e) -> {
-                assertThat(e.oldType.getName().toString()).isEqualTo("test_type_2");
-                latch.countDown();
-              });
-
-      session.execute("ALTER TYPE test_type_2 add i blob");
-      Uninterruptibles.awaitUninterruptibly(latch, 2, TimeUnit.SECONDS);
-
-      assertThat(getPreparedCacheSize(session)).isEqualTo(1);
-    }
-  }
-
-  private void invalidationVariableDefsTest(Consumer<CqlSession> createFn, boolean isCollection) {
-
-    try (CqlSession session = sessionWithCacheSizeMetric()) {
-
-      assertThat(getPreparedCacheSize(session)).isEqualTo(0);
-      createFn.accept(session);
-
-      String fStr = isCollection ? "f contains ?" : "f = ?";
-      session.prepare(String.format("select e from test_table_1 where %s allow filtering", fStr));
-      String hStr = isCollection ? "h contains ?" : "h = ?";
-      session.prepare(String.format("select g from test_table_2 where %s allow filtering", hStr));
-      assertThat(getPreparedCacheSize(session)).isEqualTo(2);
-
-      CountDownLatch latch = new CountDownLatch(1);
-      DefaultDriverContext ctx = (DefaultDriverContext) session.getContext();
-      ctx.getEventBus()
-          .register(
-              TypeChangeEvent.class,
-              (e) -> {
-                assertThat(e.oldType.getName().toString()).isEqualTo("test_type_2");
-                latch.countDown();
-              });
-
-      session.execute("ALTER TYPE test_type_2 add i blob");
-      Uninterruptibles.awaitUninterruptibly(latch, 2, TimeUnit.SECONDS);
-
-      assertThat(getPreparedCacheSize(session)).isEqualTo(1);
-    }
-  }
-
-  Consumer<CqlSession> setupCacheEntryTestBasic =
-      (session) -> {
-        session.execute("CREATE TYPE test_type_1 (a text, b int)");
-        session.execute("CREATE TYPE test_type_2 (c int, d text)");
-        session.execute("CREATE TABLE test_table_1 (e int primary key, f frozen<test_type_1>)");
-        session.execute("CREATE TABLE test_table_2 (g int primary key, h frozen<test_type_2>)");
-      };
-
-  @Test
-  public void should_invalidate_cache_entry_on_basic_udt_change_result_set() {
-    invalidationResultSetTest(setupCacheEntryTestBasic);
-  }
-
-  @Test
-  public void should_invalidate_cache_entry_on_basic_udt_change_variable_defs() {
-    invalidationVariableDefsTest(setupCacheEntryTestBasic, false);
-  }
-
-  Consumer<CqlSession> setupCacheEntryTestCollection =
-      (session) -> {
-        session.execute("CREATE TYPE test_type_1 (a text, b int)");
-        session.execute("CREATE TYPE test_type_2 (c int, d text)");
-        session.execute(
-            "CREATE TABLE test_table_1 (e int primary key, f list<frozen<test_type_1>>)");
-        session.execute(
-            "CREATE TABLE test_table_2 (g int primary key, h list<frozen<test_type_2>>)");
-      };
-
-  @Test
-  public void should_invalidate_cache_entry_on_collection_udt_change_result_set() {
-    invalidationResultSetTest(setupCacheEntryTestCollection);
-  }
-
-  @Test
-  public void should_invalidate_cache_entry_on_collection_udt_change_variable_defs() {
-    invalidationVariableDefsTest(setupCacheEntryTestCollection, true);
-  }
-
-  Consumer<CqlSession> setupCacheEntryTestTuple =
-      (session) -> {
-        session.execute("CREATE TYPE test_type_1 (a text, b int)");
-        session.execute("CREATE TYPE test_type_2 (c int, d text)");
-        session.execute(
-            "CREATE TABLE test_table_1 (e int primary key, f tuple<int, test_type_1, text>)");
-        session.execute(
-            "CREATE TABLE test_table_2 (g int primary key, h tuple<text, test_type_2, int>)");
-      };
-
-  @Test
-  public void should_invalidate_cache_entry_on_tuple_udt_change_result_set() {
-    invalidationResultSetTest(setupCacheEntryTestTuple);
-  }
-
-  @Test
-  public void should_invalidate_cache_entry_on_tuple_udt_change_variable_defs() {
-    invalidationVariableDefsTest(setupCacheEntryTestTuple, false);
-  }
-
-  Consumer<CqlSession> setupCacheEntryTestNested =
-      (session) -> {
-        session.execute("CREATE TYPE test_type_1 (a text, b int)");
-        session.execute("CREATE TYPE test_type_2 (c int, d text)");
-        session.execute("CREATE TYPE test_type_3 (e frozen<test_type_1>, f int)");
-        session.execute("CREATE TYPE test_type_4 (g int, h frozen<test_type_2>)");
-        session.execute("CREATE TABLE test_table_1 (e int primary key, f frozen<test_type_3>)");
-        session.execute("CREATE TABLE test_table_2 (g int primary key, h frozen<test_type_4>)");
-      };
-
-  @Test
-  public void should_invalidate_cache_entry_on_nested_udt_change_result_set() {
-    invalidationResultSetTest(setupCacheEntryTestNested);
-  }
-
-  @Test
-  public void should_invalidate_cache_entry_on_nested_udt_change_variable_defs() {
-    invalidationVariableDefsTest(setupCacheEntryTestNested, false);
-  }
-
   @Test
   public void should_infer_routing_information_when_partition_key_is_bound() {
     should_infer_routing_information_when_partition_key_is_bound(
@@ -621,7 +485,8 @@ public class PreparedStatementIT {
     return CompletableFutures.getUninterruptibly(stage).currentPage();
   }
 
-  private CqlSession sessionWithCacheSizeMetric() {
+  /* We have subclasses now so we must think of the children */
+  protected CqlSession sessionWithCacheSizeMetric() {
     return SessionUtils.newSession(
         ccmRule,
         sessionRule.keyspace(),
@@ -635,7 +500,8 @@ public class PreparedStatementIT {
   }
 
   @SuppressWarnings("unchecked")
-  private static long getPreparedCacheSize(CqlSession session) {
+  /* We have subclasses now so we must think of the children */
+  protected static long getPreparedCacheSize(CqlSession session) {
     return session
         .getMetrics()
         .flatMap(metrics -> metrics.getSessionMetric(DefaultSessionMetric.CQL_PREPARED_CACHE_SIZE))

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
@@ -61,11 +61,14 @@ import org.slf4j.LoggerFactory;
  * SessionRule} provides a simpler alternative.
  */
 public class SessionUtils {
+
+  public static final String SESSION_BUILDER_CLASS_PROPERTY = "session.builder";
+
   private static final Logger LOG = LoggerFactory.getLogger(SessionUtils.class);
   private static final AtomicInteger keyspaceId = new AtomicInteger();
   private static final String DEFAULT_SESSION_CLASS_NAME = CqlSession.class.getName();
   private static final String SESSION_BUILDER_CLASS =
-      System.getProperty("session.builder", DEFAULT_SESSION_CLASS_NAME);
+      System.getProperty(SESSION_BUILDER_CLASS_PROPERTY, DEFAULT_SESSION_CLASS_NAME);
 
   @SuppressWarnings("unchecked")
   public static <SessionT extends Session> SessionBuilder<?, SessionT> baseBuilder() {

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionUtils.java
@@ -67,36 +67,40 @@ public class SessionUtils {
   private static final Logger LOG = LoggerFactory.getLogger(SessionUtils.class);
   private static final AtomicInteger keyspaceId = new AtomicInteger();
   private static final String DEFAULT_SESSION_CLASS_NAME = CqlSession.class.getName();
-  private static final String SESSION_BUILDER_CLASS =
-      System.getProperty(SESSION_BUILDER_CLASS_PROPERTY, DEFAULT_SESSION_CLASS_NAME);
+
+  private static String getSessionBuilderClass() {
+    return System.getProperty(SESSION_BUILDER_CLASS_PROPERTY, DEFAULT_SESSION_CLASS_NAME);
+  }
 
   @SuppressWarnings("unchecked")
   public static <SessionT extends Session> SessionBuilder<?, SessionT> baseBuilder() {
+    String sessionBuilderClass = getSessionBuilderClass();
     try {
-      Class<?> clazz = Class.forName(SESSION_BUILDER_CLASS);
+      Class<?> clazz = Class.forName(sessionBuilderClass);
       Method m = clazz.getMethod("builder");
       return (SessionBuilder<?, SessionT>) m.invoke(null);
     } catch (Exception e) {
       LOG.warn(
           "Could not construct SessionBuilder from {} using builder(), using default "
               + "implementation.",
-          SESSION_BUILDER_CLASS,
+          sessionBuilderClass,
           e);
       return (SessionBuilder<?, SessionT>) CqlSession.builder();
     }
   }
 
   public static ProgrammaticDriverConfigLoaderBuilder configLoaderBuilder() {
+    String sessionBuilderClass = getSessionBuilderClass();
     try {
-      Class<?> clazz = Class.forName(SESSION_BUILDER_CLASS);
+      Class<?> clazz = Class.forName(sessionBuilderClass);
       Method m = clazz.getMethod("configLoaderBuilder");
       return (ProgrammaticDriverConfigLoaderBuilder) m.invoke(null);
     } catch (Exception e) {
-      if (!SESSION_BUILDER_CLASS.equals(DEFAULT_SESSION_CLASS_NAME)) {
+      if (!sessionBuilderClass.equals(DEFAULT_SESSION_CLASS_NAME)) {
         LOG.warn(
             "Could not construct ProgrammaticDriverConfigLoaderBuilder from {} using "
                 + "configLoaderBuilder(), using default implementation.",
-            SESSION_BUILDER_CLASS,
+            sessionBuilderClass,
             e);
       }
       return DriverConfigLoader.programmaticBuilder();


### PR DESCRIPTION
… around JAVA-3058

- Make PreparedStatementIT resistant to JVM GC clearing items from prepared statement cache mid-test
- Add tests around prepared statement cache garbage collection