### PR TITLE
Update changelog and docs for 3.12.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ for the development version and that some features described here might
 not yet have been released. You can find the documentation for the latest
 version through the [Java Driver
 docs](http://docs.datastax.com/en/developer/java-driver/3.11/index.html) or via the release tags,
-[e.g. 3.12.0](https://github.com/apache/cassandra-java-driver/tree/3.12.0).*
+[e.g. 3.12.1](https://github.com/apache/cassandra-java-driver/tree/3.12.1).*
 
 A modern, [feature-rich](manual/) and highly tunable Java client
 library for Apache Cassandra (2.1+) and using exclusively Cassandra's binary protocol 
@@ -62,7 +62,7 @@ using DataStax Enterprise, install the [DataStax Enterprise Java Driver][dse-dri
 <dependency>
   <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-core</artifactId>
-  <version>3.12.0</version>
+  <version>3.12.1</version>
 </dependency>
 ```
 
@@ -72,7 +72,7 @@ Note that the object mapper is published as a separate artifact:
 <dependency>
   <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-mapping</artifactId>
-  <version>3.12.0</version>
+  <version>3.12.1</version>
 </dependency>
 ```
 
@@ -82,7 +82,7 @@ The 'extras' module is also published as a separate artifact:
 <dependency>
   <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-extras</artifactId>
-  <version>3.12.0/version>
+  <version>3.12.1/version>
 </dependency>
 ```
 
@@ -96,7 +96,7 @@ is available for download.
 
 ## Compatibility
 
-The Java client driver 3.12.0 ([branch 3.x](https://github.com/apache/cassandra-java-driver/tree/3.x)) is compatible with Apache
+The Java client driver 3.12.1 ([branch 3.x](https://github.com/apache/cassandra-java-driver/tree/3.x)) is compatible with Apache
 Cassandra 2.1, 2.2 and 3.0+ (see [this page](http://docs.datastax.com/en/developer/java-driver/3.11/manual/native_protocol/) for
 the most up-to-date compatibility information).
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -24,6 +24,10 @@ under the License.
   3.x versions get published.
 -->
 
+## 3.12.1
+- [improvement] CASSJAVA-55: Remove setting "Host" header for metadata requests.
+- [bug] JAVA-3125: Match broadcast RPC for control connection and Astra events
+
 ## 3.12.0
 - [improvement] CASSANDRA-18971: Switch all archs to netty-tcnative-boringssl-static
 - [improvement] CASSJAVA-58: Update 3.x DRIVER_NAME to match 4.x Java driver

--- a/faq/README.md
+++ b/faq/README.md
@@ -308,7 +308,7 @@ version is available, you may want to reach out to the maintainer of that tool t
 an update with compatibility to this driver version.
 
 
-[Blobs.java]: https://github.com/apache/cassandra-java-driver/tree/3.12.0/driver-examples/src/main/java/com/datastax/driver/examples/datatypes/Blobs.java
+[Blobs.java]: https://github.com/apache/cassandra-java-driver/tree/3.12.1/driver-examples/src/main/java/com/datastax/driver/examples/datatypes/Blobs.java
 [CASSANDRA-7304]: https://issues.apache.org/jira/browse/CASSANDRA-7304
 [Parameters and Binding]: ../manual/statements/prepared/#parameters-and-binding
 [Mapper options]: ../manual/object_mapper/using/#mapper-options

--- a/manual/compression/README.md
+++ b/manual/compression/README.md
@@ -107,4 +107,4 @@ cluster = Cluster.builder()
     .build();
 ```
 
-[pom]: https://repo1.maven.org/maven2/com/datastax/cassandra/cassandra-driver-parent/3.12.0/cassandra-driver-parent-3.12.0.pom
+[pom]: https://repo1.maven.org/maven2/com/datastax/cassandra/cassandra-driver-parent/3.12.1/cassandra-driver-parent-3.12.1.pom

--- a/manual/custom_codecs/extras/README.md
+++ b/manual/custom_codecs/extras/README.md
@@ -29,7 +29,7 @@ The module is published as a separate Maven artifact:
 <dependency>
   <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-extras</artifactId>
-  <version>3.12.0</version>
+  <version>3.12.1</version>
 </dependency>
 ```
 

--- a/manual/metrics/README.md
+++ b/manual/metrics/README.md
@@ -57,7 +57,7 @@ To do this in a maven project:
 <dependency>
   <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-core</artifactId>
-  <version>3.12.0</version>
+  <version>3.12.1</version>
   <exclusions>
     <exclusion>
       <groupId>io.dropwizard.metrics</groupId>

--- a/manual/object_mapper/README.md
+++ b/manual/object_mapper/README.md
@@ -30,7 +30,7 @@ The mapper is published as a separate Maven artifact:
 <dependency>
   <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-mapping</artifactId>
-  <version>3.12.0</version>
+  <version>3.12.1</version>
 </dependency>
 ```
 

--- a/manual/shaded_jar/README.md
+++ b/manual/shaded_jar/README.md
@@ -31,7 +31,7 @@ package name:
 <dependency>
   <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-core</artifactId>
-  <version>3.12.0</version>
+  <version>3.12.1</version>
   <classifier>shaded</classifier>
   <!-- Because the shaded JAR uses the original POM, you still need
        to exclude this dependency explicitly: -->
@@ -55,7 +55,7 @@ non-shaded JAR:
 <dependency>
   <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-core</artifactId>
-  <version>3.12.0</version>
+  <version>3.12.1</version>
   <classifier>shaded</classifier>
   <exclusions>
     <exclusion>
@@ -71,7 +71,7 @@ non-shaded JAR:
 <dependency>
   <groupId>org.apache.cassandra</groupId>
   <artifactId>cassandra-driver-mapping</artifactId>
-  <version>3.12.0</version>
+  <version>3.12.1</version>
   <exclusions>
     <exclusion>
       <groupId>org.apache.cassandra</groupId>


### PR DESCRIPTION
Much like [the 3.12.0 version](https://github.com/apache/cassandra-java-driver/pull/1995) this isn't much more than a manual changelog update and a ripgrep for "3.12.0" in the repo.