### PR TITLE
CASSJAVA-66 Update POM to use new doclint param added in Maven 3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1015,9 +1015,6 @@ limitations under the License.
             <activation>
                 <jdk>[1.8,)</jdk>
             </activation>
-            <properties>
-                <javadoc.opts>-Xdoclint:none</javadoc.opts>
-            </properties>
             <build>
                 <plugins>
                     <!-- only activate for jdk8+ since requires java 8 -->
@@ -1034,6 +1031,13 @@ limitations under the License.
                             </execution>
                         </executions>
                     </plugin>
+		    <plugin>
+		      <groupId>org.apache.maven.plugins</groupId>
+		      <artifactId>maven-javadoc-plugin</artifactId>
+		      <configuration combine.self="override">
+			<doclint>none</doclint>
+		      </configuration>
+		    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
I'm perfectly fine moving to syntax that's only supported on Maven 3.0+