### PR TITLE
CASSANDRA-19931: Support OR operator and sub-conditions in query builder

### DIFF
--- a/query-builder/src/main/java/com/datastax/oss/driver/api/querybuilder/QueryBuilder.java
+++ b/query-builder/src/main/java/com/datastax/oss/driver/api/querybuilder/QueryBuilder.java
@@ -28,6 +28,7 @@ import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
 import com.datastax.oss.driver.api.querybuilder.delete.DeleteSelection;
 import com.datastax.oss.driver.api.querybuilder.insert.InsertInto;
+import com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause;
 import com.datastax.oss.driver.api.querybuilder.relation.Relation;
 import com.datastax.oss.driver.api.querybuilder.select.SelectFrom;
 import com.datastax.oss.driver.api.querybuilder.select.Selector;
@@ -43,6 +44,7 @@ import com.datastax.oss.driver.internal.querybuilder.DefaultLiteral;
 import com.datastax.oss.driver.internal.querybuilder.DefaultRaw;
 import com.datastax.oss.driver.internal.querybuilder.delete.DefaultDelete;
 import com.datastax.oss.driver.internal.querybuilder.insert.DefaultInsert;
+import com.datastax.oss.driver.internal.querybuilder.relation.DefaultSubConditionRelation;
 import com.datastax.oss.driver.internal.querybuilder.select.DefaultBindMarker;
 import com.datastax.oss.driver.internal.querybuilder.select.DefaultSelect;
 import com.datastax.oss.driver.internal.querybuilder.term.BinaryArithmeticTerm;
@@ -537,5 +539,11 @@ public class QueryBuilder {
   public static Truncate truncate(@Nullable String keyspace, @NonNull String table) {
     return truncate(
         keyspace == null ? null : CqlIdentifier.fromCql(keyspace), CqlIdentifier.fromCql(table));
+  }
+
+  /** Creates new sub-condition in the WHERE clause, surrounded by parenthesis. */
+  @NonNull
+  public static OngoingWhereClause<DefaultSubConditionRelation> subCondition() {
+    return new DefaultSubConditionRelation(true);
   }
 }

--- a/query-builder/src/main/java/com/datastax/oss/driver/api/querybuilder/relation/OngoingWhereClause.java
+++ b/query-builder/src/main/java/com/datastax/oss/driver/api/querybuilder/relation/OngoingWhereClause.java
@@ -27,6 +27,7 @@ import com.datastax.oss.driver.internal.querybuilder.relation.DefaultColumnCompo
 import com.datastax.oss.driver.internal.querybuilder.relation.DefaultColumnRelationBuilder;
 import com.datastax.oss.driver.internal.querybuilder.relation.DefaultMultiColumnRelationBuilder;
 import com.datastax.oss.driver.internal.querybuilder.relation.DefaultTokenRelationBuilder;
+import com.datastax.oss.driver.internal.querybuilder.relation.LogicalRelation;
 import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
