### PR TITLE
manual: correct the codeblock directive

### DIFF
--- a/manual/mapper/daos/getentity/README.md
+++ b/manual/mapper/daos/getentity/README.md
@@ -108,7 +108,7 @@ The method can return:
 * a single entity instance. If the argument is a result set type, the generated code will extract
   the first row and convert it, or return `null` if the result set is empty.
 
-    ````java
+    ```java
     @GetEntity
     Product asProduct(Row row);
 


### PR DESCRIPTION
it should start with three backticks not four of them. otherwise sphinx warns like:

```
/home/kefu/dev/cassandra-java-driver/docs/_source/manual/mapper/daos/getentity/index.md:111: WARNING: Lexing literal_block '@GetEntity\nProduct asProduct(Row row);\n\n@GetEntity\nProduct firstR
owAsProduct(ResultSet resultSet);\n```\n\n' as "java" resulted in an error at token: '`'. Retrying in relaxed mode.
```

in this change, let's use three backticks. and the warning disappears.