### PR TITLE
Fix OSGi LZ4 test

### DIFF
--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/BundleOptions.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/BundleOptions.java
@@ -128,6 +128,9 @@ public class BundleOptions {
     return () ->
         options(
             mavenBundle("at.yawk.lz4", "lz4-java").versionAsInProject(),
+            // at.yawk.lz4 requires sun.misc package
+            mavenBundle("com.diffplug.osgi", "com.diffplug.osgi.extension.sun.misc")
+                .version("0.0.0"),
             systemProperty("cassandra.compression").value("LZ4"));
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <jackson-databind.version>${jackson.version}</jackson-databind.version>
     <!-- optional dependencies -->
     <snappy.version>1.1.10.1</snappy.version>
-    <lz4.version>1.10.1</lz4.version>
+    <lz4.version>1.10.2</lz4.version>
     <!-- test dependencies -->
     <assertj.version>3.19.0</assertj.version>
     <commons-exec.version>1.3</commons-exec.version>


### PR DESCRIPTION
Fixes [CASSJAVA-122](https://issues.apache.org/jira/browse/CASSJAVA-122)

Upgrade of LZ4 library is required to fix OSGi manifest: https://github.com/yawkat/lz4-java/commit/e3aa42cc8367331993a616b1b0a00baeafb3247c