### PR TITLE
Correction of exception handling in asynchronous programming

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/HandlerSchemaQueries.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/queries/HandlerSchemaQueries.java
@@ -1,0 +1,21 @@
+package com.datastax.oss.driver.internal.core.metadata.schema.queries;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+public class HandlerSchemaQueries implements SchemaQueries {
+
+  private final CompletableFuture<SchemaRows> schemaRowsFuture = new CompletableFuture<>();
+
+  private final String message;
+
+  public HandlerSchemaQueries(String message) {
+    this.message = message;
+  }
+
+  @Override
+  public CompletionStage<SchemaRows> execute() {
+    schemaRowsFuture.completeExceptionally(new IllegalStateException(message));
+    return schemaRowsFuture;
+  }
+}


### PR DESCRIPTION
An exception is thrown from DefaultSchemaQueriesFactory.java (newInstance method) when Control connection goes down for any reason and new connection has not yet initialized yet. 

`throw new IllegalStateException("Control channel not available, aborting schema refresh");`


Exception thrown from here is not propagated to whenComplete method used in below code snippet of MetadataManager.java and refreshFuture is never marked as completed and application gets stuck. Reason for that is exception not handled properly in SchemaRows future object. Its been depicted in this PR using HandlerSchemaQueries.java

`    private void startSchemaRequest(CompletableFuture<RefreshSchemaResult> refreshFuture) {
      assert adminExecutor.inEventLoop();
      if (closeWasCalled) {
        refreshFuture.complete(new RefreshSchemaResult(metadata));
        return;
      }
      if (currentSchemaRefresh == null) {
        currentSchemaRefresh = refreshFuture;
        LOG.debug("[{}] Starting schema refresh", logPrefix);
        initControlConnectionForSchema()
            .thenCompose(v -> context.getTopologyMonitor().checkSchemaAgreement())
            .whenComplete(
                (schemaInAgreement, agreementError) -> {
                  if (agreementError != null) {
                    refreshFuture.completeExceptionally(agreementError);
                  } else {
                    schemaQueriesFactory
                        .newInstance()
                        .execute()
                        .thenApplyAsync(this::parseAndApplySchemaRows, adminExecutor)
                        .whenComplete(
                            (newMetadata, metadataError) -> {
                              if (metadataError != null) {
                                refreshFuture.completeExceptionally(metadataError);
                              } else {
                                refreshFuture.complete(
                                    new RefreshSchemaResult(newMetadata, schemaInAgreement));
                              }
                              firstSchemaRefreshFuture.complete(null);
                              currentSchemaRefresh = null;
                              // If another refresh was enqueued during this one, run it now
                              if (queuedSchemaRefresh != null) {
                                CompletableFuture<RefreshSchemaResult> tmp =
                                    this.queuedSchemaRefresh;
                                this.queuedSchemaRefresh = null;
                                startSchemaRequest(tmp);
                              }
                            });
                  }
                });
      } else if (queuedSchemaRefresh == null) {
        queuedSchemaRefresh = refreshFuture; // wait for our turn
      } else {
        CompletableFutures.completeFrom(
            queuedSchemaRefresh, refreshFuture); // join the queued request
      }
    }
`