### PR TITLE
CASSJAVA-25: Build a public CI for Apache Cassandra Java Driver

### DIFF
--- a/Jenkinsfile-asf
+++ b/Jenkinsfile-asf
@@ -67,7 +67,7 @@ pipeline {
 def executeTests() {
     def testJavaMajorVersion = (TEST_JAVA_VERSION =~ /@(?:1\.)?(\d+)/)[0][1]
     sh """
-        container_id=\$(docker run -td -e TEST_JAVA_VERSION=${TEST_JAVA_VERSION} -e SERVER_VERSION=${SERVER_VERSION} -e TEST_JAVA_MAJOR_VERSION=${testJavaMajorVersion} -v \$(pwd):/home/docker/cassandra-java-driver janehe/cassandra-java-driver-dev-env 'sleep 2h')
+        container_id=\$(docker run -td -e TEST_JAVA_VERSION=${TEST_JAVA_VERSION} -e SERVER_VERSION=${SERVER_VERSION} -e TEST_JAVA_MAJOR_VERSION=${testJavaMajorVersion} -v \$(pwd):/home/docker/cassandra-java-driver apache.jfrog.io/cassan-docker/apache/cassandra-java-driver-testing-ubuntu2204 'sleep 2h')
         docker exec --user root \$container_id bash -c \"sudo bash /home/docker/cassandra-java-driver/ci/create-user.sh docker \$(id -u) \$(id -g) /home/docker/cassandra-java-driver\"
         docker exec --user docker \$container_id './cassandra-java-driver/ci/run-tests.sh'
         ( nohup docker stop \$container_id >/dev/null 2>/dev/null & )

--- a/Jenkinsfile-asf
+++ b/Jenkinsfile-asf
@@ -39,9 +39,10 @@ pipeline {
                     }
                     axis {
                         name 'SERVER_VERSION'
-                        values  '3.11.17',
-                                '4.0.14',
-                                '5.0.2'
+                        values  '3.11',
+                                '4.0',
+                                '4.1',
+                                '5.0'
                     }
                 }
                 stages {

--- a/Jenkinsfile-asf
+++ b/Jenkinsfile-asf
@@ -40,8 +40,8 @@ pipeline {
                     axis {
                         name 'SERVER_VERSION'
                         values  '3.11.17',
-                                '4.0.13',
-                                '5.0-beta1'
+                                '4.0.14',
+                                '5.0.2'
                     }
                 }
                 stages {
@@ -66,7 +66,7 @@ pipeline {
 def executeTests() {
     def testJavaMajorVersion = (TEST_JAVA_VERSION =~ /@(?:1\.)?(\d+)/)[0][1]
     sh """
-        container_id=\$(docker run -td -e TEST_JAVA_VERSION=${TEST_JAVA_VERSION} -e SERVER_VERSION=${SERVER_VERSION} -e TEST_JAVA_MAJOR_VERSION=${testJavaMajorVersion} -v \$(pwd):/home/docker/cassandra-java-driver apache.jfrog.io/cassan-docker/apache/cassandra-java-driver-testing-ubuntu2204 'sleep 2h')
+        container_id=\$(docker run -td -e TEST_JAVA_VERSION=${TEST_JAVA_VERSION} -e SERVER_VERSION=${SERVER_VERSION} -e TEST_JAVA_MAJOR_VERSION=${testJavaMajorVersion} -v \$(pwd):/home/docker/cassandra-java-driver janehe/cassandra-java-driver-dev-env 'sleep 2h')
         docker exec --user root \$container_id bash -c \"sudo bash /home/docker/cassandra-java-driver/ci/create-user.sh docker \$(id -u) \$(id -g) /home/docker/cassandra-java-driver\"
         docker exec --user docker \$container_id './cassandra-java-driver/ci/run-tests.sh'
         ( nohup docker stop \$container_id >/dev/null 2>/dev/null & )

--- a/ci/run-tests.sh
+++ b/ci/run-tests.sh
@@ -6,5 +6,7 @@ cd $(dirname "$(readlink -f "$0")")/..
 printenv | sort
 mvn -B -V install -DskipTests -Dmaven.javadoc.skip=true
 jabba use ${TEST_JAVA_VERSION}
+# Find out the latest patch version of Cassandra
+PATCH_SERVER_VERSION=$(curl -s https://downloads.apache.org/cassandra/ | grep -oP '(?<=href=\")[0-9]+\.[0-9]+\.[0-9]+(?=)' | sort -rV | uniq -w 3 | grep $SERVER_VERSION)
 printenv | sort
-mvn -B -V verify -T 1 -Ptest-jdk-${TEST_JAVA_MAJOR_VERSION} -DtestJavaHome=$(jabba which ${TEST_JAVA_VERSION}) -Dccm.version=${SERVER_VERSION} -Dccm.dse=false -Dmaven.test.failure.ignore=true -Dmaven.javadoc.skip=true
+mvn -B -V verify -T 1 -Ptest-jdk-${TEST_JAVA_MAJOR_VERSION} -DtestJavaHome=$(jabba which ${TEST_JAVA_VERSION}) -Dccm.version=${PATCH_SERVER_VERSION} -Dccm.dse=false -Dmaven.test.failure.ignore=true -Dmaven.javadoc.skip=true


### PR DESCRIPTION
TODO: change the docker image name from "janehe/cassandra-java-driver-dev-env" to "apache.jfrog.io/cassan-docker/apache/cassandra-java-driver-testing-ubuntu2204"

The changes will figure out the latest Cassandra patch version for each minor version.