### PR TITLE
 refactor multiple publish-percentiles configuration to only one configuration.

### DIFF
--- a/core/src/main/java/com/datastax/dse/driver/api/core/config/DseDriverOption.java
+++ b/core/src/main/java/com/datastax/dse/driver/api/core/config/DseDriverOption.java
@@ -288,34 +288,6 @@ public enum DseDriverOption implements DriverOption {
    * <p>Value-type: {@link java.time.Duration Duration}
    */
   METRICS_NODE_GRAPH_MESSAGES_SLO("advanced.metrics.node.graph-messages.slo"),
-  /**
-   * Optional list of percentiles to publish for graph-requests metric. Produces an additional time
-   * series for each requested percentile. This percentile is computed locally, and so can't be
-   * aggregated with percentiles computed across other dimensions (e.g. in a different instance).
-   *
-   * <p>Value type: {@link java.util.List List}&#60;{@link Double}&#62;
-   */
-  METRICS_SESSION_GRAPH_REQUESTS_PUBLISH_PERCENTILES(
-      "advanced.metrics.session.graph-requests.publish-percentiles"),
-  /**
-   * Optional list of percentiles to publish for node graph-messages metric. Produces an additional
-   * time series for each requested percentile. This percentile is computed locally, and so can't be
-   * aggregated with percentiles computed across other dimensions (e.g. in a different instance).
-   *
-   * <p>Value type: {@link java.util.List List}&#60;{@link Double}&#62;
-   */
-  METRICS_NODE_GRAPH_MESSAGES_PUBLISH_PERCENTILES(
-      "advanced.metrics.node.graph-messages.publish-percentiles"),
-  /**
-   * Optional list of percentiles to publish for continuous paging requests metric. Produces an
-   * additional time series for each requested percentile. This percentile is computed locally, and
-   * so can't be aggregated with percentiles computed across other dimensions (e.g. in a different
-   * instance).
-   *
-   * <p>Value type: {@link java.util.List List}&#60;{@link Double}&#62;
-   */
-  CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_PUBLISH_PERCENTILES(
-      "advanced.metrics.session.continuous-cql-requests.publish-percentiles"),
   ;
 
   private final String path;

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -940,32 +940,14 @@ public enum DefaultDriverOption implements DriverOption {
    */
   METADATA_SCHEMA_CHANGE_LISTENER_CLASSES("advanced.schema-change-listener.classes"),
   /**
-   * Optional list of percentiles to publish for cql-requests metric. Produces an additional time
+   * Optional list of percentiles to publish for histogram metrics. Produces an additional time
    * series for each requested percentile. This percentile is computed locally, and so can't be
    * aggregated with percentiles computed across other dimensions (e.g. in a different instance).
    *
    * <p>Value type: {@link java.util.List List}&#60;{@link Double}&#62;
    */
-  METRICS_SESSION_CQL_REQUESTS_PUBLISH_PERCENTILES(
-      "advanced.metrics.session.cql-requests.publish-percentiles"),
-  /**
-   * Optional list of percentiles to publish for node cql-messages metric. Produces an additional
-   * time series for each requested percentile. This percentile is computed locally, and so can't be
-   * aggregated with percentiles computed across other dimensions (e.g. in a different instance).
-   *
-   * <p>Value type: {@link java.util.List List}&#60;{@link Double}&#62;
-   */
-  METRICS_NODE_CQL_MESSAGES_PUBLISH_PERCENTILES(
-      "advanced.metrics.node.cql-messages.publish-percentiles"),
-  /**
-   * Optional list of percentiles to publish for throttling delay metric.Produces an additional time
-   * series for each requested percentile. This percentile is computed locally, and so can't be
-   * aggregated with percentiles computed across other dimensions (e.g. in a different instance).
-   *
-   * <p>Value type: {@link java.util.List List}&#60;{@link Double}&#62;
-   */
-  METRICS_SESSION_THROTTLING_PUBLISH_PERCENTILES(
-      "advanced.metrics.session.throttling.delay.publish-percentiles"),
+  METRICS_HISTOGRAM_PUBLISH_LOCAL_PERCENTILES(
+      "advanced.metrics.histograms.publish-local-percentiles"),
   /**
    * Adds histogram buckets used to generate aggregable percentile approximations in monitoring
    * systems that have query facilities to do so (e.g. Prometheus histogram_quantile, Atlas

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -388,6 +388,11 @@ public class TypedDriverOption<ValueT> {
   /** The consistency level to use for trace queries. */
   public static final TypedDriverOption<String> REQUEST_TRACE_CONSISTENCY =
       new TypedDriverOption<>(DefaultDriverOption.REQUEST_TRACE_CONSISTENCY, GenericType.STRING);
+  /** Optional pre-defined percentile of histogram metrics to publish, as a list of percentiles . */
+  public static final TypedDriverOption<List<Double>> METRICS_HISTOGRAM_PUBLISH_LOCAL_PERCENTILES =
+      new TypedDriverOption<>(
+          DefaultDriverOption.METRICS_HISTOGRAM_PUBLISH_LOCAL_PERCENTILES,
+          GenericType.listOf(GenericType.DOUBLE));
   /** Whether or not to publish aggregable histogram for metrics */
   public static final TypedDriverOption<Boolean> METRICS_GENERATE_AGGREGABLE_HISTOGRAMS =
       new TypedDriverOption<>(
@@ -413,12 +418,6 @@ public class TypedDriverOption<ValueT> {
       new TypedDriverOption<>(
           DefaultDriverOption.METRICS_SESSION_CQL_REQUESTS_SLO,
           GenericType.listOf(GenericType.DURATION));
-  /** Optional pre-defined percentile of cql requests to publish, as a list of percentiles . */
-  public static final TypedDriverOption<List<Double>>
-      METRICS_SESSION_CQL_REQUESTS_PUBLISH_PERCENTILES =
-          new TypedDriverOption<>(
-              DefaultDriverOption.METRICS_SESSION_CQL_REQUESTS_PUBLISH_PERCENTILES,
-              GenericType.listOf(GenericType.DOUBLE));
   /**
    * The number of significant decimal digits to which internal structures will maintain for
    * requests.
@@ -443,12 +442,6 @@ public class TypedDriverOption<ValueT> {
       new TypedDriverOption<>(
           DefaultDriverOption.METRICS_SESSION_THROTTLING_SLO,
           GenericType.listOf(GenericType.DURATION));
-  /** Optional pre-defined percentile of throttling delay to publish, as a list of percentiles . */
-  public static final TypedDriverOption<List<Double>>
-      METRICS_SESSION_THROTTLING_PUBLISH_PERCENTILES =
-          new TypedDriverOption<>(
-              DefaultDriverOption.METRICS_SESSION_THROTTLING_PUBLISH_PERCENTILES,
-              GenericType.listOf(GenericType.DOUBLE));
   /**
    * The number of significant decimal digits to which internal structures will maintain for
    * throttling.
@@ -473,12 +466,6 @@ public class TypedDriverOption<ValueT> {
       new TypedDriverOption<>(
           DefaultDriverOption.METRICS_NODE_CQL_MESSAGES_SLO,
           GenericType.listOf(GenericType.DURATION));
-  /** Optional pre-defined percentile of node cql messages to publish, as a list of percentiles . */
-  public static final TypedDriverOption<List<Double>>
-      METRICS_NODE_CQL_MESSAGES_PUBLISH_PERCENTILES =
-          new TypedDriverOption<>(
-              DefaultDriverOption.METRICS_NODE_CQL_MESSAGES_PUBLISH_PERCENTILES,
-              GenericType.listOf(GenericType.DOUBLE));
   /**
    * The number of significant decimal digits to which internal structures will maintain for
    * requests.
@@ -723,15 +710,6 @@ public class TypedDriverOption<ValueT> {
               DseDriverOption.CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_SLO,
               GenericType.listOf(GenericType.DURATION));
   /**
-   * Optional pre-defined percentile of continuous paging cql requests to publish, as a list of
-   * percentiles .
-   */
-  public static final TypedDriverOption<List<Double>>
-      CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_PUBLISH_PERCENTILES =
-          new TypedDriverOption<>(
-              DseDriverOption.CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_PUBLISH_PERCENTILES,
-              GenericType.listOf(GenericType.DOUBLE));
-  /**
    * The number of significant decimal digits to which internal structures will maintain for
    * continuous requests.
    */
@@ -805,12 +783,6 @@ public class TypedDriverOption<ValueT> {
       new TypedDriverOption<>(
           DseDriverOption.METRICS_SESSION_GRAPH_REQUESTS_SLO,
           GenericType.listOf(GenericType.DURATION));
-  /** Optional pre-defined percentile of graph requests to publish, as a list of percentiles . */
-  public static final TypedDriverOption<List<Double>>
-      METRICS_SESSION_GRAPH_REQUESTS_PUBLISH_PERCENTILES =
-          new TypedDriverOption<>(
-              DseDriverOption.METRICS_SESSION_GRAPH_REQUESTS_PUBLISH_PERCENTILES,
-              GenericType.listOf(GenericType.DOUBLE));
   /**
    * The number of significant decimal digits to which internal structures will maintain for graph
    * requests.
@@ -835,14 +807,6 @@ public class TypedDriverOption<ValueT> {
       new TypedDriverOption<>(
           DseDriverOption.METRICS_NODE_GRAPH_MESSAGES_SLO,
           GenericType.listOf(GenericType.DURATION));
-  /**
-   * Optional pre-defined percentile of node graph requests to publish, as a list of percentiles .
-   */
-  public static final TypedDriverOption<List<Double>>
-      METRICS_NODE_GRAPH_MESSAGES_PUBLISH_PERCENTILES =
-          new TypedDriverOption<>(
-              DseDriverOption.METRICS_NODE_GRAPH_MESSAGES_PUBLISH_PERCENTILES,
-              GenericType.listOf(GenericType.DOUBLE));
   /**
    * The number of significant decimal digits to which internal structures will maintain for graph
    * requests.

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1442,6 +1442,11 @@ datastax-java-driver {
       # Modifiable at runtime: no
       # Overridable in a profile: no
       generate-aggregable = true
+
+      # An optional list of percentiles to be published by Micrometer. Produces an additional time series for each requested percentile.
+      # This percentile is computed locally, and so can't be aggregated with percentiles computed across other dimensions (e.g. in a different instance)
+      # Valid for: Micrometer.
+      // publish-local-percentiles = [ 0.75, 0.95, 0.99 ]
     }
 
     # The session-level metrics (all disabled by default).
@@ -1588,10 +1593,6 @@ datastax-java-driver {
         # Valid for: Micrometer.
         // slo = [ 100 milliseconds, 500 milliseconds, 1 second ]
 
-        # An optional list of percentiles to be published by Micrometer. Produces an additional time series for each requested percentile.
-        # This percentile is computed locally, and so can't be aggregated with percentiles computed across other dimensions (e.g. in a different instance)
-        # Valid for: Micrometer.
-        // publish-percentiles = [ 0.75, 0.95, 0.99 ]
       }
 
       # Required: if the 'throttling.delay' metric is enabled, and Dropwizard or Micrometer is used.
@@ -1603,7 +1604,6 @@ datastax-java-driver {
         significant-digits = 3
         refresh-interval = 5 minutes
         // slo = [ 100 milliseconds, 500 milliseconds, 1 second ]
-        // publish-percentiles = [ 0.75, 0.95, 0.99 ]
       }
 
       # Required: if the 'continuous-cql-requests' metric is enabled, and Dropwizard or Micrometer
@@ -1616,7 +1616,6 @@ datastax-java-driver {
         significant-digits = 3
         refresh-interval = 5 minutes
         // slo = [ 100 milliseconds, 500 milliseconds, 1 second ]
-        // publish-percentiles = [ 0.75, 0.95, 0.99 ]
       }
 
       # Required: if the 'graph-requests' metric is enabled, and Dropwizard or Micrometer is used.
@@ -1628,7 +1627,6 @@ datastax-java-driver {
         significant-digits = 3
         refresh-interval = 5 minutes
         // slo = [ 100 milliseconds, 500 milliseconds, 1 second ]
-        // publish-percentiles = [ 0.75, 0.95, 0.99 ]
       }
     }
     # The node-level metrics (all disabled by default).
@@ -1793,7 +1791,6 @@ datastax-java-driver {
         significant-digits = 3
         refresh-interval = 5 minutes
         // slo = [ 100 milliseconds, 500 milliseconds, 1 second ]
-        // publish-percentiles = [ 0.75, 0.95, 0.99 ]
       }
 
       # See graph-requests in the `session` section
@@ -1807,7 +1804,6 @@ datastax-java-driver {
         significant-digits = 3
         refresh-interval = 5 minutes
         // slo = [ 100 milliseconds, 500 milliseconds, 1 second ]
-        // publish-percentiles = [ 0.75, 0.95, 0.99 ]
       }
 
       # The time after which the node level metrics will be evicted.

--- a/metrics/micrometer/src/main/java/com/datastax/oss/driver/internal/metrics/micrometer/MicrometerMetricUpdater.java
+++ b/metrics/micrometer/src/main/java/com/datastax/oss/driver/internal/metrics/micrometer/MicrometerMetricUpdater.java
@@ -17,7 +17,6 @@ package com.datastax.oss.driver.internal.metrics.micrometer;
 
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
-import com.datastax.oss.driver.api.core.config.DriverOption;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metrics.AbstractMetricUpdater;
 import com.datastax.oss.driver.internal.core.metrics.MetricId;
@@ -158,6 +157,12 @@ public abstract class MicrometerMetricUpdater<MetricT> extends AbstractMetricUpd
     if (profile.getBoolean(DefaultDriverOption.METRICS_GENERATE_AGGREGABLE_HISTOGRAMS)) {
       builder.publishPercentileHistogram();
     }
+    if (profile.isDefined(DefaultDriverOption.METRICS_HISTOGRAM_PUBLISH_LOCAL_PERCENTILES)) {
+      builder.publishPercentiles(
+          toDoubleArray(
+              profile.getDoubleList(
+                  DefaultDriverOption.METRICS_HISTOGRAM_PUBLISH_LOCAL_PERCENTILES)));
+    }
     return builder;
   }
 
@@ -173,12 +178,5 @@ public abstract class MicrometerMetricUpdater<MetricT> extends AbstractMetricUpd
 
   static double[] toDoubleArray(List<Double> doubleList) {
     return doubleList.stream().mapToDouble(Double::doubleValue).toArray();
-  }
-
-  static void configurePercentilesPublishIfDefined(
-      Timer.Builder builder, DriverExecutionProfile profile, DriverOption driverOption) {
-    if (profile.isDefined(driverOption)) {
-      builder.publishPercentiles(toDoubleArray(profile.getDoubleList(driverOption)));
-    }
   }
 }

--- a/metrics/micrometer/src/main/java/com/datastax/oss/driver/internal/metrics/micrometer/MicrometerNodeMetricUpdater.java
+++ b/metrics/micrometer/src/main/java/com/datastax/oss/driver/internal/metrics/micrometer/MicrometerNodeMetricUpdater.java
@@ -112,8 +112,6 @@ public class MicrometerNodeMetricUpdater extends MicrometerMetricUpdater<NodeMet
           .percentilePrecision(
               profile.getInt(DefaultDriverOption.METRICS_NODE_CQL_MESSAGES_DIGITS));
 
-      configurePercentilesPublishIfDefined(
-          builder, profile, DefaultDriverOption.METRICS_NODE_CQL_MESSAGES_PUBLISH_PERCENTILES);
     } else if (metric == DseNodeMetric.GRAPH_MESSAGES) {
       builder
           .minimumExpectedValue(
@@ -127,9 +125,6 @@ public class MicrometerNodeMetricUpdater extends MicrometerMetricUpdater<NodeMet
                       .toArray(new Duration[0])
                   : null)
           .percentilePrecision(profile.getInt(DseDriverOption.METRICS_NODE_GRAPH_MESSAGES_DIGITS));
-
-      configurePercentilesPublishIfDefined(
-          builder, profile, DseDriverOption.METRICS_NODE_GRAPH_MESSAGES_PUBLISH_PERCENTILES);
     }
     return builder;
   }

--- a/metrics/micrometer/src/main/java/com/datastax/oss/driver/internal/metrics/micrometer/MicrometerSessionMetricUpdater.java
+++ b/metrics/micrometer/src/main/java/com/datastax/oss/driver/internal/metrics/micrometer/MicrometerSessionMetricUpdater.java
@@ -81,8 +81,6 @@ public class MicrometerSessionMetricUpdater extends MicrometerMetricUpdater<Sess
                   ? profile.getInt(DefaultDriverOption.METRICS_SESSION_CQL_REQUESTS_DIGITS)
                   : null);
 
-      configurePercentilesPublishIfDefined(
-          builder, profile, DefaultDriverOption.METRICS_SESSION_CQL_REQUESTS_PUBLISH_PERCENTILES);
     } else if (metric == DefaultSessionMetric.THROTTLING_DELAY) {
       builder
           .minimumExpectedValue(
@@ -100,8 +98,6 @@ public class MicrometerSessionMetricUpdater extends MicrometerMetricUpdater<Sess
                   ? profile.getInt(DefaultDriverOption.METRICS_SESSION_THROTTLING_DIGITS)
                   : null);
 
-      configurePercentilesPublishIfDefined(
-          builder, profile, DefaultDriverOption.METRICS_SESSION_THROTTLING_PUBLISH_PERCENTILES);
     } else if (metric == DseSessionMetric.CONTINUOUS_CQL_REQUESTS) {
       builder
           .minimumExpectedValue(
@@ -124,10 +120,6 @@ public class MicrometerSessionMetricUpdater extends MicrometerMetricUpdater<Sess
                       DseDriverOption.CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_DIGITS)
                   : null);
 
-      configurePercentilesPublishIfDefined(
-          builder,
-          profile,
-          DseDriverOption.CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_PUBLISH_PERCENTILES);
     } else if (metric == DseSessionMetric.GRAPH_REQUESTS) {
       builder
           .minimumExpectedValue(
@@ -144,9 +136,6 @@ public class MicrometerSessionMetricUpdater extends MicrometerMetricUpdater<Sess
               profile.isDefined(DseDriverOption.METRICS_SESSION_GRAPH_REQUESTS_DIGITS)
                   ? profile.getInt(DseDriverOption.METRICS_SESSION_GRAPH_REQUESTS_DIGITS)
                   : null);
-
-      configurePercentilesPublishIfDefined(
-          builder, profile, DseDriverOption.METRICS_SESSION_GRAPH_REQUESTS_PUBLISH_PERCENTILES);
     }
     return builder;
   }

--- a/metrics/micrometer/src/test/java/com/datastax/oss/driver/internal/metrics/micrometer/MicrometerNodeMetricUpdaterTest.java
+++ b/metrics/micrometer/src/test/java/com/datastax/oss/driver/internal/metrics/micrometer/MicrometerNodeMetricUpdaterTest.java
@@ -261,7 +261,7 @@ public class MicrometerNodeMetricUpdaterTest {
         DefaultDriverOption.METRICS_NODE_CQL_MESSAGES_HIGHEST,
         DefaultDriverOption.METRICS_NODE_CQL_MESSAGES_DIGITS,
         DefaultDriverOption.METRICS_NODE_CQL_MESSAGES_SLO,
-        DefaultDriverOption.METRICS_NODE_CQL_MESSAGES_PUBLISH_PERCENTILES,
+        DefaultDriverOption.METRICS_HISTOGRAM_PUBLISH_LOCAL_PERCENTILES,
       },
       {
         DseNodeMetric.GRAPH_MESSAGES,
@@ -269,7 +269,7 @@ public class MicrometerNodeMetricUpdaterTest {
         DseDriverOption.METRICS_NODE_GRAPH_MESSAGES_HIGHEST,
         DseDriverOption.METRICS_NODE_GRAPH_MESSAGES_DIGITS,
         DseDriverOption.METRICS_NODE_GRAPH_MESSAGES_SLO,
-        DseDriverOption.METRICS_NODE_GRAPH_MESSAGES_PUBLISH_PERCENTILES,
+        DefaultDriverOption.METRICS_HISTOGRAM_PUBLISH_LOCAL_PERCENTILES,
       },
     };
   }

--- a/metrics/micrometer/src/test/java/com/datastax/oss/driver/internal/metrics/micrometer/MicrometerSessionMetricUpdaterTest.java
+++ b/metrics/micrometer/src/test/java/com/datastax/oss/driver/internal/metrics/micrometer/MicrometerSessionMetricUpdaterTest.java
@@ -165,7 +165,7 @@ public class MicrometerSessionMetricUpdaterTest {
         DefaultDriverOption.METRICS_SESSION_CQL_REQUESTS_HIGHEST,
         DefaultDriverOption.METRICS_SESSION_CQL_REQUESTS_DIGITS,
         DefaultDriverOption.METRICS_SESSION_CQL_REQUESTS_SLO,
-        DefaultDriverOption.METRICS_SESSION_CQL_REQUESTS_PUBLISH_PERCENTILES,
+        DefaultDriverOption.METRICS_HISTOGRAM_PUBLISH_LOCAL_PERCENTILES,
       },
       {
         DseSessionMetric.GRAPH_REQUESTS,
@@ -173,7 +173,7 @@ public class MicrometerSessionMetricUpdaterTest {
         DseDriverOption.METRICS_SESSION_GRAPH_REQUESTS_HIGHEST,
         DseDriverOption.METRICS_SESSION_GRAPH_REQUESTS_DIGITS,
         DseDriverOption.METRICS_SESSION_GRAPH_REQUESTS_SLO,
-        DseDriverOption.METRICS_SESSION_GRAPH_REQUESTS_PUBLISH_PERCENTILES,
+        DefaultDriverOption.METRICS_HISTOGRAM_PUBLISH_LOCAL_PERCENTILES,
       },
       {
         DseSessionMetric.CONTINUOUS_CQL_REQUESTS,
@@ -181,7 +181,7 @@ public class MicrometerSessionMetricUpdaterTest {
         DseDriverOption.CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_HIGHEST,
         DseDriverOption.CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_DIGITS,
         DseDriverOption.CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_SLO,
-        DseDriverOption.CONTINUOUS_PAGING_METRICS_SESSION_CQL_REQUESTS_PUBLISH_PERCENTILES
+        DefaultDriverOption.METRICS_HISTOGRAM_PUBLISH_LOCAL_PERCENTILES
       },
       {
         DefaultSessionMetric.THROTTLING_DELAY,
@@ -189,7 +189,7 @@ public class MicrometerSessionMetricUpdaterTest {
         DefaultDriverOption.METRICS_SESSION_THROTTLING_HIGHEST,
         DefaultDriverOption.METRICS_SESSION_THROTTLING_DIGITS,
         DefaultDriverOption.METRICS_SESSION_THROTTLING_SLO,
-        DefaultDriverOption.METRICS_SESSION_THROTTLING_PUBLISH_PERCENTILES
+        DefaultDriverOption.METRICS_HISTOGRAM_PUBLISH_LOCAL_PERCENTILES
       },
     };
   }


### PR DESCRIPTION
As part of the PR 1689, I have added five publish-percentiles configuration, This PR changes all those five to only one configuration.
 
Motivation:
There are too many configurations for client SDK users to configure. Now I am think i added too many configurations and thought of changing to only one configuration.
 
Modifications:
change five publish-percentiles configuration to only one configuration.

Describe the modifications you've done.
 Do appropriate changes in code to use only one publish-percentiles configuration.

Result:
We can control all the histogram metrics  publish-percentiles  through only configuration. We cannot have seprate percentiles for different histogram metrics.
