### PR TITLE
CASSANDRA-19635 - Run integration tests with C* 5.x

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -242,6 +242,8 @@
               <threadCountClasses>8</threadCountClasses>
               <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-parallelized.xml</summaryFile>
               <skipITs>${skipParallelizableITs}</skipITs>
+              <argLine>${blockhound.argline}</argLine>
+              <jvm>${testing.jvm}/bin/java</jvm>
             </configuration>
           </execution>
           <execution>
@@ -253,6 +255,7 @@
               <excludedGroups>com.datastax.oss.driver.categories.ParallelizableTests, com.datastax.oss.driver.categories.IsolatedTests</excludedGroups>
               <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-serial.xml</summaryFile>
               <skipITs>${skipSerialITs}</skipITs>
+              <argLine>${blockhound.argline}</argLine>
               <jvm>${testing.jvm}/bin/java</jvm>
             </configuration>
           </execution>

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/BatchStatementIT.java
@@ -34,6 +34,7 @@ import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import com.datastax.oss.driver.api.core.servererrors.InvalidQueryException;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.ccm.SchemaChangeSynchronizer;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
@@ -72,13 +73,16 @@ public class BatchStatementIT {
           "CREATE TABLE counter3 (k0 text PRIMARY KEY, c counter)",
         };
 
