### PR TITLE
fix: fix race in Uuids.ClockSeqAndNodeContainer double-checked init

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/uuid/Uuids.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/uuid/Uuids.java
@@ -141,9 +141,8 @@ public final class Uuids {
       if (!initialized) {
         synchronized (ClockSeqAndNodeContainer.class) {
           if (!initialized) {
-
-            initialized = true;
             val = makeClockSeqAndNode();
+            initialized = true;
           }
         }
       }


### PR DESCRIPTION
Reordered writes in ClockSeqAndNodeContainer.get() to assign `val` before setting the volatile `initialized` flag.

The updated sequence ensures `val` is fully constructed and visible before publication via the volatile write.