### PR TITLE
added Snyk monitor and snyk clean up after PR closed/merged

### DIFF
--- a/.github/workflows/snyk-cli-scan.yml
+++ b/.github/workflows/snyk-cli-scan.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ 4.x ]
   pull_request:
-    branches: [ 4.x  ]
+    branches: [ 4.x ]
   workflow_dispatch:  
 
 env:

--- a/.github/workflows/snyk-cli-scan.yml
+++ b/.github/workflows/snyk-cli-scan.yml
@@ -2,9 +2,9 @@ name: 🔬 Snyk cli SCA
 
 on: 
   push:
-    branches: [ snyk-monitor ]
+    branches: [ 4.x ]
   pull_request:
-    branches: [ snyk-monitor  ]
+    branches: [ 4.x  ]
   workflow_dispatch:  
 
 env:

--- a/.github/workflows/snyk-cli-scan.yml
+++ b/.github/workflows/snyk-cli-scan.yml
@@ -1,0 +1,36 @@
+name: 🔬 Snyk cli SCA
+
+on: 
+  push:
+    branches: [ snyk-monitor ]
+  pull_request:
+    branches: [ snyk-monitor  ]
+  workflow_dispatch:  
+
+env:
+  SNYK_SEVERITY_THRESHOLD_LEVEL: high
+
+jobs:
+  snyk-cli-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+
+      - name: prepare for snyk scan
+        uses: datastax/shared-github-actions/actions/snyk-prepare@main
+
+      - name: snyk scan java
+        uses: datastax/shared-github-actions/actions/snyk-scan-java@main
+        with:
+          java-version: 8
+          directories: .
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_ORG_ID: ${{ secrets.SNYK_ORG_ID }}
+
+      - name: Snyk scan result
+        uses: datastax/shared-github-actions/actions/snyk-process-scan-results@main
+        with:
+          gh_repo_token: ${{ secrets.GITHUB_TOKEN }}
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SNYK_ORG_ID: ${{ secrets.SNYK_ORG_ID }}          

--- a/.github/workflows/snyk-cli-scan.yml
+++ b/.github/workflows/snyk-cli-scan.yml
@@ -20,11 +20,11 @@ jobs:
       - name: prepare for snyk scan
         uses: datastax/shared-github-actions/actions/snyk-prepare@main
 
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '8'
           cache: maven
           
       - name: run maven install prepare for snyk

--- a/.github/workflows/snyk-cli-scan.yml
+++ b/.github/workflows/snyk-cli-scan.yml
@@ -20,10 +20,20 @@ jobs:
       - name: prepare for snyk scan
         uses: datastax/shared-github-actions/actions/snyk-prepare@main
 
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: maven
+          
+      - name: run maven install prepare for snyk
+        run: |
+          mvn -B -V install -DskipTests -Dmaven.javadoc.skip=true
+      
       - name: snyk scan java
         uses: datastax/shared-github-actions/actions/snyk-scan-java@main
         with:
-          java-version: 11
           directories: .
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_ORG_ID: ${{ secrets.SNYK_ORG_ID }}

--- a/.github/workflows/snyk-cli-scan.yml
+++ b/.github/workflows/snyk-cli-scan.yml
@@ -23,10 +23,11 @@ jobs:
       - name: snyk scan java
         uses: datastax/shared-github-actions/actions/snyk-scan-java@main
         with:
-          java-version: 8
+          java-version: 11
           directories: .
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_ORG_ID: ${{ secrets.SNYK_ORG_ID }}
+          extra-snyk-options: "-DskipTests -Dmaven.javadoc.skip=true"
 
       - name: Snyk scan result
         uses: datastax/shared-github-actions/actions/snyk-process-scan-results@main

--- a/.github/workflows/snyk-cli-scan.yml
+++ b/.github/workflows/snyk-cli-scan.yml
@@ -1,11 +1,11 @@
 name: 🔬 Snyk cli SCA
 
-on: 
+on:
   push:
     branches: [ 4.x ]
   pull_request:
     branches: [ 4.x ]
-  workflow_dispatch:  
+  workflow_dispatch:
 
 env:
   SNYK_SEVERITY_THRESHOLD_LEVEL: high
@@ -26,11 +26,11 @@ jobs:
           distribution: 'temurin'
           java-version: '8'
           cache: maven
-          
+
       - name: run maven install prepare for snyk
         run: |
           mvn -B -V install -DskipTests -Dmaven.javadoc.skip=true
-      
+
       - name: snyk scan java
         uses: datastax/shared-github-actions/actions/snyk-scan-java@main
         with:
@@ -44,4 +44,4 @@ jobs:
         with:
           gh_repo_token: ${{ secrets.GITHUB_TOKEN }}
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          SNYK_ORG_ID: ${{ secrets.SNYK_ORG_ID }}          
+          SNYK_ORG_ID: ${{ secrets.SNYK_ORG_ID }}

--- a/.github/workflows/snyk-pr-cleanup.yml
+++ b/.github/workflows/snyk-pr-cleanup.yml
@@ -1,0 +1,16 @@
+name: 🗑️ Snyk PR cleanup - merged/closed 
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:    
+      - snyk-monitor
+  workflow_dispatch:  
+  
+jobs:
+  snyk_project_cleanup_when_pr_closed:
+    uses: datastax/shared-github-actions/.github/workflows/snyk-pr-cleanup.yml@main
+    secrets:
+      snyk_token: ${{ secrets.SNYK_TOKEN }}
+      snyk_org_id: ${{ secrets.SNYK_ORG_ID }}

