### PR TITLE
JAVA-3114 Include dropwizard metrics into the shaded dependencies list for 3.x driver

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -271,6 +271,7 @@
                     <artifactSet>
                         <includes>
                             <include>io.netty:*</include>
+                            <include>io.dropwizard.metrics:metrics-core</include>
                         </includes>
                         <excludes>
                             <exclude>io.netty:netty-transport-native-epoll</exclude>
@@ -280,6 +281,10 @@
                         <relocation>
                             <pattern>io.netty</pattern>
                             <shadedPattern>com.datastax.shaded.netty</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.codahale.metrics</pattern>
+                            <shadedPattern>com.datastax.shaded.metrics</shadedPattern>
                         </relocation>
                     </relocations>
                     <transformers>


### PR DESCRIPTION
The patch attempts to fix a backwards compatibility problem that occurs when upgrading the Dwopwizard Metrics library from 3.x to 4.x. The problem with simply upgrading the Dropwizard version is that the `JmxPerporter` class has moved from the `com.codahale.metrics` package in the 3.x version to the `com.codahale.metrics.jmx` package in the 4.x version. 

The `cassandra-driver-core' itself doesn't provide the necessary classes for metrics, and relies entirely on Cassandra's classpath. This, in turn, makes the library upgrade in the Cassandra project a bit difficult as it clashes with the library version used in the driver. 

The following solution may be possible:

- upgrade the `java-driver' in the Cassandra project first - this solves the library version upgrade problem, but won't solve all such kind of problems in the future);
- use `withoutMetrics()` to avoid metrics initialisation, the drawback of this solution - metrics won't be accessible;
- ship the required dependencies with the driver;

The same problem could exist for the 4.x version and the additional investigation is required.

Reference JIRA:
https://issues.apache.org/jira/browse/CASSANDRA-14667