### PR TITLE
JAVA-3100: Update jackson-databind to 2.13.4.1 and jackson-jaxrs-json-provider to 2.13.4 to address recent CVEs

### DIFF
--- a/core/revapi.json
+++ b/core/revapi.json
@@ -6950,6 +6950,12 @@
         "old": "method <T> com.datastax.oss.driver.api.core.type.reflect.GenericType<com.datastax.oss.driver.api.core.data.CqlVector<T>> com.datastax.oss.driver.api.core.type.reflect.GenericType<T>::vectorOf(com.datastax.oss.driver.api.core.type.reflect.GenericType<T>)",
         "new": "method <T extends java.lang.Number> com.datastax.oss.driver.api.core.type.reflect.GenericType<com.datastax.oss.driver.api.core.data.CqlVector<T>> com.datastax.oss.driver.api.core.type.reflect.GenericType<T>::vectorOf(com.datastax.oss.driver.api.core.type.reflect.GenericType<T>)",
         "justification": "Refactorings in PR 1666"
+      },
+      {
+        "code": "java.method.returnTypeChangedCovariantly",
+        "old": "method java.lang.Throwable java.lang.Throwable::fillInStackTrace() @ com.fasterxml.jackson.databind.deser.UnresolvedForwardReference",
+        "new": "method com.fasterxml.jackson.databind.deser.UnresolvedForwardReference com.fasterxml.jackson.databind.deser.UnresolvedForwardReference::fillInStackTrace()",
+        "justification": "Upgrade jackson-databind to 2.13.4.1 to address CVEs, API change cause: https://github.com/FasterXML/jackson-databind/issues/3419"
       }
     ]
   }

--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,8 @@
     <slf4j.version>1.7.26</slf4j.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>
     <json.version>20230227</json.version>
-    <jackson.version>2.13.2</jackson.version>
-    <jackson-databind.version>2.13.2.2</jackson-databind.version>
-    <legacy-jackson.version>1.9.12</legacy-jackson.version>
+    <jackson.version>2.13.4</jackson.version>
+    <jackson-databind.version>2.13.4.1</jackson-databind.version>
     <!-- optional dependencies -->
     <snappy.version>1.1.10.1</snappy.version>
     <lz4.version>1.7.1</lz4.version>


### PR DESCRIPTION

Additional:
- Remove unused maven property legacy-jackson.version
- Remove unneccesary explicit dependencies on jackson-core and jackson-jaxrs-base