### PR TITLE
Option to report trace only once during pagination

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -994,7 +994,14 @@ public enum DefaultDriverOption implements DriverOption {
    *
    * <p>Value-type: boolean
    */
-  SSL_ALLOW_DNS_REVERSE_LOOKUP_SAN("advanced.ssl-engine-factory.allow-dns-reverse-lookup-san");
+  SSL_ALLOW_DNS_REVERSE_LOOKUP_SAN("advanced.ssl-engine-factory.allow-dns-reverse-lookup-san"),
+
+  /**
+   * Report trace for every page fetch request
+   *
+   * <p>Value-type: {@link Boolean}
+   */
+  REQUEST_TRACE_REPORT_EVERY_PAGE_FETCH("advanced.request.trace.report-every-page-fetch");
 
   private final String path;
 

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
@@ -289,6 +289,7 @@ public class OptionsMap implements Serializable {
     map.put(TypedDriverOption.REQUEST_WARN_IF_SET_KEYSPACE, true);
     map.put(TypedDriverOption.REQUEST_TRACE_ATTEMPTS, 5);
     map.put(TypedDriverOption.REQUEST_TRACE_INTERVAL, Duration.ofMillis(3));
+    map.put(TypedDriverOption.REQUEST_TRACE_REPORT_EVERY_PAGE_FETCH, true);
     map.put(TypedDriverOption.REQUEST_TRACE_CONSISTENCY, "ONE");
     map.put(TypedDriverOption.REQUEST_LOG_WARNINGS, true);
     map.put(TypedDriverOption.GRAPH_PAGING_ENABLED, "AUTO");

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -400,6 +400,10 @@ public class TypedDriverOption<ValueT> {
   /** The consistency level to use for trace queries. */
   public static final TypedDriverOption<String> REQUEST_TRACE_CONSISTENCY =
       new TypedDriverOption<>(DefaultDriverOption.REQUEST_TRACE_CONSISTENCY, GenericType.STRING);
+  /** Report trace for every page fetch request */
+  public static final TypedDriverOption<Boolean> REQUEST_TRACE_REPORT_EVERY_PAGE_FETCH =
+      new TypedDriverOption<>(
+          DefaultDriverOption.REQUEST_TRACE_REPORT_EVERY_PAGE_FETCH, GenericType.BOOLEAN);
   /** Whether or not to publish aggregable histogram for metrics */
   public static final TypedDriverOption<Boolean> METRICS_GENERATE_AGGREGABLE_HISTOGRAMS =
       new TypedDriverOption<>(

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/Conversions.java
@@ -320,13 +320,14 @@ public class Conversions {
       Result result,
       ExecutionInfo executionInfo,
       CqlSession session,
-      InternalDriverContext context) {
+      InternalDriverContext context,
+      DriverExecutionProfile executionProfile) {
     if (result instanceof Rows) {
       Rows rows = (Rows) result;
       Statement<?> statement = (Statement<?>) executionInfo.getRequest();
       ColumnDefinitions columnDefinitions = getResultDefinitions(rows, statement, context);
       return new DefaultAsyncResultSet(
-          columnDefinitions, executionInfo, rows.getData(), session, context);
+          columnDefinitions, executionInfo, rows.getData(), session, context, executionProfile);
     } else if (result instanceof Prepared) {
       // This should never happen
       throw new IllegalArgumentException("Unexpected PREPARED response to a CQL query");

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
@@ -321,7 +321,7 @@ public class CqlRequestHandler implements Throttled {
       ExecutionInfo executionInfo =
           buildExecutionInfo(callback, resultMessage, responseFrame, schemaInAgreement);
       AsyncResultSet resultSet =
-          Conversions.toResultSet(resultMessage, executionInfo, session, context);
+          Conversions.toResultSet(resultMessage, executionInfo, session, context, executionProfile);
       if (result.complete(resultSet)) {
         cancelScheduledTasks();
         throttler.signalSuccess(this);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultAsyncResultSet.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultAsyncResultSet.java
@@ -18,6 +18,8 @@
 package com.datastax.oss.driver.internal.core.cql;
 
 import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
@@ -43,6 +45,7 @@ public class DefaultAsyncResultSet implements AsyncResultSet {
 
   private final ColumnDefinitions definitions;
   private final ExecutionInfo executionInfo;
+  private final DriverExecutionProfile executionProfile;
   private final CqlSession session;
   private final CountingIterator<Row> iterator;
   private final Iterable<Row> currentPage;
@@ -52,9 +55,11 @@ public class DefaultAsyncResultSet implements AsyncResultSet {
       ExecutionInfo executionInfo,
       Queue<List<ByteBuffer>> data,
       CqlSession session,
-      InternalDriverContext context) {
+      InternalDriverContext context,
+      DriverExecutionProfile executionProfile) {
     this.definitions = definitions;
     this.executionInfo = executionInfo;
+    this.executionProfile = executionProfile;
     this.session = session;
     this.iterator =
         new CountingIterator<Row>(data.size()) {
@@ -106,6 +111,11 @@ public class DefaultAsyncResultSet implements AsyncResultSet {
     Statement<?> statement = (Statement<?>) executionInfo.getRequest();
     LOG.trace("Fetching next page for {}", statement);
     Statement<?> nextStatement = statement.copy(nextState);
+    if (!executionProfile.getBoolean(DefaultDriverOption.REQUEST_TRACE_REPORT_EVERY_PAGE_FETCH)
+        && nextStatement.isTracing()) {
+      // report traces only for first page
+      nextStatement = nextStatement.setTracing(false);
+    }
     return session.executeAsync(nextStatement);
   }
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1159,6 +1159,14 @@ datastax-java-driver {
       # Modifiable at runtime: yes, the new value will be used for traces fetched after the change.
       # Overridable in a profile: yes
       consistency = ONE
+
+      # Report trace for every page fetch request. If disabled, only one trace entry will be present
+      # on server side even if client application pages through a large partition.
+      #
+      # Required: yes
+      # Modifiable at runtime: yes, the new value will be used for traces fetched after the change.
+      # Overridable in a profile: yes
+      report-every-page-fetch = true
     }
 
     # Whether logging of server warnings generated during query execution should be disabled by the

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/cql/reactive/CqlRequestReactiveProcessorTest.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/cql/reactive/CqlRequestReactiveProcessorTest.java
@@ -29,6 +29,7 @@ import com.datastax.dse.driver.DseTestFixtures;
 import com.datastax.dse.driver.api.core.cql.reactive.ReactiveResultSet;
 import com.datastax.dse.driver.api.core.cql.reactive.ReactiveRow;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
@@ -135,6 +136,7 @@ public class CqlRequestReactiveProcessorTest extends CqlRequestHandlerTestBase {
       CompletableFuture<AsyncResultSet> page2Future = new CompletableFuture<>();
       when(session.executeAsync(any(Statement.class))).thenAnswer(invocation -> page2Future);
       ExecutionInfo mockInfo = mock(ExecutionInfo.class);
+      DriverExecutionProfile mockExecutionProfile = mock(DriverExecutionProfile.class);
 
       ReactiveResultSet publisher =
           new CqlRequestReactiveProcessor(new CqlRequestAsyncProcessor())
@@ -152,7 +154,8 @@ public class CqlRequestReactiveProcessorTest extends CqlRequestHandlerTestBase {
               DseTestFixtures.tenDseRows(2, true),
               mockInfo,
               harness.getSession(),
-              harness.getContext()));
+              harness.getContext(),
+              mockExecutionProfile));
 
       List<ReactiveRow> rows = rowsPublisher.toList().blockingGet();
       assertThat(rows).hasSize(20);

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/AsyncPagingIterableWrapperTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/AsyncPagingIterableWrapperTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
 import com.datastax.oss.driver.api.core.MappedAsyncPagingIterable;
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
 import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
@@ -50,6 +51,7 @@ public class AsyncPagingIterableWrapperTest {
   @Mock private Statement<?> statement;
   @Mock private CqlSession session;
   @Mock private InternalDriverContext context;
+  @Mock private DriverExecutionProfile executionProfile;
 
   @Before
   public void setup() {
@@ -74,10 +76,15 @@ public class AsyncPagingIterableWrapperTest {
     ExecutionInfo executionInfo1 = mockExecutionInfo();
     DefaultAsyncResultSet resultSet1 =
         new DefaultAsyncResultSet(
-            columnDefinitions, executionInfo1, mockData(0, 5), session, context);
+            columnDefinitions, executionInfo1, mockData(0, 5), session, context, executionProfile);
     DefaultAsyncResultSet resultSet2 =
         new DefaultAsyncResultSet(
-            columnDefinitions, mockExecutionInfo(), mockData(5, 10), session, context);
+            columnDefinitions,
+            mockExecutionInfo(),
+            mockData(5, 10),
+            session,
+            context,
+            executionProfile);
     // chain them together:
     ByteBuffer mockPagingState = ByteBuffer.allocate(0);
     when(executionInfo1.getPagingState()).thenReturn(mockPagingState);
@@ -111,7 +118,12 @@ public class AsyncPagingIterableWrapperTest {
     // Given
     DefaultAsyncResultSet resultSet =
         new DefaultAsyncResultSet(
-            columnDefinitions, mockExecutionInfo(), mockData(0, 10), session, context);
+            columnDefinitions,
+            mockExecutionInfo(),
+            mockData(0, 10),
+            session,
+            context,
+            executionProfile);
 
     // When
     MappedAsyncPagingIterable<Integer> iterable = resultSet.map(row -> row.getInt("i"));

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/cql/DefaultAsyncResultSetTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/cql/DefaultAsyncResultSetTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.DefaultProtocolVersion;
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
 import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
@@ -55,6 +56,7 @@ public class DefaultAsyncResultSetTest {
   @Mock private Statement<?> statement;
   @Mock private CqlSession session;
   @Mock private InternalDriverContext context;
+  @Mock private DriverExecutionProfile executionProfile;
 
   @Before
   public void setup() {
@@ -73,7 +75,12 @@ public class DefaultAsyncResultSetTest {
     // When
     DefaultAsyncResultSet resultSet =
         new DefaultAsyncResultSet(
-            columnDefinitions, executionInfo, new ArrayDeque<>(), session, context);
+            columnDefinitions,
+            executionInfo,
+            new ArrayDeque<>(),
+            session,
+            context,
+            executionProfile);
 
     // Then
     assertThat(resultSet.hasMorePages()).isFalse();
@@ -95,7 +102,12 @@ public class DefaultAsyncResultSetTest {
     // When
     DefaultAsyncResultSet resultSet =
         new DefaultAsyncResultSet(
-            columnDefinitions, executionInfo, new ArrayDeque<>(), session, context);
+            columnDefinitions,
+            executionInfo,
+            new ArrayDeque<>(),
+            session,
+            context,
+            executionProfile);
     assertThat(resultSet.hasMorePages()).isTrue();
     CompletionStage<AsyncResultSet> nextPageFuture = resultSet.fetchNextPage();
 
@@ -113,7 +125,12 @@ public class DefaultAsyncResultSetTest {
     // When
     DefaultAsyncResultSet resultSet =
         new DefaultAsyncResultSet(
-            columnDefinitions, executionInfo, new ArrayDeque<>(), session, context);
+            columnDefinitions,
+            executionInfo,
+            new ArrayDeque<>(),
+            session,
+            context,
+            executionProfile);
 
     // Then
     assertThat(resultSet.wasApplied()).isTrue();
@@ -128,7 +145,8 @@ public class DefaultAsyncResultSetTest {
 
     // When
     DefaultAsyncResultSet resultSet =
-        new DefaultAsyncResultSet(columnDefinitions, executionInfo, data, session, context);
+        new DefaultAsyncResultSet(
+            columnDefinitions, executionInfo, data, session, context, executionProfile);
 
     // Then
     assertThat(resultSet.wasApplied()).isTrue();
@@ -149,7 +167,8 @@ public class DefaultAsyncResultSetTest {
 
     // When
     DefaultAsyncResultSet resultSet =
-        new DefaultAsyncResultSet(columnDefinitions, executionInfo, data, session, context);
+        new DefaultAsyncResultSet(
+            columnDefinitions, executionInfo, data, session, context, executionProfile);
 
     // Then
     assertThat(resultSet.wasApplied()).isFalse();
@@ -170,7 +189,8 @@ public class DefaultAsyncResultSetTest {
 
     // When
     DefaultAsyncResultSet resultSet =
-        new DefaultAsyncResultSet(columnDefinitions, executionInfo, data, session, context);
+        new DefaultAsyncResultSet(
+            columnDefinitions, executionInfo, data, session, context, executionProfile);
 
     // Then
     assertThat(resultSet.wasApplied()).isTrue();
@@ -187,7 +207,12 @@ public class DefaultAsyncResultSetTest {
     // When
     DefaultAsyncResultSet resultSet =
         new DefaultAsyncResultSet(
-            columnDefinitions, executionInfo, new ArrayDeque<>(), session, context);
+            columnDefinitions,
+            executionInfo,
+            new ArrayDeque<>(),
+            session,
+            context,
+            executionProfile);
 
     // Then
     resultSet.wasApplied();

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/QueryTraceIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/cql/QueryTraceIT.java
@@ -19,20 +19,31 @@ package com.datastax.oss.driver.core.cql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.awaitility.Awaitility.await;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.Version;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.cql.ExecutionInfo;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.QueryTrace;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.metadata.EndPoint;
 import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
 import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
 import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
 import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.driver.internal.core.util.Strings;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -46,8 +57,17 @@ public class QueryTraceIT {
 
   private static final SessionRule<CqlSession> SESSION_RULE = SessionRule.builder(CCM_RULE).build();
 
+  private static final SessionRule<CqlSession> SESSION_RULE_SINGLE_TRACE =
+      SessionRule.builder(CCM_RULE)
+          .withConfigLoader(
+              SessionUtils.configLoaderBuilder()
+                  .withBoolean(DefaultDriverOption.REQUEST_TRACE_REPORT_EVERY_PAGE_FETCH, false)
+                  .build())
+          .build();
+
   @ClassRule
-  public static final TestRule CHAIN = RuleChain.outerRule(CCM_RULE).around(SESSION_RULE);
+  public static final TestRule CHAIN =
+      RuleChain.outerRule(CCM_RULE).around(SESSION_RULE).around(SESSION_RULE_SINGLE_TRACE);
 
   @Test
   public void should_not_have_tracing_id_when_tracing_disabled() {
@@ -130,5 +150,79 @@ public class QueryTraceIT {
     } else {
       assertThat(sourceAddress0.getPort()).isEqualTo(0);
     }
+  }
+
+  @Test
+  public void should_report_trace_once_during_pagination() {
+    testTraceDuringPagination(SESSION_RULE_SINGLE_TRACE, 1);
+  }
+
+  @Test
+  public void should_report_trace_multiple_during_pagination() {
+    testTraceDuringPagination(SESSION_RULE, 6);
+  }
+
+  private void testTraceDuringPagination(
+      SessionRule<CqlSession> sessionRule, int traceEventsCount) {
+    String key = setupPaginationTable(sessionRule);
+
+    String cql = "SELECT v0, v1 FROM trace_pagination WHERE k = ?";
+    SimpleStatement query = SimpleStatement.builder(cql).setTracing().setPageSize(2).build();
+    PreparedStatement preparedStatement = sessionRule.session().prepare(query);
+    ResultSet resultSet = sessionRule.session().execute(preparedStatement.bind(key));
+
+    ExecutionInfo executionInfo = resultSet.getExecutionInfo();
+    assertThat(executionInfo.getTracingId()).isNotNull();
+    QueryTrace queryTrace = executionInfo.getQueryTrace();
+    assertThat(queryTrace.getTracingId()).isEqualTo(executionInfo.getTracingId());
+    assertThat(queryTrace.getRequestType()).isEqualTo("Execute CQL3 prepared query");
+
+    Iterator<Row> iterator = resultSet.iterator();
+    while (iterator.hasNext()) {
+      iterator.next(); // iterate over several pages
+    }
+
+    // assert that only one event for tracing has been recorded
+    await()
+        .untilAsserted(
+            () -> {
+              List<Row> rows =
+                  sessionRule.session().execute("SELECT * FROM system_traces.sessions").all()
+                      .stream()
+                      .filter(row -> isTraceForQuery(row, cql, key))
+                      .collect(Collectors.toList());
+              assertThat(rows).hasSize(traceEventsCount);
+            });
+  }
+
+  private String setupPaginationTable(SessionRule<CqlSession> sessionRule) {
+    String key = UUID.randomUUID().toString();
+    sessionRule
+        .session()
+        .execute(
+            SimpleStatement.builder(
+                    "CREATE TABLE IF NOT EXISTS trace_pagination (k text, v0 int, v1 int, PRIMARY KEY(k, v0))")
+                .setExecutionProfile(sessionRule.slowProfile())
+                .build());
+    for (int i = 0; i < 10; i++) {
+      sessionRule
+          .session()
+          .execute(
+              SimpleStatement.builder("INSERT INTO trace_pagination (k, v0, v1) VALUES (?, ?, ?)")
+                  .addPositionalValues(key, i, i)
+                  .build());
+    }
+    return key;
+  }
+
+  private static boolean isTraceForQuery(Row row, String cql, String key) {
+    if (!row.getColumnDefinitions().contains("parameters")) {
+      return false;
+    }
+    Map<String, String> queryParams = row.getMap("parameters", String.class, String.class);
+    if (queryParams == null || !queryParams.containsKey("query")) {
+      return false;
+    }
+    return queryParams.get("query").contains(cql) && queryParams.containsValue(Strings.quote(key));
   }
 }


### PR DESCRIPTION
Fixes [CASSJAVA-71](https://issues.apache.org/jira/browse/CASSJAVA-71).

Currently, when client executes below code:
```
ResultSet rs = session.execute(SimpleStatement.newInstance("select * from kv").setPageSize(2).setTracing(true));
Iterator<Row> iter = rs.iterator();
while (iter.hasNext()) {
    iter.next();
}
```

The following trace events are generated:
```
cqlsh> select session_id, command, coordinator, duration, parameters, started_at from system_traces.sessions;

 session_id                           | command | coordinator | duration | parameters                                                                                                              | started_at
--------------------------------------+---------+-------------+----------+-------------------------------------------------------------------------------------------------------------------------+---------------------------------
 f69b1c00-e7d7-11ef-911d-0b57c0dc9621 |   QUERY |   127.0.0.1 |     1255 | {'consistency_level': 'LOCAL_ONE', 'page_size': '2', 'query': 'select * from kv', 'serial_consistency_level': 'SERIAL'} | 2025-02-10 17:53:41.312000+0000
 f69c2d70-e7d7-11ef-911d-0b57c0dc9621 |   QUERY |   127.0.0.1 |      918 | {'consistency_level': 'LOCAL_ONE', 'page_size': '2', 'query': 'select * from kv', 'serial_consistency_level': 'SERIAL'} | 2025-02-10 17:53:41.319000+0000
 f69c5480-e7d7-11ef-911d-0b57c0dc9621 |   QUERY |   127.0.0.1 |      638 | {'consistency_level': 'LOCAL_ONE', 'page_size': '2', 'query': 'select * from kv', 'serial_consistency_level': 'SERIAL'} | 2025-02-10 17:53:41.320000+0000
 f69bdf50-e7d7-11ef-911d-0b57c0dc9621 |   QUERY |   127.0.0.1 |     1119 | {'consistency_level': 'LOCAL_ONE', 'page_size': '2', 'query': 'select * from kv', 'serial_consistency_level': 'SERIAL'} | 2025-02-10 17:53:41.317000+0000
```

After disabling `report-every-page-fetch`, only first page generates trace event:
```
cqlsh> select session_id, command, coordinator, duration, parameters, started_at from system_traces.sessions;

 session_id                           | command | coordinator | duration | parameters                                                                                                              | started_at
--------------------------------------+---------+-------------+----------+-------------------------------------------------------------------------------------------------------------------------+---------------------------------
 e8f6ad80-e7d7-11ef-911d-0b57c0dc9621 |   QUERY |   127.0.0.1 |     1628 | {'consistency_level': 'LOCAL_ONE', 'page_size': '2', 'query': 'select * from kv', 'serial_consistency_level': 'SERIAL'} | 2025-02-10 17:53:18.424000+0000
```