### PR TITLE
CASSJAVA-89 Fix deprecated table configs in Cassandra 5

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/querybuilder/RelationOptionsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/querybuilder/RelationOptionsIT.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.querybuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;
+import com.datastax.oss.driver.api.testinfra.ccm.CcmRule;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendRequirement;
+import com.datastax.oss.driver.api.testinfra.requirement.BackendType;
+import com.datastax.oss.driver.api.testinfra.session.SessionRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
+
+@Category(ParallelizableTests.class)
+public class RelationOptionsIT {
+
+  private CcmRule ccmRule = CcmRule.getInstance();
+
+  private SessionRule<CqlSession> sessionRule = SessionRule.builder(ccmRule).build();
+
+  @Rule public TestRule chain = RuleChain.outerRule(ccmRule).around(sessionRule);
+
+  @Rule public TestName name = new TestName();
+
+  @Test
+  @BackendRequirement(
+      type = BackendType.CASSANDRA,
+      minInclusive = "3.0",
+      description = "CRC check chance was moved to top level table in Cassandra 3.0")
+  public void should_create_table_with_crc_check_chance() {
+    sessionRule
+        .session()
+        .execute(
+            SchemaBuilder.createTable(name.getMethodName())
+                .withPartitionKey("id", DataTypes.INT)
+                .withColumn("name", DataTypes.TEXT)
+                .withColumn("age", DataTypes.INT)
+                .withCRCCheckChance(0.8)
+                .build());
+    KeyspaceMetadata keyspaceMetadata =
+        sessionRule
+            .session()
+            .getMetadata()
+            .getKeyspace(sessionRule.keyspace())
+            .orElseThrow(AssertionError::new);
+    String describeOutput = keyspaceMetadata.describeWithChildren(true).trim();
+
+    assertThat(describeOutput).contains("crc_check_chance = 0.8");
+  }
+
+  @Test
+  @BackendRequirement(
+      type = BackendType.CASSANDRA,
+      minInclusive = "5.0",
+      description = "chunk_length_kb was renamed to chunk_length_in_kb in Cassandra 5.0")
+  public void should_create_table_with_chunk_length_in_kb() {
+    sessionRule
+        .session()
+        .execute(
+            SchemaBuilder.createTable(name.getMethodName())
+                .withPartitionKey("id", DataTypes.INT)
+                .withColumn("name", DataTypes.TEXT)
+                .withColumn("age", DataTypes.INT)
+                .withLZ4Compression(4096)
+                .build());
+    KeyspaceMetadata keyspaceMetadata =
+        sessionRule
+            .session()
+            .getMetadata()
+            .getKeyspace(sessionRule.keyspace())
+            .orElseThrow(AssertionError::new);
+    String describeOutput = keyspaceMetadata.describeWithChildren(true).trim();
+
+    assertThat(describeOutput).contains("'class':'org.apache.cassandra.io.compress.LZ4Compressor'");
+    assertThat(describeOutput).contains("'chunk_length_in_kb':'4096'");
+  }
+
+  @Test
+  @BackendRequirement(
+      type = BackendType.CASSANDRA,
+      minInclusive = "3.0",
+      maxExclusive = "5.0",
+      description =
+          "Deprecated compression options should still work with Cassandra >= 3.0 & < 5.0")
+  public void should_create_table_with_deprecated_options() {
+    sessionRule
+        .session()
+        .execute(
+            SchemaBuilder.createTable(name.getMethodName())
+                .withPartitionKey("id", DataTypes.INT)
+                .withColumn("name", DataTypes.TEXT)
+                .withColumn("age", DataTypes.INT)
+                .withLZ4Compression(4096, 0.8)
+                .build());
+    KeyspaceMetadata keyspaceMetadata =
+        sessionRule
+            .session()
+            .getMetadata()
+            .getKeyspace(sessionRule.keyspace())
+            .orElseThrow(AssertionError::new);
+    String describeOutput = keyspaceMetadata.describeWithChildren(true).trim();
+
+    assertThat(describeOutput).contains("'class':'org.apache.cassandra.io.compress.LZ4Compressor'");
+    assertThat(describeOutput).contains("'chunk_length_in_kb':'4096'");
+    assertThat(describeOutput).contains("crc_check_chance = 0.8");
+  }
+}

