### PR TITLE
CASSANDRA-16969-copyright-check-4.4.0 fixes

### DIFF
--- a/.copyright/4.4.0_fixes
+++ b/.copyright/4.4.0_fixes
@@ -1,0 +1,7 @@
+ci/install-jdk.sh:# (C) 2018 Christian Stein
+core/src/main/java/com/datastax/oss/driver/internal/core/type/util/VIntCoding.java:// Copyright 2008 Google Inc.  All rights reserved.
+core/src/main/java/com/datastax/oss/driver/internal/core/util/CountingIterator.java:   * Copyright (C) 2007 The Guava Authors
+NOTICE.txt:Copyright 2012- The Apache Software Foundation
+NOTICE.txt:Copyright (C) 2008-2010 Wayne Meissner
+NOTICE.txt:Copyright 2008 Google Inc.
+NOTICE.txt:Copyright (C) 2007 The Guava Authors

--- a/.copyright/4.4.0_fixes
+++ b/.copyright/4.4.0_fixes
@@ -1,7 +1,0 @@
-ci/install-jdk.sh:# (C) 2018 Christian Stein
-core/src/main/java/com/datastax/oss/driver/internal/core/type/util/VIntCoding.java:// Copyright 2008 Google Inc.  All rights reserved.
-core/src/main/java/com/datastax/oss/driver/internal/core/util/CountingIterator.java:   * Copyright (C) 2007 The Guava Authors
-NOTICE.txt:Copyright 2012- The Apache Software Foundation
-NOTICE.txt:Copyright (C) 2008-2010 Wayne Meissner
-NOTICE.txt:Copyright 2008 Google Inc.
-NOTICE.txt:Copyright (C) 2007 The Guava Authors

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -13,3 +13,8 @@ Guava
 Copyright (C) 2007 The Guava Authors
 This product includes software developed as part of the Guava project ( https://guava.dev ).
 see core/src/main/java/com/datastax/oss/driver/internal/core/util/CountingIterator.java
+
+Bach - Java Shell Builder - Builds (on(ly)) Modules
+Copyrigth (C) 2018 Christian Stein
+This product includes software developed as part of the Bach - Java Shell Builder - Builds (on(ly)) Modules ( https://github.com/sormuras/bach ).
+see ci/install-jdk.sh

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -4,11 +4,6 @@ Copyright 2012- The Apache Software Foundation
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).
 
-JNR project
-Copyright (C) 2008-2010 Wayne Meissner
-This product includes software developed as part of the JNR project ( https://github.com/jnr/jnr-ffi )s.
-see core/src/main/java/com/datastax/oss/driver/internal/core/os/CpuInfo.java
-
 Protocol Buffers
 Copyright 2008 Google Inc.
 This product includes software developed as part of the Protocol Buffers project ( https://developers.google.com/protocol-buffers/ ).


### PR DESCRIPTION
All copyrights detected in code base noted in NOTICE.txt
