### PR TITLE
docs: adding an extra space to render the page correctly with mkdocs

### DIFF
--- a/manual/core/custom_codecs/README.md
+++ b/manual/core/custom_codecs/README.md
@@ -33,6 +33,7 @@ Define custom Java to CQL mappings.
         (MutableCodecRegistry) session.getContext().getCodecRegistry();    
     registry.register(myCodec);
     ```
+
 * using a codec:
   * if already registered: `row.get("columnName", MyCustomType.class)`
   * otherwise: `row.get("columnName", myCodec)`


### PR DESCRIPTION
I've been looking into details on custom codes and noticed that the there is an issue with rendering bullet points on the following page: https://apache.github.io/cassandra-java-driver/4.19.0/core/custom_codecs/ 

<img width="957" height="679" alt="Screenshot 2026-01-07 at 14 36 09" src="https://github.com/user-attachments/assets/08d20a4c-8a02-4932-a5a6-98fb0c0a8e5b" />


It seems that an additional space is needed to address that.