### PR TITLE
Fix equality operation for Geometry subclasses

### DIFF
--- a/core/src/main/java/com/datastax/dse/driver/internal/core/data/geometry/DefaultGeometry.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/data/geometry/DefaultGeometry.java
@@ -176,7 +176,7 @@ public abstract class DefaultGeometry implements Geometry, Serializable {
       return false;
     }
     DefaultGeometry that = (DefaultGeometry) o;
-    return this.getOgcGeometry().equals((Object) that.getOgcGeometry());
+    return this.getOgcGeometry().Equals(that.getOgcGeometry());
   }
 
   @Override


### PR DESCRIPTION
Wondering if I got this wrong in my [earlier change](https://github.com/apache/cassandra-java-driver/pull/2077), trying to do some testing to confirm.