### PR TITLE
CASSANDRA-18969: Mark spotbugs-annotation and jcip-annotations as provided dependencies [4.6.x branch]

### DIFF
--- a/core-shaded/pom.xml
+++ b/core-shaded/pom.xml
@@ -113,10 +113,12 @@
     <dependency>
       <groupId>com.github.stephenc.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <!--

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -124,10 +124,12 @@
     <dependency>
       <groupId>com.github.stephenc.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/distribution-tests/pom.xml
+++ b/distribution-tests/pom.xml
@@ -25,9 +25,8 @@
     <artifactId>java-driver-parent</artifactId>
     <version>4.6.2-SNAPSHOT</version>
   </parent>
-  <artifactId>java-driver-test-infra</artifactId>
-  <packaging>bundle</packaging>
-  <name>Apache Cassandra Java Driver - test infrastructure tools</name>
+  <artifactId>java-driver-distribution-tests</artifactId>
+  <name>Apache Cassandra Java Driver - distribution tests</name>
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -42,57 +41,68 @@
   <dependencies>
     <dependency>
       <groupId>com.datastax.oss</groupId>
-      <artifactId>java-driver-core</artifactId>
-      <version>${project.parent.version}</version>
+      <artifactId>java-driver-test-infra</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <scope>provided</scope>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-query-builder</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-mapper-processor</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-mapper-runtime</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.datastax.oss.simulacron</groupId>
-      <artifactId>simulacron-native-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-exec</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>com.datastax.oss.driver.tests.infrastructure</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
+          <threadCount>1</threadCount>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
         <configuration>
-          <instructions>
-            <Bundle-SymbolicName>com.datastax.oss.driver.testinfra</Bundle-SymbolicName>
-            <!-- allow SessionUtils to instantiate sessions by reflection -->
-            <DynamicImport-Package>*</DynamicImport-Package>
-            <Export-Package>com.datastax.oss.driver.*.testinfra.*, com.datastax.oss.driver.assertions, com.datastax.oss.driver.categories</Export-Package>
-          </instructions>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <configuration>
+          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         </configuration>
       </plugin>
     </plugins>

--- a/distribution-tests/src/test/java/com/datastax/oss/driver/api/core/DriverDependencyTest.java
+++ b/distribution-tests/src/test/java/com/datastax/oss/driver/api/core/DriverDependencyTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.session.Session;
+import com.datastax.oss.driver.api.mapper.MapperBuilder;
+import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
+import com.datastax.oss.driver.api.testinfra.CassandraResourceRule;
+import com.datastax.oss.driver.internal.core.util.Reflection;
+import com.datastax.oss.driver.internal.mapper.processor.MapperProcessor;
+import org.junit.Test;
+
+public class DriverDependencyTest {
+  @Test
+  public void should_include_core_jar() {
+    assertThat(Reflection.loadClass(null, "com.datastax.oss.driver.api.core.session.Session"))
+        .isEqualTo(Session.class);
+  }
+
+  @Test
+  public void should_include_query_builder_jar() {
+    assertThat(Reflection.loadClass(null, "com.datastax.oss.driver.api.querybuilder.QueryBuilder"))
+        .isEqualTo(QueryBuilder.class);
+  }
+
+  @Test
+  public void should_include_mapper_processor_jar() {
+    assertThat(
+            Reflection.loadClass(
+                null, "com.datastax.oss.driver.internal.mapper.processor.MapperProcessor"))
+        .isEqualTo(MapperProcessor.class);
+  }
+
+  @Test
+  public void should_include_mapper_runtime_jar() {
+    assertThat(Reflection.loadClass(null, "com.datastax.oss.driver.api.mapper.MapperBuilder"))
+        .isEqualTo(MapperBuilder.class);
+  }
+
+  @Test
+  public void should_include_test_infra_jar() {
+    assertThat(
+            Reflection.loadClass(
+                null, "com.datastax.oss.driver.api.testinfra.CassandraResourceRule"))
+        .isEqualTo(CassandraResourceRule.class);
+  }
+}

