### PR TITLE
JAVA-3065: PreparedStatementIT#should_fail_fast_if_id_changes_on_repr…

### DIFF
--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/requirement/BackendRequirement.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/requirement/BackendRequirement.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.testinfra.requirement;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotation for a Class or Method that defines a database backend Version requirement. If the
+ * type/version in use does not meet the requirement, the test is skipped.
+ */
+@Repeatable(BackendRequirements.class)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BackendRequirement {
+  BackendType type();
+
+  String minInclusive() default "";
+
+  String maxExclusive() default "";
+
+  String description() default "";
+}

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/requirement/BackendRequirements.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/requirement/BackendRequirements.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.testinfra.requirement;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/** Annotation to allow @BackendRequirement to be repeatable. */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BackendRequirements {
+  BackendRequirement[] value();
+}

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/requirement/BackendType.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/requirement/BackendType.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.testinfra.requirement;
+
+public enum BackendType {
+  CASSANDRA("C*"),
+  DSE("Dse"),
+  ;
+
+  final String friendlyName;
+
+  BackendType(String friendlyName) {
+    this.friendlyName = friendlyName;
+  }
+
+  public String getFriendlyName() {
+    return friendlyName;
+  }
+}

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/requirement/VersionRequirement.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/requirement/VersionRequirement.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.testinfra.requirement;
+
+import com.datastax.oss.driver.api.core.Version;
+import com.datastax.oss.driver.api.testinfra.CassandraRequirement;
+import com.datastax.oss.driver.api.testinfra.DseRequirement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.runner.Description;
+
+/**
+ * Used to unify the requirements specified by
+ * annotations @CassandraRequirement, @DseRequirment, @BackendRequirement
+ */
+public class VersionRequirement {
+  final BackendType backendType;
+  final Optional<Version> minInclusive;
+  final Optional<Version> maxExclusive;
+  final String description;
+
+  public VersionRequirement(
+      BackendType backendType, String minInclusive, String maxExclusive, String description) {
+    this.backendType = backendType;
+    this.minInclusive =
+        minInclusive.isEmpty() ? Optional.empty() : Optional.of(Version.parse(minInclusive));
+    this.maxExclusive =
+        maxExclusive.isEmpty() ? Optional.empty() : Optional.of(Version.parse(maxExclusive));
+    this.description = description;
+  }
+
+  public BackendType getBackendType() {
+    return backendType;
+  }
+
+  public Optional<Version> getMinInclusive() {
+    return minInclusive;
+  }
+
+  public Optional<Version> getMaxExclusive() {
+    return maxExclusive;
+  }
+
+  public String readableString() {
+    final String versionRange;
+    if (minInclusive.isPresent() && maxExclusive.isPresent()) {
+      versionRange =
+          String.format("%s or greater, but less than %s", minInclusive.get(), maxExclusive.get());
+    } else if (minInclusive.isPresent()) {
+      versionRange = String.format("%s or greater", minInclusive.get());
+    } else if (maxExclusive.isPresent()) {
+      versionRange = String.format("less than %s", maxExclusive.get());
+    } else {
+      versionRange = "any version";
+    }
+
+    if (!description.isEmpty()) {
+      return String.format("%s %s [%s]", backendType.getFriendlyName(), versionRange, description);
+    } else {
+      return String.format("%s %s", backendType.getFriendlyName(), versionRange);
+    }
+  }
+
+  public static VersionRequirement fromBackendRequirement(BackendRequirement requirement) {
+    return new VersionRequirement(
+        requirement.type(),
+        requirement.minInclusive(),
+        requirement.maxExclusive(),
+        requirement.description());
+  }
+
+  public static VersionRequirement fromCassandraRequirement(CassandraRequirement requirement) {
+    return new VersionRequirement(
+        BackendType.CASSANDRA, requirement.min(), requirement.max(), requirement.description());
+  }
+
+  public static VersionRequirement fromDseRequirement(DseRequirement requirement) {
+    return new VersionRequirement(
+        BackendType.DSE, requirement.min(), requirement.max(), requirement.description());
+  }
+
+  public static Collection<VersionRequirement> fromAnnotations(Description description) {
+    // collect all requirement annotation types
+    CassandraRequirement cassandraRequirement =
+        description.getAnnotation(CassandraRequirement.class);
+    DseRequirement dseRequirement = description.getAnnotation(DseRequirement.class);
+    BackendRequirements backendRequirements = description.getAnnotation(BackendRequirements.class);
+
+    // build list of required versions
+    Collection<VersionRequirement> requirements = new ArrayList<>();
+    if (cassandraRequirement != null) {
+      requirements.add(VersionRequirement.fromCassandraRequirement(cassandraRequirement));
+    }
+    if (dseRequirement != null) {
+      requirements.add(VersionRequirement.fromDseRequirement(dseRequirement));
+    }
+    if (backendRequirements != null) {
+      Arrays.stream(backendRequirements.value())
+          .forEach(r -> requirements.add(VersionRequirement.fromBackendRequirement(r)));
+    }
+    return requirements;
+  }
+
+  public static boolean meetsAny(
+      Collection<VersionRequirement> requirements,
+      BackendType configuredBackend,
+      Version configuredVersion) {
+    // special case: if there are no requirements then any backend/version is sufficient
+    if (requirements.isEmpty()) {
+      return true;
+    }
+
+    return requirements.stream()
+        .anyMatch(
+            requirement -> {
+              // requirement is different db type
+              if (requirement.getBackendType() != configuredBackend) {
+                return false;
+              }
+
+              // configured version is less than requirement min
+              if (requirement.getMinInclusive().isPresent()) {
+                if (requirement.getMinInclusive().get().compareTo(configuredVersion) > 0) {
+                  return false;
+                }
+              }
+
+              // configured version is greater than or equal to requirement max
+              if (requirement.getMaxExclusive().isPresent()) {
+                if (requirement.getMaxExclusive().get().compareTo(configuredVersion) <= 0) {
+                  return false;
+                }
+              }
+
+              // backend type and version range match
+              return true;
+            });
+  }
+
+  public static String buildReasonString(
+      Collection<VersionRequirement> requirements, BackendType backend, Version version) {
+    return String.format(
+        "Test requires one of:\n%s\nbut configuration is %s %s.",
+        requirements.stream()
+            .map(req -> String.format("  - %s", req.readableString()))
+            .collect(Collectors.joining("\n")),
+        backend.getFriendlyName(),
+        version);
+  }
+}

