### PR TITLE
Update com.github.jnr:jnr-posix to 3.1.18 to avoid M1 docker crash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-posix</artifactId>
         <!-- when changing version also update jnr-* and asm versions in LICENSE_binary  -->
-        <version>3.1.15</version>
+        <version>3.1.18</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>


### PR DESCRIPTION
Zipkin found the following crash when running a docker container that uses this driver on Apple Silicon. Note: the problem doesn't happen when run via java directly on the host. Updating jnr-posix is all that was needed to remedy the situation.

```
# below crash happens after hitting the /health endpoint on zipkin and it doesn't matter if the cassandra host is present or not.
~ $  STORAGE_TYPE=cassandra3 start-zipkin

                  oo
                 oooo
                oooooo
               oooooooo
              oooooooooo
             oooooooooooo
           ooooooo  ooooooo
          oooooo     ooooooo
         oooooo       ooooooo
        oooooo   o  o   oooooo
       oooooo   oo  oo   oooooo
     ooooooo  oooo  oooo  ooooooo
    oooooo   ooooo  ooooo  ooooooo
   oooooo   oooooo  oooooo  ooooooo
  oooooooo      oo  oo      oooooooo
  ooooooooooooo oo  oo ooooooooooooo
      oooooooooooo  oooooooooooo
          oooooooo  oooooooo
              oooo  oooo

     ________ ____  _  _____ _   _
    |__  /_ _|  _ \| |/ /_ _| \ | |
      / / | || |_) | ' / | ||  \| |
     / /_ | ||  __/| . \ | || |\  |
    |____|___|_|   |_|\_\___|_| \_|

:: version 2.25.1 :: commit 82c3d7a ::

2023-12-15 05:45:58.195  INFO [/] 8 --- [oss-http-*:9411] c.l.a.s.Server                           : Serving HTTP at /0.0.0.0:9411 - http://127.0.0.1:9411/
2023-12-15 05:46:06.887  INFO [/] 8 --- [cking-tasks-2-1] c.d.o.d.i.c.c.CqlPrepareAsyncProcessor   : Adding handler to invalidate cached prepared statements on type changes
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x0000000000005e30, pid=8, tid=59
#
# JRE version: OpenJDK Runtime Environment (21.0.1+12) (build 21.0.1+12-alpine-r1)
# Java VM: OpenJDK 64-Bit Server VM (21.0.1+12-alpine-r1, mixed mode, tiered, compressed oops, compressed class ptrs, g1 gc, linux-aarch64)
# Problematic frame:
# C  [jffi11042031320136118671.so+0x7f7c]  jffi_throwExceptionByName+0xfc
--snip--
```