### PR TITLE
JAVA-3001: Java Driver 4.13.0 - Memory leak when using C* 4.0.1 and protocol v5

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/SegmentToFrameDecoder.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/protocol/SegmentToFrameDecoder.java
@@ -15,6 +15,7 @@
  */
 package com.datastax.oss.driver.internal.core.protocol;
 
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import com.datastax.oss.protocol.internal.Frame;
 import com.datastax.oss.protocol.internal.FrameCodec;
 import com.datastax.oss.protocol.internal.Segment;
@@ -112,9 +113,7 @@ public class SegmentToFrameDecoder extends MessageToMessageDecoder<Segment<ByteB
       } finally {
         encodedFrame.release();
         // Reset our state
-        targetLength = UNKNOWN_LENGTH;
-        accumulatedSlices.clear();
-        accumulatedLength = 0;
+        resetState();
       }
       LOG.trace(
           "[{}] Decoded response frame {} from {} slices",
@@ -123,5 +122,23 @@ public class SegmentToFrameDecoder extends MessageToMessageDecoder<Segment<ByteB
           accumulatedSlicesSize);
       out.add(frame);
     }
+  }
+
+  private void resetState() {
+    targetLength = UNKNOWN_LENGTH;
+    accumulatedSlices.clear();
+    accumulatedLength = 0;
+  }
+
+  @Override
+  public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+    // release any accumulated segments and reset state
+    accumulatedSlices.forEach(ByteBuf::release);
+    resetState();
+  }
+
+  @VisibleForTesting
+  List<ByteBuf> getAccumulatedSlices() {
+    return accumulatedSlices;
   }
 }

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/protocol/SegmentToFrameDecoderTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/protocol/SegmentToFrameDecoderTest.java
@@ -32,7 +32,9 @@ import com.datastax.oss.protocol.internal.util.Bytes;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.embedded.EmbeddedChannel;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -46,11 +48,13 @@ public class SegmentToFrameDecoderTest {
           new ProtocolV5ServerCodecs());
 
   private EmbeddedChannel channel;
+  private SegmentToFrameDecoder segmentToFrameDecoder =
+      new SegmentToFrameDecoder(FRAME_CODEC, "test");
 
   @Before
   public void setup() {
     channel = new EmbeddedChannel();
-    channel.pipeline().addLast(new SegmentToFrameDecoder(FRAME_CODEC, "test"));
+    channel.pipeline().addLast(segmentToFrameDecoder);
   }
 
   @Test
@@ -65,6 +69,11 @@ public class SegmentToFrameDecoderTest {
     assertThat(frame1.message).isInstanceOf(Void.class);
     Frame frame2 = channel.readInbound();
     assertThat(frame2.message).isInstanceOf(AuthResponse.class);
+
+    // check decoder is not holding onto any segments
+    assertThat(segmentToFrameDecoder.getAccumulatedSlices())
+        .withFailMessage("Expected decoded to have no more partial frame segments")
+        .isEmpty();
   }
 
   @Test
@@ -80,6 +89,61 @@ public class SegmentToFrameDecoderTest {
 
     Frame frame = channel.readInbound();
     assertThat(frame.message).isInstanceOf(AuthResponse.class);
+
+    // check decoder is not holding onto any segments
+    assertThat(segmentToFrameDecoder.getAccumulatedSlices())
+        .withFailMessage("Expected decoded to have no more partial frame segments")
+        .isEmpty();
+  }
+
+  @Test
+  public void should_release_partial_frame_segments_on_channel_close() {
+    ByteBuf encodedFrame =
+        encodeFrame(new AuthResponse(Bytes.fromHexString("0x" + Strings.repeat("aa", 1011))));
+    int sliceLength = 100;
+    for (int i = 0; i < 5; i++) {
+      // intentionally make copies of the original frame so we can check reference counts later
+      ByteBuf payload = encodedFrame.readBytes(Math.min(sliceLength, encodedFrame.readableBytes()));
+      channel.writeInbound(new Segment<>(payload, false));
+    }
+
+    assertThat(encodedFrame.isReadable())
+        .withFailMessage("Expected remaining content in encoded frame")
+        .isTrue();
+
+    // read the segments that have been written so far (will give null response)
+    assertThat(channel.<Frame>readInbound())
+        .withFailMessage("Expected no frame to be decoded")
+        .isNull();
+
+    // make a copy of the segments we accumulated so we can check they are released later
+    // check correct number of partial frame segments have been accumulated
+    List<ByteBuf> segments = new ArrayList<>(segmentToFrameDecoder.getAccumulatedSlices());
+    assertThat(segments)
+        .withFailMessage("Expected correct number partial frame segments accumulated")
+        .hasSize(5);
+
+    // check segments have been released
+    for (ByteBuf segment : segments) {
+      assertThat(segment.refCnt())
+          .withFailMessage("Expected all partial frame segments to be live (not released)")
+          .isEqualTo(1);
+    }
+
+    // call channel close which will destroy the pipeline and call handlerRemoved on the decoder
+    channel.close();
+
+    // check decoder is not holding onto any segments
+    assertThat(segmentToFrameDecoder.getAccumulatedSlices())
+        .withFailMessage("Expected decoded to have no more partial frame segments")
+        .isEmpty();
+
+    // check segments we got from the decoder earlier have been released
+    for (ByteBuf segment : segments) {
+      assertThat(segment.refCnt())
+          .withFailMessage("Expected all partial frame segments to be released")
+          .isZero();
+    }
   }
 
   private static ByteBuf encodeFrame(Message message) {


### PR DESCRIPTION
SegmentToFrameDecoder.java
- release any accumulated segements when handler is removed from pipeline

SegmentToFrameDecoderTest.java
- add test to check partially accumulated segments are released when channel is closed