### PR TITLE
CASSJAVA-115: Java 25 support

### DIFF
--- a/Jenkinsfile-datastax
+++ b/Jenkinsfile-datastax
@@ -332,7 +332,8 @@ pipeline {
                 '1.8',           // Oracle JDK version 1.8 (current default)
                 'openjdk@1.11',  // OpenJDK version 11
                 'openjdk@1.17',  // OpenJDK version 17
-                'openjdk@1.21'   // OpenJDK version 21
+                'openjdk@1.21',   // OpenJDK version 21
+                'openjdk@1.25'   // OpenJDK version 25
                 ],
       description: '''JDK version to use for <b>TESTING</b> when running adhoc <b>BUILD-AND-EXECUTE-TESTS</b> builds. <i>All builds will use JDK8 for building the driver</i>
                       <table style="width:100%">
@@ -357,6 +358,10 @@ pipeline {
                         <tr>
                           <td><strong>openjdk@1.21</strong></td>
                           <td>OpenJDK version 21</td>
+                        </tr>
+                        <tr>
+                          <td><strong>openjdk@1.25</strong></td>
+                          <td>OpenJDK version 25</td>
                         </tr>
                       </table>''')
     booleanParam(
@@ -442,7 +447,8 @@ pipeline {
             values '1.8',           // jdk8
                    'openjdk@1.11',  // jdk11
                    'openjdk@1.17',  // jdk17
-                   'openjdk@1.21'   // jdk21
+                   'openjdk@1.21',   // jdk21
+                   'openjdk@1.25'   // jdk25
           }
         }
 

--- a/integration-tests/src/test/java/com/datastax/dse/driver/api/core/cql/continuous/ContinuousPagingIT.java
+++ b/integration-tests/src/test/java/com/datastax/dse/driver/api/core/cql/continuous/ContinuousPagingIT.java
@@ -391,9 +391,23 @@ public class ContinuousPagingIT extends ContinuousPagingITBase {
       CompletableFutures.getUninterruptibly(fetchNextPageFuture);
       fail("Expected an execution exception since paging was cancelled.");
     } catch (CancellationException e) {
-      assertThat(e)
-          .hasMessageContaining("Can't get more results")
-          .hasMessageContaining("query was cancelled");
+        /**
+         * Since Java 25 has a breaking change in CompletableFuture.get()
+         * See: https://github.com/openjdk/jdk/commit/8a4315f833f3700075d65fae6bc566011c837c07
+         * CancellationException will be wrapped in a new CancellationException, with "get" as the message,
+         * and the original CancellationException as the cause
+         */
+
+        boolean exceptionHasBothMessages = e.getMessage() != null
+                && e.getMessage().contains("Can't get more results")
+                && e.getMessage().contains("query was cancelled");
+
+        boolean causeHasBothMessages = e.getCause() != null
+                && e.getCause().getMessage() != null
+                && e.getCause().getMessage().contains("Can't get more results")
+                && e.getCause().getMessage().contains("query was cancelled");
+
+        assertThat(exceptionHasBothMessages || causeHasBothMessages).isTrue();
     }
     int i = 0;
     for (Row row : pagingResult.currentPage()) {

--- a/pom.xml
+++ b/pom.xml
@@ -445,12 +445,12 @@
       <dependency>
         <groupId>io.projectreactor.tools</groupId>
         <artifactId>blockhound</artifactId>
-        <version>1.0.8.RELEASE</version>
+        <version>1.0.16.RELEASE</version>
       </dependency>
       <dependency>
         <groupId>io.projectreactor.tools</groupId>
         <artifactId>blockhound-junit-platform</artifactId>
-        <version>1.0.8.RELEASE</version>
+        <version>1.0.16.RELEASE</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -545,7 +545,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.10</version>
+          <version>0.8.14</version>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>
@@ -1060,6 +1060,19 @@ limitations under the License.]]></inlineHeader>
       <id>test-jdk-21</id>
       <activation>
         <jdk>[21,)</jdk>
+      </activation>
+      <properties>
+        <!-- for DriverBlockHoundIntegrationIT when using JDK 13+, see https://github.com/reactor/BlockHound/issues/33 -->
+        <blockhound.argline>-XX:+AllowRedefinitionToAddDeleteMethods</blockhound.argline>
+        <!-- allow deep reflection for mockito when using JDK 17+, see https://stackoverflow.com/questions/70993863/mockito-can-not-mock-random-in-java-17 -->
+        <mockitoopens.argline>--add-opens=java.base/jdk.internal.util.random=ALL-UNNAMED</mockitoopens.argline>
+      </properties>
+    </profile>
+    <profile>
+      <!-- workarounds for running tests with JDK21 -->
+      <id>test-jdk-25</id>
+      <activation>
+        <jdk>[25,)</jdk>
       </activation>
       <properties>
         <!-- for DriverBlockHoundIntegrationIT when using JDK 13+, see https://github.com/reactor/BlockHound/issues/33 -->


### PR DESCRIPTION
Add Java 25 to DataStax CI. Adding Java 25 to ASF CI will be in another PR.
Attention needed on:
1. Dependency bumps on blockhound and jacoco
2. Java 25 [breaking change](https://github.com/openjdk/jdk/commit/8a4315f833f3700075d65fae6bc566011c837c07) on CompletableFuture.get()