### PR TITLE
IndexMetadata.describe is not appending ; after "CREATE CUSTOM INDEX"

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/metadata/schema/IndexMetadata.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/metadata/schema/IndexMetadata.java
@@ -93,6 +93,7 @@ public interface IndexMetadata extends Describable {
         }
         builder.decreaseIndent().append("}");
       }
+      builder.append(";");
     } else {
       builder
           .append("CREATE INDEX ")


### PR DESCRIPTION
The method IndexMetadata.decribe can create two types of indexes:

1.     CUSTOM INDEX
2.     INDEX

When the code produces a CQL statement for the first type (custom), there is no semicolon at the end of the statement. i.e. The method produces a CQL statement as

CREATE CUSTOM INDEX mykeyspace_mytable_idx ON mykeyspace.mytable (lucene)
USING 'com.stratio.cassandra.lucene.Index'
WITH OPTIONS = {
    'refresh_seconds' : '1',
    'schema' : '{
        default_analyzer: "english",
        fields: {
            "template_code": {
                type: "uuid"
            },
            "status": {
                type : "string"
            }
        }
    }'}

instead of


CREATE CUSTOM INDEX mykeyspace_mytable_idx ON mykeyspace.mytable (lucene)
USING 'com.stratio.cassandra.lucene.Index'
WITH OPTIONS = {
    'refresh_seconds' : '1',
    'schema' : '{
        default_analyzer: "english",
        fields: {
            "template_code": {
                type: "uuid"
            },
            "status": {
                type : "string"
            }
        }
    }'};

The second type (a non custom index) is NOT affected by this as it contains 
builder … .append(String.format(" (%s);", getTarget()));
at the end of the “else” section. The first type ends with the builder.decreaseIndent().append("}"); We should add builder.append(“;”); statement either at the end of the if section or before return builder.build(); and remove the semicolon from .append(String.format(" (%s);", getTarget()));
 

All other Describable classes (AggregateMetadata, FunctionMetadata, KeyspaceMetadata, UserDefinedType, DseGraphTableMetadata, DefaultDseViewMetadata) are NOT suffering from this defect.