### PR TITLE
Docs: Replace outdated link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,6 @@ remain unchanged, and the new API will look very familiar to 2.x and 3.x users.
 
 See the [upgrade guide](upgrade_guide/) for details.
 
-## Error Handling
-
-See the [Cassandra error handling done right blog](https://www.datastax.com/blog/cassandra-error-handling-done-right) for error handling with the Java Driver for Apache Cassandra&trade;.
-
 ## Useful links
 
 * [Manual](manual/)


### PR DESCRIPTION
The "error handling done right" blog no longer exists.

I have suggested replacements within the DataStax drivers developer guide. The server error page, in particular, links to several other pages that address specific error handling concepts (like retry policies). These pages, by extension, link to the specific Java driver docs for those subjects. 

The [Java driver documentation](https://apache.github.io/cassandra-java-driver/4.19.0/HOME-README/) will need to be republished so this change is propagated over there as well.