### PR TITLE
JAVA-3061 Re-introduce an improved CqlVector, add support for accessing vectors directly as float arrays

### DIFF
--- a/core/revapi.json
+++ b/core/revapi.json
@@ -6887,7 +6887,70 @@
        "code": "java.method.removed",
        "old": "method <T> com.datastax.oss.driver.api.core.type.reflect.GenericType<com.datastax.oss.driver.api.core.data.CqlVector<T>> com.datastax.oss.driver.api.core.type.reflect.GenericType<T>::vectorOf(com.datastax.oss.driver.api.core.type.reflect.GenericType<T>)",
        "justification": "Refactoring in JAVA-3061"
-     }
+     },
+      {
+        "code": "java.class.removed",
+        "old": "class com.datastax.oss.driver.api.core.data.CqlVector.Builder<T>",
+        "justification": "Refactorings in PR 1666"
+      },
+      {
+        "code": "java.method.removed",
+        "old": "method com.datastax.oss.driver.api.core.data.CqlVector.Builder com.datastax.oss.driver.api.core.data.CqlVector<T>::builder()",
+        "justification": "Refactorings in PR 1666"
+      },
+      {
+        "code": "java.method.removed",
+        "old": "method java.lang.Iterable<T> com.datastax.oss.driver.api.core.data.CqlVector<T>::getValues()",
+        "justification": "Refactorings in PR 1666"
+      },
+      {
+        "code": "java.generics.formalTypeParameterChanged",
+        "old": "class com.datastax.oss.driver.api.core.data.CqlVector<T>",
+        "new": "class com.datastax.oss.driver.api.core.data.CqlVector<T extends java.lang.Number>",
+        "justification": "Refactorings in PR 1666"
+      },
+      {
+        "code": "java.method.parameterTypeChanged",
+        "old": "parameter <SubtypeT> com.datastax.oss.driver.api.core.type.codec.TypeCodec<com.datastax.oss.driver.api.core.data.CqlVector<SubtypeT>> com.datastax.oss.driver.api.core.type.codec.TypeCodecs::vectorOf(===com.datastax.oss.driver.api.core.type.CqlVectorType===, com.datastax.oss.driver.api.core.type.codec.TypeCodec<SubtypeT>)",
+        "new": "parameter <SubtypeT extends java.lang.Number> com.datastax.oss.driver.api.core.type.codec.TypeCodec<com.datastax.oss.driver.api.core.data.CqlVector<SubtypeT>> com.datastax.oss.driver.api.core.type.codec.TypeCodecs::vectorOf(===com.datastax.oss.driver.api.core.type.VectorType===, com.datastax.oss.driver.api.core.type.codec.TypeCodec<SubtypeT>)",
+        "justification": "Refactorings in PR 1666"
+      },
+      {
+        "code": "java.method.parameterTypeParameterChanged",
+        "old": "parameter <SubtypeT> com.datastax.oss.driver.api.core.type.codec.TypeCodec<com.datastax.oss.driver.api.core.data.CqlVector<SubtypeT>> com.datastax.oss.driver.api.core.type.codec.TypeCodecs::vectorOf(com.datastax.oss.driver.api.core.type.CqlVectorType, ===com.datastax.oss.driver.api.core.type.codec.TypeCodec<SubtypeT>===)",
+        "new": "parameter <SubtypeT extends java.lang.Number> com.datastax.oss.driver.api.core.type.codec.TypeCodec<com.datastax.oss.driver.api.core.data.CqlVector<SubtypeT>> com.datastax.oss.driver.api.core.type.codec.TypeCodecs::vectorOf(com.datastax.oss.driver.api.core.type.VectorType, ===com.datastax.oss.driver.api.core.type.codec.TypeCodec<SubtypeT>===)",
+        "justification": "Refactorings in PR 1666"
+      },
+      {
+        "code": "java.method.returnTypeTypeParametersChanged",
+        "old": "method <SubtypeT> com.datastax.oss.driver.api.core.type.codec.TypeCodec<com.datastax.oss.driver.api.core.data.CqlVector<SubtypeT>> com.datastax.oss.driver.api.core.type.codec.TypeCodecs::vectorOf(com.datastax.oss.driver.api.core.type.CqlVectorType, com.datastax.oss.driver.api.core.type.codec.TypeCodec<SubtypeT>)",
+        "new": "method <SubtypeT extends java.lang.Number> com.datastax.oss.driver.api.core.type.codec.TypeCodec<com.datastax.oss.driver.api.core.data.CqlVector<SubtypeT>> com.datastax.oss.driver.api.core.type.codec.TypeCodecs::vectorOf(com.datastax.oss.driver.api.core.type.VectorType, com.datastax.oss.driver.api.core.type.codec.TypeCodec<SubtypeT>)",
+        "justification": "Refactorings in PR 1666"
+      },
+      {
+        "code": "java.generics.formalTypeParameterChanged",
+        "old": "method <SubtypeT> com.datastax.oss.driver.api.core.type.codec.TypeCodec<com.datastax.oss.driver.api.core.data.CqlVector<SubtypeT>> com.datastax.oss.driver.api.core.type.codec.TypeCodecs::vectorOf(com.datastax.oss.driver.api.core.type.CqlVectorType, com.datastax.oss.driver.api.core.type.codec.TypeCodec<SubtypeT>)",
+        "new": "method <SubtypeT extends java.lang.Number> com.datastax.oss.driver.api.core.type.codec.TypeCodec<com.datastax.oss.driver.api.core.data.CqlVector<SubtypeT>> com.datastax.oss.driver.api.core.type.codec.TypeCodecs::vectorOf(com.datastax.oss.driver.api.core.type.VectorType, com.datastax.oss.driver.api.core.type.codec.TypeCodec<SubtypeT>)",
+        "justification": "Refactorings in PR 1666"
+      },
+      {
+        "code": "java.method.parameterTypeParameterChanged",
+        "old": "parameter <T> com.datastax.oss.driver.api.core.type.reflect.GenericType<com.datastax.oss.driver.api.core.data.CqlVector<T>> com.datastax.oss.driver.api.core.type.reflect.GenericType<T>::vectorOf(===com.datastax.oss.driver.api.core.type.reflect.GenericType<T>===)",
+        "new": "parameter <T extends java.lang.Number> com.datastax.oss.driver.api.core.type.reflect.GenericType<com.datastax.oss.driver.api.core.data.CqlVector<T>> com.datastax.oss.driver.api.core.type.reflect.GenericType<T>::vectorOf(===com.datastax.oss.driver.api.core.type.reflect.GenericType<T>===)",
+        "justification": "Refactorings in PR 1666"
+      },
+      {
+        "code": "java.method.returnTypeTypeParametersChanged",
+        "old": "method <T> com.datastax.oss.driver.api.core.type.reflect.GenericType<com.datastax.oss.driver.api.core.data.CqlVector<T>> com.datastax.oss.driver.api.core.type.reflect.GenericType<T>::vectorOf(com.datastax.oss.driver.api.core.type.reflect.GenericType<T>)",
+        "new": "method <T extends java.lang.Number> com.datastax.oss.driver.api.core.type.reflect.GenericType<com.datastax.oss.driver.api.core.data.CqlVector<T>> com.datastax.oss.driver.api.core.type.reflect.GenericType<T>::vectorOf(com.datastax.oss.driver.api.core.type.reflect.GenericType<T>)",
+        "justification": "Refactorings in PR 1666"
+      },
+      {
+        "code": "java.generics.formalTypeParameterChanged",
+        "old": "method <T> com.datastax.oss.driver.api.core.type.reflect.GenericType<com.datastax.oss.driver.api.core.data.CqlVector<T>> com.datastax.oss.driver.api.core.type.reflect.GenericType<T>::vectorOf(com.datastax.oss.driver.api.core.type.reflect.GenericType<T>)",
+        "new": "method <T extends java.lang.Number> com.datastax.oss.driver.api.core.type.reflect.GenericType<com.datastax.oss.driver.api.core.data.CqlVector<T>> com.datastax.oss.driver.api.core.type.reflect.GenericType<T>::vectorOf(com.datastax.oss.driver.api.core.type.reflect.GenericType<T>)",
+        "justification": "Refactorings in PR 1666"
+      }
     ]
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlVector.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlVector.java
@@ -81,11 +81,13 @@ public class CqlVector<T extends Number> implements Iterable<T> {
    */
   public static <V extends Number> CqlVector<V> from(
       @NonNull String str, @NonNull TypeCodec<V> subtypeCodec) {
+    Preconditions.checkArgument(str != null, "Cannot create CqlVector from null string");
+    Preconditions.checkArgument(!str.isEmpty(), "Cannot create CqlVector from empty string");
     ArrayList<V> vals =
         Streams.stream(Splitter.on(", ").split(str.substring(1, str.length() - 1)))
             .map(subtypeCodec::parse)
             .collect(Collectors.toCollection(ArrayList::new));
-    return CqlVector.newInstance(vals);
+    return new CqlVector(vals);
   }
 
   private final List<T> list;

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlVector.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlVector.java
@@ -70,6 +70,23 @@ public class CqlVector<T extends Number> implements Iterable<T> {
     return new CqlVector(list);
   }
 
+  /**
+   * Create a new CqlVector instance from the specified string representation. Note that this method
+   * is intended to mirror {@link #toString()}; passing this method the output from a <code>toString</code>
+   * call on some CqlVector should return a CqlVector that is equal to the origin instance.
+   *
+   * @param str a String representation of a CqlVector
+   * @param subtypeCodec
+   * @return a new CqlVector built from the String representation
+   */
+  public static <V extends Number> CqlVector<V> from(@NonNull String str, @NonNull TypeCodec<V> subtypeCodec) {
+    ArrayList<V> vals =
+            Streams.stream(Splitter.on(", ").split(str.substring(1, str.length() - 1)))
+                    .map(subtypeCodec::parse)
+                    .collect(Collectors.toCollection(ArrayList::new));
+    return CqlVector.newInstance(vals);
+  }
+
   private final List<T> list;
 
   private CqlVector(@NonNull List<T> list) {
@@ -169,22 +186,5 @@ public class CqlVector<T extends Number> implements Iterable<T> {
   @Override
   public String toString() {
     return Iterables.toString(this.list);
-  }
-
-  /**
-   * Create a new CqlVector instance from the specified string representation. Note that this method
-   * is intended to mirror {@link #toString()}; calling this method from a <code>toString</code>
-   * call on some CqlVector should return a CqlVector that is equal to the origin instance.
-   *
-   * @param str a String representation of a CqlVector
-   * @param subtypeCodec
-   * @return
-   */
-  public CqlVector<T> from(@NonNull String str, @NonNull TypeCodec<T> subtypeCodec) {
-    ArrayList<T> vals =
-        Streams.stream(Splitter.on(", ").split(str.substring(1, str.length() - 1)))
-            .map(subtypeCodec::parse)
-            .collect(Collectors.toCollection(ArrayList::new));
-    return CqlVector.newInstance(vals);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlVector.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlVector.java
@@ -72,18 +72,19 @@ public class CqlVector<T extends Number> implements Iterable<T> {
 
   /**
    * Create a new CqlVector instance from the specified string representation. Note that this method
-   * is intended to mirror {@link #toString()}; passing this method the output from a <code>toString</code>
-   * call on some CqlVector should return a CqlVector that is equal to the origin instance.
+   * is intended to mirror {@link #toString()}; passing this method the output from a <code>toString
+   * </code> call on some CqlVector should return a CqlVector that is equal to the origin instance.
    *
    * @param str a String representation of a CqlVector
    * @param subtypeCodec
    * @return a new CqlVector built from the String representation
    */
-  public static <V extends Number> CqlVector<V> from(@NonNull String str, @NonNull TypeCodec<V> subtypeCodec) {
+  public static <V extends Number> CqlVector<V> from(
+      @NonNull String str, @NonNull TypeCodec<V> subtypeCodec) {
     ArrayList<V> vals =
-            Streams.stream(Splitter.on(", ").split(str.substring(1, str.length() - 1)))
-                    .map(subtypeCodec::parse)
-                    .collect(Collectors.toCollection(ArrayList::new));
+        Streams.stream(Splitter.on(", ").split(str.substring(1, str.length() - 1)))
+            .map(subtypeCodec::parse)
+            .collect(Collectors.toCollection(ArrayList::new));
     return CqlVector.newInstance(vals);
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlVector.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlVector.java
@@ -122,6 +122,15 @@ public class CqlVector<T extends Number> implements Iterable<T> {
   }
 
   /**
+   * Return a boolean indicating whether the vector is empty. Modelled after {@link List#isEmpty()}
+   *
+   * @return true if the list is empty, false otherwise
+   */
+  public boolean isEmpty() {
+    return this.list.isEmpty();
+  }
+
+  /**
    * Create an {@link Iterator} for this vector
    *
    * @return the generated iterator

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlVector.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/CqlVector.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.data;
+
+import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
+import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
+import com.datastax.oss.driver.shaded.guava.common.base.Predicates;
+import com.datastax.oss.driver.shaded.guava.common.base.Splitter;
+import com.datastax.oss.driver.shaded.guava.common.collect.Iterables;
+import com.datastax.oss.driver.shaded.guava.common.collect.Streams;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Representation of a vector as defined in CQL.
+ *
+ * A CQL vector is a fixed-length array of non-null numeric values.  These properties don't map cleanly to an
+ * existing class in the standard JDK Collections hierarchy so we provide this value object instead.  Like other
+ * value object collections returned by the driver instances of this class are not immutable; think of these value
+ * objects as a representation of a vector stored in the database as an initial step in some additional computation.
+ *
+ * While we don't implement any Collection APIs we do implement Iterable.  We also attempt to play nice with the
+ * Streams API in order to better facilitate integration with data pipelines.  Finally, where possible we've tried to
+ * make the API of this class similar to the equivalent methods on {@link List}.
+ */
+public class CqlVector<T extends Number> implements Iterable<T> {
+
+    /**
+     * Create a new CqlVector containing the specified values.
+     *
+     * @param vals  the collection of values to wrap.
+     * @return a CqlVector wrapping those values
+     */
+    public static <V extends Number> CqlVector<V> newInstance(V... vals) {
+
+        // Note that Array.asList() guarantees the return of an array which implements RandomAccess
+        return new CqlVector(Arrays.asList(vals));
+    }
+
+    /**
+     * Create a new CqlVector that "wraps" an existing ArrayList.  Modifications to the
+     * passed ArrayList will also be reflected in the returned CqlVector.
+     *
+     * @param list the collection of values to wrap.
+     * @return a CqlVector wrapping those values
+     */
+    public static <V extends Number> CqlVector<V> newInstance(List<V> list) {
+        Preconditions.checkArgument(list != null, "Input list should not be null");
+        return new CqlVector(list);
+    }
+
+    private final List<T> list;
+
+    private CqlVector(@NonNull List<T> list) {
+
+        Preconditions.checkArgument(Iterables.all(list, Predicates.notNull()), "CqlVectors cannot contain null values");
+        this.list = list;
+    }
+
+    /**
+     * Retrieve the value at the specified index.  Modelled after {@link List#get(int)}
+     *
+     * @param idx the index to retrieve
+     * @return the value at the specified index
+     */
+    public T get(int idx) { return list.get(idx); }
+
+    /**
+     * Update the value at the specified index.  Modelled after {@link List#set(int, Object)}
+
+     * @param idx the index to set
+     * @param val the new value for the specified index
+     * @return the old value for the specified index
+     */
+    public T set(int idx, T val) { return list.set(idx,val); }
+
+    /**
+     * Return the size of this vector.  Modelled after {@link List#size()} 
+     *
+     * @return the vector size
+     */
+    public int size() { return this.list.size(); }
+
+    /**
+     * Return a CqlVector consisting of the contents of a portion of this vector.  Modelled after {@link List#subList(int, int)}
+     *
+     * @param from the index to start from (inclusive)
+     * @param to the index to end on (exclusive)
+     * @return a new CqlVector wrapping the sublist
+     */
+    public CqlVector<T> subVector(int from, int to) { return new CqlVector<T>(this.list.subList(from,to)); }
+
+    /**
+     * Create an {@link Iterator} for this vector
+     *
+     * @return the generated iterator
+     */
+    @Override
+    public Iterator<T> iterator() { return this.list.iterator(); }
+
+    /**
+     * Create a {@link Stream} of the values in this vector
+     *
+     * @return the Stream instance
+     */
+    public Stream<T> stream() { return this.list.stream(); }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CqlVector<?> cqlVector = (CqlVector<?>) o;
+        return list.equals(cqlVector.list);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(list);
+    }
+
+    @Override
+    public String toString() {
+        return Iterables.toString(this.list);
+    }
+
+    /**
+     * Create a new CqlVector instance from the specified string representation.  Note that this method is intended
+     * to mirror {@link #toString()}; calling this method from a <code>toString</code> call on some CqlVector should
+     * return a CqlVector that is equal to the origin instance.
+     *
+     * @param str a String representation of a CqlVector
+     * @param subtypeCodec
+     * @return
+     */
+    public CqlVector<T> from(@NonNull String str, @NonNull TypeCodec<T> subtypeCodec) {
+        ArrayList<T> vals =  Streams.stream(Splitter.on(", ").split(str.substring(1, str.length() - 1)))
+                .map(subtypeCodec::parse)
+                .collect(Collectors.toCollection(ArrayList::new));
+        return CqlVector.newInstance(vals);
+    }
+}

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableById.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableById.java
@@ -529,7 +529,7 @@ public interface GettableById extends GettableByIndex, AccessibleById {
    * @throws IllegalArgumentException if the id is invalid.
    */
   @Nullable
-  default <ElementT> List<ElementT> getVector(
+  default <ElementT extends Number> CqlVector<ElementT> getVector(
       @NonNull CqlIdentifier id, @NonNull Class<ElementT> elementsClass) {
     return getVector(firstIndexOf(id), elementsClass);
   }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByIndex.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByIndex.java
@@ -444,8 +444,8 @@ public interface GettableByIndex extends AccessibleByIndex {
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @Nullable
-  default <ElementT> List<ElementT> getVector(int i, @NonNull Class<ElementT> elementsClass) {
-    return get(i, GenericType.listOf(elementsClass));
+  default <ElementT extends Number> CqlVector<ElementT> getVector(int i, @NonNull Class<ElementT> elementsClass) {
+    return get(i, GenericType.vectorOf(elementsClass));
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByIndex.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByIndex.java
@@ -444,7 +444,8 @@ public interface GettableByIndex extends AccessibleByIndex {
    * @throws IndexOutOfBoundsException if the index is invalid.
    */
   @Nullable
-  default <ElementT extends Number> CqlVector<ElementT> getVector(int i, @NonNull Class<ElementT> elementsClass) {
+  default <ElementT extends Number> CqlVector<ElementT> getVector(
+      int i, @NonNull Class<ElementT> elementsClass) {
     return get(i, GenericType.vectorOf(elementsClass));
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByName.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/GettableByName.java
@@ -525,9 +525,9 @@ public interface GettableByName extends GettableByIndex, AccessibleByName {
    * @throws IllegalArgumentException if the name is invalid.
    */
   @Nullable
-  default <ElementT> List<ElementT> getVector(
+  default <ElementT extends Number> CqlVector<ElementT> getVector(
       @NonNull String name, @NonNull Class<ElementT> elementsClass) {
-    return getList(firstIndexOf(name), elementsClass);
+    return getVector(firstIndexOf(name), elementsClass);
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableById.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableById.java
@@ -571,9 +571,9 @@ public interface SettableById<SelfT extends SettableById<SelfT>>
    */
   @NonNull
   @CheckReturnValue
-  default <ElementT> SelfT setVector(
+  default <ElementT extends Number> SelfT setVector(
       @NonNull CqlIdentifier id,
-      @Nullable List<ElementT> v,
+      @Nullable CqlVector<ElementT> v,
       @NonNull Class<ElementT> elementsClass) {
     SelfT result = null;
     for (Integer i : allIndicesOf(id)) {

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableByIndex.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableByIndex.java
@@ -423,9 +423,9 @@ public interface SettableByIndex<SelfT extends SettableByIndex<SelfT>> extends A
    */
   @NonNull
   @CheckReturnValue
-  default <ElementT> SelfT setVector(
-      int i, @Nullable List<ElementT> v, @NonNull Class<ElementT> elementsClass) {
-    return set(i, v, GenericType.listOf(elementsClass));
+  default <ElementT extends Number> SelfT setVector(
+      int i, @Nullable CqlVector<ElementT> v, @NonNull Class<ElementT> elementsClass) {
+    return set(i, v, GenericType.vectorOf(elementsClass));
   }
 
   /**

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableByName.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableByName.java
@@ -570,8 +570,8 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
    */
   @NonNull
   @CheckReturnValue
-  default <ElementT> SelfT setVector(
-      @NonNull String name, @Nullable List<ElementT> v, @NonNull Class<ElementT> elementsClass) {
+  default <ElementT extends Number> SelfT setVector(
+      @NonNull String name, @Nullable CqlVector<ElementT> v, @NonNull Class<ElementT> elementsClass) {
     SelfT result = null;
     for (Integer i : allIndicesOf(name)) {
       result = (result == null ? this : result).setVector(i, v, elementsClass);

--- a/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableByName.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/data/SettableByName.java
@@ -571,7 +571,9 @@ public interface SettableByName<SelfT extends SettableByName<SelfT>>
   @NonNull
   @CheckReturnValue
   default <ElementT extends Number> SelfT setVector(
-      @NonNull String name, @Nullable CqlVector<ElementT> v, @NonNull Class<ElementT> elementsClass) {
+      @NonNull String name,
+      @Nullable CqlVector<ElementT> v,
+      @NonNull Class<ElementT> elementsClass) {
     SelfT result = null;
     for (Integer i : allIndicesOf(name)) {
       result = (result == null ? this : result).setVector(i, v, elementsClass);

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/codec/ExtraTypeCodecs.java
@@ -16,8 +16,10 @@
 package com.datastax.oss.driver.api.core.type.codec;
 
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
+import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.codec.registry.MutableCodecRegistry;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import com.datastax.oss.driver.internal.core.type.DefaultVectorType;
 import com.datastax.oss.driver.internal.core.type.codec.SimpleBlobCodec;
 import com.datastax.oss.driver.internal.core.type.codec.TimestampCodec;
 import com.datastax.oss.driver.internal.core.type.codec.extras.OptionalCodec;
@@ -36,6 +38,7 @@ import com.datastax.oss.driver.internal.core.type.codec.extras.time.LocalTimesta
 import com.datastax.oss.driver.internal.core.type.codec.extras.time.PersistentZonedTimestampCodec;
 import com.datastax.oss.driver.internal.core.type.codec.extras.time.TimestampMillisCodec;
 import com.datastax.oss.driver.internal.core.type.codec.extras.time.ZonedTimestampCodec;
+import com.datastax.oss.driver.internal.core.type.codec.extras.vector.FloatVectorToArrayCodec;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.ByteBuffer;
@@ -478,5 +481,10 @@ public class ExtraTypeCodecs {
   public static <T> TypeCodec<T> json(
       @NonNull Class<T> javaType, @NonNull ObjectMapper objectMapper) {
     return new JsonCodec<>(javaType, objectMapper);
+  }
+
+  /** Builds a new codec that maps CQL float vectors of the specified size to an array of floats. */
+  public static TypeCodec<float[]> floatVectorToArray(int dimensions) {
+    return new FloatVectorToArrayCodec(new DefaultVectorType(DataTypes.FLOAT, dimensions));
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/codec/TypeCodecs.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/codec/TypeCodecs.java
@@ -214,6 +214,11 @@ public class TypeCodecs {
         DataTypes.vectorOf(subtypeCodec.getCqlType(), type.getDimensions()), subtypeCodec);
   }
 
+  public static <SubtypeT extends Number> TypeCodec<CqlVector<SubtypeT>> vectorOf(
+      int dimensions, @NonNull TypeCodec<SubtypeT> subtypeCodec) {
+    return new VectorCodec(DataTypes.vectorOf(subtypeCodec.getCqlType(), dimensions), subtypeCodec);
+  }
+
   /**
    * Builds a new codec that maps a CQL user defined type to the driver's {@link UdtValue}, for the
    * given type definition.

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/codec/TypeCodecs.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/codec/TypeCodecs.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.api.core.type.codec;
 
 import com.datastax.oss.driver.api.core.data.CqlDuration;
+import com.datastax.oss.driver.api.core.data.CqlVector;
 import com.datastax.oss.driver.api.core.data.TupleValue;
 import com.datastax.oss.driver.api.core.data.UdtValue;
 import com.datastax.oss.driver.api.core.type.CustomType;
@@ -207,7 +208,7 @@ public class TypeCodecs {
     return new TupleCodec(cqlType);
   }
 
-  public static <SubtypeT> TypeCodec<List<SubtypeT>> vectorOf(
+  public static <SubtypeT extends Number> TypeCodec<CqlVector<SubtypeT>> vectorOf(
       @NonNull VectorType type, @NonNull TypeCodec<SubtypeT> subtypeCodec) {
     return new VectorCodec(
         DataTypes.vectorOf(subtypeCodec.getCqlType(), type.getDimensions()), subtypeCodec);

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/reflect/GenericType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/reflect/GenericType.java
@@ -145,16 +145,19 @@ public class GenericType<T> {
   }
 
   @NonNull
-  public static <T extends Number> GenericType<CqlVector<T>> vectorOf(@NonNull Class<T> elementType) {
+  public static <T extends Number> GenericType<CqlVector<T>> vectorOf(
+      @NonNull Class<T> elementType) {
     TypeToken<CqlVector<T>> token =
-            new TypeToken<CqlVector<T>>() {}.where(new TypeParameter<T>() {}, TypeToken.of(elementType));
+        new TypeToken<CqlVector<T>>() {}.where(
+            new TypeParameter<T>() {}, TypeToken.of(elementType));
     return new GenericType<>(token);
   }
 
   @NonNull
-  public static <T extends Number> GenericType<CqlVector<T>> vectorOf(@NonNull GenericType<T> elementType) {
+  public static <T extends Number> GenericType<CqlVector<T>> vectorOf(
+      @NonNull GenericType<T> elementType) {
     TypeToken<CqlVector<T>> token =
-            new TypeToken<CqlVector<T>>() {}.where(new TypeParameter<T>() {}, elementType.token);
+        new TypeToken<CqlVector<T>>() {}.where(new TypeParameter<T>() {}, elementType.token);
     return new GenericType<>(token);
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/reflect/GenericType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/reflect/GenericType.java
@@ -15,7 +15,11 @@
  */
 package com.datastax.oss.driver.api.core.type.reflect;
 
-import com.datastax.oss.driver.api.core.data.*;
+import com.datastax.oss.driver.api.core.data.CqlDuration;
+import com.datastax.oss.driver.api.core.data.CqlVector;
+import com.datastax.oss.driver.api.core.data.GettableByIndex;
+import com.datastax.oss.driver.api.core.data.TupleValue;
+import com.datastax.oss.driver.api.core.data.UdtValue;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.shaded.guava.common.primitives.Primitives;
 import com.datastax.oss.driver.shaded.guava.common.reflect.TypeParameter;

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/reflect/GenericType.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/reflect/GenericType.java
@@ -15,10 +15,7 @@
  */
 package com.datastax.oss.driver.api.core.type.reflect;
 
-import com.datastax.oss.driver.api.core.data.CqlDuration;
-import com.datastax.oss.driver.api.core.data.GettableByIndex;
-import com.datastax.oss.driver.api.core.data.TupleValue;
-import com.datastax.oss.driver.api.core.data.UdtValue;
+import com.datastax.oss.driver.api.core.data.*;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.shaded.guava.common.primitives.Primitives;
 import com.datastax.oss.driver.shaded.guava.common.reflect.TypeParameter;
@@ -144,6 +141,20 @@ public class GenericType<T> {
   public static <T> GenericType<Set<T>> setOf(@NonNull GenericType<T> elementType) {
     TypeToken<Set<T>> token =
         new TypeToken<Set<T>>() {}.where(new TypeParameter<T>() {}, elementType.token);
+    return new GenericType<>(token);
+  }
+
+  @NonNull
+  public static <T extends Number> GenericType<CqlVector<T>> vectorOf(@NonNull Class<T> elementType) {
+    TypeToken<CqlVector<T>> token =
+            new TypeToken<CqlVector<T>>() {}.where(new TypeParameter<T>() {}, TypeToken.of(elementType));
+    return new GenericType<>(token);
+  }
+
+  @NonNull
+  public static <T extends Number> GenericType<CqlVector<T>> vectorOf(@NonNull GenericType<T> elementType) {
+    TypeToken<CqlVector<T>> token =
+            new TypeToken<CqlVector<T>>() {}.where(new TypeParameter<T>() {}, elementType.token);
     return new GenericType<>(token);
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/VectorCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/VectorCodec.java
@@ -153,15 +153,6 @@ public class VectorCodec<SubtypeT extends Number> implements TypeCodec<CqlVector
   public CqlVector<SubtypeT> parse(@Nullable String value) {
     return (value == null || value.isEmpty() || value.equalsIgnoreCase("NULL"))
         ? null
-        : this.from(value);
-  }
-
-  private CqlVector<SubtypeT> from(@Nullable String value) {
-
-    ArrayList<SubtypeT> vals =
-        Streams.stream(Splitter.on(", ").split(value.substring(1, value.length() - 1)))
-            .map(subtypeCodec::parse)
-            .collect(Collectors.toCollection(ArrayList::new));
-    return CqlVector.newInstance(vals);
+        : CqlVector.from(value, this.subtypeCodec);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/VectorCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/VectorCodec.java
@@ -22,9 +22,7 @@ import com.datastax.oss.driver.api.core.type.VectorType;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import com.datastax.oss.driver.internal.core.type.DefaultVectorType;
-import com.datastax.oss.driver.shaded.guava.common.base.Splitter;
 import com.datastax.oss.driver.shaded.guava.common.collect.Iterables;
-import com.datastax.oss.driver.shaded.guava.common.collect.Streams;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.nio.ByteBuffer;
@@ -32,7 +30,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.stream.Collectors;
 
 public class VectorCodec<SubtypeT extends Number> implements TypeCodec<CqlVector<SubtypeT>> {
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/VectorCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/VectorCodec.java
@@ -153,9 +153,10 @@ public class VectorCodec<SubtypeT extends Number> implements TypeCodec<CqlVector
 
   private CqlVector<SubtypeT> from(@Nullable String value) {
 
-    ArrayList<SubtypeT> vals =  Streams.stream(Splitter.on(", ").split(value.substring(1, value.length() - 1)))
-        .map(subtypeCodec::parse)
-        .collect(Collectors.toCollection(ArrayList::new));
+    ArrayList<SubtypeT> vals =
+        Streams.stream(Splitter.on(", ").split(value.substring(1, value.length() - 1)))
+            .map(subtypeCodec::parse)
+            .collect(Collectors.toCollection(ArrayList::new));
     return CqlVector.newInstance(vals);
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/VectorCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/VectorCodec.java
@@ -21,6 +21,7 @@ import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.driver.api.core.type.VectorType;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import com.datastax.oss.driver.internal.core.type.DefaultVectorType;
 import com.datastax.oss.driver.shaded.guava.common.base.Splitter;
 import com.datastax.oss.driver.shaded.guava.common.collect.Iterables;
 import com.datastax.oss.driver.shaded.guava.common.collect.Streams;
@@ -43,6 +44,10 @@ public class VectorCodec<SubtypeT extends Number> implements TypeCodec<CqlVector
     this.cqlType = cqlType;
     this.subtypeCodec = subtypeCodec;
     this.javaType = GenericType.vectorOf(subtypeCodec.getJavaType());
+  }
+
+  public VectorCodec(int dimensions, TypeCodec<SubtypeT> subtypeCodec) {
+    this(new DefaultVectorType(subtypeCodec.getCqlType(), dimensions), subtypeCodec);
   }
 
   @NonNull

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/VectorCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/VectorCodec.java
@@ -37,13 +37,13 @@ public class VectorCodec<SubtypeT extends Number> implements TypeCodec<CqlVector
   private final GenericType<CqlVector<SubtypeT>> javaType;
   private final TypeCodec<SubtypeT> subtypeCodec;
 
-  public VectorCodec(VectorType cqlType, TypeCodec<SubtypeT> subtypeCodec) {
+  public VectorCodec(@NonNull VectorType cqlType, @NonNull TypeCodec<SubtypeT> subtypeCodec) {
     this.cqlType = cqlType;
     this.subtypeCodec = subtypeCodec;
     this.javaType = GenericType.vectorOf(subtypeCodec.getJavaType());
   }
 
-  public VectorCodec(int dimensions, TypeCodec<SubtypeT> subtypeCodec) {
+  public VectorCodec(int dimensions, @NonNull TypeCodec<SubtypeT> subtypeCodec) {
     this(new DefaultVectorType(subtypeCodec.getCqlType(), dimensions), subtypeCodec);
   }
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/extras/vector/AbstractVectorToArrayCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/extras/vector/AbstractVectorToArrayCodec.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.type.codec.extras.vector;
+
+import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.VectorType;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.lang.reflect.Array;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/** Common super-class for all codecs which map a CQL vector type onto a primitive array */
+public abstract class AbstractVectorToArrayCodec<ArrayT> implements TypeCodec<ArrayT> {
+
+  @NonNull protected final VectorType cqlType;
+  @NonNull protected final GenericType<ArrayT> javaType;
+
+  /**
+   * @param cqlType The CQL type. Must be a list type.
+   * @param arrayType The Java type. Must be an array class.
+   */
+  protected AbstractVectorToArrayCodec(
+      @NonNull VectorType cqlType, @NonNull GenericType<ArrayT> arrayType) {
+    this.cqlType = Objects.requireNonNull(cqlType, "cqlType cannot be null");
+    this.javaType = Objects.requireNonNull(arrayType, "arrayType cannot be null");
+    if (!arrayType.isArray()) {
+      throw new IllegalArgumentException("Expecting Java array class, got " + arrayType);
+    }
+  }
+
+  @NonNull
+  @Override
+  public GenericType<ArrayT> getJavaType() {
+    return this.javaType;
+  }
+
+  @NonNull
+  @Override
+  public DataType getCqlType() {
+    return this.cqlType;
+  }
+
+  @Nullable
+  @Override
+  public ByteBuffer encode(@Nullable ArrayT array, @NonNull ProtocolVersion protocolVersion) {
+    if (array == null) {
+      return null;
+    }
+    int length = Array.getLength(array);
+    int totalSize = length * sizeOfComponentType();
+    ByteBuffer output = ByteBuffer.allocate(totalSize);
+    for (int i = 0; i < length; i++) {
+      serializeElement(output, array, i, protocolVersion);
+    }
+    output.flip();
+    return output;
+  }
+
+  @Nullable
+  @Override
+  public ArrayT decode(@Nullable ByteBuffer bytes, @NonNull ProtocolVersion protocolVersion) {
+    if (bytes == null || bytes.remaining() == 0) {
+      throw new IllegalArgumentException(
+          "Input ByteBuffer must not be null and must have non-zero remaining bytes");
+    }
+    ByteBuffer input = bytes.duplicate();
+    int length = this.cqlType.getDimensions();
+    int elementSize = sizeOfComponentType();
+    ArrayT array = newInstance();
+    for (int i = 0; i < length; i++) {
+      // Null elements can happen on the decode path, but we cannot tolerate them
+      if (elementSize < 0) {
+        throw new NullPointerException("Primitive arrays cannot store null elements");
+      } else {
+        deserializeElement(input, array, i, protocolVersion);
+      }
+    }
+    return array;
+  }
+
+  /**
+   * Creates a new array instance with a size matching the specified vector.
+   *
+   * @return a new array instance with a size matching the specified vector.
+   */
+  @NonNull
+  protected abstract ArrayT newInstance();
+
+  /**
+   * Return the size in bytes of the array component type.
+   *
+   * @return the size in bytes of the array component type.
+   */
+  protected abstract int sizeOfComponentType();
+
+  /**
+   * Write the {@code index}th element of {@code array} to {@code output}.
+   *
+   * @param output The ByteBuffer to write to.
+   * @param array The array to read from.
+   * @param index The element index.
+   * @param protocolVersion The protocol version to use.
+   */
+  protected abstract void serializeElement(
+      @NonNull ByteBuffer output,
+      @NonNull ArrayT array,
+      int index,
+      @NonNull ProtocolVersion protocolVersion);
+
+  /**
+   * Read the {@code index}th element of {@code array} from {@code input}.
+   *
+   * @param input The ByteBuffer to read from.
+   * @param array The array to write to.
+   * @param index The element index.
+   * @param protocolVersion The protocol version to use.
+   */
+  protected abstract void deserializeElement(
+      @NonNull ByteBuffer input,
+      @NonNull ArrayT array,
+      int index,
+      @NonNull ProtocolVersion protocolVersion);
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/extras/vector/FloatVectorToArrayCodec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/extras/vector/FloatVectorToArrayCodec.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.type.codec.extras.vector;
+
+import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.type.VectorType;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import com.datastax.oss.driver.internal.core.type.codec.FloatCodec;
+import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
+import com.datastax.oss.driver.shaded.guava.common.base.Splitter;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Objects;
+
+/** A codec that maps CQL vectors to the Java type {@code float[]}. */
+public class FloatVectorToArrayCodec extends AbstractVectorToArrayCodec<float[]> {
+
+  public FloatVectorToArrayCodec(VectorType type) {
+    super(type, GenericType.of(float[].class));
+  }
+
+  @Override
+  public boolean accepts(@NonNull Class<?> javaClass) {
+    Objects.requireNonNull(javaClass);
+    return float[].class.equals(javaClass);
+  }
+
+  @Override
+  public boolean accepts(@NonNull Object value) {
+    Objects.requireNonNull(value);
+    return value instanceof float[];
+  }
+
+  @NonNull
+  @Override
+  protected float[] newInstance() {
+    return new float[cqlType.getDimensions()];
+  }
+
+  @Override
+  protected int sizeOfComponentType() {
+    return 4;
+  }
+
+  @Override
+  protected void serializeElement(
+      @NonNull ByteBuffer output,
+      @NonNull float[] array,
+      int index,
+      @NonNull ProtocolVersion protocolVersion) {
+    output.putFloat(array[index]);
+  }
+
+  @Override
+  protected void deserializeElement(
+      @NonNull ByteBuffer input,
+      @NonNull float[] array,
+      int index,
+      @NonNull ProtocolVersion protocolVersion) {
+    array[index] = input.getFloat();
+  }
+
+  @NonNull
+  @Override
+  public String format(@Nullable float[] value) {
+    return value == null ? "NULL" : Arrays.toString(value);
+  }
+
+  @Nullable
+  @Override
+  public float[] parse(@Nullable String str) {
+    Preconditions.checkArgument(str != null, "Cannot create float array from null string");
+    Preconditions.checkArgument(!str.isEmpty(), "Cannot create float array from empty string");
+
+    FloatCodec codec = new FloatCodec();
+    float[] rv = this.newInstance();
+    Iterator<String> strIter =
+        Splitter.on(", ").trimResults().split(str.substring(1, str.length() - 1)).iterator();
+    for (int i = 0; i < rv.length; ++i) {
+      String strVal = strIter.next();
+      if (strVal == null) {
+        throw new IllegalArgumentException("Null element observed in float array string");
+      }
+      Float f = codec.parse(strVal);
+      rv[i] = f.floatValue();
+    }
+    return rv;
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistry.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.type.codec.registry;
 
 import com.datastax.oss.driver.api.core.data.CqlDuration;
+import com.datastax.oss.driver.api.core.data.CqlVector;
 import com.datastax.oss.driver.api.core.data.TupleValue;
 import com.datastax.oss.driver.api.core.data.UdtValue;
 import com.datastax.oss.driver.api.core.type.*;
@@ -593,9 +594,10 @@ public abstract class CachingCodecRegistry implements MutableCodecRegistry {
       } else if (cqlType instanceof UserDefinedType
           && UdtValue.class.isAssignableFrom(token.getRawType())) {
         return TypeCodecs.udtOf((UserDefinedType) cqlType);
-      } else if (cqlType instanceof VectorType && List.class.isAssignableFrom(token.getRawType())) {
+      } else if (cqlType instanceof VectorType && CqlVector.class.isAssignableFrom(token.getRawType())) {
         VectorType vectorType = (VectorType) cqlType;
-        TypeCodec<Object> elementCodec = getElementCodec(vectorType, token, isJavaCovariant);
+        /* Something of a hack to make the typing work out */
+        TypeCodec<? extends Number> elementCodec = uncheckedCast(getElementCodec(vectorType, token, isJavaCovariant));
         return TypeCodecs.vectorOf(vectorType, elementCodec);
       } else if (cqlType instanceof CustomType
           && ByteBuffer.class.isAssignableFrom(token.getRawType())) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistry.java
@@ -373,11 +373,11 @@ public abstract class CachingCodecRegistry implements MutableCodecRegistry {
         return GenericType.mapOf(keyType, valueType);
       }
     } else if (value instanceof CqlVector) {
-      CqlVector<?> set = (CqlVector<?>) value;
-      if (set.isEmpty()) {
+      CqlVector<?> vector = (CqlVector<?>) value;
+      if (vector.isEmpty()) {
         return cqlType == null ? JAVA_TYPE_FOR_EMPTY_CQLVECTORS : inferJavaTypeFromCqlType(cqlType);
       } else {
-        Object firstElement = set.iterator().next();
+        Object firstElement = vector.iterator().next();
         if (firstElement == null) {
           throw new IllegalArgumentException(
               "Can't infer vector codec because the first element is null "

--- a/core/src/test/java/com/datastax/oss/driver/api/core/data/CqlVectorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/data/CqlVectorTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.datastax.oss.driver.internal.core.type.codec.FloatCodec;
+import com.datastax.oss.driver.shaded.guava.common.collect.Iterators;
+import org.assertj.core.util.Lists;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CqlVectorTest {
+
+    private static final Float[] VECTOR_ARGS = {1.0f, 2.5f};
+
+    private void validate_built_vector(CqlVector<Float> vec) {
+
+        assertThat(vec.size()).isEqualTo(2);
+        assertThat(vec.isEmpty()).isFalse();
+        assertThat(vec.get(0)).isEqualTo(VECTOR_ARGS[0]);
+        assertThat(vec.get(1)).isEqualTo(VECTOR_ARGS[1]);
+    }
+
+    @Test
+    public void should_build_vector_from_elements() {
+
+        validate_built_vector(CqlVector.newInstance(VECTOR_ARGS));
+    }
+
+    @Test
+    public void should_build_vector_from_list() {
+
+        validate_built_vector(CqlVector.newInstance(Lists.newArrayList(VECTOR_ARGS)));
+    }
+
+    @Test
+    public void should_build_vector_from_tostring_output() {
+
+        CqlVector<Float> vector1 = CqlVector.newInstance(VECTOR_ARGS);
+        CqlVector<Float> vector2 = CqlVector.from(vector1.toString(), new FloatCodec());
+        assertThat(vector2).isEqualTo(vector1);
+    }
+
+    @Test
+    public void should_throw_when_building_with_nulls() {
+
+        assertThatThrownBy(() -> { CqlVector.newInstance(1.1f, null, 2.2f); }).isInstanceOf(IllegalArgumentException.class);
+
+        Float[] theArray = new Float[] { 1.1f, null, 2.2f };
+        assertThatThrownBy(() -> { CqlVector.newInstance(theArray); }).isInstanceOf(IllegalArgumentException.class);
+
+        List<Float> theList = Lists.newArrayList(1.1f, null, 2.2f);
+        assertThatThrownBy(() -> { CqlVector.newInstance(theList); }).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void should_build_empty_vector() {
+
+        CqlVector<Float> vector = CqlVector.newInstance();
+        assertThat(vector.isEmpty()).isTrue();
+        assertThat(vector.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void should_behave_mostly_like_a_list() {
+
+        CqlVector<Float> vector = CqlVector.newInstance(VECTOR_ARGS);
+        assertThat(vector.get(0)).isEqualTo(VECTOR_ARGS[0]);
+        Float newVal = VECTOR_ARGS[0] * 2;
+        vector.set(0, newVal);
+        assertThat(vector.get(0)).isEqualTo(newVal);
+        assertThat(vector.isEmpty()).isFalse();
+        assertThat(vector.size()).isEqualTo(2);
+        assertThat(Iterators.toArray(vector.iterator(), Float.class)).isEqualTo(VECTOR_ARGS);
+    }
+
+    @Test
+    public void should_play_nicely_with_streams() {
+
+        CqlVector<Float> vector = CqlVector.newInstance(VECTOR_ARGS);
+        List<Float> results = vector.stream().map((f) -> f * 2).collect(Collectors.toCollection(() -> new ArrayList<Float>()));
+        for (int i = 0; i < vector.size(); ++i) {
+            assertThat(results.get(i)).isEqualTo(vector.get(i) * 2);
+        }
+    }
+
+    @Test
+    public void should_reflect_changes_to_mutable_list() {
+
+        List<Float> theList = Lists.newArrayList(1.1f, 2.2f, 3.3f);
+        CqlVector<Float> vector = CqlVector.newInstance(theList);
+        assertThat(vector.size()).isEqualTo(3);
+        assertThat(vector.get(2)).isEqualTo(3.3f);
+
+        float newVal1 = 4.4f;
+        theList.set(2, newVal1);
+        assertThat(vector.size()).isEqualTo(3);
+        assertThat(vector.get(2)).isEqualTo(newVal1);
+
+        float newVal2 = 5.5f;
+        theList.add(newVal2);
+        assertThat(vector.size()).isEqualTo(4);
+        assertThat(vector.get(3)).isEqualTo(newVal2);
+    }
+
+    @Test
+    public void should_reflect_changes_to_array() {
+
+        Float[] theArray = new Float[] {1.1f, 2.2f, 3.3f};
+        CqlVector<Float> vector = CqlVector.newInstance(theArray);
+        assertThat(vector.size()).isEqualTo(3);
+        assertThat(vector.get(2)).isEqualTo(3.3f);
+
+        float newVal1 = 4.4f;
+        theArray[2] = newVal1;
+        assertThat(vector.size()).isEqualTo(3);
+        assertThat(vector.get(2)).isEqualTo(newVal1);
+    }
+
+    @Test
+    public void should_correctly_compare_vectors() {
+
+        Float[] args = VECTOR_ARGS.clone();
+        CqlVector<Float> vector1 = CqlVector.newInstance(args);
+        CqlVector<Float> vector2 = CqlVector.newInstance(args);
+        CqlVector<Float> vector3 = CqlVector.newInstance(Lists.newArrayList(args));
+        assertThat(vector1).isNotSameAs(vector2);
+        assertThat(vector1).isEqualTo(vector2);
+        assertThat(vector1).isNotSameAs(vector3);
+        assertThat(vector1).isEqualTo(vector3);
+
+        Float[] differentArgs = args.clone();
+        float newVal = differentArgs[0] * 2;
+        differentArgs[0] = newVal;
+        CqlVector<Float> vector4 = CqlVector.newInstance(differentArgs);
+        assertThat(vector1).isNotSameAs(vector4);
+        assertThat(vector1).isNotEqualTo(vector4);
+
+        Float[] biggerArgs = Arrays.copyOf(args, args.length + 1);
+        biggerArgs[biggerArgs.length - 1] = newVal;
+        CqlVector<Float> vector5 = CqlVector.newInstance(biggerArgs);
+        assertThat(vector1).isNotSameAs(vector5);
+        assertThat(vector1).isNotEqualTo(vector5);
+    }
+}

--- a/core/src/test/java/com/datastax/oss/driver/api/core/data/CqlVectorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/data/CqlVectorTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
-import com.datastax.oss.driver.internal.core.type.codec.FloatCodec;
 import com.datastax.oss.driver.shaded.guava.common.collect.Iterators;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -67,7 +66,7 @@ public class CqlVectorTest {
             () -> {
               CqlVector.from(null, TypeCodecs.FLOAT);
             })
-            .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -77,10 +76,10 @@ public class CqlVectorTest {
             () -> {
               CqlVector.from("", TypeCodecs.FLOAT);
             })
-            .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
-    @Test
+  @Test
   public void should_throw_when_building_with_nulls() {
 
     assertThatThrownBy(

--- a/core/src/test/java/com/datastax/oss/driver/api/core/data/CqlVectorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/api/core/data/CqlVectorTest.java
@@ -18,6 +18,7 @@ package com.datastax.oss.driver.api.core.data;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 import com.datastax.oss.driver.internal.core.type.codec.FloatCodec;
 import com.datastax.oss.driver.shaded.guava.common.collect.Iterators;
 import java.util.ArrayList;
@@ -55,11 +56,31 @@ public class CqlVectorTest {
   public void should_build_vector_from_tostring_output() {
 
     CqlVector<Float> vector1 = CqlVector.newInstance(VECTOR_ARGS);
-    CqlVector<Float> vector2 = CqlVector.from(vector1.toString(), new FloatCodec());
+    CqlVector<Float> vector2 = CqlVector.from(vector1.toString(), TypeCodecs.FLOAT);
     assertThat(vector2).isEqualTo(vector1);
   }
 
   @Test
+  public void should_throw_from_null_string() {
+
+    assertThatThrownBy(
+            () -> {
+              CqlVector.from(null, TypeCodecs.FLOAT);
+            })
+            .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void should_throw_from_empty_string() {
+
+    assertThatThrownBy(
+            () -> {
+              CqlVector.from("", TypeCodecs.FLOAT);
+            })
+            .isInstanceOf(IllegalArgumentException.class);
+  }
+
+    @Test
   public void should_throw_when_building_with_nulls() {
 
     assertThatThrownBy(

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/VectorCodecTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/VectorCodecTest.java
@@ -24,8 +24,6 @@ import com.datastax.oss.driver.api.core.type.VectorType;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import com.datastax.oss.driver.internal.core.type.DefaultVectorType;
-import com.google.common.collect.Lists;
-
 import java.util.Arrays;
 import org.junit.Test;
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistryTestDataProviders.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistryTestDataProviders.java
@@ -296,43 +296,43 @@ public class CachingCodecRegistryTestDataProviders {
       {
         DataTypes.vectorOf(DataTypes.BIGINT, 1),
         GenericType.vectorOf(Long.class),
-        GenericType.vectorOf(Long.class),
+        GenericType.vectorOf(Integer.class),
         CqlVector.newInstance(1l)
       },
       {
         DataTypes.vectorOf(DataTypes.SMALLINT, 1),
         GenericType.vectorOf(Short.class),
-        GenericType.vectorOf(Short.class),
-        CqlVector.newInstance(1)
+        GenericType.vectorOf(Integer.class),
+        CqlVector.newInstance((short) 1)
       },
       {
         DataTypes.vectorOf(DataTypes.TINYINT, 1),
         GenericType.vectorOf(Byte.class),
-        GenericType.vectorOf(Byte.class),
-        CqlVector.newInstance(1)
+        GenericType.vectorOf(Integer.class),
+        CqlVector.newInstance((byte) 1)
       },
       {
         DataTypes.vectorOf(DataTypes.FLOAT, 1),
         GenericType.vectorOf(Float.class),
-        GenericType.vectorOf(Float.class),
+        GenericType.vectorOf(Integer.class),
         CqlVector.newInstance(1.0f)
       },
       {
         DataTypes.vectorOf(DataTypes.DOUBLE, 1),
         GenericType.vectorOf(Double.class),
-        GenericType.vectorOf(Double.class),
+        GenericType.vectorOf(Integer.class),
         CqlVector.newInstance(1.0d)
       },
       {
         DataTypes.vectorOf(DataTypes.DECIMAL, 1),
         GenericType.vectorOf(BigDecimal.class),
-        GenericType.vectorOf(BigDecimal.class),
+        GenericType.vectorOf(Integer.class),
         CqlVector.newInstance(BigDecimal.ONE)
       },
       {
         DataTypes.vectorOf(DataTypes.VARINT, 1),
         GenericType.vectorOf(BigInteger.class),
-        GenericType.vectorOf(BigInteger.class),
+        GenericType.vectorOf(Integer.class),
         CqlVector.newInstance(BigInteger.ONE)
       },
     };

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistryTestDataProviders.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistryTestDataProviders.java
@@ -285,6 +285,61 @@ public class CachingCodecRegistryTestDataProviders {
         ImmutableMap.of(
             ImmutableMap.of(udtValue, udtValue), ImmutableMap.of(tupleValue, tupleValue))
       },
+            // vexctors
+            {
+                    DataTypes.vectorOf(DataTypes.INT,1),
+                    GenericType.listOf(Integer.class),
+                    GenericType.listOf(Integer.class),
+                    ImmutableList.of(1)
+            },
+            {
+                    DataTypes.vectorOf(DataTypes.TEXT,1),
+                    GenericType.listOf(String.class),
+                    GenericType.listOf(String.class),
+                    ImmutableList.of("foo")
+            },
+            {
+                    DataTypes.vectorOf(DataTypes.BLOB,1),
+                    GenericType.listOf(ByteBuffer.class),
+                    GenericType.listOf(Class.forName("java.nio.HeapByteBuffer")),
+                    ImmutableList.of(ByteBuffer.wrap(new byte[] {127, 0, 0, 1}))
+            },
+            {
+                    DataTypes.vectorOf(DataTypes.INET,1),
+                    GenericType.listOf(InetAddress.class),
+                    GenericType.listOf(Inet4Address.class),
+                    ImmutableList.of(InetAddress.getByAddress(new byte[] {127, 0, 0, 1}))
+            },
+            {
+                    DataTypes.vectorOf(tupleType,1),
+                    GenericType.listOf(TupleValue.class),
+                    GenericType.listOf(DefaultTupleValue.class),
+                    ImmutableList.of(tupleValue)
+            },
+            {
+                    DataTypes.vectorOf(userType,1),
+                    GenericType.listOf(UdtValue.class),
+                    GenericType.listOf(DefaultUdtValue.class),
+                    ImmutableList.of(udtValue)
+            },
+            {
+                    DataTypes.vectorOf(DataTypes.listOf(DataTypes.INT), 1),
+                    GenericType.listOf(GenericType.listOf(Integer.class)),
+                    GenericType.listOf(GenericType.listOf(Integer.class)),
+                    ImmutableList.of(ImmutableList.of(1))
+            },
+            {
+                    DataTypes.vectorOf(DataTypes.listOf(tupleType), 1),
+                    GenericType.listOf(GenericType.listOf(TupleValue.class)),
+                    GenericType.listOf(GenericType.listOf(DefaultTupleValue.class)),
+                    ImmutableList.of(ImmutableList.of(tupleValue))
+            },
+            {
+                    DataTypes.vectorOf(DataTypes.listOf(userType), 1),
+                    GenericType.listOf(GenericType.listOf(UdtValue.class)),
+                    GenericType.listOf(GenericType.listOf(DefaultUdtValue.class)),
+                    ImmutableList.of(ImmutableList.of(udtValue))
+            },
     };
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistryTestDataProviders.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistryTestDataProviders.java
@@ -286,7 +286,7 @@ public class CachingCodecRegistryTestDataProviders {
         ImmutableMap.of(
             ImmutableMap.of(udtValue, udtValue), ImmutableMap.of(tupleValue, tupleValue))
       },
-      // vexctors
+      // vectors
       {
         DataTypes.vectorOf(DataTypes.INT, 1),
         GenericType.vectorOf(Integer.class),

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistryTestDataProviders.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistryTestDataProviders.java
@@ -296,43 +296,43 @@ public class CachingCodecRegistryTestDataProviders {
       {
         DataTypes.vectorOf(DataTypes.BIGINT, 1),
         GenericType.vectorOf(Long.class),
-        GenericType.vectorOf(Integer.class),
+        GenericType.vectorOf(Long.class),
         CqlVector.newInstance(1l)
       },
       {
         DataTypes.vectorOf(DataTypes.SMALLINT, 1),
         GenericType.vectorOf(Short.class),
-        GenericType.vectorOf(Integer.class),
+        GenericType.vectorOf(Short.class),
         CqlVector.newInstance((short) 1)
       },
       {
         DataTypes.vectorOf(DataTypes.TINYINT, 1),
         GenericType.vectorOf(Byte.class),
-        GenericType.vectorOf(Integer.class),
+        GenericType.vectorOf(Byte.class),
         CqlVector.newInstance((byte) 1)
       },
       {
         DataTypes.vectorOf(DataTypes.FLOAT, 1),
         GenericType.vectorOf(Float.class),
-        GenericType.vectorOf(Integer.class),
+        GenericType.vectorOf(Float.class),
         CqlVector.newInstance(1.0f)
       },
       {
         DataTypes.vectorOf(DataTypes.DOUBLE, 1),
         GenericType.vectorOf(Double.class),
-        GenericType.vectorOf(Integer.class),
+        GenericType.vectorOf(Double.class),
         CqlVector.newInstance(1.0d)
       },
       {
         DataTypes.vectorOf(DataTypes.DECIMAL, 1),
         GenericType.vectorOf(BigDecimal.class),
-        GenericType.vectorOf(Integer.class),
+        GenericType.vectorOf(BigDecimal.class),
         CqlVector.newInstance(BigDecimal.ONE)
       },
       {
         DataTypes.vectorOf(DataTypes.VARINT, 1),
         GenericType.vectorOf(BigInteger.class),
-        GenericType.vectorOf(Integer.class),
+        GenericType.vectorOf(BigInteger.class),
         CqlVector.newInstance(BigInteger.ONE)
       },
     };

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistryTestDataProviders.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistryTestDataProviders.java
@@ -17,6 +17,7 @@ package com.datastax.oss.driver.internal.core.type.codec.registry;
 
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.data.CqlDuration;
+import com.datastax.oss.driver.api.core.data.CqlVector;
 import com.datastax.oss.driver.api.core.data.TupleValue;
 import com.datastax.oss.driver.api.core.data.UdtValue;
 import com.datastax.oss.driver.api.core.type.DataTypes;
@@ -285,61 +286,55 @@ public class CachingCodecRegistryTestDataProviders {
         ImmutableMap.of(
             ImmutableMap.of(udtValue, udtValue), ImmutableMap.of(tupleValue, tupleValue))
       },
-            // vexctors
-            {
-                    DataTypes.vectorOf(DataTypes.INT,1),
-                    GenericType.listOf(Integer.class),
-                    GenericType.listOf(Integer.class),
-                    ImmutableList.of(1)
-            },
-            {
-                    DataTypes.vectorOf(DataTypes.TEXT,1),
-                    GenericType.listOf(String.class),
-                    GenericType.listOf(String.class),
-                    ImmutableList.of("foo")
-            },
-            {
-                    DataTypes.vectorOf(DataTypes.BLOB,1),
-                    GenericType.listOf(ByteBuffer.class),
-                    GenericType.listOf(Class.forName("java.nio.HeapByteBuffer")),
-                    ImmutableList.of(ByteBuffer.wrap(new byte[] {127, 0, 0, 1}))
-            },
-            {
-                    DataTypes.vectorOf(DataTypes.INET,1),
-                    GenericType.listOf(InetAddress.class),
-                    GenericType.listOf(Inet4Address.class),
-                    ImmutableList.of(InetAddress.getByAddress(new byte[] {127, 0, 0, 1}))
-            },
-            {
-                    DataTypes.vectorOf(tupleType,1),
-                    GenericType.listOf(TupleValue.class),
-                    GenericType.listOf(DefaultTupleValue.class),
-                    ImmutableList.of(tupleValue)
-            },
-            {
-                    DataTypes.vectorOf(userType,1),
-                    GenericType.listOf(UdtValue.class),
-                    GenericType.listOf(DefaultUdtValue.class),
-                    ImmutableList.of(udtValue)
-            },
-            {
-                    DataTypes.vectorOf(DataTypes.listOf(DataTypes.INT), 1),
-                    GenericType.listOf(GenericType.listOf(Integer.class)),
-                    GenericType.listOf(GenericType.listOf(Integer.class)),
-                    ImmutableList.of(ImmutableList.of(1))
-            },
-            {
-                    DataTypes.vectorOf(DataTypes.listOf(tupleType), 1),
-                    GenericType.listOf(GenericType.listOf(TupleValue.class)),
-                    GenericType.listOf(GenericType.listOf(DefaultTupleValue.class)),
-                    ImmutableList.of(ImmutableList.of(tupleValue))
-            },
-            {
-                    DataTypes.vectorOf(DataTypes.listOf(userType), 1),
-                    GenericType.listOf(GenericType.listOf(UdtValue.class)),
-                    GenericType.listOf(GenericType.listOf(DefaultUdtValue.class)),
-                    ImmutableList.of(ImmutableList.of(udtValue))
-            },
+      // vexctors
+      {
+        DataTypes.vectorOf(DataTypes.INT, 1),
+        GenericType.vectorOf(Integer.class),
+        GenericType.vectorOf(Integer.class),
+        CqlVector.newInstance(1)
+      },
+      {
+        DataTypes.vectorOf(DataTypes.BIGINT, 1),
+        GenericType.vectorOf(Long.class),
+        GenericType.vectorOf(Long.class),
+        CqlVector.newInstance(1l)
+      },
+      {
+        DataTypes.vectorOf(DataTypes.SMALLINT, 1),
+        GenericType.vectorOf(Short.class),
+        GenericType.vectorOf(Short.class),
+        CqlVector.newInstance(1)
+      },
+      {
+        DataTypes.vectorOf(DataTypes.TINYINT, 1),
+        GenericType.vectorOf(Byte.class),
+        GenericType.vectorOf(Byte.class),
+        CqlVector.newInstance(1)
+      },
+      {
+        DataTypes.vectorOf(DataTypes.FLOAT, 1),
+        GenericType.vectorOf(Float.class),
+        GenericType.vectorOf(Float.class),
+        CqlVector.newInstance(1.0f)
+      },
+      {
+        DataTypes.vectorOf(DataTypes.DOUBLE, 1),
+        GenericType.vectorOf(Double.class),
+        GenericType.vectorOf(Double.class),
+        CqlVector.newInstance(1.0d)
+      },
+      {
+        DataTypes.vectorOf(DataTypes.DECIMAL, 1),
+        GenericType.vectorOf(BigDecimal.class),
+        GenericType.vectorOf(BigDecimal.class),
+        CqlVector.newInstance(BigDecimal.ONE)
+      },
+      {
+        DataTypes.vectorOf(DataTypes.VARINT, 1),
+        GenericType.vectorOf(BigInteger.class),
+        GenericType.vectorOf(BigInteger.class),
+        CqlVector.newInstance(BigInteger.ONE)
+      },
     };
   }
 


### PR DESCRIPTION
Fixes in the same vein as #1643 adapted to play nicely with recent changes to the Java types representing CQL vectors.