### PR TITLE
Update revapi to look at ASF releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -575,7 +575,7 @@
             </analysisConfiguration>
             <oldArtifacts>
               <!-- The previous release used DataStax groupId, remove this after the next release -->
-              <artifact>com.datastax.oss:${project.artifactId}:RELEASE</artifact>
+              <artifact>${project.groupId}:${project.artifactId}:RELEASE</artifact>
             </oldArtifacts>
           </configuration>
           <dependencies>


### PR DESCRIPTION
Noted while trying to setup 4.x duration tests for Netty updates (CASSJAVA-77).  Trying to resolve current versions of ASF releases against the com.datastax.oss group was pretty clearly failing:

```
2025-04-08 21:57:35,764 [CmdOut:13872]    INFO  client-0       - STDOUT: [INFO] --- revapi-maven-plugin:0.10.5:check (default) @ java-driver-core ---
2025-04-08 21:57:35,774 [CmdOut:13872]    INFO  client-0       - STDOUT: Downloading from artifactory: https://repo.datastax.com/dse/com/datastax/oss/java-driver-core/maven-metadata.xml
2025-04-08 21:57:40,393 [CmdOut:13872]    INFO  client-0       - STDOUT: Progress (1): 663 B
2025-04-08 21:57:40,576 [CmdOut:13872]    INFO  client-0       - STDOUT: Downloaded from artifactory: https://repo.datastax.com/dse/com/datastax/oss/java-driver-core/maven-metadata.xml (663 B at 138 B/s)
2025-04-08 21:57:40,578 [CmdOut:13872]    INFO  client-0       - STDOUT: [WARNING] Failed to resolve old artifacts: Failed to find a version of artifact 'com.datastax.oss:java-driver-core:RELEASE' that would correspond to an expression '\d+\.\d+\.\d+'. The versions found were: [4.6.0-alpha4, 4.6.0-alpha3, 4.6.0-alpha2, 4.6.0-alpha1, 4.4.0-unified+20191205, 4.3.0-cloud+20191013, 4.2.0-cloud-01]. The API analysis will proceed comparing the new archives against an empty archive.
...
2025-04-08 21:57:40,904 [CmdOut:13872]    INFO  client-0       - STDOUT: [INFO] Comparing [] against [org.apache.cassandra:java-driver-core:jar:4.19.1-SNAPSHOT] (including their transitive dependencies).
```