### PR TITLE
JAVA-3078: Provide support for building with Java 11 and Java 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,20 @@ matrix:
     # 8
     - env: JDK='OpenJDK 8'
       jdk: openjdk8
+      before_install:
+        # Require JDK8 for compiling
+        - jdk_switcher use openjdk8
+        - ./install-snapshots.sh
     # 11
     - env: JDK='OpenJDK 11'
-      # switch to JDK 11 before running tests
-      before_script: . $TRAVIS_BUILD_DIR/ci/install-jdk.sh -F 11 -L GPL
-before_install:
-  # Require JDK8 for compiling
-  - jdk_switcher use openjdk8
-  - ./install-snapshots.sh
+      before_install:
+        - . $TRAVIS_BUILD_DIR/ci/install-jdk.sh -F 11 -L GPL
+        - ./install-snapshots.sh
+    # 17
+    - env: JDK='OpenJDK 17'
+      before_install:
+        - . $TRAVIS_BUILD_DIR/ci/install-jdk.sh -F 17 -L GPL
+        - ./install-snapshots.sh
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn test -Djacoco.skip=true -Dmaven.test.failure.ignore=true -Dmaven.javadoc.skip=true -B -V
 cache:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,35 +19,12 @@ def initializeEnvironment() {
   env.MAVEN_HOME = "${env.HOME}/.mvn/apache-maven-3.3.9"
   env.PATH = "${env.MAVEN_HOME}/bin:${env.PATH}"
 
-  /*
-  * As of JAVA-3042 JAVA_HOME is always set to JDK8 and this is currently necessary for mvn compile and DSE Search/Graph.
-  * To facilitate testing with JDK11/17 we feed the appropriate JAVA_HOME into the maven build via commandline.
-  *
-  * Maven command-line flags:
-  * - -DtestJavaHome=/path/to/java/home: overrides JAVA_HOME for surefire/failsafe tests, defaults to environment JAVA_HOME.
-  * - -Ptest-jdk-N: enables profile for running tests with a specific JDK version (substitute N for 8/11/17).
-  *
-  * Note test-jdk-N is also automatically loaded based off JAVA_HOME SDK version so testing with an older SDK is not supported.
-  *
-  * Environment variables:
-  * - JAVA_HOME: Path to JDK used for mvn (all steps except surefire/failsafe), Cassandra, DSE.
-  * - JAVA8_HOME: Path to JDK8 used for Cassandra/DSE if ccm determines JAVA_HOME is not compatible with the chosen backend.
-  * - TEST_JAVA_HOME: PATH to JDK used for surefire/failsafe testing.
-  * - TEST_JAVA_VERSION: TEST_JAVA_HOME SDK version number [8/11/17], used to configure test-jdk-N profile in maven (see above)
-  */
-
   env.JAVA_HOME = sh(label: 'Get JAVA_HOME',script: '''#!/bin/bash -le
     . ${JABBA_SHELL}
     jabba which ${JABBA_VERSION}''', returnStdout: true).trim()
   env.JAVA8_HOME = sh(label: 'Get JAVA8_HOME',script: '''#!/bin/bash -le
     . ${JABBA_SHELL}
     jabba which 1.8''', returnStdout: true).trim()
-
-  env.TEST_JAVA_HOME = sh(label: 'Get TEST_JAVA_HOME',script: '''#!/bin/bash -le
-    . ${JABBA_SHELL}
-    jabba which ${JABBA_VERSION}''', returnStdout: true).trim()
-  env.TEST_JAVA_VERSION = sh(label: 'Get TEST_JAVA_VERSION',script: '''#!/bin/bash -le
-    echo "${JABBA_VERSION##*.}"''', returnStdout: true).trim()
 
   sh label: 'Download Apache CassandraⓇ or DataStax Enterprise',script: '''#!/bin/bash -le
     . ${JABBA_SHELL}
@@ -77,7 +54,7 @@ ENVIRONMENT_EOF
     set +o allexport
 
     . ${JABBA_SHELL}
-    jabba use 1.8
+    jabba use ${JABBA_VERSION}
 
     java -version
     mvn -v
@@ -85,15 +62,13 @@ ENVIRONMENT_EOF
   '''
 }
 
