### PR TITLE
Fix openjdk@1.17.0 instead of openjdk@17 for ASF CI

### DIFF
--- a/Jenkinsfile-asf
+++ b/Jenkinsfile-asf
@@ -35,7 +35,7 @@ pipeline {
                 axes {
                     axis {
                         name 'TEST_JAVA_VERSION'
-                        values  'openjdk@1.8.0-292', 'openjdk@1.11.0-9', 'openjdk@17', 'openjdk@1.21.0'
+                        values  'openjdk@1.8.0-292', 'openjdk@1.11.0-9', 'openjdk@1.17.0', 'openjdk@1.21.0'
                     }
                     axis {
                         name 'SERVER_VERSION'


### PR DESCRIPTION
All the java 17 runs in ASF CI are failing because we installed openjdk@1.17.0, but try to `jabba use openjdk@17`.
Example failure: https://ci-cassandra.apache.org/job/cassandra-java-driver/job/4.x/59/cloudbees-pipeline-explorer/