### PR TITLE
Compile 4.x driver with java11

### DIFF
--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -283,6 +283,11 @@
                   <artifactId>esri-geometry-api</artifactId>
                   <version>1.2.1</version>
                 </additionalDependency>
+                <additionalDependency>
+                  <groupId>org.jetbrains</groupId>
+                  <artifactId>annotations</artifactId>
+                  <version>24.0.1</version>
+                </additionalDependency>
               </additionalDependencies>
             </configuration>
           </execution>

--- a/core/src/main/java/com/datastax/oss/driver/api/core/CqlIdentifier.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/CqlIdentifier.java
@@ -41,7 +41,8 @@ import net.jcip.annotations.Immutable;
  *
  * Examples:
  *
- * <table summary="examples">
+ * <table>
+ *   <caption>examples</caption>
  *   <tr><th>Create statement</th><th>Case-sensitive?</th><th>CQL id</th><th>Internal id</th></tr>
  *   <tr><td>CREATE TABLE t(foo int PRIMARY KEY)</td><td>No</td><td>foo</td><td>foo</td></tr>
  *   <tr><td>CREATE TABLE t(Foo int PRIMARY KEY)</td><td>No</td><td>foo</td><td>foo</td></tr>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -220,6 +220,37 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>process-test-annotations</id>
+            <phase>generate-test-resources</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.datastax.oss</groupId>
+                  <artifactId>java-driver-mapper-processor</artifactId>
+                  <version>${project.version}</version>
+                </path>
+                <path>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-nop</artifactId>
+                  <version>${slf4j.version}</version>
+                </path>
+                <path>
+                  <groupId>org.apache.tinkerpop</groupId>
+                  <artifactId>gremlin-core</artifactId>
+                  <version>${tinkerpop.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <executions>

--- a/osgi-tests/pom.xml
+++ b/osgi-tests/pom.xml
@@ -159,6 +159,32 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>process-annotations</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.datastax.oss</groupId>
+                  <artifactId>java-driver-mapper-processor</artifactId>
+                  <version>${project.version}</version>
+                </path>
+                <path>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-nop</artifactId>
+                  <version>${slf4j.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.servicemix.tooling</groupId>
         <artifactId>depends-maven-plugin</artifactId>
         <version>1.4.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.datastax.oss</groupId>
   <artifactId>java-driver-parent</artifactId>
-  <version>4.17.1-SNAPSHOT</version>
+  <version>4.16.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>DataStax Java driver for Apache Cassandra(R)</name>
   <description>A driver for Apache Cassandra(R) 2.1+ that works exclusively with the Cassandra Query Language version 3 (CQL3) and Cassandra's native protocol versions 3 and above.</description>
@@ -82,6 +82,7 @@
     <apacheds.version>2.0.0-M19</apacheds.version>
     <surefire.version>2.22.2</surefire.version>
     <graalapi.version>22.0.0.2</graalapi.version>
+    <error-prone.version>2.19.1</error-prone.version>
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
   </properties>
@@ -440,6 +441,11 @@
         <artifactId>blockhound-junit-platform</artifactId>
         <version>1.0.8.RELEASE</version>
       </dependency>
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>24.0.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>
@@ -580,33 +586,34 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <compilerId>javac-with-errorprone</compilerId>
           <forceJavacCompilerUse>true</forceJavacCompilerUse>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>8</release>
+          <encoding>UTF-8</encoding>
           <compilerArgs combine.children="override">
-            <compilerArg>-Xep:FutureReturnValueIgnored:OFF</compilerArg>
-            <compilerArg>-Xep:PreferJavaTimeOverload:OFF</compilerArg>
-            <compilerArg>-Xep:AnnotateFormatMethod:OFF</compilerArg>
-            <compilerArg>-Xep:WildcardImport:WARN</compilerArg>
-            <compilerArg>-XepExcludedPaths:.*/target/(?:generated-sources|generated-test-sources)/.*</compilerArg>
+            <arg>-J--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+            <arg>-J--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+            <arg>-J--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+            <arg>-J--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+            <arg>-J--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+            <arg>-J--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+            <arg>-J--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+            <arg>-J--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+            <arg>-J--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+            <arg>-J--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne -Xep:FutureReturnValueIgnored:OFF -Xep:PreferJavaTimeOverload:OFF -Xep:AnnotateFormatMethod:OFF -Xep:MissingSummary:OFF -Xep:InvalidBlockTag:OFF -Xep:OptionalMapUnusedValue:OFF -Xep:ReturnValueIgnored:OFF -Xep:BanJNDI:OFF -Xep:InlineMeSuggester:OFF -Xep:StringSplitter:OFF -Xep:JavaUtilDate:OFF -Xep:ObjectEqualsForPrimitives:OFF -Xep:EmptyCatch:OFF -Xep:ProtectedMembersInFinalClass:OFF -Xep:StringCaseLocaleUsage:OFF -Xep:MutablePublicArray:OFF -Xep:DirectInvocationOnMock:OFF -Xep:MockNotUsedInProduction:OFF -Xep:LongDoubleConversion:OFF -Xep:EmptyBlockTag:OFF -Xep:AlmostJavadoc:OFF -Xep:DoNotClaimAnnotations:OFF -Xep:BadImport:OFF -Xep:DefaultCharset:OFF -Xep:UseCorrectAssertInTests:OFF -Xep:NarrowCalculation:OFF -Xep:WildcardImport:WARN -XepExcludedPaths:.*/target/(?:generated-sources|generated-test-sources)/.*</arg>
           </compilerArgs>
+          <annotationProcessorPaths combine.children="append">
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>${error-prone.version}</version>
+            </path>
+          </annotationProcessorPaths>
           <showWarnings>true</showWarnings>
           <failOnWarning>true</failOnWarning>
           <useIncrementalCompilation>false</useIncrementalCompilation>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>2.8.6</version>
-          </dependency>
-          <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <version>2.3.4</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <groupId>com.coveo</groupId>
@@ -760,12 +767,8 @@ limitations under the License.]]></inlineHeader>
               <placement>a</placement>
               <head>API note:</head>
             </tag>
-            <!--
-              For custom `leaks-private-api` tag (apparently dash separators are not handled
-              correctly)
-            -->
             <tag>
-              <name>leaks</name>
+              <name>leaks-private-api</name>
               <placement>X</placement>
             </tag>
           </tags>
@@ -805,12 +808,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
               <docletArtifact>
                 <groupId>com.datastax.oss</groupId>
                 <artifactId>api-plumber-doclet</artifactId>
-                <version>1.0.0</version>
+                <version>2.0.0-SNAPSHOT</version>
               </docletArtifact>
               <additionalJOptions>
                 <!-- API types do not leak internal types -->
                 <additionalparam>-preventleak</additionalparam>
                 <additionalparam>com.datastax.oss.driver.internal</additionalparam>
+                <additionalparam>-preventleak</additionalparam>
                 <additionalparam>com.datastax.dse.driver.internal</additionalparam>
                 <!-- Shaded dependencies (Guava, Netty, etc.) -->
                 <additionalparam>-preventleak</additionalparam>


### PR DESCRIPTION
… under the same pom.xml)

Update to api-plumber-doclet 2.0 (todo: remove dependence on SNAPSHOT build)