### PR TITLE
CASSJAVA-40: Driver testing against Java 21

### DIFF
--- a/Jenkinsfile-asf
+++ b/Jenkinsfile-asf
@@ -35,7 +35,7 @@ pipeline {
                 axes {
                     axis {
                         name 'TEST_JAVA_VERSION'
-                        values  'openjdk@1.8.0-292', 'openjdk@1.11.0-9', 'openjdk@17'
+                        values  'openjdk@1.8.0-292', 'openjdk@1.11.0-9', 'openjdk@17', 'openjdk@1.21.0'
                     }
                     axis {
                         name 'SERVER_VERSION'
@@ -67,7 +67,7 @@ pipeline {
 def executeTests() {
     def testJavaMajorVersion = (TEST_JAVA_VERSION =~ /@(?:1\.)?(\d+)/)[0][1]
     sh """
-        container_id=\$(docker run -td -e TEST_JAVA_VERSION=${TEST_JAVA_VERSION} -e SERVER_VERSION=${SERVER_VERSION} -e TEST_JAVA_MAJOR_VERSION=${testJavaMajorVersion} -v \$(pwd):/home/docker/cassandra-java-driver apache.jfrog.io/cassan-docker/apache/cassandra-java-driver-testing-ubuntu2204 'sleep 2h')
+        container_id=\$(docker run -td -e TEST_JAVA_VERSION=${TEST_JAVA_VERSION} -e SERVER_VERSION=${SERVER_VERSION} -e TEST_JAVA_MAJOR_VERSION=${testJavaMajorVersion} -v \$(pwd):/home/docker/cassandra-java-driver janehe158/cassandra-java-driver-dev-env 'sleep 2h')
         docker exec --user root \$container_id bash -c \"sudo bash /home/docker/cassandra-java-driver/ci/create-user.sh docker \$(id -u) \$(id -g) /home/docker/cassandra-java-driver\"
         docker exec --user docker \$container_id './cassandra-java-driver/ci/run-tests.sh'
         ( nohup docker stop \$container_id >/dev/null 2>/dev/null & )

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/ArrayUtils.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/ArrayUtils.java
@@ -18,6 +18,7 @@
 package com.datastax.oss.driver.internal.core.util;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class ArrayUtils {
@@ -77,7 +78,7 @@ public class ArrayUtils {
    *     Fisher-Yates shuffle</a>
    */
   public static <ElementT> void shuffleHead(
-      @NonNull ElementT[] elements, int n, @NonNull ThreadLocalRandom random) {
+      @NonNull ElementT[] elements, int n, @NonNull Random random) {
     if (n > elements.length) {
       throw new ArrayIndexOutOfBoundsException(
           String.format(

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/QueryTraceFetcherTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/QueryTraceFetcherTest.java
@@ -79,7 +79,7 @@ public class QueryTraceFetcherTest {
   @Mock private NettyOptions nettyOptions;
   @Mock private EventExecutorGroup adminEventExecutorGroup;
   @Mock private EventExecutor eventExecutor;
-  @Mock private InetAddress address;
+  private InetAddress address = InetAddress.getLoopbackAddress();
 
   @Captor private ArgumentCaptor<SimpleStatement> statementCaptor;
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/util/ArrayUtilsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/util/ArrayUtilsTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.Random;
 import org.junit.Test;
 
 public class ArrayUtilsTest {
@@ -86,7 +86,7 @@ public class ArrayUtilsTest {
   @Test
   public void should_shuffle_head() {
     String[] array = {"a", "b", "c", "d", "e"};
-    ThreadLocalRandom random = mock(ThreadLocalRandom.class);
+    Random random = mock(Random.class);
     when(random.nextInt(anyInt()))
         .thenAnswer(
             (invocation) -> {

--- a/pom.xml
+++ b/pom.xml
@@ -1016,6 +1016,19 @@ limitations under the License.]]></inlineHeader>
         <mockitoopens.argline>--add-opens java.base/jdk.internal.util.random=ALL-UNNAMED</mockitoopens.argline>
       </properties>
     </profile>
+    <profile>
+      <!-- workarounds for running tests with JDK21 -->
+      <id>test-jdk-21</id>
+      <activation>
+        <jdk>[21,)</jdk>
+      </activation>
+      <properties>
+        <!-- for DriverBlockHoundIntegrationIT when using JDK 13+, see https://github.com/reactor/BlockHound/issues/33 -->
+        <blockhound.argline>-XX:+AllowRedefinitionToAddDeleteMethods</blockhound.argline>
+        <!-- allow deep reflection for mockito when using JDK 17+, see https://stackoverflow.com/questions/70993863/mockito-can-not-mock-random-in-java-17 -->
+        <mockitoopens.argline>--add-opens=java.base/jdk.internal.util.random=ALL-UNNAMED</mockitoopens.argline>
+      </properties>
+    </profile>
   </profiles>
   <licenses>
     <license>


### PR DESCRIPTION
TODO: change the docker image name to "apache.jfrog.io/cassan-docker/apache/cassandra-java-driver-testing-ubuntu2204" after Mick update the docker image.