### PR TITLE
CASSANDRA-19568: Use Jabba to specify Java 1.8 for building the driver

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,14 +98,16 @@ ENVIRONMENT_EOF
 }
 
 def buildDriver(jabbaVersion) {
-  withEnv(["BUILD_JABBA_VERSION=${jabbaVersion}"]) {
-    sh label: 'Build driver', script: '''#!/bin/bash -le
-      . ${JABBA_SHELL}
-      jabba use ${BUILD_JABBA_VERSION}
+  def buildDriverScript = '''#!/bin/bash -le
 
-      mvn -B -V install -DskipTests -Dmaven.javadoc.skip=true
-    '''
-  }
+    . ${JABBA_SHELL}
+    jabba use '''+jabbaVersion+'''
+
+    echo "Building with Java version '''+jabbaVersion+'''
+
+    mvn -B -V install -DskipTests -Dmaven.javadoc.skip=true
+  '''
+  sh label: 'Build driver', script: buildDriverScript
 }
 
 def executeTests() {
@@ -484,7 +486,7 @@ pipeline {
           }
           stage('Build-Driver') {
             steps {
-              buildDriver('default')
+              buildDriver('1.8')
             }
           }
           stage('Execute-Tests') {
@@ -600,8 +602,7 @@ pipeline {
           }
           stage('Build-Driver') {
             steps {
-              // Jabba default should be a JDK8 for now
-              buildDriver('default')
+              buildDriver('1.8')
             }
           }
           stage('Execute-Tests') {


### PR DESCRIPTION
Started out with work originally done by @SiyaoIsHiding on #1929 .  There's no way to test Jenkinsfile changes, however, since Jenkins is automatically pulling the Jenkinsfile from 4.x when a PR contains only Jenkinsfile changes.  So in order to minimize the disruption this was changed to use something similar to what was done for CASSANDRA-19504 (#1923).