### PR TITLE
CASSJAVA-52: Do not always cleanup Guava shaded module before packaging

### DIFF
--- a/guava-shaded/pom.xml
+++ b/guava-shaded/pom.xml
@@ -65,6 +65,32 @@
   <build>
     <plugins>
       <plugin>
+        <!--
+          Do not attempt to recompile the module if we are not running JVM 1.8.
+          Having additional Java source files and having to shade Guava will break
+          in CI environment, when we run 'mvn verify' on newer JVM and assume that
+          all classes have been compiled with JVM 1.8.
+        -->
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.12</version>
+        <executions>
+          <execution>
+            <id>regex-property</id>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <configuration>
+              <name>maven.main.skip</name>
+              <value>${java.version}</value>
+              <regex>^(?!1.8).+</regex>
+              <replacement>true</replacement>
+              <failIfNoMatch>false</failIfNoMatch>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
@@ -101,6 +127,12 @@
         </executions>
       </plugin>
       <plugin>
+        <!--
+          Cleaning up target directory is required, because module's Java source files
+          (e.g. LexicographicalComparatorHolderSubstitution) will be left with
+          their original Java package AND eventually shaded one. This plugin removes
+          the Java class from its unshaded package.
+        -->
         <artifactId>maven-clean-plugin</artifactId>
         <executions>
           <execution>


### PR DESCRIPTION
Fixes [CASSJAVA-52](https://issues.apache.org/jira/browse/CASSJAVA-52).

ASF CI performs the following sequence of operations to compile the driver and run integration tests:
```
$ mvn clean install -DskipTests
$ java11 (or any other version that we wish to run the tests with)
$ mvn verify -DccmJvm.version=11 -Dccm.version=4.0.4 -DtestJavaHome=...
```

`mvn verify` should not need to recompile source code, because JVM version is not set to 1.8 any more. Build failure:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project java-driver-guava-shaded: Compilation failure
[ERROR] /cassandra-java-driver/guava-shaded/src/main/java/com/google/common/primitives/LexicographicalComparatorHolderSubstitution.java:[24,17] cannot access java.util.Comparator
[ERROR]   bad class file: /modules/java.base/java/util/Comparator.class
[ERROR]     class file has wrong version 55.0, should be 53.0
[ERROR]     Please remove or make sure it appears in the correct subdirectory of the classpath.
```
CI failed job: [link](https://ci-cassandra.apache.org/blue/organizations/jenkins/cassandra-java-driver/detail/4.x/21/pipeline/).