--- a/.github/workflows/snyk-pr-cleanup.yml
+++ b/.github/workflows/snyk-pr-cleanup.yml
@@ -1,13 +1,13 @@
-name: 🗑️ Snyk PR cleanup - merged/closed 
+name: 🗑️ Snyk PR cleanup - merged/closed
 
 on:
   pull_request:
     types:
       - closed
-    branches:    
+    branches:
       - snyk-monitor
-  workflow_dispatch:  
-  
+  workflow_dispatch:
+
 jobs:
   snyk_project_cleanup_when_pr_closed:
     uses: datastax/shared-github-actions/.github/workflows/snyk-pr-cleanup.yml@main

--- a/.snyk
+++ b/.snyk
@@ -1,1 +1,19 @@
-# vulns will be ignored by snyk 
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.22.2
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JAVA-ORGGRAALVMSDK-2767964:
+    - '*':
+        reason: cannot upgrade to graal-sdk 22.1.0+ until we move off Java8, which is slated for later this year
+        expires: 2024-01-10T00:00:00.000Z
+        created: 2023-06-21T00:00:00.000Z
+  SNYK-JAVA-ORGGRAALVMSDK-2769618:
+    - '*':
+        reason: cannot upgrade to graal-sdk 22.1.0+ until we move off Java8, which is slated for later this year
+        expires: 2024-01-10T00:00:00.000Z
+        created: 2023-06-21T00:00:00.000Z
+  SNYK-JAVA-ORGGRAALVMSDK-5457933:
+    - '*':
+        reason: cannot upgrade to graal-sdk 22.1.0+ until we move off Java8, which is slated for later this year
+        expires: 2024-01-10T00:00:00.000Z
+        created: 2023-06-21T00:00:00.000Z

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,1 @@
+# vulns will be ignored by snyk 

--- a/.snyk.ignore.example
+++ b/.snyk.ignore.example
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.22.2
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-PYTHON-URLLIB3-1533435:
+    - '*':
+        reason: state your ignore reason here
+        expires: 2030-01-01T00:00:00.000Z
+        created: 2022-03-21T00:00:00.000Z

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/BundleOptions.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/BundleOptions.java
@@ -91,6 +91,7 @@ public class BundleOptions {
             mavenBundle("io.netty", "netty-codec").versionAsInProject(),
             mavenBundle("io.netty", "netty-common").versionAsInProject(),
             mavenBundle("io.netty", "netty-transport").versionAsInProject(),
+            mavenBundle("io.netty", "netty-transport-native-unix-common").versionAsInProject(),
             mavenBundle("io.netty", "netty-resolver").versionAsInProject());
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <config.version>1.4.1</config.version>
     <hdrhistogram.version>2.1.12</hdrhistogram.version>
     <metrics.version>4.1.18</metrics.version>
-    <netty.version>4.1.77.Final</netty.version>
+    <netty.version>4.1.94.Final</netty.version>
     <esri.version>1.2.1</esri.version>
     <!--
     When upgrading TinkerPop please upgrade the version matrix in

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <tinkerpop.version>3.5.6</tinkerpop.version>
     <slf4j.version>1.7.26</slf4j.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>
-    <json.version>20210307</json.version>
+    <json.version>20230227</json.version>
     <jackson.version>2.13.2</jackson.version>
     <jackson-databind.version>2.13.2.2</jackson-databind.version>
     <legacy-jackson.version>1.9.12</legacy-jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,13 +47,13 @@
     <config.version>1.4.1</config.version>
     <hdrhistogram.version>2.1.12</hdrhistogram.version>
     <metrics.version>4.1.18</metrics.version>
-    <netty.version>4.1.77.Final</netty.version>
+    <netty.version>4.1.94.Final</netty.version>
     <esri.version>1.2.1</esri.version>
     <!--
     When upgrading TinkerPop please upgrade the version matrix in
     manual/core/integration/README.md
     -->
-    <tinkerpop.version>3.5.3</tinkerpop.version>
+    <tinkerpop.version>3.5.6</tinkerpop.version>
     <slf4j.version>1.7.26</slf4j.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>
     <json.version>20210307</json.version>
@@ -61,7 +61,7 @@
     <jackson-databind.version>2.13.2.2</jackson-databind.version>
     <legacy-jackson.version>1.9.12</legacy-jackson.version>
     <!-- optional dependencies -->
-    <snappy.version>1.1.7.3</snappy.version>
+    <snappy.version>1.1.10.1</snappy.version>
     <lz4.version>1.7.1</lz4.version>
     <!-- test dependencies -->
     <assertj.version>3.19.0</assertj.version>
@@ -73,7 +73,7 @@
     <pax-exam.version>4.13.4</pax-exam.version>
     <simulacron.version>0.11.0</simulacron.version>
     <jsr353-api.version>1.1.4</jsr353-api.version>
-    <jersey.version>2.28</jersey.version>
+    <jersey.version>2.31</jersey.version>
     <hk2.version>2.5.0</hk2.version>
     <jax-rs.version>2.1.1</jax-rs.version>
     <jsr353-ri.version>1.1.4</jsr353-ri.version>


### PR DESCRIPTION
This PR adds automated snyk scan to main branch 4.x. Any High or Critical CVEs found will block a new PR from being merged.

Along with the new Github Actions for snyk scan, we also remedied a number of dependencies with the currently identified High CVEs, including netty, TinkerPop, json, snappy, jersey, so once this PR is merged, it should not immediately block new PRs.

Some identified issues require upgrading graal-sdk to 22.3.2 and we can only do that after moving to java11 or higher, so for now, we've noted these CVEs to be remedied later.

Credit to @hhughes for fixing osgi test issues with the netty upgrade in this PR https://github.com/datastax/java-driver/pull/1655