### PR TITLE
Fix agent label on 3.x jenkinsfile-datastax

### DIFF
--- a/Jenkinsfile-datastax
+++ b/Jenkinsfile-datastax
@@ -341,7 +341,7 @@ pipeline {
   }
 
   environment {
-    OS_VERSION = 'ubuntu/bionic64/java-driver'
+    OS_VERSION = 'ubuntu/focal64/java-driver'
     JABBA_SHELL = '/usr/lib/jabba/jabba.sh'
     CCM_ENVIRONMENT_SHELL = '/usr/local/bin/ccm_environment.sh'
   }


### PR DESCRIPTION
3.x builds are hanging forever because the agent label no longer exists. This patch updates the agent label to the correct one.