### PR TITLE
Changelog updates to reflect work that went out in 4.18.0

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -21,6 +21,16 @@ under the License.
 
 <!-- Note: contrary to 3.x, insert new entries *first* in their section -->
 
+### 4.18.0
+
+- [improvement] PR 1689: Add support for publishing percentile time series for the histogram metrics (nparaddi-walmart)
+- [improvement] JAVA-3104: Do not eagerly pre-allocate array when deserializing CqlVector
+- [improvement] JAVA-3111: upgrade jackson-databind to 2.13.4.2 to address gradle dependency issue
+- [improvement] PR 1617: Improve ByteBufPrimitiveCodec readBytes (chibenwa)
+- [improvement] JAVA-3095: Fix CREATE keyword in vector search example in upgrade guide
+- [improvement] JAVA-3100: Update jackson-databind to 2.13.4.1 and jackson-jaxrs-json-provider to 2.13.4 to address recent CVEs
+- [improvement] JAVA-3089: Forbid wildcard imports
+
 ### 4.17.0
 
 - [improvement] JAVA-3070: Make CqlVector and CqlDuration serializable


### PR DESCRIPTION
When 4.18.0 was released we had a number of fixes already in the 4.x branch that hadn't been released with the last DataStax release (4.17.0).  This PR updates the changelog to correctly indicate the various fixes that were included in this release.