### PR TITLE
Include support for comma seperated strings for basic.contact-points

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/SessionBuilder.java
@@ -55,6 +55,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -856,8 +857,16 @@ public abstract class SessionBuilder<SelfT extends SessionBuilder, SessionT> {
           cloudConfigInputStream = () -> getURL(configUrlString).openStream();
         }
       }
-      List<String> configContactPoints =
-          defaultConfig.getStringList(DefaultDriverOption.CONTACT_POINTS, Collections.emptyList());
+      List<String> configContactPoints;
+      if (defaultConfig.getString(DefaultDriverOption.CONTACT_POINTS).contains(",")) {
+        configContactPoints =
+            Arrays.asList(
+                defaultConfig.getString(DefaultDriverOption.CONTACT_POINTS, "").split(","));
+      } else {
+        configContactPoints =
+            defaultConfig.getStringList(
+                DefaultDriverOption.CONTACT_POINTS, Collections.emptyList());
+      }
       if (cloudConfigInputStream != null) {
         if (!programmaticContactPoints.isEmpty() || !configContactPoints.isEmpty()) {
           LOG.info(

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -20,9 +20,9 @@ datastax-java-driver {
   # automatically), but it is usually a good idea to provide more than one contact point, because if
   # that single contact point is unavailable, the driver cannot initialize itself correctly.
   #
-  # This must be a list of strings with each contact point specified as "host:port". If the host is
-  # a DNS name that resolves to multiple A-records, all the corresponding addresses will be used. Do
-  # not use "localhost" as the host name (since it resolves to both IPv4 and IPv6 addresses on some
+  # This must be a list of strings or a comma seperated string with each contact point specified as "host:port".
+  # If the host is a DNS name that resolves to multiple A-records, all the corresponding addresses will be used.
+  # Do not use "localhost" as the host name (since it resolves to both IPv4 and IPv6 addresses on some
   # platforms).
   #
   # Note that Cassandra 3 and below requires all nodes in a cluster to share the same port (see
@@ -36,6 +36,7 @@ datastax-java-driver {
   # Modifiable at runtime: no
   # Overridable in a profile: no
   // basic.contact-points = [ "127.0.0.1:9042", "127.0.0.2:9042" ]
+  // basic.contact-points = "127.0.0.1:9042,127.0.0.2:9042"
 
   # A name that uniquely identifies the driver instance created from this configuration. This is
   # used as a prefix for log messages and metrics.


### PR DESCRIPTION
The motivation for the PR is that in my project while using environment variables for the configuration via a Helm chart, I am unable to pass an array as an environment variable because it ends up as a string in the application configuration. Please let me know if I missed anything in the PR.