### PR TITLE
JAVA-3055 CqlPrepareAsyncProcessor must handle cancellations of the r…

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareAsyncProcessor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareAsyncProcessor.java
@@ -151,7 +151,7 @@ public class CqlPrepareAsyncProcessor
                     if (error != null) {
                       mine.completeExceptionally(error);
                       cache.invalidate(request); // Make sure failure isn't cached indefinitely
-                    } else if (mine.isCancelled()){
+                    } else if (mine.isCancelled()) {
                       cache.invalidate(request);
                       process(request, session, context, sessionLogPrefix);
                     } else {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareAsyncProcessor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareAsyncProcessor.java
@@ -151,6 +151,9 @@ public class CqlPrepareAsyncProcessor
                     if (error != null) {
                       mine.completeExceptionally(error);
                       cache.invalidate(request); // Make sure failure isn't cached indefinitely
+                    } else if (mine.isCancelled()){
+                      cache.invalidate(request);
+                      process(request, session, context, sessionLogPrefix);
                     } else {
                       mine.complete(preparedStatement);
                     }


### PR DESCRIPTION
[JAVA-3055](https://datastax-oss.atlassian.net/browse/JAVA-3055)
CqlPrepareAsyncProcessor must handle cancellations of the returned Future

[JAVA-3055]: https://datastax-oss.atlassian.net/browse/JAVA-3055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