### PR TITLE
JAVA-3103: Update shaded-guava/guava to 32.0.1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -76,7 +76,7 @@
       <dependency>
         <groupId>com.datastax.oss</groupId>
         <artifactId>java-driver-shaded-guava</artifactId>
-        <version>25.1-jre-graal-sub-1</version>
+        <version>32.0.1-jre-graal-sub-1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/cql/reactive/TestSubscriber.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/cql/reactive/TestSubscriber.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.dse.driver.internal.core.cql.reactive;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
 import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
@@ -79,7 +80,9 @@ public class TestSubscriber<T> implements Subscriber<T> {
   }
 
   public void awaitTermination() {
-    Uninterruptibles.awaitUninterruptibly(latch, 1, TimeUnit.MINUTES);
-    if (latch.getCount() > 0) fail("subscriber not terminated");
+    assertThat(Uninterruptibles.awaitUninterruptibly(latch, 1, TimeUnit.MINUTES))
+        .withFailMessage("latch await failed, subscriber not terminated")
+        .isTrue();
+    assertThat(latch.getCount()).withFailMessage("subscriber not terminated").isGreaterThan(0);
   }
 }

--- a/mapper-runtime/src/test/java/com/datastax/dse/driver/api/mapper/reactive/TestSubscriber.java
+++ b/mapper-runtime/src/test/java/com/datastax/dse/driver/api/mapper/reactive/TestSubscriber.java
@@ -15,6 +15,8 @@
  */
 package com.datastax.dse.driver.api.mapper.reactive;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -68,6 +70,9 @@ public class TestSubscriber<T> implements Subscriber<T> {
   }
 
   public void awaitTermination() {
-    Uninterruptibles.awaitUninterruptibly(latch, 1, TimeUnit.MINUTES);
+    assertThat(Uninterruptibles.awaitUninterruptibly(latch, 1, TimeUnit.MINUTES))
+        .withFailMessage("latch await failed, subscriber not terminated")
+        .isTrue();
+    assertThat(latch.getCount()).withFailMessage("subscriber not terminated").isGreaterThan(0);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <!-- Only for integration tests, use the shaded JAR for production code -->
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>25.1-jre</version>
+        <version>32.0.1-jre</version>
       </dependency>
       <dependency>
         <groupId>com.typesafe</groupId>


### PR DESCRIPTION
Depends on https://github.com/datastax/java-driver-shaded-guava/pull/11 + new version of shaded-guava being published