--- a/test-infra/src/test/java/com/datastax/oss/driver/api/testinfra/requirement/VersionRequirementTest.java
+++ b/test-infra/src/test/java/com/datastax/oss/driver/api/testinfra/requirement/VersionRequirementTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.testinfra.requirement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.Version;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+public class VersionRequirementTest {
+  // backend aliases
+  private static BackendType CASSANDRA = BackendType.CASSANDRA;
+  private static BackendType DSE = BackendType.DSE;
+
+  // version numbers
+  private static Version V_0_0_0 = Version.parse("0.0.0");
+  private static Version V_0_1_0 = Version.parse("0.1.0");
+  private static Version V_1_0_0 = Version.parse("1.0.0");
+  private static Version V_1_0_1 = Version.parse("1.0.1");
+  private static Version V_1_1_0 = Version.parse("1.1.0");
+  private static Version V_2_0_0 = Version.parse("2.0.0");
+  private static Version V_2_0_1 = Version.parse("2.0.1");
+  private static Version V_3_0_0 = Version.parse("3.0.0");
+  private static Version V_3_1_0 = Version.parse("3.1.0");
+  private static Version V_4_0_0 = Version.parse("4.0.0");
+
+  // requirements
+  private static VersionRequirement CASSANDRA_ANY = new VersionRequirement(CASSANDRA, "", "", "");
+  private static VersionRequirement CASSANDRA_FROM_1_0_0 =
+      new VersionRequirement(CASSANDRA, "1.0.0", "", "");
+  private static VersionRequirement CASSANDRA_TO_1_0_0 =
+      new VersionRequirement(CASSANDRA, "", "1.0.0", "");
+  private static VersionRequirement CASSANDRA_FROM_1_0_0_TO_2_0_0 =
+      new VersionRequirement(CASSANDRA, "1.0.0", "2.0.0", "");
+  private static VersionRequirement CASSANDRA_FROM_1_1_0 =
+      new VersionRequirement(CASSANDRA, "1.1.0", "", "");
+  private static VersionRequirement CASSANDRA_FROM_3_0_0_TO_3_1_0 =
+      new VersionRequirement(CASSANDRA, "3.0.0", "3.1.0", "");
+  private static VersionRequirement DSE_ANY = new VersionRequirement(DSE, "", "", "");
+
+  @Test
+  public void empty_requirements() {
+    List<VersionRequirement> req = Collections.emptyList();
+
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_0_0_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_0_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, DSE, V_0_0_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, DSE, V_1_0_0)).isTrue();
+  }
+
+  @Test
+  public void single_requirement_any_version() {
+    List<VersionRequirement> anyCassandra = Collections.singletonList(CASSANDRA_ANY);
+    List<VersionRequirement> anyDse = Collections.singletonList(DSE_ANY);
+
+    assertThat(VersionRequirement.meetsAny(anyCassandra, CASSANDRA, V_0_0_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(anyCassandra, CASSANDRA, V_1_0_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(anyDse, DSE, V_0_0_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(anyDse, DSE, V_1_0_0)).isTrue();
+
+    assertThat(VersionRequirement.meetsAny(anyDse, CASSANDRA, V_0_0_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(anyDse, CASSANDRA, V_1_0_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(anyCassandra, DSE, V_0_0_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(anyCassandra, DSE, V_1_0_0)).isFalse();
+  }
+
+  @Test
+  public void single_requirement_min_only() {
+    List<VersionRequirement> req = Collections.singletonList(CASSANDRA_FROM_1_0_0);
+
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_0_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_0_1)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_1_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_2_0_0)).isTrue();
+
+    assertThat(VersionRequirement.meetsAny(req, DSE, V_1_0_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_0_0_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_0_1_0)).isFalse();
+  }
+
+  @Test
+  public void single_requirement_max_only() {
+    List<VersionRequirement> req = Collections.singletonList(CASSANDRA_TO_1_0_0);
+
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_0_0_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_0_1_0)).isTrue();
+
+    assertThat(VersionRequirement.meetsAny(req, DSE, V_0_0_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_0_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_0_1)).isFalse();
+  }
+
+  @Test
+  public void single_requirement_min_and_max() {
+    List<VersionRequirement> req = Collections.singletonList(CASSANDRA_FROM_1_0_0_TO_2_0_0);
+
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_0_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_0_1)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_1_0)).isTrue();
+
+    assertThat(VersionRequirement.meetsAny(req, DSE, V_1_0_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_0_0_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_0_1_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_2_0_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_2_0_1)).isFalse();
+  }
+
+  @Test
+  public void multi_requirement_any_version() {
+    List<VersionRequirement> req = ImmutableList.of(CASSANDRA_ANY, DSE_ANY);
+
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_0_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, DSE, V_1_0_0)).isTrue();
+  }
+
+  @Test
+  public void multi_db_requirement_min_one_any_other() {
+    List<VersionRequirement> req = ImmutableList.of(CASSANDRA_FROM_1_0_0, DSE_ANY);
+
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_0_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_2_0_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, DSE, V_0_0_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, DSE, V_1_0_0)).isTrue();
+
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_0_0_0)).isFalse();
+  }
+
+  @Test
+  public void multi_requirement_two_ranges() {
+    List<VersionRequirement> req =
+        ImmutableList.of(CASSANDRA_FROM_1_0_0_TO_2_0_0, CASSANDRA_FROM_3_0_0_TO_3_1_0);
+
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_0_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_1_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_3_0_0)).isTrue();
+
+    assertThat(VersionRequirement.meetsAny(req, DSE, V_1_0_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_0_0_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_2_0_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_3_1_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_4_0_0)).isFalse();
+  }
+
+  @Test
+  public void multi_requirement_overlapping() {
+    List<VersionRequirement> req =
+        ImmutableList.of(CASSANDRA_FROM_1_0_0_TO_2_0_0, CASSANDRA_FROM_1_1_0);
+
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_0_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_1_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_2_0_0)).isTrue();
+
+    assertThat(VersionRequirement.meetsAny(req, DSE, V_1_0_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_0_0_0)).isFalse();
+  }
+
+  @Test
+  public void multi_requirement_not_range() {
+    List<VersionRequirement> req = ImmutableList.of(CASSANDRA_TO_1_0_0, CASSANDRA_FROM_1_1_0);
+
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_0_0_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_1_0)).isTrue();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_2_0_0)).isTrue();
+
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_0_0)).isFalse();
+    assertThat(VersionRequirement.meetsAny(req, CASSANDRA, V_1_0_1)).isFalse();
+  }
+}


### PR DESCRIPTION
…epare fails with recent C*/DSE versions

PreparedStatementIT.java
- adds logic to should_fail_fast_if_id_changes_on_reprepare to check for an exception/no-exception depending on whether CASSANDRA-15252 should be fixed

CcmBridge.java
- set ccm.version 4.0.0->4.0.10 to use the same 4.0 cassandra version as Jenkins