### PR TITLE
Fix uncaught exception during graceful channel shutdown after exceeding max orphan ids

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/channel/InFlightHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/channel/InFlightHandler.java
@@ -199,14 +199,14 @@ public class InFlightHandler extends ChannelDuplexHandler {
       LOG.debug("[{}] No pending queries, completing graceful shutdown now", logPrefix);
       ctx.channel().close();
     } else {
-      // remove heartbeat handler from pipeline if present.
+      // Remove heartbeat handler from pipeline if present.
       ChannelHandler heartbeatHandler = ctx.pipeline().get(ChannelFactory.HEARTBEAT_HANDLER_NAME);
       if (heartbeatHandler != null) {
         ctx.pipeline().remove(heartbeatHandler);
       }
       LOG.debug("[{}] There are pending queries, delaying graceful shutdown", logPrefix);
       closingGracefully = true;
-      closeStartedFuture.setSuccess();
+      closeStartedFuture.trySuccess();
     }
   }
 


### PR DESCRIPTION
Hi, this PR fixes the warning log spam when cancelling queries after the maximum orphan limit has been reached.

```
2024-06-04 05:36:38 UTC WARNING [<server,0xe>] [<<com.datastax.oss.driver.internal.core.util>>, UncaughtExceptions] Uncaught exception in scheduled task
java.lang.IllegalStateException: complete already: DefaultChannelPromise@750fc995(success)
	at io.netty.util.concurrent.DefaultPromise.setSuccess(DefaultPromise.java:100)
	at io.netty.channel.DefaultChannelPromise.setSuccess(DefaultChannelPromise.java:78)
	at io.netty.channel.DefaultChannelPromise.setSuccess(DefaultChannelPromise.java:73)
	at com.datastax.oss.driver.internal.core.channel.InFlightHandler.startGracefulShutdown(InFlightHandler.java:207)
	at com.datastax.oss.driver.internal.core.channel.InFlightHandler.cancel(InFlightHandler.java:186)
	at com.datastax.oss.driver.internal.core.channel.InFlightHandler.write(InFlightHandler.java:110)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:879)
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863)
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968)
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856)
	at io.netty.channel.DefaultChannelPipeline.write(DefaultChannelPipeline.java:1015)
	at io.netty.channel.AbstractChannel.write(AbstractChannel.java:301)
	at com.datastax.oss.driver.internal.core.channel.DefaultWriteCoalescer$Flusher.runOnEventLoop(DefaultWriteCoalescer.java:100)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Unknown Source)
```