### PR TITLE
JAVA-3055 Prevent reusing cached cancelled requests

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareAsyncProcessor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareAsyncProcessor.java
@@ -159,7 +159,9 @@ public class CqlPrepareAsyncProcessor
                   });
         }
       }
-      return result;
+      // Return a defensive copy. So if a client cancels its request, the cache won't be impacted
+      // nor a potential concurrent request.
+      return result.thenApply(x -> x); // copy() is available only since Java 9
     } catch (ExecutionException e) {
       return CompletableFutures.failedFuture(e.getCause());
     }


### PR DESCRIPTION
There was a critical issue in the driver that may occur when the external code cancels a request, indeed the CompletableFuture will then always throw a CancellationException.

This could occur for example when used in a reactive context with a Mono.zip failed.