### PR TITLE
JAVA-3099: Fix failing integration tests

### DIFF
--- a/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/CCMTestsSupport.java
@@ -56,6 +56,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.ITestResult;
+import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -1135,6 +1136,15 @@ public class CCMTestsSupport {
       Constructor<?> constructor = clazz.getDeclaredConstructor(enclosingClass);
       constructor.setAccessible(true);
       return (T) constructor.newInstance(enclosingInstance);
+    }
+  }
+
+  protected void skipTestWithCassandraVersionOrHigher(String version, String testKind) {
+    if (CCMBridge.getGlobalCassandraVersion().compareTo(VersionNumber.parse(version)) >= 0) {
+      throw new SkipException(
+          String.format(
+              "%s tests not applicable to cassandra version >= %s (configured: %s)",
+              testKind, version, CCMBridge.getGlobalCassandraVersion()));
     }
   }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ClusterInitTest.java
@@ -107,6 +107,8 @@ public class ClusterInitTest {
       cluster =
           Cluster.builder()
               .withPort(scassandra.getBinaryPort())
+              // scassandra supports max V4 protocol
+              .withProtocolVersion(ProtocolVersion.V4)
               .addContactPoints(
                   ipOfNode(1),
                   failingHosts.get(0).address,

--- a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
@@ -52,7 +52,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.log4j.Level;
-import org.junit.Ignore;
 import org.scassandra.http.client.PrimingClient;
 import org.scassandra.http.client.PrimingRequest;
 import org.scassandra.http.client.Result;
@@ -335,11 +334,17 @@ public class ControlConnectionTest extends CCMTestsSupport {
       cluster.init();
 
       InetAddress node2Address = scassandraCluster.address(2).getAddress();
+      String invalidValues =
+          withPeersV2
+              ? columnData
+              : String.format(
+                  "missing native_transport_address, missing native_transport_port, missing native_transport_port_ssl, %s",
+                  columnData);
       String expectedError =
           String.format(
               "Found invalid row in system.peers: [peer=%s, %s]. "
                   + "This is likely a gossip or snitch issue, this host will be ignored.",
-              node2Address, columnData);
+              node2Address, invalidValues);
       String log = logs.get();
       // then: A peer with a null rack should not show up in host metadata, unless allowed via
       // system property.
@@ -614,9 +619,8 @@ public class ControlConnectionTest extends CCMTestsSupport {
    * be selected if the Cluster is created with SSL support (i.e. if {@link
    * Cluster.Builder#withSSL()} is used).
    */
-  @Test(groups = "short")
+  @Test(groups = "short", enabled = false /* Requires SSL support in scassandra */)
   @CCMConfig(createCcm = false)
-  @Ignore("Requires SSL support in scassandra")
   public void should_extract_hosts_using_native_transport_address_port_ssl_from_peers()
       throws UnknownHostException {
 

--- a/driver-core/src/test/java/com/datastax/driver/core/DirectCompressionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/DirectCompressionTest.java
@@ -29,6 +29,7 @@ public class DirectCompressionTest extends CompressionTest {
    */
   @Test(groups = "short")
   public void should_function_with_snappy_compression() throws Exception {
+    skipTestWithCassandraVersionOrHigher("4.0.0", "snappy");
     compressionTest(ProtocolOptions.Compression.SNAPPY);
   }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/HeapCompressionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/HeapCompressionTest.java
@@ -37,6 +37,7 @@ public class HeapCompressionTest extends CompressionTest {
    */
   @Test(groups = "isolated")
   public void should_function_with_snappy_compression() throws Exception {
+    skipTestWithCassandraVersionOrHigher("4.0.0", "snappy");
     compressionTest(ProtocolOptions.Compression.SNAPPY);
   }
 

--- a/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyBootstrapTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/LoadBalancingPolicyBootstrapTest.java
@@ -57,10 +57,13 @@ public class LoadBalancingPolicyBootstrapTest extends CCMTestsSupport {
     try {
       cluster.init();
 
+      // To support astra, only hosts in Metadata#getContactPoints are passed to init()
+      // TestUtils#configureClusterBuilder only uses the first host as the contact point
+      // Remaining hosts are learned after connection via onAdd()
       assertThat(policy.history)
           .containsOnly(
               entry(INIT, TestUtils.findHost(cluster, 1)),
-              entry(INIT, TestUtils.findHost(cluster, 2)));
+              entry(ADD, TestUtils.findHost(cluster, 2)));
     } finally {
       cluster.close();
     }

--- a/driver-core/src/test/java/com/datastax/driver/core/OPPTokenIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/OPPTokenIntegrationTest.java
@@ -28,4 +28,10 @@ public class OPPTokenIntegrationTest extends TokenIntegrationTest {
   protected Token.Factory tokenFactory() {
     return OPPToken.FACTORY;
   }
+
+  @Override
+  public void beforeTestClass(Object testInstance) throws Exception {
+    skipTestWithCassandraVersionOrHigher("4.0.0", "ByteOrderedPartitioner");
+    super.beforeTestClass(testInstance);
+  }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/OPPTokenVnodeIntegrationTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/OPPTokenVnodeIntegrationTest.java
@@ -26,4 +26,10 @@ public class OPPTokenVnodeIntegrationTest extends TokenIntegrationTest {
   protected Token.Factory tokenFactory() {
     return Token.OPPToken.FACTORY;
   }
+
+  @Override
+  public void beforeTestClass(Object testInstance) throws Exception {
+    skipTestWithCassandraVersionOrHigher("4.0.0", "ByteOrderedPartitioner");
+    super.beforeTestClass(testInstance);
+  }
 }

--- a/driver-core/src/test/java/com/datastax/driver/core/exceptions/ExceptionsScassandraTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/exceptions/ExceptionsScassandraTest.java
@@ -78,7 +78,7 @@ public class ExceptionsScassandraTest extends ScassandraTestBase {
     } catch (ReadTimeoutException e) {
       assertThat(e.getMessage())
           .isEqualTo(
-              "Cassandra timeout during read query at consistency LOCAL_ONE (1 responses were required but only 0 replica responded)");
+              "Cassandra timeout during read query at consistency LOCAL_ONE (1 responses were required but only 0 replica responded). In case this was generated during read repair, the consistency level is not representative of the actual consistency.");
       assertThat(e.getConsistencyLevel()).isEqualTo(LOCAL_ONE);
       assertThat(e.getReceivedAcknowledgements()).isEqualTo(0);
       assertThat(e.getRequiredAcknowledgements()).isEqualTo(1);

--- a/driver-tests/osgi/pom.xml
+++ b/driver-tests/osgi/pom.xml
@@ -180,6 +180,9 @@
                         <jackson.version>${jackson.version}</jackson.version>
                         <jackson-databind.version>${jackson-databind.version}</jackson-databind.version>
                         <ipprefix>${ipprefix}</ipprefix>
+                        <org.ops4j.pax.url.mvn.useFallbackRepositories>false</org.ops4j.pax.url.mvn.useFallbackRepositories>
+                        <!-- repo1.maven.org requires https but the old version of pax-exam we use hard-codes http -->
+                        <org.ops4j.pax.url.mvn.repositories>https://repo1.maven.org/maven2@id=central</org.ops4j.pax.url.mvn.repositories>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/driver-tests/osgi/src/main/java/com/datastax/driver/osgi/impl/Activator.java
+++ b/driver-tests/osgi/src/main/java/com/datastax/driver/osgi/impl/Activator.java
@@ -16,6 +16,7 @@
 package com.datastax.driver.osgi.impl;
 
 import static com.datastax.driver.core.ProtocolOptions.Compression.LZ4;
+import static com.datastax.driver.core.ProtocolOptions.Compression.SNAPPY;
 import static com.datastax.driver.osgi.api.MailboxMessage.TABLE;
 
 import com.datastax.driver.core.Cluster;
@@ -69,7 +70,10 @@ public class Activator implements BundleActivator {
     String compression = context.getProperty("cassandra.compression");
     if (compression != null) {
       if (ver.getMajor() < 2 && compression.equals(LZ4.name())) {
-        LOGGER.warn("Requested LZ4 compression but C* version is not compatible, disabling");
+        LOGGER.warn("Requested LZ4 compression but C* version < 2.0 is not compatible, disabling");
+      } else if (ver.getMajor() >= 4 && compression.equals(SNAPPY.name())) {
+        LOGGER.warn(
+            "Requested snappy compression but C* version >= 4.0 is not compatible, disabling");
       } else {
         LOGGER.info("Compression: {}", compression);
         builder.withCompression(ProtocolOptions.Compression.valueOf(compression));

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/BundleOptions.java
@@ -136,7 +136,9 @@ public class BundleOptions {
             mavenBundle("io.netty", "netty-codec", nettyVersion),
             mavenBundle("io.netty", "netty-common", nettyVersion),
             mavenBundle("io.netty", "netty-handler", nettyVersion),
-            mavenBundle("io.netty", "netty-transport", nettyVersion));
+            mavenBundle("io.netty", "netty-transport", nettyVersion),
+            mavenBundle("io.netty", "netty-transport-native-unix-common", nettyVersion),
+            mavenBundle("io.netty", "netty-resolver", nettyVersion));
       }
     };
   }

--- a/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceSnappyIT.java
+++ b/driver-tests/osgi/src/test/java/com/datastax/driver/osgi/MailboxServiceSnappyIT.java
@@ -25,10 +25,12 @@ import static com.datastax.driver.osgi.BundleOptions.nettyBundles;
 import static com.datastax.driver.osgi.BundleOptions.snappyBundle;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
+import com.datastax.driver.core.VersionNumber;
 import com.datastax.driver.osgi.api.MailboxException;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.testng.listener.PaxExam;
+import org.testng.SkipException;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -59,6 +61,10 @@ public class MailboxServiceSnappyIT extends MailboxServiceTests {
    */
   @Test(groups = "short")
   public void test_snappy() throws MailboxException {
+    VersionNumber ver = VersionNumber.parse(bundleContext.getProperty("cassandra.version"));
+    if (ver.getMajor() >= 4) {
+      throw new SkipException("Snappy not supported with cassandra 4.0+");
+    }
     checkService();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1141,6 +1141,7 @@ limitations under the License.
                 <netty-tcnative.artifact>netty-tcnative-boringssl-static</netty-tcnative.artifact>
                 <!-- https://github.com/jnr/jffi/pull/116 apple-silicon requires signed jffi binaries, added in 1.3.8 (jnr-ffi 2.2.10+) -->
                 <jnr-ffi.version>2.2.10</jnr-ffi.version>
+                <snappy.version>1.1.10.1</snappy.version>
             </properties>
 
         </profile>


### PR DESCRIPTION
should_extract_hosts_using_native_transport_address_port_ssl_from_peers
- use testng style ignore

should_function_with_snappy_compression
- skip for cassandra 4.0.0 and greater (not supported)

should_handle_failing_or_missing_contact_points
- use V4 protocol to avoid initial retry with default V5

should_ignore_and_warn_peers_with_null_entries_by_default
- encode expected "missing native_transport_*" strings when not using v2-style peers

should_init_policy_with_up_contact_points
- since adding SNI support for astra, only contact points will have state INIT

should_throw_proper_read_timeout_exception
- update expected error message string

should_throw_exception_when_frame_exceeds_configured_max
- use V4 protocol for cassandra 4.0+

OPPTokenIntegrationTest/OPPTokenVnodeIntegrationTest
- not applicable for cassandra 4.0+

MailboxServiceSnappyIT
- not applicable for cassandra 4.0+

osgi/BundleOptions
- add missing dependencies for recent library upgrades

override org.ops4j.pax.url.mvn.repositories in osgi tests because https is now required by maven central