### PR TITLE
Remove unnecessary locking in DefaultNettyOptions

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultNettyOptions.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultNettyOptions.java
@@ -200,7 +200,7 @@ public class DefaultNettyOptions implements NettyOptions {
   }
 
   @Override
-  public synchronized Timer getTimer() {
+  public Timer getTimer() {
     return timer;
   }
 }


### PR DESCRIPTION
This value is initialized at constructor time and marked final, so it can never change. There is no need to have access to this reference synchronized.