--- a/query-builder/src/main/java/com/datastax/oss/driver/api/querybuilder/schema/RelationOptions.java
+++ b/query-builder/src/main/java/com/datastax/oss/driver/api/querybuilder/schema/RelationOptions.java
@@ -59,6 +59,18 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
   }
 
   /**
+   * Defines the crc check chance.
+   *
+   * <p>Note that using this option with a version of Apache Cassandra less than 3.0 will raise a
+   * syntax error.
+   */
+  @NonNull
+  @CheckReturnValue
+  default SelfT withCRCCheckChance(double crcCheckChance) {
+    return withOption("crc_check_chance", crcCheckChance);
+  }
+
+  /**
    * Defines the caching criteria.
    *
    * <p>If no call is made to this method, the default value is determined by the global caching
@@ -97,11 +109,10 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
   }
 
   /**
-   * Configures compression using the LZ4 algorithm with the given chunk length and crc check
-   * chance.
-   *
-   * @see #withCompression(String, int, double)
+   * @deprecated This method only exists for backward compatibility. Will not work with Apache
+   *     Cassandra 5.0 or later. Use {@link #withLZ4Compression(int)} instead.
    */
+  @Deprecated
   @NonNull
   @CheckReturnValue
   default SelfT withLZ4Compression(int chunkLengthKB, double crcCheckChance) {
@@ -109,10 +120,21 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
   }
 
   /**
-   * Configures compression using the LZ4 algorithm using the default configuration (64kb
-   * chunk_length, and 1.0 crc_check_chance).
+   * Configures compression using the LZ4 algorithm with the given chunk length.
    *
-   * @see #withCompression(String, int, double)
+   * @see #withCompression(String, int)
+   */
+  @NonNull
+  @CheckReturnValue
+  default SelfT withLZ4Compression(int chunkLengthKB) {
+    return withCompression("LZ4Compressor", chunkLengthKB);
+  }
+
+  /**
+   * Configures compression using the LZ4 algorithm using the default configuration (64kb
+   * chunk_length).
+   *
+   * @see #withCompression(String, int)
    */
   @NonNull
   @CheckReturnValue
@@ -121,11 +143,35 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
   }
 
   /**
-   * Configures compression using the Snappy algorithm with the given chunk length and crc check
-   * chance.
+   * Configures compression using the Zstd algorithm with the given chunk length.
    *
-   * @see #withCompression(String, int, double)
+   * @see #withCompression(String, int)
    */
+  @NonNull
+  @CheckReturnValue
+  default SelfT withZstdCompression(int chunkLengthKB) {
+    return withCompression("ZstdCompressor", chunkLengthKB);
+  }
+
+  /**
+   * Configures compression using the Zstd algorithm using the default configuration (64kb
+   * chunk_length).
+   *
+   * @see #withCompression(String, int)
+   */
+  @NonNull
+  @CheckReturnValue
+  default SelfT withZstdCompression() {
+    return withCompression("ZstdCompressor");
+  }
+
+  /**
+   * @deprecated This method only exists for backward compatibility. Will not work with Apache
+   *     Cassandra 5.0 or later due to removal of deprecated table properties (<a
+   *     href="https://issues.apache.org/jira/browse/CASSANDRA-18742">CASSANDRA-18742</a>). Use
+   *     {@link #withSnappyCompression(int)} instead.
+   */
+  @Deprecated
   @NonNull
   @CheckReturnValue
   default SelfT withSnappyCompression(int chunkLengthKB, double crcCheckChance) {
@@ -133,10 +179,21 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
   }
 
   /**
-   * Configures compression using the Snappy algorithm using the default configuration (64kb
-   * chunk_length, and 1.0 crc_check_chance).
+   * Configures compression using the Snappy algorithm with the given chunk length.
    *
-   * @see #withCompression(String, int, double)
+   * @see #withCompression(String, int)
+   */
+  @NonNull
+  @CheckReturnValue
+  default SelfT withSnappyCompression(int chunkLengthKB) {
+    return withCompression("SnappyCompressor", chunkLengthKB);
+  }
+
+  /**
+   * Configures compression using the Snappy algorithm using the default configuration (64kb
+   * chunk_length).
+   *
+   * @see #withCompression(String, int)
    */
   @NonNull
   @CheckReturnValue
@@ -145,11 +202,12 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
   }
 
   /**
-   * Configures compression using the Deflate algorithm with the given chunk length and crc check
-   * chance.
-   *
-   * @see #withCompression(String, int, double)
+   * @deprecated This method only exists for backward compatibility. Will not work with Apache
+   *     Cassandra 5.0 or later due to removal of deprecated table properties (<a
+   *     href="https://issues.apache.org/jira/browse/CASSANDRA-18742">CASSANDRA-18742</a>). Use
+   *     {@link #withDeflateCompression(int)} instead.
    */
