### PR TITLE
CASSJAVA-59: Upgrade Netty to 4.1.115.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <!-- when changing version also update version in LICENSE_binary  -->
     <hdrhistogram.version>2.1.12</hdrhistogram.version>
     <metrics.version>4.1.18</metrics.version>
-    <netty.version>4.1.94.Final</netty.version>
+    <netty.version>4.1.115.Final</netty.version>
     <esri.version>1.2.1</esri.version>
     <!--
     When upgrading TinkerPop please upgrade the version matrix in


### PR DESCRIPTION
This version fixes a CVE: https://github.com/netty/netty/security/advisories/GHSA-xq3w-v528-46rv