### PR TITLE
Minor fix to unit test

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/session/DefaultSession.java
@@ -39,6 +39,7 @@ import com.datastax.oss.driver.internal.core.metadata.MetadataManager;
 import com.datastax.oss.driver.internal.core.metadata.MetadataManager.RefreshSchemaResult;
 import com.datastax.oss.driver.internal.core.metadata.NodeStateEvent;
 import com.datastax.oss.driver.internal.core.metadata.NodeStateManager;
+import com.datastax.oss.driver.internal.core.metrics.NodeMetricUpdater;
 import com.datastax.oss.driver.internal.core.metrics.SessionMetricUpdater;
 import com.datastax.oss.driver.internal.core.pool.ChannelPool;
 import com.datastax.oss.driver.internal.core.util.Loggers;
@@ -549,10 +550,11 @@ public class DefaultSession implements CqlSession {
 
       // clear metrics to prevent memory leak
       for (Node n : metadataManager.getMetadata().getNodes().values()) {
-        ((DefaultNode) n).getMetricUpdater().clearMetrics();
+        NodeMetricUpdater updater = ((DefaultNode) n).getMetricUpdater();
+        if (updater != null) updater.clearMetrics();
       }
 
-      DefaultSession.this.metricUpdater.clearMetrics();
+      if (metricUpdater != null) metricUpdater.clearMetrics();
 
       List<CompletionStage<Void>> childrenCloseStages = new ArrayList<>();
       for (AsyncAutoCloseable closeable : internalComponentsToClose()) {
@@ -575,10 +577,11 @@ public class DefaultSession implements CqlSession {
 
       // clear metrics to prevent memory leak
       for (Node n : metadataManager.getMetadata().getNodes().values()) {
-        ((DefaultNode) n).getMetricUpdater().clearMetrics();
+        NodeMetricUpdater updater = ((DefaultNode) n).getMetricUpdater();
+        if (updater != null) updater.clearMetrics();
       }
 
-      DefaultSession.this.metricUpdater.clearMetrics();
+      if (metricUpdater != null) metricUpdater.clearMetrics();
 
       if (closeWasCalled) {
         // onChildrenClosed has already been scheduled


### PR DESCRIPTION
The recent metrics changes to prevent session leakage ([this PR](https://github.com/apache/cassandra-java-driver/pull/1916)) introduced a small issue in one of the unit tests.  This PR addresses that issue.

A combo branch containing this fix + [the fix for CASSANDRA-19292](https://github.com/apache/cassandra-java-driver/pull/1924) passed all unit and integration tests in a local run using Cassandra 4.1.