### PR TITLE
CASSJAVA-3 Fix Ordering for LIMIT and PER PARTITION LIMIT on Select Queries

### DIFF
--- a/query-builder/src/main/java/com/datastax/oss/driver/internal/querybuilder/select/DefaultSelect.java
+++ b/query-builder/src/main/java/com/datastax/oss/driver/internal/querybuilder/select/DefaultSelect.java
@@ -457,21 +457,21 @@ public class DefaultSelect implements SelectFrom, Select {
       }
     }
 
-    if (limit != null) {
-      builder.append(" LIMIT ");
-      if (limit instanceof BindMarker) {
-        ((BindMarker) limit).appendTo(builder);
-      } else {
-        builder.append(limit);
-      }
-    }
-
     if (perPartitionLimit != null) {
       builder.append(" PER PARTITION LIMIT ");
       if (perPartitionLimit instanceof BindMarker) {
         ((BindMarker) perPartitionLimit).appendTo(builder);
       } else {
         builder.append(perPartitionLimit);
+      }
+    }
+
+    if (limit != null) {
+      builder.append(" LIMIT ");
+      if (limit instanceof BindMarker) {
+        ((BindMarker) limit).appendTo(builder);
+      } else {
+        builder.append(limit);
       }
     }
 

--- a/query-builder/src/test/java/com/datastax/oss/driver/api/querybuilder/select/SelectLimitTest.java
+++ b/query-builder/src/test/java/com/datastax/oss/driver/api/querybuilder/select/SelectLimitTest.java
@@ -49,4 +49,10 @@ public class SelectLimitTest {
     assertThat(selectFrom("foo").all().perPartitionLimit(1).perPartitionLimit(2))
         .hasCql("SELECT * FROM foo PER PARTITION LIMIT 2");
   }
+
+  @Test
+  public void should_put_limit_after_partition_limit() {
+    assertThat(selectFrom("foo").all().perPartitionLimit(1).limit(1))
+        .hasCql("SELECT * FROM foo PER PARTITION LIMIT 1 LIMIT 1");
+  }
 }


### PR DESCRIPTION
Correct the ordering of the literals LIMIT and PER PARTITION LIMIT for SELECT queries.