### PR TITLE
Compliance changes for generated source and binary distributable tarballs

### DIFF
--- a/LICENSE_binary
+++ b/LICENSE_binary
@@ -1,0 +1,229 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+Apache Cassandra Java Driver bundles code and files from the following projects:
+
+Protocol Buffers
+Copyright 2008 Google Inc.
+This product includes software developed as part of the Protocol Buffers project ( https://developers.google.com/protocol-buffers/ ).
+see driver-core/src/main/java/com/datastax/driver/core/VIntCoding.java
+
+This product bundles Java Native Runtime - POSIX 3.1.15,
+which is available under the Eclipse Public License version 2.0.
+see licenses/jnr-posix.txt
+
+This product bundles jnr-x86asm 1.0.2,
+which is available under the MIT License.
+see licenses/jnr-x86asm.txt
+
+This product bundles ASM 9.2: a very small and fast Java bytecode manipulation framework,
+which is available under the 3-Clause BSD License.
+see licenses/asm.txt
+
+This product bundles HdrHistogram 2.1.12: A High Dynamic Range (HDR) Histogram,
+which is available under the 2-Clause BSD License.
+see licenses/HdrHistogram.txt
+
+This product bundles The Simple Logging Facade for Java (SLF4J) API 1.7.26,
+which is available under the MIT License.
+see licenses/slf4j-api.txt

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Java Driver for Apache Cassandra®
 
+:warning: The java-driver has recently been donated by Datastax to The Apache Software Foundation and the Apache Cassandra project.  Bear with us as we move assets and coordinates.
+
 *If you're reading this on github.com, please note that this is the readme
 for the development version and that some features described here might
 not yet have been released. You can find the documentation for the latest
 version through the [Java Driver
 docs](http://docs.datastax.com/en/developer/java-driver/3.11/index.html) or via the release tags,
-[e.g. 3.11.5](https://github.com/datastax/java-driver/tree/3.11.5).*
+[e.g. 3.11.5](https://github.com/apache/cassandra-java-driver/tree/3.11.5).*
 
 A modern, [feature-rich](manual/) and highly tunable Java client
 library for Apache Cassandra (2.1+) and using exclusively Cassandra's binary protocol 
@@ -42,17 +44,12 @@ The driver contains the following modules:
 
 **Useful links:**
 
-- JIRA (bug tracking): https://datastax-oss.atlassian.net/browse/JAVA
-- MAILING LIST: https://groups.google.com/a/lists.datastax.com/forum/#!forum/java-driver-user
-- DATASTAX ACADEMY SLACK: #datastax-drivers on https://academy.datastax.com/slack 
-- TWITTER: [@dsJavaDriver](https://twitter.com/dsJavaDriver) tweets Java
-  driver releases and important announcements (low frequency).
-  [@DataStaxEng](https://twitter.com/datastaxeng) has more news including
-  other drivers, Cassandra, and DSE.
+- JIRA (bug tracking): https://issues.apache.org/jira/projects/CASSJAVA
+- MAILING LIST: https://cassandra.apache.org/_/community.html#discussions
 - DOCS: the [manual](http://docs.datastax.com/en/developer/java-driver/3.11/manual/) has quick
   start material and technical details about the driver and its features.
 - API: https://docs.datastax.com/en/drivers/java/3.11
-- GITHUB REPOSITORY: https://github.com/datastax/java-driver
+- GITHUB REPOSITORY: https://github.com/apache/cassandra-java-driver
 - [changelog](changelog/)
 
 ## Getting the driver
@@ -63,7 +60,7 @@ using DataStax Enterprise, install the [DataStax Enterprise Java Driver][dse-dri
 
 ```xml
 <dependency>
-  <groupId>com.datastax.cassandra</groupId>
+  <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-core</artifactId>
   <version>3.11.5</version>
 </dependency>
@@ -73,7 +70,7 @@ Note that the object mapper is published as a separate artifact:
 
 ```xml
 <dependency>
-  <groupId>com.datastax.cassandra</groupId>
+  <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-mapping</artifactId>
   <version>3.11.5</version>
 </dependency>
@@ -83,7 +80,7 @@ The 'extras' module is also published as a separate artifact:
 
 ```xml
 <dependency>
-  <groupId>com.datastax.cassandra</groupId>
+  <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-extras</artifactId>
   <version>3.11.5/version>
 </dependency>
@@ -94,55 +91,31 @@ We also provide a [shaded JAR](manual/shaded_jar/)
 to avoid the explicit dependency to Netty.
 
 If you can't use a dependency management tool, a
-[binary tarball](https://github.com/datastax/java-driver/releases/3.11.5)
+[binary tarball](https://cassandra.apache.org/_/download.html)
 is available for download.
 
 ## Compatibility
 
-The Java client driver 3.11.5 ([branch 3.x](https://github.com/datastax/java-driver/tree/3.x)) is compatible with Apache
+The Java client driver 3.11.5 ([branch 3.x](https://github.com/apache/cassandra-java-driver/tree/3.x)) is compatible with Apache
 Cassandra 2.1, 2.2 and 3.0+ (see [this page](http://docs.datastax.com/en/developer/java-driver/3.11/manual/native_protocol/) for
 the most up-to-date compatibility information).
 
 UDT and tuple support is available only when using Apache Cassandra 2.1 or higher (see [CQL improvements in Cassandra 2.1](http://www.datastax.com/dev/blog/cql-in-2-1)).
 
 Other features are available only when using Apache Cassandra 2.0 or higher (e.g. result set paging,
-[BatchStatement](https://github.com/datastax/java-driver/blob/3.x/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java),
+[BatchStatement](https://github.com/apache/cassandra-java-driver/blob/3.x/driver-core/src/main/java/com/datastax/driver/core/BatchStatement.java),
 [lightweight transactions](http://www.datastax.com/documentation/cql/3.1/cql/cql_using/use_ltweight_transaction_t.html) 
 -- see [What's new in Cassandra 2.0](http://www.datastax.com/documentation/cassandra/2.0/cassandra/features/features_key_c.html)). 
 Trying to use these with a cluster running Cassandra 1.2 will result in 
-an [UnsupportedFeatureException](https://github.com/datastax/java-driver/blob/3.x/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnsupportedFeatureException.java) being thrown.
+an [UnsupportedFeatureException](https://github.com/apache/cassandra-java-driver/blob/3.x/driver-core/src/main/java/com/datastax/driver/core/exceptions/UnsupportedFeatureException.java) being thrown.
 
 The java driver supports Java JDK versions 6 and above.
-
-If using _DataStax Enterprise_, the [DataStax Enterprise Java Driver][dse-driver] provides 
-more features and better compatibility.
-
-__Disclaimer__: Some _DataStax/DataStax Enterprise_ products might partially work on 
-big-endian systems, but _DataStax_ does not officially support these systems.
 
 ## Upgrading from previous versions
 
 If you are upgrading from a previous version of the driver, be sure to have a look at
 the [upgrade guide](/upgrade_guide/).
 
-If you are upgrading to _DataStax Enterprise_, use the [DataStax Enterprise Java Driver][dse-driver] for more
-features and better compatibility.
-
-## License
-
-&copy; The Apache Software Foundation
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
 
 ----
 
@@ -150,4 +123,5 @@ Apache Cassandra, Apache, Tomcat, Lucene, Solr, Hadoop, Spark, TinkerPop, and Ca
 trademarks of the [Apache Software Foundation](http://www.apache.org/) or its subsidiaries in
 Canada, the United States and/or other countries. 
 
-[dse-driver]: http://docs.datastax.com/en/developer/java-driver-dse/latest/
+
+Binary artifacts of this product bundle Java Native Runtime libraries, which is available under the Eclipse Public License version 2.0.

--- a/docs.yaml
+++ b/docs.yaml
@@ -50,7 +50,7 @@ sections:
         files: 'faq/**/*.md'
 links:
   - title: Code
-    href:  https://github.com/datastax/java-driver/
+    href:  https://github.com/apache/cassandra-java-driver/
   - title: Docs
     href:  http://docs.datastax.com/en/developer/java-driver/
   - title: Issues

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.datastax.cassandra</groupId>
+        <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
         <version>3.11.6-SNAPSHOT</version>
     </parent>
@@ -179,8 +179,10 @@
             <resource>
                 <directory>${project.basedir}/..</directory>
                 <includes>
+                    <include>LICENSE_binary</include>
                     <include>LICENSE</include>
                     <include>NOTICE_binary.txt</include>
+                    <include>NOTICE.txt</include>
                 </includes>
                 <targetPath>META-INF</targetPath>
             </resource>

--- a/driver-core/src/main/java/com/datastax/driver/core/Host.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Host.java
@@ -343,9 +343,9 @@ public class Host {
    * {@code null}, and the caller should always be aware of this possibility.
    *
    * @return the DSE version the host is running.
-   * @deprecated Please use the <a href="https://github.com/datastax/java-driver-dse">Java Driver
-   *     for DSE</a> if you are connecting to a DataStax Enterprise (DSE) cluster. This method might
-   *     not function properly with future versions of DSE.
+   * @deprecated Please use the <a href="https://github.com/datastax/java-driver-dse">Java
+   *     Driver for DSE</a> if you are connecting to a DataStax Enterprise (DSE) cluster. This
+   *     method might not function properly with future versions of DSE.
    */
   @Deprecated
   public VersionNumber getDseVersion() {
@@ -359,9 +359,9 @@ public class Host {
    * {@code null}, and the caller should always be aware of this possibility.
    *
    * @return the DSE workload the host is running.
-   * @deprecated Please use the <a href="https://github.com/datastax/java-driver-dse">Java Driver
-   *     for DSE</a> if you are connecting to a DataStax Enterprise (DSE) cluster. This method might
-   *     not function properly with future versions of DSE.
+   * @deprecated Please use the <a href="https://github.com/apache/cassandra-java-driver-dse">Java
+   *     Driver for DSE</a> if you are connecting to a DataStax Enterprise (DSE) cluster. This
+   *     method might not function properly with future versions of DSE.
    */
   @Deprecated
   public String getDseWorkload() {
@@ -372,9 +372,9 @@ public class Host {
    * Returns whether the host is running DSE Graph.
    *
    * @return whether the node is running DSE Graph.
-   * @deprecated Please use the <a href="https://github.com/datastax/java-driver-dse">Java Driver
-   *     for DSE</a> if you are connecting to a DataStax Enterprise (DSE) cluster. This method might
-   *     not function properly with future versions of DSE.
+   * @deprecated Please use the <a href="https://github.com/apache/cassandra-java-driver-dse">Java
+   *     Driver for DSE</a> if you are connecting to a DataStax Enterprise (DSE) cluster. This
+   *     method might not function properly with future versions of DSE.
    */
   @Deprecated
   public boolean isDseGraphEnabled() {

--- a/driver-dist-source/pom.xml
+++ b/driver-dist-source/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.cassandra</groupId>
+    <artifactId>cassandra-driver-parent</artifactId>
+    <version>3.11.6-SNAPSHOT</version>
+  </parent>
+  <artifactId>java-driver-distribution-source</artifactId>
+  <packaging>pom</packaging>
+  <name>Apache Cassandra Java Driver - source distribution</name>
+  <build>
+    <finalName>apache-cassandra-java-driver-${project.version}-source</finalName>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <!-- http://stackoverflow.com/questions/13218313/unable-to-disable-generation-of-empty-jar-maven-jar-plugin -->
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+        <configuration>
+          <skipSource>true</skipSource>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <configuration>
+          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>assemble-source-tarball</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <appendAssemblyId>false</appendAssemblyId>
+              <descriptors>
+                <descriptor>src/assembly/source-tarball.xml</descriptor>
+              </descriptors>
+              <tarLongFileMode>posix</tarLongFileMode>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>net.nicoulaj.maven.plugins</groupId>
+            <artifactId>checksum-maven-plugin</artifactId>
+            <version>1.7</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>artifacts</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <attachChecksums>true</attachChecksums>
+              <algorithms>
+                <algorithm>sha256</algorithm>
+                <algorithm>sha512</algorithm>
+              </algorithms>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/driver-dist-source/src/assembly/source-tarball.xml
+++ b/driver-dist-source/src/assembly/source-tarball.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+  <id>source-tarball</id>
+  <formats>
+    <format>tar.gz</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>..</directory>
+      <outputDirectory>.</outputDirectory>
+      <useDefaultExcludes>true</useDefaultExcludes>
+      <excludes>
+        <!-- essentially the same list as .gitignore -->
+        <exclude>**/*.iml</exclude>
+        <exclude>**/.classpath</exclude>
+        <exclude>**/.project</exclude>
+        <exclude>**/.java-version</exclude>
+        <exclude>**/.flattened-pom.xml</exclude>
+        <exclude>**/dependency-reduced-pom.xml</exclude>
+        <exclude>**/${project.build.directory}/**</exclude>
+      </excludes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/driver-dist/pom.xml
+++ b/driver-dist/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.datastax.cassandra</groupId>
+        <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
         <version>3.11.6-SNAPSHOT</version>
     </parent>
@@ -36,17 +36,17 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-mapping</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-extras</artifactId>
         </dependency>
 
@@ -54,7 +54,7 @@
 
     <build>
 
-        <finalName>cassandra-java-driver-${project.version}</finalName>
+        <finalName>apache-cassandra-java-driver-${project.version}</finalName>
 
         <plugins>
 
@@ -101,21 +101,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>dependencies-javadoc</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                                <configuration>
-                                    <includeDependencySources>true</includeDependencySources>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>
                         <executions>
                             <execution>
@@ -140,6 +125,25 @@
                         <configuration>
                             <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
                         </configuration>
+                    </plugin>
+                    <plugin>
+                      <groupId>net.nicoulaj.maven.plugins</groupId>
+                      <artifactId>checksum-maven-plugin</artifactId>
+                      <version>1.7</version>
+                      <executions>
+                        <execution>
+                          <goals>
+                            <goal>artifacts</goal>
+                          </goals>
+                        </execution>
+                      </executions>
+                      <configuration>
+                        <attachChecksums>true</attachChecksums>
+                        <algorithms>
+                          <algorithm>sha256</algorithm>
+                          <algorithm>sha512</algorithm>
+                        </algorithms>
+                      </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/driver-dist/src/assembly/binary-tarball.xml
+++ b/driver-dist/src/assembly/binary-tarball.xml
@@ -32,7 +32,7 @@
         <moduleSet>
             <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
-                <include>com.datastax.cassandra:cassandra-driver-core</include>
+                <include>org.apache.cassandra:cassandra-driver-core</include>
             </includes>
             <binaries>
                 <unpack>false</unpack>
@@ -41,9 +41,9 @@
                         <outputDirectory>lib</outputDirectory>
                         <excludes>
                             <!-- reactor projects -->
-                            <exclude>com.datastax.cassandra:cassandra-driver-core</exclude>
-                            <exclude>com.datastax.cassandra:cassandra-driver-mapping</exclude>
-                            <exclude>com.datastax.cassandra:cassandra-driver-extras</exclude>
+                            <exclude>org.apache.cassandra:cassandra-driver-core</exclude>
+                            <exclude>org.apache.cassandra:cassandra-driver-mapping</exclude>
+                            <exclude>org.apache.cassandra:cassandra-driver-extras</exclude>
                             <!-- platform-dependent -->
                             <exclude>io.netty:netty-transport-native-epoll:*</exclude>
                         </excludes>
@@ -65,7 +65,7 @@
         <moduleSet>
             <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
-                <include>com.datastax.cassandra:cassandra-driver-mapping</include>
+                <include>org.apache.cassandra:cassandra-driver-mapping</include>
             </includes>
             <binaries>
                 <unpack>false</unpack>
@@ -74,9 +74,9 @@
                         <outputDirectory>lib/mapping</outputDirectory>
                         <excludes>
                             <!-- reactor projects -->
-                            <exclude>com.datastax.cassandra:cassandra-driver-core</exclude>
-                            <exclude>com.datastax.cassandra:cassandra-driver-mapping</exclude>
-                            <exclude>com.datastax.cassandra:cassandra-driver-extras</exclude>
+                            <exclude>org.apache.cassandra:cassandra-driver-core</exclude>
+                            <exclude>org.apache.cassandra:cassandra-driver-mapping</exclude>
+                            <exclude>org.apache.cassandra:cassandra-driver-extras</exclude>
                             <!-- already included in lib/core -->
                             <exclude>com.google.guava:guava</exclude>
                             <exclude>org.slf4j:slf4j-api</exclude>
@@ -91,7 +91,7 @@
         <moduleSet>
             <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
-                <include>com.datastax.cassandra:cassandra-driver-extras</include>
+                <include>org.apache.cassandra:cassandra-driver-extras</include>
             </includes>
             <binaries>
                 <unpack>false</unpack>
@@ -100,9 +100,9 @@
                         <outputDirectory>lib/extras</outputDirectory>
                         <excludes>
                             <!-- reactor projects -->
-                            <exclude>com.datastax.cassandra:cassandra-driver-core</exclude>
-                            <exclude>com.datastax.cassandra:cassandra-driver-mapping</exclude>
-                            <exclude>com.datastax.cassandra:cassandra-driver-extras</exclude>
+                            <exclude>org.apache.cassandra:cassandra-driver-core</exclude>
+                            <exclude>org.apache.cassandra:cassandra-driver-mapping</exclude>
+                            <exclude>org.apache.cassandra:cassandra-driver-extras</exclude>
                             <!-- already included in lib/core -->
                             <exclude>com.google.guava:guava</exclude>
                             <exclude>org.slf4j:slf4j-api</exclude>
@@ -117,10 +117,10 @@
         <moduleSet>
             <useAllReactorProjects>true</useAllReactorProjects>
             <includes>
-                <include>com.datastax.cassandra:cassandra-driver-core</include>
-                <include>com.datastax.cassandra:cassandra-driver-mapping</include>
-                <include>com.datastax.cassandra:cassandra-driver-extras</include>
-                <include>com.datastax.cassandra:cassandra-driver-examples</include>
+                <include>org.apache.cassandra:cassandra-driver-core</include>
+                <include>org.apache.cassandra:cassandra-driver-mapping</include>
+                <include>org.apache.cassandra:cassandra-driver-extras</include>
+                <include>org.apache.cassandra:cassandra-driver-examples</include>
             </includes>
             <binaries>
                 <unpack>false</unpack>
@@ -138,17 +138,12 @@
     <fileSets>
 
         <fileSet>
-            <directory>target/apidocs</directory>
-            <outputDirectory>apidocs</outputDirectory>
-        </fileSet>
-
-        <fileSet>
             <directory>..</directory>
             <outputDirectory>.</outputDirectory>
             <includes>
                 <include>README*</include>
-                <include>LICENSE*</include>
-                <include>NOTICE*</include>
+                <include>LICENSE_binary</include>
+                <include>NOTICE_binary.txt</include>
             </includes>
         </fileSet>
 

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.datastax.cassandra</groupId>
+        <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
         <version>3.11.6-SNAPSHOT</version>
     </parent>
@@ -36,12 +36,12 @@
         <!-- driver dependencies -->
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-extras</artifactId>
             <optional>true</optional>
         </dependency>
@@ -143,8 +143,10 @@
             <resource>
                 <directory>${project.basedir}/..</directory>
                 <includes>
+                    <include>LICENSE_binary</include>
                     <include>LICENSE</include>
                     <include>NOTICE_binary.txt</include>
+                    <include>NOTICE.txt</include>
                 </includes>
                 <targetPath>META-INF</targetPath>
             </resource>
@@ -163,13 +165,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>clirr-maven-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/driver-examples/src/main/java/com/datastax/driver/examples/json/JacksonJsonColumn.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/json/JacksonJsonColumn.java
@@ -44,7 +44,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * <pre>{@code
  * <dependency>
- *     <groupId>com.datastax.cassandra</groupId>
+ *     <groupId>org.apache.cassandra</groupId>
  *     <artifactId>cassandra-driver-extras</artifactId>
  *     <version>${driver.version}</version>
  * </dependency>

--- a/driver-examples/src/main/java/com/datastax/driver/examples/json/JacksonJsonFunction.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/json/JacksonJsonFunction.java
@@ -49,7 +49,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  *
  * <pre>{@code
  * <dependency>
- *     <groupId>com.datastax.cassandra</groupId>
+ *     <groupId>org.apache.cassandra</groupId>
  *     <artifactId>cassandra-driver-extras</artifactId>
  *     <version>${driver.version}</version>
  * </dependency>

--- a/driver-examples/src/main/java/com/datastax/driver/examples/json/JacksonJsonRow.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/json/JacksonJsonRow.java
@@ -45,7 +45,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * <pre>{@code
  * <dependency>
- *     <groupId>com.datastax.cassandra</groupId>
+ *     <groupId>org.apache.cassandra</groupId>
  *     <artifactId>cassandra-driver-extras</artifactId>
  *     <version>${driver.version}</version>
  * </dependency>

--- a/driver-examples/src/main/java/com/datastax/driver/examples/json/Jsr353JsonColumn.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/json/Jsr353JsonColumn.java
@@ -46,7 +46,7 @@ import javax.json.JsonStructure;
  *
  * <pre>{@code
  * <dependency>
- *     <groupId>com.datastax.cassandra</groupId>
+ *     <groupId>org.apache.cassandra</groupId>
  *     <artifactId>cassandra-driver-extras</artifactId>
  *     <version>${driver.version}</version>
  * </dependency>

--- a/driver-examples/src/main/java/com/datastax/driver/examples/json/Jsr353JsonFunction.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/json/Jsr353JsonFunction.java
@@ -47,7 +47,7 @@ import javax.json.JsonStructure;
  *
  * <pre>{@code
  * <dependency>
- *     <groupId>com.datastax.cassandra</groupId>
+ *     <groupId>org.apache.cassandra</groupId>
  *     <artifactId>cassandra-driver-extras</artifactId>
  *     <version>${driver.version}</version>
  * </dependency>

--- a/driver-examples/src/main/java/com/datastax/driver/examples/json/Jsr353JsonRow.java
+++ b/driver-examples/src/main/java/com/datastax/driver/examples/json/Jsr353JsonRow.java
@@ -46,7 +46,7 @@ import javax.json.JsonStructure;
  *
  * <pre>{@code
  * <dependency>
- *     <groupId>com.datastax.cassandra</groupId>
+ *     <groupId>org.apache.cassandra</groupId>
  *     <artifactId>cassandra-driver-extras</artifactId>
  *     <version>${driver.version}</version>
  * </dependency>

--- a/driver-extras/pom.xml
+++ b/driver-extras/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.datastax.cassandra</groupId>
+        <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
         <version>3.11.6-SNAPSHOT</version>
     </parent>
@@ -35,7 +35,7 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
         </dependency>
 
@@ -69,14 +69,14 @@
         </dependency>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-mapping</artifactId>
             <scope>test</scope>
         </dependency>
@@ -134,8 +134,10 @@
             <resource>
                 <directory>${project.basedir}/..</directory>
                 <includes>
+                    <include>LICENSE_binary</include>
                     <include>LICENSE</include>
                     <include>NOTICE_binary.txt</include>
+                    <include>NOTICE.txt</include>
                 </includes>
                 <targetPath>META-INF</targetPath>
             </resource>

--- a/driver-mapping/pom.xml
+++ b/driver-mapping/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.datastax.cassandra</groupId>
+        <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
         <version>3.11.6-SNAPSHOT</version>
     </parent>
@@ -35,7 +35,7 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
         </dependency>
 
@@ -56,7 +56,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
@@ -115,8 +115,10 @@
             <resource>
                 <directory>${project.basedir}/..</directory>
                 <includes>
+                    <include>LICENSE_binary</include>
                     <include>LICENSE</include>
                     <include>NOTICE_binary.txt</include>
+                    <include>NOTICE.txt</include>
                 </includes>
                 <targetPath>META-INF</targetPath>
             </resource>

--- a/driver-tests/osgi/common/pom.xml
+++ b/driver-tests/osgi/common/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.datastax.cassandra</groupId>
+        <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-driver-tests-osgi</artifactId>
         <version>3.11.6-SNAPSHOT</version>
     </parent>

--- a/driver-tests/osgi/pom.xml
+++ b/driver-tests/osgi/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.datastax.cassandra</groupId>
+        <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
         <version>3.11.6-SNAPSHOT</version>
     </parent>
@@ -40,12 +40,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-mapping</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-extras</artifactId>
         </dependency>
 
@@ -65,7 +65,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
             <type>test-jar</type>
             <scope>test</scope>

--- a/driver-tests/osgi/shaded/pom.xml
+++ b/driver-tests/osgi/shaded/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.datastax.cassandra</groupId>
+        <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-driver-tests-osgi</artifactId>
         <version>3.11.6-SNAPSHOT</version>
     </parent>
@@ -33,7 +33,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
             <!-- note we're depending on the *shaded* driver-core jar -->
             <classifier>shaded</classifier>

--- a/driver-tests/osgi/unshaded/pom.xml
+++ b/driver-tests/osgi/unshaded/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.datastax.cassandra</groupId>
+        <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-driver-tests-osgi</artifactId>
         <version>3.11.6-SNAPSHOT</version>
     </parent>
@@ -33,7 +33,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
             <!-- note we're depending on the *unshaded* driver-core jar -->
             <exclusions>

--- a/driver-tests/pom.xml
+++ b/driver-tests/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.datastax.cassandra</groupId>
+        <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
         <version>3.11.6-SNAPSHOT</version>
     </parent>
@@ -54,13 +54,6 @@
                 <artifactId>maven-source-plugin</artifactId>
                 <configuration>
                     <skipSource>true</skipSource>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
                 </configuration>
             </plugin>
 

--- a/driver-tests/shading/pom.xml
+++ b/driver-tests/shading/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.datastax.cassandra</groupId>
+        <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
         <version>3.11.6-SNAPSHOT</version>
     </parent>

--- a/driver-tests/shading/shaded/pom.xml
+++ b/driver-tests/shading/shaded/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.datastax.cassandra</groupId>
+        <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-driver-tests-shading</artifactId>
         <version>3.11.6-SNAPSHOT</version>
     </parent>
@@ -34,7 +34,7 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
             <classifier>shaded</classifier>
             <exclusions>

--- a/driver-tests/shading/unshaded/pom.xml
+++ b/driver-tests/shading/unshaded/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.datastax.cassandra</groupId>
+        <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-driver-tests-shading</artifactId>
         <version>3.11.6-SNAPSHOT</version>
     </parent>
@@ -34,7 +34,7 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
         </dependency>
 

--- a/driver-tests/stress/pom.xml
+++ b/driver-tests/stress/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.datastax.cassandra</groupId>
+        <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
         <version>3.11.6-SNAPSHOT</version>
     </parent>
@@ -34,7 +34,7 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.datastax.cassandra</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
         </dependency>
 

--- a/faq/README.md
+++ b/faq/README.md
@@ -176,7 +176,7 @@ and we've had many reports where the problem turned out to be in user code.
 
 See [Blobs.java] in the `driver-examples` module for some examples and explanations.
 
-[Blobs.java]: https://github.com/datastax/java-driver/tree/3.x/driver-examples/src/main/java/com/datastax/driver/examples/datatypes/Blobs.java
+[Blobs.java]: https://github.com/apache/cassandra-java-driver/tree/3.x/driver-examples/src/main/java/com/datastax/driver/examples/datatypes/Blobs.java
 
 
 ### How do I use the driver in an OSGi application?
@@ -308,7 +308,7 @@ version is available, you may want to reach out to the maintainer of that tool t
 an update with compatibility to this driver version.
 
 
-[Blobs.java]: https://github.com/datastax/java-driver/tree/3.11.5/driver-examples/src/main/java/com/datastax/driver/examples/datatypes/Blobs.java
+[Blobs.java]: https://github.com/apache/cassandra-java-driver/tree/3.11.5/driver-examples/src/main/java/com/datastax/driver/examples/datatypes/Blobs.java
 [CASSANDRA-7304]: https://issues.apache.org/jira/browse/CASSANDRA-7304
 [Parameters and Binding]: ../manual/statements/prepared/#parameters-and-binding
 [Mapper options]: ../manual/object_mapper/using/#mapper-options

--- a/faq/osgi/README.md
+++ b/faq/osgi/README.md
@@ -175,7 +175,7 @@ it is also normal to see the following log lines when starting the driver:
 [JAVA-1127]:https://datastax-oss.atlassian.net/browse/JAVA-1127
 [BND]:http://bnd.bndtools.org/
 [Maven bundle plugin]:https://cwiki.apache.org/confluence/display/FELIX/Apache+Felix+Maven+Bundle+Plugin+%28BND%29
-[OSGi examples repository]:https://github.com/datastax/java-driver-examples-osgi
+[OSGi examples repository]:https://github.com/apache/cassandra-java-driver-examples-osgi
 [without metrics]:https://docs.datastax.com/en/drivers/java/3.11/com/datastax/driver/core/Cluster.Builder.html#withoutMetrics--
 [SLF4J]:http://www.slf4j.org/
 [Logback]:http://logback.qos.ch/

--- a/licenses/HdrHistogram.txt
+++ b/licenses/HdrHistogram.txt
@@ -1,0 +1,41 @@
+The code in this repository code was Written by Gil Tene, Michael Barker,
+and Matt Warren, and released to the public domain, as explained at
+http://creativecommons.org/publicdomain/zero/1.0/
+
+For users of this code who wish to consume it under the "BSD" license
+rather than under the public domain or CC0 contribution text mentioned
+above, the code found under this directory is *also* provided under the
+following license (commonly referred to as the BSD 2-Clause License). This
+license does not detract from the above stated release of the code into
+the public domain, and simply represents an additional license granted by
+the Author.
+
+-----------------------------------------------------------------------------
+** Beginning of "BSD 2-Clause License" text. **
+
+ Copyright (c) 2012, 2013, 2014, 2015, 2016 Gil Tene
+ Copyright (c) 2014 Michael Barker
+ Copyright (c) 2014 Matt Warren
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/asm.txt
+++ b/licenses/asm.txt
@@ -1,0 +1,27 @@
+ASM: a very small and fast Java bytecode manipulation framework
+Copyright (c) 2000-2011 INRIA, France Telecom
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holders nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/jnr-posix.txt
+++ b/licenses/jnr-posix.txt
@@ -1,0 +1,1076 @@
+jnr-posix is released under a tri EPL/GPL/LGPL license. You can use it,
+redistribute it and/or modify it under the terms of the:
+
+  Eclipse Public License version 2.0
+    OR
+  GNU General Public License version 2
+    OR
+  GNU Lesser General Public License version 2.1
+
+The complete text of the Eclipse Public License is as follows:
+
+  Eclipse Public License - v 2.0
+
+      THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+      PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+      OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+  1. DEFINITIONS
+
+  "Contribution" means:
+
+    a) in the case of the initial Contributor, the initial content
+       Distributed under this Agreement, and
+
+    b) in the case of each subsequent Contributor:
+       i) changes to the Program, and
+       ii) additions to the Program;
+    where such changes and/or additions to the Program originate from
+    and are Distributed by that particular Contributor. A Contribution
+    "originates" from a Contributor if it was added to the Program by
+    such Contributor itself or anyone acting on such Contributor's behalf.
+    Contributions do not include changes or additions to the Program that
+    are not Modified Works.
+
+  "Contributor" means any person or entity that Distributes the Program.
+
+  "Licensed Patents" mean patent claims licensable by a Contributor which
+  are necessarily infringed by the use or sale of its Contribution alone
+  or when combined with the Program.
+
+  "Program" means the Contributions Distributed in accordance with this
+  Agreement.
+
+  "Recipient" means anyone who receives the Program under this Agreement
+  or any Secondary License (as applicable), including Contributors.
+
+  "Derivative Works" shall mean any work, whether in Source Code or other
+  form, that is based on (or derived from) the Program and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship.
+
+  "Modified Works" shall mean any work in Source Code or other form that
+  results from an addition to, deletion from, or modification of the
+  contents of the Program, including, for purposes of clarity any new file
+  in Source Code form that contains any contents of the Program. Modified
+  Works shall not include works that contain only declarations,
+  interfaces, types, classes, structures, or files of the Program solely
+  in each case in order to link to, bind by name, or subclass the Program
+  or Modified Works thereof.
+
+  "Distribute" means the acts of a) distributing or b) making available
+  in any manner that enables the transfer of a copy.
+
+  "Source Code" means the form of a Program preferred for making
+  modifications, including but not limited to software source code,
+  documentation source, and configuration files.
+
+  "Secondary License" means either the GNU General Public License,
+  Version 2.0, or any later versions of that license, including any
+  exceptions or additional permissions as identified by the initial
+  Contributor.
+
+  2. GRANT OF RIGHTS
+
+    a) Subject to the terms of this Agreement, each Contributor hereby
+    grants Recipient a non-exclusive, worldwide, royalty-free copyright
+    license to reproduce, prepare Derivative Works of, publicly display,
+    publicly perform, Distribute and sublicense the Contribution of such
+    Contributor, if any, and such Derivative Works.
+
+    b) Subject to the terms of this Agreement, each Contributor hereby
+    grants Recipient a non-exclusive, worldwide, royalty-free patent
+    license under Licensed Patents to make, use, sell, offer to sell,
+    import and otherwise transfer the Contribution of such Contributor,
+    if any, in Source Code or other form. This patent license shall
+    apply to the combination of the Contribution and the Program if, at
+    the time the Contribution is added by the Contributor, such addition
+    of the Contribution causes such combination to be covered by the
+    Licensed Patents. The patent license shall not apply to any other
+    combinations which include the Contribution. No hardware per se is
+    licensed hereunder.
+
+    c) Recipient understands that although each Contributor grants the
+    licenses to its Contributions set forth herein, no assurances are
+    provided by any Contributor that the Program does not infringe the
+    patent or other intellectual property rights of any other entity.
+    Each Contributor disclaims any liability to Recipient for claims
+    brought by any other entity based on infringement of intellectual
+    property rights or otherwise. As a condition to exercising the
+    rights and licenses granted hereunder, each Recipient hereby
+    assumes sole responsibility to secure any other intellectual
+    property rights needed, if any. For example, if a third party
+    patent license is required to allow Recipient to Distribute the
+    Program, it is Recipient's responsibility to acquire that license
+    before distributing the Program.
+
+    d) Each Contributor represents that to its knowledge it has
+    sufficient copyright rights in its Contribution, if any, to grant
+    the copyright license set forth in this Agreement.
+
+    e) Notwithstanding the terms of any Secondary License, no
+    Contributor makes additional grants to any Recipient (other than
+    those set forth in this Agreement) as a result of such Recipient's
+    receipt of the Program under the terms of a Secondary License
+    (if permitted under the terms of Section 3).
+
+  3. REQUIREMENTS
+
+  3.1 If a Contributor Distributes the Program in any form, then:
+
+    a) the Program must also be made available as Source Code, in
+    accordance with section 3.2, and the Contributor must accompany
+    the Program with a statement that the Source Code for the Program
+    is available under this Agreement, and informs Recipients how to
+    obtain it in a reasonable manner on or through a medium customarily
+    used for software exchange; and
+
+    b) the Contributor may Distribute the Program under a license
+    different than this Agreement, provided that such license:
+       i) effectively disclaims on behalf of all other Contributors all
+       warranties and conditions, express and implied, including
+       warranties or conditions of title and non-infringement, and
+       implied warranties or conditions of merchantability and fitness
+       for a particular purpose;
+
+       ii) effectively excludes on behalf of all other Contributors all
+       liability for damages, including direct, indirect, special,
+       incidental and consequential damages, such as lost profits;
+
+       iii) does not attempt to limit or alter the recipients' rights
+       in the Source Code under section 3.2; and
+
+       iv) requires any subsequent distribution of the Program by any
+       party to be under a license that satisfies the requirements
+       of this section 3.
+
+  3.2 When the Program is Distributed as Source Code:
+
+    a) it must be made available under this Agreement, or if the
+    Program (i) is combined with other material in a separate file or
+    files made available under a Secondary License, and (ii) the initial
+    Contributor attached to the Source Code the notice described in
+    Exhibit A of this Agreement, then the Program may be made available
+    under the terms of such Secondary Licenses, and
+
+    b) a copy of this Agreement must be included with each copy of
+    the Program.
+
+  3.3 Contributors may not remove or alter any copyright, patent,
+  trademark, attribution notices, disclaimers of warranty, or limitations
+  of liability ("notices") contained within the Program from any copy of
+  the Program which they Distribute, provided that Contributors may add
+  their own appropriate notices.
+
+  4. COMMERCIAL DISTRIBUTION
+
+  Commercial distributors of software may accept certain responsibilities
+  with respect to end users, business partners and the like. While this
+  license is intended to facilitate the commercial use of the Program,
+  the Contributor who includes the Program in a commercial product
+  offering should do so in a manner which does not create potential
+  liability for other Contributors. Therefore, if a Contributor includes
+  the Program in a commercial product offering, such Contributor
+  ("Commercial Contributor") hereby agrees to defend and indemnify every
+  other Contributor ("Indemnified Contributor") against any losses,
+  damages and costs (collectively "Losses") arising from claims, lawsuits
+  and other legal actions brought by a third party against the Indemnified
+  Contributor to the extent caused by the acts or omissions of such
+  Commercial Contributor in connection with its distribution of the Program
+  in a commercial product offering. The obligations in this section do not
+  apply to any claims or Losses relating to any actual or alleged
+  intellectual property infringement. In order to qualify, an Indemnified
+  Contributor must: a) promptly notify the Commercial Contributor in
+  writing of such claim, and b) allow the Commercial Contributor to control,
+  and cooperate with the Commercial Contributor in, the defense and any
+  related settlement negotiations. The Indemnified Contributor may
+  participate in any such claim at its own expense.
+
+  For example, a Contributor might include the Program in a commercial
+  product offering, Product X. That Contributor is then a Commercial
+  Contributor. If that Commercial Contributor then makes performance
+  claims, or offers warranties related to Product X, those performance
+  claims and warranties are such Commercial Contributor's responsibility
+  alone. Under this section, the Commercial Contributor would have to
+  defend claims against the other Contributors related to those performance
+  claims and warranties, and if a court requires any other Contributor to
+  pay any damages as a result, the Commercial Contributor must pay
+  those damages.
+
+  5. NO WARRANTY
+
+  EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+  PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+  BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+  IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+  TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+  PURPOSE. Each Recipient is solely responsible for determining the
+  appropriateness of using and distributing the Program and assumes all
+  risks associated with its exercise of rights under this Agreement,
+  including but not limited to the risks and costs of program errors,
+  compliance with applicable laws, damage to or loss of data, programs
+  or equipment, and unavailability or interruption of operations.
+
+  6. DISCLAIMER OF LIABILITY
+
+  EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+  PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+  SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+  PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+  EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGES.
+
+  7. GENERAL
+
+  If any provision of this Agreement is invalid or unenforceable under
+  applicable law, it shall not affect the validity or enforceability of
+  the remainder of the terms of this Agreement, and without further
+  action by the parties hereto, such provision shall be reformed to the
+  minimum extent necessary to make such provision valid and enforceable.
+
+  If Recipient institutes patent litigation against any entity
+  (including a cross-claim or counterclaim in a lawsuit) alleging that the
+  Program itself (excluding combinations of the Program with other software
+  or hardware) infringes such Recipient's patent(s), then such Recipient's
+  rights granted under Section 2(b) shall terminate as of the date such
+  litigation is filed.
+
+  All Recipient's rights under this Agreement shall terminate if it
+  fails to comply with any of the material terms or conditions of this
+  Agreement and does not cure such failure in a reasonable period of
+  time after becoming aware of such noncompliance. If all Recipient's
+  rights under this Agreement terminate, Recipient agrees to cease use
+  and distribution of the Program as soon as reasonably practicable.
+  However, Recipient's obligations under this Agreement and any licenses
+  granted by Recipient relating to the Program shall continue and survive.
+
+  Everyone is permitted to copy and distribute copies of this Agreement,
+  but in order to avoid inconsistency the Agreement is copyrighted and
+  may only be modified in the following manner. The Agreement Steward
+  reserves the right to publish new versions (including revisions) of
+  this Agreement from time to time. No one other than the Agreement
+  Steward has the right to modify this Agreement. The Eclipse Foundation
+  is the initial Agreement Steward. The Eclipse Foundation may assign the
+  responsibility to serve as the Agreement Steward to a suitable separate
+  entity. Each new version of the Agreement will be given a distinguishing
+  version number. The Program (including Contributions) may always be
+  Distributed subject to the version of the Agreement under which it was
+  received. In addition, after a new version of the Agreement is published,
+  Contributor may elect to Distribute the Program (including its
+  Contributions) under the new version.
+
+  Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+  receives no rights or licenses to the intellectual property of any
+  Contributor under this Agreement, whether expressly, by implication,
+  estoppel or otherwise. All rights in the Program not expressly granted
+  under this Agreement are reserved. Nothing in this Agreement is intended
+  to be enforceable by any entity that is not a Contributor or Recipient.
+  No third-party beneficiary rights are created under this Agreement.
+
+  Exhibit A - Form of Secondary Licenses Notice
+
+  "This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set forth
+  in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+  version(s), and exceptions or additional permissions here}."
+
+    Simply including a copy of this Agreement, including this Exhibit A
+    is not sufficient to license the Source Code under Secondary Licenses.
+
+    If it is not possible or desirable to put the notice in a particular
+    file, then You may include the notice in a location (such as a LICENSE
+    file in a relevant directory) where a recipient would be likely to
+    look for such a notice.
+
+    You may add additional accurate notices of copyright ownership.
+
+The complete text of the GNU General Public License v2 is as follows:
+
+          GNU GENERAL PUBLIC LICENSE
+             Version 2, June 1991
+
+   Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+                         59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+   Everyone is permitted to copy and distribute verbatim copies
+   of this license document, but changing it is not allowed.
+
+            Preamble
+
+    The licenses for most software are designed to take away your
+  freedom to share and change it.  By contrast, the GNU General Public
+  License is intended to guarantee your freedom to share and change free
+  software--to make sure the software is free for all its users.  This
+  General Public License applies to most of the Free Software
+  Foundation's software and to any other program whose authors commit to
+  using it.  (Some other Free Software Foundation software is covered by
+  the GNU Library General Public License instead.)  You can apply it to
+  your programs, too.
+
+    When we speak of free software, we are referring to freedom, not
+  price.  Our General Public Licenses are designed to make sure that you
+  have the freedom to distribute copies of free software (and charge for
+  this service if you wish), that you receive source code or can get it
+  if you want it, that you can change the software or use pieces of it
+  in new free programs; and that you know you can do these things.
+
+    To protect your rights, we need to make restrictions that forbid
+  anyone to deny you these rights or to ask you to surrender the rights.
+  These restrictions translate to certain responsibilities for you if you
+  distribute copies of the software, or if you modify it.
+
+    For example, if you distribute copies of such a program, whether
+  gratis or for a fee, you must give the recipients all the rights that
+  you have.  You must make sure that they, too, receive or can get the
+  source code.  And you must show them these terms so they know their
+  rights.
+
+    We protect your rights with two steps: (1) copyright the software, and
+  (2) offer you this license which gives you legal permission to copy,
+  distribute and/or modify the software.
+
+    Also, for each author's protection and ours, we want to make certain
+  that everyone understands that there is no warranty for this free
+  software.  If the software is modified by someone else and passed on, we
+  want its recipients to know that what they have is not the original, so
+  that any problems introduced by others will not reflect on the original
+  authors' reputations.
+
+    Finally, any free program is threatened constantly by software
+  patents.  We wish to avoid the danger that redistributors of a free
+  program will individually obtain patent licenses, in effect making the
+  program proprietary.  To prevent this, we have made it clear that any
+  patent must be licensed for everyone's free use or not licensed at all.
+
+    The precise terms and conditions for copying, distribution and
+  modification follow.
+
+          GNU GENERAL PUBLIC LICENSE
+     TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+    0. This License applies to any program or other work which contains
+  a notice placed by the copyright holder saying it may be distributed
+  under the terms of this General Public License.  The "Program", below,
+  refers to any such program or work, and a "work based on the Program"
+  means either the Program or any derivative work under copyright law:
+  that is to say, a work containing the Program or a portion of it,
+  either verbatim or with modifications and/or translated into another
+  language.  (Hereinafter, translation is included without limitation in
+  the term "modification".)  Each licensee is addressed as "you".
+
+  Activities other than copying, distribution and modification are not
+  covered by this License; they are outside its scope.  The act of
+  running the Program is not restricted, and the output from the Program
+  is covered only if its contents constitute a work based on the
+  Program (independent of having been made by running the Program).
+  Whether that is true depends on what the Program does.
+
+    1. You may copy and distribute verbatim copies of the Program's
+  source code as you receive it, in any medium, provided that you
+  conspicuously and appropriately publish on each copy an appropriate
+  copyright notice and disclaimer of warranty; keep intact all the
+  notices that refer to this License and to the absence of any warranty;
+  and give any other recipients of the Program a copy of this License
+  along with the Program.
+
+  You may charge a fee for the physical act of transferring a copy, and
+  you may at your option offer warranty protection in exchange for a fee.
+
+    2. You may modify your copy or copies of the Program or any portion
+  of it, thus forming a work based on the Program, and copy and
+  distribute such modifications or work under the terms of Section 1
+  above, provided that you also meet all of these conditions:
+
+      a) You must cause the modified files to carry prominent notices
+      stating that you changed the files and the date of any change.
+
+      b) You must cause any work that you distribute or publish, that in
+      whole or in part contains or is derived from the Program or any
+      part thereof, to be licensed as a whole at no charge to all third
+      parties under the terms of this License.
+
+      c) If the modified program normally reads commands interactively
+      when run, you must cause it, when started running for such
+      interactive use in the most ordinary way, to print or display an
+      announcement including an appropriate copyright notice and a
+      notice that there is no warranty (or else, saying that you provide
+      a warranty) and that users may redistribute the program under
+      these conditions, and telling the user how to view a copy of this
+      License.  (Exception: if the Program itself is interactive but
+      does not normally print such an announcement, your work based on
+      the Program is not required to print an announcement.)
+
+  These requirements apply to the modified work as a whole.  If
+  identifiable sections of that work are not derived from the Program,
+  and can be reasonably considered independent and separate works in
+  themselves, then this License, and its terms, do not apply to those
+  sections when you distribute them as separate works.  But when you
+  distribute the same sections as part of a whole which is a work based
+  on the Program, the distribution of the whole must be on the terms of
+  this License, whose permissions for other licensees extend to the
+  entire whole, and thus to each and every part regardless of who wrote it.
+
+  Thus, it is not the intent of this section to claim rights or contest
+  your rights to work written entirely by you; rather, the intent is to
+  exercise the right to control the distribution of derivative or
+  collective works based on the Program.
+
+  In addition, mere aggregation of another work not based on the Program
+  with the Program (or with a work based on the Program) on a volume of
+  a storage or distribution medium does not bring the other work under
+  the scope of this License.
+
+    3. You may copy and distribute the Program (or a work based on it,
+  under Section 2) in object code or executable form under the terms of
+  Sections 1 and 2 above provided that you also do one of the following:
+
+      a) Accompany it with the complete corresponding machine-readable
+      source code, which must be distributed under the terms of Sections
+      1 and 2 above on a medium customarily used for software interchange; or,
+
+      b) Accompany it with a written offer, valid for at least three
+      years, to give any third party, for a charge no more than your
+      cost of physically performing source distribution, a complete
+      machine-readable copy of the corresponding source code, to be
+      distributed under the terms of Sections 1 and 2 above on a medium
+      customarily used for software interchange; or,
+
+      c) Accompany it with the information you received as to the offer
+      to distribute corresponding source code.  (This alternative is
+      allowed only for noncommercial distribution and only if you
+      received the program in object code or executable form with such
+      an offer, in accord with Subsection b above.)
+
+  The source code for a work means the preferred form of the work for
+  making modifications to it.  For an executable work, complete source
+  code means all the source code for all modules it contains, plus any
+  associated interface definition files, plus the scripts used to
+  control compilation and installation of the executable.  However, as a
+  special exception, the source code distributed need not include
+  anything that is normally distributed (in either source or binary
+  form) with the major components (compiler, kernel, and so on) of the
+  operating system on which the executable runs, unless that component
+  itself accompanies the executable.
+
+  If distribution of executable or object code is made by offering
+  access to copy from a designated place, then offering equivalent
+  access to copy the source code from the same place counts as
+  distribution of the source code, even though third parties are not
+  compelled to copy the source along with the object code.
+
+    4. You may not copy, modify, sublicense, or distribute the Program
+  except as expressly provided under this License.  Any attempt
+  otherwise to copy, modify, sublicense or distribute the Program is
+  void, and will automatically terminate your rights under this License.
+  However, parties who have received copies, or rights, from you under
+  this License will not have their licenses terminated so long as such
+  parties remain in full compliance.
+
+    5. You are not required to accept this License, since you have not
+  signed it.  However, nothing else grants you permission to modify or
+  distribute the Program or its derivative works.  These actions are
+  prohibited by law if you do not accept this License.  Therefore, by
+  modifying or distributing the Program (or any work based on the
+  Program), you indicate your acceptance of this License to do so, and
+  all its terms and conditions for copying, distributing or modifying
+  the Program or works based on it.
+
+    6. Each time you redistribute the Program (or any work based on the
+  Program), the recipient automatically receives a license from the
+  original licensor to copy, distribute or modify the Program subject to
+  these terms and conditions.  You may not impose any further
+  restrictions on the recipients' exercise of the rights granted herein.
+  You are not responsible for enforcing compliance by third parties to
+  this License.
+
+    7. If, as a consequence of a court judgment or allegation of patent
+  infringement or for any other reason (not limited to patent issues),
+  conditions are imposed on you (whether by court order, agreement or
+  otherwise) that contradict the conditions of this License, they do not
+  excuse you from the conditions of this License.  If you cannot
+  distribute so as to satisfy simultaneously your obligations under this
+  License and any other pertinent obligations, then as a consequence you
+  may not distribute the Program at all.  For example, if a patent
+  license would not permit royalty-free redistribution of the Program by
+  all those who receive copies directly or indirectly through you, then
+  the only way you could satisfy both it and this License would be to
+  refrain entirely from distribution of the Program.
+
+  If any portion of this section is held invalid or unenforceable under
+  any particular circumstance, the balance of the section is intended to
+  apply and the section as a whole is intended to apply in other
+  circumstances.
+
+  It is not the purpose of this section to induce you to infringe any
+  patents or other property right claims or to contest validity of any
+  such claims; this section has the sole purpose of protecting the
+  integrity of the free software distribution system, which is
+  implemented by public license practices.  Many people have made
+  generous contributions to the wide range of software distributed
+  through that system in reliance on consistent application of that
+  system; it is up to the author/donor to decide if he or she is willing
+  to distribute software through any other system and a licensee cannot
+  impose that choice.
+
+  This section is intended to make thoroughly clear what is believed to
+  be a consequence of the rest of this License.
+
+    8. If the distribution and/or use of the Program is restricted in
+  certain countries either by patents or by copyrighted interfaces, the
+  original copyright holder who places the Program under this License
+  may add an explicit geographical distribution limitation excluding
+  those countries, so that distribution is permitted only in or among
+  countries not thus excluded.  In such case, this License incorporates
+  the limitation as if written in the body of this License.
+
+    9. The Free Software Foundation may publish revised and/or new versions
+  of the General Public License from time to time.  Such new versions will
+  be similar in spirit to the present version, but may differ in detail to
+  address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the Program
+  specifies a version number of this License which applies to it and "any
+  later version", you have the option of following the terms and conditions
+  either of that version or of any later version published by the Free
+  Software Foundation.  If the Program does not specify a version number of
+  this License, you may choose any version ever published by the Free Software
+  Foundation.
+
+    10. If you wish to incorporate parts of the Program into other free
+  programs whose distribution conditions are different, write to the author
+  to ask for permission.  For software which is copyrighted by the Free
+  Software Foundation, write to the Free Software Foundation; we sometimes
+  make exceptions for this.  Our decision will be guided by the two goals
+  of preserving the free status of all derivatives of our free software and
+  of promoting the sharing and reuse of software generally.
+
+            NO WARRANTY
+
+    11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+  FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+  OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+  PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+  OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+  TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+  PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+  REPAIR OR CORRECTION.
+
+    12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+  WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+  REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+  INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+  OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+  TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+  YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+  PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGES.
+
+           END OF TERMS AND CONDITIONS
+
+The complete text of the GNU Lesser General Public License 2.1 is as follows:
+
+        GNU LESSER GENERAL PUBLIC LICENSE
+             Version 2.1, February 1999
+
+   Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+       59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+   Everyone is permitted to copy and distribute verbatim copies
+   of this license document, but changing it is not allowed.
+
+  [This is the first released version of the Lesser GPL.  It also counts
+   as the successor of the GNU Library Public License, version 2, hence
+   the version number 2.1.]
+
+            Preamble
+
+    The licenses for most software are designed to take away your
+  freedom to share and change it.  By contrast, the GNU General Public
+  Licenses are intended to guarantee your freedom to share and change
+  free software--to make sure the software is free for all its users.
+
+    This license, the Lesser General Public License, applies to some
+  specially designated software packages--typically libraries--of the
+  Free Software Foundation and other authors who decide to use it.  You
+  can use it too, but we suggest you first think carefully about whether
+  this license or the ordinary General Public License is the better
+  strategy to use in any particular case, based on the explanations below.
+
+    When we speak of free software, we are referring to freedom of use,
+  not price.  Our General Public Licenses are designed to make sure that
+  you have the freedom to distribute copies of free software (and charge
+  for this service if you wish); that you receive source code or can get
+  it if you want it; that you can change the software and use pieces of
+  it in new free programs; and that you are informed that you can do
+  these things.
+
+    To protect your rights, we need to make restrictions that forbid
+  distributors to deny you these rights or to ask you to surrender these
+  rights.  These restrictions translate to certain responsibilities for
+  you if you distribute copies of the library or if you modify it.
+
+    For example, if you distribute copies of the library, whether gratis
+  or for a fee, you must give the recipients all the rights that we gave
+  you.  You must make sure that they, too, receive or can get the source
+  code.  If you link other code with the library, you must provide
+  complete object files to the recipients, so that they can relink them
+  with the library after making changes to the library and recompiling
+  it.  And you must show them these terms so they know their rights.
+
+    We protect your rights with a two-step method: (1) we copyright the
+  library, and (2) we offer you this license, which gives you legal
+  permission to copy, distribute and/or modify the library.
+
+    To protect each distributor, we want to make it very clear that
+  there is no warranty for the free library.  Also, if the library is
+  modified by someone else and passed on, the recipients should know
+  that what they have is not the original version, so that the original
+  author's reputation will not be affected by problems that might be
+  introduced by others.
+
+    Finally, software patents pose a constant threat to the existence of
+  any free program.  We wish to make sure that a company cannot
+  effectively restrict the users of a free program by obtaining a
+  restrictive license from a patent holder.  Therefore, we insist that
+  any patent license obtained for a version of the library must be
+  consistent with the full freedom of use specified in this license.
+
+    Most GNU software, including some libraries, is covered by the
+  ordinary GNU General Public License.  This license, the GNU Lesser
+  General Public License, applies to certain designated libraries, and
+  is quite different from the ordinary General Public License.  We use
+  this license for certain libraries in order to permit linking those
+  libraries into non-free programs.
+
+    When a program is linked with a library, whether statically or using
+  a shared library, the combination of the two is legally speaking a
+  combined work, a derivative of the original library.  The ordinary
+  General Public License therefore permits such linking only if the
+  entire combination fits its criteria of freedom.  The Lesser General
+  Public License permits more lax criteria for linking other code with
+  the library.
+
+    We call this license the "Lesser" General Public License because it
+  does Less to protect the user's freedom than the ordinary General
+  Public License.  It also provides other free software developers Less
+  of an advantage over competing non-free programs.  These disadvantages
+  are the reason we use the ordinary General Public License for many
+  libraries.  However, the Lesser license provides advantages in certain
+  special circumstances.
+
+    For example, on rare occasions, there may be a special need to
+  encourage the widest possible use of a certain library, so that it becomes
+  a de-facto standard.  To achieve this, non-free programs must be
+  allowed to use the library.  A more frequent case is that a free
+  library does the same job as widely used non-free libraries.  In this
+  case, there is little to gain by limiting the free library to free
+  software only, so we use the Lesser General Public License.
+
+    In other cases, permission to use a particular library in non-free
+  programs enables a greater number of people to use a large body of
+  free software.  For example, permission to use the GNU C Library in
+  non-free programs enables many more people to use the whole GNU
+  operating system, as well as its variant, the GNU/Linux operating
+  system.
+
+    Although the Lesser General Public License is Less protective of the
+  users' freedom, it does ensure that the user of a program that is
+  linked with the Library has the freedom and the wherewithal to run
+  that program using a modified version of the Library.
+
+    The precise terms and conditions for copying, distribution and
+  modification follow.  Pay close attention to the difference between a
+  "work based on the library" and a "work that uses the library".  The
+  former contains code derived from the library, whereas the latter must
+  be combined with the library in order to run.
+
+        GNU LESSER GENERAL PUBLIC LICENSE
+     TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+    0. This License Agreement applies to any software library or other
+  program which contains a notice placed by the copyright holder or
+  other authorized party saying it may be distributed under the terms of
+  this Lesser General Public License (also called "this License").
+  Each licensee is addressed as "you".
+
+    A "library" means a collection of software functions and/or data
+  prepared so as to be conveniently linked with application programs
+  (which use some of those functions and data) to form executables.
+
+    The "Library", below, refers to any such software library or work
+  which has been distributed under these terms.  A "work based on the
+  Library" means either the Library or any derivative work under
+  copyright law: that is to say, a work containing the Library or a
+  portion of it, either verbatim or with modifications and/or translated
+  straightforwardly into another language.  (Hereinafter, translation is
+  included without limitation in the term "modification".)
+
+    "Source code" for a work means the preferred form of the work for
+  making modifications to it.  For a library, complete source code means
+  all the source code for all modules it contains, plus any associated
+  interface definition files, plus the scripts used to control compilation
+  and installation of the library.
+
+    Activities other than copying, distribution and modification are not
+  covered by this License; they are outside its scope.  The act of
+  running a program using the Library is not restricted, and output from
+  such a program is covered only if its contents constitute a work based
+  on the Library (independent of the use of the Library in a tool for
+  writing it).  Whether that is true depends on what the Library does
+  and what the program that uses the Library does.
+
+    1. You may copy and distribute verbatim copies of the Library's
+  complete source code as you receive it, in any medium, provided that
+  you conspicuously and appropriately publish on each copy an
+  appropriate copyright notice and disclaimer of warranty; keep intact
+  all the notices that refer to this License and to the absence of any
+  warranty; and distribute a copy of this License along with the
+  Library.
+
+    You may charge a fee for the physical act of transferring a copy,
+  and you may at your option offer warranty protection in exchange for a
+  fee.
+
+    2. You may modify your copy or copies of the Library or any portion
+  of it, thus forming a work based on the Library, and copy and
+  distribute such modifications or work under the terms of Section 1
+  above, provided that you also meet all of these conditions:
+
+      a) The modified work must itself be a software library.
+
+      b) You must cause the files modified to carry prominent notices
+      stating that you changed the files and the date of any change.
+
+      c) You must cause the whole of the work to be licensed at no
+      charge to all third parties under the terms of this License.
+
+      d) If a facility in the modified Library refers to a function or a
+      table of data to be supplied by an application program that uses
+      the facility, other than as an argument passed when the facility
+      is invoked, then you must make a good faith effort to ensure that,
+      in the event an application does not supply such function or
+      table, the facility still operates, and performs whatever part of
+      its purpose remains meaningful.
+
+      (For example, a function in a library to compute square roots has
+      a purpose that is entirely well-defined independent of the
+      application.  Therefore, Subsection 2d requires that any
+      application-supplied function or table used by this function must
+      be optional: if the application does not supply it, the square
+      root function must still compute square roots.)
+
+  These requirements apply to the modified work as a whole.  If
+  identifiable sections of that work are not derived from the Library,
+  and can be reasonably considered independent and separate works in
+  themselves, then this License, and its terms, do not apply to those
+  sections when you distribute them as separate works.  But when you
+  distribute the same sections as part of a whole which is a work based
+  on the Library, the distribution of the whole must be on the terms of
+  this License, whose permissions for other licensees extend to the
+  entire whole, and thus to each and every part regardless of who wrote
+  it.
+
+  Thus, it is not the intent of this section to claim rights or contest
+  your rights to work written entirely by you; rather, the intent is to
+  exercise the right to control the distribution of derivative or
+  collective works based on the Library.
+
+  In addition, mere aggregation of another work not based on the Library
+  with the Library (or with a work based on the Library) on a volume of
+  a storage or distribution medium does not bring the other work under
+  the scope of this License.
+
+    3. You may opt to apply the terms of the ordinary GNU General Public
+  License instead of this License to a given copy of the Library.  To do
+  this, you must alter all the notices that refer to this License, so
+  that they refer to the ordinary GNU General Public License, version 2,
+  instead of to this License.  (If a newer version than version 2 of the
+  ordinary GNU General Public License has appeared, then you can specify
+  that version instead if you wish.)  Do not make any other change in
+  these notices.
+
+    Once this change is made in a given copy, it is irreversible for
+  that copy, so the ordinary GNU General Public License applies to all
+  subsequent copies and derivative works made from that copy.
+
+    This option is useful when you wish to copy part of the code of
+  the Library into a program that is not a library.
+
+    4. You may copy and distribute the Library (or a portion or
+  derivative of it, under Section 2) in object code or executable form
+  under the terms of Sections 1 and 2 above provided that you accompany
+  it with the complete corresponding machine-readable source code, which
+  must be distributed under the terms of Sections 1 and 2 above on a
+  medium customarily used for software interchange.
+
+    If distribution of object code is made by offering access to copy
+  from a designated place, then offering equivalent access to copy the
+  source code from the same place satisfies the requirement to
+  distribute the source code, even though third parties are not
+  compelled to copy the source along with the object code.
+
+    5. A program that contains no derivative of any portion of the
+  Library, but is designed to work with the Library by being compiled or
+  linked with it, is called a "work that uses the Library".  Such a
+  work, in isolation, is not a derivative work of the Library, and
+  therefore falls outside the scope of this License.
+
+    However, linking a "work that uses the Library" with the Library
+  creates an executable that is a derivative of the Library (because it
+  contains portions of the Library), rather than a "work that uses the
+  library".  The executable is therefore covered by this License.
+  Section 6 states terms for distribution of such executables.
+
+    When a "work that uses the Library" uses material from a header file
+  that is part of the Library, the object code for the work may be a
+  derivative work of the Library even though the source code is not.
+  Whether this is true is especially significant if the work can be
+  linked without the Library, or if the work is itself a library.  The
+  threshold for this to be true is not precisely defined by law.
+
+    If such an object file uses only numerical parameters, data
+  structure layouts and accessors, and small macros and small inline
+  functions (ten lines or less in length), then the use of the object
+  file is unrestricted, regardless of whether it is legally a derivative
+  work.  (Executables containing this object code plus portions of the
+  Library will still fall under Section 6.)
+
+    Otherwise, if the work is a derivative of the Library, you may
+  distribute the object code for the work under the terms of Section 6.
+  Any executables containing that work also fall under Section 6,
+  whether or not they are linked directly with the Library itself.
+
+    6. As an exception to the Sections above, you may also combine or
+  link a "work that uses the Library" with the Library to produce a
+  work containing portions of the Library, and distribute that work
+  under terms of your choice, provided that the terms permit
+  modification of the work for the customer's own use and reverse
+  engineering for debugging such modifications.
+
+    You must give prominent notice with each copy of the work that the
+  Library is used in it and that the Library and its use are covered by
+  this License.  You must supply a copy of this License.  If the work
+  during execution displays copyright notices, you must include the
+  copyright notice for the Library among them, as well as a reference
+  directing the user to the copy of this License.  Also, you must do one
+  of these things:
+
+      a) Accompany the work with the complete corresponding
+      machine-readable source code for the Library including whatever
+      changes were used in the work (which must be distributed under
+      Sections 1 and 2 above); and, if the work is an executable linked
+      with the Library, with the complete machine-readable "work that
+      uses the Library", as object code and/or source code, so that the
+      user can modify the Library and then relink to produce a modified
+      executable containing the modified Library.  (It is understood
+      that the user who changes the contents of definitions files in the
+      Library will not necessarily be able to recompile the application
+      to use the modified definitions.)
+
+      b) Use a suitable shared library mechanism for linking with the
+      Library.  A suitable mechanism is one that (1) uses at run time a
+      copy of the library already present on the user's computer system,
+      rather than copying library functions into the executable, and (2)
+      will operate properly with a modified version of the library, if
+      the user installs one, as long as the modified version is
+      interface-compatible with the version that the work was made with.
+
+      c) Accompany the work with a written offer, valid for at
+      least three years, to give the same user the materials
+      specified in Subsection 6a, above, for a charge no more
+      than the cost of performing this distribution.
+
+      d) If distribution of the work is made by offering access to copy
+      from a designated place, offer equivalent access to copy the above
+      specified materials from the same place.
+
+      e) Verify that the user has already received a copy of these
+      materials or that you have already sent this user a copy.
+
+    For an executable, the required form of the "work that uses the
+  Library" must include any data and utility programs needed for
+  reproducing the executable from it.  However, as a special exception,
+  the materials to be distributed need not include anything that is
+  normally distributed (in either source or binary form) with the major
+  components (compiler, kernel, and so on) of the operating system on
+  which the executable runs, unless that component itself accompanies
+  the executable.
+
+    It may happen that this requirement contradicts the license
+  restrictions of other proprietary libraries that do not normally
+  accompany the operating system.  Such a contradiction means you cannot
+  use both them and the Library together in an executable that you
+  distribute.
+
+    7. You may place library facilities that are a work based on the
+  Library side-by-side in a single library together with other library
+  facilities not covered by this License, and distribute such a combined
+  library, provided that the separate distribution of the work based on
+  the Library and of the other library facilities is otherwise
+  permitted, and provided that you do these two things:
+
+      a) Accompany the combined library with a copy of the same work
+      based on the Library, uncombined with any other library
+      facilities.  This must be distributed under the terms of the
+      Sections above.
+
+      b) Give prominent notice with the combined library of the fact
+      that part of it is a work based on the Library, and explaining
+      where to find the accompanying uncombined form of the same work.
+
+    8. You may not copy, modify, sublicense, link with, or distribute
+  the Library except as expressly provided under this License.  Any
+  attempt otherwise to copy, modify, sublicense, link with, or
+  distribute the Library is void, and will automatically terminate your
+  rights under this License.  However, parties who have received copies,
+  or rights, from you under this License will not have their licenses
+  terminated so long as such parties remain in full compliance.
+
+    9. You are not required to accept this License, since you have not
+  signed it.  However, nothing else grants you permission to modify or
+  distribute the Library or its derivative works.  These actions are
+  prohibited by law if you do not accept this License.  Therefore, by
+  modifying or distributing the Library (or any work based on the
+  Library), you indicate your acceptance of this License to do so, and
+  all its terms and conditions for copying, distributing or modifying
+  the Library or works based on it.
+
+    10. Each time you redistribute the Library (or any work based on the
+  Library), the recipient automatically receives a license from the
+  original licensor to copy, distribute, link with or modify the Library
+  subject to these terms and conditions.  You may not impose any further
+  restrictions on the recipients' exercise of the rights granted herein.
+  You are not responsible for enforcing compliance by third parties with
+  this License.
+
+    11. If, as a consequence of a court judgment or allegation of patent
+  infringement or for any other reason (not limited to patent issues),
+  conditions are imposed on you (whether by court order, agreement or
+  otherwise) that contradict the conditions of this License, they do not
+  excuse you from the conditions of this License.  If you cannot
+  distribute so as to satisfy simultaneously your obligations under this
+  License and any other pertinent obligations, then as a consequence you
+  may not distribute the Library at all.  For example, if a patent
+  license would not permit royalty-free redistribution of the Library by
+  all those who receive copies directly or indirectly through you, then
+  the only way you could satisfy both it and this License would be to
+  refrain entirely from distribution of the Library.
+
+  If any portion of this section is held invalid or unenforceable under any
+  particular circumstance, the balance of the section is intended to apply,
+  and the section as a whole is intended to apply in other circumstances.
+
+  It is not the purpose of this section to induce you to infringe any
+  patents or other property right claims or to contest validity of any
+  such claims; this section has the sole purpose of protecting the
+  integrity of the free software distribution system which is
+  implemented by public license practices.  Many people have made
+  generous contributions to the wide range of software distributed
+  through that system in reliance on consistent application of that
+  system; it is up to the author/donor to decide if he or she is willing
+  to distribute software through any other system and a licensee cannot
+  impose that choice.
+
+  This section is intended to make thoroughly clear what is believed to
+  be a consequence of the rest of this License.
+
+    12. If the distribution and/or use of the Library is restricted in
+  certain countries either by patents or by copyrighted interfaces, the
+  original copyright holder who places the Library under this License may add
+  an explicit geographical distribution limitation excluding those countries,
+  so that distribution is permitted only in or among countries not thus
+  excluded.  In such case, this License incorporates the limitation as if
+  written in the body of this License.
+
+    13. The Free Software Foundation may publish revised and/or new
+  versions of the Lesser General Public License from time to time.
+  Such new versions will be similar in spirit to the present version,
+  but may differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the Library
+  specifies a version number of this License which applies to it and
+  "any later version", you have the option of following the terms and
+  conditions either of that version or of any later version published by
+  the Free Software Foundation.  If the Library does not specify a
+  license version number, you may choose any version ever published by
+  the Free Software Foundation.
+
+    14. If you wish to incorporate parts of the Library into other free
+  programs whose distribution conditions are incompatible with these,
+  write to the author to ask for permission.  For software which is
+  copyrighted by the Free Software Foundation, write to the Free
+  Software Foundation; we sometimes make exceptions for this.  Our
+  decision will be guided by the two goals of preserving the free status
+  of all derivatives of our free software and of promoting the sharing
+  and reuse of software generally.
+
+            NO WARRANTY
+
+    15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+  WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+  OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+  KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+  PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+  LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+  THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+    16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+  WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+  AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+  FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+  CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+  LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+  RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+  FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+  SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+  DAMAGES.
+
+           END OF TERMS AND CONDITIONS
+
+             How to Apply These Terms to Your New Libraries
+
+    If you develop a new library, and you want it to be of the greatest
+  possible use to the public, we recommend making it free software that
+  everyone can redistribute and change.  You can do so by permitting
+  redistribution under these terms (or, alternatively, under the terms of the
+  ordinary General Public License).
+
+    To apply these terms, attach the following notices to the library.  It is
+  safest to attach them to the start of each source file to most effectively
+  convey the exclusion of warranty; and each file should have at least the
+  "copyright" line and a pointer to where the full notice is found.
+
+      <one line to give the library's name and a brief idea of what it does.>
+      Copyright (C) <year>  <name of author>
+
+      This library is free software; you can redistribute it and/or
+      modify it under the terms of the GNU Lesser General Public
+      License as published by the Free Software Foundation; either
+      version 2.1 of the License, or (at your option) any later version.
+
+      This library is distributed in the hope that it will be useful,
+      but WITHOUT ANY WARRANTY; without even the implied warranty of
+      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+      Lesser General Public License for more details.
+
+      You should have received a copy of the GNU Lesser General Public
+      License along with this library; if not, write to the Free Software
+      Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+  Also add information on how to contact you by electronic and paper mail.
+
+  You should also get your employer (if you work as a programmer) or your
+  school, if any, to sign a "copyright disclaimer" for the library, if
+  necessary.  Here is a sample; alter the names:
+
+    Yoyodyne, Inc., hereby disclaims all copyright interest in the
+    library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+    <signature of Ty Coon>, 1 April 1990
+    Ty Coon, President of Vice
+
+  That's all there is to it!

--- a/licenses/jnr-x86asm.txt
+++ b/licenses/jnr-x86asm.txt
@@ -1,0 +1,24 @@
+
+ Copyright (C) 2010 Wayne Meissner
+ Copyright (c) 2008-2009, Petr Kobalicek <kobalicek.petr@gmail.com>
+
+ Permission is hereby granted, free of charge, to any person
+ obtaining a copy of this software and associated documentation
+ files (the "Software"), to deal in the Software without
+ restriction, including without limitation the rights to use,
+ copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following
+ conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.

--- a/licenses/slf4j-api.txt
+++ b/licenses/slf4j-api.txt
@@ -1,0 +1,21 @@
+Copyright (c) 2004-2023 QOS.ch
+All rights reserved.
+
+Permission is hereby granted, free  of charge, to any person obtaining
+a  copy  of this  software  and  associated  documentation files  (the
+"Software"), to  deal in  the Software without  restriction, including
+without limitation  the rights to  use, copy, modify,  merge, publish,
+distribute,  sublicense, and/or sell  copies of  the Software,  and to
+permit persons to whom the Software  is furnished to do so, subject to
+the following conditions:
+
+The  above  copyright  notice  and  this permission  notice  shall  be
+included in all copies or substantial portions of the Software.
+
+THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/manual/README.md
+++ b/manual/README.md
@@ -307,7 +307,7 @@ Besides explicit work with queries and rows, you can also use
 If you're reading this from the [generated HTML documentation on
 github.io](http://datastax.github.io/java-driver/), use the "Contents"
 menu on the left hand side to navigate sub-sections. If you're [browsing the source files on
-github.com](https://github.com/datastax/java-driver/tree/3.x/manual),
+github.com](https://github.com/apache/cassandra-java-driver/tree/3.x/manual),
 simply navigate to each sub-directory.
 
 [Cluster]: https://docs.datastax.com/en/drivers/java/3.11/com/datastax/driver/core/Cluster.html

--- a/manual/custom_codecs/extras/README.md
+++ b/manual/custom_codecs/extras/README.md
@@ -27,7 +27,7 @@ The module is published as a separate Maven artifact:
 
 ```xml
 <dependency>
-  <groupId>com.datastax.cassandra</groupId>
+  <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-extras</artifactId>
   <version>3.11.5</version>
 </dependency>

--- a/manual/metrics/README.md
+++ b/manual/metrics/README.md
@@ -55,7 +55,7 @@ To do this in a maven project:
 
 ```xml
 <dependency>
-  <groupId>com.datastax.cassandra</groupId>
+  <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-core</artifactId>
   <version>3.11.5</version>
   <exclusions>

--- a/manual/object_mapper/README.md
+++ b/manual/object_mapper/README.md
@@ -28,7 +28,7 @@ The mapper is published as a separate Maven artifact:
 
 ```xml
 <dependency>
-  <groupId>com.datastax.cassandra</groupId>
+  <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-mapping</artifactId>
   <version>3.11.5</version>
 </dependency>

--- a/manual/shaded_jar/README.md
+++ b/manual/shaded_jar/README.md
@@ -29,7 +29,7 @@ package name:
 
 ```xml
 <dependency>
-  <groupId>com.datastax.cassandra</groupId>
+  <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-core</artifactId>
   <version>3.11.5</version>
   <classifier>shaded</classifier>
@@ -53,7 +53,7 @@ non-shaded JAR:
 
 ```xml
 <dependency>
-  <groupId>com.datastax.cassandra</groupId>
+  <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-core</artifactId>
   <version>3.11.5</version>
   <classifier>shaded</classifier>
@@ -69,12 +69,12 @@ non-shaded JAR:
   </exclusions>
 </dependency>
 <dependency>
-  <groupId>com.datastax.cassandra</groupId>
+  <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-mapping</artifactId>
   <version>3.11.5</version>
   <exclusions>
     <exclusion>
-      <groupId>com.datastax.cassandra</groupId>
+      <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-driver-core</artifactId>
     </exclusion>
   </exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <artifactId>apache</artifactId>
         <version>23</version>
     </parent>
-    <groupId>com.datastax.cassandra</groupId>
+    <groupId>org.apache.cassandra</groupId>
     <artifactId>cassandra-driver-parent</artifactId>
     <version>3.11.6-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -35,7 +35,7 @@
         (CQL3) and Cassandra's binary protocol.
     </description>
 
-    <url>https://github.com/datastax/java-driver</url>
+    <url>https://github.com/apache/cassandra-java-driver</url>
 
     <inceptionYear>2012</inceptionYear>
 
@@ -45,6 +45,7 @@
         <module>driver-extras</module>
         <module>driver-examples</module>
         <module>driver-tests</module>
+        <module>driver-dist-source</module>
         <module>driver-dist</module>
     </modules>
 
@@ -101,33 +102,33 @@
         <dependencies>
 
             <dependency>
-                <groupId>com.datastax.cassandra</groupId>
+                <groupId>org.apache.cassandra</groupId>
                 <artifactId>cassandra-driver-core</artifactId>
                 <version>${project.parent.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.datastax.cassandra</groupId>
+                <groupId>org.apache.cassandra</groupId>
                 <artifactId>cassandra-driver-core</artifactId>
                 <version>${project.parent.version}</version>
                 <classifier>shaded</classifier>
             </dependency>
 
             <dependency>
-                <groupId>com.datastax.cassandra</groupId>
+                <groupId>org.apache.cassandra</groupId>
                 <artifactId>cassandra-driver-core</artifactId>
                 <version>${project.parent.version}</version>
                 <type>test-jar</type>
             </dependency>
 
             <dependency>
-                <groupId>com.datastax.cassandra</groupId>
+                <groupId>org.apache.cassandra</groupId>
                 <artifactId>cassandra-driver-mapping</artifactId>
                 <version>${project.parent.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.datastax.cassandra</groupId>
+                <groupId>org.apache.cassandra</groupId>
                 <artifactId>cassandra-driver-extras</artifactId>
                 <version>${project.parent.version}</version>
             </dependency>
@@ -510,77 +511,6 @@
                                     <exclude>NOTICE_binary.txt</exclude>
                                 </excludes>
                             </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.4</version>
-                    <inherited>true</inherited>
-                    <configuration>
-                        <quiet>true</quiet>
-                        <verbose>false</verbose>
-                        <additionalparam>${javadoc.opts}</additionalparam>
-                        <links>
-                            <link>https://docs.oracle.com/javase/8/docs/api/</link>
-                            <link>https://google.github.io/guava/releases/19.0/api/docs/</link>
-                            <link>http://netty.io/4.0/api/</link>
-                            <link>http://www.joda.org/joda-time/apidocs/</link>
-                            <link>http://fasterxml.github.io/jackson-core/javadoc/2.8/</link>
-                            <link>http://fasterxml.github.io/jackson-databind/javadoc/2.7/</link>
-                            <link>https://javaee-spec.java.net/nonav/javadocs/</link>
-                        </links>
-                        <!-- optional dependencies from other modules (must be explicitly declared here in order to be correctly resolved) -->
-                        <additionalDependencies>
-                            <additionalDependency>
-                                <groupId>org.xerial.snappy</groupId>
-                                <artifactId>snappy-java</artifactId>
-                                <version>${snappy.version}</version>
-                            </additionalDependency>
-                            <additionalDependency>
-                                <groupId>org.lz4</groupId>
-                                <artifactId>lz4-java</artifactId>
-                                <version>${lz4.version}</version>
-                            </additionalDependency>
-                            <additionalDependency>
-                                <groupId>org.hdrhistogram</groupId>
-                                <artifactId>HdrHistogram</artifactId>
-                                <version>${hdr.version}</version>
-                            </additionalDependency>
-                            <additionalDependency>
-                                <groupId>com.fasterxml.jackson.core</groupId>
-                                <artifactId>jackson-core</artifactId>
-                                <version>${jackson.version}</version>
-                            </additionalDependency>
-                            <additionalDependency>
-                                <groupId>com.fasterxml.jackson.core</groupId>
-                                <artifactId>jackson-annotations</artifactId>
-                                <version>${jackson.version}</version>
-                            </additionalDependency>
-                            <additionalDependency>
-                                <groupId>com.fasterxml.jackson.core</groupId>
-                                <artifactId>jackson-databind</artifactId>
-                                <version>${jackson-databind.version}</version>
-                            </additionalDependency>
-                            <additionalDependency>
-                                <groupId>joda-time</groupId>
-                                <artifactId>joda-time</artifactId>
-                                <version>${joda.version}</version>
-                            </additionalDependency>
-                            <additionalDependency>
-                                <groupId>javax.json</groupId>
-                                <artifactId>javax.json-api</artifactId>
-                                <version>${jsr353-api.version}</version>
-                            </additionalDependency>
-                        </additionalDependencies>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>attach-javadocs</id>
-                            <goals>
-                                <goal>jar</goal>
-                            </goals>
                         </execution>
                     </executions>
                 </plugin>
@@ -1054,17 +984,6 @@ limitations under the License.
                         </executions>
                     </plugin>
                     <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <executions>
                             <execution>
@@ -1176,13 +1095,6 @@ limitations under the License.
         </profile>
     </profiles>
 
-    <distributionManagement>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
     <licenses>
         <license>
             <name>Apache 2</name>
@@ -1195,7 +1107,7 @@ limitations under the License.
     <scm>
         <connection>scm:git:git@github.com:datastax/java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:datastax/java-driver.git</developerConnection>
-        <url>https://github.com/datastax/java-driver</url>
+        <url>https://github.com/apache/cassandra-java-driver</url>
         <tag>HEAD</tag>
     </scm>
 

--- a/upgrade_guide/README.md
+++ b/upgrade_guide/README.md
@@ -71,7 +71,7 @@ versions of the Java Driver.
     
 [JAVA-1752]:https://datastax-oss.atlassian.net/browse/JAVA-1752
 [JAVA-1376]:https://datastax-oss.atlassian.net/browse/JAVA-1376
-[online example]:https://github.com/datastax/java-driver/blob/3.x/driver-examples/src/main/java/com/datastax/driver/examples/retry/DowngradingRetry.java
+[online example]:https://github.com/apache/cassandra-java-driver/blob/3.x/driver-examples/src/main/java/com/datastax/driver/examples/retry/DowngradingRetry.java
 
 2.  The `TokenAwarePolicy` now has a new constructor that takes a `ReplicaOrdering` 
     argument, see [JAVA-1448]. 


### PR DESCRIPTION
CASSANDRA-18969

* New submodule to generate distribution source tarball
* Binary/source tarball artifacts should be prefixed with apache-cassandra
* Change groupId to org.apache.cassandra
* Create binary versions for LICENSE and NOTICE, with licenses and entries for asm, HdrHistogram, jnr-posix, jnr-x86asm, slf4j-api
* Add checksums to distribution tarballs, and clean toplevel readme a little
* Remove distributionManagement, the apache parent defines this for us
