### PR TITLE
JAVA-3071: OsgiGraphIT.test_graph fails with dse-6.8.30

### DIFF
--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/BundleOptions.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/BundleOptions.java
@@ -152,7 +152,9 @@ public class BundleOptions {
                 .overwriteManifest(WrappedUrlProvisionOption.OverwriteMode.FULL),
             // Note: the versions below are hard-coded because they shouldn't change very often,
             // but if the tests fail because of them, we should consider parameterizing them
-            mavenBundle("commons-configuration", "commons-configuration", "1.10"),
+            mavenBundle("com.sun.mail", "mailapi", "1.6.4"),
+            mavenBundle("org.apache.commons", "commons-text", "1.8"),
+            mavenBundle("org.apache.commons", "commons-configuration2", "2.7"),
             CoreOptions.wrappedBundle(mavenBundle("commons-logging", "commons-logging", "1.1.1"))
                 .exports("org.apache.commons.logging.*")
                 .bundleVersion("1.1.1")


### PR DESCRIPTION
Test fails because tinkerpop classes cannot be loaded which gates enabling GraphRequest* processors

Add missing dependencies required by TinkerIoRegistryV3d0 to the osgi testing bundle
- com.sun.mail:mailapi:1.6.4
- org.apache.commons:commons-text:1.8
- org.apache.commons:commons-configuration2:2.7