### PR TITLE
Update Jenkins label to Jammy, 3.x edition

### DIFF
--- a/Jenkinsfile-datastax
+++ b/Jenkinsfile-datastax
@@ -341,7 +341,7 @@ pipeline {
   }
 
   environment {
-    OS_VERSION = 'ubuntu/focal64/java-driver'
+    OS_VERSION = 'ubuntu/jammy64/java-driver'
     JABBA_SHELL = '/usr/lib/jabba/jabba.sh'
     CCM_ENVIRONMENT_SHELL = '/usr/local/bin/ccm_environment.sh'
   }


### PR DESCRIPTION
🥷 to update the build label in the Jenkinsfile to Jammy now that the runners have been upgraded

3.x version of https://github.com/apache/cassandra-java-driver/pull/2082