--- a/distribution-tests/src/test/java/com/datastax/oss/driver/api/core/OptionalDependencyTest.java
+++ b/distribution-tests/src/test/java/com/datastax/oss/driver/api/core/OptionalDependencyTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.internal.core.util.DependencyCheck;
+import org.junit.Test;
+
+public class OptionalDependencyTest {
+  @Test
+  public void should_not_include_snappy_jar() {
+    assertThat(DependencyCheck.SNAPPY.isPresent()).isFalse();
+  }
+
+  @Test
+  public void should_not_include_l4z_jar() {
+    assertThat(DependencyCheck.LZ4.isPresent()).isFalse();
+  }
+}

--- a/distribution-tests/src/test/java/com/datastax/oss/driver/api/core/ProvidedDependencyTest.java
+++ b/distribution-tests/src/test/java/com/datastax/oss/driver/api/core/ProvidedDependencyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.internal.core.util.Reflection;
+import org.junit.Test;
+
+public class ProvidedDependencyTest {
+  @Test
+  public void should_not_include_graal_sdk_jar() {
+    assertThat(Reflection.loadClass(null, "org.graalvm.nativeimage.VMRuntime")).isNull();
+  }
+
+  @Test
+  public void should_not_include_spotbugs_annotations_jar() {
+    assertThat(Reflection.loadClass(null, "edu.umd.cs.findbugs.annotations.NonNull")).isNull();
+  }
+
+  @Test
+  public void should_not_include_jicp_annotations_jar() {
+    assertThat(Reflection.loadClass(null, "net.jcip.annotations.ThreadSafe")).isNull();
+  }
+
+  @Test
+  public void should_not_include_blockhound_jar() {
+    assertThat(Reflection.loadClass(null, "reactor.blockhound.BlockHoundRuntime")).isNull();
+  }
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -137,6 +137,11 @@
       <artifactId>bcrypt</artifactId>
       <version>0.8.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -74,6 +74,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.github.stephenc.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <scope>test</scope>

--- a/manual/core/integration/README.md
+++ b/manual/core/integration/README.md
@@ -460,25 +460,22 @@ The driver team uses annotations to document certain aspects of the code:
 * nullability with [SpotBugs](https://spotbugs.github.io/) annotations `@Nullable` and `@NonNull`.
 
 This is mostly used during development; while these annotations are retained in class files, they
-serve no purpose at runtime. If you want to minimize the number of JARs in your classpath, you can
-exclude them:
+serve no purpose at runtime. This class is an optional dependency of the driver. If you wish to
+make use of these annotations in your own code you have to explicitly depend on these jars:
 
 ```xml
-<dependency>
-  <groupId>com.datastax.oss</groupId>
-  <artifactId>java-driver-core</artifactId>
-  <version>${driver.version}</version>
-  <exclusions>
-    <exclusion>
-      <groupId>com.github.stephenc.jcip</groupId>
-      <artifactId>jcip-annotations</artifactId>
-    </exclusion>
-    <exclusion>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-    </exclusion>
-  </exclusions>
-</dependency>
+<dependencies>
+  <dependency>
+    <groupId>com.github.stephenc.jcip</groupId>
+    <artifactId>jcip-annotations</artifactId>
+    <version>1.0-1</version>
+  </dependency>
+  <dependency>
+    <groupId>com.github.spotbugs</groupId>
+    <artifactId>spotbugs-annotations</artifactId>
+    <version>3.1.12</version>
+  </dependency>
+</dependencies>
 ```
 
 However, there is one case when excluding those dependencies won't work: if you use [annotation

--- a/mapper-processor/pom.xml
+++ b/mapper-processor/pom.xml
@@ -54,10 +54,12 @@
     <dependency>
       <groupId>com.github.stephenc.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.testing.compile</groupId>

--- a/mapper-runtime/pom.xml
+++ b/mapper-runtime/pom.xml
@@ -51,10 +51,12 @@
     <dependency>
       <groupId>com.github.stephenc.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <module>test-infra</module>
     <module>integration-tests</module>
     <module>distribution</module>
+    <module>distribution-tests</module>
     <module>examples</module>
     <module>bom</module>
   </modules>

--- a/query-builder/pom.xml
+++ b/query-builder/pom.xml
@@ -51,10 +51,12 @@
     <dependency>
       <groupId>com.github.stephenc.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION

patch by Henry Hughes; reviewed by Mick Semb Wever for CASSANDRA-18969