### PR TITLE
JAVA-3068: Use fully qualified table CQL in should_not_allow_unset_va…

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.core.cql;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
@@ -338,16 +339,20 @@ public class BatchStatementIT {
     sessionRule.session().execute(batchStatement);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void should_not_allow_unset_value_when_protocol_less_than_v4() {
     //    CREATE TABLE test (k0 text, k1 int, v int, PRIMARY KEY (k0, k1))
     DriverConfigLoader loader =
         SessionUtils.configLoaderBuilder()
             .withString(DefaultDriverOption.PROTOCOL_VERSION, "V3")
             .build();
-    try (CqlSession v3Session = SessionUtils.newSession(ccmRule, sessionRule.keyspace(), loader)) {
+    try (CqlSession v3Session = SessionUtils.newSession(ccmRule, loader)) {
+      // Intentionally use fully qualified table here to avoid warnings as these are not supported
+      // by v3 protocol version, see JAVA-3068
       PreparedStatement prepared =
-          v3Session.prepare("INSERT INTO test (k0, k1, v) values (?, ?, ?)");
+          v3Session.prepare(
+              String.format(
+                  "INSERT INTO %s.test (k0, k1, v) values (?, ?, ?)", sessionRule.keyspace()));
 
       BatchStatementBuilder builder = BatchStatement.builder(DefaultBatchType.LOGGED);
       builder.addStatements(
@@ -361,7 +366,9 @@ public class BatchStatementIT {
               .unset(2)
               .build());
 
-      v3Session.execute(builder.build());
+      assertThatThrownBy(() -> v3Session.execute(builder.build()))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Unset value at index");
     }
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BoundStatementCcmIT.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.core.cql;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
@@ -126,19 +127,25 @@ public class BoundStatementCcmIT {
                 .build());
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void should_not_allow_unset_value_when_protocol_less_than_v4() {
     DriverConfigLoader loader =
         SessionUtils.configLoaderBuilder()
             .withString(DefaultDriverOption.PROTOCOL_VERSION, "V3")
             .build();
-    try (CqlSession v3Session = SessionUtils.newSession(ccmRule, sessionRule.keyspace(), loader)) {
-      PreparedStatement prepared = v3Session.prepare("INSERT INTO test2 (k, v0) values (?, ?)");
+    try (CqlSession v3Session = SessionUtils.newSession(ccmRule, loader)) {
+      // Intentionally use fully qualified table here to avoid warnings as these are not supported
+      // by v3 protocol version, see JAVA-3068
+      PreparedStatement prepared =
+          v3Session.prepare(
+              String.format("INSERT INTO %s.test2 (k, v0) values (?, ?)", sessionRule.keyspace()));
 
       BoundStatement boundStatement =
           prepared.boundStatementBuilder().setString(0, name.getMethodName()).unset(1).build();
 
-      v3Session.execute(boundStatement);
+      assertThatThrownBy(() -> v3Session.execute(boundStatement))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Unset value at index");
     }
   }
 


### PR DESCRIPTION
…lue_when_protocol_less_than_v4 to work around intermittent server error