### PR TITLE
CASSANDRA-19290: Replace uses of AttributeKey.newInstance

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/DriverChannel.java
@@ -49,9 +49,9 @@ import net.jcip.annotations.ThreadSafe;
 @ThreadSafe
 public class DriverChannel {
 
-  static final AttributeKey<String> CLUSTER_NAME_KEY = AttributeKey.newInstance("cluster_name");
+  static final AttributeKey<String> CLUSTER_NAME_KEY = AttributeKey.valueOf("cluster_name");
   static final AttributeKey<Map<String, List<String>>> OPTIONS_KEY =
-      AttributeKey.newInstance("options");
+      AttributeKey.valueOf("options");
 
   @SuppressWarnings("RedundantStringConstructorCall")
   static final Object GRACEFUL_CLOSE_MESSAGE = new String("GRACEFUL_CLOSE_MESSAGE");


### PR DESCRIPTION
The java driver uses netty channel attributes to decorate a connection's channel with the cluster name (returned from the system.local table) and the map from the OPTIONS response, both of which are obtained on connection initialization.

There's an issue here that I wouldn't expect to see in practice in that the AttributeKey's used are created using
AttributeKey.newInstance, which throws an exception if an AttributeKey of that name is defined anywhere else in evaluated code.

This change attempts to resolve this issue by changing AttributeKey initialiation in DriverChannel from newInstance to valueOf, which avoids throwing an exception if an AttributeKey of the same name was previously instantiated.

JIRA: [CASSANDRA-19290](https://issues.apache.org/jira/browse/CASSANDRA-19290)