### PR TITLE
JAVA-2967: Add support for OSS Cassandra peers_v2 columns

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/DefaultEndPointFactory.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DefaultEndPointFactory.java
@@ -48,18 +48,23 @@ public class DefaultEndPointFactory implements EndPointFactory {
     if (peersRow.getColumnDefinitions().contains("native_address")) {
       InetAddress nativeAddress = peersRow.getInet("native_address");
       int nativePort = peersRow.getInt("native_port");
+      if (cluster.getConfiguration().getProtocolOptions().getSSLOptions() != null
+          && !peersRow.isNull("native_port_ssl")) {
+        nativePort = peersRow.getInt("native_port_ssl");
+      }
       InetSocketAddress translateAddress =
           cluster.manager.translateAddress(new InetSocketAddress(nativeAddress, nativePort));
       return new TranslatedAddressEndPoint(translateAddress);
     } else if (peersRow.getColumnDefinitions().contains("native_transport_address")) {
-      InetAddress nativeAddress = peersRow.getInet("native_transport_address");
-      int nativePort = peersRow.getInt("native_transport_port");
+      InetAddress nativeTransportAddress = peersRow.getInet("native_transport_address");
+      int nativeTransportPort = peersRow.getInt("native_transport_port");
       if (cluster.getConfiguration().getProtocolOptions().getSSLOptions() != null
           && !peersRow.isNull("native_transport_port_ssl")) {
-        nativePort = peersRow.getInt("native_transport_port_ssl");
+        nativeTransportPort = peersRow.getInt("native_transport_port_ssl");
       }
       InetSocketAddress translateAddress =
-          cluster.manager.translateAddress(new InetSocketAddress(nativeAddress, nativePort));
+          cluster.manager.translateAddress(
+              new InetSocketAddress(nativeTransportAddress, nativeTransportPort));
       return new TranslatedAddressEndPoint(translateAddress);
     } else {
       InetAddress broadcastAddress = peersRow.getInet("peer");

--- a/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ControlConnectionTest.java
@@ -623,7 +623,7 @@ public class ControlConnectionTest extends CCMTestsSupport {
    */
   @Test(groups = "short", enabled = false /* Requires SSL support in scassandra */)
   @CCMConfig(createCcm = false)
-  public void should_extract_hosts_using_native_transport_address_port_ssl_from_peers()
+  public void should_extract_hosts_using_native_transport_address_port_ssl_from_peers_dse()
       throws UnknownHostException {
 
     InetAddress expectedAddress = InetAddress.getByName("4.3.2.1");
@@ -633,6 +633,28 @@ public class ControlConnectionTest extends CCMTestsSupport {
             .peers("native_transport_address", expectedAddress)
             .peers("native_transport_port", expectedPort - 100)
             .peers("native_transport_port_ssl", expectedPort)
+            .expectedAddress(expectedAddress)
+            .expectedPort(expectedPort)
+            .build();
+    runPeerTest(state);
+  }
+
+  /**
+   * As of CASSANDRA-16999 the relevant column names for OSS Cassandra are slightly different so
+   * test those as well.
+   */
+  @Test(groups = "short", enabled = false /* Requires SSL support in scassandra */)
+  @CCMConfig(createCcm = false)
+  public void should_extract_hosts_using_native_transport_address_port_ssl_from_peers_cassandra()
+      throws UnknownHostException {
+
+    InetAddress expectedAddress = InetAddress.getByName("4.3.2.1");
+    int expectedPort = 2409;
+    PeerRowState state =
+        PeerRowState.builder()
+            .peers("native_address", expectedAddress)
+            .peers("native_port", expectedPort - 100)
+            .peers("native_port_ssl", expectedPort)
             .expectedAddress(expectedAddress)
             .expectedPort(expectedPort)
             .build();

--- a/driver-core/src/test/java/com/datastax/driver/core/ScassandraCluster.java
+++ b/driver-core/src/test/java/com/datastax/driver/core/ScassandraCluster.java
@@ -642,6 +642,7 @@ public class ScassandraCluster {
     column("peer_port", INT),
     column("native_address", INET),
     column("native_port", INT),
+    column("native_port_ssl", INT),
     column("data_center", TEXT),
     column("rack", TEXT),
     column("release_version", TEXT),


### PR DESCRIPTION
CASSANDRA-16999 adds information about an SSL-enabled CQL port to peers_v2.  Goal of this PR is to transparently support this implementation as well as DSE 6.8.x (which we already added support for).