### PR TITLE
CASSJAVA-53 Upgrade Guava to 33.3.1-jre

### DIFF
--- a/core/src/test/java/com/datastax/dse/driver/internal/core/cql/reactive/TestSubscriber.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/cql/reactive/TestSubscriber.java
@@ -81,7 +81,8 @@ public class TestSubscriber<T> implements Subscriber<T> {
   }
 
   public void awaitTermination() {
-    Uninterruptibles.awaitUninterruptibly(latch, 1, TimeUnit.MINUTES);
-    if (latch.getCount() > 0) fail("subscriber not terminated");
+    if (!Uninterruptibles.awaitUninterruptibly(latch, 1, TimeUnit.MINUTES)) {
+      fail("subscriber not terminated");
+    }
   }
 }

--- a/guava-shaded/pom.xml
+++ b/guava-shaded/pom.xml
@@ -45,14 +45,6 @@
           <groupId>com.google.errorprone</groupId>
           <artifactId>error_prone_annotations</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>com.google.j2objc</groupId>
-          <artifactId>j2objc-annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-annotations</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -78,6 +70,8 @@
                 <includes>
                   <include>org.apache.cassandra:java-driver-guava-shaded</include>
                   <include>com.google.guava:guava</include>
+                  <include>com.google.guava:failureaccess</include>
+                  <include>com.google.j2objc:j2objc-annotations</include>
                 </includes>
               </artifactSet>
               <relocations>

--- a/mapper-runtime/src/test/java/com/datastax/dse/driver/api/mapper/reactive/TestSubscriber.java
+++ b/mapper-runtime/src/test/java/com/datastax/dse/driver/api/mapper/reactive/TestSubscriber.java
@@ -17,6 +17,8 @@
  */
 package com.datastax.dse.driver.api.mapper.reactive;
 
+import static org.assertj.core.api.Fail.fail;
+
 import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -70,6 +72,8 @@ public class TestSubscriber<T> implements Subscriber<T> {
   }
 
   public void awaitTermination() {
-    Uninterruptibles.awaitUninterruptibly(latch, 1, TimeUnit.MINUTES);
+    if (!Uninterruptibles.awaitUninterruptibly(latch, 1, TimeUnit.MINUTES)) {
+      fail("subscriber not terminated");
+    }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <!-- Version of Guava used in shaded module and for integration tests. -->
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>25.1-jre</version>
+        <version>33.3.1-jre</version>
       </dependency>
       <dependency>
         <groupId>com.typesafe</groupId>


### PR DESCRIPTION
Fixes [CASSJAVA-53](https://issues.apache.org/jira/browse/CASSJAVA-53).