@@ -46,6 +47,20 @@ public interface OngoingWhereClause<SelfT extends OngoingWhereClause<SelfT>> {
   @NonNull
   @CheckReturnValue
   SelfT where(@NonNull Relation relation);
+
+  /** Adds conjunction clause. Next relation is logically joined with AND. */
+  @NonNull
+  @CheckReturnValue
+  default SelfT and() {
+    return where(LogicalRelation.AND);
+  }
+
+  /** Adds alternative clause. Next relation is logically joined with OR. */
+  @NonNull
+  @CheckReturnValue
+  default SelfT or() {
+    return where(LogicalRelation.OR);
+  }
 
   /**
    * Adds multiple relations at once. All relations are logically joined with AND.

--- a/query-builder/src/main/java/com/datastax/oss/driver/internal/querybuilder/relation/DefaultSubConditionRelation.java
+++ b/query-builder/src/main/java/com/datastax/oss/driver/internal/querybuilder/relation/DefaultSubConditionRelation.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.querybuilder.relation;
+
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.cql.SimpleStatementBuilder;
+import com.datastax.oss.driver.api.querybuilder.BuildableQuery;
+import com.datastax.oss.driver.api.querybuilder.CqlSnippet;
+import com.datastax.oss.driver.api.querybuilder.relation.OngoingWhereClause;
+import com.datastax.oss.driver.api.querybuilder.relation.Relation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class DefaultSubConditionRelation
+    implements OngoingWhereClause<DefaultSubConditionRelation>, BuildableQuery, Relation {
+
+  private final List<Relation> relations;
+  private final boolean isSubCondition;
+
+  /** Construct sub-condition relation with empty WHERE clause. */
+  public DefaultSubConditionRelation(boolean isSubCondition) {
+    this.relations = new ArrayList<>();
+    this.isSubCondition = isSubCondition;
+  }
+
+  @NonNull
+  @Override
+  public DefaultSubConditionRelation where(@NonNull Relation relation) {
+    relations.add(relation);
+    return this;
+  }
+
+  @NonNull
+  @Override
+  public DefaultSubConditionRelation where(@NonNull Iterable<Relation> additionalRelations) {
+    for (Relation relation : additionalRelations) {
+      relations.add(relation);
+    }
+    return this;
+  }
+
+  @NonNull
+  public DefaultSubConditionRelation withRelations(@NonNull List<Relation> newRelations) {
+    relations.addAll(newRelations);
+    return this;
+  }
+
+  @NonNull
+  @Override
+  public String asCql() {
+    StringBuilder builder = new StringBuilder();
+
+    if (isSubCondition) {
+      builder.append("(");
+    }
+    appendWhereClause(builder, relations, isSubCondition);
+    if (isSubCondition) {
+      builder.append(")");
+    }
+
+    return builder.toString();
+  }
+
+  public static void appendWhereClause(
+      StringBuilder builder, List<Relation> relations, boolean isSubCondition) {
+    boolean first = true;
+    for (int i = 0; i < relations.size(); ++i) {
+      CqlSnippet snippet = relations.get(i);
+      if (first && !isSubCondition) {
+        builder.append(" WHERE ");
+      }
+      first = false;
+
+      snippet.appendTo(builder);
+
+      boolean logicalOperatorAdded = false;
+      LogicalRelation logicalRelation = lookAheadNextRelation(relations, i, LogicalRelation.class);
+      if (logicalRelation != null) {
+        builder.append(" ");
+        logicalRelation.appendTo(builder);
+        builder.append(" ");
+        logicalOperatorAdded = true;
+        ++i;
+      }
+      if (!logicalOperatorAdded && i + 1 < relations.size()) {
+        builder.append(" AND ");
+      }
+    }
+  }
+
+  private static <T extends Relation> T lookAheadNextRelation(
+      List<Relation> relations, int position, Class<T> clazz) {
+    if (position + 1 >= relations.size()) {
+      return null;
+    }
+    Relation relation = relations.get(position + 1);
+    if (relation.getClass().isAssignableFrom(clazz)) {
+      return (T) relation;
+    }
+    return null;
+  }
+
+  @NonNull
+  @Override
+  public SimpleStatement build() {
+    return builder().build();
+  }
+
+  @NonNull
+  @Override
+  public SimpleStatement build(@NonNull Object... values) {
+    return builder().addPositionalValues(values).build();
+  }
+
+  @NonNull
+  @Override
+  public SimpleStatement build(@NonNull Map<String, Object> namedValues) {
+    SimpleStatementBuilder builder = builder();
+    for (Map.Entry<String, Object> entry : namedValues.entrySet()) {
+      builder.addNamedValue(entry.getKey(), entry.getValue());
+    }
+    return builder.build();
+  }
+
+  @Override
+  public String toString() {
+    return asCql();
+  }
+
+  @Override
+  public void appendTo(@NonNull StringBuilder builder) {
+    builder.append(asCql());
+  }
+
+  @Override
+  public boolean isIdempotent() {
+    for (Relation relation : relations) {
+      if (!relation.isIdempotent()) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/query-builder/src/main/java/com/datastax/oss/driver/internal/querybuilder/relation/LogicalRelation.java
+++ b/query-builder/src/main/java/com/datastax/oss/driver/internal/querybuilder/relation/LogicalRelation.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.querybuilder.relation;
+
+import com.datastax.oss.driver.api.querybuilder.relation.Relation;
+import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.jcip.annotations.Immutable;
+
+@Immutable
+public class LogicalRelation implements Relation {
+  public static final LogicalRelation AND = new LogicalRelation("AND");
+  public static final LogicalRelation OR = new LogicalRelation("OR");
+
+  private final String operator;
+
+  public LogicalRelation(@NonNull String operator) {
+    Preconditions.checkNotNull(operator);
+    this.operator = operator;
+  }
+
+  @Override
+  public void appendTo(@NonNull StringBuilder builder) {
+    builder.append(operator);
+  }
+
+  @Override
+  public boolean isIdempotent() {
+    return true;
+  }
+}

--- a/query-builder/src/main/java/com/datastax/oss/driver/internal/querybuilder/select/DefaultSelect.java
+++ b/query-builder/src/main/java/com/datastax/oss/driver/internal/querybuilder/select/DefaultSelect.java
@@ -28,6 +28,7 @@ import com.datastax.oss.driver.api.querybuilder.select.SelectFrom;
 import com.datastax.oss.driver.api.querybuilder.select.Selector;
 import com.datastax.oss.driver.internal.querybuilder.CqlHelper;
 import com.datastax.oss.driver.internal.querybuilder.ImmutableCollections;
+import com.datastax.oss.driver.internal.querybuilder.relation.DefaultSubConditionRelation;
 import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
@@ -388,7 +389,8 @@ public class DefaultSelect implements SelectFrom, Select {
     builder.append(" FROM ");
     CqlHelper.qualify(keyspace, table, builder);
 
-    CqlHelper.append(relations, builder, " WHERE ", " AND ", null);
+    DefaultSubConditionRelation.appendWhereClause(builder, relations, false);
+
     CqlHelper.append(groupByClauses, builder, " GROUP BY ", ",", null);
 
     boolean first = true;

--- a/query-builder/src/test/java/com/datastax/oss/driver/api/querybuilder/select/SelectOrderingTest.java
+++ b/query-builder/src/test/java/com/datastax/oss/driver/api/querybuilder/select/SelectOrderingTest.java
@@ -122,10 +122,15 @@ public class SelectOrderingTest {
                 .where(
                     subCondition()
                         .where(Relation.column("l").isEqualTo(literal(2)))
+                        .or()
                         .where(Relation.column("m").isEqualTo(literal(3)))
                         .or()
-                        .where(Relation.column("x").isEqualTo(literal(4)))))
-        .hasCql("SELECT * FROM foo WHERE k=1 AND (l=2 AND m=3 OR x=4)");
+                        .where(
+                            subCondition()
+                                .where(Relation.column("q").isEqualTo(literal(4)))
+                                .and()
+                                .where(Relation.column("p").isEqualTo(literal(5))))))
+        .hasCql("SELECT * FROM foo WHERE k=1 AND (l=2 OR m=3 OR (q=4 AND p=5))");
   }
 
   @Test

--- a/query-builder/src/test/java/com/datastax/oss/driver/api/querybuilder/select/SelectOrderingTest.java
+++ b/query-builder/src/test/java/com/datastax/oss/driver/api/querybuilder/select/SelectOrderingTest.java
@@ -22,6 +22,7 @@ import static com.datastax.oss.driver.api.core.metadata.schema.ClusteringOrder.D
 import static com.datastax.oss.driver.api.querybuilder.Assertions.assertThat;
 import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.literal;
 import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.selectFrom;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.subCondition;
 
 import com.datastax.oss.driver.api.querybuilder.relation.Relation;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
@@ -44,6 +45,103 @@ public class SelectOrderingTest {
                 .where(Relation.column("k").isEqualTo(literal(1)))
                 .orderBy(ImmutableMap.of("c1", ASC, "c2", DESC)))
         .hasCql("SELECT * FROM foo WHERE k=1 ORDER BY c1 ASC,c2 DESC");
+  }
+
+  @Test
+  public void should_support_nested_sub_conditions() {
+    assertThat(
+            selectFrom("foo")
+                .all()
+                .where(Relation.column("k").isEqualTo(literal(1)))
+                .and()
+                .where(
+                    subCondition()
+                        .where(Relation.column("l").isEqualTo(literal(2)))
+                        .where(
+                            subCondition()
+                                .where(Relation.column("m").isEqualTo(literal(3)))
+                                .or()
+                                .where(Relation.column("x").isEqualTo(literal(4)))))
+                .orderBy("c1", ASC))
+        .hasCql("SELECT * FROM foo WHERE k=1 AND (l=2 AND (m=3 OR x=4)) ORDER BY c1 ASC");
+  }
+
+  @Test
+  public void should_generate_criteria_alternative() {
+    assertThat(
+            selectFrom("foo")
+                .all()
+                .where(Relation.column("k").isEqualTo(literal(1)))
+                .or()
+                .where(Relation.column("l").isEqualTo(literal(2)))
+                .orderBy("c1", ASC)
+                .orderBy("c2", DESC))
+        .hasCql("SELECT * FROM foo WHERE k=1 OR l=2 ORDER BY c1 ASC,c2 DESC");
+  }
+
+  @Test
+  public void should_support_sub_condition() {
+    assertThat(
+            selectFrom("foo")
+                .all()
+                .where(Relation.column("k").isEqualTo(literal(1)))
+                .and()
+                .where(
+                    subCondition()
+                        .where(Relation.column("l").isEqualTo(literal(2)))
+                        .or()
+                        .where(Relation.column("m").isEqualTo(literal(3))))
+                .orderBy("c1", ASC)
+                .orderBy("c2", DESC))
+        .hasCql("SELECT * FROM foo WHERE k=1 AND (l=2 OR m=3) ORDER BY c1 ASC,c2 DESC");
+    assertThat(
+            selectFrom("foo")
+                .all()
+                .where(
+                    subCondition()
+                        .where(Relation.column("l").isEqualTo(literal(2)))
+                        .where(Relation.column("m").isEqualTo(literal(3))))
+                .and()
+                .where(Relation.column("k").isEqualTo(literal(1)))
+                .orderBy("c1", ASC))
+        .hasCql("SELECT * FROM foo WHERE (l=2 AND m=3) AND k=1 ORDER BY c1 ASC");
+    assertThat(
+            selectFrom("foo")
+                .all()
+                .where(
+                    subCondition()
+                        .where(Relation.column("l").isEqualTo(literal(2)))
+                        .where(Relation.column("m").isEqualTo(literal(3)))
+                        .where(Relation.column("x").isEqualTo(literal(4))))
+                .orderBy("c1", ASC))
+        .hasCql("SELECT * FROM foo WHERE (l=2 AND m=3 AND x=4) ORDER BY c1 ASC");
+    assertThat(
+            selectFrom("foo")
+                .all()
+                .where(Relation.column("k").isEqualTo(literal(1)))
+                .where(
+                    subCondition()
+                        .where(Relation.column("l").isEqualTo(literal(2)))
+                        .where(Relation.column("m").isEqualTo(literal(3)))
+                        .or()
+                        .where(Relation.column("x").isEqualTo(literal(4)))))
+        .hasCql("SELECT * FROM foo WHERE k=1 AND (l=2 AND m=3 OR x=4)");
+  }
+
+  @Test
+  public void should_use_conjunction_as_default_logical_operator() {
+    assertThat(
+            selectFrom("foo")
+                .all()
+                .where(Relation.column("k").isEqualTo(literal(1)))
+                .where(
+                    subCondition()
+                        .where(Relation.column("l").isEqualTo(literal(2)))
+                        .or()
+                        .where(Relation.column("m").isEqualTo(literal(3))))
+                .orderBy("c1", ASC)
+                .orderBy("c2", DESC))
+        .hasCql("SELECT * FROM foo WHERE k=1 AND (l=2 OR m=3) ORDER BY c1 ASC,c2 DESC");
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Fix [CASSANDRA-19931](https://issues.apache.org/jira/browse/CASSANDRA-19931).

Example OR operator:
```
assertThat(
        selectFrom("foo")
            .all()
            .where(Relation.column("k").isEqualTo(literal(1)))
            .and()
            .where(Relation.column("l").isEqualTo(literal(2)))
            .or()
            .where(Relation.column("m").isEqualTo(literal(3)))
            .orderBy("c1", ASC)
            .orderBy("c2", DESC))
    .hasCql("SELECT * FROM foo WHERE k=1 AND l=2 OR m=3 ORDER BY c1 ASC,c2 DESC");
```

Example sub-condition:
```
assertThat(
        selectFrom("foo")
            .all()
            .where(Relation.column("k").isEqualTo(literal(1)))
            .and()
            .where(
                subCondition()
                    .where(Relation.column("l").isEqualTo(literal(2)))
                    .or()
                    .where(Relation.column("m").isEqualTo(literal(3))))
            .orderBy("c1", ASC)
            .orderBy("c2", DESC))
    .hasCql("SELECT * FROM foo WHERE k=1 AND (l=2 OR m=3) ORDER BY c1 ASC,c2 DESC");
```