### PR TITLE
JAVA-3094: Fix decrement query error

### DIFF
--- a/query-builder/src/main/java/com/datastax/oss/driver/internal/querybuilder/update/CounterAssignment.java
+++ b/query-builder/src/main/java/com/datastax/oss/driver/internal/querybuilder/update/CounterAssignment.java
@@ -27,7 +27,7 @@ public abstract class CounterAssignment implements Assignment {
 
   public enum Operator {
     INCREMENT("%1$s=%1$s+%2$s"),
-    DECREMENT("%1$s=%1$s-%2$s"),
+    DECREMENT("%1$s=%1$s- %2$s"),
     ;
 
     public final String pattern;


### PR DESCRIPTION
If decrement with a negative value, then the query is made like `COLUMN = COLUMN--value`. so it can occur error because, double dashes (--) is used for comment.