### PR TITLE
Fix CustomCcmRule to drop `CURRENT` flag no matter what

### DIFF
--- a/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
+++ b/test-infra/src/main/java/com/datastax/oss/driver/api/testinfra/ccm/CustomCcmRule.java
@@ -53,6 +53,7 @@ public class CustomCcmRule extends BaseCcmRule {
           after();
         } catch (Exception e1) {
           LOG.warn("Error cleaning up CustomCcmRule before() failure", e1);
+          e.addSuppressed(e1);
         }
         throw e;
       }
@@ -64,8 +65,11 @@ public class CustomCcmRule extends BaseCcmRule {
 
   @Override
   protected void after() {
-    super.after();
-    CURRENT.compareAndSet(this, null);
+    try {
+      super.after();
+    } finally {
+      CURRENT.compareAndSet(this, null);
+    }
   }
 
   public CcmBridge getCcmBridge() {


### PR DESCRIPTION
It is follow up for https://github.com/apache/cassandra-java-driver/pull/1720

If `super.after()` throws an Exception `CURRENT` flag is never dropped which leads next tests with `CustomCcmMRule` to fail with `IllegalStateException("Attempting to use a Ccm rule while another is in use.  This is disallowed")`
