### PR TITLE
CASSJAVA-67 Fixes to get "mvn release:prepare" back on track

### DIFF
--- a/driver-dist/pom.xml
+++ b/driver-dist/pom.xml
@@ -34,30 +34,23 @@
 
     <!-- These dependencies are only here to ensure proper build order and proper inclusion of binaries in the final tarball -->
     <dependencies>
-
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-mapping</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-driver-extras</artifactId>
         </dependency>
-
     </dependencies>
 
     <build>
-
         <finalName>apache-cassandra-java-driver-${project.version}</finalName>
-
         <plugins>
-
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <!-- http://stackoverflow.com/questions/13218313/unable-to-disable-generation-of-empty-jar-maven-jar-plugin -->
@@ -68,34 +61,34 @@
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
                 <configuration>
                     <skipSource>true</skipSource>
                 </configuration>
             </plugin>
-
             <plugin>
                 <artifactId>maven-install-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
-
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
-
     </build>
 
     <profiles>
-
         <profile>
             <id>release</id>
             <build>
@@ -145,10 +138,15 @@
                         </algorithms>
                       </configuration>
                     </plugin>
+                    <plugin>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
-
     </profiles>
 
 </project>

--- a/driver-tests/pom.xml
+++ b/driver-tests/pom.xml
@@ -39,9 +39,7 @@
     </modules>
 
     <build>
-
         <plugins>
-
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>clirr-maven-plugin</artifactId>
@@ -49,21 +47,18 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
                 <configuration>
                     <skipSource>true</skipSource>
                 </configuration>
             </plugin>
-
             <plugin>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
-
             <plugin>
                 <artifactId>maven-install-plugin</artifactId>
                 <configuration>
@@ -77,13 +72,21 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>net.nicoulaj.maven.plugins</groupId>
+                <artifactId>checksum-maven-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <id>source-release-checksum</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
-
     </build>
 
     <profiles>
-
         <profile>
             <id>release</id>
             <build>
@@ -98,7 +101,6 @@
                 </plugins>
             </build>
         </profile>
-
     </profiles>
 
 </project>


### PR DESCRIPTION
Note: all of the fixes here were developed by @adutra (who has apparently forgotten more about Maven than I'll ever know).

Broken into two commits (for now) to clearly decouple the fix for the initial problem as well as the (completely separate) fix for a follow-on problem @adutra discovered during testing.