+  @Deprecated
   @NonNull
   @CheckReturnValue
   default SelfT withDeflateCompression(int chunkLengthKB, double crcCheckChance) {
@@ -157,10 +215,21 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
   }
 
   /**
-   * Configures compression using the Deflate algorithm using the default configuration (64kb
-   * chunk_length, and 1.0 crc_check_chance).
+   * Configures compression using the Deflate algorithm with the given chunk length.
    *
-   * @see #withCompression(String, int, double)
+   * @see #withCompression(String, int)
+   */
+  @NonNull
+  @CheckReturnValue
+  default SelfT withDeflateCompression(int chunkLengthKB) {
+    return withCompression("DeflateCompressor", chunkLengthKB);
+  }
+
+  /**
+   * Configures compression using the Deflate algorithm using the default configuration (64kb
+   * chunk_length).
+   *
+   * @see #withCompression(String, int)
    */
   @NonNull
   @CheckReturnValue
@@ -170,13 +239,13 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
 
   /**
    * Configures compression using the given algorithm using the default configuration (64kb
-   * chunk_length, and 1.0 crc_check_chance).
+   * chunk_length).
    *
    * <p>Unless specifying a custom compression algorithm implementation, it is recommended to use
    * {@link #withLZ4Compression()}, {@link #withSnappyCompression()}, or {@link
    * #withDeflateCompression()}.
    *
-   * @see #withCompression(String, int, double)
+   * @see #withCompression(String, int)
    */
   @NonNull
   @CheckReturnValue
@@ -185,7 +254,7 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
   }
 
   /**
-   * Configures compression using the given algorithm, chunk length and crc check chance.
+   * Configures compression using the given algorithm, chunk length.
    *
    * <p>Unless specifying a custom compression algorithm implementation, it is recommended to use
    * {@link #withLZ4Compression()}, {@link #withSnappyCompression()}, or {@link
@@ -193,11 +262,24 @@ public interface RelationOptions<SelfT extends RelationOptions<SelfT>>
    *
    * @param compressionAlgorithmName The class name of the compression algorithm.
    * @param chunkLengthKB The chunk length in KB of compression blocks. Defaults to 64.
-   * @param crcCheckChance The probability (0.0 to 1.0) that checksum will be checked on each read.
-   *     Defaults to 1.0.
    */
   @NonNull
   @CheckReturnValue
+  default SelfT withCompression(@NonNull String compressionAlgorithmName, int chunkLengthKB) {
+    return withOption(
+        "compression",
+        ImmutableMap.of("class", compressionAlgorithmName, "chunk_length_in_kb", chunkLengthKB));
+  }
+
+  /**
+   * @deprecated This method only exists for backward compatibility. Will not work with Apache
+   *     Cassandra 5.0 or later due to removal of deprecated table properties (<a
+   *     href="https://issues.apache.org/jira/browse/CASSANDRA-18742">CASSANDRA-18742</a>). Use
+   *     {@link #withCompression(String, int)} instead.
+   */
+  @NonNull
+  @CheckReturnValue
+  @Deprecated
   default SelfT withCompression(
       @NonNull String compressionAlgorithmName, int chunkLengthKB, double crcCheckChance) {
     return withOption(

--- a/query-builder/src/test/java/com/datastax/dse/driver/api/querybuilder/schema/CreateDseTableTest.java
+++ b/query-builder/src/test/java/com/datastax/dse/driver/api/querybuilder/schema/CreateDseTableTest.java
@@ -199,9 +199,42 @@ public class CreateDseTableTest {
             createDseTable("bar")
                 .withPartitionKey("k", DataTypes.INT)
                 .withColumn("v", DataTypes.TEXT)
+                .withLZ4Compression(1024))
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'LZ4Compressor','chunk_length_in_kb':1024}");
+  }
+
+  @Test
+  public void should_generate_create_table_lz4_compression_options_crc() {
+    assertThat(
+            createDseTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
                 .withLZ4Compression(1024, .5))
         .hasCql(
             "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'LZ4Compressor','chunk_length_kb':1024,'crc_check_chance':0.5}");
+  }
+
+  @Test
+  public void should_generate_create_table_zstd_compression() {
+    assertThat(
+            createDseTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withZstdCompression())
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'ZstdCompressor'}");
+  }
+
+  @Test
+  public void should_generate_create_table_zstd_compression_options() {
+    assertThat(
+            createDseTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withZstdCompression(1024))
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'ZstdCompressor','chunk_length_in_kb':1024}");
   }
 
   @Test
