### PR TITLE
CASSJAVA-103: Quoting column identifiers in DefaultCreateIndex

### DIFF
--- a/query-builder/src/main/java/com/datastax/oss/driver/internal/querybuilder/schema/DefaultCreateIndex.java
+++ b/query-builder/src/main/java/com/datastax/oss/driver/internal/querybuilder/schema/DefaultCreateIndex.java
@@ -164,9 +164,9 @@ public class DefaultCreateIndex implements CreateIndexStart, CreateIndexOnTable,
         builder.append(",");
       }
       if (entry.getValue().equals(NO_INDEX_TYPE)) {
-        builder.append(entry.getKey());
+        builder.append(entry.getKey().asCql(true));
       } else {
-        builder.append(entry.getValue()).append("(").append(entry.getKey()).append(")");
+        builder.append(entry.getValue()).append("(").append(entry.getKey().asCql(true)).append(")");
       }
     }
     builder.append(")");

--- a/query-builder/src/test/java/com/datastax/oss/driver/api/querybuilder/schema/CreateIndexTest.java
+++ b/query-builder/src/test/java/com/datastax/oss/driver/api/querybuilder/schema/CreateIndexTest.java
@@ -20,6 +20,7 @@ package com.datastax.oss.driver.api.querybuilder.schema;
 import static com.datastax.oss.driver.api.querybuilder.Assertions.assertThat;
 import static com.datastax.oss.driver.api.querybuilder.SchemaBuilder.createIndex;
 
+import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import org.junit.Test;
 
@@ -80,6 +81,17 @@ public class CreateIndexTest {
   public void should_generate_create_index_with_name_if_not_exists() {
     assertThat(createIndex("bar").ifNotExists().onTable("x").andColumn("y"))
         .hasCql("CREATE INDEX IF NOT EXISTS bar ON x (y)");
+  }
+
+  @Test
+  public void should_generate_create_index_with_correct_quoting() {
+    assertThat(createIndex("bAr").onTable("xY").andColumn("aB"))
+        .hasCql("CREATE INDEX bar ON xy (ab)");
+    assertThat(
+            createIndex(CqlIdentifier.fromInternal("bAr"))
+                .onTable(CqlIdentifier.fromInternal("xY"))
+                .andColumn(CqlIdentifier.fromInternal("aB")))
+        .hasCql("CREATE INDEX \"bAr\" ON \"xY\" (\"aB\")");
   }
 
   @Test

--- a/query-builder/src/test/java/com/datastax/oss/driver/api/querybuilder/schema/CreateTableTest.java
+++ b/query-builder/src/test/java/com/datastax/oss/driver/api/querybuilder/schema/CreateTableTest.java
@@ -21,6 +21,7 @@ import static com.datastax.oss.driver.api.querybuilder.Assertions.assertThat;
 import static com.datastax.oss.driver.api.querybuilder.SchemaBuilder.createTable;
 import static com.datastax.oss.driver.api.querybuilder.SchemaBuilder.udt;
 
+import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.metadata.schema.ClusteringOrder;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;
@@ -42,6 +43,25 @@ public class CreateTableTest {
   public void should_generate_create_table_if_not_exists() {
     assertThat(createTable("bar").ifNotExists().withPartitionKey("k", DataTypes.INT))
         .hasCql("CREATE TABLE IF NOT EXISTS bar (k int PRIMARY KEY)");
+  }
+
+  @Test
+  public void should_generate_create_table_with_correct_quoting() {
+    assertThat(
+            createTable("bAr")
+                .withPartitionKey("kY", DataTypes.INT)
+                .withClusteringColumn("xZ", DataTypes.INT)
+                .withStaticColumn("sT", DataTypes.TEXT)
+                .withColumn("cL", DataTypes.BLOB))
+        .hasCql("CREATE TABLE bar (ky int,xz int,st text STATIC,cl blob,PRIMARY KEY(ky,xz))");
+    assertThat(
+            createTable(CqlIdentifier.fromInternal("bAr"))
+                .withPartitionKey(CqlIdentifier.fromInternal("kY"), DataTypes.INT)
+                .withClusteringColumn(CqlIdentifier.fromInternal("xZ"), DataTypes.INT)
+                .withStaticColumn(CqlIdentifier.fromInternal("sT"), DataTypes.TEXT)
+                .withColumn(CqlIdentifier.fromInternal("cL"), DataTypes.BLOB))
+        .hasCql(
+            "CREATE TABLE \"bAr\" (\"kY\" int,\"xZ\" int,\"sT\" text STATIC,\"cL\" blob,PRIMARY KEY(\"kY\",\"xZ\"))");
   }
 
   @Test


### PR DESCRIPTION
JIRA link: [CASSJAVA-103](https://issues.apache.org/jira/browse/CASSJAVA-103).

In all schema builder classes (e.g. `DefaultCreateTable`), column identifiers are rendered using `CqlIdentifier.asCql(true)` method. This was not the case in `DefaultCreateIndex`, which led to missing quotes in CQL statement.

```
createIndex(CqlIdentifier.fromInternal("bAr"))
   .onTable(CqlIdentifier.fromInternal("xY"))
   .andColumn(CqlIdentifier.fromInternal("aB"))
```
Result: `CREATE INDEX "bAr" ON "xY" (aB)`
Expected: `CREATE INDEX "bAr" ON "xY" ("aB")`

Added test in `CreateTableTest` to make sure same behaviour applies there.