-    for (String schemaStatement : schemaStatements) {
-      sessionRule
-          .session()
-          .execute(
-              SimpleStatement.newInstance(schemaStatement)
-                  .setExecutionProfile(sessionRule.slowProfile()));
-    }
+    SchemaChangeSynchronizer.withLock(
+        () -> {
+          for (String schemaStatement : schemaStatements) {
+            sessionRule
+                .session()
+                .execute(
+                    SimpleStatement.newInstance(schemaStatement)
+                        .setExecutionProfile(sessionRule.slowProfile()));
+          }
+        });
   }
 
   @Test

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/ExecutionInfoWarningsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/ExecutionInfoWarningsIT.java
@@ -33,6 +33,7 @@ import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
+import com.datastax.oss.driver.api.testinfra.ccm.SchemaChangeSynchronizer;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
@@ -88,12 +89,16 @@ public class ExecutionInfoWarningsIT {
   @Before
   public void createSchema() {
     // table with simple primary key, single cell.
-    sessionRule
-        .session()
-        .execute(
-            SimpleStatement.builder("CREATE TABLE IF NOT EXISTS test (k int primary key, v text)")
-                .setExecutionProfile(sessionRule.slowProfile())
-                .build());
+    SchemaChangeSynchronizer.withLock(
+        () -> {
+          sessionRule
+              .session()
+              .execute(
+                  SimpleStatement.builder(
+                          "CREATE TABLE IF NOT EXISTS test (k int primary key, v text)")
+                      .setExecutionProfile(sessionRule.slowProfile())
+                      .build());
+        });
     for (int i = 0; i < 100; i++) {
       sessionRule
           .session()

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCachingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCachingIT.java
@@ -30,6 +30,7 @@ import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
 import com.datastax.oss.driver.api.core.session.ProgrammaticArguments;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
 import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
+import com.datastax.oss.driver.api.testinfra.ccm.SchemaChangeSynchronizer;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.categories.IsolatedTests;
@@ -305,12 +306,19 @@ public class PreparedStatementCachingIT {
 
   @Test
   public void should_invalidate_cache_entry_on_basic_udt_change_result_set() {
-    invalidationResultSetTest(setupCacheEntryTestBasic, ImmutableSet.of("test_type_2"));
+    SchemaChangeSynchronizer.withLock(
+        () -> {
+          invalidationResultSetTest(setupCacheEntryTestBasic, ImmutableSet.of("test_type_2"));
+        });
   }
 
   @Test
   public void should_invalidate_cache_entry_on_basic_udt_change_variable_defs() {
-    invalidationVariableDefsTest(setupCacheEntryTestBasic, false, ImmutableSet.of("test_type_2"));
+    SchemaChangeSynchronizer.withLock(
+        () -> {
+          invalidationVariableDefsTest(
+              setupCacheEntryTestBasic, false, ImmutableSet.of("test_type_2"));
+        });
   }
 
   Consumer<CqlSession> setupCacheEntryTestCollection =
@@ -325,13 +333,19 @@ public class PreparedStatementCachingIT {
 
   @Test
   public void should_invalidate_cache_entry_on_collection_udt_change_result_set() {
-    invalidationResultSetTest(setupCacheEntryTestCollection, ImmutableSet.of("test_type_2"));
+    SchemaChangeSynchronizer.withLock(
+        () -> {
+          invalidationResultSetTest(setupCacheEntryTestCollection, ImmutableSet.of("test_type_2"));
+        });
   }
 
   @Test
   public void should_invalidate_cache_entry_on_collection_udt_change_variable_defs() {
-    invalidationVariableDefsTest(
-        setupCacheEntryTestCollection, true, ImmutableSet.of("test_type_2"));
+    SchemaChangeSynchronizer.withLock(
+        () -> {
+          invalidationVariableDefsTest(
+              setupCacheEntryTestCollection, true, ImmutableSet.of("test_type_2"));
+        });
   }
 
   Consumer<CqlSession> setupCacheEntryTestTuple =
@@ -346,12 +360,19 @@ public class PreparedStatementCachingIT {
 
   @Test
   public void should_invalidate_cache_entry_on_tuple_udt_change_result_set() {
-    invalidationResultSetTest(setupCacheEntryTestTuple, ImmutableSet.of("test_type_2"));
+    SchemaChangeSynchronizer.withLock(
+        () -> {
+          invalidationResultSetTest(setupCacheEntryTestTuple, ImmutableSet.of("test_type_2"));
+        });
   }
 
   @Test
   public void should_invalidate_cache_entry_on_tuple_udt_change_variable_defs() {
-    invalidationVariableDefsTest(setupCacheEntryTestTuple, false, ImmutableSet.of("test_type_2"));
+    SchemaChangeSynchronizer.withLock(
+        () -> {
+          invalidationVariableDefsTest(
+              setupCacheEntryTestTuple, false, ImmutableSet.of("test_type_2"));
+        });
   }
 
   Consumer<CqlSession> setupCacheEntryTestNested =
@@ -366,14 +387,20 @@ public class PreparedStatementCachingIT {
 
   @Test
   public void should_invalidate_cache_entry_on_nested_udt_change_result_set() {
-    invalidationResultSetTest(
-        setupCacheEntryTestNested, ImmutableSet.of("test_type_2", "test_type_4"));
+    SchemaChangeSynchronizer.withLock(
+        () -> {
+          invalidationResultSetTest(
+              setupCacheEntryTestNested, ImmutableSet.of("test_type_2", "test_type_4"));
+        });
   }
 
   @Test
   public void should_invalidate_cache_entry_on_nested_udt_change_variable_defs() {
-    invalidationVariableDefsTest(
-        setupCacheEntryTestNested, false, ImmutableSet.of("test_type_2", "test_type_4"));
+    SchemaChangeSynchronizer.withLock(
+        () -> {
+          invalidationVariableDefsTest(
+              setupCacheEntryTestNested, false, ImmutableSet.of("test_type_2", "test_type_4"));
+        });
   }
 
   /* ========================= Infrastructure copied from PreparedStatementIT ========================= */

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metadata/SchemaIT.java
@@ -278,6 +278,20 @@ public class SchemaIT {
                   + "    total bigint,\n"
                   + "    unit text,\n"
                   + "    PRIMARY KEY (keyspace_name, table_name, task_id)\n"
+                  + "); */",
+              // Cassandra 5.0
+              "/* VIRTUAL TABLE system_views.sstable_tasks (\n"
+                  + "    keyspace_name text,\n"
+                  + "    table_name text,\n"
+                  + "    task_id timeuuid,\n"
+                  + "    completion_ratio double,\n"
+                  + "    kind text,\n"
+                  + "    progress bigint,\n"
+                  + "    sstables int,\n"
+                  + "    target_directory text,\n"
+                  + "    total bigint,\n"
+                  + "    unit text,\n"
+                  + "    PRIMARY KEY (keyspace_name, table_name, task_id)\n"
                   + "); */");
       // ColumnMetadata is as expected
       ColumnMetadata cm = tm.getColumn("progress").get();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/type/codec/registry/CodecRegistryIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/type/codec/registry/CodecRegistryIT.java
@@ -38,6 +38,7 @@ import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 import com.datastax.oss.driver.api.core.type.codec.registry.MutableCodecRegistry;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.ccm.SchemaChangeSynchronizer;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.categories.ParallelizableTests;
@@ -78,35 +79,39 @@ public class CodecRegistryIT {
 
   @BeforeClass
   public static void createSchema() {
-    // table with simple primary key, single cell.
-    SESSION_RULE
-        .session()
-        .execute(
-            SimpleStatement.builder("CREATE TABLE IF NOT EXISTS test (k text primary key, v int)")
-                .setExecutionProfile(SESSION_RULE.slowProfile())
-                .build());
-    // table with map value
-    SESSION_RULE
-        .session()
-        .execute(
-            SimpleStatement.builder(
-                    "CREATE TABLE IF NOT EXISTS test2 (k0 text, k1 int, v map<int,text>, primary key (k0, k1))")
-                .setExecutionProfile(SESSION_RULE.slowProfile())
-                .build());
-    // table with UDT
-    SESSION_RULE
-        .session()
-        .execute(
-            SimpleStatement.builder("CREATE TYPE IF NOT EXISTS coordinates (x int, y int)")
-                .setExecutionProfile(SESSION_RULE.slowProfile())
-                .build());
-    SESSION_RULE
-        .session()
-        .execute(
-            SimpleStatement.builder(
-                    "CREATE TABLE IF NOT EXISTS test3 (k0 text, k1 int, v map<text,frozen<coordinates>>, primary key (k0, k1))")
-                .setExecutionProfile(SESSION_RULE.slowProfile())
-                .build());
+    SchemaChangeSynchronizer.withLock(
+        () -> {
+          // table with simple primary key, single cell.
+          SESSION_RULE
+              .session()
+              .execute(
+                  SimpleStatement.builder(
+                          "CREATE TABLE IF NOT EXISTS test (k text primary key, v int)")
+                      .setExecutionProfile(SESSION_RULE.slowProfile())
+                      .build());
+          // table with map value
+          SESSION_RULE
+              .session()
+              .execute(
+                  SimpleStatement.builder(
+                          "CREATE TABLE IF NOT EXISTS test2 (k0 text, k1 int, v map<int,text>, primary key (k0, k1))")
+                      .setExecutionProfile(SESSION_RULE.slowProfile())
+                      .build());
+          // table with UDT
+          SESSION_RULE
+              .session()
+              .execute(
+                  SimpleStatement.builder("CREATE TYPE IF NOT EXISTS coordinates (x int, y int)")
+                      .setExecutionProfile(SESSION_RULE.slowProfile())
+                      .build());
+          SESSION_RULE
+              .session()
+              .execute(
+                  SimpleStatement.builder(
+                          "CREATE TABLE IF NOT EXISTS test3 (k0 text, k1 int, v map<text,frozen<coordinates>>, primary key (k0, k1))")
+                      .setExecutionProfile(SESSION_RULE.slowProfile())
+                      .build());
+        });
   }
 
   // A simple codec that allows float values to be used for cassandra int column type.

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DeleteIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/DeleteIT.java
@@ -38,11 +38,10 @@ import com.datastax.oss.driver.api.mapper.annotations.Insert;
 import com.datastax.oss.driver.api.mapper.annotations.Mapper;
 import com.datastax.oss.driver.api.mapper.annotations.Select;
 import com.datastax.oss.driver.api.mapper.entity.saving.NullSavingStrategy;
-import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
-import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -51,18 +50,18 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
-@Category(ParallelizableTests.class)
+// Do not run LWT tests in parallel because they may interfere. Tests operate on the same row.
 @BackendRequirement(
     type = BackendType.CASSANDRA,
     minInclusive = "3.0",
     description = ">= in WHERE clause not supported in legacy versions")
 public class DeleteIT extends InventoryITBase {
 
-  private static final CcmRule CCM_RULE = CcmRule.getInstance();
+  private static CustomCcmRule CCM_RULE =
+      CustomCcmRule.builder().withCassandraConfiguration("enable_sasi_indexes", "true").build();
 
   private static final SessionRule<CqlSession> SESSION_RULE = SessionRule.builder(CCM_RULE).build();
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/ImmutableEntityIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/ImmutableEntityIT.java
@@ -42,6 +42,7 @@ import com.datastax.oss.driver.api.mapper.annotations.PropertyStrategy;
 import com.datastax.oss.driver.api.mapper.annotations.Select;
 import com.datastax.oss.driver.api.mapper.entity.saving.NullSavingStrategy;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.ccm.SchemaChangeSynchronizer;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
 import com.datastax.oss.driver.categories.ParallelizableTests;
 import java.util.Objects;
@@ -70,10 +71,15 @@ public class ImmutableEntityIT extends InventoryITBase {
   public static void setup() {
     CqlSession session = SESSION_RULE.session();
 
-    for (String query : createStatements(CCM_RULE)) {
-      session.execute(
-          SimpleStatement.builder(query).setExecutionProfile(SESSION_RULE.slowProfile()).build());
-    }
+    SchemaChangeSynchronizer.withLock(
+        () -> {
+          for (String query : createStatements(CCM_RULE)) {
+            session.execute(
+                SimpleStatement.builder(query)
+                    .setExecutionProfile(SESSION_RULE.slowProfile())
+                    .build());
+          }
+        });
 
     UserDefinedType dimensions2d =
         session

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InventoryITBase.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/InventoryITBase.java
@@ -22,7 +22,7 @@ import com.datastax.oss.driver.api.core.uuid.Uuids;
 import com.datastax.oss.driver.api.mapper.annotations.ClusteringColumn;
 import com.datastax.oss.driver.api.mapper.annotations.Entity;
 import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
-import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.ccm.BaseCcmRule;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Objects;
@@ -58,7 +58,7 @@ public abstract class InventoryITBase {
   protected static ProductSale MP3_DOWNLOAD_SALE_1 =
       new ProductSale(MP3_DOWNLOAD.getId(), DATE_3, 7, Uuids.startOf(915192000), 0.99, 12);
 
-  protected static List<String> createStatements(CcmRule ccmRule) {
+  protected static List<String> createStatements(BaseCcmRule ccmRule) {
     ImmutableList.Builder<String> builder =
         ImmutableList.<String>builder()
             .add(
@@ -92,13 +92,13 @@ public abstract class InventoryITBase {
   private static final Version MINIMUM_SASI_VERSION = Version.parse("3.4.0");
   private static final Version BROKEN_SASI_VERSION = Version.parse("6.8.0");
 
-  protected static boolean isSasiBroken(CcmRule ccmRule) {
+  protected static boolean isSasiBroken(BaseCcmRule ccmRule) {
     Optional<Version> dseVersion = ccmRule.getDseVersion();
     // creating SASI indexes is broken in DSE 6.8.0
     return dseVersion.isPresent() && dseVersion.get().compareTo(BROKEN_SASI_VERSION) == 0;
   }
 
-  protected static boolean supportsSASI(CcmRule ccmRule) {
+  protected static boolean supportsSASI(BaseCcmRule ccmRule) {
     return ccmRule.getCassandraVersion().compareTo(MINIMUM_SASI_VERSION) >= 0;
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectCustomWhereClauseIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/mapper/SelectCustomWhereClauseIT.java
@@ -35,6 +35,7 @@ import com.datastax.oss.driver.api.mapper.annotations.Insert;
 import com.datastax.oss.driver.api.mapper.annotations.Mapper;
 import com.datastax.oss.driver.api.mapper.annotations.Select;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.ccm.SchemaChangeSynchronizer;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
@@ -72,10 +73,15 @@ public class SelectCustomWhereClauseIT extends InventoryITBase {
 
     CqlSession session = SESSION_RULE.session();
 
-    for (String query : createStatements(CCM_RULE)) {
-      session.execute(
-          SimpleStatement.builder(query).setExecutionProfile(SESSION_RULE.slowProfile()).build());
-    }
+    SchemaChangeSynchronizer.withLock(
+        () -> {
+          for (String query : createStatements(CCM_RULE)) {
+            session.execute(
+                SimpleStatement.builder(query)
+                    .setExecutionProfile(SESSION_RULE.slowProfile())
+                    .build());
+          }
+        });
 
     InventoryMapper inventoryMapper =
         new SelectCustomWhereClauseIT_InventoryMapperBuilder(session).build();

--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/CcmStagedReactor.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/CcmStagedReactor.java
@@ -81,7 +81,7 @@ public class CcmStagedReactor extends AllConfinedStagedReactor {
     if (running) {
       LOGGER.info("Stopping CCM");
       CCM_BRIDGE.stop();
-      CCM_BRIDGE.remove();
+      CCM_BRIDGE.close();
       running = false;
       LOGGER.info("CCM stopped");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -992,6 +992,17 @@ limitations under the License.]]></inlineHeader>
       </activation>
     </profile>
     <profile>
+      <!-- workarounds for running tests with JDK14 -->
+      <id>test-jdk-14</id>
+      <activation>
+        <jdk>[14,)</jdk>
+      </activation>
+      <properties>
+        <!-- for DriverBlockHoundIntegrationIT when using JDK 13+, see https://github.com/reactor/BlockHound/issues/33 -->
+        <blockhound.argline>-XX:+AllowRedefinitionToAddDeleteMethods</blockhound.argline>
+      </properties>
+    </profile>
+    <profile>
       <!-- workarounds for running tests with JDK17 -->
       <id>test-jdk-17</id>
       <activation>

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/BaseCcmRule.java
@@ -38,7 +38,7 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
             new Thread(
                 () -> {
                   try {
-                    ccmBridge.remove();
+                    ccmBridge.close();
                   } catch (Exception e) {
                     // silently remove as may have already been removed.
                   }
@@ -53,7 +53,7 @@ public abstract class BaseCcmRule extends CassandraResourceRule {
 
   @Override
   protected void after() {
-    ccmBridge.remove();
+    ccmBridge.close();
   }
 
   @Override

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/SchemaChangeSynchronizer.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/SchemaChangeSynchronizer.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.api.testinfra.ccm;
+
+import java.util.concurrent.Semaphore;
+
+/**
+ * Running multiple parallel integration tests may fail due to query timeout when trying to apply
+ * several schema changes at once. Limit concurrently executed DDLs to 5.
+ */
+public class SchemaChangeSynchronizer {
+  private static final Semaphore lock = new Semaphore(5);
+
+  public static void withLock(Runnable callback) {
+    try {
+      lock.acquire();
+      try {
+        callback.run();
+      } finally {
+        lock.release();
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Thread interrupted wile waiting to obtain DDL lock", e);
+    }
+  }
+}

--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/session/SessionRule.java
@@ -29,6 +29,7 @@ import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListener;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.testinfra.CassandraResourceRule;
 import com.datastax.oss.driver.api.testinfra.ccm.BaseCcmRule;
+import com.datastax.oss.driver.api.testinfra.ccm.SchemaChangeSynchronizer;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
 import java.util.Objects;
 import java.util.Optional;
@@ -195,7 +196,10 @@ public class SessionRule<SessionT extends Session> extends ExternalResource {
               ScriptGraphStatement.SYNC);
     }
     if (keyspace != null) {
-      SessionUtils.dropKeyspace(session, keyspace, slowProfile);
+      SchemaChangeSynchronizer.withLock(
+          () -> {
+            SessionUtils.dropKeyspace(session, keyspace, slowProfile);
+          });
     }
     session.close();
   }


### PR DESCRIPTION
JIRA link: https://issues.apache.org/jira/browse/CASSANDRA-19635

PR contains necessary changes to run integration tests with Apache Cassandra 5.0-beta1. Developers can run the tests using:
```
$ mvn clean install -Dccm.version=5.0-beta1 -DtestJavaHome=/opt/java17/home -Ptest-jdk-17
```
Make sure you have latest CCM version installed locally and available in `$PATH`.