### PR TITLE
Fix initialization of shaded Guava for GraalVM 25

### DIFF
--- a/core/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-core/native-image.properties
+++ b/core/src/main/resources/META-INF/native-image/com.datastax.oss/java-driver-core/native-image.properties
@@ -22,4 +22,4 @@ Args=-H:IncludeResources=reference\\.conf \
   -H:IncludeResources=.*Driver\\.properties \
   -H:DynamicProxyConfigurationResources=${.}/proxy.json \
   -H:ReflectionConfigurationResources=${.}/reflection.json \
-  --initialize-at-build-time=com.datastax.oss.driver.internal.core.util.Dependency
+  --initialize-at-build-time=com.datastax.oss.driver.internal.core.util.Dependency,com.datastax.oss.driver.shaded.guava.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$PureJavaComparator


### PR DESCRIPTION
Fixes [CASSJAVA-114](https://issues.apache.org/jira/browse/CASSJAVA-114).

Reproduction steps:
1. Checkout _main_ branch of https://github.com/spring-projects/spring-aot-smoke-tests
2. Remove workaround applied in https://github.com/spring-projects/spring-aot-smoke-tests/commit/8b99eb7fc811eca37d3fc8682651fbd623d869b4
3. Update `data/data-cassandra-reactive/build.gradle` with:
```
repositories {
	mavenLocal()
}

configurations.all {
	resolutionStrategy {
		force("org.apache.cassandra:java-driver-core:4.19.1-SNAPSHOT")
		force("org.apache.cassandra:java-driver-guava-shaded:4.19.1-SNAPSHOT")
		force("org.apache.cassandra:java-driver-query-builder:4.19.1-SNAPSHOT")
	}
}
```
4. Apply changes locally to Java driver and install it in local Maven repository.
5. Run Gradle build to check the fix:
```
./gradlew clean :data:data-cassandra-reactive:nativeCompile --rerun-tasks
```