-def buildDriver(jabbaVersion) {
-  withEnv(["BUILD_JABBA_VERSION=${jabbaVersion}"]) {
-    sh label: 'Build driver', script: '''#!/bin/bash -le
-      . ${JABBA_SHELL}
-      jabba use ${BUILD_JABBA_VERSION}
+def buildDriver() {
+  sh label: 'Build driver', script: '''#!/bin/bash -le
+    . ${JABBA_SHELL}
+    jabba use ${JABBA_VERSION}
 
-      mvn -B -V install -DskipTests -Dmaven.javadoc.skip=true
-    '''
-  }
+    mvn -B -V install -DskipTests -Dmaven.javadoc.skip=true
+  '''
 }
 
 def executeTests() {
@@ -104,13 +79,7 @@ def executeTests() {
     set +o allexport
 
     . ${JABBA_SHELL}
-    jabba use 1.8
-
-    if [ "${JABBA_VERSION}" != "1.8" ]; then
-      SKIP_JAVADOCS=true
-    else
-      SKIP_JAVADOCS=false
-    fi
+    jabba use ${JABBA_VERSION}
 
     INTEGRATION_TESTS_FILTER_ARGUMENT=""
     if [ ! -z "${INTEGRATION_TESTS_FILTER}" ]; then
@@ -119,11 +88,8 @@ def executeTests() {
     printenv | sort
 
     mvn -B -V ${INTEGRATION_TESTS_FILTER_ARGUMENT} -T 1 verify \
-      -Ptest-jdk-${TEST_JAVA_VERSION} \
-      -DtestJavaHome=${TEST_JAVA_HOME} \
       -DfailIfNoTests=false \
       -Dmaven.test.failure.ignore=true \
-      -Dmaven.javadoc.skip=${SKIP_JAVADOCS} \
       -Dccm.version=${CCM_CASSANDRA_VERSION} \
       -Dccm.dse=${CCM_IS_DSE} \
       -Dproxy.path=${HOME}/proxy \
@@ -459,7 +425,7 @@ pipeline {
           }
           stage('Build-Driver') {
             steps {
-              buildDriver('default')
+              buildDriver()
             }
           }
           stage('Execute-Tests') {
@@ -573,8 +539,7 @@ pipeline {
           }
           stage('Build-Driver') {
             steps {
-              // Jabba default should be a JDK8 for now
-              buildDriver('default')
+              buildDriver()
             }
           }
           stage('Execute-Tests') {

--- a/ci/install-jdk.sh
+++ b/ci/install-jdk.sh
@@ -200,6 +200,7 @@ function determine_url() {
        10-BCL) url="${ORACLE}/10.0.2+13/19aef61b38124481863b1413dce1855f/jdk-10.0.2_${os}_bin.tar.gz"; return;;
        11-GPL) url="${DOWNLOAD}/GA/jdk11/13/GPL/openjdk-11.0.1_${os}_bin.tar.gz"; return;;
        11-BCL) url="${ORACLE}/11.0.1+13/90cf5d8f270a4347a95050320eef3fb7/jdk-11.0.1_${os}_bin.tar.gz"; return;;
+       17-GPL) url="${DOWNLOAD}/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_${os}_bin.tar.gz"; return;;
     esac
 
     # EA or RC build?

--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -283,6 +283,11 @@
                   <artifactId>esri-geometry-api</artifactId>
                   <version>1.2.1</version>
                 </additionalDependency>
+                <additionalDependency>
+                  <groupId>org.jetbrains</groupId>
+                  <artifactId>annotations</artifactId>
+                  <version>24.0.1</version>
+                </additionalDependency>
               </additionalDependencies>
             </configuration>
           </execution>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -248,7 +248,6 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <jvm>${testing.jvm}/bin/java</jvm>
           <argLine>${mockitoopens.argline}</argLine>
           <threadCount>1</threadCount>
           <properties>

--- a/core/src/main/java/com/datastax/oss/driver/api/core/CqlIdentifier.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/CqlIdentifier.java
@@ -41,7 +41,8 @@ import net.jcip.annotations.Immutable;
  *
  * Examples:
  *
- * <table summary="examples">
+ * <table>
+ *   <caption>examples</caption>
  *   <tr><th>Create statement</th><th>Case-sensitive?</th><th>CQL id</th><th>Internal id</th></tr>
  *   <tr><td>CREATE TABLE t(foo int PRIMARY KEY)</td><td>No</td><td>foo</td><td>foo</td></tr>
  *   <tr><td>CREATE TABLE t(Foo int PRIMARY KEY)</td><td>No</td><td>foo</td><td>foo</td></tr>

--- a/core/src/main/java/com/datastax/oss/driver/api/core/paging/OffsetPager.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/paging/OffsetPager.java
@@ -44,7 +44,7 @@ import net.jcip.annotations.ThreadSafe;
  * a reasonable trade-off if the cardinality stays low. This class provides a way to emulate this
  * behavior on the client side.
  *
- * <h3>Performance considerations</h3>
+ * <h2>Performance considerations</h2>
  *
  * For each page that you want to retrieve:
  *
@@ -69,7 +69,7 @@ import net.jcip.annotations.ThreadSafe;
  * OffsetPager.Page&lt;Row&gt; page5 = pager.getPage(rs, 5);
  * </pre>
  *
- * <h3>Establishing application-level guardrails</h3>
+ * <h2>Establishing application-level guardrails</h2>
  *
  * Linear performance should be fine for the values typically encountered in real-world
  * applications: for example, if the page size is 25 and users never go past page 10, the worst case
@@ -79,7 +79,7 @@ import net.jcip.annotations.ThreadSafe;
  * maximum, so that an attacker can't inject a large value that could potentially fetch millions of
  * rows.
  *
- * <h3>Relation with protocol-level paging</h3>
+ * <h2>Relation with protocol-level paging</h2>
  *
  * Protocol-level paging refers to the ability to split large response into multiple network chunks:
  * see {@link Statement#setPageSize(int)} and {@code basic.request.page-size} in the configuration.

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -220,6 +220,37 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>process-test-annotations</id>
+            <phase>generate-test-resources</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.datastax.oss</groupId>
+                  <artifactId>java-driver-mapper-processor</artifactId>
+                  <version>${project.version}</version>
+                </path>
+                <path>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-nop</artifactId>
+                  <version>${slf4j.version}</version>
+                </path>
+                <path>
+                  <groupId>org.apache.tinkerpop</groupId>
+                  <artifactId>gremlin-core</artifactId>
+                  <version>${tinkerpop.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <executions>
@@ -229,7 +260,6 @@
               <goal>integration-test</goal>
             </goals>
             <configuration>
-              <jvm>${testing.jvm}/bin/java</jvm>
               <groups>com.datastax.oss.driver.categories.ParallelizableTests</groups>
               <parallel>classes</parallel>
               <threadCountClasses>8</threadCountClasses>
@@ -246,7 +276,6 @@
               <excludedGroups>com.datastax.oss.driver.categories.ParallelizableTests, com.datastax.oss.driver.categories.IsolatedTests</excludedGroups>
               <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-serial.xml</summaryFile>
               <skipITs>${skipSerialITs}</skipITs>
-              <jvm>${testing.jvm}/bin/java</jvm>
             </configuration>
           </execution>
           <execution>
@@ -262,7 +291,6 @@
               <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-isolated.xml</summaryFile>
               <skipITs>${skipIsolatedITs}</skipITs>
               <argLine>${blockhound.argline}</argLine>
-              <jvm>${testing.jvm}/bin/java</jvm>
             </configuration>
           </execution>
           <execution>

--- a/mapper-runtime/pom.xml
+++ b/mapper-runtime/pom.xml
@@ -122,7 +122,6 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <jvm>${testing.jvm}/bin/java</jvm>
           <threadCount>1</threadCount>
           <properties>
             <!-- tell TestNG not to run jUnit tests -->

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Delete.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Delete.java
@@ -45,7 +45,7 @@ import java.util.function.UnaryOperator;
  * }
  * </pre>
  *
- * <h3>Parameters</h3>
+ * <h2>Parameters</h2>
  *
  * The method can operate either on an entity instance, or on a primary key (partition key +
  * clustering columns).
@@ -75,7 +75,7 @@ import java.util.function.UnaryOperator;
  * parameter. It will be applied to the statement before execution. This allows you to customize
  * certain aspects of the request (page size, timeout, etc) at runtime.
  *
- * <h3>Return type</h3>
+ * <h2>Return type</h2>
  *
  * The method can return:
  *
@@ -125,7 +125,7 @@ import java.util.function.UnaryOperator;
  * practical purpose for that since those queries always return {@code wasApplied = true} and an
  * empty result set.
  *
- * <h3>Target keyspace and table</h3>
+ * <h2>Target keyspace and table</h2>
  *
  * If a keyspace was specified when creating the DAO (see {@link DaoFactory}), then the generated
  * query targets that keyspace. Otherwise, it doesn't specify a keyspace, and will only work if the

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/GetEntity.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/GetEntity.java
@@ -53,7 +53,7 @@ import java.lang.annotation.Target;
  * <p>It does not perform a query. Instead, those methods are intended for cases where you already
  * have a query result, and just need the conversion logic.
  *
- * <h3>Parameters</h3>
+ * <h2>Parameters</h2>
  *
  * The method must have a single parameter. The following types are allowed:
  *
@@ -67,7 +67,7 @@ import java.lang.annotation.Target;
  * The data must match the target entity: the generated code will try to extract every mapped
  * property, and fail if one is missing.
  *
- * <h3>Return type</h3>
+ * <h2>Return type</h2>
  *
  * The method can return:
  *

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Increment.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Increment.java
@@ -56,7 +56,7 @@ import java.util.function.UnaryOperator;
  * }
  * </pre>
  *
- * <h3>Parameters</h3>
+ * <h2>Parameters</h2>
  *
  * The entity class must be specified with {@link #entityClass()}.
  *
@@ -90,12 +90,12 @@ import java.util.function.UnaryOperator;
  * parameter. It will be applied to the statement before execution. This allows you to customize
  * certain aspects of the request (page size, timeout, etc) at runtime.
  *
- * <h3>Return type</h3>
+ * <h2>Return type</h2>
  *
  * <p>The method can return {@code void}, a void {@link CompletionStage} or {@link
  * CompletableFuture}, or a {@link ReactiveResultSet}.
  *
- * <h3>Target keyspace and table</h3>
+ * <h2>Target keyspace and table</h2>
  *
  * <p>If a keyspace was specified when creating the DAO (see {@link DaoFactory}), then the generated
  * query targets that keyspace. Otherwise, it doesn't specify a keyspace, and will only work if the

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Insert.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Insert.java
@@ -46,7 +46,7 @@ import java.util.function.UnaryOperator;
  * }
  * </pre>
  *
- * <h3>Parameters</h3>
+ * <h2>Parameters</h2>
  *
  * The first parameter must be the entity to insert.
  *
@@ -64,7 +64,7 @@ import java.util.function.UnaryOperator;
  * parameter. It will be applied to the statement before execution. This allows you to customize
  * certain aspects of the request (page size, timeout, etc) at runtime.
  *
- * <h3>Return type</h3>
+ * <h2>Return type</h2>
  *
  * The method can return:
  *
@@ -120,7 +120,7 @@ import java.util.function.UnaryOperator;
  *   <li>a {@linkplain MapperResultProducer custom type}.
  * </ul>
  *
- * <h3>Target keyspace and table</h3>
+ * <h2>Target keyspace and table</h2>
  *
  * If a keyspace was specified when creating the DAO (see {@link DaoFactory}), then the generated
  * query targets that keyspace. Otherwise, it doesn't specify a keyspace, and will only work if the

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Query.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Query.java
@@ -53,7 +53,7 @@ import java.util.function.UnaryOperator;
  *
  * This is the equivalent of what was called "accessor methods" in the driver 3 mapper.
  *
- * <h3>Parameters</h3>
+ * <h2>Parameters</h2>
  *
  * The query string provided in {@link #value()} will typically contain CQL placeholders. The
  * method's parameters must match those placeholders: same name and a compatible Java type.
@@ -68,7 +68,7 @@ import java.util.function.UnaryOperator;
  * parameter. It will be applied to the statement before execution. This allows you to customize
  * certain aspects of the request (page size, timeout, etc) at runtime.
  *
- * <h3>Return type</h3>
+ * <h2>Return type</h2>
  *
  * The method can return:
  *
@@ -98,7 +98,7 @@ import java.util.function.UnaryOperator;
  *   <li>a {@linkplain MapperResultProducer custom type}.
  * </ul>
  *
- * <h3>Target keyspace and table</h3>
+ * <h2>Target keyspace and table</h2>
  *
  * To avoid hard-coding the keyspace and table name, the query string supports 3 additional
  * placeholders: {@code ${keyspaceId}}, {@code ${tableId}} and {@code ${qualifiedTableId}}. They get

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Select.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Select.java
@@ -46,7 +46,7 @@ import java.util.function.UnaryOperator;
  * }
  * </pre>
  *
- * <h3>Parameters</h3>
+ * <h2>Parameters</h2>
  *
  * If {@link #customWhereClause()} is empty, the mapper defaults to a selection by primary key
  * (partition key + clustering columns). The method's parameters must match the types of the primary
@@ -85,7 +85,7 @@ import java.util.function.UnaryOperator;
  * parameter. It will be applied to the statement before execution. This allows you to customize
  * certain aspects of the request (page size, timeout, etc) at runtime.
  *
- * <h3>Return type</h3>
+ * <h2>Return type</h2>
  *
  * <p>In all cases, the method can return:
  *
@@ -130,7 +130,7 @@ import java.util.function.UnaryOperator;
  *   <li>a {@linkplain MapperResultProducer custom type}.
  * </ul>
  *
- * <h3>Target keyspace and table</h3>
+ * <h2>Target keyspace and table</h2>
  *
  * If a keyspace was specified when creating the DAO (see {@link DaoFactory}), then the generated
  * query targets that keyspace. Otherwise, it doesn't specify a keyspace, and will only work if the

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/SetEntity.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/SetEntity.java
@@ -49,7 +49,7 @@ import java.lang.annotation.Target;
  * It does not perform a query. Instead, those methods are intended for cases where you will execute
  * the query yourself, and just need the conversion logic.
  *
- * <h3>Parameters</h3>
+ * <h2>Parameters</h2>
  *
  * The method must have two parameters: one is the entity instance, the other must be a subtype of
  * {@link SettableByName} (the most likely candidates are {@link BoundStatement}, {@link
@@ -58,7 +58,7 @@ import java.lang.annotation.Target;
  *
  * <p>The order of the parameters does not matter.
  *
- * <h3>Return type</h3>
+ * <h2>Return type</h2>
  *
  * The method can either be void, or return the exact same type as its settable parameter.
  *

--- a/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Update.java
+++ b/mapper-runtime/src/main/java/com/datastax/oss/driver/api/mapper/annotations/Update.java
@@ -47,7 +47,7 @@ import java.util.function.UnaryOperator;
  * }
  * </pre>
  *
- * <h3>Parameters</h3>
+ * <h2>Parameters</h2>
  *
  * <p>The first parameter must be an entity instance. All of its non-PK properties will be
  * interpreted as values to update.
@@ -86,7 +86,7 @@ import java.util.function.UnaryOperator;
  * parameter. It will be applied to the statement before execution. This allows you to customize
  * certain aspects of the request (page size, timeout, etc) at runtime.
  *
- * <h3>Return type</h3>
+ * <h2>Return type</h2>
  *
  * <p>The method can return:
  *
@@ -133,7 +133,7 @@ import java.util.function.UnaryOperator;
  *   <li>a {@linkplain MapperResultProducer custom type}.
  * </ul>
  *
- * <h3>Target keyspace and table</h3>
+ * <h2>Target keyspace and table</h2>
  *
  * <p>If a keyspace was specified when creating the DAO (see {@link DaoFactory}), then the generated
  * query targets that keyspace. Otherwise, it doesn't specify a keyspace, and will only work if the

--- a/osgi-tests/pom.xml
+++ b/osgi-tests/pom.xml
@@ -159,6 +159,32 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>process-annotations</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.datastax.oss</groupId>
+                  <artifactId>java-driver-mapper-processor</artifactId>
+                  <version>${project.version}</version>
+                </path>
+                <path>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-nop</artifactId>
+                  <version>${slf4j.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.servicemix.tooling</groupId>
         <artifactId>depends-maven-plugin</artifactId>
         <version>1.4.0</version>
@@ -220,7 +246,6 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <jvm>${testing.jvm}/bin/java</jvm>
           <systemPropertyVariables>
             <logback.configurationFile>${project.basedir}/src/test/resources/logback-test.xml</logback.configurationFile>
           </systemPropertyVariables>
@@ -238,7 +263,6 @@
           </execution>
         </executions>
         <configuration>
-          <jvm>${testing.jvm}/bin/java</jvm>
           <systemPropertyVariables>
             <logback.configurationFile>${project.basedir}/src/test/resources/logback-test.xml</logback.configurationFile>
           </systemPropertyVariables>

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/BundleOptions.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/BundleOptions.java
@@ -152,9 +152,10 @@ public class BundleOptions {
                 .overwriteManifest(WrappedUrlProvisionOption.OverwriteMode.FULL),
             // Note: the versions below are hard-coded because they shouldn't change very often,
             // but if the tests fail because of them, we should consider parameterizing them
-            mavenBundle("com.sun.mail", "mailapi", "1.6.4"),
+            mavenBundle("com.sun.activation", "jakarta.activation", "2.0.1"),
+            mavenBundle("com.sun.mail", "mailapi", "2.0.1"),
             mavenBundle("org.apache.commons", "commons-text", "1.8"),
-            mavenBundle("org.apache.commons", "commons-configuration2", "2.7"),
+            mavenBundle("org.apache.commons", "commons-configuration2", "2.9.0"),
             CoreOptions.wrappedBundle(mavenBundle("commons-logging", "commons-logging", "1.1.1"))
                 .exports("org.apache.commons.logging.*")
                 .bundleVersion("1.1.1")

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <junit.version>4.13.2</junit.version>
     <logback.version>1.2.3</logback.version>
     <osgi.version>6.0.0</osgi.version>
-    <felix.version>6.0.3</felix.version>
+    <felix.version>7.0.1</felix.version>
     <pax-exam.version>4.13.4</pax-exam.version>
     <simulacron.version>0.11.0</simulacron.version>
     <jsr353-api.version>1.1.4</jsr353-api.version>
@@ -81,8 +81,12 @@
     <apacheds.version>2.0.0-M19</apacheds.version>
     <surefire.version>2.22.2</surefire.version>
     <graalapi.version>22.0.0.2</graalapi.version>
+    <error-prone.version>2.3.4</error-prone.version>
+    <api-plumber-doclet.version>1.0.0</api-plumber-doclet.version>
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
+    <!-- For custom `leaks-private-api` tag (apparently dash separators are not handled correctly) -->
+    <javadoc-leak-tag>leaks</javadoc-leak-tag>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -577,37 +581,6 @@
     </pluginManagement>
     <plugins>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <compilerId>javac-with-errorprone</compilerId>
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-          <source>1.8</source>
-          <target>1.8</target>
-          <compilerArgs combine.children="override">
-            <compilerArg>-Xep:FutureReturnValueIgnored:OFF</compilerArg>
-            <compilerArg>-Xep:PreferJavaTimeOverload:OFF</compilerArg>
-            <compilerArg>-Xep:AnnotateFormatMethod:OFF</compilerArg>
-            <compilerArg>-Xep:WildcardImport:WARN</compilerArg>
-            <compilerArg>-XepExcludedPaths:.*/target/(?:generated-sources|generated-test-sources)/.*</compilerArg>
-          </compilerArgs>
-          <showWarnings>true</showWarnings>
-          <failOnWarning>true</failOnWarning>
-          <useIncrementalCompilation>false</useIncrementalCompilation>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>2.8.6</version>
-          </dependency>
-          <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <version>2.3.4</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
         <executions>
@@ -759,12 +732,8 @@ limitations under the License.]]></inlineHeader>
               <placement>a</placement>
               <head>API note:</head>
             </tag>
-            <!--
-              For custom `leaks-private-api` tag (apparently dash separators are not handled
-              correctly)
-            -->
             <tag>
-              <name>leaks</name>
+              <name>${javadoc-leak-tag}</name>
               <placement>X</placement>
             </tag>
           </tags>
@@ -804,12 +773,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
               <docletArtifact>
                 <groupId>com.datastax.oss</groupId>
                 <artifactId>api-plumber-doclet</artifactId>
-                <version>1.0.0</version>
+                <version>${api-plumber-doclet.version}</version>
               </docletArtifact>
               <additionalJOptions>
                 <!-- API types do not leak internal types -->
                 <additionalparam>-preventleak</additionalparam>
                 <additionalparam>com.datastax.oss.driver.internal</additionalparam>
+                <additionalparam>-preventleak</additionalparam>
                 <additionalparam>com.datastax.dse.driver.internal</additionalparam>
                 <!-- Shaded dependencies (Guava, Netty, etc.) -->
                 <additionalparam>-preventleak</additionalparam>
@@ -936,56 +906,98 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <revapi.skip>true</revapi.skip>
       </properties>
     </profile>
-    <!-- Use $JAVA_HOME as the default JDK to run surefire/failsafe to maintain portability -->
     <profile>
-      <id>test-jdk-environment</id>
+      <id>build-java-8</id>
       <activation>
-        <property>
-          <name>!testJavaHome</name>
-        </property>
+        <jdk>[,8)</jdk>
       </activation>
-      <properties>
-        <testing.jvm>${env.JAVA_HOME}</testing.jvm>
-      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerId>javac-with-errorprone</compilerId>
+              <forceJavacCompilerUse>true</forceJavacCompilerUse>
+              <source>1.8</source>
+              <target>1.8</target>
+              <compilerArgs combine.children="override">
+                <compilerArg>-Xep:FutureReturnValueIgnored:OFF</compilerArg>
+                <compilerArg>-Xep:PreferJavaTimeOverload:OFF</compilerArg>
+                <compilerArg>-Xep:AnnotateFormatMethod:OFF</compilerArg>
+                <compilerArg>-Xep:WildcardImport:WARN</compilerArg>
+                <compilerArg>-XepExcludedPaths:.*/target/(?:generated-sources|generated-test-sources)/.*</compilerArg>
+              </compilerArgs>
+              <showWarnings>true</showWarnings>
+              <failOnWarning>true</failOnWarning>
+              <useIncrementalCompilation>false</useIncrementalCompilation>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                <version>2.8.6</version>
+              </dependency>
+              <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_core</artifactId>
+                <version>2.3.4</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
-    <!-- set -DtestJavaHome=/path/to/jdk/home to use a different JDK for surefire/failsafe -->
     <profile>
-      <id>test-jdk-specified</id>
-      <activation>
-        <property>
-          <name>testJavaHome</name>
-        </property>
-      </activation>
-      <properties>
-        <testing.jvm>${testJavaHome}</testing.jvm>
-      </properties>
-    </profile>
-    <profile>
-      <!-- workarounds for running tests with JDK1.8 -->
-      <id>test-jdk-8</id>
-      <activation>
-        <jdk>[8,)</jdk>
-      </activation>
-    </profile>
-    <profile>
-      <!-- workarounds for running tests with JDK11 -->
-      <id>test-jdk-11</id>
+      <id>build-java-11</id>
       <activation>
         <jdk>[11,)</jdk>
       </activation>
-    </profile>
-    <profile>
-      <!-- workarounds for running tests with JDK17 -->
-      <id>test-jdk-17</id>
-      <activation>
-        <jdk>[17,)</jdk>
-      </activation>
       <properties>
+        <error-prone.version>2.19.1</error-prone.version>
+        <api-plumber-doclet.version>2.0.0</api-plumber-doclet.version>
+        <javadoc-leak-tag>leaks-private-api</javadoc-leak-tag>
         <!-- for DriverBlockHoundIntegrationIT when using JDK 13+, see https://github.com/reactor/BlockHound/issues/33 -->
         <blockhound.argline>-XX:+AllowRedefinitionToAddDeleteMethods</blockhound.argline>
         <!-- allow deep reflection for mockito when using JDK 17+, see https://stackoverflow.com/questions/70993863/mockito-can-not-mock-random-in-java-17 -->
         <mockitoopens.argline>--add-opens java.base/jdk.internal.util.random=ALL-UNNAMED</mockitoopens.argline>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <forceJavacCompilerUse>true</forceJavacCompilerUse>
+              <release>8</release>
+              <encoding>UTF-8</encoding>
+              <compilerArgs combine.children="override">
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>-Xplugin:ErrorProne -Xep:FutureReturnValueIgnored:OFF -Xep:PreferJavaTimeOverload:OFF -Xep:AnnotateFormatMethod:OFF -Xep:MissingSummary:OFF -Xep:InvalidBlockTag:OFF -Xep:OptionalMapUnusedValue:OFF -Xep:ReturnValueIgnored:OFF -Xep:BanJNDI:OFF -Xep:InlineMeSuggester:OFF -Xep:StringSplitter:OFF -Xep:JavaUtilDate:OFF -Xep:ObjectEqualsForPrimitives:OFF -Xep:EmptyCatch:OFF -Xep:ProtectedMembersInFinalClass:OFF -Xep:StringCaseLocaleUsage:OFF -Xep:MutablePublicArray:OFF -Xep:DirectInvocationOnMock:OFF -Xep:MockNotUsedInProduction:OFF -Xep:LongDoubleConversion:OFF -Xep:EmptyBlockTag:OFF -Xep:AlmostJavadoc:OFF -Xep:DoNotClaimAnnotations:OFF -Xep:BadImport:OFF -Xep:DefaultCharset:OFF -Xep:UseCorrectAssertInTests:OFF -Xep:NarrowCalculation:OFF -Xep:WildcardImport:WARN -XepExcludedPaths:.*/target/(?:generated-sources|generated-test-sources)/.*</arg>
+              </compilerArgs>
+              <annotationProcessorPaths combine.children="append">
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${error-prone.version}</version>
+                </path>
+              </annotationProcessorPaths>
+              <showWarnings>true</showWarnings>
+              <failOnWarning>true</failOnWarning>
+              <useIncrementalCompilation>false</useIncrementalCompilation>
+              <fork>true</fork>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
   <distributionManagement>


### PR DESCRIPTION
Details:
- Update to api-plumber-doclet 2.0.0
- Add org.jetbrains:annotations as additionalDependency for core-shaded
- Refactor table summary tag as caption element to conform to HTML5
- Refactor &lt;h3> usage to &lt;h2> to conform to heading tag ordering for HTML5
- Explicitly define annotationProcessorPaths for mapper-processor, slf4j-nop and gremlin-core
- [java11+] Upgrade errorprone to 2.19.1
- [java11+] Update custom javadoc leaks tag to full string: leaks-private-api
- Add build-java<span>-</span>8 profile for compiling with java 8
- Add build-java<span>-</span>11 profile for compiling with java 11
- [java11+] Exclude many new error prone checks enabled by default in the new version (see JAVA-3102)
- [java11+] Use release=8 instead of source/target=1.8 to automatically select correct bootstrap path
- [java11+] Use fork=true with maven-compiler-plugin to pick up compilerArgs
- [java11+] Load error-prone plugin using annotationProcessorPaths, per documentation guidance
- Refactor Jenkinsfile to compile project with the Java version selected in the pipeline matrix
- Remove test-jdk profiles and surefire/failsafe JVM overrides added in JAVA-3042
- Update org.apache.felix.framework to 7.0.1 to support java17 without forking new JVM (FELIX-6287)
- Update commons-configuration2 in OSGi BundleOptions to 2.9.0 for java11
- [java11+] Set JAVA_HOME=JAVA8_HOME in CcmBridge if using DSE which only supports java8