### PR TITLE
Add note about guardrails on `WHERE … IN … `

### DIFF
--- a/manual/core/statements/simple/README.md
+++ b/manual/core/statements/simple/README.md
@@ -144,6 +144,15 @@ session.execute(
 // Invalid amount of bind variables
 ```
 
+> **NOTE:** 
+> Guardrails ensure consistent behavior by limiting the number of partition keys selected by an `IN` restriction and the cartesian product of multiple `IN` restrictions.
+> 
+> **Example 1:** Providing a `WHERE` clause with a high number of elements in the `IN` clause (not part of the same partitions) causes the coordinator receiving the request to trigger other internal requests to cope, making
+> one node unnecessarily busy. Instead, distribute a simple request with `WHERE` and a single value.
+> 
+> **Example 2:** Using more than 25 values in the `IN` clause is an invalid pattern because the load is transferred from the client to the coordinator. Use parallel queries and reduce on the client side for faster speed and
+> to distribute the load on the nodes.
+
 ### Type inference
 
 Another consequence of not parsing query strings is that the driver has to guess how to serialize 


### PR DESCRIPTION
For [DOC-4062](https://datastax.jira.com/browse/DOC-4062) (private)

Issue: One of my customer has encountered an issue while using more than 25 values in the IN clause.

Answer: “It is invalid pattern with Cassandra 4 and guardails. The problem is the load is transferred from the client to the coordinator. They should go with parallal queries and reduce on the client side: faster and dstribute the load on the nodes”