### PR TITLE
JAVA-3055 CqlPrepareAsyncProcessor must handle cancellations of the returned Future

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareAsyncProcessor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareAsyncProcessor.java
@@ -37,14 +37,19 @@ import com.datastax.oss.driver.internal.core.util.concurrent.RunOrSchedule;
 import com.datastax.oss.driver.shaded.guava.common.cache.Cache;
 import com.datastax.oss.driver.shaded.guava.common.cache.CacheBuilder;
 import com.datastax.oss.driver.shaded.guava.common.collect.Iterables;
+import com.datastax.oss.driver.shaded.guava.common.collect.Sets;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
+import com.google.common.base.Functions;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.netty.util.concurrent.EventExecutor;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,23 +58,73 @@ import org.slf4j.LoggerFactory;
 public class CqlPrepareAsyncProcessor
     implements RequestProcessor<PrepareRequest, CompletionStage<PreparedStatement>> {
 
+  public class CacheEntry {
+
+    private CompletableFuture<PreparedStatement> result;
+    private Set<CompletableFuture<PreparedStatement>> futures;
+    private AtomicBoolean lock;
+
+    public CacheEntry() {
+
+      result = new CompletableFuture<>();
+      futures = Sets.newHashSet(result);
+      lock = new AtomicBoolean(false);
+    }
+
+    public void addFuture(CompletableFuture<PreparedStatement> future) {
+
+      futures.add(future);
+    }
+
+    public void tryStart(
+        PrepareRequest request,
+        DefaultSession session,
+        InternalDriverContext context,
+        String sessionLogPrefix) {
+      // Guarantee that we'll only create one CqlPrepareHandler for each cache entry
+      if (lock.compareAndSet(false, true)) {
+
+        new CqlPrepareHandler(request, session, context, sessionLogPrefix)
+            .handle()
+            .whenComplete(
+                (ps, t) -> {
+                  if (t == null) {
+                    for (CompletableFuture<PreparedStatement> future : futures) {
+                      future.complete(ps);
+                    }
+                  } else {
+                    cache.invalidate(request);
+                    for (CompletableFuture<PreparedStatement> future : futures) {
+                      future.completeExceptionally(t);
+                    }
+                  }
+                });
+      }
+    }
+
+    public PreparedStatement waitForResult() {
+      return this.result.join();
+    }
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(CqlPrepareAsyncProcessor.class);
 
-  protected final Cache<PrepareRequest, CompletableFuture<PreparedStatement>> cache;
+  protected final Cache<PrepareRequest, CacheEntry> cache;
 
   public CqlPrepareAsyncProcessor() {
     this(Optional.empty());
   }
 
   public CqlPrepareAsyncProcessor(@NonNull Optional<? extends DefaultDriverContext> context) {
-    this(CacheBuilder.newBuilder().weakValues().build(), context);
+    this(context, Functions.identity());
   }
 
   protected CqlPrepareAsyncProcessor(
-      Cache<PrepareRequest, CompletableFuture<PreparedStatement>> cache,
-      Optional<? extends DefaultDriverContext> context) {
+      Optional<? extends DefaultDriverContext> context,
+      Function<CacheBuilder<Object, Object>, CacheBuilder<Object, Object>> decorator) {
 
-    this.cache = cache;
+    CacheBuilder<Object, Object> baseCache = CacheBuilder.newBuilder().weakValues();
+    this.cache = decorator.apply(baseCache).build();
     context.ifPresent(
         (ctx) -> {
           LOG.info("Adding handler to invalidate cached prepared statements on type changes");
@@ -108,11 +163,10 @@ public class CqlPrepareAsyncProcessor
   }
 
   private void onTypeChanged(TypeChangeEvent event) {
-    for (Map.Entry<PrepareRequest, CompletableFuture<PreparedStatement>> entry :
-        this.cache.asMap().entrySet()) {
+    for (Map.Entry<PrepareRequest, CacheEntry> entry : this.cache.asMap().entrySet()) {
 
       try {
-        PreparedStatement stmt = entry.getValue().get();
+        PreparedStatement stmt = entry.getValue().waitForResult();
         if (Iterables.any(
                 stmt.getResultSetDefinitions(), (def) -> typeMatches(event.oldType, def.getType()))
             || Iterables.any(
@@ -141,25 +195,23 @@ public class CqlPrepareAsyncProcessor
       String sessionLogPrefix) {
 
     try {
-      CompletableFuture<PreparedStatement> result = cache.getIfPresent(request);
-      if (result == null) {
-        CompletableFuture<PreparedStatement> mine = new CompletableFuture<>();
-        result = cache.get(request, () -> mine);
-        if (result == mine) {
-          new CqlPrepareHandler(request, session, context, sessionLogPrefix)
-              .handle()
-              .whenComplete(
-                  (preparedStatement, error) -> {
-                    if (error != null) {
-                      mine.completeExceptionally(error);
-                      cache.invalidate(request); // Make sure failure isn't cached indefinitely
-                    } else {
-                      mine.complete(preparedStatement);
-                    }
-                  });
-        }
-      }
-      return result;
+      CompletableFuture<PreparedStatement> rv = new CompletableFuture<>();
+      CacheEntry entry =
+          cache.get(
+              request,
+              () -> {
+                CacheEntry newEntry = new CacheEntry();
+                newEntry.addFuture(rv);
+                newEntry.tryStart(request, session, context, sessionLogPrefix);
+                return newEntry;
+              });
+
+      // We don't know whether we're dealing with a newly-created entry or one that was
+      // already cached so try the future insert again.  We wind up duoing an extra hash op
+      // on the initial insert this way but that's a relatively small price to pay.
+      entry.addFuture(rv);
+
+      return rv;
     } catch (ExecutionException e) {
       return CompletableFutures.failedFuture(e.getCause());
     }
@@ -170,7 +222,7 @@ public class CqlPrepareAsyncProcessor
     return CompletableFutures.failedFuture(error);
   }
 
-  public Cache<PrepareRequest, CompletableFuture<PreparedStatement>> getCache() {
+  public Cache<PrepareRequest, CacheEntry> getCache() {
     return cache;
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareSyncProcessor.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlPrepareSyncProcessor.java
@@ -27,7 +27,6 @@ import com.datastax.oss.driver.internal.core.session.RequestProcessor;
 import com.datastax.oss.driver.internal.core.util.concurrent.BlockingOperation;
 import com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures;
 import com.datastax.oss.driver.shaded.guava.common.cache.Cache;
-import java.util.concurrent.CompletableFuture;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
@@ -62,7 +61,7 @@ public class CqlPrepareSyncProcessor
         asyncProcessor.process(request, session, context, sessionLogPrefix));
   }
 
-  public Cache<PrepareRequest, CompletableFuture<PreparedStatement>> getCache() {
+  public Cache<PrepareRequest, CqlPrepareAsyncProcessor.CacheEntry> getCache() {
     return asyncProcessor.getCache();
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCachingIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCachingIT.java
@@ -24,8 +24,6 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.context.DriverContext;
-import com.datastax.oss.driver.api.core.cql.PrepareRequest;
-import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
 import com.datastax.oss.driver.api.core.session.ProgrammaticArguments;
 import com.datastax.oss.driver.api.core.session.SessionBuilder;
@@ -41,7 +39,6 @@ import com.datastax.oss.driver.internal.core.metadata.schema.events.TypeChangeEv
 import com.datastax.oss.driver.internal.core.session.BuiltInRequestProcessors;
 import com.datastax.oss.driver.internal.core.session.RequestProcessor;
 import com.datastax.oss.driver.internal.core.session.RequestProcessorRegistry;
-import com.datastax.oss.driver.shaded.guava.common.cache.CacheBuilder;
 import com.datastax.oss.driver.shaded.guava.common.cache.RemovalListener;
 import com.datastax.oss.driver.shaded.guava.common.util.concurrent.Uninterruptibles;
 import com.google.common.collect.ImmutableList;
@@ -54,7 +51,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -119,12 +115,12 @@ public class PreparedStatementCachingIT {
     private static final Logger LOG =
         LoggerFactory.getLogger(PreparedStatementCachingIT.TestCqlPrepareAsyncProcessor.class);
 
-    private static RemovalListener<PrepareRequest, CompletableFuture<PreparedStatement>>
-        buildCacheRemoveCallback(@NonNull Optional<DefaultDriverContext> context) {
+    private static RemovalListener<Object, Object> buildCacheRemoveCallback(
+        @NonNull Optional<DefaultDriverContext> context) {
       return (evt) -> {
         try {
-          CompletableFuture<PreparedStatement> future = evt.getValue();
-          ByteBuffer queryId = Uninterruptibles.getUninterruptibly(future).getId();
+          CacheEntry entry = (CacheEntry) evt.getValue();
+          ByteBuffer queryId = entry.waitForResult().getId();
           context.ifPresent(
               ctx -> ctx.getEventBus().fire(new PreparedStatementRemovalEvent(queryId)));
         } catch (Exception e) {
@@ -136,9 +132,7 @@ public class PreparedStatementCachingIT {
     public TestCqlPrepareAsyncProcessor(@NonNull Optional<DefaultDriverContext> context) {
       // Default CqlPrepareAsyncProcessor uses weak values here as well.  We avoid doing so
       // to prevent cache entries from unexpectedly disappearing mid-test.
-      super(
-          CacheBuilder.newBuilder().removalListener(buildCacheRemoveCallback(context)).build(),
-          context);
+      super(context, builder -> builder.removalListener(buildCacheRemoveCallback(context)));
     }
   }
 

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCancellationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCancellationIT.java
@@ -104,8 +104,8 @@ public class PreparedStatementCancellationIT {
 
     // Waiting for results on the cache entry should prevent us from continuing until the CacheEntry
     // future returns
-    assertThat(cf1.isDone());
-    assertThat(cf2.isDone());
+    assertThat(cf1.isDone()).isTrue();
+    assertThat(cf2.isDone()).isTrue();
 
     assertThat(cf1.join()).isEqualTo(stmt);
     assertThat(cf2.join()).isEqualTo(stmt);
@@ -157,13 +157,10 @@ public class PreparedStatementCancellationIT {
     assertThat(cache.size()).isEqualTo(1);
     CqlPrepareAsyncProcessor.CacheEntry entry =
         (CqlPrepareAsyncProcessor.CacheEntry) Iterables.get(cache.asMap().values(), 0);
-    try {
-      PreparedStatement rv = entry.waitForResult();
-      assertThat(rv).isNotNull();
-      assertThat(rv.getQuery()).isEqualTo(cql);
-    } catch (Exception e) {
-      fail("Unexpected exception when waiting on cache CompletableFuture");
-    }
+
+    PreparedStatement rv = entry.waitForResult();
+    assertThat(rv).isNotNull();
+    assertThat(rv.getQuery()).isEqualTo(cql);
     assertThat(cache.size()).isEqualTo(1);
   }
 }

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCancellationIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/PreparedStatementCancellationIT.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.core.cql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.testinfra.ccm.CustomCcmRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import com.datastax.oss.driver.categories.IsolatedTests;
+import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
+import com.datastax.oss.driver.internal.core.cql.CqlPrepareAsyncProcessor;
+import com.datastax.oss.driver.shaded.guava.common.base.Predicates;
+import com.datastax.oss.driver.shaded.guava.common.cache.Cache;
+import com.datastax.oss.driver.shaded.guava.common.collect.Iterables;
+import java.util.concurrent.CompletableFuture;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+@Category(IsolatedTests.class)
+public class PreparedStatementCancellationIT {
+
+  private CustomCcmRule ccmRule = CustomCcmRule.builder().build();
+
+  private SessionRule<CqlSession> sessionRule = SessionRule.builder(ccmRule).build();
+
+  @Rule public TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
+
+  @Before
+  public void setup() {
+
+    CqlSession session = SessionUtils.newSession(ccmRule, sessionRule.keyspace());
+    session.execute("DROP TABLE IF EXISTS test_table_1");
+    session.execute("CREATE TABLE test_table_1 (k int primary key, v int)");
+    session.execute("INSERT INTO test_table_1 (k,v) VALUES (1, 100)");
+    session.execute("INSERT INTO test_table_1 (k,v) VALUES (2, 200)");
+    session.execute("INSERT INTO test_table_1 (k,v) VALUES (3, 300)");
+    session.close();
+  }
+
+  @After
+  public void teardown() {
+
+    CqlSession session = SessionUtils.newSession(ccmRule, sessionRule.keyspace());
+    session.execute("DROP TABLE test_table_1");
+    session.close();
+  }
+
+  private CompletableFuture<PreparedStatement> toCompletableFuture(CqlSession session, String cql) {
+
+    return session.prepareAsync(cql).toCompletableFuture();
+  }
+
+  private CqlPrepareAsyncProcessor findProcessor(CqlSession session) {
+
+    DefaultDriverContext context = (DefaultDriverContext) session.getContext();
+    return (CqlPrepareAsyncProcessor)
+        Iterables.find(
+            context.getRequestProcessorRegistry().getProcessors(),
+            Predicates.instanceOf(CqlPrepareAsyncProcessor.class));
+  }
+
+  @Test
+  public void should_cache_valid_cql() throws Exception {
+
+    CqlSession session = SessionUtils.newSession(ccmRule, sessionRule.keyspace());
+    CqlPrepareAsyncProcessor processor = findProcessor(session);
+    Cache<?, ?> cache = processor.getCache();
+    assertThat(cache.size()).isEqualTo(0);
+
+    // Make multiple CompletableFuture requests for the specified CQL, then wait until
+    // the cached request finishes and confirm that all futures got the same values
+    String cql = "select v from test_table_1 where k = ?";
+    CompletableFuture<PreparedStatement> cf1 = toCompletableFuture(session, cql);
+    CompletableFuture<PreparedStatement> cf2 = toCompletableFuture(session, cql);
+    assertThat(cache.size()).isEqualTo(1);
+
+    CqlPrepareAsyncProcessor.CacheEntry entry =
+        (CqlPrepareAsyncProcessor.CacheEntry) Iterables.get(cache.asMap().values(), 0);
+    PreparedStatement stmt = entry.waitForResult();
+
+    // Waiting for results on the cache entry should prevent us from continuing until the CacheEntry
+    // future returns
+    assertThat(cf1.isDone());
+    assertThat(cf2.isDone());
+
+    assertThat(cf1.join()).isEqualTo(stmt);
+    assertThat(cf2.join()).isEqualTo(stmt);
+  }
+
+  @Test
+  public void should_not_cache_invalid_cql() throws Exception {
+
+    CqlSession session = SessionUtils.newSession(ccmRule, sessionRule.keyspace());
+    CqlPrepareAsyncProcessor processor = findProcessor(session);
+    Cache<?, ?> cache = processor.getCache();
+    assertThat(cache.size()).isEqualTo(0);
+
+    // Verify that we get the CompletableFuture even if the CQL is invalid but that nothing is
+    // cached
+    String cql = "select v fromfrom test_table_1 where k = ?";
+    CompletableFuture<PreparedStatement> cf = toCompletableFuture(session, cql);
+
+    // join() here should throw exceptions due to the invalid syntax... for purposes of this test we
+    // can ignore this
+    try {
+      cf.join();
+      fail();
+    } catch (Exception e) {
+    }
+
+    assertThat(cache.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void should_not_affect_cache_if_returned_futures_are_cancelled() throws Exception {
+
+    CqlSession session = SessionUtils.newSession(ccmRule, sessionRule.keyspace());
+    CqlPrepareAsyncProcessor processor = findProcessor(session);
+    Cache<?, ?> cache = processor.getCache();
+    assertThat(cache.size()).isEqualTo(0);
+
+    String cql = "select v from test_table_1 where k = ?";
+    CompletableFuture<PreparedStatement> cf = toCompletableFuture(session, cql);
+
+    assertThat(cf.isCancelled()).isFalse();
+    assertThat(cf.cancel(false)).isTrue();
+    assertThat(cf.isCancelled()).isTrue();
+    assertThat(cf.isCompletedExceptionally()).isTrue();
+
+    // Confirm that cancelling the CompletableFuture returned to the user does _not_ cancel the
+    // future used within the cache.  CacheEntry very deliberately doesn't maintain a reference
+    // to it's contained CompletableFuture so we have to get at this by secondary effects.
+    assertThat(cache.size()).isEqualTo(1);
+    CqlPrepareAsyncProcessor.CacheEntry entry =
+        (CqlPrepareAsyncProcessor.CacheEntry) Iterables.get(cache.asMap().values(), 0);
+    try {
+      PreparedStatement rv = entry.waitForResult();
+      assertThat(rv).isNotNull();
+      assertThat(rv.getQuery()).isEqualTo(cql);
+    } catch (Exception e) {
+      fail("Unexpected exception when waiting on cache CompletableFuture");
+    }
+    assertThat(cache.size()).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
My goal here is to completely decouple the CompletableFuture returned by CqlPrepareAsyncProcessor from the CompletableFuture that retrieves the PreparedStatement.  The current implementation merges these two concerns in ways that don't behave nicely with each other.

Note that this approach is functionally very similar to the suggestion offered by @lucboutier in #1757 ... this PR just goes a bit further in explicitly decoupling the elements involved.