### PR TITLE
Make MetricsITBase tests serial instead of parallelizable (CASSJAVA-19)

### DIFF
--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/DropwizardMetricsIT.java
@@ -32,7 +32,6 @@ import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
 import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
 import com.datastax.oss.driver.api.core.metrics.Metrics;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
-import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metrics.MetricId;
 import com.datastax.oss.driver.internal.core.metrics.MetricIdGenerator;
@@ -40,9 +39,7 @@ import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
 
-@Category(ParallelizableTests.class)
 public class DropwizardMetricsIT extends MetricsITBase {
 
   @ClassRule

--- a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/micrometer/MicrometerMetricsIT.java
@@ -25,7 +25,6 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
 import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
-import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.core.metrics.MetricsITBase;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metrics.MetricId;
@@ -40,9 +39,7 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
 
-@Category(ParallelizableTests.class)
 public class MicrometerMetricsIT extends MetricsITBase {
 
   @ClassRule

--- a/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/metrics/microprofile/MicroProfileMetricsIT.java
@@ -25,7 +25,6 @@ import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
 import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
 import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
-import com.datastax.oss.driver.categories.ParallelizableTests;
 import com.datastax.oss.driver.core.metrics.MetricsITBase;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.metrics.MetricId;
@@ -44,9 +43,7 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Tag;
 import org.eclipse.microprofile.metrics.Timer;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
 
-@Category(ParallelizableTests.class)
 public class MicroProfileMetricsIT extends MetricsITBase {
 
   @ClassRule


### PR DESCRIPTION
This change fixes random failures by removing `MicrometerMetricsIT`, `MicroProfileMetricsIT` and `DropwizardMetricsIT` from the `ParallelizableTests` category.
It is not the only solution but seems to be the simplest workaround.

The reasoning is as follows:
`should_evict_down_node_metrics_when_timeout_fires()` has two places where it manipulates `AbstractMetricUpdater.MIN_EXPIRE_AFTER` in order to set `DefaultDriverOption.METRICS_NODE_EXPIRE_AFTER` to 1 second during session initialization. Otherwise `MIN_EXPIRE_AFTER` would not allow for that and warning log would be printed about using higher value than what user wanted to set.
It lowers it before session initialization:
https://github.com/apache/cassandra-java-driver/blob/17ebe6092e2877d8c524e07489c4c3d005cfeea5/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/MetricsITBase.java#L157 And sets it back to 5 mintues at the end of the test: https://github.com/apache/cassandra-java-driver/blob/17ebe6092e2877d8c524e07489c4c3d005cfeea5/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/MetricsITBase.java#L186 The code comment in AbstractMetricUpdater also mentions that this variable is intentionally not made final for testing purposes. I believe this is what causes the intermittent failures. When those three tests that extend this class run in parallel it is possible that test B sets the minimum back to 5 minutes after the test A lowers it to 1 second but before test A initializes its session.
The test waits around 10 seconds for the change to happen, but in such case it would need to wait for 5 minutes.
Warnings with this pattern should be visible when the test fails on the CI:
```
c.d.o.d.i.c.m.AbstractMetricUpdater - [s6] Value too low for advanced.metrics.node.expire-after: PT1S. Forcing to PT5M instead.
```
I can confirm that this is what was happening when I was testing this locally, but I did not try to search for the logs on cassandra-java-driver's CI.