### PR TITLE
CASSANDRA-18969 - added missing copyrights [4.x]

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -22,4 +22,3 @@ see core/src/main/java/com/datastax/oss/driver/internal/core/util/CountingIterat
 (C) 2018 Christian Stein
 This product includes software developed by Christian Stein
 see ci/install-jdk.sh 
-

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -18,3 +18,8 @@ Guava
 Copyright (C) 2007 The Guava Authors
 This product includes software developed as part of the Guava project ( https://guava.dev ).
 see core/src/main/java/com/datastax/oss/driver/internal/core/util/CountingIterator.java
+
+(C) 2018 Christian Stein
+This product includes software developed by Christian Stein
+see ci/install-jdk.sh 
+


### PR DESCRIPTION
added Christian Stein copyright notice

performing grep for `[Cc]opyright`, `(C)`, and `(c)` only uncovered the one copyright not listed in the Notice file.