### PR TITLE
JAVA-3042: Support testing against Java17

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -248,6 +248,8 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <jvm>${testing.jvm}/bin/java</jvm>
+          <argLine>${mockitoopens.argline}</argLine>
           <threadCount>1</threadCount>
           <properties>
             <property>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -229,6 +229,7 @@
               <goal>integration-test</goal>
             </goals>
             <configuration>
+              <jvm>${testing.jvm}/bin/java</jvm>
               <groups>com.datastax.oss.driver.categories.ParallelizableTests</groups>
               <parallel>classes</parallel>
               <threadCountClasses>8</threadCountClasses>
@@ -245,6 +246,7 @@
               <excludedGroups>com.datastax.oss.driver.categories.ParallelizableTests, com.datastax.oss.driver.categories.IsolatedTests</excludedGroups>
               <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-serial.xml</summaryFile>
               <skipITs>${skipSerialITs}</skipITs>
+              <jvm>${testing.jvm}/bin/java</jvm>
             </configuration>
           </execution>
           <execution>
@@ -260,6 +262,7 @@
               <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-isolated.xml</summaryFile>
               <skipITs>${skipIsolatedITs}</skipITs>
               <argLine>${blockhound.argline}</argLine>
+              <jvm>${testing.jvm}/bin/java</jvm>
             </configuration>
           </execution>
           <execution>
@@ -322,16 +325,4 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>jdk 13+</id>
-      <activation>
-        <jdk>[13,)</jdk>
-      </activation>
-      <properties>
-        <!-- for DriverBlockHoundIntegrationIT when using JDK 13+, see https://github.com/reactor/BlockHound/issues/33 -->
-        <blockhound.argline>-XX:+AllowRedefinitionToAddDeleteMethods</blockhound.argline>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/mapper-runtime/pom.xml
+++ b/mapper-runtime/pom.xml
@@ -122,6 +122,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <jvm>${testing.jvm}/bin/java</jvm>
           <threadCount>1</threadCount>
           <properties>
             <!-- tell TestNG not to run jUnit tests -->

--- a/osgi-tests/pom.xml
+++ b/osgi-tests/pom.xml
@@ -220,6 +220,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <jvm>${testing.jvm}/bin/java</jvm>
           <systemPropertyVariables>
             <logback.configurationFile>${project.basedir}/src/test/resources/logback-test.xml</logback.configurationFile>
           </systemPropertyVariables>
@@ -237,6 +238,7 @@
           </execution>
         </executions>
         <configuration>
+          <jvm>${testing.jvm}/bin/java</jvm>
           <systemPropertyVariables>
             <logback.configurationFile>${project.basedir}/src/test/resources/logback-test.xml</logback.configurationFile>
           </systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -433,12 +433,12 @@
       <dependency>
         <groupId>io.projectreactor.tools</groupId>
         <artifactId>blockhound</artifactId>
-        <version>1.0.4.RELEASE</version>
+        <version>1.0.8.RELEASE</version>
       </dependency>
       <dependency>
         <groupId>io.projectreactor.tools</groupId>
         <artifactId>blockhound-junit-platform</artifactId>
-        <version>1.0.4.RELEASE</version>
+        <version>1.0.8.RELEASE</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -533,12 +533,12 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.5</version>
+          <version>0.8.10</version>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>4.2.1</version>
+          <version>5.1.1</version>
         </plugin>
         <plugin>
           <groupId>org.revapi</groupId>
@@ -934,6 +934,57 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <maven.source.skip>true</maven.source.skip>
         <revapi.skip>true</revapi.skip>
+      </properties>
+    </profile>
+    <!-- Use $JAVA_HOME as the default JDK to run surefire/failsafe to maintain portability -->
+    <profile>
+      <id>test-jdk-environment</id>
+      <activation>
+        <property>
+          <name>!testJavaHome</name>
+        </property>
+      </activation>
+      <properties>
+        <testing.jvm>${env.JAVA_HOME}</testing.jvm>
+      </properties>
+    </profile>
+    <!-- set -DtestJavaHome=/path/to/jdk/home to use a different JDK for surefire/failsafe -->
+    <profile>
+      <id>test-jdk-specified</id>
+      <activation>
+        <property>
+          <name>testJavaHome</name>
+        </property>
+      </activation>
+      <properties>
+        <testing.jvm>${testJavaHome}</testing.jvm>
+      </properties>
+    </profile>
+    <profile>
+      <!-- workarounds for running tests with JDK1.8 -->
+      <id>test-jdk-8</id>
+      <activation>
+        <jdk>[8,)</jdk>
+      </activation>
+    </profile>
+    <profile>
+      <!-- workarounds for running tests with JDK11 -->
+      <id>test-jdk-11</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+    </profile>
+    <profile>
+      <!-- workarounds for running tests with JDK17 -->
+      <id>test-jdk-17</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <properties>
+        <!-- for DriverBlockHoundIntegrationIT when using JDK 13+, see https://github.com/reactor/BlockHound/issues/33 -->
+        <blockhound.argline>-XX:+AllowRedefinitionToAddDeleteMethods</blockhound.argline>
+        <!-- allow deep reflection for mockito when using JDK 17+, see https://stackoverflow.com/questions/70993863/mockito-can-not-mock-random-in-java-17 -->
+        <mockitoopens.argline>--add-opens java.base/jdk.internal.util.random=ALL-UNNAMED</mockitoopens.argline>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Add property 'testJavaHome' to specify a different JDK for surefire/failsafe to run tests to facilitate testing with different JDKs.

pom.xml:
- Add '--add-opens java.base/jdk.internal.util.random=ALL-UNNAMED' as maven-surefire-plugin argLine to support deep reflection for mockito, only loaded for JDK17

Dependency updates:
- jacoco-maven-plugin -> 0.8.10, resolves "Error while instrumenting path/to/class" with JDK17
- maven-bundle-plugin -> 5.1.1, resolves java.util.ConcurrentModificationException [FELIX-6259] with JDK17
- blockhound-junit-platform -> 1.0.8.RELEASE, earlier version did not pick up -XX:+AllowRedefinitionToAddDeleteMethods properly

Jenkinsfile:
- Add matrix axis for JABBER_VERSION for each of JDK8, JDK11, JDK17
- Always run maven with JDK8, use testJavaHome to set JDK version for testing