### PR TITLE
CASSJAVA-61 Update link to Jira to be CASSJAVA

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,3 +34,4 @@ github:
     projects: false
   autolink_jira:
     - CASSANDRA
+    - CASSJAVA

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ See the [Cassandra error handling done right blog](https://www.datastax.com/blog
 
 * [Manual](manual/)
 * [API docs]
-* Bug tracking: [JIRA].  Make sure to select the "Client/java-driver" component when filing new tickets!
+* Bug tracking: [JIRA]
 * [Mailing list]
 * [Changelog]
 * [FAQ]
 
 [API docs]: https://docs.datastax.com/en/drivers/java/4.17
-[JIRA]: https://issues.apache.org/jira/issues/?jql=project%20%3D%20CASSANDRA%20AND%20component%20%3D%20%22Client%2Fjava-driver%22%20ORDER%20BY%20key%20DESC
+[JIRA]: https://issues.apache.org/jira/issues/?jql=project%20%3D%20CASSJAVA%20ORDER%20BY%20key%20DESC
 [Mailing list]: https://groups.google.com/a/lists.datastax.com/forum/#!forum/java-driver-user
 [Changelog]: changelog/
 [FAQ]: faq/


### PR DESCRIPTION
Updating the link to Jira.

Previously we had a component in the CASSANDRA Jira project but now we have a project for each driver - in the case of Java, it's CASSJAVA.