### PR TITLE
CASSJAVA-68 Improve DefaultCodecRegistry.CacheKey#hashCode() to eliminate Object[] allocation

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/DefaultCodecRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/DefaultCodecRegistry.java
@@ -159,7 +159,10 @@ public class DefaultCodecRegistry extends CachingCodecRegistry {
 
     @Override
     public int hashCode() {
-      return Objects.hash(cqlType, javaType, isJavaCovariant);
+      // NOTE: inlined Objects.hash for performance reasons (avoid Object[] allocation
+      // seen in profiler allocation traces)
+      return ((31 + Objects.hashCode(cqlType)) * 31 + Objects.hashCode(javaType)) * 31
+              + Boolean.hashCode(isJavaCovariant);
     }
   }
 }


### PR DESCRIPTION
So: while this may seem trivial, profiling showed significant `Object[]` allocations here (since `Object.hashCode(Object... args)` takes varargs which gets converted into `Object[]`) so figured out it's worth improving upon.
Should produce same hash code (although that should not matter greatly as long as hash code works well enough).