### PR TITLE
JAVA-3145: Implement some notion of retry logic around call to metadata service for Astra clients

### DIFF
--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/cloud/CloudConfigFactoryTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/cloud/CloudConfigFactoryTest.java
@@ -24,6 +24,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.datastax.oss.driver.internal.core.ssl.SniSslEngineFactory;
@@ -137,6 +138,27 @@ public class CloudConfigFactoryTest {
     CloudConfigFactory cloudConfigFactory = new CloudConfigFactory();
     Throwable t = catchThrowable(() -> cloudConfigFactory.createCloudConfig(configFile));
     assertThat(t).isInstanceOf(FileNotFoundException.class).hasMessageContaining("metadata");
+  }
+
+  @Test
+  public void should_retry_when_metadata_return_non_200() throws Exception {
+    // given, first attempt 421, subsequent attempts 200
+    mockHttpSecureBundle(secureBundle());
+    URL configFile = new URL("http", "localhost", wireMockRule.port(), BUNDLE_PATH);
+    stubFor(any(urlPathEqualTo("/metadata")).inScenario("retry")
+            .whenScenarioStateIs(STARTED)
+            .willReturn(aResponse().withStatus(421))
+            .willSetStateTo("second-200"));
+    stubFor(any(urlPathEqualTo("/metadata")).inScenario("retry")
+            .whenScenarioStateIs("second-200")
+            .willReturn(aResponse().withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(jsonMetadata())));
+    // when
+    CloudConfigFactory cloudConfigFactory = new CloudConfigFactory();
+    CloudConfig cloudConfig = cloudConfigFactory.createCloudConfig(configFile);
+    // then
+    assertCloudConfig(cloudConfig);
   }
 
   @Test


### PR DESCRIPTION
I implemented the retry mechanism in two ways. Apart from the current one, the following also works:
```java
  @NonNull
  protected BufferedReader fetchProxyMetadata(
      @NonNull URL metadataServiceUrl, @NonNull SSLContext sslContext) throws IOException {
    HttpsURLConnection connection = null;
    int attempt = 0;
    while(attempt < METADATA_RETRY_MAX_ATTEMPTS){
      try {
        connection = (HttpsURLConnection) metadataServiceUrl.openConnection();
        connection.setSSLSocketFactory(sslContext.getSocketFactory());
        connection.setRequestMethod("GET");
        connection.setRequestProperty("host", "localhost");
        return new BufferedReader(
                new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
      } catch (ConnectException e) {
        throw new IllegalStateException(
                "Unable to connect to cloud metadata service. Please make sure your cluster is not parked or terminated",
                e);
      } catch (UnknownHostException e) {
        throw new IllegalStateException(
                "Unable to resolve host for cloud metadata service. Please make sure your cluster is not terminated",
                e);
      } catch (IOException e) {
        attempt++;
        // if this is the last try, throw
        // else if status code not 200, retry; otherwise, throw
        if (attempt != METADATA_RETRY_MAX_ATTEMPTS && connection != null && connection.getResponseCode() != 200) {
          try {
            Thread.sleep(METADATA_RETRY_INITIAL_DELAY_MS);
          } catch (InterruptedException interruptedException) {
            Thread.currentThread().interrupt();
            throw new IOException("Interrupted while waiting to retry metadata fetch", interruptedException);
          }
        } else {
          throw e;
        }
      }
    }
    throw new DriverTimeoutException("Unable to fetch metadata from cloud metadata service"); // dead code
  }
```
We could discuss those design decisions in our next meeting :)