### PR TITLE
add "ann" as reserved keyword

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/Strings.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/Strings.java
@@ -282,6 +282,7 @@ public class Strings {
           "allow",
           "alter",
           "and",
+          "ann",
           "apply",
           "asc",
           "authorize",


### PR DESCRIPTION
I found a corner case when using Data API (https://github.com/stargate/data-api/issues/1806). I cannot use `ann` as my table name, but I can use it in CQL:
```
cassandra@cqlsh:default_keyspace> CREATE TABLE default_keyspace."ann" (t text PRIMARY KEY,v VECTOR<float,5>);
```

The reason is, inside the Java Driver, it has a [set that contains all the reserved keywords](https://github.com/apache/cassandra-java-driver/blob/342e2dcf47afab238f357ac2afde65b079ce6b79/core/src/main/java/com/datastax/oss/driver/internal/core/util/Strings.java#L278). When the query builder builds the create table query, it will call `tableName.asCql(true)`. Inside `asCql(true)` method, it will check if the string is in the reserved keywords set and double quoted if it’s in. Unfortunately, the set doesn’t contain `ann`.

I guess `ann` was introduced later and the keywords set hasn't been updated accordingly. 