@@ -217,6 +250,17 @@ public class CreateDseTableTest {
 
   @Test
   public void should_generate_create_table_snappy_compression_options() {
+    assertThat(
+            createDseTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withSnappyCompression(2048))
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'SnappyCompressor','chunk_length_in_kb':2048}");
+  }
+
+  @Test
+  public void should_generate_create_table_snappy_compression_options_crc() {
     assertThat(
             createDseTable("bar")
                 .withPartitionKey("k", DataTypes.INT)
@@ -239,6 +283,17 @@ public class CreateDseTableTest {
 
   @Test
   public void should_generate_create_table_deflate_compression_options() {
+    assertThat(
+            createDseTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withDeflateCompression(4096))
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'DeflateCompressor','chunk_length_in_kb':4096}");
+  }
+
+  @Test
+  public void should_generate_create_table_deflate_compression_options_crc() {
     assertThat(
             createDseTable("bar")
                 .withPartitionKey("k", DataTypes.INT)
@@ -388,5 +443,15 @@ public class CreateDseTableTest {
                 + "AND EDGE LABEL contrib "
                 + "FROM person(contributor) "
                 + "TO soft((company_name,software_name),software_version)");
+  }
+
+  @Test
+  public void should_generate_create_table_crc_check_chance() {
+    assertThat(
+            createDseTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withCRCCheckChance(0.8))
+        .hasCql("CREATE TABLE bar (k int PRIMARY KEY,v text) WITH crc_check_chance=0.8");
   }
 }

--- a/query-builder/src/test/java/com/datastax/oss/driver/api/querybuilder/schema/CreateTableTest.java
+++ b/query-builder/src/test/java/com/datastax/oss/driver/api/querybuilder/schema/CreateTableTest.java
@@ -203,9 +203,42 @@ public class CreateTableTest {
             createTable("bar")
                 .withPartitionKey("k", DataTypes.INT)
                 .withColumn("v", DataTypes.TEXT)
+                .withLZ4Compression(1024))
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'LZ4Compressor','chunk_length_in_kb':1024}");
+  }
+
+  @Test
+  public void should_generate_create_table_lz4_compression_options_crc() {
+    assertThat(
+            createTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
                 .withLZ4Compression(1024, .5))
         .hasCql(
             "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'LZ4Compressor','chunk_length_kb':1024,'crc_check_chance':0.5}");
+  }
+
+  @Test
+  public void should_generate_create_table_zstd_compression() {
+    assertThat(
+            createTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withZstdCompression())
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'ZstdCompressor'}");
+  }
+
+  @Test
+  public void should_generate_create_table_zstd_compression_options() {
+    assertThat(
+            createTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withZstdCompression(1024))
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'ZstdCompressor','chunk_length_in_kb':1024}");
   }
 
   @Test
@@ -221,6 +254,17 @@ public class CreateTableTest {
 
   @Test
   public void should_generate_create_table_snappy_compression_options() {
+    assertThat(
+            createTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withSnappyCompression(2048))
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'SnappyCompressor','chunk_length_in_kb':2048}");
+  }
+
+  @Test
+  public void should_generate_create_table_snappy_compression_options_crc() {
     assertThat(
             createTable("bar")
                 .withPartitionKey("k", DataTypes.INT)
@@ -243,6 +287,17 @@ public class CreateTableTest {
 
   @Test
   public void should_generate_create_table_deflate_compression_options() {
+    assertThat(
+            createTable("bar")
+                .withPartitionKey("k", DataTypes.INT)
+                .withColumn("v", DataTypes.TEXT)
+                .withDeflateCompression(4096))
+        .hasCql(
+            "CREATE TABLE bar (k int PRIMARY KEY,v text) WITH compression={'class':'DeflateCompressor','chunk_length_in_kb':4096}");
+  }
+
+  @Test
+  public void should_generate_create_table_deflate_compression_options_crc() {
     assertThat(
             createTable("bar")
                 .withPartitionKey("k", DataTypes.INT)


### PR DESCRIPTION
This fixes CASSJAVA-89 by switching from deprecated `chunk_length_kb` to `chunk_length_in_kb`