### PR TITLE
Add SubnetAddressTranslator to translate Cassandra node IPs from private network based on its subnet mask

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -994,7 +994,48 @@ public enum DefaultDriverOption implements DriverOption {
    *
    * <p>Value-type: boolean
    */
-  SSL_ALLOW_DNS_REVERSE_LOOKUP_SAN("advanced.ssl-engine-factory.allow-dns-reverse-lookup-san");
+  SSL_ALLOW_DNS_REVERSE_LOOKUP_SAN("advanced.ssl-engine-factory.allow-dns-reverse-lookup-san"),
+  /**
+   * An address to always translate all node addresses to that same proxy hostname no matter what IP
+   * address a node has, but still using its native transport port.
+   *
+   * <p>Value-Type: {@link String}
+   */
+  ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME("advanced.address-translator.advertised-hostname"),
+  /**
+   * A map of Cassandra node subnets (CIDR notations) to target addresses, for example (note quoted
+   * keys):
+   *
+   * <pre>
+   * advanced.address-translator.subnet-addresses {
+   *   "100.64.0.0/15" = "cassandra.datacenter1.com:9042"
+   *   "100.66.0.0/15" = "cassandra.datacenter2.com:9042"
+   *   # IPv6 example:
+   *   # "::ffff:6440:0/111" = "cassandra.datacenter1.com:9042"
+   *   # "::ffff:6442:0/111" = "cassandra.datacenter2.com:9042"
+   * }
+   * </pre>
+   *
+   * Note: subnets must be represented as prefix blocks, see {@link
+   * inet.ipaddr.Address#isPrefixBlock()}.
+   *
+   * <p>Value type: {@link java.util.Map Map}&#60;{@link String},{@link String}&#62;
+   */
+  ADDRESS_TRANSLATOR_SUBNET_ADDRESSES("advanced.address-translator.subnet-addresses"),
+  /**
+   * A default address to fallback to if Cassandra node IP isn't contained in any of the configured
+   * subnets.
+   *
+   * <p>Value-Type: {@link String}
+   */
+  ADDRESS_TRANSLATOR_DEFAULT_ADDRESS("advanced.address-translator.default-address"),
+  /**
+   * Whether to resolve the addresses on initialization (if true) or on each node (re-)connection
+   * (if false). Defaults to false.
+   *
+   * <p>Value-Type: boolean
+   */
+  ADDRESS_TRANSLATOR_RESOLVE_ADDRESSES("advanced.address-translator.resolve-addresses");
 
   private final String path;
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -896,6 +896,20 @@ public class TypedDriverOption<ValueT> {
               DefaultDriverOption.LOAD_BALANCING_DC_FAILOVER_ALLOW_FOR_LOCAL_CONSISTENCY_LEVELS,
               GenericType.BOOLEAN);
 
+  public static final TypedDriverOption<String> ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME =
+      new TypedDriverOption<>(
+          DefaultDriverOption.ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME, GenericType.STRING);
+  public static final TypedDriverOption<Map<String, String>> ADDRESS_TRANSLATOR_SUBNET_ADDRESSES =
+      new TypedDriverOption<>(
+          DefaultDriverOption.ADDRESS_TRANSLATOR_SUBNET_ADDRESSES,
+          GenericType.mapOf(GenericType.STRING, GenericType.STRING));
+  public static final TypedDriverOption<String> ADDRESS_TRANSLATOR_DEFAULT_ADDRESS =
+      new TypedDriverOption<>(
+          DefaultDriverOption.ADDRESS_TRANSLATOR_DEFAULT_ADDRESS, GenericType.STRING);
+  public static final TypedDriverOption<Boolean> ADDRESS_TRANSLATOR_RESOLVE_ADDRESSES =
+      new TypedDriverOption<>(
+          DefaultDriverOption.ADDRESS_TRANSLATOR_RESOLVE_ADDRESSES, GenericType.BOOLEAN);
+
   /**
    * Ordered preference list of remote dcs optionally supplied for automatic failover and included
    * in query plan. This feature is enabled only when max-nodes-per-remote-dc is greater than 0.

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/ContactPoints.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/ContactPoints.java
@@ -19,14 +19,11 @@ package com.datastax.oss.driver.internal.core;
 
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint;
+import com.datastax.oss.driver.internal.core.util.AddressUtils;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import com.datastax.oss.driver.shaded.guava.common.collect.Sets;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -41,7 +38,22 @@ public class ContactPoints {
 
     Set<EndPoint> result = Sets.newHashSet(programmaticContactPoints);
     for (String spec : configContactPoints) {
-      for (InetSocketAddress address : extract(spec, resolve)) {
+
+      Set<InetSocketAddress> addresses = Collections.emptySet();
+      try {
+        addresses = AddressUtils.extract(spec, resolve);
+      } catch (RuntimeException e) {
+        LOG.warn("Ignoring invalid contact point {} ({})", spec, e.getMessage(), e);
+      }
+
+      if (addresses.size() > 1) {
+        LOG.info(
+            "Contact point {} resolves to multiple addresses, will use them all ({})",
+            spec,
+            addresses);
+      }
+
+      for (InetSocketAddress address : addresses) {
         DefaultEndPoint endPoint = new DefaultEndPoint(address);
         boolean wasNew = result.add(endPoint);
         if (!wasNew) {
@@ -50,44 +62,5 @@ public class ContactPoints {
       }
     }
     return ImmutableSet.copyOf(result);
-  }
-
-  private static Set<InetSocketAddress> extract(String spec, boolean resolve) {
-    int separator = spec.lastIndexOf(':');
-    if (separator < 0) {
-      LOG.warn("Ignoring invalid contact point {} (expecting host:port)", spec);
-      return Collections.emptySet();
-    }
-
-    String host = spec.substring(0, separator);
-    String portSpec = spec.substring(separator + 1);
-    int port;
-    try {
-      port = Integer.parseInt(portSpec);
-    } catch (NumberFormatException e) {
-      LOG.warn("Ignoring invalid contact point {} (expecting a number, got {})", spec, portSpec);
-      return Collections.emptySet();
-    }
-    if (!resolve) {
-      return ImmutableSet.of(InetSocketAddress.createUnresolved(host, port));
-    } else {
-      try {
-        InetAddress[] inetAddresses = InetAddress.getAllByName(host);
-        if (inetAddresses.length > 1) {
-          LOG.info(
-              "Contact point {} resolves to multiple addresses, will use them all ({})",
-              spec,
-              Arrays.deepToString(inetAddresses));
-        }
-        Set<InetSocketAddress> result = new HashSet<>();
-        for (InetAddress inetAddress : inetAddresses) {
-          result.add(new InetSocketAddress(inetAddress, port));
-        }
-        return result;
-      } catch (UnknownHostException e) {
-        LOG.warn("Ignoring invalid contact point {} (unknown host {})", spec, host);
-        return Collections.emptySet();
-      }
-    }
   }
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslator.java
@@ -17,8 +17,9 @@
  */
 package com.datastax.oss.driver.internal.core.addresstranslation;
 
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME;
+
 import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
-import com.datastax.oss.driver.api.core.config.DriverOption;
 import com.datastax.oss.driver.api.core.context.DriverContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.net.InetSocketAddress;
@@ -37,28 +38,13 @@ public class FixedHostNameAddressTranslator implements AddressTranslator {
 
   private static final Logger LOG = LoggerFactory.getLogger(FixedHostNameAddressTranslator.class);
 
-  public static final String ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME =
-      "advanced.address-translator.advertised-hostname";
-
-  public static DriverOption ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME_OPTION =
-      new DriverOption() {
-        @NonNull
-        @Override
-        public String getPath() {
-          return ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME;
-        }
-      };
-
   private final String advertisedHostname;
   private final String logPrefix;
 
   public FixedHostNameAddressTranslator(@NonNull DriverContext context) {
     logPrefix = context.getSessionName();
     advertisedHostname =
-        context
-            .getConfig()
-            .getDefaultProfile()
-            .getString(ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME_OPTION);
+        context.getConfig().getDefaultProfile().getString(ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME);
   }
 
   @NonNull

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/Subnet.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/Subnet.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.addresstranslation;
+
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import com.datastax.oss.driver.shaded.guava.common.base.Splitter;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+
+class Subnet {
+  private final byte[] subnet;
+  private final byte[] networkMask;
+  private final byte[] upper;
+  private final byte[] lower;
+
+  private Subnet(byte[] subnet, byte[] networkMask) {
+    this.subnet = subnet;
+    this.networkMask = networkMask;
+
+    byte[] upper = new byte[subnet.length];
+    byte[] lower = new byte[subnet.length];
+    for (int i = 0; i < subnet.length; i++) {
+      upper[i] = (byte) (subnet[i] | ~networkMask[i]);
+      lower[i] = (byte) (subnet[i] & networkMask[i]);
+    }
+    this.upper = upper;
+    this.lower = lower;
+  }
+
+  static Subnet parse(String subnetCIDR) throws UnknownHostException {
+    List<String> parts = Splitter.on("/").splitToList(subnetCIDR);
+    if (parts.size() != 2) {
+      throw new IllegalArgumentException("Invalid subnet: " + subnetCIDR);
+    }
+
+    boolean isIPv6 = parts.get(0).contains(":");
+    byte[] subnet = InetAddress.getByName(parts.get(0)).getAddress();
+    if (isIPv4(subnet) && isIPv6) {
+      subnet = toIPv6(subnet);
+    }
+    int prefixLength = Integer.parseInt(parts.get(1));
+    validatePrefixLength(subnet, prefixLength);
+
+    byte[] networkMask = toNetworkMask(subnet, prefixLength);
+    validateSubnetIsPrefixBlock(subnet, networkMask, subnetCIDR);
+    return new Subnet(subnet, networkMask);
+  }
+
+  private static byte[] toNetworkMask(byte[] subnet, int prefixLength) {
+    int fullBytes = prefixLength / 8;
+    int remainingBits = prefixLength % 8;
+    byte[] mask = new byte[subnet.length];
+    Arrays.fill(mask, 0, fullBytes, (byte) 0xFF);
+    if (remainingBits > 0) {
+      mask[fullBytes] = (byte) (0xFF << (8 - remainingBits));
+    }
+    return mask;
+  }
+
+  private static void validatePrefixLength(byte[] subnet, int prefixLength) {
+    int max_prefix_length = subnet.length * 8;
+    if (prefixLength < 0 || max_prefix_length < prefixLength) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Prefix length %s must be within [0; %s]", prefixLength, max_prefix_length));
+    }
+  }
+
+  private static void validateSubnetIsPrefixBlock(
+      byte[] subnet, byte[] networkMask, String subnetCIDR) {
+    byte[] prefixBlock = toPrefixBlock(subnet, networkMask);
+    if (!Arrays.equals(subnet, prefixBlock)) {
+      throw new IllegalArgumentException(
+          String.format("Subnet %s must be represented as a network prefix block", subnetCIDR));
+    }
+  }
+
+  private static byte[] toPrefixBlock(byte[] subnet, byte[] networkMask) {
+    byte[] prefixBlock = new byte[subnet.length];
+    for (int i = 0; i < subnet.length; i++) {
+      prefixBlock[i] = (byte) (subnet[i] & networkMask[i]);
+    }
+    return prefixBlock;
+  }
+
+  @VisibleForTesting
+  byte[] getSubnet() {
+    return Arrays.copyOf(subnet, subnet.length);
+  }
+
+  @VisibleForTesting
+  byte[] getNetworkMask() {
+    return Arrays.copyOf(networkMask, networkMask.length);
+  }
+
+  byte[] getUpper() {
+    return Arrays.copyOf(upper, upper.length);
+  }
+
+  byte[] getLower() {
+    return Arrays.copyOf(lower, lower.length);
+  }
+
+  boolean isIPv4() {
+    return isIPv4(subnet);
+  }
+
+  boolean isIPv6() {
+    return isIPv6(subnet);
+  }
+
+  boolean contains(byte[] ip) {
+    if (isIPv4() && !isIPv4(ip)) {
+      return false;
+    }
+    if (isIPv6() && isIPv4(ip)) {
+      ip = toIPv6(ip);
+    }
+    if (subnet.length != ip.length) {
+      throw new IllegalArgumentException(
+          "IP version is unknown: " + Arrays.toString(toZeroBasedByteArray(ip)));
+    }
+    for (int i = 0; i < subnet.length; i++) {
+      if (subnet[i] != (byte) (ip[i] & networkMask[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isIPv4(byte[] ip) {
+    return ip.length == 4;
+  }
+
+  private static boolean isIPv6(byte[] ip) {
+    return ip.length == 16;
+  }
+
+  private static byte[] toIPv6(byte[] ipv4) {
+    byte[] ipv6 = new byte[16];
+    ipv6[10] = (byte) 0xFF;
+    ipv6[11] = (byte) 0xFF;
+    System.arraycopy(ipv4, 0, ipv6, 12, 4);
+    return ipv6;
+  }
+
+  @Override
+  public String toString() {
+    return Arrays.toString(toZeroBasedByteArray(subnet));
+  }
+
+  private static int[] toZeroBasedByteArray(byte[] bytes) {
+    int[] res = new int[bytes.length];
+    for (int i = 0; i < bytes.length; i++) {
+      res[i] = bytes[i] & 0xFF;
+    }
+    return res;
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddress.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddress.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.addresstranslation;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+class SubnetAddress {
+  private final Subnet subnet;
+  private final InetSocketAddress address;
+
+  SubnetAddress(String subnetCIDR, InetSocketAddress address) {
+    try {
+      this.subnet = Subnet.parse(subnetCIDR);
+    } catch (UnknownHostException e) {
+      throw new RuntimeException(e);
+    }
+    this.address = address;
+  }
+
+  InetSocketAddress getAddress() {
+    return this.address;
+  }
+
+  boolean isOverlapping(SubnetAddress other) {
+    Subnet thisSubnet = this.subnet;
+    Subnet otherSubnet = other.subnet;
+    return thisSubnet.contains(otherSubnet.getLower())
+        || thisSubnet.contains(otherSubnet.getUpper())
+        || otherSubnet.contains(thisSubnet.getLower())
+        || otherSubnet.contains(thisSubnet.getUpper());
+  }
+
+  boolean contains(InetSocketAddress address) {
+    return subnet.contains(address.getAddress().getAddress());
+  }
+
+  boolean isIPv4() {
+    return subnet.isIPv4();
+  }
+
+  boolean isIPv6() {
+    return subnet.isIPv6();
+  }
+
+  @Override
+  public String toString() {
+    return "SubnetAddress[subnet=" + subnet + ", address=" + address + "]";
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddressTranslator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddressTranslator.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.addresstranslation;
+
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.ADDRESS_TRANSLATOR_DEFAULT_ADDRESS;
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.ADDRESS_TRANSLATOR_RESOLVE_ADDRESSES;
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.ADDRESS_TRANSLATOR_SUBNET_ADDRESSES;
+
+import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.internal.core.util.AddressUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This translator returns the proxy address of the private subnet containing the Cassandra node IP,
+ * or default address if no matching subnets, or passes through the original node address if no
+ * default configured.
+ *
+ * <p>The translator can be used for scenarios when all nodes are behind some kind of proxy, and
+ * that proxy is different for nodes located in different subnets (eg. when Cassandra is deployed in
+ * multiple datacenters/regions). One can use this, for example, for Cassandra on Kubernetes with
+ * different Cassandra datacenters deployed to different Kubernetes clusters.
+ */
+public class SubnetAddressTranslator implements AddressTranslator {
+  private static final Logger LOG = LoggerFactory.getLogger(SubnetAddressTranslator.class);
+
+  private final List<SubnetAddress> subnetAddresses;
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  private final Optional<InetSocketAddress> defaultAddress;
+
+  private final String logPrefix;
+
+  public SubnetAddressTranslator(@NonNull DriverContext context) {
+    logPrefix = context.getSessionName();
+    boolean resolveAddresses =
+        context
+            .getConfig()
+            .getDefaultProfile()
+            .getBoolean(ADDRESS_TRANSLATOR_RESOLVE_ADDRESSES, false);
+    this.subnetAddresses =
+        context.getConfig().getDefaultProfile().getStringMap(ADDRESS_TRANSLATOR_SUBNET_ADDRESSES)
+            .entrySet().stream()
+            .map(
+                e -> {
+                  // Quoted and/or containing forward slashes map keys in reference.conf are read to
+                  // strings with additional quotes, eg. 100.64.0.0/15 -> '100.64.0."0/15"' or
+                  // "100.64.0.0/15" -> '"100.64.0.0/15"'
+                  String subnetCIDR = e.getKey().replaceAll("\"", "");
+                  String address = e.getValue();
+                  return new SubnetAddress(subnetCIDR, parseAddress(address, resolveAddresses));
+                })
+            .collect(Collectors.toList());
+    this.defaultAddress =
+        Optional.ofNullable(
+                context
+                    .getConfig()
+                    .getDefaultProfile()
+                    .getString(ADDRESS_TRANSLATOR_DEFAULT_ADDRESS, null))
+            .map(address -> parseAddress(address, resolveAddresses));
+
+    validateSubnetsAreOfSameProtocol(this.subnetAddresses);
+    validateSubnetsAreNotOverlapping(this.subnetAddresses);
+  }
+
+  private static void validateSubnetsAreOfSameProtocol(List<SubnetAddress> subnets) {
+    for (int i = 0; i < subnets.size() - 1; i++) {
+      for (int j = i + 1; j < subnets.size(); j++) {
+        SubnetAddress subnet1 = subnets.get(i);
+        SubnetAddress subnet2 = subnets.get(j);
+        if (subnet1.isIPv4() != subnet2.isIPv4() && subnet1.isIPv6() != subnet2.isIPv6()) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "Configured subnets are of the different protocols: %s, %s", subnet1, subnet2));
+        }
+      }
+    }
+  }
+
+  private static void validateSubnetsAreNotOverlapping(List<SubnetAddress> subnets) {
+    for (int i = 0; i < subnets.size() - 1; i++) {
+      for (int j = i + 1; j < subnets.size(); j++) {
+        SubnetAddress subnet1 = subnets.get(i);
+        SubnetAddress subnet2 = subnets.get(j);
+        if (subnet1.isOverlapping(subnet2)) {
+          throw new IllegalArgumentException(
+              String.format("Configured subnets are overlapping: %s, %s", subnet1, subnet2));
+        }
+      }
+    }
+  }
+
+  @NonNull
+  @Override
+  public InetSocketAddress translate(@NonNull InetSocketAddress address) {
+    InetSocketAddress translatedAddress = null;
+    for (SubnetAddress subnetAddress : subnetAddresses) {
+      if (subnetAddress.contains(address)) {
+        translatedAddress = subnetAddress.getAddress();
+      }
+    }
+    if (translatedAddress == null && defaultAddress.isPresent()) {
+      translatedAddress = defaultAddress.get();
+    }
+    if (translatedAddress == null) {
+      translatedAddress = address;
+    }
+    LOG.debug("[{}] Translated {} to {}", logPrefix, address, translatedAddress);
+    return translatedAddress;
+  }
+
+  @Override
+  public void close() {}
+
+  @Nullable
+  private InetSocketAddress parseAddress(String address, boolean resolve) {
+    try {
+      InetSocketAddress parsedAddress = AddressUtils.extract(address, resolve).iterator().next();
+      LOG.debug("[{}] Parsed {} to {}", logPrefix, address, parsedAddress);
+      return parsedAddress;
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException(
+          String.format("Invalid address %s (%s)", address, e.getMessage()), e);
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/util/AddressUtils.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/util/AddressUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.util;
+
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.HashSet;
+import java.util.Set;
+
+public class AddressUtils {
+
+  public static Set<InetSocketAddress> extract(String address, boolean resolve) {
+    int separator = address.lastIndexOf(':');
+    if (separator < 0) {
+      throw new IllegalArgumentException("expecting format host:port");
+    }
+
+    String host = address.substring(0, separator);
+    String portString = address.substring(separator + 1);
+    int port;
+    try {
+      port = Integer.parseInt(portString);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("expecting port to be a number, got " + portString, e);
+    }
+    if (!resolve) {
+      return ImmutableSet.of(InetSocketAddress.createUnresolved(host, port));
+    } else {
+      InetAddress[] inetAddresses;
+      try {
+        inetAddresses = InetAddress.getAllByName(host);
+      } catch (UnknownHostException e) {
+        throw new RuntimeException(e);
+      }
+      Set<InetSocketAddress> result = new HashSet<>();
+      for (InetAddress inetAddress : inetAddresses) {
+        result.add(new InetSocketAddress(inetAddress, port));
+      }
+      return result;
+    }
+  }
+}

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1026,8 +1026,9 @@ datastax-java-driver {
     # the package com.datastax.oss.driver.internal.core.addresstranslation.
     #
     # The driver provides the following implementations out of the box:
-    # - PassThroughAddressTranslator: returns all addresses unchanged
+    # - PassThroughAddressTranslator: returns all addresses unchanged.
     # - FixedHostNameAddressTranslator: translates all addresses to a specific hostname.
+    # - SubnetAddressTranslator: translates addresses to hostname based on the subnet match.
     # - Ec2MultiRegionAddressTranslator: suitable for an Amazon multi-region EC2 deployment where
     #   clients are also deployed in EC2. It optimizes network costs by favoring private IPs over
     #   public ones whenever possible.
@@ -1035,8 +1036,23 @@ datastax-java-driver {
     # You can also specify a custom class that implements AddressTranslator and has a public
     # constructor with a DriverContext argument.
     class = PassThroughAddressTranslator
+    #
     # This property has to be set only in case you use FixedHostNameAddressTranslator.
     # advertised-hostname = mycustomhostname
+    #
+    # These properties are only applicable in case you use SubnetAddressTranslator.
+    # subnet-addresses {
+    #   "100.64.0.0/15" = "cassandra.datacenter1.com:9042"
+    #   "100.66.0.0/15" = "cassandra.datacenter2.com:9042"
+    #   # IPv6 example:
+    #   # "::ffff:6440:0/111" = "cassandra.datacenter1.com:9042"
+    #   # "::ffff:6442:0/111" = "cassandra.datacenter2.com:9042"
+    # }
+    # Optional. When configured, addresses not matching the configured subnets are translated to this address.
+    # default-address = "cassandra.datacenter1.com:9042"
+    # Whether to resolve the addresses once on initialization (if true) or on each node (re-)connection (if false).
+    # If not configured, defaults to false.
+    # resolve-addresses = false
   }
 
   # Whether to resolve the addresses passed to `basic.contact-points`.

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/ContactPointsTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/ContactPointsTest.java
@@ -121,7 +121,7 @@ public class ContactPointsTest {
         ContactPoints.merge(Collections.emptySet(), ImmutableList.of("foobar"), true);
 
     assertThat(endPoints).isEmpty();
-    assertLog(Level.WARN, "Ignoring invalid contact point foobar (expecting host:port)");
+    assertLog(Level.WARN, "Ignoring invalid contact point foobar (expecting format host:port)");
   }
 
   @Test
@@ -132,7 +132,7 @@ public class ContactPointsTest {
     assertThat(endPoints).isEmpty();
     assertLog(
         Level.WARN,
-        "Ignoring invalid contact point 127.0.0.1:foobar (expecting a number, got foobar)");
+        "Ignoring invalid contact point 127.0.0.1:foobar (expecting port to be a number, got foobar)");
   }
 
   @Test

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslatorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslatorTest.java
@@ -17,6 +17,7 @@
  */
 package com.datastax.oss.driver.internal.core.addresstranslation;
 
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -33,9 +34,7 @@ public class FixedHostNameAddressTranslatorTest {
   @Test
   public void should_translate_address() {
     DriverExecutionProfile defaultProfile = mock(DriverExecutionProfile.class);
-    when(defaultProfile.getString(
-            FixedHostNameAddressTranslator.ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME_OPTION))
-        .thenReturn("myaddress");
+    when(defaultProfile.getString(ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME)).thenReturn("myaddress");
     DefaultDriverContext defaultDriverContext =
         MockedDriverContextFactory.defaultDriverContext(Optional.of(defaultProfile));
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddressTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddressTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.addresstranslation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.net.InetSocketAddress;
+import org.junit.Test;
+
+public class SubnetAddressTest {
+  @Test
+  public void should_return_return_true_on_overlapping_with_another_subnet_address() {
+    SubnetAddress subnetAddress1 =
+        new SubnetAddress("100.64.0.0/15", mock(InetSocketAddress.class));
+    SubnetAddress subnetAddress2 =
+        new SubnetAddress("100.65.0.0/16", mock(InetSocketAddress.class));
+    assertThat(subnetAddress1.isOverlapping(subnetAddress2)).isTrue();
+  }
+
+  @Test
+  public void should_return_return_false_on_not_overlapping_with_another_subnet_address() {
+    SubnetAddress subnetAddress1 =
+        new SubnetAddress("100.64.0.0/15", mock(InetSocketAddress.class));
+    SubnetAddress subnetAddress2 =
+        new SubnetAddress("100.66.0.0/15", mock(InetSocketAddress.class));
+    assertThat(subnetAddress1.isOverlapping(subnetAddress2)).isFalse();
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddressTranslatorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetAddressTranslatorTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.addresstranslation;
+
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.ADDRESS_TRANSLATOR_DEFAULT_ADDRESS;
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.ADDRESS_TRANSLATOR_SUBNET_ADDRESSES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
+import com.datastax.oss.driver.internal.core.context.MockedDriverContextFactory;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Test;
+
+@SuppressWarnings("resource")
+public class SubnetAddressTranslatorTest {
+
+  @Test
+  public void should_translate_to_correct_subnet_address_ipv4() {
+    Map<String, String> subnetAddresses =
+        ImmutableMap.of(
+            "\"100.64.0.0/15\"", "cassandra.datacenter1.com:19042",
+            "100.66.0.\"0/15\"", "cassandra.datacenter2.com:19042");
+    DefaultDriverContext context = context(subnetAddresses);
+    SubnetAddressTranslator translator = new SubnetAddressTranslator(context);
+    InetSocketAddress address = new InetSocketAddress("100.64.0.1", 9042);
+    assertThat(translator.translate(address))
+        .isEqualTo(InetSocketAddress.createUnresolved("cassandra.datacenter1.com", 19042));
+  }
+
+  @Test
+  public void should_translate_to_correct_subnet_address_ipv6() {
+    Map<String, String> subnetAddresses =
+        ImmutableMap.of(
+            "\"::ffff:6440:0/111\"", "cassandra.datacenter1.com:19042",
+            "\"::ffff:6442:0/111\"", "cassandra.datacenter2.com:19042");
+    DefaultDriverContext context = context(subnetAddresses);
+    SubnetAddressTranslator translator = new SubnetAddressTranslator(context);
+    InetSocketAddress address = new InetSocketAddress("::ffff:6440:1", 9042);
+    assertThat(translator.translate(address))
+        .isEqualTo(InetSocketAddress.createUnresolved("cassandra.datacenter1.com", 19042));
+  }
+
+  @Test
+  public void should_translate_to_default_address() {
+    DefaultDriverContext context = context(ImmutableMap.of());
+    when(context
+            .getConfig()
+            .getDefaultProfile()
+            .getString(ADDRESS_TRANSLATOR_DEFAULT_ADDRESS, null))
+        .thenReturn("cassandra.com:19042");
+    SubnetAddressTranslator translator = new SubnetAddressTranslator(context);
+    InetSocketAddress address = new InetSocketAddress("100.68.0.1", 9042);
+    assertThat(translator.translate(address))
+        .isEqualTo(InetSocketAddress.createUnresolved("cassandra.com", 19042));
+  }
+
+  @Test
+  public void should_pass_through_not_matched_address() {
+    DefaultDriverContext context = context(ImmutableMap.of());
+    SubnetAddressTranslator translator = new SubnetAddressTranslator(context);
+    InetSocketAddress address = new InetSocketAddress("100.68.0.1", 9042);
+    assertThat(translator.translate(address)).isEqualTo(address);
+  }
+
+  @Test
+  public void should_fail_on_intersecting_subnets_ipv4() {
+    Map<String, String> subnetAddresses =
+        ImmutableMap.of(
+            "\"100.64.0.0/15\"", "cassandra.datacenter1.com:19042",
+            "100.65.0.\"0/16\"", "cassandra.datacenter2.com:19042");
+    DefaultDriverContext context = context(subnetAddresses);
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new SubnetAddressTranslator(context))
+        .withMessage(
+            "Configured subnets are overlapping: "
+                + String.format(
+                    "SubnetAddress[subnet=[100, 64, 0, 0], address=%s], ",
+                    InetSocketAddress.createUnresolved("cassandra.datacenter1.com", 19042))
+                + String.format(
+                    "SubnetAddress[subnet=[100, 65, 0, 0], address=%s]",
+                    InetSocketAddress.createUnresolved("cassandra.datacenter2.com", 19042)));
+  }
+
+  @Test
+  public void should_fail_on_intersecting_subnets_ipv6() {
+    Map<String, String> subnetAddresses =
+        ImmutableMap.of(
+            "\"::ffff:6440:0/111\"", "cassandra.datacenter1.com:19042",
+            "\"::ffff:6441:0/112\"", "cassandra.datacenter2.com:19042");
+    DefaultDriverContext context = context(subnetAddresses);
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new SubnetAddressTranslator(context))
+        .withMessage(
+            "Configured subnets are overlapping: "
+                + String.format(
+                    "SubnetAddress[subnet=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 100, 64, 0, 0], address=%s], ",
+                    InetSocketAddress.createUnresolved("cassandra.datacenter1.com", 19042))
+                + String.format(
+                    "SubnetAddress[subnet=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 100, 65, 0, 0], address=%s]",
+                    InetSocketAddress.createUnresolved("cassandra.datacenter2.com", 19042)));
+  }
+
+  @Test
+  public void should_fail_on_subnet_address_without_port() {
+    Map<String, String> subnetAddresses =
+        ImmutableMap.of("\"100.64.0.0/15\"", "cassandra.datacenter1.com");
+    DefaultDriverContext context = context(subnetAddresses);
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new SubnetAddressTranslator(context))
+        .withMessage("Invalid address cassandra.datacenter1.com (expecting format host:port)");
+  }
+
+  @Test
+  public void should_fail_on_default_address_without_port() {
+    DefaultDriverContext context = context(ImmutableMap.of());
+    when(context
+            .getConfig()
+            .getDefaultProfile()
+            .getString(ADDRESS_TRANSLATOR_DEFAULT_ADDRESS, null))
+        .thenReturn("cassandra.com");
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new SubnetAddressTranslator(context))
+        .withMessage("Invalid address cassandra.com (expecting format host:port)");
+  }
+
+  private static DefaultDriverContext context(Map<String, String> subnetAddresses) {
+    DriverExecutionProfile profile = mock(DriverExecutionProfile.class);
+    when(profile.getStringMap(ADDRESS_TRANSLATOR_SUBNET_ADDRESSES)).thenReturn(subnetAddresses);
+    return MockedDriverContextFactory.defaultDriverContext(Optional.of(profile));
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/SubnetTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.addresstranslation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.net.UnknownHostException;
+import org.junit.Test;
+
+public class SubnetTest {
+  @Test
+  public void should_parse_to_correct_ipv4_subnet() throws UnknownHostException {
+    Subnet subnet = Subnet.parse("100.64.0.0/15");
+    assertThat(subnet.getSubnet()).containsExactly(100, 64, 0, 0);
+    assertThat(subnet.getNetworkMask()).containsExactly(255, 254, 0, 0);
+    assertThat(subnet.getUpper()).containsExactly(100, 65, 255, 255);
+    assertThat(subnet.getLower()).containsExactly(100, 64, 0, 0);
+  }
+
+  @Test
+  public void should_parse_to_correct_ipv6_subnet() throws UnknownHostException {
+    Subnet subnet = Subnet.parse("2001:db8:85a3::8a2e:370:0/111");
+    assertThat(subnet.getSubnet())
+        .containsExactly(32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 0, 0);
+    assertThat(subnet.getNetworkMask())
+        .containsExactly(
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 254, 0, 0);
+    assertThat(subnet.getUpper())
+        .containsExactly(32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 113, 255, 255);
+    assertThat(subnet.getLower())
+        .containsExactly(32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 0, 0);
+  }
+
+  @Test
+  public void should_parse_to_correct_ipv6_subnet_ipv4_convertible() throws UnknownHostException {
+    Subnet subnet = Subnet.parse("::ffff:6440:0/111");
+    assertThat(subnet.getSubnet())
+        .containsExactly(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 100, 64, 0, 0);
+    assertThat(subnet.getNetworkMask())
+        .containsExactly(
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 254, 0, 0);
+    assertThat(subnet.getUpper())
+        .containsExactly(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 100, 65, 255, 255);
+    assertThat(subnet.getLower())
+        .containsExactly(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 100, 64, 0, 0);
+  }
+
+  @Test
+  public void should_fail_on_invalid_cidr_format() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> Subnet.parse("invalid"))
+        .withMessage("Invalid subnet: invalid");
+  }
+
+  @Test
+  public void should_parse_bounding_prefix_lengths_correctly() {
+    assertThatNoException().isThrownBy(() -> Subnet.parse("0.0.0.0/0"));
+    assertThatNoException().isThrownBy(() -> Subnet.parse("100.64.0.0/32"));
+  }
+
+  @Test
+  public void should_fail_on_invalid_prefix_length() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> Subnet.parse("100.64.0.0/-1"))
+        .withMessage("Prefix length -1 must be within [0; 32]");
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> Subnet.parse("100.64.0.0/33"))
+        .withMessage("Prefix length 33 must be within [0; 32]");
+  }
+
+  @Test
+  public void should_fail_on_not_prefix_block_subnet_ipv4() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> Subnet.parse("100.65.0.0/15"))
+        .withMessage("Subnet 100.65.0.0/15 must be represented as a network prefix block");
+  }
+
+  @Test
+  public void should_fail_on_not_prefix_block_subnet_ipv6() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> Subnet.parse("::ffff:6441:0/111"))
+        .withMessage("Subnet ::ffff:6441:0/111 must be represented as a network prefix block");
+  }
+
+  @Test
+  public void should_return_true_on_containing_address() throws UnknownHostException {
+    Subnet subnet = Subnet.parse("100.64.0.0/15");
+    assertThat(subnet.contains(new byte[] {100, 64, 0, 0})).isTrue();
+    assertThat(subnet.contains(new byte[] {100, 65, (byte) 255, (byte) 255})).isTrue();
+    assertThat(subnet.contains(new byte[] {100, 65, 100, 100})).isTrue();
+  }
+
+  @Test
+  public void should_return_false_on_not_containing_address() throws UnknownHostException {
+    Subnet subnet = Subnet.parse("100.64.0.0/15");
+    assertThat(subnet.contains(new byte[] {100, 63, (byte) 255, (byte) 255})).isFalse();
+    assertThat(subnet.contains(new byte[] {100, 66, 0, 0})).isFalse();
+    // IPv6 cannot be contained by IPv4 subnet.
+    assertThat(subnet.contains(new byte[16])).isFalse();
+  }
+}

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/MockOptions.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/MockOptions.java
@@ -24,6 +24,7 @@ public enum MockOptions implements DriverOption {
   INT1("int1"),
   INT2("int2"),
   AUTH_PROVIDER("auth_provider"),
+  SUBNET_ADDRESSES("subnet_addresses"),
   ;
 
   private final String path;

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/TypesafeDriverConfigTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/config/typesafe/TypesafeDriverConfigTest.java
@@ -101,12 +101,24 @@ public class TypesafeDriverConfigTest {
         parse(
             "int1 = 42 \n auth_provider { auth_thing_one= one \n auth_thing_two = two \n auth_thing_three = three}");
     DriverExecutionProfile base = config.getDefaultProfile();
-    base.getStringMap(MockOptions.AUTH_PROVIDER);
     Map<String, String> map = base.getStringMap(MockOptions.AUTH_PROVIDER);
     assertThat(map.entrySet().size()).isEqualTo(3);
     assertThat(map.get("auth_thing_one")).isEqualTo("one");
     assertThat(map.get("auth_thing_two")).isEqualTo("two");
     assertThat(map.get("auth_thing_three")).isEqualTo("three");
+  }
+
+  @Test
+  public void should_fetch_string_map_with_forward_slash_in_keys() {
+    TypesafeDriverConfig config =
+        parse(
+            "subnet_addresses { 100.64.0.0/15 = \"cassandra.datacenter1.com:9042\" \n \"100.66.0.0/15\" = \"cassandra.datacenter2.com\" \n \"::ffff:6440:0/111\" = \"cassandra.datacenter3.com:19042\" }");
+    DriverExecutionProfile base = config.getDefaultProfile();
+    Map<String, String> map = base.getStringMap(MockOptions.SUBNET_ADDRESSES);
+    assertThat(map.entrySet().size()).isEqualTo(3);
+    assertThat(map.get("100.64.0.\"0/15\"")).isEqualTo("cassandra.datacenter1.com:9042");
+    assertThat(map.get("\"100.66.0.0/15\"")).isEqualTo("cassandra.datacenter2.com");
+    assertThat(map.get("\"::ffff:6440:0/111\"")).isEqualTo("cassandra.datacenter3.com:19042");
   }
 
   @Test

--- a/manual/core/address_resolution/README.md
+++ b/manual/core/address_resolution/README.md
@@ -118,6 +118,55 @@ datastax-java-driver.advanced.address-translator.class = com.mycompany.MyAddress
 Note: the contact points provided while creating the `CqlSession` are not translated, only addresses
 retrieved from or sent by Cassandra nodes are.
 
+### Fixed proxy hostname
+
+If your client applications access Cassandra through some kind of proxy (eg. with AWS PrivateLink when all Cassandra
+nodes are exposed via one hostname pointing to AWS Endpoint), you can configure driver with
+`FixedHostNameAddressTranslator` to always translate all node addresses to that same proxy hostname, no matter what IP
+address a node has but still using its native transport port.
+
+To use it, specify the following in the [configuration](../configuration):
+
+```
+datastax-java-driver.advanced.address-translator.class = FixedHostNameAddressTranslator
+advertised-hostname = proxyhostname
+```
+
+### Fixed proxy hostname per subnet
+
+When running Cassandra in a private network and accessing it from outside of that private network via some kind of
+proxy, we have an option to use `FixedHostNameAddressTranslator`. But for multi-datacenter Cassandra deployments, we
+want to have more control over routing queries to a specific datacenter (eg. for optimizing latencies), which requires
+setting up a separate proxy per datacenter.
+
+Normally, each Cassandra datacenter nodes are deployed to a different subnet to support internode communications in the
+cluster and avoid IP address collisions. So when Cassandra broadcasts its nodes IP addresses, we can determine which
+datacenter that node belongs to by checking its IP address against the given datacenter subnet.
+
+For such scenarios you can use `SubnetAddressTranslator` to translate node IPs to the datacenter proxy address
+associated with it. 
+
+To use it, specify the following in the [configuration](../configuration):
+```
+datastax-java-driver.advanced.address-translator {
+  class = SubnetAddressTranslator
+  subnet-addresses {
+    "100.64.0.0/15" = "cassandra.datacenter1.com:9042"
+    "100.66.0.0/15" = "cassandra.datacenter2.com:9042"
+    # IPv6 example:
+    # "::ffff:6440:0/111" = "cassandra.datacenter1.com:9042"
+    # "::ffff:6442:0/111" = "cassandra.datacenter2.com:9042"
+  }
+  # Optional. When configured, addresses not matching the configured subnets are translated to this address.
+  default-address = "cassandra.datacenter1.com:9042"
+  # Whether to resolve the addresses once on initialization (if true) or on each node (re-)connection (if false).
+  # If not configured, defaults to false.
+  resolve-addresses = false
+}
+```
+
+Such setup is common for running Cassandra on Kubernetes with [k8ssandra](https://docs.k8ssandra.io/).
+
 ### EC2 multi-region
 
 If you deploy both Cassandra and client applications on Amazon EC2, and your cluster spans multiple regions, you'll have


### PR DESCRIPTION
When running Cassandra in a private network and accessing it from outside of that private network via some kind of proxy, we have an option to use FixedHostNameAddressTranslator. But when we want to set it up in a HA way and have more control over latencies in multi-datacenter deployments, that is not enough.

This PR proposes a SubnetAddressTranslator, which translates Cassandra node IP addresses based on the match to the configured subnet IP range (CIDR notation). The assumption is that each Cassandra datacenter nodes belong to different subnets not having intersecting IP ranges, which is the usual configuration for multi-DC Kubernetes and K8ssandra, for example.