### PR TITLE
CASSANDRA-19568: Jennkins pipeline's default Java version for Jabba has changed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -592,7 +592,6 @@ pipeline {
           }
           stage('Build-Driver') {
             steps {
-              // Jabba default should be a JDK8 for now
               buildDriver('1.8')
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -478,7 +478,7 @@ pipeline {
           }
           stage('Build-Driver') {
             steps {
-              buildDriver('default')
+              buildDriver('1.8')
             }
           }
           stage('Execute-Tests') {
@@ -593,7 +593,7 @@ pipeline {
           stage('Build-Driver') {
             steps {
               // Jabba default should be a JDK8 for now
-              buildDriver('default')
+              buildDriver('1.8')
             }
           }
           stage('Execute-Tests') {


### PR DESCRIPTION
For DataStax internal jenkins.