### PR TITLE
JAVA-3082: Fix maven build for Apple-silicon

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -125,7 +125,7 @@
 
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative</artifactId>
+            <artifactId>${netty-tcnative.artifact}</artifactId>
             <classifier>${os.detected.classifier}</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
         <guava.version>19.0</guava.version>
         <netty.version>4.1.77.Final</netty.version>
+        <netty-tcnative.artifact>netty-tcnative</netty-tcnative.artifact>
         <netty-tcnative.version>2.0.52.Final</netty-tcnative.version>
         <metrics.version>3.2.2</metrics.version>
         <snappy.version>1.1.2.6</snappy.version>
@@ -350,7 +351,7 @@
 
             <dependency>
                 <groupId>io.netty</groupId>
-                <artifactId>netty-tcnative</artifactId>
+                <artifactId>${netty-tcnative.artifact}</artifactId>
                 <version>${netty-tcnative.version}</version>
                 <classifier>${os.detected.classifier}</classifier>
             </dependency>
@@ -717,7 +718,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-maven-plugin</artifactId>
-                    <version>1.15</version>
+                    <version>1.16</version>
                     <executions>
                         <execution>
                             <id>check-jdk6</id>
@@ -1124,6 +1125,24 @@ limitations under the License.
                 <!-- skip osgi testing for JDK 10 as pax-exam does not support it yet. -->
                 <test.osgi.skip>true</test.osgi.skip>
             </properties>
+        </profile>
+
+        <profile>
+            <id>apple-silicon-dev</id>
+            <activation>
+                <os>
+                    <name>mac os x</name>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <!-- https://netty.io/wiki/forked-tomcat-native.html netty on apple-silicon requires the boringssl variant of tc-native -->
+                <netty-tcnative.artifact>netty-tcnative-boringssl-static</netty-tcnative.artifact>
+                <!-- https://github.com/jnr/jffi/pull/116 apple-silicon requires signed jffi binaries, added in 1.3.8 (jnr-ffi 2.2.10+) -->
+                <jnr-ffi.version>2.2.10</jnr-ffi.version>
+            </properties>
+
         </profile>
     </profiles>
 


### PR DESCRIPTION
pom.xml:
- add apple-silicon-dev profile which switches netty-tcnative for netty-tcnative-boringssl-static and updates to newer jffi (only at build-time, reference links in pom.xml)
- upgrade animal-sniffer plugin to 1.16 to address error IllegalArgumentException during check-jdk6 step (see https://github.com/mojohaus/animal-sniffer/issues/29)