### PR TITLE
JAVA-3116: update surefire/failsafe to 3.0.0 to fix issue running tests with specified jvm

### DIFF
--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/BundleOptions.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/BundleOptions.java
@@ -152,9 +152,10 @@ public class BundleOptions {
                 .overwriteManifest(WrappedUrlProvisionOption.OverwriteMode.FULL),
             // Note: the versions below are hard-coded because they shouldn't change very often,
             // but if the tests fail because of them, we should consider parameterizing them
-            mavenBundle("com.sun.mail", "mailapi", "1.6.4"),
+            mavenBundle("com.sun.activation", "jakarta.activation", "2.0.1"),
+            mavenBundle("com.sun.mail", "mailapi", "2.0.1"),
             mavenBundle("org.apache.commons", "commons-text", "1.8"),
-            mavenBundle("org.apache.commons", "commons-configuration2", "2.7"),
+            mavenBundle("org.apache.commons", "commons-configuration2", "2.9.0"),
             CoreOptions.wrappedBundle(mavenBundle("commons-logging", "commons-logging", "1.1.1"))
                 .exports("org.apache.commons.logging.*")
                 .bundleVersion("1.1.1")

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,9 @@
     <junit.version>4.13.2</junit.version>
     <logback.version>1.2.3</logback.version>
     <osgi.version>6.0.0</osgi.version>
-    <felix.version>6.0.3</felix.version>
+    <felix.version>7.0.1</felix.version>
     <pax-exam.version>4.13.4</pax-exam.version>
+    <pax-url.version>2.6.4</pax-url.version>
     <simulacron.version>0.11.0</simulacron.version>
     <jsr353-api.version>1.1.4</jsr353-api.version>
     <jersey.version>2.31</jersey.version>
@@ -79,7 +80,7 @@
     <rxjava.version>2.2.2</rxjava.version>
     <awaitility.version>4.0.3</awaitility.version>
     <apacheds.version>2.0.0-M19</apacheds.version>
-    <surefire.version>2.22.2</surefire.version>
+    <surefire.version>3.0.0</surefire.version>
     <graalapi.version>22.0.0.2</graalapi.version>
     <skipTests>false</skipTests>
     <skipUnitTests>${skipTests}</skipUnitTests>
@@ -269,12 +270,17 @@
       <dependency>
         <groupId>org.ops4j.pax.url</groupId>
         <artifactId>pax-url-wrap</artifactId>
-        <version>2.6.3</version>
+        <version>${pax-url.version}</version>
       </dependency>
       <dependency>
         <groupId>org.ops4j.pax.url</groupId>
         <artifactId>pax-url-reference</artifactId>
-        <version>2.6.2</version>
+        <version>${pax-url.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.tinybundles</groupId>
+        <artifactId>tinybundles</artifactId>
+        <version>3.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish</groupId>

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
@@ -44,6 +44,7 @@ import org.apache.commons.exec.ExecuteWatchdog;
 import org.apache.commons.exec.Executor;
 import org.apache.commons.exec.LogOutputStream;
 import org.apache.commons.exec.PumpStreamHandler;
+import org.assertj.core.util.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -267,8 +268,11 @@ public class CcmBridge implements AutoCloseable {
 
   public void start() {
     if (started.compareAndSet(false, true)) {
+      List<String> cmdAndArgs = Lists.newArrayList("start", jvmArgs, "--wait-for-binary-proto");
+      overrideJvmVersionForDseWorkloads()
+          .ifPresent(jvmVersion -> cmdAndArgs.add(String.format("--jvm_version=%d", jvmVersion)));
       try {
-        execute("start", jvmArgs, "--wait-for-binary-proto");
+        execute(cmdAndArgs.toArray(new String[0]));
       } catch (RuntimeException re) {
         // if something went wrong starting CCM, see if we can also dump the error
         executeCheckLogError();
@@ -296,7 +300,10 @@ public class CcmBridge implements AutoCloseable {
   }
 
   public void start(int n) {
-    execute("node" + n, "start");
+    List<String> cmdAndArgs = Lists.newArrayList("node" + n, "start");
+    overrideJvmVersionForDseWorkloads()
+        .ifPresent(jvmVersion -> cmdAndArgs.add(String.format("--jvm_version=%d", jvmVersion)));
+    execute(cmdAndArgs.toArray(new String[0]));
   }
 
   public void stop(int n) {
@@ -414,6 +421,44 @@ public class CcmBridge implements AutoCloseable {
       LOG.warn("Failure to write keystore, SSL-enabled servers may fail to start.", e);
     }
     return f;
+  }
+
+  /**
+   * Get the current JVM major version (1.8.0_372 -> 8, 11.0.19 -> 11)
+   *
+   * @return major version of current JVM
+   */
+  private static int getCurrentJvmMajorVersion() {
+    String version = System.getProperty("java.version");
+    if (version.startsWith("1.")) {
+      version = version.substring(2, 3);
+    } else {
+      int dot = version.indexOf(".");
+      if (dot != -1) {
+        version = version.substring(0, dot);
+      }
+    }
+    return Integer.parseInt(version);
+  }
+
+  private Optional<Integer> overrideJvmVersionForDseWorkloads() {
+    if (getCurrentJvmMajorVersion() <= 8) {
+      return Optional.empty();
+    }
+
+    if (!DSE_ENABLEMENT || !getDseVersion().isPresent()) {
+      return Optional.empty();
+    }
+
+    if (getDseVersion().get().compareTo(Version.parse("6.8.19")) < 0) {
+      return Optional.empty();
+    }
+
+    if (dseWorkloads.contains("graph")) {
+      return Optional.of(8);
+    }
+
+    return Optional.empty();
   }
 
   public static Builder builder() {


### PR DESCRIPTION
Additionally:
- Set --jvm_version=8 when running dse 6.8.19+ with graph workloads (DSP-23501)
- Update commons-configuration2 to 2.9.0 + deps in BundleOptions to support java17
- Update felix framework version to 7.0.1 for java17 (FELIX-6287)
- Pick up newer bndlib for ArrayIndexOutOfBounds error printed with OsgiGraphIT (bndtools/bnd issue#3405)
  - Update pax-url-wrap to 2.6.4 (and bring pax-url-reference up to the same version)
  - Force newer tinybundles version 3.0.0 (default 2.1.1 version required older bndlib)