### PR TITLE
Default to empty DC failover preferred remoted DCs

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
@@ -381,8 +381,7 @@ public class OptionsMap implements Serializable {
     map.put(TypedDriverOption.LOAD_BALANCING_DC_FAILOVER_MAX_NODES_PER_REMOTE_DC, 0);
     map.put(TypedDriverOption.LOAD_BALANCING_DC_FAILOVER_ALLOW_FOR_LOCAL_CONSISTENCY_LEVELS, false);
     map.put(TypedDriverOption.METRICS_GENERATE_AGGREGABLE_HISTOGRAMS, true);
-    map.put(
-        TypedDriverOption.LOAD_BALANCING_DC_FAILOVER_PREFERRED_REMOTE_DCS, ImmutableList.of(""));
+    map.put(TypedDriverOption.LOAD_BALANCING_DC_FAILOVER_PREFERRED_REMOTE_DCS, ImmutableList.of());
   }
 
   @Immutable

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -580,7 +580,7 @@ datastax-java-driver {
       # Required: no
       # Modifiable at runtime: no
       # Overridable in a profile: no
-      preferred-remote-dcs = [""]
+      preferred-remote-dcs = []
     }
   }
 


### PR DESCRIPTION
In https://github.com/apache/cassandra-java-driver/pull/1896 we added a feature to prefer the order of the remote DCs on the x-DC failovers. As described in https://github.com/apache/cassandra-java-driver/pull/1896#discussion_r1983231999, the default is misleading to errors. With this tiny change I propose to default to empty list i/o containing a single empty string value.

cc @nitinitt 