### PR TITLE
Fix LatencyAwarePolicy scale docstring

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/policies/LatencyAwarePolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/policies/LatencyAwarePolicy.java
@@ -709,7 +709,7 @@ public class LatencyAwarePolicy implements ChainableLoadBalancingPolicy {
      *
      * <pre>{@code d = (t - t') / scale
      * alpha = 1 - (ln(d+1) / d)
-     * avg = alpha * l + (1 - alpha * prev)}</pre>
+     * avg = alpha * l + (1 - alpha) * prev}</pre>
      *
      * Typically, with a {@code scale} of 100 milliseconds (the default), if a new latency is
      * measured and the previous measure is 10 millisecond old (so {@code d=0.1}), then {@code


### PR DESCRIPTION
A parenthesis was too far to the right.
> I'm contributing this code on behalf of my employer ScyllaDB. We have signed Contributor License Agreement in the past when we were contributing fixes to Java driver. For more context see https://github.com/datastax/java-driver/pull/1195