### PR TITLE
Fix logback dependency changes for 4.19.3

### DIFF
--- a/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/BundleOptions.java
+++ b/osgi-tests/src/test/java/com/datastax/oss/driver/internal/osgi/support/BundleOptions.java
@@ -102,16 +102,6 @@ public class BundleOptions {
         options(
             mavenBundle("ch.qos.logback", "logback-classic").versionAsInProject(),
             mavenBundle("ch.qos.logback", "logback-core").versionAsInProject(),
-
-            // slf4j 2.x requires spifly in order to operate in an OSGi context
-            mavenBundle("org.apache.aries.spifly", "org.apache.aries.spifly.dynamic.bundle")
-                .version("1.3.7"),
-            mavenBundle("org.apache.aries", "org.apache.aries.util").version("1.1.1"),
-            mavenBundle("org.ow2.asm", "asm").version("9.6"),
-            mavenBundle("org.ow2.asm", "asm-commons").version("9.6"),
-            mavenBundle("org.ow2.asm", "asm-util").version("9.6"),
-            mavenBundle("org.ow2.asm", "asm-tree").version("9.6"),
-            mavenBundle("org.ow2.asm", "asm-analysis").version("9.6"),
             systemProperty("logback.configurationFile")
                 .value("file:src/test/resources/logback-test.xml"));
   }

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     -->
     <tinkerpop.version>3.5.6</tinkerpop.version>
     <!-- when changing version also update version in LICENSE_binary  -->
-    <slf4j.version>2.0.16</slf4j.version>
+    <slf4j.version>1.7.26</slf4j.version>
     <!-- when changing version also update version in LICENSE_binary  -->
     <reactive-streams.version>1.0.3</reactive-streams.version>
     <jackson.version>2.20.1</jackson.version>
@@ -77,7 +77,7 @@
     <assertj.version>3.19.0</assertj.version>
     <commons-exec.version>1.3</commons-exec.version>
     <junit.version>4.13.2</junit.version>
-    <logback.version>1.3.15</logback.version>
+    <logback.version>1.2.13</logback.version>
     <osgi.version>6.0.0</osgi.version>
     <felix.version>7.0.1</felix.version>
     <pax-exam.version>4.13.4</pax-exam.version>


### PR DESCRIPTION
Revert #2051 and replace it with something closer to the intent of the original PR (#1901).

#2051 attempted to bump us up to the most recent Java8-compatible logback impl.  This moved us from 1.2.x to 1.3.x which in turn brought some dependency changes that were excessive, especially for a patch release.