### PR TITLE
Extended visibility of CqlIdentifier constructor

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/CqlIdentifier.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/CqlIdentifier.java
@@ -93,7 +93,7 @@ public class CqlIdentifier implements Serializable {
   /** @serial */
   private final String internal;
 
-  private CqlIdentifier(String internal) {
+  protected CqlIdentifier(String internal) {
     this.internal = internal;
   }
 


### PR DESCRIPTION
In `spring-data-cassandra`, we need to have an ability to extend `CqlIdentifier` and invoke its constructor. If you will extend the visibility of `CqlIdentnfier` constructor, that would be great.

The issue in details exaplined here: https://datastax-oss.atlassian.net/browse/JAVA-3088
Corresponding PR in `spring-data-cassandra` module: https://github.com/spring-projects/spring-data-cassandra/pull/1400