### PR TITLE
JAVA-3001: Java Driver 4.13.0 - Memory leak when using C* 4.0.1 and p…

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/SegmentToFrameDecoder.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/SegmentToFrameDecoder.java
@@ -112,9 +112,7 @@ public class SegmentToFrameDecoder extends MessageToMessageDecoder<Segment<ByteB
       } finally {
         encodedFrame.release();
         // Reset our state
-        targetLength = UNKNOWN_LENGTH;
-        accumulatedSlices.clear();
-        accumulatedLength = 0;
+        resetState();
       }
       LOG.trace(
           "[{}] Decoded response frame {} from {} slices",
@@ -123,5 +121,18 @@ public class SegmentToFrameDecoder extends MessageToMessageDecoder<Segment<ByteB
           accumulatedSlicesSize);
       out.add(frame);
     }
+  }
+
+  private void resetState() {
+    targetLength = UNKNOWN_LENGTH;
+    accumulatedSlices.clear();
+    accumulatedLength = 0;
+  }
+
+  @Override
+  public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+    // release any accumulated segments and reset state
+    accumulatedSlices.forEach(ByteBuf::release);
+    resetState();
   }
 }


### PR DESCRIPTION
…rotocol v5

SegmentToFrameDecoder.java
- release any accumulated segements when handler is removed from pipeline

ProtocolInitHandler.java
- expose class for sub-classing in testing

NettyResourceLeakDetectionIT.java
- add leak test with simulated disconnect while assembling segments [disconnect_between_segments_leak]