### PR TITLE
CASSANDRA-19292 Enable Jenkins to test against Cassandra 4.1.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -256,8 +256,10 @@ pipeline {
       choices: ['2.1',       // Legacy Apache CassandraⓇ
                 '2.2',       // Legacy Apache CassandraⓇ
                 '3.0',       // Previous Apache CassandraⓇ
-                '3.11',      // Current Apache CassandraⓇ
-                '4.0',       // Development Apache CassandraⓇ
+                '3.11',      // Previous Apache CassandraⓇ
+                '4.0',       // Previous Apache CassandraⓇ
+                '4.1',       // Current Apache CassandraⓇ
+                '5.0',       // Development Apache CassandraⓇ
                 'dse-4.8.16',   // Previous EOSL DataStax Enterprise
                 'dse-5.0.15',   // Long Term Support DataStax Enterprise
                 'dse-5.1.35',   // Legacy DataStax Enterprise
@@ -291,7 +293,11 @@ pipeline {
                         </tr>
                         <tr>
                           <td><strong>4.0</strong></td>
-                          <td>Apache Cassandra&reg; v4.x (<b>CURRENTLY UNDER DEVELOPMENT</b>)</td>
+                          <td>Apache Cassandra&reg; v4.0.x</td>
+                        </tr>
+                        <tr>
+                          <td><strong>4.1</strong></td>
+                          <td>Apache Cassandra&reg; v4.1.x</td>
                         </tr>
                         <tr>
                           <td><strong>dse-4.8.16</strong></td>
@@ -445,7 +451,7 @@ pipeline {
           axis {
             name 'SERVER_VERSION'
             values '3.11',     // Latest stable Apache CassandraⓇ
-                   '4.0',      // Development Apache CassandraⓇ
+                   '4.1',      // Development Apache CassandraⓇ
                    'dse-6.8.30' // Current DataStax Enterprise
           }
           axis {
@@ -554,8 +560,10 @@ pipeline {
             name 'SERVER_VERSION'
             values '2.1',       // Legacy Apache CassandraⓇ
                    '3.0',       // Previous Apache CassandraⓇ
-                   '3.11',      // Current Apache CassandraⓇ
-                   '4.0',       // Development Apache CassandraⓇ
+                   '3.11',      // Previous Apache CassandraⓇ
+                   '4.0',       // Previous Apache CassandraⓇ
+                   '4.1',       // Current Apache CassandraⓇ
+                   '5.0',       // Development Apache CassandraⓇ
                    'dse-4.8.16',   // Previous EOSL DataStax Enterprise
                    'dse-5.0.15',   // Last EOSL DataStax Enterprise
                    'dse-5.1.35',   // Legacy DataStax Enterprise

--- a/core/src/main/java/com/datastax/oss/driver/api/core/Version.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/Version.java
@@ -52,6 +52,7 @@ public class Version implements Comparable<Version>, Serializable {
   @NonNull public static final Version V2_2_0 = Objects.requireNonNull(parse("2.2.0"));
   @NonNull public static final Version V3_0_0 = Objects.requireNonNull(parse("3.0.0"));
   @NonNull public static final Version V4_0_0 = Objects.requireNonNull(parse("4.0.0"));
+  @NonNull public static final Version V4_1_0 = Objects.requireNonNull(parse("4.1.0"));
   @NonNull public static final Version V5_0_0 = Objects.requireNonNull(parse("5.0.0"));
   @NonNull public static final Version V6_7_0 = Objects.requireNonNull(parse("6.7.0"));
   @NonNull public static final Version V6_8_0 = Objects.requireNonNull(parse("6.8.0"));

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
@@ -265,6 +265,19 @@ public class SchemaIT {
                   + "    total bigint,\n"
                   + "    unit text,\n"
                   + "    PRIMARY KEY (keyspace_name, table_name, task_id)\n"
+                  + "); */",
+              // Cassandra 4.1
+              "/* VIRTUAL TABLE system_views.sstable_tasks (\n"
+                  + "    keyspace_name text,\n"
+                  + "    table_name text,\n"
+                  + "    task_id timeuuid,\n"
+                  + "    completion_ratio double,\n"
+                  + "    kind text,\n"
+                  + "    progress bigint,\n"
+                  + "    sstables int,\n"
+                  + "    total bigint,\n"
+                  + "    unit text,\n"
+                  + "    PRIMARY KEY (keyspace_name, table_name, task_id)\n"
                   + "); */");
       // ColumnMetadata is as expected
       ColumnMetadata cm = tm.getColumn("progress").get();

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CcmBridge.java
@@ -236,12 +236,33 @@ public class CcmBridge implements AutoCloseable {
           Arrays.stream(nodes).mapToObj(n -> "" + n).collect(Collectors.joining(":")),
           createOptions.stream().collect(Collectors.joining(" ")));
 
+      Version cassandraVersion = getCassandraVersion();
       for (Map.Entry<String, Object> conf : cassandraConfiguration.entrySet()) {
-        execute("updateconf", String.format("%s:%s", conf.getKey(), conf.getValue()));
+        String originalKey = conf.getKey();
+        Object originalValue = conf.getValue();
+        execute(
+            "updateconf",
+            String.join(
+                ":",
+                getConfigKey(originalKey, originalValue, cassandraVersion),
+                getConfigValue(originalKey, originalValue, cassandraVersion)));
       }
-      if (getCassandraVersion().compareTo(Version.V2_2_0) >= 0) {
-        execute("updateconf", "enable_user_defined_functions:true");
+
+      // If we're dealing with anything more recent than 2.2 explicitly enable UDF... but run it
+      // through our conversion process to make
+      // sure more recent versions don't have a problem.
+      if (cassandraVersion.compareTo(Version.V2_2_0) >= 0) {
+        String originalKey = "enable_user_defined_functions";
+        Object originalValue = "true";
+        execute(
+            "updateconf",
+            String.join(
+                ":",
+                getConfigKey(originalKey, originalValue, cassandraVersion),
+                getConfigValue(originalKey, originalValue, cassandraVersion)));
       }
+
+      // Note that we aren't performing any substitution on DSE key/value props (at least for now)
       if (DSE_ENABLEMENT) {
         for (Map.Entry<String, Object> conf : dseConfiguration.entrySet()) {
           execute("updatedseconf", String.format("%s:%s", conf.getKey(), conf.getValue()));
@@ -461,6 +482,40 @@ public class CcmBridge implements AutoCloseable {
     }
 
     return Optional.empty();
+  }
+
+  private static String IN_MS_STR = "_in_ms";
+  private static int IN_MS_STR_LENGTH = IN_MS_STR.length();
+  private static String ENABLE_STR = "enable_";
+  private static int ENABLE_STR_LENGTH = ENABLE_STR.length();
+  private static String IN_KB_STR = "_in_kb";
+  private static int IN_KB_STR_LENGTH = IN_KB_STR.length();
+
+  @SuppressWarnings("unused")
+  private String getConfigKey(String originalKey, Object originalValue, Version cassandraVersion) {
+
+    // At least for now we won't support substitutions on nested keys.  This requires an extra
+    // traversal of the string
+    // but we'll live with that for now
+    if (originalKey.contains(".")) return originalKey;
+    if (cassandraVersion.compareTo(Version.V4_1_0) < 0) return originalKey;
+    if (originalKey.endsWith(IN_MS_STR))
+      return originalKey.substring(0, originalKey.length() - IN_MS_STR_LENGTH);
+    if (originalKey.startsWith(ENABLE_STR))
+      return originalKey.substring(ENABLE_STR_LENGTH) + "_enabled";
+    if (originalKey.endsWith(IN_KB_STR))
+      return originalKey.substring(0, originalKey.length() - IN_KB_STR_LENGTH);
+    return originalKey;
+  }
+
+  private String getConfigValue(
+      String originalKey, Object originalValue, Version cassandraVersion) {
+
+    String originalValueStr = originalValue.toString();
+    if (cassandraVersion.compareTo(Version.V4_1_0) < 0) return originalValueStr;
+    if (originalKey.endsWith(IN_MS_STR)) return originalValueStr + "ms";
+    if (originalKey.endsWith(IN_KB_STR)) return originalValueStr + "KiB";
+    return originalValueStr;
   }
 
   public static Builder builder() {


### PR DESCRIPTION
Confirmed that with this PR we get a green run of a per-commit build using existing DataStax Jenkins infrastructure