### PR TITLE
CASSJAVA-136 Ninja fix to correct geometry equality actually broke geometry equality

### DIFF
--- a/core/src/main/java/com/datastax/dse/driver/internal/core/data/geometry/DefaultGeometry.java
+++ b/core/src/main/java/com/datastax/dse/driver/internal/core/data/geometry/DefaultGeometry.java
@@ -176,7 +176,7 @@ public abstract class DefaultGeometry implements Geometry, Serializable {
       return false;
     }
     DefaultGeometry that = (DefaultGeometry) o;
-    return this.getOgcGeometry().Equals(that.getOgcGeometry());
+    return this.getOgcGeometry().equals((Object) that.getOgcGeometry());
   }
 
   @Override


### PR DESCRIPTION
See discussion on the ticket for more detail.

This change would need to go into 4.x and trunk.