### PR TITLE
Make guava an optional dependency of java-driver-guava-shaded

### DIFF
--- a/guava-shaded/pom.xml
+++ b/guava-shaded/pom.xml
@@ -46,6 +46,7 @@
           <artifactId>error_prone_annotations</artifactId>
         </exclusion>
       </exclusions>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.graalvm.nativeimage</groupId>


### PR DESCRIPTION
With CASSJAVA-52, the java-driver-guava-shaded module is now in tree.

This appears to work great, but there is a slight issue with the dependency tree that allows unshaded guava packages to be imported within the project.

It looks like marking guava as an optional dependency in java-driver-guava-shaded resolves this.

patch by Andy Tolbert; reviewed by <pending> for CASSJAVA-76